### PR TITLE
Added message type and message format options to Matrix node

### DIFF
--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -127,8 +127,9 @@ export async function handleMatrixCall(this: IExecuteFunctions | IExecuteSingleF
 		if (operation === 'create') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const text = this.getNodeParameter('text', index) as string;
+			const msgType = this.getNodeParameter('msgType', index) as string;
 			const body: IDataObject = {
-				msgtype: 'm.text',
+				msgtype: msgType,
 				body: text,
 			};
 			const messageId = uuid();

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -128,10 +128,17 @@ export async function handleMatrixCall(this: IExecuteFunctions | IExecuteSingleF
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const text = this.getNodeParameter('text', index) as string;
 			const msgType = this.getNodeParameter('msgType', index) as string;
+			const format = this.getNodeParameter('format', index) as string;
 			const body: IDataObject = {
 				msgtype: msgType,
 				body: text,
 			};
+			if (format === 'org.matrix.custom.html') {
+				const fallbackText = this.getNodeParameter('fallbackText', index) as string;
+				body.format = format;
+				body.formatted_body = text;
+				body.body = fallbackText;
+			}
 			const messageId = uuid();
 			return await matrixApiRequest.call(this, 'PUT', `/rooms/${roomId}/send/m.room.message/${messageId}`, body);
 		} else if (operation === 'getAll') {

--- a/packages/nodes-base/nodes/Matrix/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/MessageDescription.ts
@@ -113,6 +113,58 @@ export const messageFields = [
 		default: 'm.text',
 		description: 'The type of message to send.',
 	},
+	{
+		name: 'format',
+		displayName: 'Message format',
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'message',
+				],
+			},
+		},
+		type: 'options',
+		options: [
+			{
+				name: 'Plain text',
+				value: 'plain',
+				description: 'Text only',
+			},
+			{
+				name: 'HTML',
+				value: 'org.matrix.custom.html',
+				description: 'HTML-formatted text',
+			},
+		],
+		default: 'plain',
+		description: "The format of the message's body.",
+	},
+	{
+		name: 'fallbackText',
+		displayName: 'Fallback text',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'create',
+				],
+				format: [
+					'org.matrix.custom.html',
+				],
+			},
+		},
+		type: 'string',
+		typeOptions: {
+			alwaysOpenEditWindow: true,
+		},
+		placeholder: 'HTML message could not be displayed.',
+		description: 'A plain text message to display in case the HTML cannot be rendered by the Matrix client.',
+	},
 
 
 	/* ----------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Matrix/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Matrix/MessageDescription.ts
@@ -79,6 +79,40 @@ export const messageFields = [
 		},
 		description: 'The text to send.',
 	},
+	{
+		name: 'msgType',
+		displayName: 'Message type',
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'message',
+				],
+			},
+		},
+		type: 'options',
+		options: [
+			{
+				name: 'Text',
+				value: 'm.text',
+				description: 'Send a text message.',
+			},
+			{
+				name: 'Emote',
+				value: 'm.emote',
+				description: 'Perform an action (similar to /me in IRC).'
+			},
+			{
+				name: 'Notice',
+				value: 'm.notice',
+				description: 'Send a notice.'
+			},
+		],
+		default: 'm.text',
+		description: 'The type of message to send.',
+	},
 
 
 	/* ----------------------------------------------------------------------- */


### PR DESCRIPTION
I modified the Matrix node to allow creating messages of different type and different format: 

- message type (`msgtype`) can now be not only `m.text`, but also `m.notice` and `m.emote`, as per [Matrix specification](https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes). 

- message format (`format`) can now be not only plain text, but also HTML. When HTML is selected, a new field appears called "fallback text", which serves to provide an alternate plain text message in case the Matrix client cannot render the HTML, as per [the same Matrix specification](https://matrix.org/docs/spec/client_server/latest#m-room-message-msgtypes). 

I've also created a PR to n8n-docs to adapt the documentation: https://github.com/n8n-io/n8n-docs/pull/273