### PR TITLE
Added feature for Slack node: get and set your status

### DIFF
--- a/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
@@ -10,6 +10,8 @@ const userScopes = [
 	'files:write',
 	'stars:read',
 	'stars:write',
+	'users.profile:read',
+	'users.profile:write'
 ];
 
 export class SlackOAuth2Api implements ICredentialType {

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -863,12 +863,23 @@ export class Slack implements INodeType {
 				//https://api.slack.com/methods/users.profile.set
 				if (operation === 'set') {
 					const statusText = this.getNodeParameter('status_text', i) as string;
-					const statusEmoji = this.getNodeParameter('status_emoji', i) as string;
-					const statusExpiration = this.getNodeParameter('status_expiration', i) as string;
+					let statusEmoji = this.getNodeParameter('status_emoji', i) as string;
+					if (!statusEmoji.startsWith(":")) {
+						statusEmoji = ":" + statusEmoji;
+					}
+					if (!statusEmoji.endsWith(":")) {
+						statusEmoji = statusEmoji + ":";
+					}
+					// although we say "as string" it is returned as number if no value is set
+					let statusExpiration = this.getNodeParameter('status_expiration', i) as string;
+					let statusExpirationUnixTimestamp = 0; // 0 means: ignore
+					if (statusExpiration !== "" && statusExpiration !== "0" && typeof(statusExpiration) !== "number") {
+						statusExpirationUnixTimestamp = Date.parse(statusExpiration) / 1000;
+					}
 					const profile: IDataObject = {
-						statusText,
-						statusEmoji,
-						statusExpiration,
+						status_text: statusText,
+						status_emoji: statusEmoji,
+						status_expiration: statusExpirationUnixTimestamp,
 					};
 					const body: IDataObject = {
 						profile,

--- a/packages/nodes-base/nodes/Slack/StatusDescription.ts
+++ b/packages/nodes-base/nodes/Slack/StatusDescription.ts
@@ -1,0 +1,89 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const statusOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'status',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get your status',
+			},
+			{
+				name: 'Set',
+				value: 'set',
+				description: 'Set your status',
+			},
+		],
+		default: 'get',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const statusFields = [
+
+/* -------------------------------------------------------------------------- */
+/*                                status:set                                  */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Status text',
+		name: 'status_text',
+		type: 'string',
+		default: '',
+		placeholder: 'Status text',
+		displayOptions: {
+			show: {
+				operation: [
+					'set',
+				],
+				resource: [
+					'status',
+				],
+			},
+		},
+		description: 'The status text to set.',
+	},
+	{
+		displayName: 'Status emoji',
+		name: 'status_emoji',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				operation: [
+					'set',
+				],
+				resource: [
+					'status',
+				],
+			},
+		},
+		description: 'The status emoji to set.',
+	},
+	{
+		displayName: 'Status expiration',
+		name: 'status_expiration',
+		type: 'dateTime',
+		default: 0,
+		displayOptions: {
+			show: {
+				operation: [
+					'set'
+				],
+				resource: [
+					'status',
+				],
+			},
+		},
+		description: 'When this status should expire.',
+	},
+] as INodeProperties[];


### PR DESCRIPTION
The current slack node is missing a way to get and set your status - the status text and the status icon. This PR is changing this. With this PR, you can change your Slack status based on calendar events (e.g. "I am in a meeting") or based on MQTT events (like [this](https://www.instructables.com/id/Slack-Status-Updater-With-ESP8266/))