### PR TITLE
Fixed Strava Trigger node description

### DIFF
--- a/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
@@ -25,7 +25,7 @@ export class StravaTrigger implements INodeType {
 		icon: 'file:strava.svg',
 		group: ['trigger'],
 		version: 1,
-		description: 'Starts the workflow when a Github events occurs.',
+		description: 'Starts the workflow when a Strava events occurs.',
 		defaults: {
 			name: 'Strava Trigger',
 			color: '#ea5929',


### PR DESCRIPTION
Changed description from
`Starts the workflow when a Github events occurs.`
to
`Starts the workflow when a Strava events occurs.`