### PR TITLE
SFTP: make dir creation more robust

### DIFF
--- a/packages/nodes-base/nodes/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp.node.ts
@@ -348,13 +348,11 @@ export class Ftp implements INodeType {
 					const remotePath = this.getNodeParameter('path', i) as string;
 
 					// Check if dir path exists
-					const dirExists = await sftp!.exists(dirname(remotePath));
+					const dirPath = dirname(remotePath);
+					const dirExists = await sftp!.exists(dirPath);
 
 					// If dir does not exist, create all recursively in path
 					if (!dirExists) {
-						// Separate filename from dir path
-						const fileName = basename(remotePath);
-						const dirPath = remotePath.replace(fileName, '');
 						// Create directory
 						await sftp!.mkdir(dirPath, true);
 					}


### PR DESCRIPTION
Fixes issue as described here: https://community.n8n.io/t/ftp-node-no-option-to-provide-keyfile-and-passphrase/2954/6

It seems that some (Windows?) SFTP servers are more sensitive than others. In my case it seems `mkdir` didn't work because of the way the path was extracted from the filename, i.e. it had a trailing slash (/). Changing the path extraction to `dirname`, which does not contain a trailing slash has solved it.