### PR TITLE
Add additional parameters to Pipedrive getAll for Notes

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -1420,6 +1420,7 @@ export class Pipedrive implements INodeType {
 					show: {
 						operation: [
 							'create',
+							'getAll'
 						],
 						resource: [
 							'note',
@@ -2516,13 +2517,25 @@ export class Pipedrive implements INodeType {
 					// ----------------------------------
 
 					requestMethod = 'GET';
+					endpoint = `/notes`;
 
 					returnAll = this.getNodeParameter('returnAll', i) as boolean;
 					if (returnAll === false) {
 						qs.limit = this.getNodeParameter('limit', i) as number;
 					}
+					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 
-					endpoint = `/notes`;
+					if (additionalFields.deal_id) {
+						qs.deal_id = parseInt(additionalFields.deal_id as string, 10);
+					}
+
+					if (additionalFields.org_id) {
+						qs.org_id = parseInt(additionalFields.org_id as string, 10);
+					}
+
+					if (additionalFields.person_id) {
+						qs.person_id = parseInt(additionalFields.person_id as string, 10);
+					}
 
 				} else if (operation === 'update') {
 					// ----------------------------------

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -2524,18 +2524,7 @@ export class Pipedrive implements INodeType {
 						qs.limit = this.getNodeParameter('limit', i) as number;
 					}
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
-
-					if (additionalFields.deal_id) {
-						qs.deal_id = parseInt(additionalFields.deal_id as string, 10);
-					}
-
-					if (additionalFields.org_id) {
-						qs.org_id = parseInt(additionalFields.org_id as string, 10);
-					}
-
-					if (additionalFields.person_id) {
-						qs.person_id = parseInt(additionalFields.person_id as string, 10);
-					}
+					addAdditionalFields(qs, additionalFields);
 
 				} else if (operation === 'update') {
 					// ----------------------------------


### PR DESCRIPTION
These are just a few of what's available. Before, there wasn't a parameter to specify which deal to retrieve notes from. This pull request adds parameters to allow filtering by Deal ID, Organization ID, and Person ID.