### PR TITLE
Update Facebook Graph API versions

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -79,8 +79,12 @@ export class FacebookGraphApi implements INodeType {
 				type: 'options',
 				options: [
 					{
-						name: 'Latest',
+						name: 'Default',
 						value: '',
+					},
+					{
+						name: 'v7.0',
+						value: 'v7.0',
 					},
 					{
 						name: 'v6.0',
@@ -109,10 +113,6 @@ export class FacebookGraphApi implements INodeType {
 					{
 						name: 'v3.0',
 						value: 'v3.0',
-					},
-					{
-						name: 'v2.12',
-						value: 'v2.12',
 					},
 				],
 				default: '',


### PR DESCRIPTION
This PR adds the following changes to the `Graph API Version` property of the Facebook Graph API node:

1. Renames the label used to send no specific version from `Latest` to `Default` to reflect that the latest available version may not be used by default.
1. Adds support for v7.0, released on May 5, 2020. ([Blog post](https://developers.facebook.com/blog/post/2020/05/05/introducing-graph-api-v7-marketing-api-v7/))
1. Removes support for v2.12, deprecated on May 5, 2020 ([Reference](https://developers.facebook.com/docs/graph-api/changelog/version2.12))