### PR TITLE
Fix typo in YouTube unlisted setting

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/PlaylistDescription.ts
@@ -107,7 +107,7 @@ export const playlistFields = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',
@@ -553,7 +553,7 @@ export const playlistFields = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',

--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -210,7 +210,7 @@ export const videoFields = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',


### PR DESCRIPTION
The setting for `Unlisted` is `unlistef` instead of `unlisted`, so the YouTube API claims that `unlistef` is not supported. If you change it manually to `unlisted`, it works fine.

This PR fixes the problem.