### PR TITLE
Add option to ignore SSL issues to Facebook Graph API node

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -138,6 +138,13 @@ export class FacebookGraphApi implements INodeType {
 				required: false,
 			},
 			{
+				displayName: 'Ignore SSL Issues',
+				name: 'allowUnauthorizedCerts',
+				type: 'boolean',
+				default: false,
+				description: 'Still download the response even if SSL certificate validation is not possible. (Not recommended)',
+			},
+			{
 				displayName: 'Send Binary Data',
 				name: 'sendBinaryData',
 				type: 'boolean',
@@ -301,6 +308,7 @@ export class FacebookGraphApi implements INodeType {
 				qs: {
 					access_token: graphApiCredentials!.accessToken,
 				},
+				rejectUnauthorized: !this.getNodeParameter('allowUnauthorizedCerts', itemIndex, false) as boolean,
 			};
 
 			if (options !== undefined) {


### PR DESCRIPTION
This PR adds a new property to the Facebook Graph API node, which mirrors the one available in the HTTP Request Node, to allow ignoring SSL certificate issues.

While activating this setting is NOT recommended, it may be necessary in some environments (perhaps because of some corporate network restrictions.)