### PR TITLE
Add a configuration option for searchin emails.

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap.node.ts
@@ -131,6 +131,27 @@ export class EmailReadImap implements INodeType {
 				description: 'Prefix for name of the binary property to which to<br />write the attachments. An index starting with 0 will be added.<br />So if name is "attachment_" the first attachment is saved to "attachment_0"',
 			},
 			{
+				displayName: 'Use custom email config',
+				name: 'useCustomEmailConfig',
+				type: 'boolean',
+				default: false,
+				description: 'If custom email rules should be used.',
+			},
+			{
+				displayName: 'Custom email rules',
+				name: 'customEmailConfig',
+				type: 'string',
+				default: "['UNSEEN']",
+				displayOptions: {
+					show: {
+						useCustomEmailConfig: [
+							true
+						],
+					},
+				},
+				description: 'Custom email fetching rules. See <a href="https://github.com/mscdex/node-imap">node-imap</a>\'s search function for more details'
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				type: 'collection',
@@ -211,10 +232,20 @@ export class EmailReadImap implements INodeType {
 		// Returns all the new unseen messages
 		const getNewEmails = async (connection: ImapSimple): Promise<INodeExecutionData[]> => {
 			const format = this.getNodeParameter('format', 0) as string;
-			const searchCriteria = [
+
+			let searchCriteria = [
 				'UNSEEN'
 			];
-
+			const useCustomEmailConfig = this.getNodeParameter('useCustomEmailConfig') as boolean;
+			if (useCustomEmailConfig) {
+				const customEmailConfig = this.getNodeParameter('customEmailConfig') as string;
+				try {
+					searchCriteria = eval(customEmailConfig);
+				} catch (err) {
+					throw new Error(`Parsing of ${customEmailConfig}\nfailed with error ${err}`);
+				}
+			}
+			
 			let fetchOptions = {};
 
 			if (format === 'simple' || format === 'raw') {
@@ -334,6 +365,19 @@ export class EmailReadImap implements INodeType {
 
 
 		let connection: ImapSimple;
+		let empty: INodeExecutionData[] = [];
+		let errToJson = (err: Error) => {
+			return {
+				json:
+				{
+					message: err.message,
+					stack: err.stack
+				}
+			};
+		}
+		let emitError = (err: Error) => {
+			this.emit([empty, [errToJson(err)]]);
+		}
 
 		const config: ImapSimpleOptions = {
 			imap: {
@@ -345,10 +389,14 @@ export class EmailReadImap implements INodeType {
 				authTimeout: 3000
 			},
 			onmail: async () => {
-				const returnData = await getNewEmails(connection);
+				try{
+					const returnData = await getNewEmails(connection);
 
-				if (returnData.length) {
-					this.emit([returnData]);
+					if (returnData.length) {
+						this.emit([returnData, empty]);
+					}
+				}catch(e) {
+					emitError(e);
 				}
 			},
 		};
@@ -361,9 +409,12 @@ export class EmailReadImap implements INodeType {
 
 		// Connect to the IMAP server and open the mailbox
 		// that we get informed whenever a new email arrives
-		connection = await imapConnect(config);
-		await connection.openBox(mailbox);
-
+		try {
+			connection = await imapConnect(config);
+			await connection.openBox(mailbox);
+		} catch (e) {
+			emitError(e);
+		}
 
 		// When workflow and so node gets set to inactive close the connectoin
 		async function closeFunction() {

--- a/packages/nodes-base/nodes/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap.node.ts
@@ -198,7 +198,11 @@ export class EmailReadImap implements INodeType {
 				return '';
 			}
 
-			return await connection.getPartData(message, textParts[0]);
+			try{
+				return await connection.getPartData(message, textParts[0]);
+			} catch {
+				return '';
+			}
 		};
 
 


### PR DESCRIPTION
This PR adds a configuration option that allows to override the default 'UNSEEN' rule with a rule of your choosing.
The configuration must be valid JS code that expresses the same filters as node-imap `search` filters  and it is `eval`ed directly in the search criteria. 

This is a bit clunky but it also allows to express any valid filter which I was not able to with a GUI like interface. Suggestions on how to do it better are welcome :)

The PR also adds a second output to expose the errors that may happen at runtime and would result in an unfulfilled promise exception (which will terminate the app in the future)

Finally, I've added some exception handling to `getText` to handle the cases where one of the parts is not available.
