### PR TITLE
fix: use .bin for tsc

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -64,7 +64,7 @@ export async function buildFiles (options?: IBuildOptions): Promise<string> {
 	options = options || {};
 
 	// Get the path of the TypeScript cli of this project
-	const tscPath = join(__dirname, '../../node_modules/typescript/bin/tsc');
+	const tscPath = join(__dirname, '../../node_modules/.bin/tsc');
 
 	const tsconfigData = await createCustomTsconfig();
 


### PR DESCRIPTION
Use "tsc" executable in .bit folder from node_modules, this will help in monorepos using lerna hoist (or yarn workspaces) because node_modules dependencies are not installed in all packages