### PR TITLE
uses non-root user

### DIFF
--- a/docker/images/n8n-ubuntu/Dockerfile
+++ b/docker/images/n8n-ubuntu/Dockerfile
@@ -6,7 +6,7 @@ RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" 
 
 RUN \
 	apt-get update && \
-	apt-get -y install graphicsmagick
+	apt-get -y install graphicsmagick gosu
 
 # Set a custom user to not have n8n run as root
 USER root
@@ -15,4 +15,5 @@ RUN npm_config_user=root npm install -g n8n@${N8N_VERSION}
 
 WORKDIR /data
 
-CMD "n8n"
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker/images/n8n-ubuntu/docker-entrypoint.sh
+++ b/docker/images/n8n-ubuntu/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -d /root/.n8n ] ; then
+  chmod o+rx /root
+  chown -R node /root/.n8n
+  ln -s /root/.n8n /home/node/
+fi
+
+exec gosu node n8n

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -5,7 +5,7 @@ ARG N8N_VERSION
 RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" ; exit 1; fi
 
 # Update everything and install needed dependencies
-RUN apk add --update graphicsmagick tzdata git
+RUN apk add --update graphicsmagick tzdata git tini su-exec
 
 # # Set a custom user to not have n8n run as root
 USER root
@@ -18,4 +18,5 @@ RUN apk --update add --virtual build-dependencies python build-base ca-certifica
 
 WORKDIR /data
 
-CMD ["n8n"]
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -d /root/.n8n ] ; then
+  chmod o+rx /root
+  chown -R node /root/.n8n
+  ln -s /root/.n8n /home/node/
+fi
+
+exec su-exec node n8n


### PR DESCRIPTION
Another approach to https://github.com/n8n-io/n8n/pull/89 using an entrypoint switching from root to built-in node-user.

This "opens" /root/.n8n (if any) so this is backwards compatible with as much security as it is possible without breaking installations out there.

Please keep in mind, that a major upgrade should remove the entrypoint and instead use something like this:

```
USER node
CMD n8n
```

This requires user to upgrade their installations, so this should be hinted in an upgrade-path (e.g. UPGRADE.md).