### PR TITLE
update salesforce node's get subdomain function

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -10,7 +10,7 @@ import {
 
 export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	const credentials = this.getCredentials('salesforceOAuth2Api');
-	const subdomain = (credentials!.accessTokenUrl as string).split('.')[0].split('/')[2];
+	const subdomain = ((credentials!.accessTokenUrl as string).match(/https:\/\/(.+).salesforce\.com/) || [])[1]
 	const options: OptionsWithUri = {
 		method,
 		body,


### PR DESCRIPTION
Original function will not match subdomains like `https://a.b.c.salesforce.com` and use regular expression to get the subdomain.