### PR TITLE
🐛 Fix wrong authentication name

### DIFF
--- a/packages/nodes-base/nodes/AcuityScheduling/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/GenericFunctions.ts
@@ -24,7 +24,7 @@ export async function acuitySchedulingApiRequest(this: IHookFunctions | IExecute
 	};
 
 	try {
-		if (authenticationMethod === 'accessToken') {
+		if (authenticationMethod === 'apiKey') {
 			const credentials = this.getCredentials('acuitySchedulingApi');
 			if (credentials === undefined) {
 				throw new Error('No credentials got returned!');


### PR DESCRIPTION
Fixes https://community.n8n.io/t/acuity-scheduling-api-credentials/2200