### PR TITLE
Fixes edit method

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -853,7 +853,7 @@ export class Gitlab implements INodeType {
 					//         edit
 					// ----------------------------------
 
-					requestMethod = 'PATCH';
+					requestMethod = 'PUT';
 
 					const issueNumber = this.getNodeParameter('issueNumber', i) as string;
 


### PR DESCRIPTION
Gitlab docs says call a PUT  on issue to edit : 
```
Edit issue
Updates an existing project issue. This call is also used to mark an issue as closed.
PUT /projects/:id/issues/:issue_iid
```

the node method is PATCH
https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts#L856


For github with this node is based on, it is PATCH
`
PATCH /repos/:owner/:repo/issues/:issue_number
`