### PR TITLE
feat: add balance endpoint to messagebird

### DIFF
--- a/packages/nodes-base/nodes/MessageBird/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MessageBird/GenericFunctions.ts
@@ -43,8 +43,10 @@ export async function messageBirdApiRequest(
 		uri: `https://rest.messagebird.com${resource}`,
 		json: true,
 	};
-
 	try {
+		if (Object.keys(body).length === 0) {
+			delete options.body;
+		}
 		return await this.helpers.request(options);
 	} catch (error) {
 		if (error.statusCode === 401) {

--- a/packages/nodes-base/nodes/MessageBird/MessageBird.node.ts
+++ b/packages/nodes-base/nodes/MessageBird/MessageBird.node.ts
@@ -1,6 +1,6 @@
 import {
 	IExecuteFunctions,
- } from 'n8n-core';
+} from 'n8n-core';
 
 import {
 	IDataObject,
@@ -44,6 +44,10 @@ export class MessageBird implements INodeType {
 						name: 'SMS',
 						value: 'sms',
 					},
+					{
+						name: 'Balance',
+						value: 'balance',
+					},
 				],
 				default: 'sms',
 				description: 'The resource to operate on.',
@@ -67,6 +71,27 @@ export class MessageBird implements INodeType {
 					},
 				],
 				default: 'send',
+				description: 'The operation to perform.',
+			},
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				displayOptions: {
+					show: {
+						resource: [
+							'balance',
+						],
+					},
+				},
+				options: [
+					{
+						name: 'Get',
+						value: 'get',
+						description: 'Get the balance',
+					},
+				],
+				default: 'get',
 				description: 'The operation to perform.',
 			},
 
@@ -269,11 +294,12 @@ export class MessageBird implements INodeType {
 		let resource: string;
 
 		// For POST
-		let bodyRequest: IDataObject;
+		let bodyRequest: IDataObject = {};
 		// For Query string
 		let qs: IDataObject;
 
 		let requestMethod;
+		let requestPath;
 
 		for (let i = 0; i < items.length; i++) {
 			qs = {};
@@ -289,6 +315,7 @@ export class MessageBird implements INodeType {
 					// ----------------------------------
 
 					requestMethod = 'POST';
+					requestPath = '/messages';
 					const originator = this.getNodeParameter('originator', i) as string;
 					const body = this.getNodeParameter('message', i) as string;
 
@@ -337,21 +364,27 @@ export class MessageBird implements INodeType {
 					}
 
 					const receivers = this.getNodeParameter('recipients', i) as string;
-
 					bodyRequest.recipients = receivers.split(',').map(item => {
+
 						return parseInt(item, 10);
 					});
-				} else {
+				}
+				else {
 					throw new Error(`The operation "${operation}" is not known!`);
 				}
-			} else {
+
+			} else if (resource === 'balance') {
+				requestMethod = 'GET';
+				requestPath = '/balance';
+			}
+			else {
 				throw new Error(`The resource "${resource}" is not known!`);
 			}
 
 			const responseData = await messageBirdApiRequest.call(
 				this,
 				requestMethod,
-				'/messages',
+				requestPath,
 				bodyRequest,
 				qs,
 			);


### PR DESCRIPTION
Hi everybody, 

So this is my first PR, not this repo and I hope I followed the contribution guidelines in the correct way. 
This PR will introduce a new feature to the Messagebird node where you can get your balance (credits) from your account.
By adding this people could send themself our customers emails/SMS/slack or team messages when the credits are below a threshold. Of course, this last part (sending messages and threshold) should be added to the workflow.
