### PR TITLE
:zap: Added continue option

### DIFF
--- a/packages/nodes-base/nodes/Google/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/GoogleSheets.node.ts
@@ -20,7 +20,6 @@ import {
 	ValueRenderOption,
 } from './GoogleSheet';
 
-
 export class GoogleSheets implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Google Sheets ',
@@ -407,6 +406,21 @@ export class GoogleSheets implements INodeType {
 				},
 				options: [
 					{
+						displayName: 'Continue If Response Is Empty',
+						name: 'continue',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'/operation': [
+									'lookup',
+									'read',
+								],
+							},
+						},
+						description: 'By default, the workflow stops executing if the lookup/read does not return values',
+					},
+					{
 						displayName: 'Return All Matches',
 						name: 'returnAllMatches',
 						type: 'boolean',
@@ -678,7 +692,14 @@ export class GoogleSheets implements INodeType {
 				});
 			}
 
-			const returnData = await sheet.lookupValues(sheetData, keyRow, dataStartRow, lookupValues, options.returnAllMatches as boolean | undefined);
+			let returnData = await sheet.lookupValues(sheetData, keyRow, dataStartRow, lookupValues, options.returnAllMatches as boolean | undefined);
+
+			if (returnData.length === 0 && options.continue && options.returnAllMatches) {
+				returnData = [{}];
+
+			} else if (returnData.length === 1 && Object.keys(returnData[0]).length === 0 && !options.continue && !options.returnAllMatches) {
+				returnData = [];
+			}
 
 			return [this.helpers.returnJsonArray(returnData)];
 		} else if (operation === 'read') {
@@ -705,6 +726,10 @@ export class GoogleSheets implements INodeType {
 				const keyRow = this.getNodeParameter('keyRow', 0) as number;
 
 				returnData = sheet.structureArrayDataByColumn(sheetData, keyRow, dataStartRow);
+			}
+
+			if (returnData.length === 0 && options.continue) {
+				returnData = [{}];
 			}
 
 			return [this.helpers.returnJsonArray(returnData)];


### PR DESCRIPTION
With the lookup operation depending on the configuration, this might change the behavior in workflows since the node was doing the opposite depending on if returnAllMatches was true o false.

Before:

If **returnAllMatches** false and **returnData.length** === 0  --> response  [{ json: {} }] (execute next node)
If **returnAllMatches** true and **returnData.length** === 0  --> response  [] (stops workflow)

Now:

If **returnAllMatches** false and **returnData.length** === 0 response -->  [] (stops workflow unless continue is set to true)
If **returnAllMatches** true and **returnData.length** === 0 response  --> [] (stops workflow unless continue is set to true)

