### PR TITLE
:zap: encode file to base64

### DIFF
--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -328,7 +328,7 @@ export class Webhook implements INodeType {
 						const fileJson = files[file].toJSON() as IDataObject;
 						const [fileName, fileExtension] = (fileJson.name as string).split('.');
 						const fileContent = await fs.promises.readFile(files[file].path);
-						const buffer = new Buffer(fileContent);
+						const buffer = Buffer.from(fileContent);
 						set(returnData[0], `binary[${fileName}]`, {
 							data: buffer.toString('base64'),
 							mimeType: fileJson.type,

--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -328,8 +328,9 @@ export class Webhook implements INodeType {
 						const fileJson = files[file].toJSON() as IDataObject;
 						const [fileName, fileExtension] = (fileJson.name as string).split('.');
 						const fileContent = await fs.promises.readFile(files[file].path);
+						const buffer = new Buffer(fileContent);
 						set(returnData[0], `binary[${fileName}]`, {
-							data: fileContent,
+							data: buffer.toString('base64'),
 							mimeType: fileJson.type,
 							fileName: fileJson.name,
 							fileExtension,


### PR DESCRIPTION
I was checking if the webhook would work well with .ogg files if the data was sent using multipart data and realized that it was working well with images but not with .ogg files. The ogg file when I selected  "show binary data" was not showing the preview. After digging a little bit realized that I was not parsing the content to base64. Just added it and now it works fine. This should not break anything.

![image](https://user-images.githubusercontent.com/16496553/77178200-21efe100-6a9d-11ea-8938-2125d8ae16cc.png)
