### PR TITLE
Added description to ShopifyCredentials subdomain

### DIFF
--- a/packages/nodes-base/credentials/ShopifyApi.credentials.ts
+++ b/packages/nodes-base/credentials/ShopifyApi.credentials.ts
@@ -28,6 +28,7 @@ export class ShopifyApi implements ICredentialType {
 			required: true,
 			type: 'string' as NodePropertyTypes,
 			default: '',
+			description: 'Only the subdomain without .myshopify.com',
 		},
 		{
 			displayName: 'Shared Secret',


### PR DESCRIPTION
After having a support case regarding the shopify subdomain I think a hint would be great.