### PR TITLE
JWT extras

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -332,8 +332,8 @@ const config = convict({
 				default: '',
 				env: 'N8N_JWT_AUTH_HEADER',
 				doc: 'The request header containing a signed JWT'
-      },
-      jwtHeaderValuePrefix: {
+			},
+			jwtHeaderValuePrefix: {
 				format: String,
 				default: '',
 				env: 'N8N_JWT_AUTH_HEADER_VALUE_PREFIX',
@@ -344,32 +344,32 @@ const config = convict({
 				default: '',
 				env: 'N8N_JWKS_URI',
 				doc: 'The URI to fetch JWK Set for JWT authentication'
-      },
-      jwtIssuer: {
-        format: String,
+			},
+			jwtIssuer: {
+				format: String,
 				default: '',
 				env: 'N8N_JWT_ISSUER',
 				doc: 'JWT issuer to expect (optional)'
-      },
-      jwtNamespace: {
-        format: String,
+			},
+			jwtNamespace: {
+				format: String,
 				default: '',
 				env: 'N8N_JWT_NAMESPACE',
 				doc: 'JWT namespace to expect (optional)'
-      },
-      jwtAllowedTenantKey: {
-        format: String,
+			},
+			jwtAllowedTenantKey: {
+				format: String,
 				default: '',
 				env: 'N8N_JWT_ALLOWED_TENANT_KEY',
 				doc: 'JWT tenant key name to inspect within JWT namespace (optional)'
-      },
-      jwtAllowedTenant: {
-        format: String,
+			},
+			jwtAllowedTenant: {
+				format: String,
 				default: '',
 				env: 'N8N_JWT_ALLOWED_TENANT',
 				doc: 'JWT tenant to allow (optional)'
-      },
-		}
+			},
+		},
 	},
 
 	endpoints: {

--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -332,13 +332,43 @@ const config = convict({
 				default: '',
 				env: 'N8N_JWT_AUTH_HEADER',
 				doc: 'The request header containing a signed JWT'
+      },
+      jwtHeaderValuePrefix: {
+				format: String,
+				default: '',
+				env: 'N8N_JWT_AUTH_HEADER_VALUE_PREFIX',
+				doc: 'The request header value prefix to strip (optional)'
 			},
 			jwksUri: {
 				format: String,
 				default: '',
 				env: 'N8N_JWKS_URI',
-				doc: 'The URI to fetch JWK Set for JWT auh'
-			},
+				doc: 'The URI to fetch JWK Set for JWT authentication'
+      },
+      jwtIssuer: {
+        format: String,
+				default: '',
+				env: 'N8N_JWT_ISSUER',
+				doc: 'JWT issuer to expect (optional)'
+      },
+      jwtNamespace: {
+        format: String,
+				default: '',
+				env: 'N8N_JWT_NAMESPACE',
+				doc: 'JWT namespace to expect (optional)'
+      },
+      jwtAllowedTenantKey: {
+        format: String,
+				default: '',
+				env: 'N8N_JWT_ALLOWED_TENANT_KEY',
+				doc: 'JWT tenant key name to inspect within JWT namespace (optional)'
+      },
+      jwtAllowedTenant: {
+        format: String,
+				default: '',
+				env: 'N8N_JWT_ALLOWED_TENANT',
+				doc: 'JWT tenant to allow (optional)'
+      },
 		}
 	},
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -213,37 +213,64 @@ class App {
 			const jwtAuthHeader = await GenericHelpers.getConfigValue('security.jwtAuth.jwtHeader') as string;
 			if (jwtAuthHeader === '') {
 				throw new Error('JWT auth is activated but no request header was defined. Please set one!');
-			}
-
+      }
 			const jwksUri = await GenericHelpers.getConfigValue('security.jwtAuth.jwksUri') as string;
 			if (jwksUri === '') {
 				throw new Error('JWT auth is activated but no JWK Set URI was defined. Please set one!');
-			}
+      }
+      const jwtHeaderValuePrefix = await GenericHelpers.getConfigValue('security.jwtAuth.jwtHeaderValuePrefix') as string;
+      const jwtIssuer = await GenericHelpers.getConfigValue('security.jwtAuth.jwtIssuer') as string;
+      const jwtNamespace = await GenericHelpers.getConfigValue('security.jwtAuth.jwtNamespace') as string;
+      const jwtAllowedTenantKey = await GenericHelpers.getConfigValue('security.jwtAuth.jwtAllowedTenantKey') as string;
+      const jwtAllowedTenant = await GenericHelpers.getConfigValue('security.jwtAuth.jwtAllowedTenant') as string;
 
