### PR TITLE
⚡️Improvement: load node properties on demand

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -716,7 +716,10 @@ class App {
 			const allNodes = nodeTypes.getAll();
 
 			allNodes.forEach((nodeData) => {
-				let nodeInfo: INodeTypeDescription = nodeData.description;
+				// Make a copy of the object. If we don't do this, then when 
+				// The method below is called the properties are removed for good
+				// This happens because nodes are returned as reference.
+				let nodeInfo: INodeTypeDescription = {...nodeData.description};
 				if (!['true', '1'].includes(req.query.includeProperties as string)) {
 					delete nodeInfo.properties;
 				}

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -101,7 +101,6 @@ import * as timezones from 'google-timezones-json';
 import * as parseUrl from 'parseurl';
 import * as querystring from 'querystring';
 import { OptionsWithUrl } from 'request-promise-native';
-import { getDataLastExecutedNodeData } from './WorkflowHelpers';
 
 class App {
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -728,8 +728,8 @@ class App {
 
 
 		// Returns node information baesd on namese
-		this.app.get(`/${this.restEndpoint}/node-types/:nodeNames`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<INodeTypeDescription[]> => {
-			const nodeNames = req.params.nodeNames.split(',');
+		this.app.post(`/${this.restEndpoint}/node-types`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<INodeTypeDescription[]> => {
+			const nodeNames = _.get(req, 'body.nodeNames', []);
 			const nodeTypes = NodeTypes();
 			const allNodes = nodeTypes.getAll();
 			return allNodes.filter(node => nodeNames.includes(node.description.name)).map(node => node.description);

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -101,6 +101,7 @@ import * as timezones from 'google-timezones-json';
 import * as parseUrl from 'parseurl';
 import * as querystring from 'querystring';
 import { OptionsWithUrl } from 'request-promise-native';
+import { getDataLastExecutedNodeData } from './WorkflowHelpers';
 
 class App {
 
@@ -715,10 +716,23 @@ class App {
 			const allNodes = nodeTypes.getAll();
 
 			allNodes.forEach((nodeData) => {
-				returnData.push(nodeData.description);
+				let nodeInfo: INodeTypeDescription = nodeData.description;
+				if (!['true', '1'].includes(req.query.includeProperties as string)) {
+					delete nodeInfo.properties;
+				}
+				returnData.push(nodeInfo);
 			});
 
 			return returnData;
+		}));
+
+
+		// Returns node information baesd on namese
+		this.app.get(`/${this.restEndpoint}/node-types/:nodeNames`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<INodeTypeDescription[]> => {
+			const nodeNames = req.params.nodeNames.split(',');
+			const nodeTypes = NodeTypes();
+			const allNodes = nodeTypes.getAll();
+			return allNodes.filter(node => nodeNames.includes(node.description.name)).map(node => node.description);
 		}));
 
 

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -126,6 +126,7 @@ export interface IRestApi {
 	makeRestApiRequest(method: string, endpoint: string, data?: any): Promise<any>; // tslint:disable-line:no-any
 	getSettings(): Promise<IN8nUISettings>;
 	getNodeTypes(): Promise<INodeTypeDescription[]>;
+	getNodesInformation(nodeList: string[]): Promise<INodeTypeDescription[]>;
 	getNodeParameterOptions(nodeType: string, methodName: string, currentNodeParameters: INodeParameters, credentials?: INodeCredentials): Promise<INodePropertyOptions[]>;
 	removeTestWebhook(workflowId: string): Promise<boolean>;
 	runWorkflow(runData: IStartRunData): Promise<IExecutionPushResponse>;

--- a/packages/editor-ui/src/components/mixins/restApi.ts
+++ b/packages/editor-ui/src/components/mixins/restApi.ts
@@ -152,6 +152,10 @@ export const restApi = Vue.extend({
 					return self.restApi().makeRestApiRequest('GET', `/node-types`);
 				},
 
+				getNodesInformation: (nodeList: string[]): Promise<INodeTypeDescription[]> => {
+					return self.restApi().makeRestApiRequest('POST', `/node-types`, {nodeNames: nodeList});
+				},
+
 				// Returns all the parameter options from the server
 				getNodeParameterOptions: (nodeType: string, methodName: string, currentNodeParameters: INodeParameters, credentials?: INodeCredentials): Promise<INodePropertyOptions[]> => {
 					const sendData = {

--- a/packages/editor-ui/src/store.ts
+++ b/packages/editor-ui/src/store.ts
@@ -562,6 +562,14 @@ export const store = new Vuex.Store({
 				Vue.set(state.workflow, 'settings', {});
 			}
 		},
+
+		updateNodeTypes (state, nodeTypes: INodeTypeDescription[]) {
+			const updatedNodeNames = nodeTypes.map(node => node.name) as string[];
+			const oldNodesNotChanged = state.nodeTypes.filter(node => !updatedNodeNames.includes(node.name));
+			const updatedNodes = [...oldNodesNotChanged, ...nodeTypes];
+			Vue.set(state, 'nodeTypes', updatedNodes);
+			state.nodeTypes = updatedNodes;
+		},
 	},
 	getters: {
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -539,7 +539,7 @@ export interface INodeTypeDescription {
 	inputNames?: string[];
 	outputs: string[];
 	outputNames?: string[];
-	properties: INodeProperties[];
+	properties?: INodeProperties[];
 	credentials?: INodeCredentialDescription[];
 	maxNodes?: number; // How many nodes of that type can be created in a workflow
 	polling?: boolean;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -539,7 +539,7 @@ export interface INodeTypeDescription {
 	inputNames?: string[];
 	outputs: string[];
 	outputNames?: string[];
-	properties?: INodeProperties[];
+	properties: INodeProperties[];
 	credentials?: INodeCredentialDescription[];
 	maxNodes?: number; // How many nodes of that type can be created in a workflow
 	polling?: boolean;

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -215,7 +215,7 @@ export class Workflow {
 					typeUnknown: true,
 				};
 			} else {
-				nodeIssues = NodeHelpers.getNodeParametersIssues(nodeType.description.properties, node);
+				nodeIssues = NodeHelpers.getNodeParametersIssues(nodeType.description.properties!, node);
 			}
 
 			if (nodeIssues !== null) {


### PR DESCRIPTION
- Changed API so that it returns node information without properties (currently it represents 95% of payload size)
- Added a parameter to existing endpoint to return full payload as before (for any existing use cases)
- Created a new endpoint that returns node information with properties based on a list of node names
- Changed editor so that it requests information from API whenever a node is added, be it from manually adding or pasting data / opening workflows

Below is a short video explaining the motivation and how it's working in action

https://www.loom.com/share/ad5ce71362e24c558112020d859fc47b