### PR TITLE
Slack Node extended

### DIFF
--- a/packages/nodes-base/nodes/Slack/ChannelDescription.ts
+++ b/packages/nodes-base/nodes/Slack/ChannelDescription.ts
@@ -64,6 +64,11 @@ export const channelOperations = [
 				description: 'Leaves a conversation.',
 			},
 			{
+				name: 'Members',
+				value: 'members',
+				description: 'List members of a conversation.',
+			},
+			{
 				name: 'Open',
 				value: 'open',
 				description: 'Opens or resumes a direct message or multi-person direct message.',
@@ -580,6 +585,48 @@ export const channelFields = [
 		default: '',
 		required: true,
 		description: 'The name of the channel to leave.',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                  channel:members                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Channel',
+		name: 'channelId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
+		default: '',
+		placeholder: 'Channel name',
+		displayOptions: {
+			show: {
+				operation: [
+					'members',
+				],
+				resource: [
+					'channel',
+				],
+			},
+		},
+		required: true,
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 100,
+		placeholder: 'Limit',
+		displayOptions: {
+			show: {
+				operation: [
+					'members',
+				],
+				resource: [
+					'channel',
+				],
+			},
+		},
+		required: false,
 	},
 /* -------------------------------------------------------------------------- */
 /*                                channel:open                                */

--- a/packages/nodes-base/nodes/Slack/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/MessageDescription.ts
@@ -23,11 +23,6 @@ export const messageOperations = [
 				value: 'update',
 				description: 'Updates a message.',
 			},
-			{
-				name: 'React',
-				value: 'react',
-				description: 'React to a message.',
-			},
 		],
 		default: 'post',
 		description: 'The operation to perform.',
@@ -432,7 +427,7 @@ export const messageFields = [
 		],
 	},
 /* ----------------------------------------------------------------------- */
-/*                          message:update, react                          */
+/*                                 message:update                          */
 /* ----------------------------------------------------------------------- */
 	{
 		displayName: 'Channel',
@@ -450,7 +445,6 @@ export const messageFields = [
 				],
 				operation: [
 					'update',
-					'react',
 				],
 			},
 		},
@@ -475,24 +469,6 @@ export const messageFields = [
 		description: `New text for the message, using the default formatting rules. It's not required when presenting attachments.`,
 	},
 	{
-		displayName: 'Emoji',
-		name: 'emoji',
-		type: 'string',
-		required: true,
-		default: '',
-		displayOptions: {
-			show: {
-				resource: [
-					'message',
-				],
-				operation: [
-					'react',
-				],
-			},
-		},
-		description: `Name of emoji to use.`,
-	},
-	{
 		displayName: 'TS',
 		name: 'ts',
 		type: 'string',
@@ -505,7 +481,6 @@ export const messageFields = [
 				],
 				operation: [
 					'update',
-					'react',
 				],
 			},
 		},

--- a/packages/nodes-base/nodes/Slack/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/MessageDescription.ts
@@ -23,6 +23,11 @@ export const messageOperations = [
 				value: 'update',
 				description: 'Updates a message.',
 			},
+			{
+				name: 'React',
+				value: 'react',
+				description: 'React to a message.',
+			},
 		],
 		default: 'post',
 		description: 'The operation to perform.',
@@ -427,7 +432,7 @@ export const messageFields = [
 		],
 	},
 /* ----------------------------------------------------------------------- */
-/*                                 message:update                          */
+/*                          message:update, react                          */
 /* ----------------------------------------------------------------------- */
 	{
 		displayName: 'Channel',
@@ -445,6 +450,7 @@ export const messageFields = [
 				],
 				operation: [
 					'update',
+					'react',
 				],
 			},
 		},
@@ -469,6 +475,24 @@ export const messageFields = [
 		description: `New text for the message, using the default formatting rules. It's not required when presenting attachments.`,
 	},
 	{
+		displayName: 'Emoji',
+		name: 'emoji',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'react',
+				],
+			},
+		},
+		description: `Name of emoji to use.`,
+	},
+	{
 		displayName: 'TS',
 		name: 'ts',
 		type: 'string',
@@ -481,6 +505,7 @@ export const messageFields = [
 				],
 				operation: [
 					'update',
+					'react',
 				],
 			},
 		},

