### PR TITLE
Change GitHub Trigger Node from app to oAuth Token

### DIFF
--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -31,10 +31,6 @@ export class GithubTrigger implements INodeType {
 		inputs: [],
 		outputs: ['main'],
 		credentials: [
-			// {
-			// 	name: 'githubApi',
-			// 	required: true,
-			// }, 
 			{
 				name: 'githubOAuth2Api',
 				required: true,

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -31,10 +31,14 @@ export class GithubTrigger implements INodeType {
 		inputs: [],
 		outputs: ['main'],
 		credentials: [
+			// {
+			// 	name: 'githubApi',
+			// 	required: true,
+			// }, 
 			{
-				name: 'githubApi',
+				name: 'githubOAuth2Api',
 				required: true,
-			}
+			}, 
 		],
 		webhooks: [
 			{

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -31,14 +31,28 @@ export class GithubTrigger implements INodeType {
 		inputs: [],
 		outputs: ['main'],
 		credentials: [
-			// {
-			// 	name: 'githubApi',
-			// 	required: true,
-			// }, 
+			{
+				name: 'githubApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: [
+							'accessToken',
+						],
+					},
+				},
+			},
 			{
 				name: 'githubOAuth2Api',
 				required: true,
-			}, 
+				displayOptions: {
+					show: {
+						authentication: [
+							'oAuth2',
+						],
+					},
+				},
+			},
 		],
 		webhooks: [
 			{
@@ -49,6 +63,23 @@ export class GithubTrigger implements INodeType {
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'Access Token',
+						value: 'accessToken',
+					},
+					{
+						name: 'OAuth2',
+						value: 'oAuth2',
+					},
+				],
+				default: 'accessToken',
+				description: 'The resource to operate on.',
+			},
 			{
 				displayName: 'Repository Owner',
 				name: 'owner',


### PR DESCRIPTION
Hey, I'm a part of the [MLH Fellowship](https://github.com/MLH-Fellowship). 

We were getting started with n8n and followed [this video tutorial on getting started with n8n and github](https://www.youtube.com/watch?v=3w7xIMKLVAg).

When following the tutorial, we noticed some funky behavior with the GitHub Trigger node. It was requiring that we supply an "oAuth" token, but there was no field to supply it. The node was incorrectly configured to accept githubApi app-based tokens instead.

This pull updates the GitHub Trigger node to accept Oauth tokens rather than an app-based token.