### PR TITLE
Add option to match key by keypath when append data to google sheet

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
@@ -15,6 +15,8 @@ import {
 	utils as xlsxUtils,
 } from 'xlsx';
 
+import { get } from 'lodash';
+
 export interface ISheetOptions {
 	scope: string[];
 }
@@ -229,8 +231,8 @@ export class GoogleSheet {
 	}
 
 
-	async appendSheetData(inputData: IDataObject[], range: string, keyRowIndex: number, valueInputMode: ValueInputOption): Promise<string[][]> {
-		const data = await this.convertStructuredDataToArray(inputData, range, keyRowIndex);
+	async appendSheetData(inputData: IDataObject[], range: string, keyRowIndex: number, valueInputMode: ValueInputOption, usePathForKeyRow: boolean): Promise<string[][]> {
+		const data = await this.convertStructuredDataToArray(inputData, range, keyRowIndex, usePathForKeyRow);
 		return this.appendData(range, data, valueInputMode);
 	}
 
@@ -424,7 +426,7 @@ export class GoogleSheet {
 	}
 
 
-	async convertStructuredDataToArray(inputData: IDataObject[], range: string, keyRowIndex: number): Promise<string[][]> {
+	async convertStructuredDataToArray(inputData: IDataObject[], range: string, keyRowIndex: number, usePathForKeyRow: boolean): Promise<string[][]> {
 		let startColumn, endColumn;
 		let sheet: string | undefined = undefined;
 		if (range.includes('!')) {
@@ -453,7 +455,9 @@ export class GoogleSheet {
 		inputData.forEach((item) => {
 			rowData = [];
 			keyColumnOrder.forEach((key) => {
-				if (item.hasOwnProperty(key) && item[key]) {
+				if (usePathForKeyRow && (get(item, key) != undefined)) { //match by key path 
+					rowData.push(get(item, key)!.toString());
+				} else if (!usePathForKeyRow && (item.hasOwnProperty(key) && (item[key] != undefined))) { //match by exact key name
 					rowData.push(item[key]!.toString());
 				} else {
 					rowData.push('');

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
@@ -562,6 +562,21 @@ export class GoogleSheets implements INodeType {
 						default: 'UNFORMATTED_VALUE',
 						description: 'Determines how values should be rendered in the output.',
 					},
+					{
+						displayName: 'Use path for key row',
+						name: 'usePathForKeyRow',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'/operation': [
+									'append',
+								],
+							},
+						},
+						description: 'Enable if you want to match key as key path, for example "category.name" will match with nested object "category" and get the field "name" for it. By default "category.name" will match with the field with exact name, not nested object.',
+					},
+
 
 				],
 			}
@@ -631,8 +646,10 @@ export class GoogleSheets implements INodeType {
 				setData.push(item.json);
 			});
 
+			const usePathForKeyRow = (options.usePathForKeyRow || false) as boolean;
+
 			// Convert data into array format
-			const data = await sheet.appendSheetData(setData, range, keyRow, valueInputMode);
+			const data = await sheet.appendSheetData(setData, range, keyRow, valueInputMode, usePathForKeyRow);
 
 			// TODO: Should add this data somewhere
 			// TODO: Should have something like add metadata which does not get passed through


### PR DESCRIPTION
This PR add ability to match key by path. For example, if we have a key in google sheet like `order.id` it will match the nested object like the following one:

```
{ 
  name: "object",
  '/order.id': "top level object field",
  order: {
     id: 1,
    name: "nested object"
......
}
```

When the option is off, you will get the value `"top level object field"`, if the option is on, you will get the value: `"nested object"`.


And one fix on append is fixed as well. If the value of the field is `false` regarding JS rules, this cell is skipped. That's why numeric fields with value `0` are skipping.


