### PR TITLE
Changed glob pattern to also search nodes in subfolders.

### DIFF
--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -192,7 +192,7 @@ class LoadNodesAndCredentialsClass {
 	 * @memberof N8nPackagesInformationClass
 	 */
 	async loadDataFromDirectory(setPackageName: string, directory: string): Promise<void> {
-		const files = await glob(path.join(directory, '*\.@(node|credentials)\.js'));
+		const files = await glob(path.join(directory, '**/*\.@(node|credentials)\.js'));
 
 		let fileName: string;
 		let type: string;


### PR DESCRIPTION
Put up this pull request to be able to load n8n-nodes from sub-directory when used a custom directory. I couldn't find any explanation how those custom directory works , so possibly later I will put another pull request to update the documentation.