### PR TITLE
Add support for specifying Matrix homeserver URL

### DIFF
--- a/packages/nodes-base/credentials/MatrixApi.credentials.ts
+++ b/packages/nodes-base/credentials/MatrixApi.credentials.ts
@@ -15,5 +15,11 @@ export class MatrixApi implements ICredentialType {
 			type: 'string' as NodePropertyTypes,
 			default: '',
 		},
+		{
+			displayName: 'Homeserver URL',
+			name: 'homeserverUrl',
+			type: 'string' as NodePropertyTypes,
+			default: 'https://matrix-client.matrix.org',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -36,9 +36,7 @@ export async function matrixApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		},
 		body,
 		qs: query,
-		// Override URL when working with media only. All other endpoints use client.
-		//@ts-ignore
-		uri: option.hasOwnProperty('overridePrefix') ? `https://matrix.org/_matrix/${option.overridePrefix}/r0${resource}` : `https://matrix.org/_matrix/client/r0${resource}`,
+		uri: '',
 		json: true,
 	};
 	options = Object.assign({}, options, option);
@@ -56,6 +54,8 @@ export async function matrixApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		if (credentials === undefined) {
 			throw new Error('No credentials got returned!');
 		}
+		//@ts-ignore
+		options.uri = `${credentials.homeserverUrl}/_matrix/${option.overridePrefix || 'client'}/r0${resource}`;
 		options.headers!.Authorization = `Bearer ${credentials.accessToken}`;
 		//@ts-ignore
 		response = await this.helpers.request(options);


### PR DESCRIPTION
Matrix is a decentralized protocol where anyone can run a homeserver, not a centralized service on matrix.org. Defaulting to the matrix.org homeserver is fine(-ish), but it shouldn't be hardcoded.