### PR TITLE
:bug: Fix parameters when inviting a user #1175

### DIFF
--- a/packages/nodes-base/nodes/Slack/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/ChannelDescription.ts
@@ -195,16 +195,6 @@ export const channelFields = [
 				default: false,
 				description: 'Create a private channel instead of a public one',
 			},
-			{
-				displayName: 'Users',
-				name: 'users',
-				type: 'multiOptions',
-				typeOptions: {
-					loadOptionsMethod: 'getUsers',
-				},
-				default: [],
-				description: `Required for workspace apps. A list of between 1 and 30 human users that will be added to the newly-created conversation`,
-			},
 		],
 	},
 /* -------------------------------------------------------------------------- */
@@ -232,9 +222,9 @@ export const channelFields = [
 		description: 'The ID of the channel to invite user to.',
 	},
 	{
-		displayName: 'User ID',
-		name: 'userId',
-		type: 'options',
+		displayName: 'User IDs',
+		name: 'userIds',
+		type: 'multiOptions',
 		typeOptions: {
 			loadOptionsMethod: 'getUsers',
 		},

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -294,9 +294,6 @@ export class Slack implements INodeType {
 					if (additionalFields.isPrivate) {
 						body.is_private = additionalFields.isPrivate as boolean;
 					}
-					if (additionalFields.users) {
-						body.user_ids = (additionalFields.users as string[]).join(',');
-					}
 					responseData = await slackApiRequest.call(this, 'POST', '/conversations.create', body, qs);
 					responseData = responseData.channel;
 				}
@@ -370,10 +367,10 @@ export class Slack implements INodeType {
 				//https://api.slack.com/methods/conversations.invite
 				if (operation === 'invite') {
 					const channel = this.getNodeParameter('channelId', i) as string;
-					const userId = this.getNodeParameter('userId', i) as string;
+					const userIds = (this.getNodeParameter('userIds', i) as string[]).join(',');
 					const body: IDataObject = {
 						channel,
-						user: userId,
+						users: userIds,
 					};
 					responseData = await slackApiRequest.call(this, 'POST', '/conversations.invite', body, qs);
 					responseData = responseData.channel;


### PR DESCRIPTION
- User IDs parameters are not allowed when creating a channel so it got removed.
- User field is not valid when inviting a user to a channel. The correct name should be users so it got renamed to it.