### PR TITLE
Bug: Typescript tsc could not be located when building node in Node-Dev

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -63,8 +63,15 @@ export async function createCustomTsconfig () {
 export async function buildFiles (options?: IBuildOptions): Promise<string> {
 	options = options || {};
 
-	// Get the path of the TypeScript cli of this project
-	const tscPath = join(__dirname, '../../node_modules/.bin/tsc');
+	let typescriptPath;
+
+	// Check for OS to designate correct tsc path
+	if (process.platform === 'win32') {
+		typescriptPath = '../../node_modules/TypeScript/lib/tsc';
+	} else {
+		typescriptPath = '../../node_modules/.bin/tsc';
+	}
+    const tscPath = join(__dirname, typescriptPath);
 
 	const tsconfigData = await createCustomTsconfig();
 

--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -71,7 +71,7 @@ export async function buildFiles (options?: IBuildOptions): Promise<string> {
 	} else {
 		typescriptPath = '../../node_modules/.bin/tsc';
 	}
-    const tscPath = join(__dirname, typescriptPath);
+	const tscPath = join(__dirname, typescriptPath);
 
 	const tsconfigData = await createCustomTsconfig();
 


### PR DESCRIPTION
n8n now checks if user is using windows or otherwise before assigning path to tsc. 

Tested on:
- Linux subsystem (Ubuntu)
- Windows 10 

Thanks to @ivov for reporting and providing explanation (and essentially fix). 