### PR TITLE
Fix PNG file copy for CLI build --watch command

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -105,10 +105,10 @@ export async function buildFiles (options?: IBuildOptions): Promise<string> {
 	}
 
 	return new Promise((resolve, reject) => {
+		copyfiles([join(process.cwd(), './*.png'), outputDirectory], { up: true }, () => resolve(outputDirectory));
 		buildProcess.on('exit', code => {
 			// Remove the tmp tsconfig file
 			tsconfigData.cleanup();
-			copyfiles([join(process.cwd(), './*.png'), outputDirectory], { up: true }, () => resolve(outputDirectory));
 		});
 	});
 }


### PR DESCRIPTION
Fixes #654

As noted by @janober, this fix covers most use cases, but it enables the command `n8n-node-dev build --watch` to copy the icon only once, so the fix can be further improved in the future.