### PR TITLE
Webhook: add support to set Content-Disposition (show "Save as" dialog on browser)

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -288,6 +288,7 @@ export function getWorkflowWebhooks(workflow: Workflow, additionalData: IWorkflo
 			}
 
 			const responseData = workflow.getSimpleParameterValue(workflowStartNode, webhookData.webhookDescription['responseData'], 'firstEntryJson');
+			const responseContentDisposition = workflow.getSimpleParameterValue(workflowStartNode, webhookData.webhookDescription['responseContentDisposition'], undefined);
 
 			if (didSendResponse === false) {
 				let data: IDataObject | IDataObject[];
@@ -357,6 +358,11 @@ export function getWorkflowWebhooks(workflow: Workflow, additionalData: IWorkflo
 					if (didSendResponse === false) {
 						// Send the webhook response manually
 						res.setHeader('Content-Type', binaryData.mimeType);
+						if (responseContentDisposition === 'inline') {
+							res.setHeader('Content-Disposition', 'inline');
+						} else if (responseContentDisposition === 'attachment') {
+							res.setHeader('Content-Disposition', `attachment; filename="${binaryData.fileName}"`);
+						}
 						res.end(Buffer.from(binaryData.data, BINARY_ENCODING));
 
 						responseCallback(null, {

--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -85,6 +85,7 @@ export class Webhook implements INodeType {
 				responseBinaryPropertyName: '={{$parameter["responseBinaryPropertyName"]}}',
 				responseContentType: '={{$parameter["options"]["responseContentType"]}}',
 				responsePropertyName: '={{$parameter["options"]["responsePropertyName"]}}',
+				responseContentDisposition: '={{$parameter["options"]["responseContentDisposition"]}}',
 				path: '={{$parameter["path"]}}',
 			},
 		],
@@ -267,6 +268,35 @@ export class Webhook implements INodeType {
 						default: '',
 						placeholder: 'application/xml',
 						description: 'Set a custom content-type to return if another one as the "application/json" should be returned.',
+					},
+					{
+						displayName: 'Response Content-Disposition',
+						name: 'responseContentDisposition',
+						type: 'options',
+						displayOptions: {
+							show: {
+								'/responseData': [
+									'firstEntryBinary',
+								],
+								'/responseMode': [
+									'lastNode',
+								],
+							},
+						},
+						options: [
+							{
+								name: 'Inline',
+								value: 'inline',
+								description: 'The content returned should be displayed inline in the browser.',
+							},
+							{
+								name: 'Attachment',
+								value: 'attachment',
+								description: 'The response should be downloaded (most browsers presenting a "Save-as" dialog).',
+							},
+						],
+						default: 'attachment',
+						description: 'Indicates whether the content is expected to be displayed inline in the browser, or as an attachment, that is downloaded and saved locally.',
 					},
 					{
 						displayName: 'Property Name',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -527,6 +527,7 @@ export interface IWebhookDescription {
 	responsePropertyName?: string;
 	responseMode?: WebhookResponseMode | string;
 	responseData?: WebhookResponseData | string;
+	responseContentDisposition?: WebhookContentDisposition | string;
 }
 
 export interface IWorkflowDataProxyData {
@@ -558,6 +559,7 @@ export interface IWebhookResponseData {
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary';
 export type WebhookResponseMode = 'onReceived' | 'lastNode';
+export type WebhookContentDisposition = 'inline' | 'attachment';
 
 export interface INodeTypes {
 	nodeTypes: INodeTypeData;


### PR DESCRIPTION
This patch adds a _Content-Dispotiion_ option for webhooks configured with
**Response Mode**: Last Node
**Response Data**: First Entry Binary

Setting that option the flow may include a 
> response header indicating if the content is expected to be displayed inline in the browser, or as an attachment, that is downloaded and saved locally

see [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#As_a_response_header_for_the_main_body) header spec.