### PR TITLE
docs: adds MySQL database option to intro

### DIFF
--- a/docker/images/n8n/README.md
+++ b/docker/images/n8n/README.md
@@ -107,7 +107,7 @@ docker run -it --rm \
 ### Start with other Database
 
 By default n8n uses SQLite to save credentials, past executions and workflows.
-n8n however also supports MongoDB and PostgresDB. To use them simply a few
+n8n however also supports MongoDB, PostgresDB and MySQL. To use them simply a few
 environment variables have to be set.
 
 It is important to still persist the data in the `/root/.n8` folder. The reason


### PR DESCRIPTION
The example for MySQL is present, it just isn't in the intro.
I almost missed that MySQL was an option :)

Sidenote: I might create a Kubernetes deployment and a Helm chart wouldn't be that far away then is this something you guys would be interested in?