### PR TITLE
Rename display name of Google Firebase Realtime Database node

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/RealtimeDatabase.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/RealtimeDatabase.node.ts
@@ -18,7 +18,7 @@ import {
 
 export class RealtimeDatabase implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Google Firebase Realtime Database',
+		displayName: 'Google Cloud Realtime Database',
 		name: 'googleFirebaseRealtimeDatabase',
 		icon: 'file:googleFirebaseRealtimeDatabase.png',
 		group: ['input'],


### PR DESCRIPTION
The display name of Google Firebase Realtime Database node is different in the search panel and the editor UI. To make it easy for the user we should use uniform name.