### PR TITLE
⚡ TheHive: Add Mark as Read operation to alerts

### DIFF
--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -216,7 +216,7 @@ export class TheHive implements INodeType {
 					{ name: 'Execute Responder', value: 'executeResponder', description: 'Execute a responder on the specified alert' },
 					{ name: 'Get', value: 'get', description: 'Get an alert' },
 					{ name: 'Get All', value: 'getAll', description: 'Get all alerts' },
-					...(version === 'v1') ? [{ name: 'Mark as Read', value: 'markAsRead', description: 'Mark the alert as read' }] : [],
+					{ name: 'Mark as Read', value: 'markAsRead', description: 'Mark the alert as read' },
 					{ name: 'Merge', value: 'merge', description: 'Merge alert into an existing case' },
 					{ name: 'Promote', value: 'promote', description: 'Promote an alert into a case' },
 					{ name: 'Update', value: 'update', description: 'Update alert' },

--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -217,6 +217,7 @@ export class TheHive implements INodeType {
 					{ name: 'Get', value: 'get', description: 'Get an alert' },
 					{ name: 'Get All', value: 'getAll', description: 'Get all alerts' },
 					{ name: 'Mark as Read', value: 'markAsRead', description: 'Mark the alert as read' },
+					{ name: 'Mark as Unread', value: 'markAsUnread', description: 'Mark the alert as unread' },
 					{ name: 'Merge', value: 'merge', description: 'Merge alert into an existing case' },
 					{ name: 'Promote', value: 'promote', description: 'Promote an alert into a case' },
 					{ name: 'Update', value: 'update', description: 'Update alert' },
@@ -543,6 +544,16 @@ export class TheHive implements INodeType {
 						this,
 						'POST',
 						`/alert/${alertId}/markAsRead`
+					);
+				}
+				
+				if (operation === 'markAsUnread') {
+					const alertId = this.getNodeParameter('id', i) as string;
+
+					responseData = await theHiveApiRequest.call(
+						this,
+						'POST',
+						`/alert/${alertId}/markAsUnread`
 					);
 				}
 

--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -216,6 +216,7 @@ export class TheHive implements INodeType {
 					{ name: 'Execute Responder', value: 'executeResponder', description: 'Execute a responder on the specified alert' },
 					{ name: 'Get', value: 'get', description: 'Get an alert' },
 					{ name: 'Get All', value: 'getAll', description: 'Get all alerts' },
+					...(version === 'v1') ? [{ name: 'Mark as Read', value: 'markAsRead', description: 'Mark the alert as read' }] : [],
 					{ name: 'Merge', value: 'merge', description: 'Merge alert into an existing case' },
 					{ name: 'Promote', value: 'promote', description: 'Promote an alert into a case' },
 					{ name: 'Update', value: 'update', description: 'Update alert' },
@@ -532,6 +533,16 @@ export class TheHive implements INodeType {
 						endpoint as string,
 						body,
 						qs,
+					);
+				}
+
+				if (operation === 'markAsRead') {
+					const alertId = this.getNodeParameter('id', i) as string;
+
+					responseData = await theHiveApiRequest.call(
+						this,
+						'POST',
+						`/alert/${alertId}/markAsRead`
 					);
 				}
 

--- a/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
@@ -83,6 +83,7 @@ export const alertFields = [
 				operation: [
 					'promote',
 					'markAsRead',
+					'markAsUnread',
 					'merge',
 					'update',
 					'executeResponder',

--- a/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
@@ -82,6 +82,7 @@ export const alertFields = [
 				],
 				operation: [
 					'promote',
+					'markAsRead',
 					'merge',
 					'update',
 					'executeResponder',


### PR DESCRIPTION
~~TheHive 4 uses a different API endpoint for marking alerts as read than TheHive 3, and the node currently has no way to mark alerts as read in TheHive 4. This PR adds operation "Mark as Read" to Alert resource when the API version is set as v1.~~

TheHive uses API endpoints ` /api/alert/<alert_id>/markAsRead ` and ` /api/alert/<alert_id>/markAsUnread ` to mark alerts as read or unread. They aren't currently implemented so this PR adds both operations.

Fixes #1226, as marking alert as read sets its status as Ignored.