### PR TITLE
TheHive Trigger: Add support for TheHive 3 webhook events

### DIFF
--- a/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
@@ -123,13 +123,6 @@ export class TheHiveTrigger implements INodeType {
 					},
 				],
 			},
-			{
-				displayName: 'TheHive 3 Support',
-				name: 'hive3Support',
-				default: false,
-				type: 'boolean',
-				description: 'Enable support for TheHive 3 webhook events',
-			},
 		],
 	};
 	// @ts-ignore (because of request)
@@ -151,16 +144,14 @@ export class TheHiveTrigger implements INodeType {
 		// Get the request body
 		const bodyData = this.getBodyData();
 		const events = this.getNodeParameter('events', []) as string[];
-		const hive3Support = this.getNodeParameter('hive3Support', false);
-
 		if (!bodyData.operation || !bodyData.objectType) {
 			// Don't start the workflow if mandatory fields are not specified
 			return {};
 		}
 
 		// Don't start the workflow if the event is not fired
-		const operation = hive3Support ? 
-			(bodyData.operation as string).replace("Creation", "Create") : bodyData.operation as string;
+		// Replace Creation with Create for TheHive 3 support
+		const operation = (bodyData.operation as string).replace("Creation", "Create")
 		const event = `${(bodyData.objectType as string).toLowerCase()}_${operation.toLowerCase()}`;
 		if (events.indexOf('*') === -1 && events.indexOf(event) === -1) {
 			return {};

--- a/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
@@ -111,6 +111,16 @@ export class TheHiveTrigger implements INodeType {
 						value: 'case_task_log_create',
 						description: 'Triggered when a task log is created',
 					},
+					{
+						name: 'Log Updated',
+						value: 'case_task_log_update',
+						description: 'Triggered when a task log is updated',
+					},
+					{
+						name: 'Log Deleted',
+						value: 'case_task_log_delete',
+						description: 'Triggered when a task log is deleted',
+					},
 				],
 			},
 			{

--- a/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
@@ -113,6 +113,13 @@ export class TheHiveTrigger implements INodeType {
 					},
 				],
 			},
+			{
+				displayName: 'TheHive 3 Support',
+				name: 'hive3Support',
+				default: false,
+				type: 'boolean',
+				description: 'Enable support for TheHive 3 webhook events',
+			},
 		],
 	};
 	// @ts-ignore (because of request)
@@ -134,13 +141,17 @@ export class TheHiveTrigger implements INodeType {
 		// Get the request body
 		const bodyData = this.getBodyData();
 		const events = this.getNodeParameter('events', []) as string[];
+		const hive3Support = this.getNodeParameter('hive3Support', false);
+
 		if (!bodyData.operation || !bodyData.objectType) {
 			// Don't start the workflow if mandatory fields are not specified
 			return {};
 		}
 
 		// Don't start the workflow if the event is not fired
-		const event = `${(bodyData.objectType as string).toLowerCase()}_${(bodyData.operation as string).toLowerCase()}`;
+		const operation = hive3Support ? 
+			(bodyData.operation as string).replace("Creation", "Create") : bodyData.operation as string;
+		const event = `${(bodyData.objectType as string).toLowerCase()}_${operation.toLowerCase()}`;
 		if (events.indexOf('*') === -1 && events.indexOf(event) === -1) {
 			return {};
 		}


### PR DESCRIPTION
This pull request adds support for TheHive 3 webhook events by adding a configuration option, which rewrites the operation name from ` Creation ` to ` Create `.

![image](https://user-images.githubusercontent.com/12100880/101406620-f8504180-38d9-11eb-948d-54f38106f57f.png)

Additionally adds two events to the filter list:
* Log Updated
* Log Deleted