### PR TITLE
Add link to list of nodes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ so also used with internal tools.
 automatically sends a new Slack notification every time a Github repository
 received or lost a star.
 
+## Available integrations
+
+n8n has 50+ different nodes to automate workflows. The list can be found in: [https://n8n.io/nodes](https://n8n.io/nodes)
+
 
 ## Documentation
 


### PR DESCRIPTION
@janober This is what I had in mind. I think this information is something that anyone that is looking to the project for the first time might be interested.

n8n actually has 49 nodes, but I included 50+ considering that the AWS SNS and AWS Lambda nodes are already implemented, just waiting the PR to finish to be merged :)