-			this.app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
-				if (req.url.match(authIgnoreRegex)) {
-					return next();
-				}
+      function isTenantAllowed(decodedToken: object): Boolean  {
+        if (jwtNamespace === '' || jwtAllowedTenantKey === '' || jwtAllowedTenant === '') return true;
+        else {
+          for (let [k, v] of Object.entries(decodedToken)) {
+            if (k === jwtNamespace) {
+              for (let [kn, kv] of Object.entries(v)) {
+                if (kn === jwtAllowedTenantKey && kv === jwtAllowedTenant) {
+                  return true;
+                }
+              }
+            }
+          }
+        }
+        return false;
+      }
 
-				const token = req.header(jwtAuthHeader) as string;
-				if (token === '') {
-					return ResponseHelper.jwtAuthAuthorizationError(res, "Missing token");
-				}
+      this.app.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
+        if (req.url.match(authIgnoreRegex)) {
+          return next();
+        }
 
-				const jwkClient = jwks({ cache: true, jwksUri });
-				function getKey(header: any, callback: Function) { // tslint:disable-line:no-any
-					jwkClient.getSigningKey(header.kid, (err: Error, key: any) => { // tslint:disable-line:no-any
-						if (err) throw ResponseHelper.jwtAuthAuthorizationError(res, err.message);
+        var token = req.header(jwtAuthHeader) as string;
+        if (token === undefined || token === '') {
+          return ResponseHelper.jwtAuthAuthorizationError(res, "Missing token");
+        }
+        if (jwtHeaderValuePrefix != '' && token.startsWith(jwtHeaderValuePrefix)) {
+          token = token.replace(jwtHeaderValuePrefix + ' ', '').trimLeft();
+        }
 
-						const signingKey = key.publicKey || key.rsaPublicKey;
-						callback(null, signingKey);
-					});
-				}
+        const jwkClient = jwks({ cache: true, jwksUri });
+        function getKey(header: any, callback: Function) { // tslint:disable-line:no-any
+          jwkClient.getSigningKey(header.kid, (err: Error, key: any) => { // tslint:disable-line:no-any
+            if (err) throw ResponseHelper.jwtAuthAuthorizationError(res, err.message);
 
-				jwt.verify(token, getKey, {}, (err: jwt.VerifyErrors, decoded: object) => {
-					if (err) return ResponseHelper.jwtAuthAuthorizationError(res, 'Invalid token');
+            const signingKey = key.publicKey || key.rsaPublicKey;
+            callback(null, signingKey);
+          });
+        }
 
-					next();
+        var jwtVerifyOptions: jwt.VerifyOptions = {
+          issuer: jwtIssuer != '' ? jwtIssuer : undefined,
+          ignoreExpiration: false
+        }
+        jwt.verify(token, getKey, jwtVerifyOptions, (err: jwt.VerifyErrors, decoded: object) => {
+          if (err) ResponseHelper.jwtAuthAuthorizationError(res, 'Invalid token');
+          else if (!isTenantAllowed(decoded)) ResponseHelper.jwtAuthAuthorizationError(res, 'Tenant not allowed');
+          else next();
 				});
 			});
 		}


### PR DESCRIPTION
This change extends JWT authentication as follows:
1. Allow validation of issuer, token expiration, namespace and tenant
2. Allow striping custom prefixes in auth headers, e.g. `Bearer`

For example for Acme corp with Auth0 this works as follows:
```bash
N8N_JWT_AUTH_ACTIVE=true \
N8N_JWT_AUTH_HEADER=Authorization \
N8N_JWKS_URI="https://acme.auth0.com/.well-known/jwks.json" \
N8N_JWT_AUTH_HEADER_VALUE_PREFIX=Bearer \
N8N_JWT_ISSUER="https://acme.auth0.com/" \
N8N_JWT_NAMESPACE="https://api.acme.com" \
N8N_JWT_ALLOWED_TENANT_KEY=tenantId \
N8N_JWT_ALLOWED_TENANT=my-acme-tenant \
npm run dev
```

Would only allow JWT with payload contents:
```json
{
  "https://api.acme.com": {    
    "tenantId": "my-acme-tenant"
  },
  "iss": "https://acme.auth0.com/",
  "sub": "github|123456",
  "aud": [
    "https://api.acme.com/",
    "https://acme.auth0.com/userinfo"
  ],
  "iat": 1596592554,
  "exp": 1596851754,
  "azp": "...",
  "scope": "openid profile email",
  "permissions": []
}
```

TODOs:
- [ ] update documentation
- [ ] pass JWT token through a cookie (perhaps in a separate PR). more info [here](https://stackoverflow.com/questions/26340275/where-to-save-a-jwt-in-a-browser-based-application-and-how-to-use-it/40376819#40376819).  