### PR TITLE
docs: added dark mode for docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,53 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>n8n Documentation</title>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+		<meta
+			name="description"
+			content="Documentation of n8n - Open Source Workflow Automation Tool"
+		/>
+		<meta
+			name="viewport"
+			content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+		/>
+		<link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" />
+		<link
+			rel="stylesheet"
+			href="//cdn.jsdelivr.net/npm/docsify-dark-mode@latest/dist/style.min.css"
+		/>
+		<style>
+			.app-name-link img {
+				width: 200px;
+			}
 
-<head>
-	<meta charset="UTF-8">
-	<title>n8n Documentation</title>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-	<meta name="description" content="Documentation of n8n - Open Source Workflow Automation Tool">
-	<meta name="viewport"
-		content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-	<link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
-	<style>
-		.app-name-link img {
-			width: 200px;
-		}
+			.sidebar-nav a img {
+				position: relative;
+				top: 3px;
+				margin-right: 0.5em;
+			}
+			#dark_mode {
+				left: 0;
+				right: unset;
+			}
+		</style>
+	</head>
 
-		.sidebar-nav a img {
-			position: relative;
-			top: 3px;
-			margin-right: 0.5em;
-		}
-	</style>
-</head>
-
-<body>
-	<div id="app"></div>
-	<script src="//unpkg.com/docsify-edit-on-github/index.js"></script>
-	<script>
-		window.$docsify = {
-			auto2top: true,
-			ga: 'UA-146470481-3',
-			themeColor: '#ff0000',
-			name: 'docs.n8n.io',
-			logo: 'images/n8n-logo.png',
-			loadSidebar: true,
-			subMaxLevel: 2,
-			repo: '',
-			plugins: [
-				EditOnGithubPlugin.create('https://github.com/n8n-io/n8n/tree/master/docs/')
-			]
-		}
-	</script>
-	<script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-	<script src="https://unpkg.com/docsify-copy-code@2"></script>
-	<script src="//unpkg.com/prismjs/components/prism-bash.min.js"></script>
-	<script src="//unpkg.com/prismjs/components/prism-yaml.min.js"></script>
-	<script src="//unpkg.com/prismjs/components/prism-json.min.js"></script>
-	<script src="//unpkg.com/prismjs/components/prism-typescript.min.js"></script>
-	<script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
-	<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
-</body>
-
+	<body>
+		<div id="app"></div>
+		<script src="//unpkg.com/docsify-edit-on-github/index.js"></script>
+		<script>
+			window.$docsify = {
+				auto2top: true,
+				ga: "UA-146470481-3",
+				themeColor: "#ff0000",
+				name: "docs.n8n.io",
+				logo: "images/n8n-logo.png",
+				loadSidebar: true,
+				subMaxLevel: 2,
+				repo: "",
+				plugins: [
+					EditOnGithubPlugin.create(
+						"https://github.com/n8n-io/n8n/tree/master/docs/"
+					)
+				]
+			};
+		</script>
+		<script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+		<script src="https://unpkg.com/docsify-copy-code@2"></script>
+		<script src="//cdn.jsdelivr.net/npm/docsify-dark-mode@latest/dist/index.min.js"></script>
+		<script src="//unpkg.com/prismjs/components/prism-bash.min.js"></script>
+		<script src="//unpkg.com/prismjs/components/prism-yaml.min.js"></script>
+		<script src="//unpkg.com/prismjs/components/prism-json.min.js"></script>
+		<script src="//unpkg.com/prismjs/components/prism-typescript.min.js"></script>
+		<script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
+		<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+	</body>
 </html>


### PR DESCRIPTION
Added `docsify-dark-mode` in documentation for dark mode

Screen shots

![image](https://user-images.githubusercontent.com/26347874/77231060-88b8eb80-6bbe-11ea-9fe0-bcfed24fa664.png)


![image](https://user-images.githubusercontent.com/26347874/77231109-c61d7900-6bbe-11ea-8fef-01afd47eda19.png)


`Mobile`

![image](https://user-images.githubusercontent.com/26347874/77231117-d59cc200-6bbe-11ea-94e6-4e4cddad409a.png)


![image](https://user-images.githubusercontent.com/26347874/77231121-dd5c6680-6bbe-11ea-8b09-873b2fc25109.png)
