### PR TITLE
Use n8n user rather than root

### DIFF
--- a/docker/compose/withMongo/docker-compose.yml
+++ b/docker/compose/withMongo/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     links:
       - mongo
     volumes:
-      - ~/.n8n:/root/.n8n
+      - ~/.n8n:/home/n8n/.n8n
     # Wait 5 seconds to start n8n to make sure that MongoDB is ready
     # when n8n tries to connect to it
     command: /bin/sh -c "sleep 5; n8n start"

--- a/docker/compose/withPostgres/docker-compose.yml
+++ b/docker/compose/withPostgres/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     links:
       - postgres
     volumes:
-      - ~/.n8n:/root/.n8n
+      - ~/.n8n:/home/n8n/.n8n
     # Wait 5 seconds to start n8n to make sure that PostgreSQL is ready
     # when n8n tries to connect to it
     command: /bin/sh -c "sleep 5; n8n start"

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -7,7 +7,7 @@ RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" 
 # Update everything, install needed dependencies and create n8n user
 RUN apk add --update \
 	graphicsmagick; \
-	adduser -S -h /home/n8n n8n
+	adduser -S -h /home/n8n -u 1001 n8n
 
 # Install n8n and the also temporary all the packages
 # it needs to build it correctly.

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -4,18 +4,19 @@ ARG N8N_VERSION
 
 RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" ; exit 1; fi
 
-# Update everything and install needed dependencies
+# Update everything, install needed dependencies and create n8n user
 RUN apk add --update \
-	graphicsmagick
-
-# # Set a custom user to not have n8n run as root
-USER root
+	graphicsmagick; \
+	adduser -S -h /home/n8n n8n
 
 # Install n8n and the also temporary all the packages
 # it needs to build it correctly.
+
 RUN apk --update add --virtual build-dependencies python build-base && \
 	npm_config_user=root npm install -g n8n@${N8N_VERSION} && \
-	apk del build-dependencies
+	 apk del build-dependencies
+
+USER n8n
 
 WORKDIR /data
 

--- a/docker/images/n8n/README.md
+++ b/docker/images/n8n/README.md
@@ -95,6 +95,7 @@ N8N_BASIC_AUTH_PASSWORD=<PASSWORD>
 
 ## Persist data
 
+`n8n` runs as the 'n8n' user which has a UID of `1001`, take this into account when persisting data.
 The workflow data gets by default saved in an SQLite database in the user
 folder (`/home/n8n/.n8n`). That folder also additionally contains the
 settings like webhook URL and encryption key.

--- a/docker/images/n8n/README.md
+++ b/docker/images/n8n/README.md
@@ -72,7 +72,7 @@ To use it simply start n8n with `--tunnel`
 docker run -it --rm \
   --name n8n \
   -p 5678:5678 \
-  -v ~/.n8n:/root/.n8n \
+  -v ~/.n8n:/home/n8n/.n8n \
   n8nio/n8n \
   n8n start --tunnel
 ```
@@ -96,14 +96,14 @@ N8N_BASIC_AUTH_PASSWORD=<PASSWORD>
 ## Persist data
 
 The workflow data gets by default saved in an SQLite database in the user
-folder (`/root/.n8n`). That folder also additionally contains the
+folder (`/home/n8n/.n8n`). That folder also additionally contains the
 settings like webhook URL and encryption key.
 
 ```
 docker run -it --rm \
   --name n8n \
   -p 5678:5678 \
-  -v ~/.n8n:/root/.n8n \
+  -v ~/.n8n:/home/n8n/.n8n \
   n8nio/n8n
 ```
 
@@ -113,7 +113,7 @@ By default n8n uses SQLite to save credentials, past executions and workflows.
 n8n however also supports MongoDB and PostgresDB. To use them simply a few
 environment variables have to be set.
 
-It is important to still persist the data in the `/root/.n8` folder. The reason
+It is important to still persist the data in the `/home/n8n/.n8` folder. The reason
 is that it contains n8n user data. That is the name of the webhook
 (in case) the n8n tunnel gets used and even more important the encryption key
 for the credentials. If none gets found n8n creates automatically one on
@@ -140,7 +140,7 @@ docker run -it --rm \
   -p 5678:5678 \
 	-e DB_TYPE=mongodb \
 	-e DB_MONGODB_CONNECTION_URL="mongodb://<MONGO_USER>:<MONGO_PASSWORD>@<MONGO_SERVER>:<MONGO_PORT>/<MONGO_DATABASE>" \
-  -v ~/.n8n:/root/.n8n \
+  -v ~/.n8n:/home/n8n/.n8n \
   n8nio/n8n \
   n8n start
 ```
@@ -167,7 +167,7 @@ docker run -it --rm \
 	-e DB_POSTGRESDB_PORT=<POSTGRES_PORT> \
 	-e DB_POSTGRESDB_USER=<POSTGRES_USER> \
 	-e DB_POSTGRESDB_PASSWORD=<POSTGRES_PASSWORD> \
-  -v ~/.n8n:/root/.n8n \
+  -v ~/.n8n:/home/n8n/.n8n \
   n8nio/n8n \
   n8n start
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ persist the data mount the `~/.n8n` folder:
 docker run -it --rm \
   --name n8n \
   -p 5678:5678 \
-  -v ~/.n8n:/root/.n8n \
+  -v ~/.n8n:/home/n8n/.n8n \
   n8nio/n8n
 ```
 


### PR DESCRIPTION
Builds and runs.
For security reasons, run as n8n user rather than root. Docs updated.

[Reasoning](https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html)