### PR TITLE
Fix 'run start' for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
-	"name": "n8n",
-	"private": true,
-	"homepage": "https://n8n.io",
-	"scripts": {
-		"bootstrap": "lerna bootstrap --hoist --no-ci",
-		"build": "lerna exec npm run build",
-		"dev": "lerna exec npm run dev --parallel",
-		"start": "cd packages/cli/bin && n8n",
-		"test": "lerna run test",
-		"watch": "lerna run --parallel watch"
-	},
-	"devDependencies": {
-		"lerna": "^3.13.1"
-	},
-	"postcss": {}
+  "name": "n8n",
+  "private": true,
+  "homepage": "https://n8n.io",
+  "scripts": {
+    "bootstrap": "lerna bootstrap --hoist --no-ci",
+    "build": "lerna exec npm run build",
+    "dev": "lerna exec npm run dev --parallel",
+    "start": "run-script-os",
+    "start:default": "cd packages/cli/bin && ./n8n",
+    "start:windows": "cd packages/cli/bin && n8n",
+    "test": "lerna run test",
+    "watch": "lerna run --parallel watch"
+  },
+  "devDependencies": {
+    "lerna": "^3.13.1",
+    "run-script-os": "^1.0.7"
+  },
+  "postcss": {}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"bootstrap": "lerna bootstrap --hoist --no-ci",
 		"build": "lerna exec npm run build",
 		"dev": "lerna exec npm run dev --parallel",
-		"start": "cd packages/cli && bin/n8n",
+		"start": "cd packages/cli/bin && n8n",
 		"test": "lerna run test",
 		"watch": "lerna run --parallel watch"
 	},


### PR DESCRIPTION
As brought up [here](https://community.n8n.io/t/trying-to-run-on-according-to-instructions-windows-10-fails/152), the current 'npm run' command doesn't work on windows.
This is a silly matter I could only find addressed [here](https://stackoverflow.com/questions/50243229/run-batch-file-in-npm-script).

No reason to think this syntax won't work for Mac/Linux, but I tested on Linux anyhow.
Please validate that it works for Mac as well.