### PR TITLE
Select executions by the firstId

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -38,6 +38,7 @@ import {
 	IExecutionDeleteFilter,
 	IExecutionFlatted,
 	IExecutionFlattedDb,
+	IExecutionResponse,
 	IExecutionFlattedResponse,
 	IExecutionPushResponse,
 	IExecutionsListResponse,
@@ -1449,16 +1450,23 @@ class App {
 
 
 		// Returns a specific execution
-		this.app.get(`/${this.restEndpoint}/executions/:id`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<IExecutionFlattedResponse | undefined> => {
+		this.app.get(`/${this.restEndpoint}/executions/:id`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<IExecutionResponse | IExecutionFlattedResponse | undefined> => {
 			const result = await Db.collections.Execution!.findOne(req.params.id);
 
 			if (result === undefined) {
 				return undefined;
 			}
 
-			// Convert to response format in which the id is a string
-			(result as IExecutionFlatted as IExecutionFlattedResponse).id = result.id.toString();
-			return result as IExecutionFlatted as IExecutionFlattedResponse;
+			if (req.query.unflattedResponse) {
+ 				const fullExecutionData = ResponseHelper.unflattenExecutionData(result);
+				return fullExecutionData as IExecutionResponse;
+			} else {
+				// Convert to response format in which the id is a string
+				(result as IExecutionFlatted as IExecutionFlattedResponse).id = result.id.toString();
+				return result as IExecutionFlatted as IExecutionFlattedResponse;
+			}
+
+			return undefined;
 		}));
 
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -89,6 +89,7 @@ import {
 	FindOneOptions,
 	LessThan,
 	LessThanOrEqual,
+	MoreThanOrEqual,
 	Not,
 } from 'typeorm';
 
@@ -1400,6 +1401,8 @@ class App {
 			const countFilter = JSON.parse(JSON.stringify(filter));
 			if (req.query.lastId) {
 				filter.id = LessThan(req.query.lastId);
+			} else if (req.query.firstId) {
+				filter.id = MoreThanOrEqual(req.query.firstId);
 			}
 			countFilter.select = ['id'];
 


### PR DESCRIPTION
For getting all the executions after a given id this new parameter for the call is needed.