### PR TITLE
Introduce INTERNAL_API_URL to allow for deployments behind auth-proxy

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow.node.ts
@@ -158,7 +158,7 @@ export class ExecuteWorkflow implements INodeType {
 			async getWorkflows(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const options: OptionsWithUri = {
 					method: 'GET',
-					uri: this.getRestApiUrl() + '/workflows',
+					uri: (process.env.INTERNAL_API_URL || this.getRestApiUrl()) + '/workflows',
 					json: true
 				};
 


### PR DESCRIPTION
We are currently using n8n deployed behind an authenticated proxy which exposes only the /webhooks to public. 
This PR allows for overriding the hostname/url used for internal api call in execute workflow node via environment variable.