### PR TITLE
Changed reponseMode to responseMode

### DIFF
--- a/packages/node-dev/templates/webhook/simple.ts
+++ b/packages/node-dev/templates/webhook/simple.ts
@@ -27,7 +27,7 @@ export class ClassNameReplace implements INodeType {
 			{
 				name: 'default',
 				httpMethod: 'POST',
-				reponseMode: 'onReceived',
+				responseMode: 'onReceived',
 				// Each webhook property can either be hardcoded
 				// like the above ones or referenced from a parameter
 				// like the "path" property bellow


### PR DESCRIPTION
The spelling of the `responseMode` webhook property in the template on the CLI tool was incorrect, and so I fixed it.