### PR TITLE
'npm run dev' / 'npm run start' OS fix for CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,114 +1,117 @@
 {
-    "name": "n8n",
-    "version": "0.24.0",
-    "description": "n8n Workflow Automation Tool",
-    "license": "SEE LICENSE IN LICENSE.md",
-    "homepage": "https://n8n.io",
-    "author": {
-        "name": "Jan Oberhauser",
-        "email": "jan@n8n.io"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/n8n-io/n8n.git"
-    },
-    "main": "dist/index",
-    "types": "dist/src/index.d.ts",
-    "oclif": {
-        "commands": "./dist/commands",
-        "bin": "n8n"
-    },
-    "scripts": {
-        "build": "tsc",
-        "dev": "nodemon",
-        "postpack": "rm -f oclif.manifest.json",
-        "prepack": "echo \"Building project...\" && rm -rf dist && tsc -b && oclif-dev manifest",
-        "start": "bin/n8n start",
-        "test": "jest",
-        "tslint": "tslint -p tsconfig.json -c tslint.json",
-        "watch": "tsc --watch"
-    },
-    "bin": {
-        "n8n": "./bin/n8n"
-    },
-    "keywords": [
-        "automate",
-        "automation",
-        "IaaS",
-        "iPaaS",
-        "n8n",
-        "workflow"
-    ],
-    "engines": {
-        "node": ">=8.0.0"
-    },
-    "files": [
-        "bin",
-        "dist",
-        "oclif.manifest.json"
-    ],
-    "devDependencies": {
-        "@oclif/dev-cli": "^1.22.2",
-        "@types/basic-auth": "^1.1.2",
-        "@types/compression": "0.0.36",
-        "@types/connect-history-api-fallback": "^1.3.1",
-        "@types/convict": "^4.2.1",
-        "@types/dotenv": "^6.1.1",
-        "@types/express": "^4.16.1",
-        "@types/jest": "^24.0.18",
-        "@types/localtunnel": "^1.9.0",
-        "@types/node": "^10.10.1",
-        "@types/open": "^6.1.0",
-        "@types/parseurl": "^1.3.1",
-        "@types/request-promise-native": "^1.0.15",
-        "jest": "^24.9.0",
-        "nodemon": "^1.19.1",
-        "ts-jest": "^24.0.2",
-        "tslint": "^5.17.0",
-        "typescript": "~3.5.2"
-    },
-    "dependencies": {
-        "@oclif/command": "^1.5.18",
-        "@oclif/errors": "^1.2.2",
-        "basic-auth": "^2.0.1",
-        "body-parser": "^1.18.3",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "convict": "^5.0.0",
-        "dotenv": "^8.0.0",
-        "express": "^4.16.4",
-        "flatted": "^2.0.0",
-        "glob-promise": "^3.4.0",
-        "google-timezones-json": "^1.0.2",
-        "inquirer": "^6.5.1",
-        "localtunnel": "^1.9.1",
-        "mongodb": "^3.2.3",
-        "n8n-core": "~0.11.0",
-        "n8n-editor-ui": "~0.20.0",
-        "n8n-nodes-base": "~0.19.0",
-        "n8n-workflow": "~0.12.0",
-        "open": "^6.1.0",
-        "pg": "^7.11.0",
-        "request-promise-native": "^1.0.7",
-        "sqlite3": "^4.0.6",
-        "sse-channel": "^3.1.1",
-        "typeorm": "^0.2.16"
-    },
-    "jest": {
-        "transform": {
-            "^.+\\.tsx?$": "ts-jest"
-        },
-        "testURL": "http://localhost/",
-        "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-        "testPathIgnorePatterns": [
-            "/dist/",
-            "/node_modules/"
-        ],
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js",
-            "json"
-        ]
-    }
+	"name": "n8n",
+	"version": "0.24.0",
+	"description": "n8n Workflow Automation Tool",
+	"license": "SEE LICENSE IN LICENSE.md",
+	"homepage": "https://n8n.io",
+	"author": {
+		"name": "Jan Oberhauser",
+		"email": "jan@n8n.io"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/n8n-io/n8n.git"
+	},
+	"main": "dist/index",
+	"types": "dist/src/index.d.ts",
+	"oclif": {
+		"commands": "./dist/commands",
+		"bin": "n8n"
+	},
+	"scripts": {
+		"build": "tsc",
+		"dev": "nodemon",
+		"postpack": "rm -f oclif.manifest.json",
+		"prepack": "echo \"Building project...\" && rm -rf dist && tsc -b && oclif-dev manifest",
+		"start": "run-script-os",
+		"start:default": "cd bin && ./n8n",
+		"start:windows": "cd bin && n8n",
+		"test": "jest",
+		"tslint": "tslint -p tsconfig.json -c tslint.json",
+		"watch": "tsc --watch"
+	},
+	"bin": {
+		"n8n": "./bin/n8n"
+	},
+	"keywords": [
+		"automate",
+		"automation",
+		"IaaS",
+		"iPaaS",
+		"n8n",
+		"workflow"
+	],
+	"engines": {
+		"node": ">=8.0.0"
+	},
+	"files": [
+		"bin",
+		"dist",
+		"oclif.manifest.json"
+	],
+	"devDependencies": {
+		"@oclif/dev-cli": "^1.22.2",
+		"@types/basic-auth": "^1.1.2",
+		"@types/compression": "0.0.36",
+		"@types/connect-history-api-fallback": "^1.3.1",
+		"@types/convict": "^4.2.1",
+		"@types/dotenv": "^6.1.1",
+		"@types/express": "^4.16.1",
+		"@types/jest": "^24.0.18",
+		"@types/localtunnel": "^1.9.0",
+		"@types/node": "^10.10.1",
+		"@types/open": "^6.1.0",
+		"@types/parseurl": "^1.3.1",
+		"@types/request-promise-native": "^1.0.15",
+		"jest": "^24.9.0",
+		"nodemon": "^1.19.1",
+		"run-script-os": "^1.0.7",
+		"ts-jest": "^24.0.2",
+		"tslint": "^5.17.0",
+		"typescript": "~3.5.2"
+	},
+	"dependencies": {
+		"@oclif/command": "^1.5.18",
+		"@oclif/errors": "^1.2.2",
+		"basic-auth": "^2.0.1",
+		"body-parser": "^1.18.3",
+		"compression": "^1.7.4",
+		"connect-history-api-fallback": "^1.6.0",
+		"convict": "^5.0.0",
+		"dotenv": "^8.0.0",
+		"express": "^4.16.4",
+		"flatted": "^2.0.0",
+		"glob-promise": "^3.4.0",
+		"google-timezones-json": "^1.0.2",
+		"inquirer": "^6.5.1",
+		"localtunnel": "^1.9.1",
+		"mongodb": "^3.2.3",
+		"n8n-core": "~0.11.0",
+		"n8n-editor-ui": "~0.20.0",
+		"n8n-nodes-base": "~0.19.0",
+		"n8n-workflow": "~0.12.0",
+		"open": "^6.1.0",
+		"pg": "^7.11.0",
+		"request-promise-native": "^1.0.7",
+		"sqlite3": "^4.0.6",
+		"sse-channel": "^3.1.1",
+		"typeorm": "^0.2.16"
+	},
+	"jest": {
+		"transform": {
+			"^.+\\.tsx?$": "ts-jest"
+		},
+		"testURL": "http://localhost/",
+		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+		"testPathIgnorePatterns": [
+			"/dist/",
+			"/node_modules/"
+		],
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"json"
+		]
+	}
 }


### PR DESCRIPTION
Same as was needed for the main entry-point to work on Windows.