### PR TITLE
Fixed typos and grammatical errors

### DIFF
--- a/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
+++ b/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
@@ -28,12 +28,12 @@ import { IDeal } from './DealInterface';
 
 export class AgileCrm implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'AgileCRM',
+		displayName: 'Agile CRM',
 		name: 'agileCrm',
 		icon: 'file:agilecrm.png',
 		group: ['transform'],
 		version: 1,
-		description: 'Consume AgileCRM API',
+		description: 'Consume Agile CRM API',
 		defaults: {
 			name: 'AgileCRM',
 			color: '#772244',

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -44,12 +44,12 @@ export class Airtable implements INodeType {
 					{
 						name: 'Append',
 						value: 'append',
-						description: 'Appends the data to a table',
+						description: 'Append the data to a table',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Deletes data from a table'
+						description: 'Delete data from a table'
 					},
 					{
 						name: 'List',
@@ -59,12 +59,12 @@ export class Airtable implements INodeType {
 					{
 						name: 'Read',
 						value: 'read',
-						description: 'Reads data from a table'
+						description: 'Read data from a table'
 					},
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Updates data in a table'
+						description: 'Update data in a table'
 					},
 				],
 				default: 'read',

--- a/packages/nodes-base/nodes/Asana/Asana.node.ts
+++ b/packages/nodes-base/nodes/Asana/Asana.node.ts
@@ -84,7 +84,7 @@ export class Asana implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Get data of task',
+						description: 'Get data of a task',
 					},
 					{
 						name: 'Update',
@@ -369,12 +369,12 @@ export class Asana implements INodeType {
 					{
 						name: 'Get All',
 						value: 'getAll',
-						description: 'Data of all users',
+						description: 'Get data of all users',
 					},
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Get data of user',
+						description: 'Get data of a user',
 					},
 				],
 				default: 'get',

--- a/packages/nodes-base/nodes/Aws/S3/BucketDescription.ts
+++ b/packages/nodes-base/nodes/Aws/S3/BucketDescription.ts
@@ -18,7 +18,7 @@ export const bucketOperations = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: 'Create an bucket',
+				description: 'Create a bucket',
 			},
 			{
 				name: 'Get All',
@@ -28,7 +28,7 @@ export const bucketOperations = [
 			{
 				name: 'Search',
 				value: 'search',
-				description: 'Search withim a bucket',
+				description: 'Search a bucket',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Aws/S3/BucketDescription.ts
+++ b/packages/nodes-base/nodes/Aws/S3/BucketDescription.ts
@@ -28,7 +28,7 @@ export const bucketOperations = [
 			{
 				name: 'Search',
 				value: 'search',
-				description: 'Search a bucket',
+				description: 'Search within a bucket',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
+++ b/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
@@ -215,12 +215,12 @@ export class Chargebee implements INodeType {
 					{
 						name: 'List',
 						value: 'list',
-						description: 'Returns the invoices',
+						description: 'Return the invoices',
 					},
 					{
 						name: 'PDF Invoice URL',
 						value: 'pdfUrl',
-						description: 'Gets PDF invoice URL and adds it as property "pdfUrl"',
+						description: 'Get URL for the invoice PDF',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Clearbit/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Clearbit/CompanyDescription.ts
@@ -16,12 +16,12 @@ export const companyOperations = [
 			{
 				name: 'Enrich',
 				value: 'enrich',
-				description: 'Look up person and company data based on an email or domain.',
+				description: 'Look up person and company data based on an email or domain',
 			},
 			{
 				name: 'Autocomplete',
 				value: 'autocomplete',
-				description: 'Auto-complete company names and retrieve logo and domain.',
+				description: 'Auto-complete company names and retrieve logo and domain',
 			},
 		],
 		default: 'enrich',

--- a/packages/nodes-base/nodes/Clearbit/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Clearbit/CompanyDescription.ts
@@ -16,12 +16,12 @@ export const companyOperations = [
 			{
 				name: 'Enrich',
 				value: 'enrich',
-				description: 'Lets you look up person and company data based on an email or domain',
+				description: 'Look up person and company data based on an email or domain.',
 			},
 			{
 				name: 'Autocomplete',
 				value: 'autocomplete',
-				description: 'Lets you auto-complete company names and retreive logo and domain',
+				description: 'Auto-complete company names and retrieve logo and domain.',
 			},
 		],
 		default: 'enrich',

--- a/packages/nodes-base/nodes/Clearbit/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Clearbit/PersonDescription.ts
@@ -16,7 +16,7 @@ export const personOperations = [
 			{
 				name: 'Enrich',
 				value: 'enrich',
-				description: 'Lets you look up person and company data based on an email or domain',
+				description: 'Look up a person and company data based on an email or domain.',
 			},
 		],
 		default: 'enrich',

--- a/packages/nodes-base/nodes/Clearbit/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Clearbit/PersonDescription.ts
@@ -16,7 +16,7 @@ export const personOperations = [
 			{
 				name: 'Enrich',
 				value: 'enrich',
-				description: 'Look up a person and company data based on an email or domain.',
+				description: 'Look up a person and company data based on an email or domain',
 			},
 		],
 		default: 'enrich',

--- a/packages/nodes-base/nodes/ClickUp/TimeTrackingDescription.ts
+++ b/packages/nodes-base/nodes/ClickUp/TimeTrackingDescription.ts
@@ -28,7 +28,7 @@ export const timeTrackingOperations = [
 			{
 				name: 'Get All',
 				value: 'getAll',
-				description: 'Get all loggin times on task',
+				description: 'Get all logging times on task',
 			},
 			{
 				name: 'Update',

--- a/packages/nodes-base/nodes/Cockpit/CollectionDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/CollectionDescription.ts
@@ -26,7 +26,7 @@ export const collectionOperations = [
 			{
 				name: 'Update an Entry',
 				value: 'update',
-				description: 'Update a collection entries',
+				description: 'Update a collection entry',
 			},
 		],
 		default: 'getAll',

--- a/packages/nodes-base/nodes/Cockpit/FormDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/FormDescription.ts
@@ -16,7 +16,7 @@ export const formOperations = [
 			{
 				name: 'Submit a Form',
 				value: 'submit',
-				description: 'Store data from a form',
+				description: 'Store data from a form submission',
 			},
 
 		],

--- a/packages/nodes-base/nodes/Cockpit/FormDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/FormDescription.ts
@@ -16,7 +16,7 @@ export const formOperations = [
 			{
 				name: 'Submit a Form',
 				value: 'submit',
-				description: 'Store submission of a form',
+				description: 'Store data from a form',
 			},
 
 		],

--- a/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
@@ -16,7 +16,7 @@ export const singletonOperations = [
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get a Singleton',
+				description: 'Get a singleton',
 			},
 		],
 		default: 'get',

--- a/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
+++ b/packages/nodes-base/nodes/Cockpit/SingletonDescription.ts
@@ -16,7 +16,7 @@ export const singletonOperations = [
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Gets a Singleton',
+				description: 'Get a Singleton',
 			},
 		],
 		default: 'get',

--- a/packages/nodes-base/nodes/Coda/TableDescription.ts
+++ b/packages/nodes-base/nodes/Coda/TableDescription.ts
@@ -16,7 +16,7 @@ export const tableOperations = [
 			{
 				name: 'Create Row',
 				value: 'createRow',
-				description: 'Create/Upsert a row',
+				description: 'Create/Insert a row',
 			},
 			{
 				name: 'Delete Row',
@@ -41,7 +41,7 @@ export const tableOperations = [
 			{
 				name: 'Get Row',
 				value: 'getRow',
-				description: 'Get row',
+				description: 'Get a row',
 			},
 			{
 				name: 'Push Button',

--- a/packages/nodes-base/nodes/Disqus/Disqus.node.ts
+++ b/packages/nodes-base/nodes/Disqus/Disqus.node.ts
@@ -65,22 +65,22 @@ export class Disqus implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Retrieve forum details.',
+						description: 'Return forum details',
 					},
 					{
 						name: 'Get All Categories',
 						value: 'getCategories',
-						description: 'Retrieve a list of categories from a forum.',
+						description: 'Return a list of categories within a forum',
 					},
 					{
 						name: 'Get All Threads',
 						value: 'getThreads',
-						description: 'Retrieve a list of threads from a forum.',
+						description: 'Return a list of threads within a forum',
 					},
 					{
 						name: 'Get All Posts',
 						value: 'getPosts',
-						description: 'Retrieve a list of posts from a forum.',
+						description: 'Return a list of posts within a forum',
 					}
 				],
 				default: 'get',

--- a/packages/nodes-base/nodes/Disqus/Disqus.node.ts
+++ b/packages/nodes-base/nodes/Disqus/Disqus.node.ts
@@ -65,22 +65,22 @@ export class Disqus implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Returns forum details.',
+						description: 'Retrieve forum details.',
 					},
 					{
 						name: 'Get All Categories',
 						value: 'getCategories',
-						description: 'Returns a list of categories within a forum.',
+						description: 'Retrieve a list of categories from a forum.',
 					},
 					{
 						name: 'Get All Threads',
 						value: 'getThreads',
-						description: 'Returns a list of threads within a forum.',
+						description: 'Retrieve a list of threads from a forum.',
 					},
 					{
 						name: 'Get All Posts',
 						value: 'getPosts',
-						description: 'Returns a list of posts within a forum.',
+						description: 'Retrieve a list of posts from a forum.',
 					}
 				],
 				default: 'get',

--- a/packages/nodes-base/nodes/Flow/Flow.node.ts
+++ b/packages/nodes-base/nodes/Flow/Flow.node.ts
@@ -49,7 +49,7 @@ export class Flow implements INodeType {
 					{
 						name: 'Task',
 						value: 'task',
-						description: `Tasks track units of work and can be assigned, sorted, nested, and tagged. Through this endpoint you are able to create, update and read your tasks in Flow.`,
+						description: `Tasks are units of work that can be private or assigned to a list. Through this endpoint, you can manipulate your tasks in Flow, including creating new ones`,
 					},
 				],
 				default: 'task',

--- a/packages/nodes-base/nodes/Flow/Flow.node.ts
+++ b/packages/nodes-base/nodes/Flow/Flow.node.ts
@@ -49,9 +49,7 @@ export class Flow implements INodeType {
 					{
 						name: 'Task',
 						value: 'task',
-						description: `The primary unit within Flow; tasks track units of work and can be assigned, sorted, nested, and tagged.</br>
-						Tasks can either be part of a List, or "private" (meaning "without a list", essentially).</br>
-						Through this endpoint you are able to do anything you wish to your tasks in Flow, including create new ones.`,
+						description: `Tasks track units of work and can be assigned, sorted, nested, and tagged. Through this endpoint you are able to create, update and read your tasks in Flow.`,
 					},
 				],
 				default: 'task',

--- a/packages/nodes-base/nodes/Flow/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Flow/TaskDescription.ts
@@ -31,7 +31,7 @@ export const taskOpeations = [
 			{
 				name: 'Get All',
 				value: 'getAll',
-				description: 'Get all tasks',
+				description: 'Get all the tasks',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Flow/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Flow/TaskDescription.ts
@@ -21,17 +21,17 @@ export const taskOpeations = [
 			{
 				name: 'Update',
 				value: 'update',
-				description: 'Update task',
+				description: 'Update a task',
 			},
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get task',
+				description: 'Get a task',
 			},
 			{
 				name: 'Get All',
 				value: 'getAll',
-				description: 'Get all the tasks',
+				description: 'Get all tasks',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
@@ -59,7 +59,7 @@ export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions,
 	} catch (error) {
 		if (error.statusCode === 401) {
 			// Return a clear error
-			throw new Error('The Gitlab credentials are not valid!');
+			throw new Error('The GitLab credentials are not valid!');
 		}
 
 		if (error.response && error.response.body && error.response.body.message) {

--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -15,13 +15,13 @@ import {
 
 export class Gitlab implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Gitlab',
+		displayName: 'GitLab',
 		name: 'gitlab',
 		icon: 'file:gitlab.png',
 		group: ['input'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Retrieve data from Gitlab API.',
+		description: 'Retrieve data from GitLab API.',
 		defaults: {
 			name: 'Gitlab',
 			color: '#FC6D27',
@@ -131,7 +131,7 @@ export class Gitlab implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Get the data of a single issues',
+						description: 'Get the data of single issue',
 					},
 					{
 						name: 'Lock',

--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -131,7 +131,7 @@ export class Gitlab implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Get the data of single issue',
+						description: 'Get the data of a single issue',
 					},
 					{
 						name: 'Lock',
@@ -207,7 +207,7 @@ export class Gitlab implements INodeType {
 					{
 						name: 'Create',
 						value: 'create',
-						description: 'Creates a new release',
+						description: 'Create a new release',
 					},
 				],
 				default: 'create',

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -16,13 +16,13 @@ import {
 
 export class GitlabTrigger implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Gitlab Trigger',
+		displayName: 'GitLab Trigger',
 		name: 'gitlabTrigger',
 		icon: 'file:gitlab.png',
 		group: ['trigger'],
 		version: 1,
 		subtitle: '={{$parameter["owner"] + "/" + $parameter["repository"] + ": " + $parameter["events"].join(", ")}}',
-		description: 'Starts the workflow when a Gitlab events occurs.',
+		description: 'Starts the workflow when a GitLab event occurs.',
 		defaults: {
 			name: 'Gitlab Trigger',
 			color: '#FC6D27',
@@ -237,7 +237,7 @@ export class GitlabTrigger implements INodeType {
 
 				if (responseData.id === undefined) {
 					// Required data is missing so was not successful
-					throw new Error('Gitlab webhook creation response did not contain the expected data.');
+					throw new Error('GitLab webhook creation response did not contain the expected data.');
 				}
 
 				const webhookData = this.getWorkflowStaticData('node');

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -122,7 +122,7 @@ export class GoogleDrive implements INodeType {
 					{
 						name: 'List',
 						value: 'list',
-						description: 'Returns files and folders',
+						description: 'Get list of files and folders',
 					},
 					{
 						name: 'Upload',

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -122,7 +122,7 @@ export class GoogleDrive implements INodeType {
 					{
 						name: 'List',
 						value: 'list',
-						description: 'Get list of files and folders',
+						description: 'List files and folders',
 					},
 					{
 						name: 'Upload',

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
@@ -84,32 +84,32 @@ export class GoogleSheets implements INodeType {
 					{
 						name: 'Append',
 						value: 'append',
-						description: 'Appends the data to a Sheet',
+						description: 'Append data to a sheet',
 					},
 					{
 						name: 'Clear',
 						value: 'clear',
-						description: 'Clears data from a Sheet',
+						description: 'Clear data from a sheet',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Delete columns and rows from a Sheet',
+						description: 'Delete columns and rows from a sheet',
 					},
 					{
 						name: 'Lookup',
 						value: 'lookup',
-						description: 'Looks for a specific column value and then returns the matching row'
+						description: 'Look up a specific column value and return the matching row'
 					},
 					{
 						name: 'Read',
 						value: 'read',
-						description: 'Reads data from a Sheet'
+						description: 'Read data from a sheet'
 					},
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Updates rows in a sheet'
+						description: 'Update rows in a sheet'
 					},
 				],
 				default: 'read',

--- a/packages/nodes-base/nodes/Harvest/EstimateDescription.ts
+++ b/packages/nodes-base/nodes/Harvest/EstimateDescription.ts
@@ -16,7 +16,7 @@ export const estimateOperations = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: `Create a estimate`,
+				description: `Create an estimate`,
 			},
 			{
 				name: 'Delete',
@@ -36,7 +36,7 @@ export const estimateOperations = [
 			{
 				name: 'Update',
 				value: 'update',
-				description: `Update a estimate`,
+				description: `Update an estimate`,
 			},
 		],
 		default: 'getAll',

--- a/packages/nodes-base/nodes/Harvest/ExpenseDescription.ts
+++ b/packages/nodes-base/nodes/Harvest/ExpenseDescription.ts
@@ -26,12 +26,12 @@ export const expenseOperations = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: `Create a expense`,
+				description: `Create an expense`,
 			},
 			{
 				name: 'Update',
 				value: 'update',
-				description: `Update a expense`,
+				description: `Update an expense`,
 			},
 			{
 				name: 'Delete',

--- a/packages/nodes-base/nodes/Harvest/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/Harvest/InvoiceDescription.ts
@@ -16,7 +16,7 @@ export const invoiceOperations = [
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get data of a invoice',
+				description: 'Get data of an invoice',
 			},
 			{
 				name: 'Get All',
@@ -26,17 +26,17 @@ export const invoiceOperations = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: `Create a invoice`,
+				description: `Create an invoice`,
 			},
 			{
 				name: 'Update',
 				value: 'update',
-				description: `Update a invoice`,
+				description: `Update an invoice`,
 			},
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: `Delete a invoice`,
+				description: `Delete an invoice`,
 			},
 		],
 		default: 'getAll',

--- a/packages/nodes-base/nodes/Hubspot/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CompanyDescription.ts
@@ -33,7 +33,7 @@ export const companyOperations = [
 			{
 				name: 'Get All',
 				value: 'getAll',
-				description: 'Get all company',
+				description: 'Get all companies',
 			},
 			{
 				name: 'Get Recently Created',

--- a/packages/nodes-base/nodes/Hubspot/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/ContactDescription.ts
@@ -23,7 +23,7 @@ export const contactOperations = [
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a contacts',
+				description: 'Delete a contact',
 			},
 			{
 				name: 'Get',

--- a/packages/nodes-base/nodes/Hubspot/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/DealDescription.ts
@@ -23,7 +23,7 @@ export const dealOperations = [
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a deals',
+				description: 'Delete a deal',
 			},
 			{
 				name: 'Get',

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -56,13 +56,13 @@ import {
 
 export class Hubspot implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Hubspot',
+		displayName: 'HubSpot',
 		name: 'hubspot',
 		icon: 'file:hubspot.png',
 		group: ['output'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Consume Hubspot API',
+		description: 'Consume HubSpot API',
 		defaults: {
 			name: 'Hubspot',
 			color: '#ff7f64',

--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -20,13 +20,13 @@ import {
 
 export class HubspotTrigger implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Hubspot Trigger',
+		displayName: 'HubSpot Trigger',
 		name: 'hubspotTrigger',
 		icon: 'file:hubspot.png',
 		group: ['trigger'],
 		version: 1,
 		subtitle: '={{($parameter["appId"]) ? $parameter["event"] : ""}}',
-		description: 'Starts the workflow when Hubspot events occure.',
+		description: 'Starts the workflow when HubSpot events occur.',
 		defaults: {
 			name: 'Hubspot Trigger',
 			color: '#ff7f64',

--- a/packages/nodes-base/nodes/Hubspot/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/TicketDescription.ts
@@ -23,7 +23,7 @@ export const ticketOperations = [
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a tickets',
+				description: 'Delete a ticket',
 			},
 			{
 				name: 'Get',

--- a/packages/nodes-base/nodes/Hunter/Hunter.node.ts
+++ b/packages/nodes-base/nodes/Hunter/Hunter.node.ts
@@ -42,12 +42,12 @@ export class Hunter implements INodeType {
 					{
 						name: ' Domain Search',
 						value: 'domainSearch',
-						description: 'Get every email address found on the internet using a given domain name, with sources.',
+						description: 'Get every email address found on the internet for a given domain name, with sources.',
 					},
 					{
 						name: ' Email Finder',
 						value: 'emailFinder',
-						description: 'Generates or retrieves the most likely email address from a domain name, a first name and a last name.',
+						description: 'Generates or retrieves the most likely email address using a domain name, a first name and a last name.',
 					},
 					{
 						name: 'Email Verifier',

--- a/packages/nodes-base/nodes/Hunter/Hunter.node.ts
+++ b/packages/nodes-base/nodes/Hunter/Hunter.node.ts
@@ -42,17 +42,17 @@ export class Hunter implements INodeType {
 					{
 						name: ' Domain Search',
 						value: 'domainSearch',
-						description: 'Get every email address found on the internet for a given domain name, with sources.',
+						description: 'Get every email address found on the internet using a given domain name, with sources',
 					},
 					{
 						name: ' Email Finder',
 						value: 'emailFinder',
-						description: 'Generates or retrieves the most likely email address using a domain name, a first name and a last name.',
+						description: 'Generate or retrieve the most likely email address from a domain name, a first name and a last name',
 					},
 					{
 						name: 'Email Verifier',
 						value: 'emailVerifier',
-						description: 'Allows you to verify the deliverability of an email address.',
+						description: 'Verify the deliverability of an email address',
 					},
 				],
 				default: 'domainSearch',

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -51,22 +51,22 @@ export class MicrosoftSql implements INodeType {
 					{
 						name: 'Execute Query',
 						value: 'executeQuery',
-						description: 'Execute an SQL query.',
+						description: 'Execute an SQL query',
 					},
 					{
 						name: 'Insert',
 						value: 'insert',
-						description: 'Insert rows in database.',
+						description: 'Insert rows in database',
 					},
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Update rows in database.',
+						description: 'Update rows in database',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Delete rows in database.',
+						description: 'Delete rows in database',
 					},
 				],
 				default: 'insert',

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -51,7 +51,7 @@ export class MicrosoftSql implements INodeType {
 					{
 						name: 'Execute Query',
 						value: 'executeQuery',
-						description: 'Executes a SQL query.',
+						description: 'Execute an SQL query.',
 					},
 					{
 						name: 'Insert',
@@ -61,12 +61,12 @@ export class MicrosoftSql implements INodeType {
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Updates rows in database.',
+						description: 'Update rows in database.',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Deletes rows in database.',
+						description: 'Delete rows in database.',
 					},
 				],
 				default: 'insert',

--- a/packages/nodes-base/nodes/Msg91/Msg91.node.ts
+++ b/packages/nodes-base/nodes/Msg91/Msg91.node.ts
@@ -13,7 +13,7 @@ import {
 
 export class Msg91 implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Msg91',
+		displayName: 'MSG91',
 		name: 'msg91',
 		icon: 'file:msg91.png',
 		group: ['transform'],

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -17,7 +17,7 @@ export class MySql implements INodeType {
 		icon: 'file:mysql.png',
 		group: ['input'],
 		version: 1,
-		description: 'Gets, add and update data in MySQL.',
+		description: 'Get, add and update data in MySQL.',
 		defaults: {
 			name: 'MySQL',
 			color: '#4279a2',
@@ -39,7 +39,7 @@ export class MySql implements INodeType {
 					{
 						name: 'Execute Query',
 						value: 'executeQuery',
-						description: 'Executes a SQL query.',
+						description: 'Execute an SQL query.',
 					},
 					{
 						name: 'Insert',
@@ -49,7 +49,7 @@ export class MySql implements INodeType {
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Updates rows in database.',
+						description: 'Update rows in database.',
 					},
 				],
 				default: 'insert',

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -309,7 +309,7 @@ export class Pipedrive implements INodeType {
 					{
 						name: 'Get All',
 						value: 'getAll',
-						description: 'Get data of all note',
+						description: 'Get data of all notes',
 					},
 					{
 						name: 'Update',
@@ -341,7 +341,7 @@ export class Pipedrive implements INodeType {
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Delete anorganization',
+						description: 'Delete an organization',
 					},
 					{
 						name: 'Get',

--- a/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
+++ b/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
@@ -50,7 +50,7 @@ export class Rundeck implements INodeType {
 					{
 						name: 'Execute',
 						value: 'execute',
-						description: 'Executes job',
+						description: 'Execute a job',
 					},
 					{
 						name: 'Get Metadata',

--- a/packages/nodes-base/nodes/Salesmate/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Salesmate/ActivityDescription.ts
@@ -16,17 +16,17 @@ export const activityOperations = [
 			{
 				name: 'Create',
 				value: 'create',
-				description: 'Create a activity',
+				description: 'Create an activity',
 			},
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a activity',
+				description: 'Delete an activity',
 			},
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get a activity',
+				description: 'Get an activity',
 			},
 			{
 				name: 'Get All',
@@ -36,7 +36,7 @@ export const activityOperations = [
 			{
 				name: 'Update',
 				value: 'update',
-				description: 'Update a activity',
+				description: 'Update an activity',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Salesmate/DealDescription.ts
+++ b/packages/nodes-base/nodes/Salesmate/DealDescription.ts
@@ -31,7 +31,7 @@ export const dealOperations = [
 			{
 				name: 'Get All',
 				value: 'getAll',
-				description: 'Get all companies',
+				description: 'Get all deals',
 			},
 			{
 				name: 'Update',

--- a/packages/nodes-base/nodes/Segment/TrackDescription.ts
+++ b/packages/nodes-base/nodes/Segment/TrackDescription.ts
@@ -16,12 +16,12 @@ export const trackOperations = [
 			{
 				name: 'Event',
 				value: 'event',
-				description: 'lets you record the actions your users perform.Every action triggers what we call an “event”, which can also have associated properties.',
+				description: 'Record the actions your users perform. Every action triggers an event, which can also have associated properties.',
 			},
 			{
 				name: 'Page',
 				value: 'page',
-				description: ' lets you record page views on your website, along with optional extra information about the page being viewed.',
+				description: 'Record page views on your website, along with optional extra information about the page being viewed.',
 			},
 		],
 		default: 'event',

--- a/packages/nodes-base/nodes/Sms77/Sms77.node.ts
+++ b/packages/nodes-base/nodes/Sms77/Sms77.node.ts
@@ -4,7 +4,7 @@ import {sms77ApiRequest} from './GenericFunctions';
 
 export class Sms77 implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Sms77',
+		displayName: 'sms77',
 		name: 'sms77',
 		icon: 'file:sms77.png',
 		group: ['transform'],

--- a/packages/nodes-base/nodes/Vero/EventDescripion.ts
+++ b/packages/nodes-base/nodes/Vero/EventDescripion.ts
@@ -16,8 +16,7 @@ export const eventOperations = [
 			{
 				name: 'Track',
 				value: 'track',
-				description: `This endpoint tracks an event for a specific customer.
-				If the customer profile doesn’t exist, Vero will create it.`,
+				description: `Track an event for a specific customer`,
 			},
 		],
 		default: 'track',

--- a/packages/nodes-base/nodes/Vero/UserDescription.ts
+++ b/packages/nodes-base/nodes/Vero/UserDescription.ts
@@ -22,32 +22,32 @@ export const userOperations = [
 			{
 				name: 'Alias',
 				value: 'alias',
-				description: 'Changes a user’s identifier.',
+				description: 'Changes an user’s identifier.',
 			},
 			{
 				name: 'Unsubscribe',
 				value: 'unsubscribe',
-				description: 'Unsubscribes a single user.',
+				description: 'Unsubscribe an user.',
 			},
 			{
 				name: 'Re-subscribe',
 				value: 'resubscribe',
-				description: 'Resubscribe a single user.',
+				description: 'Resubscribe an user.',
 			},
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a single user.',
+				description: 'Delete an user.',
 			},
 			{
 				name: 'Add Tags',
 				value: 'addTags',
-				description: 'Adds a tag to a user’s profile.',
+				description: 'Adds a tag to an user profile.',
 			},
 			{
 				name: 'Remove Tags',
 				value: 'removeTags',
-				description: 'Removes a tag from a user’s profile.',
+				description: 'Removes a tag from an user profile.',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Vero/UserDescription.ts
+++ b/packages/nodes-base/nodes/Vero/UserDescription.ts
@@ -16,38 +16,37 @@ export const userOperations = [
 			{
 				name: 'Create/Update',
 				value: 'create',
-				description: `Creates a new user profile if the user doesn’t exist yet.
-				Otherwise, the user profile is updated based on the properties provided.`,
+				description: `Create or update a user profile`,
 			},
 			{
 				name: 'Alias',
 				value: 'alias',
-				description: 'Changes an user’s identifier.',
+				description: 'Change a users identifier',
 			},
 			{
 				name: 'Unsubscribe',
 				value: 'unsubscribe',
-				description: 'Unsubscribe an user.',
+				description: 'Unsubscribe a user.',
 			},
 			{
 				name: 'Re-subscribe',
 				value: 'resubscribe',
-				description: 'Resubscribe an user.',
+				description: 'Resubscribe a user.',
 			},
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete an user.',
+				description: 'Delete a user.',
 			},
 			{
 				name: 'Add Tags',
 				value: 'addTags',
-				description: 'Adds a tag to an user profile.',
+				description: 'Adds a tag to a users profile.',
 			},
 			{
 				name: 'Remove Tags',
 				value: 'removeTags',
-				description: 'Removes a tag from an user profile.',
+				description: 'Removes a tag from a users profile.',
 			},
 		],
 		default: 'create',

--- a/packages/nodes-base/nodes/Vero/Vero.node.ts
+++ b/packages/nodes-base/nodes/Vero/Vero.node.ts
@@ -50,12 +50,12 @@ export class Vero implements INodeType {
 					{
 						name: 'User',
 						value: 'user',
-						description: `Lets you create, update and manage the subscription status of your users.`,
+						description: `Create, update and manage the subscription status of your users.`,
 					},
 					{
 						name: 'Event',
 						value: 'event',
-						description: `Lets you track events based on actions your customers take in real time.`,
+						description: `Track events based on actions your customers take in real time.`,
 					},
 				],
 				default: 'user',


### PR DESCRIPTION
# Changelog

- Fixed node description in Rundeck
- Fixed the name of the sms77 node in n8n
- Fixed the name of the MSG91 node in n8n
- Fixed description in the Chargebee node
- Fixed description of Pipedrive node
- Fixed description in the Clearbit node
- Fixed description of the HubSpot node
- Fixed description in the ClickUp node
- Fixed node name for Agile CRM
- Fixed the description in the Airtable node to look like in the screenshot
- Fixed the description in the Asana node to look like in the screenshot
- Fixed the description in the MSFT SQL node to look like in the screenshot
- Fixed the node name of HubSpot
- Fixed description of GitLab node
- Fixed description in the Google Sheets node
- Fixed description in the Coda node
- Fixed MySQL node description
- Fixed Disqus descriptions
- Fixed Harvest node descriptions
- Fixed Segment node descriptions
- Fixed Vero node descriptions
- Fixed description in the Salesmate node
- Fixed description in the Flow node
- Fixed node description in AWS S3
- Fixed node description for Google Drive
- Fixed node description for Cockpit
- Fixed node description for Hunter