### PR TITLE
Increase timeout to IMAP node.

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap.node.ts
@@ -362,7 +362,7 @@ export class EmailReadImap implements INodeType {
 				host: credentials.host as string,
 				port: credentials.port as number,
 				tls: credentials.secure as boolean,
-				authTimeout: 3000,
+				authTimeout: 10000,
 			},
 			onmail: async () => {
 				const returnData = await getNewEmails(connection, searchCriteria);


### PR DESCRIPTION
Yahoo mail is unable to provide a response in under 3 seconds. Increasing
this limit to 10 seconds seems to solve the timeout issue.

I was unable to properly login to Yahoo but at least the timeout error
is not happening anymore.

Setting the node to work with Gmail worked fine although it is a
somewhat painful process as Gmail avoids the so called non secure apps.