### PR TITLE
:bug: Fix comment create with assignee ID (repair field name)

### DIFF
--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -414,7 +414,7 @@ export class ClickUp implements INodeType {
 						comment_text: commentText,
 					};
 					if (additionalFields.assignee) {
-						body.assigneeId = additionalFields.assignee as string;
+						body.assignee = parseInt(additionalFields.assignee as string, 10);
 					}
 					if (additionalFields.notifyAll) {
 						body.notify_all = additionalFields.notifyAll as boolean;


### PR DESCRIPTION
As [doc](https://jsapi.apiary.io/apis/clickup20/reference/0/comments/post-task-comment.html) says assignee field name should be `assignee` instead of `assigneeId`