### PR TITLE
Make server listen address configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,9 @@ Sets how n8n should be made available.
 # The port n8n should be made available on
 N8N_PORT=5678
 
+# The IP address n8n should listen on
+N8N_LISTEN_ADDRESS=0.0.0.0
+
 # This ones are currently only important for the webhook URL creation.
 # So if "WEBHOOK_TUNNEL_URL" got set they do get ignored. It is however
 # encouraged to set them correctly anyway in case they will become

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -105,6 +105,7 @@ services:
       - N8N_BASIC_AUTH_PASSWORD
       - N8N_HOST=${SUBDOMAIN}.${DOMAIN_NAME}
       - N8N_PORT=5678
+      - N8N_LISTEN_ADDRESS=0.0.0.0
       - N8N_PROTOCOL=https
       - NODE_ENV=production
       - WEBHOOK_TUNNEL_URL=https://${SUBDOMAIN}.${DOMAIN_NAME}/

--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -169,6 +169,12 @@ const config = convict({
 		env: 'N8N_PORT',
 		doc: 'HTTP port n8n can be reached'
 	},
+	listen_address: {
+		format: String,
+		default: '0.0.0.0',
+		env: 'N8N_LISTEN_ADDRESS',
+		doc: 'IP address n8n should listen on'
+	},
 	protocol: {
 		format: ['http', 'https'],
 		default: 'http',

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1294,6 +1294,7 @@ class App {
 
 export async function start(): Promise<void> {
 	const PORT = config.get('port');
+	const ADDRESS = config.get('listen_address');
 
 	const app = new App();
 
@@ -1312,9 +1313,9 @@ export async function start(): Promise<void> {
 		server = http.createServer(app.app);
 	}
 
-	server.listen(PORT, async () => {
+	server.listen(PORT, ADDRESS, async () => {
 		const versions = await GenericHelpers.getVersions();
-		console.log(`n8n ready on port ${PORT}`);
+		console.log(`n8n ready on ${ADDRESS}, port ${PORT}`);
 		console.log(`Version: ${versions.cli}`);
 	});
 }


### PR DESCRIPTION
This change adds a configuration value to specify the IP address the web server listens on. This would be advantageous in a case where, for example, the user is running n8n behind a reverse proxy, and using the proxy for SSL termination and/or auth. The ability to have n8n listen on 127.0.0.1 would help to ensure n8n can _only_ be accessed via the proxy, without relying solely on firewall rules. Thanks for considering.