### PR TITLE
Allow HEAD webhooks

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1151,6 +1151,28 @@ class App {
 		});
 
 
+		// HEAD webhook requests
+		this.app.head(`/${this.endpointWebhook}/*`, async (req: express.Request, res: express.Response) => {
+			// Cut away the "/webhook/" to get the registred part of the url
+			const requestUrl = (req as ICustomRequest).parsedUrl!.pathname!.slice(this.endpointWebhook.length + 2);
+
+			let response;
+			try {
+				response = await this.activeWorkflowRunner.executeWebhook('HEAD', requestUrl, req, res);
+			} catch (error) {
+				ResponseHelper.sendErrorResponse(res, error);
+				return;
+			}
+
+			if (response.noWebhookResponse === true) {
+				// Nothing else to do as the response got already sent
+				return;
+			}
+
+			ResponseHelper.sendSuccessResponse(res, response.data, true, response.responseCode);
+		});
+
+
 		// GET webhook requests (test for UI)
 		this.app.get(`/${this.endpointWebhookTest}/*`, async (req: express.Request, res: express.Response) => {
 			// Cut away the "/webhook-test/" to get the registred part of the url

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1217,6 +1217,28 @@ class App {
 		});
 
 
+		// HEAD webhook requests (test for UI)
+		this.app.head(`/${this.endpointWebhookTest}/*`, async (req: express.Request, res: express.Response) => {
+			// Cut away the "/webhook-test/" to get the registred part of the url
+			const requestUrl = (req as ICustomRequest).parsedUrl!.pathname!.slice(this.endpointWebhookTest.length + 2);
+
+			let response;
+			try {
+				response = await this.testWebhooks.callTestWebhook('HEAD', requestUrl, req, res);
+			} catch (error) {
+				ResponseHelper.sendErrorResponse(res, error);
+				return;
+			}
+
+			if (response.noWebhookResponse === true) {
+				// Nothing else to do as the response got already sent
+				return;
+			}
+
+			ResponseHelper.sendSuccessResponse(res, response.data, true, response.responseCode);
+		});
+
+
 		// Serve the website
 		const startTime = (new Date()).toUTCString();
 		const editorUiPath = require.resolve('n8n-editor-ui');

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -489,7 +489,7 @@ export interface IWorkflowDataProxyData {
 	$parameter: any; // tslint:disable-line:no-any
 }
 
-export type WebhookHttpMethod = 'GET' | 'POST';
+export type WebhookHttpMethod = 'GET' | 'POST' | 'HEAD';
 
 export interface IWebhookResponseData {
 	workflowData?: INodeExecutionData[][];


### PR DESCRIPTION
Trello webhooks require a `200` HTTP response to the same webhook path but with a `HEAD` HTTP method when setting up the webhook for the first time.

Seems that the server does not listen on these paths for `HEAD` requests, so this change adds that functionality in for any webhook configured as such.