### PR TITLE
Support for binary data on webhooks

### DIFF
--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -212,6 +212,28 @@ export class Webhook implements INodeType {
 				description: 'Name of the binary property to return',
 			},
 			{
+				displayName: 'Binary Data',
+				name: 'binaryData',
+				type: 'boolean',
+				default: false,
+				description: 'If the data to upload should be taken from binary field.',
+			},
+			{
+				displayName: 'Binary Property',
+				name: 'binaryPropertyName',
+				type: 'string',
+				default: 'data',
+				required: true,
+				displayOptions: {
+					show: {
+						binaryData: [
+							true,
+						],
+					},
+				},
+				description: 'Name of the binary property which contains<br />the data for the file to be uploaded.',
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				type: 'collection',
@@ -253,13 +275,6 @@ export class Webhook implements INodeType {
 						default: 'data',
 						description: 'Name of the property to return the data of instead of the whole JSON.',
 					},
-					{
-						displayName: 'Raw Body',
-						name: 'rawBody',
-						type: 'boolean',
-						default: false,
-						description: 'Raw body (binary)',
-					},
 				],
 			},
 		],
@@ -268,7 +283,7 @@ export class Webhook implements INodeType {
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const authentication = this.getNodeParameter('authentication', 0) as string;
-		const options = this.getNodeParameter('options', 0) as IDataObject;
+		const binaryData = this.getNodeParameter('binaryData', 0) as boolean;
 		const req = this.getRequestObject();
 		const resp = this.getResponseObject();
 		const headers = this.getHeaderData();
@@ -345,6 +360,34 @@ export class Webhook implements INodeType {
 			});
 		}
 
+		if (binaryData) {
+			return new Promise((resolve, reject) => {
+				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+				const data: Buffer[] = [];
+
+				req.on('data', (chunk) => {
+					data.push(chunk);
+				});
+
+				req.on('end', () => {
+					const returnData: IDataObject[] = [{}];
+					set(returnData[0], `binary[${binaryPropertyName}]`, {
+						data: Buffer.concat(data).toString('base64'),
+						mimeType: req.headers['content-type'],
+					});
+					return resolve({
+						workflowData: [
+							returnData as INodeExecutionData[],
+						],
+					});
+				});
+
+				req.on('error', (err) => {
+					throw new Error(err.message);
+				});
+			});
+		}
+
 		const response: INodeExecutionData = {
 			json: {
 				body: this.getBodyData(),
@@ -352,15 +395,6 @@ export class Webhook implements INodeType {
 				query: this.getQueryData(),
 			},
 		};
-		if (options.rawBody) {
-			response.binary = {
-				data: {
-					// @ts-ignore
-					data: req.rawBody.toString('base64'),
-					mimeType,
-				}
-			};
-		}
 
 		return {
 			workflowData: [

--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -275,14 +275,21 @@ export class Webhook implements INodeType {
 						default: 'data',
 						description: 'Name of the property to return the data of instead of the whole JSON.',
 					},
+					{
+						displayName: 'Raw Body',
+						name: 'rawBody',
+						type: 'boolean',
+						default: false,
+						description: 'Raw body (binary)',
+					},
 				],
 			},
 		],
 	};
 
-
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const authentication = this.getNodeParameter('authentication', 0) as string;
+		const options = this.getNodeParameter('options', 0) as IDataObject;
 		const binaryData = this.getNodeParameter('binaryData', 0) as boolean;
 		const req = this.getRequestObject();
 		const resp = this.getResponseObject();
@@ -395,6 +402,16 @@ export class Webhook implements INodeType {
 				query: this.getQueryData(),
 			},
 		};
+
+		if (options.rawBody) {
+			response.binary = {
+				data: {
+					// @ts-ignore
+					data: req.rawBody.toString('base64'),
+					mimeType,
+				}
+			};
+		}
 
 		return {
 			workflowData: [


### PR DESCRIPTION
@janober This should solve this issue. https://community.n8n.io/t/handling-of-binary-data-in-webhook/1035?u=ricardoe105

To test it just go to postman, set the body to binary and upload a file.

![image](https://user-images.githubusercontent.com/16496553/77197811-2e376680-6abc-11ea-90aa-fc3e6a184eae.png)

Let me know if something.
