### PR TITLE
Add HMAC-SHA256 for Oauth 1

### DIFF
--- a/packages/nodes-base/credentials/OAuth1Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth1Api.credentials.ts
@@ -56,6 +56,10 @@ export class OAuth1Api implements ICredentialType {
 					name: 'HMAC-SHA256',
 					value: 'HMAC-SHA256'
 				},
+				{
+					name: 'HMAC-SHA512',
+					value: 'HMAC-SHA512'
+				},
 			],
 			default: '',
 			required: true,


### PR DESCRIPTION
In order to implement a PaaS named Clever Cloud, I need to have an Oauth 1 with SHA512.