### PR TITLE
EmailSend without username/password

### DIFF
--- a/packages/nodes-base/nodes/EmailSend.node.ts
+++ b/packages/nodes-base/nodes/EmailSend.node.ts
@@ -139,12 +139,15 @@ export class EmailSend implements INodeType {
 			host: credentials.host as string,
 			port: credentials.port as number,
 			secure: credentials.secure as boolean,
-			// @ts-ignore
-			auth: {
-				user: credentials.user,
-				pass: credentials.password,
-			}
 		};
+
+		if(credentials.user || credentials.password) {
+			// @ts-ignore
+			connectionOptions.auth = {
+				user: credentials.user,
+				pass: credentials.password
+			};
+		}
 
 		if (options.allowUnauthorizedCerts === true) {
 			connectionOptions.tls = {


### PR DESCRIPTION
EmailSend Node sets username/password even if there aren't any set in credentials.
Causing error:
![image](https://user-images.githubusercontent.com/5815009/68089993-0a59e800-fe6f-11e9-8590-9caac7da21b3.png)

adding check for username/password