### PR TITLE
workflow execution data pruning

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -161,8 +161,8 @@ const config = convict({
 
 		// If a workflow executes all the data gets saved by default. This
 		// could be a problem when a workflow gets executed a lot and processes
-		// a lot of data. To not write the database full it is possible to
-		// not save the execution at all.
+		// a lot of data. To not exceed the database's capacity it is possible to
+		// prune the database regularly or to not save the execution at all.
 		// Depending on if the execution did succeed or error a different
 		// save behaviour can be set.
 		saveDataOnError: {
@@ -187,6 +187,27 @@ const config = convict({
 			doc: 'Save data of executions when started manually via editor',
 			default: false,
 			env: 'EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS'
+		},
+
+		// To not exceed the database's capacity and keep its size moderate
+		// the execution data gets pruned regularly (default: 1 hour interval).
+		// All saved execution data older than the max age will be deleted.
+		// Pruning is currently not activated by default, which will change in
+		// a future version.
+		pruneData: {
+			doc: 'Delete data of past executions on a rolling basis',
+			default: false,
+			env: 'EXECUTIONS_DATA_PRUNE'
+		},
+		pruneDataMaxAge: {
+			doc: 'How old (hours) the execution data has to be to get deleted',
+			default: 336,
+			env: 'EXECUTIONS_DATA_MAX_AGE'
+		},
+		pruneDataTimeout: {
+			doc: 'Timeout (ms) after execution data has been pruned',
+			default: 3600000,
+			env: 'EXECUTIONS_DATA_PRUNE_TIMEOUT'
 		},
 	},
 


### PR DESCRIPTION
Execution data of workflows get saved in the n8n database to allow for later inspection

This PR:

- adds a cleaning mechanism to prevent uncontrolled database growth

- ensures through throttling that the pruning does not hamper performance

- allows configuration of the mechanism 