### PR TITLE
Add support for custom AWS endpoints

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -60,7 +60,7 @@ export class Aws implements ICredentialType {
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SES using a VPC endpoint. Leave blank to use the default endpoint.',
 			type: 'string' as NodePropertyTypes,
 			default: '',
-			placeholder: 'https://ses.{region}.amazonaws.com',
+			placeholder: 'https://email.{region}.amazonaws.com',
 		},
 		{
 			displayName: 'S3 Endpoint',

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -55,6 +55,14 @@ export class Aws implements ICredentialType {
 			placeholder: 'https://sns.{region}.amazonaws.com',
 		},
 		{
+			displayName: 'SES Endpoint',
+			name: 'sesEndpoint',
+			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SES using a VPC endpoint. Leave blank to use the default endpoint.',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			placeholder: 'https://ses.{region}.amazonaws.com',
+		},
+		{
 			displayName: 'S3 Endpoint',
 			name: 's3Endpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and S3 using a VPC endpoint. Leave blank to use the default endpoint.',

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -30,5 +30,37 @@ export class Aws implements ICredentialType {
 				password: true,
 			},
 		},
+		{
+			displayName: 'Rekognition Endpoint',
+			name: 'rekognitionEndpoint',
+			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and Rekognition using a VPC endpoint. Leave blank to use the default endpoint.',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			placeholder: 'https://rekognition.{region}.amazonaws.com',
+		},
+		{
+			displayName: 'Lambda Endpoint',
+			name: 'lambdaEndpoint',
+			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and Lambda using a VPC endpoint. Leave blank to use the default endpoint.',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			placeholder: 'https://lambda.{region}.amazonaws.com',
+		},
+		{
+			displayName: 'SNS Endpoint',
+			name: 'snsEndpoint',
+			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SNS using a VPC endpoint. Leave blank to use the default endpoint.',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			placeholder: 'https://sns.{region}.amazonaws.com',
+		},
+		{
+			displayName: 'S3 Endpoint',
+			name: 's3Endpoint',
+			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and S3 using a VPC endpoint. Leave blank to use the default endpoint.',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+			placeholder: 'https://s3.{region}.amazonaws.com',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Aws/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/GenericFunctions.ts
@@ -45,14 +45,14 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	const options: OptionsWithUri = {
 		headers: signOpts.headers,
 		method,
-		uri: `https://${endpoint}${signOpts.path}`,
+		uri: new URL(signOpts.path, endpoint).href,
 		body: signOpts.body,
 	};
 
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		const errorMessage = error.response.body.message || error.response.body.Message || error.message;
+		const errorMessage = (error.response && error.response.body.message) || (error.response && error.response.body.Message) || error.message;
 
 		if (error.statusCode === 403) {
 			if (errorMessage === 'The security token included in the request is invalid.') {

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -45,7 +45,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	const options: OptionsWithUri = {
 		headers: signOpts.headers,
 		method,
-		uri: `https://${endpoint}${signOpts.path}`,
+		uri: new URL(signOpts.path, endpoint).href,
 		body: signOpts.body,
 	};
 
@@ -55,7 +55,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		const errorMessage = error.response.body.message || error.response.body.Message || error.message;
+		const errorMessage = (error.response && error.response.body.message) || (error.response && error.response.body.Message) || error.message;
 
 		if (error.statusCode === 403) {
 			if (errorMessage === 'The security token included in the request is invalid.') {

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -1,4 +1,8 @@
 import {
+	URL,
+} from 'url';
+
+import {
 	sign,
 } from 'aws4';
 
@@ -31,7 +35,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		throw new Error('No credentials got returned!');
 	}
 
-	const endpoint = `${service}.${region || credentials.region}.amazonaws.com`;
+	const endpoint = (credentials.rekognitionEndpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`;
 
 	// Sign AWS API request with the user credentials
 	const signOpts = {headers: headers || {}, host: endpoint, method, path, body};

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -35,17 +35,17 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		throw new Error('No credentials got returned!');
 	}
 
-	const endpoint = (credentials.rekognitionEndpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`;
+	const endpoint = new URL((credentials.rekognitionEndpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`);
 
 	// Sign AWS API request with the user credentials
-	const signOpts = {headers: headers || {}, host: endpoint, method, path, body};
+	const signOpts = {headers: headers || {}, host: endpoint.host, method, path, body};
 
 	sign(signOpts, { accessKeyId: `${credentials.accessKeyId}`.trim(), secretAccessKey: `${credentials.secretAccessKey}`.trim()});
 
 	const options: OptionsWithUri = {
 		headers: signOpts.headers,
 		method,
-		uri: new URL(signOpts.path, endpoint).href,
+		uri: endpoint.href,
 		body: signOpts.body,
 	};
 

--- a/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
@@ -46,7 +46,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		headers: signOpts.headers,
 		method,
 		qs: query,
-		uri: `https://${endpoint}${signOpts.path}`,
+		uri: new URL(signOpts.path, endpoint).href,
 		body: signOpts.body,
 	};
 
@@ -56,7 +56,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		const errorMessage = error.response.body.message || error.response.body.Message || error.message;
+		const errorMessage = (error.response && error.response.body.message) || (error.response && error.response.body.Message) || error.message;
 
 		if (error.statusCode === 403) {
 			if (errorMessage === 'The security token included in the request is invalid.') {

--- a/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
@@ -35,10 +35,11 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		throw new Error('No credentials got returned!');
 	}
 
-	const endpoint = (credentials.s3Endpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`;
+	const endpoint = new URL((credentials.s3Endpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`);
 
 	// Sign AWS API request with the user credentials
-	const signOpts = {headers: headers || {}, host: endpoint, method, path: `${path}?${queryToString(query).replace(/\+/g, '%2B')}`, body};
+	const signOpts = {headers: headers || {}, host: endpoint.host, method, path: `${endpoint.pathname}?${queryToString(query).replace(/\+/g, '%2B')}`, body};
+	endpoint.pathname = path;
 
 	sign(signOpts, { accessKeyId: `${credentials.accessKeyId}`.trim(), secretAccessKey: `${credentials.secretAccessKey}`.trim()});
 
@@ -46,7 +47,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		headers: signOpts.headers,
 		method,
 		qs: query,
-		uri: new URL(signOpts.path, endpoint).href,
+		uri: endpoint.href,
 		body: signOpts.body,
 	};
 

--- a/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
@@ -1,4 +1,8 @@
 import {
+	URL,
+} from 'url';
+
+import {
 	sign,
 } from 'aws4';
 
@@ -31,7 +35,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		throw new Error('No credentials got returned!');
 	}
 
-	const endpoint = `${service}.${region || credentials.region}.amazonaws.com`;
+	const endpoint = (credentials.s3Endpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`;
 
 	// Sign AWS API request with the user credentials
 	const signOpts = {headers: headers || {}, host: endpoint, method, path: `${path}?${queryToString(query).replace(/\+/g, '%2B')}`, body};

--- a/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
@@ -1,4 +1,8 @@
 import {
+	URL,
+} from 'url';
+
+import {
 	sign,
 } from 'aws4';
 
@@ -31,23 +35,24 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 		throw new Error('No credentials got returned!');
 	}
 
-	const endpoint = `${service}.${credentials.region}.amazonaws.com`;
+	const endpoint = new URL((credentials.sesEndpoint as string).replace('{region}', credentials.region as string) || `https://${service}.${credentials.region}.amazonaws.com`);
 
 	// Sign AWS API request with the user credentials
-	const signOpts = { headers: headers || {}, host: endpoint, method, path, body };
+
+	const signOpts = { headers: headers || {}, host: endpoint.host, method, path, body };
 	sign(signOpts, { accessKeyId: `${credentials.accessKeyId}`.trim(), secretAccessKey: `${credentials.secretAccessKey}`.trim() });
 
 	const options: OptionsWithUri = {
 		headers: signOpts.headers,
 		method,
-		uri: `https://${endpoint}${signOpts.path}`,
+		uri: endpoint.href,
 		body: signOpts.body,
 	};
 
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		const errorMessage = error.response.body.message || error.response.body.Message || error.message;
+		const errorMessage = (error.response && error.response.body.message) || (error.response && error.response.body.Message) || error.message;
 
 		if (error.statusCode === 403) {
 			if (errorMessage === 'The security token included in the request is invalid.') {


### PR DESCRIPTION
Adds optional, backwards-compatible property fields for specifying custom AWS service endpoints in the AWS Credentials. Based on existing node implementations, I figured the credentials data was the best place to configure these rather than at the node level. Let me know if I got that wrong and I'll move the endpoint config to the node definition instead.

The rationale for this feature is to use a VPC Endpoint for accessing AWS services without going through the public internet. This is essential for making the SNS trigger node compatible with n8n installations running on AWS VPC private subnets. The SNS service could not route packets directly to n8n in such a scenario unless we gave it a public IP, which I'd prefer to avoid in our case.

I looked around for existing tests around the code I altered, but couldn't find any - I'm doing what I can to validate my changes and ensure there are no regressions. I also noticed there's a fair bit of code duplication around the different AWS node types. In any case, I've avoided making any unnecessary code changes other than the bare minimum to add support for these custom endpoints. Although I'm happy to help clean it up a bit and add some test coverage in a separate PR if that would be welcome - let me know :)