### PR TITLE
Add Feebusy resource to the Google Calendar node

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/FreebusyDescription.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/FreebusyDescription.ts
@@ -1,0 +1,86 @@
+import {
+	INodeProperties,
+} from 'n8n-workflow';
+
+export const freeBusyOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'freeBusy',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Returns free/busy information for a set of calendars',
+			},
+		],
+		default: 'get',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const freeBusyFields = [
+	{
+		displayName: 'Calendar',
+		name: 'calendar',
+		type: 'multiOptions',
+		typeOptions: {
+			loadOptionsMethod: 'getCalendars',
+		},
+		required: true,
+		displayOptions: {
+			show: {
+				operation: [
+					'get',
+				],
+				resource: [
+					'freeBusy',
+				],
+			},
+		},
+		default: '',
+	},
+	{
+		displayName: 'Time Min.',
+		name: 'timeMin',
+		type: 'dateTime',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: [
+					'get',
+				],
+				resource: [
+					'freeBusy',
+				],
+			},
+		},
+		default: '',
+		description: 'Start of the interval',
+	},
+	{
+		displayName: 'Time Max.',
+		name: 'timeMax',
+		type: 'dateTime',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: [
+					'get',
+				],
+				resource: [
+					'freeBusy',
+				],
+			},
+		},
+		default: '',
+		description: 'End of the interval',
+	},
+] as INodeProperties[];

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -22,6 +22,11 @@ import {
 } from './EventDescription';
 
 import {
+	freeBusyFields,
+	freeBusyOperations,
+} from './freeBusyDescription';
+
+import {
 	IEvent,
 } from './EventInterface';
 
@@ -60,12 +65,18 @@ export class GoogleCalendar implements INodeType {
 						name: 'Event',
 						value: 'event',
 					},
+					{
+						name: 'Freebusy',
+						value: 'freeBusy'
+					}
 				],
 				default: 'event',
 				description: 'The resource to operate on.',
 			},
 			...eventOperations,
 			...eventFields,
+			...freeBusyOperations,
+			...freeBusyFields,
 		],
 	};
 
@@ -541,6 +552,31 @@ export class GoogleCalendar implements INodeType {
 						body,
 						qs,
 					);
+				}
+			}
+			if (resource === 'freeBusy') {
+				//https://developers.google.com/calendar/v3/reference/freebusy/query
+				if (operation === 'get') {
+					const calendarIds = this.getNodeParameter('calendar', i) as string[];
+					const timeMin = this.getNodeParameter('timeMin', i);
+					const timeMax = this.getNodeParameter('timeMax', i);
+					let items: IDataObject[] = [];
+					let body: IDataObject = {
+						timeMin: timeMin,
+						timeMax: timeMax,
+					};
+					for (let j=0; j< calendarIds.length; j++) {
+						items.push({id:calendarIds[j]})
+					}
+					body.items = items;
+					console.log(body)
+					responseData = await googleApiRequest.call(
+						this,
+						'POST',
+						`/calendar/v3/freeBusy`,
+						body,
+						{}
+					)
 				}
 			}
 			if (Array.isArray(responseData)) {


### PR DESCRIPTION
This PR adds the [Freebusy](https://developers.google.com/calendar/v3/reference/freebusy) resource to the Google Calendar node. This resource is important to get availability from the calendar.