### PR TITLE
Update CredentialsEdit.vue

### DIFF
--- a/packages/editor-ui/src/components/CredentialsEdit.vue
+++ b/packages/editor-ui/src/components/CredentialsEdit.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-if="dialogVisible" @keydown.stop>
-		<el-dialog :visible="dialogVisible" append-to-body width="55%" :title="title" :before-close="closeDialog">
+		<el-dialog :visible="dialogVisible" append-to-body width="75%" :title="title" :before-close="closeDialog">
 
 			<div class="credential-type-item">
 				<el-row v-if="!setCredentialType">


### PR DESCRIPTION
Changed width of Credentials modal from 55% to 75%. Result is the "Nodes with Access" UI now only collapses in a UX-unfriendly manner on viewport widths under 1108px (previously was 1506px)