### PR TITLE
Adding encryptionKey to the config file

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -126,6 +126,13 @@ const config = convict({
 		},
 	},
 
+	encryptionKey: {
+		format: String,
+		default: '',
+		env: 'N8N_ENCRYPTION_KEY',
+		doc: 'Encryption key for credentials',
+	},
+
 	credentials: {
 		overwrite: {
 			data: {


### PR DESCRIPTION
The encryptionKey was missing from the configuration file description. This resulted in n8n adding it on startup an then not being able to start up a second time.