--- a/packages/nodes-base/nodes/Slack/ReactionDescription.ts
+++ b/packages/nodes-base/nodes/Slack/ReactionDescription.ts
@@ -1,0 +1,100 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const reactionOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'reaction',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Add',
+				value: 'add',
+				description: 'Adds a reaction to a message',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get the reactions of a message',
+			},
+			{
+				name: 'Remove',
+				value: 'remove',
+				description: 'Remove a reaction of a message',
+			},
+		],
+		default: 'add',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const reactionFields = [
+	{
+		displayName: 'Channel',
+		name: 'channelId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'reaction',
+				],
+				operation: [
+					'add',
+					'get',
+					'remove',
+				],
+			},
+		},
+		description: 'Channel containing the message.',
+	},
+	{
+		displayName: 'Emoji',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'reaction',
+				],
+				operation: [
+					'add',
+					'remove',
+				],
+			},
+		},
+		description: `Name of emoji`,
+	},
+	{
+		displayName: 'Timestamp',
+		name: 'timestamp',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'reaction',
+				],
+				operation: [
+					'add',
+					'get',
+					'remove',
+				],
+			},
+		},
+		description: `Timestamp of the message`,
+	},
+] as INodeProperties[];

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -744,6 +744,21 @@ export class Slack implements INodeType {
 					Object.assign(body, updateFields);
 					responseData = await slackApiRequest.call(this, 'POST', '/chat.update', body, qs);
 				}
