### PR TITLE
🐛 typo: replace "Github" with "Box" in trigger description

### DIFF
--- a/packages/nodes-base/nodes/Box/BoxTrigger.node.ts
+++ b/packages/nodes-base/nodes/Box/BoxTrigger.node.ts
@@ -21,7 +21,7 @@ export class BoxTrigger implements INodeType {
 		icon: 'file:box.png',
 		group: ['trigger'],
 		version: 1,
-		description: 'Starts the workflow when a Github events occurs.',
+		description: 'Starts the workflow when a Box events occurs.',
 		defaults: {
 			name: 'Box Trigger',
 			color: '#00aeef',


### PR DESCRIPTION
This trigger probably used the Github trigger as template and forgot to replace the description.