### PR TITLE
Feature/Salesforce Node - Flow List and Invoke

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/FlowDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/FlowDescription.ts
@@ -1,0 +1,138 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const flowOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'flow',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Invoke',
+				value: 'invoke',
+				description: 'Invoke a flow',
+            },
+            {
+				name: 'List',
+				value: 'list',
+				description: 'List flows',
+			},
+		],
+		default: 'invoke',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const flowFields = [
+
+/* -------------------------------------------------------------------------- */
+/*                                flow:invoke                                 */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'API Name',
+		name: 'apiName',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'flow',
+				],
+				operation: [
+					'invoke'
+				],
+			},
+		},
+		description: 'Required. API name of the flow.',
+	},
+	{
+		displayName: 'JSON/RAW Inputs',
+		name: 'jsonInputVariables',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: [
+					'flow',
+				],
+				operation: [
+					'invoke'
+				],
+			},
+		},
+		description: 'If the input variables should be set via the value-key pair UI or JSON/RAW.',
+	},
+	{
+		displayName: 'Input Variables',
+		name: 'inputVariables',
+		type: 'json',
+		displayOptions: {
+			show: {
+				resource: [
+					'flow',
+				],
+				operation: [
+					'invoke'
+				],
+				jsonInputVariables: [
+					true,
+				],
+			},
+		},
+		default: '',
+		description: 'Input variables as JSON object',
+	},
+	{
+		displayName: 'Input Variables',
+		name: 'inputVariablesUi',
+		placeholder: 'Add Input Variable',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		displayOptions: {
+			show: {
+				resource: [
+					'flow',
+				],
+				operation: [
+					'invoke'
+				],
+				jsonInputVariables: [
+					false,
+				],
+			},
+		},
+		description: 'The input variable to send.',
+		default: {},
+		options: [
+			{
+				name: 'inputVariable',
+				displayName: 'Input Variable',
+				values: [
+					{
+						displayName: 'Name',
+						name: 'name',
+						type: 'string',
+						default: '',
+						description: 'Name of the input variable.',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						description: 'Value of the input variable.',
+					},
+				]
+			},
+		],
+	},
+] as INodeProperties[];


### PR DESCRIPTION
Adds listing and invoking of autolaunched flows to Salesforce node.
Input variables passed to flow can be either raw JSON or built via UI.

![Screen Shot 2020-10-09 at 4 09 36 PM](https://user-images.githubusercontent.com/5472147/95631866-0acd0c80-0a4a-11eb-924b-93e7d13c6eae.png)
![Screen Shot 2020-10-09 at 4 09 56 PM](https://user-images.githubusercontent.com/5472147/95631867-0b65a300-0a4a-11eb-82ef-e82066dc18a9.png)
![Screen Shot 2020-10-09 at 4 10 18 PM](https://user-images.githubusercontent.com/5472147/95631869-0b65a300-0a4a-11eb-9245-71b7e3a10b87.png)