### PR TITLE
Add HTTPS support by giving an SSL Cert and Key

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -175,6 +175,18 @@ const config = convict({
 		env: 'N8N_PROTOCOL',
 		doc: 'HTTP Protocol via which n8n can be reached'
 	},
+	ssl_key: {
+		format: String,
+		default: 'server.key',
+		env: 'N8N_SSL_KEY',
+		doc: 'SSL Key for HTTPS Protocol'
+	},
+	ssl_cert: {
+		format: String,
+		default: 'server.pem',
+		env: 'N8N_SSL_CERT',
+		doc: 'SSL Cert for HTTPS Protocol'
+	},
 
 	security: {
 		basicAuth: {
@@ -276,10 +288,10 @@ const config = convict({
 // Overwrite default configuration with settings which got defined in
 // optional configuration files
 if (process.env.N8N_CONFIG_FILES !== undefined) {
-	const configFiles = process.env.N8N_CONFIG_FILES.split(',');
-	console.log(`\nLoading configuration overwrites from:\n - ${configFiles.join('\n - ')}\n`);
+       const configFiles = process.env.N8N_CONFIG_FILES.split(',');
+       console.log(`\nLoading configuration overwrites from:\n - ${configFiles.join('\n - ')}\n`);
 
-	config.loadFile(configFiles);
+       config.loadFile(configFiles);
 }
 
 config.validate({


### PR DESCRIPTION
Users may now deploy HTTPS n8n server without other services.

Steps:
1. Add'N8N_SSL_KEY', 'N8N_SSL_CERT' into the environment setting
2. Select N8N_PROTOCOL=https

Example docker-compose

  n8n:
    image: n8n_custom # change this to n8n after pull request accepted
    restart: always
    environment:
      #...
      - N8N_PROTOCOL=https
      - N8N_SSL_KEY=/data/ssl/server.key
      - N8N_SSL_CERT=/data/ssl/server.pem
      - WEBHOOK_TUNNEL_URL=https://${SUBDOMAIN}.${DOMAIN_NAME}:8443/
      - VUE_APP_URL_BASE_API=https://${SUBDOMAIN}.${DOMAIN_NAME}:8443/
      #...
      #    May use secrets instead of volumes
      volumes:
      - /home/ubuntu/auth_server/ssl:/data/ssl
     #...

