### PR TITLE
:bug: Fixes issue #663 and #664

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
@@ -1,6 +1,7 @@
 import {
 	IExecuteFunctions,
 	IHookFunctions,
+	ILoadOptionsFunctions,
 } from 'n8n-core';
 
 import {
@@ -16,7 +17,7 @@ import {
  * @param {object} body
  * @returns {Promise<any>}
  */
-export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, body: object, query?: object): Promise<any> { // tslint:disable-line:no-any
+export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: object, query?: object): Promise<any> { // tslint:disable-line:no-any
 	const credentials = this.getCredentials('gitlabApi');
 	if (credentials === undefined) {
 		throw new Error('No credentials got returned!');
@@ -34,7 +35,9 @@ export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions,
 	};
 
 	try {
-		return await this.helpers.request(options);
+		//@ts-ignore
+		return await this.helpers?.request(options);
+
 	} catch (error) {
 		if (error.statusCode === 401) {
 			// Return a clear error

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -135,7 +135,10 @@ export class GitlabTrigger implements INodeType {
 				// Webhook got created before so check if it still exists
 				const owner = this.getNodeParameter('owner') as string;
 				const repository = this.getNodeParameter('repository') as string;
-				const endpoint = `/projects/${owner}%2F${repository}/hooks/${webhookData.webhookId}`;
+
+				const path = (`${owner}/${repository}`).replace(/\//g,'%2F');
+
+				const endpoint = `/projects/${path}/hooks/${webhookData.webhookId}`;
 
 				try {
 					await gitlabApiRequest.call(this, 'GET', endpoint, {});
@@ -175,14 +178,21 @@ export class GitlabTrigger implements INodeType {
 					events[`${e}_events`] = true;
 				}
 
-				const endpoint = `/projects/${owner}%2F${repository}/hooks`;
+				// gitlab set the push_events to true when the field it's not sent.
+				// set it to false when it's not picked by the user.
+				if (events['push_events'] === undefined) {
+					events['push_events'] = false;
+				}
+
+				const path = (`${owner}/${repository}`).replace(/\//g,'%2F');
+
+				const endpoint = `/projects/${path}/hooks`;
 
 				const body = {
 					url: webhookUrl,
-					events,
+					...events,
 					enable_ssl_verification: false,
 				};
-
 
 				let responseData;
 				try {
@@ -208,7 +218,10 @@ export class GitlabTrigger implements INodeType {
 				if (webhookData.webhookId !== undefined) {
 					const owner = this.getNodeParameter('owner') as string;
 					const repository = this.getNodeParameter('repository') as string;
-					const endpoint = `/projects/${owner}%2F${repository}/hooks/${webhookData.webhookId}`;
+
+					const path = (`${owner}/${repository}`).replace(/\//g,'%2F');
+
+					const endpoint = `/projects/${path}/hooks/${webhookData.webhookId}`;
 					const body = {};
 
 					try {


### PR DESCRIPTION
The fix for #663 it's very simple; the data was being sent within the event properties and should have been in the object root level.

The fix for #664, however, will break workflows just when they are deactivated. It applies the approach suggested in #664 of using the project ID instead of owner + repository, and it makes it easy for the user to pick the project, with just one select.

#664 can be fixed without breaking by encoding the owner string. However, it would not be as easy for the user as using the project ID.

I wonder if we should do the breaking change right now to avoid future issues. If we decide to do so, I will modify it to return just the webhook's body as it currently returns body, query, and headers.