### PR TITLE
TLS option for MSSQL credentials type

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
@@ -44,5 +44,11 @@ export class MicrosoftSql implements ICredentialType {
 			type: 'string' as NodePropertyTypes,
 			default: '',
 		},
+		{
+			displayName: 'TLS',
+			name: 'tls',
+			type: 'boolean' as NodePropertyTypes,
+			default: true,
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -219,7 +219,7 @@ export class MicrosoftSql implements INodeType {
 			domain: credentials.domain ? (credentials.domain as string) : undefined,
 			options: {
                              encrypt: credentials.tls as boolean
-                        } 
+                        },
 		};
 
 		const pool = new mssql.ConnectionPool(config);

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -217,6 +217,9 @@ export class MicrosoftSql implements INodeType {
 			user: credentials.user as string,
 			password: credentials.password as string,
 			domain: credentials.domain ? (credentials.domain as string) : undefined,
+			options: {
+                             encrypt: credentials.tls as boolean
+                        } 
 		};
 
 		const pool = new mssql.ConnectionPool(config);


### PR DESCRIPTION
Adding a TLS toggle would help users connect to certain Azure-based MSSQL products and older instances of MSSQL that do not support modern encryption protocols.

The default is set to true since this is the default setting for the mssql node package.