+				//https://api.slack.com/methods/reactions.add
+				if (operation === 'react') {
+					const channel = this.getNodeParameter('channelId', i) as string;
+					const name = this.getNodeParameter('emoji', i) as string;
+					const ts = this.getNodeParameter('ts', i) as string;
+					const body: IDataObject = {
+						channel,
+						name,
+						ts,
+					};
+					// Add all the other options to the request
+					const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
+					Object.assign(body, updateFields);
+					responseData = await slackApiRequest.call(this, 'POST', '/reactions.add', body, qs);
+				}
 			}
 			if (resource === 'star') {
 				//https://api.slack.com/methods/stars.add

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -217,7 +217,7 @@ export class Slack implements INodeType {
 			// select them easily
 			async getChannels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const qs = { types: 'public_channel,private_channel' };
+				const qs = { types: 'public_channel,private_channel', limit: 1000 }; // big companies have lots of channels
 				const channels = await slackApiRequestAllItems.call(this, 'channels', 'GET', '/conversations.list', {}, qs);
 				for (const channel of channels) {
 					const channelName = channel.name;
@@ -754,9 +754,6 @@ export class Slack implements INodeType {
 						name,
 						ts,
 					};
-					// Add all the other options to the request
-					const updateFields = this.getNodeParameter('updateFields', i) as IDataObject;
-					Object.assign(body, updateFields);
 					responseData = await slackApiRequest.call(this, 'POST', '/reactions.add', body, qs);
 				}
 			}

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -770,7 +770,7 @@ export class Slack implements INodeType {
 					responseData = await slackApiRequest.call(this, 'POST', '/reactions.add', body, qs);
 				}
 				//https://api.slack.com/methods/reactions.remove
-				if (operation === 'add') {
+				if (operation === 'remove') {
 					const name = this.getNodeParameter('name', i) as string;
 					const body: IDataObject = {
 						channel,

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -788,7 +788,7 @@ export class Slack implements INodeType {
 				//https://api.slack.com/methods/reactions.get
 				if (operation === 'get') {
 					qs.channel = channel;
-					qs.timestampe = timestamp;
+					qs.timestamp = timestamp;
 					responseData = await slackApiRequest.call(this, 'GET', '/reactions.get', {}, qs);
 				}
 			}

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -394,6 +394,12 @@ export class Slack implements INodeType {
 					};
 					responseData = await slackApiRequest.call(this, 'POST', '/conversations.leave', body, qs);
 				}
+				//https://api.slack.com/methods/conversations.members
+				if (operation === 'members') {
+					qs.channel = this.getNodeParameter('channelId', i) as string;
+					qs.limit = this.getNodeParameter('limit', i) as number;
+					responseData = await slackApiRequest.call(this, 'GET', '/conversations.members', {}, qs);
+				}
 				//https://api.slack.com/methods/conversations.open
 				if (operation === 'open') {
 					const options = this.getNodeParameter('options', i) as IDataObject;

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -761,7 +761,7 @@ export class Slack implements INodeType {
 				const timestamp = this.getNodeParameter('timestamp', i) as string;
 				//https://api.slack.com/methods/reactions.add
 				if (operation === 'add') {
-					const name = this.getNodeParameter('emoji', i) as string;
+					const name = this.getNodeParameter('name', i) as string;
 					const body: IDataObject = {
 						channel,
 						name,
@@ -771,7 +771,7 @@ export class Slack implements INodeType {
 				}
 				//https://api.slack.com/methods/reactions.remove
 				if (operation === 'add') {
-					const name = this.getNodeParameter('emoji', i) as string;
+					const name = this.getNodeParameter('name', i) as string;
 					const body: IDataObject = {
 						channel,
 						name,

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -189,6 +189,8 @@ export class Slack implements INodeType {
 			...starFields,
 			...fileOperations,
 			...fileFields,
+			...reactionOperations,
+			...reactionFields,
 			...userProfileOperations,
 			...userProfileFields,
 		],

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -33,6 +33,11 @@ import {
 } from './FileDescription';
 
 import {
+	reactionFields,
+	reactionOperations,
+} from './ReactionDescription';
+
+import {
 	userProfileFields,
 	userProfileOperations,
 } from './UserProfileDescription';
@@ -744,17 +749,37 @@ export class Slack implements INodeType {
 					Object.assign(body, updateFields);
 					responseData = await slackApiRequest.call(this, 'POST', '/chat.update', body, qs);
 				}
+			}
+			if (resource === 'reaction') {
+				const channel = this.getNodeParameter('channelId', i) as string;
+				const timestamp = this.getNodeParameter('timestamp', i) as string;
 				//https://api.slack.com/methods/reactions.add
-				if (operation === 'react') {
-					const channel = this.getNodeParameter('channelId', i) as string;
+				if (operation === 'add') {
 					const name = this.getNodeParameter('emoji', i) as string;
-					const ts = this.getNodeParameter('ts', i) as string;
 					const body: IDataObject = {
 						channel,
 						name,
-						ts,
+						timestamp,
 					};
 					responseData = await slackApiRequest.call(this, 'POST', '/reactions.add', body, qs);
+				}
+				//https://api.slack.com/methods/reactions.remove
+				if (operation === 'add') {
+					const name = this.getNodeParameter('emoji', i) as string;
+					const body: IDataObject = {
+						channel,
+						name,
+						timestamp,
+					};
+					responseData = await slackApiRequest.call(this, 'POST', '/reactions.remove', body, qs);
+				}
+				//https://api.slack.com/methods/reactions.get
+				if (operation === 'get') {
+					const body: IDataObject = {
+						channel,
+						timestamp,
+					};
+					responseData = await slackApiRequest.call(this, 'POST', '/reactions.get', body, qs);
 				}
 			}
 			if (resource === 'star') {

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -939,12 +939,12 @@ export class Slack implements INodeType {
 			}
 			if (resource === 'user') {
 				//https://api.slack.com/methods/users.info
-				if (operation === 'get') {
+				if (operation === 'info') {
 					qs.user = this.getNodeParameter('user', i) as string;
 					responseData = await slackApiRequest.call(this, 'GET', '/users.info', {}, qs);
 				}
 				//https://api.slack.com/methods/users.getPresence
-				if (operation === 'get') {
+				if (operation === 'getPresence') {
 					qs.user = this.getNodeParameter('user', i) as string;
 					responseData = await slackApiRequest.call(this, 'GET', '/users.getPresence', {}, qs);
 				}

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -169,6 +169,10 @@ export class Slack implements INodeType {
 						value: 'message',
 					},
 					{
+						name: 'Reaction',
+						value: 'reaction',
+					},
+					{
 						name: 'Star',
 						value: 'star',
 					},

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -781,11 +781,9 @@ export class Slack implements INodeType {
 				}
 				//https://api.slack.com/methods/reactions.get
 				if (operation === 'get') {
-					const body: IDataObject = {
-						channel,
-						timestamp,
-					};
-					responseData = await slackApiRequest.call(this, 'POST', '/reactions.get', body, qs);
+					qs.channel = channel;
+					qs.timestampe = timestamp;
+					responseData = await slackApiRequest.call(this, 'GET', '/reactions.get', {}, qs);
 				}
 			}
 			if (resource === 'star') {

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -38,6 +38,11 @@ import {
 } from './ReactionDescription';
 
 import {
+	userFields,
+	userOperations,
+} from './UserDescription';
+
+import {
 	userProfileFields,
 	userProfileOperations,
 } from './UserProfileDescription';
@@ -177,6 +182,10 @@ export class Slack implements INodeType {
 						value: 'star',
 					},
 					{
+						name: 'User',
+						value: 'user',
+					},
+					{
 						name: 'User Profile',
 						value: 'userProfile',
 					},
@@ -195,6 +204,8 @@ export class Slack implements INodeType {
 			...fileFields,
 			...reactionOperations,
 			...reactionFields,
+			...userOperations,
+			...userFields,
 			...userProfileOperations,
 			...userProfileFields,
 		],
@@ -924,6 +935,18 @@ export class Slack implements INodeType {
 					qs.file = fileId;
 					responseData = await slackApiRequest.call(this, 'GET', '/files.info', {}, qs);
 					responseData = responseData.file;
+				}
+			}
+			if (resource === 'user') {
+				//https://api.slack.com/methods/users.info
+				if (operation === 'get') {
+					qs.user = this.getNodeParameter('user', i) as string;
+					responseData = await slackApiRequest.call(this, 'GET', '/users.info', {}, qs);
+				}
+				//https://api.slack.com/methods/users.getPresence
+				if (operation === 'get') {
+					qs.user = this.getNodeParameter('user', i) as string;
+					responseData = await slackApiRequest.call(this, 'GET', '/users.getPresence', {}, qs);
 				}
 			}
 			if (resource === 'userProfile') {

--- a/packages/nodes-base/nodes/Slack/UserDescription.ts
+++ b/packages/nodes-base/nodes/Slack/UserDescription.ts
@@ -1,0 +1,84 @@
+import {
+	INodeProperties,
+} from 'n8n-workflow';
+
+export const userOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'user',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Info',
+				value: 'info',
+				description: `Get information about a user`,
+			},
+			{
+				name: 'Get Presence',
+				value: 'getPresence',
+				description: `Get online status of a user`,
+			},
+		],
+		default: 'info',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const userFields = [
+
+/* -------------------------------------------------------------------------- */
+/*                                user:info                                   */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'User ID',
+		name: 'user',
+		type: 'string',
+		typeOptions: {
+			loadOptionsMethod: 'getUsers',
+		},
+		default: '',
+		displayOptions: {
+			show: {
+				operation: [
+					'info',
+				],
+				resource: [
+					'user',
+				],
+			},
+		},
+		required: true,
+		description: 'The ID of the user to get information about.',
+	},
+/* -------------------------------------------------------------------------- */
+/*                                user:getPresence                            */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'User ID',
+		name: 'user',
+		type: 'string',
+		typeOptions: {
+			loadOptionsMethod: 'getUsers',
+		},
+		default: '',
+		displayOptions: {
+			show: {
+				operation: [
+					'getPresence',
+				],
+				resource: [
+					'user',
+				],
+			},
+		},
+		required: true,
+		description: 'The ID of the user to get the online status of.',
+	},
+] as INodeProperties[];


### PR DESCRIPTION
https://community.n8n.io/t/slack-node-conversations-members-reactions-add/3066

I added:
- users.info
- users.getPresence
- conversations.members
- reactions.add
- reactions.remove
- reactions.get

Increased limit of getChannels from default 100 to 1.000 as my company for example has ~400 public channels.