### PR TITLE
Add JWT-based authentication

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -141,8 +141,27 @@ const config = convict({
 				env: 'N8N_BASIC_AUTH_PASSWORD',
 				doc: 'The password of the basic auth user'
 			},
+		},
+		jwtAuth: {
+			active: {
+				format: 'Boolean',
+				default: false,
+				env: 'N8N_JWT_AUTH_ACTIVE',
+				doc: 'If JWT auth should be activated for editor and REST-API'
+			},
+			jwtHeader: {
+				format: String,
+				default: '',
+				env: 'N8N_JWT_AUTH_HEADER',
+				doc: 'The request header containing a signed JWT'
+			},
+			jwksUri: {
+				format: String,
+				default: '',
+				env: 'N8N_JWKS_URI',
+				doc: 'The URI to fetch JWK Set for JWT auh'
+			},
 		}
-
 	},
 
 	endpoints: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
         "typescript": "~3.5.2"
     },
     "dependencies": {
+        "@types/jsonwebtoken": "^8.3.4",
         "@oclif/command": "^1.5.18",
         "@oclif/errors": "^1.2.2",
         "basic-auth": "^2.0.1",
@@ -81,6 +82,8 @@
         "glob-promise": "^3.4.0",
         "google-timezones-json": "^1.0.2",
         "inquirer": "^6.5.1",
+        "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^1.6.0",
         "localtunnel": "^1.9.1",
         "mongodb": "^3.2.3",
         "n8n-core": "~0.11.0",

--- a/packages/cli/src/ResponseHelper.ts
+++ b/packages/cli/src/ResponseHelper.ts
@@ -52,6 +52,11 @@ export function basicAuthAuthorizationError(resp: Response, realm: string, messa
 	resp.end(message);
 }
 
+export function jwtAuthAuthorizationError(resp: Response, message?: string) {
+	resp.statusCode = 403;
+	resp.end(message);
+}
+
 
 export function sendSuccessResponse(res: Response, data: any, raw?: boolean, responseCode?: number) { // tslint:disable-line:no-any
 	res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
I know this doesn't have a proper user system, but this adds basic JWT verification alongside the HTTP authentication process useful for running this behind a proxy etc. If n8n gets a user/login system in the future this would be pretty trivial to support

Note: not a professional JS or TS dev so the code might be a bit shoddy. Specifically the lack of downcasting `jwks.SigningKey` before checking the `publicKey || rsaPublicKey` field ([here](https://github.com/ccakes/n8n/blob/jwt-auth/packages/cli/src/Server.ts#L192-L197))