### PR TITLE
Add full-icu to Dockerfiles

### DIFF
--- a/docker/images/n8n-ubuntu/Dockerfile
+++ b/docker/images/n8n-ubuntu/Dockerfile
@@ -11,7 +11,9 @@ RUN \
 # Set a custom user to not have n8n run as root
 USER root
 
-RUN npm_config_user=root npm install -g n8n@${N8N_VERSION}
+RUN npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION}
+
+ENV NODE_ICU_DATA /usr/local/lib/node_modules/full-icu
 
 WORKDIR /data
 

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.0-alpine
+FROM node:12.16-alpine
 
 ARG N8N_VERSION
 
@@ -13,8 +13,10 @@ USER root
 # Install n8n and the also temporary all the packages
 # it needs to build it correctly.
 RUN apk --update add --virtual build-dependencies python build-base ca-certificates && \
-	npm_config_user=root npm install -g n8n@${N8N_VERSION} && \
+	npm_config_user=root npm install -g full-icu n8n@${N8N_VERSION} && \
 	apk del build-dependencies
+
+ENV NODE_ICU_DATA /usr/local/lib/node_modules/full-icu
 
 WORKDIR /data
 

--- a/packages/cli/commands/start.ts
+++ b/packages/cli/commands/start.ts
@@ -20,10 +20,6 @@ import {
 } from "../src";
 
 
-// // Add support for internationalization
-// const fullIcuPath = require.resolve('full-icu');
-// process.env.NODE_ICU_DATA = dirname(fullIcuPath);
-
 let activeWorkflowRunner: ActiveWorkflowRunner.ActiveWorkflowRunner | undefined;
 let processExistCode = 0;
 


### PR DESCRIPTION
Adding the full-icu package (https://github.com/icu-project/full-icu-npm) to the Docker files to backfill the node 12 support for proper internationalization.

This enables the node runtime and n8n nodes like Function to make full use of JS internationalization features like the Intl object. 

Status of support in node:
For node <= 12 the support is only partial, i.e. features like the Intl object are available but only support English.
Full support is implemented in node >= 13, which ships with full-icu integrated. When we switch the Dockerfiles to node 14 (the next LTS version) we should remove these additions.

We could also think about "deeper" integration as was attempted in packages/cli/commands/start.ts, but I see no need as the "problem" will solve itself within then next 6 months.