### PR TITLE
fix focus of ParameterInput with type multiOptions

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -473,7 +473,7 @@ export default mixins(
 
 				// Set focus on field
 				setTimeout(() => {
-					(this.$refs.inputField as HTMLInputElement).focus();
+					(this.$refs.inputField.$el.querySelector('input') as HTMLInputElement).focus();
 				});
 			},
 			valueChanged (value: string | number | boolean | Date | null) {


### PR DESCRIPTION
In case of ParameterInput with type multiOptions, the HTML structure of the `<el-select>` component is different so the method `setFocus` fails to focus the `<input>` element

fix issues #78 and #2