### PR TITLE
Extends custom nodes with scoped npm packages

### DIFF
--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -97,23 +97,27 @@ class LoadNodesAndCredentialsClass {
 	 * @memberof LoadNodesAndCredentialsClass
 	 */
 	async getN8nNodePackages(): Promise<string[]> {
-		const packages: string[] = [];
-		for (const file of await fsReaddirAsync(this.nodeModulesPath)) {
-			if (file.indexOf('n8n-nodes-') !== 0) {
-				continue;
-			}
-
-			// Check if it is really a folder
-			if (!(await fsStatAsync(path.join(this.nodeModulesPath, file))).isDirectory()) {
-				continue;
-			}
-
-			packages.push(file);
+		const getN8nNodePackagesRecursive = async (relativePath: string): Promise<string[]> => {
+			const results: string[] = [];
+			const nodeModulesPath = `${this.nodeModulesPath}/${relativePath}`;
+			for (const file of await fsReaddirAsync(nodeModulesPath)) {
+				const isN8nNodesPackage = file.indexOf('n8n-nodes-') === 0;
+				const isNpmScopedPackage = file.indexOf('@') === 0;
+				if (!isN8nNodesPackage && !isNpmScopedPackage) {
+					continue;
+				}
+				if (!(await fsStatAsync(nodeModulesPath)).isDirectory()) {
+					continue;
+				}
+				if (isN8nNodesPackage) { results.push(`${relativePath}${file}`); }
+				if (isNpmScopedPackage) {
+					results.push(...await getN8nNodePackagesRecursive(`${relativePath}${file}/`));
+				}
+			}	
+			return results;
 		}
-
-		return packages;
+		return getN8nNodePackagesRecursive('');
 	}
-
 
 	/**
 	 * Loads credentials from a file

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -597,8 +597,8 @@ class App {
 
 
 		// Returns the node icon
-		this.app.get('/rest/node-icon/:nodeType', async (req: express.Request, res: express.Response): Promise<void> => {
-			const nodeTypeName = req.params.nodeType;
+		this.app.get(['/rest/node-icon/:nodeType', '/rest/node-icon/:scope/:nodeType'], async (req: express.Request, res: express.Response): Promise<void> => {
+			const nodeTypeName = `${req.params.scope ? `${req.params.scope}/` : ''}${req.params.nodeType}`;
 
 			const nodeTypes = NodeTypes();
 			const nodeType = nodeTypes.getByName(nodeTypeName);


### PR DESCRIPTION
# What

This PR is to use custom nodes with scoped npm packages.

# Why

When I created a custom node with scoped npm package, the package did not recognized.
I want to be able to use with scoped packages because of no name conflit.

# How

There are two modifications.

First one is n8n node package loading.

This change makes loading not just n8n-nodes-... but @.../n8n-nodes-... .

Second one is add more icon endpoint.

This change makes able to receive requests also with scoped nodes.

For example, "@tei1988/n8n-nodes-test" npm package and its node named "test" are here.
In this case, `/rest/node-icon/@tei1988/n8n-nodes-test.test' is requested to the server.

If there are some more better idea, please give me advice.

# Ref
- https://docs.npmjs.com/using-npm/scope.html