### PR TITLE
Fixing issue with gmail enconding on email subject

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
@@ -329,7 +329,7 @@ export class Gmail implements INodeType {
 					method = 'POST';
 
 					body = {
-						raw: encodeEmail(email),
+						raw: await encodeEmail(email),
 					};
 
 					responseData = await googleApiRequest.call(this, method, endpoint, body, qs);
@@ -427,7 +427,7 @@ export class Gmail implements INodeType {
 					email.reference = id;
 
 					body = {
-						raw: encodeEmail(email),
+						raw: await encodeEmail(email),
 						threadId: this.getNodeParameter('threadId', i) as string,
 					};
 
@@ -625,7 +625,7 @@ export class Gmail implements INodeType {
 
 					body = {
 						message: {
-							raw: encodeEmail(email),
+							raw: await encodeEmail(email),
 						},
 					};
 


### PR DESCRIPTION
Reported by community user huuich (https://community.n8n.io/t/gmail-integration-partly-created/693/12?u=jan)

An attempt to fix the problem using basic JS functions (escape / unescape / encoding / decoding) did not work, so I decided to use MailComposer as suggested by Jan on Jira Issue PROD-575.

Notes: 
- encodeEmail function is now flagged as `async` due to how buffers are used in MailComposer.
- Changed attachments verification from using `email.attachments !== []` to `Array.isArray(email.attachments) && email.attachments.length > 0` as the image below demonstrates this won't work as expected.

![image](https://user-images.githubusercontent.com/219272/97918720-51561400-1d35-11eb-8300-9d8554fc293e.png)
