### PR TITLE
[Bug fix]sfdc query request with body may get error

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -13,7 +13,7 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 	const subdomain = ((credentials!.accessTokenUrl as string).match(/https:\/\/(.+).salesforce\.com/) || [])[1]
 	const options: OptionsWithUri = {
 		method,
-		body,
+		body: method === "GET" ? undefined : body,
 		qs,
 		uri: uri || `https://${subdomain}.salesforce.com/services/data/v39.0${resource}`,
 		json: true


### PR DESCRIPTION
As mentioned in this [doc](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm), sfdc use query string to represent a SOQL query. It may get error response in some environment if we provide the body param such as sandbox env.