### PR TITLE
Allowing Gmail node to send messages formatted as HTML

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
@@ -82,6 +82,44 @@ export const draftFields = [
 		description: 'The message subject.',
 	},
 	{
+		displayName: 'HTML',
+		name: 'includeHtml',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'draft',
+				],
+				operation: [
+					'create',
+				],
+			},
+		},
+		default: false,
+		description: 'Switch ON if the message should also be included as HTML.',
+	},
+	{
+		displayName: 'HTML Message',
+		name: 'htmlMessage',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				includeHtml: [
+					true,
+				],
+				resource: [
+					'draft',
+				],
+				operation: [
+					'create',
+				],
+			},
+		},
+		description: 'The HTML message body.',
+	},
+	{
 		displayName: 'Message',
 		name: 'message',
 		type: 'string',
@@ -178,33 +216,6 @@ export const draftFields = [
 				],
 				default: '',
 				description: 'Array of supported attachments to add to the message.',
-			},
-		],
-	},
-	{
-		displayName: 'Additional Options',
-		name: 'additionalOptions',
-		type: 'collection',
-		displayOptions: {
-			show: {
-				resource: [
-					'draft',
-				],
-				operation: [
-					'create',
-				],
-			},
-		},
-		default: {},
-		description: 'Additional options to the message',
-		placeholder: 'Add Option',
-		options: [
-			{
-				displayName: 'HTML content',
-				name: 'htmlContent',
-				type: 'boolean',
-				default: false,
-				description: 'Switch ON if the message is in HTML format.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
@@ -98,7 +98,7 @@ export const draftFields = [
 			},
 		},
 		placeholder: 'Hello World!',
-		description: 'The message body. This can be in HTML.',
+		description:  'The message body. If HTML formatted, then you have to add and activate the option "HTML content" in the "Additional Options" section.'
 	},
 	{
 		displayName: 'Additional Fields',

--- a/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
@@ -182,6 +182,33 @@ export const draftFields = [
 		],
 	},
 	{
+		displayName: 'Additional Options',
+		name: 'additionalOptions',
+		type: 'collection',
+		displayOptions: {
+			show: {
+				resource: [
+					'draft',
+				],
+				operation: [
+					'create',
+				],
+			},
+		},
+		default: {},
+		description: 'Additional options to the message',
+		placeholder: 'Add Option',
+		options: [
+			{
+				displayName: 'HTML content',
+				name: 'htmlContent',
+				type: 'boolean',
+				default: false,
+				description: 'Switch ON if the message is in HTML format.',
+			},
+		],
+	},
+	{
 		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',

--- a/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/DraftDescription.ts
@@ -98,7 +98,7 @@ export const draftFields = [
 			},
 		},
 		placeholder: 'Hello World!',
-		description:  'The message body. If HTML formatted, then you have to add and activate the option "HTML content" in the "Additional Options" section.'
+		description:  'The message body. If HTML formatted, then you have to add and activate the option "HTML content" in the "Additional Options" section.',
 	},
 	{
 		displayName: 'Additional Fields',

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -133,16 +133,15 @@ export async function encodeEmail(email: IEmail) {
 
 	const mailOptions = {
 		to: email.to,
-		cc : email.cc,
+		cc: email.cc,
 		bcc: email.bcc,
 		replyTo: email.inReplyTo,
 		references: email.reference,
 		subject: email.subject,
 		text: email.body,
 	} as IDataObject;
-	if (email.htmlContent) {
-		mailOptions.html = email.body;
-		mailOptions.text = removeTags(email.body);
+	if (email.htmlBody) {
+		mailOptions.html = email.htmlBody;
 	}
 
 	if (email.attachments !== undefined && Array.isArray(email.attachments) && email.attachments.length > 0) {
@@ -150,7 +149,7 @@ export async function encodeEmail(email: IEmail) {
 			filename: attachment.name,
 			content: attachment.content,
 			contentType: attachment.type,
-			encoding : 'base64',
+			encoding: 'base64',
 		}));
 
 		mailOptions.attachments = attachments;
@@ -191,14 +190,3 @@ export function extractEmail(s: string) {
 	const data = s.split('<')[1];
 	return data.substring(0, data.length - 1);
 }
-
-function removeTags(str: string | undefined) { 
-	if (!str) {
-		return false; 
-	}
-
-	// Regular expression to identify HTML tags in  
-	// the input string. Replacing the identified  
-	// HTML tag with a null string. 
-	return str.replace( /(<([^>]+)>)/ig, ''); 
-} 

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -140,6 +140,10 @@ export async function encodeEmail(email: IEmail) {
 		subject: email.subject,
 		text: email.body,
 	} as IDataObject;
+	if (email.htmlContent) {
+		mailOptions.html = email.body;
+		mailOptions.text = removeTags(email.body)
+	}
 
 	if (email.attachments !== undefined && Array.isArray(email.attachments) && email.attachments.length > 0) {
 		const attachments = email.attachments.map((attachment) => ({
@@ -187,3 +191,13 @@ export function extractEmail(s: string) {
 	const data = s.split('<')[1];
 	return data.substring(0, data.length - 1);
 }
+
+function removeTags(str: string | undefined) { 
+    if (!str) 
+        return false; 
+          
+    // Regular expression to identify HTML tags in  
+    // the input string. Replacing the identified  
+    // HTML tag with a null string. 
+    return str.replace( /(<([^>]+)>)/ig, ''); 
+} 

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -142,7 +142,7 @@ export async function encodeEmail(email: IEmail) {
 	} as IDataObject;
 	if (email.htmlContent) {
 		mailOptions.html = email.body;
-		mailOptions.text = removeTags(email.body)
+		mailOptions.text = removeTags(email.body);
 	}
 
 	if (email.attachments !== undefined && Array.isArray(email.attachments) && email.attachments.length > 0) {
@@ -193,11 +193,12 @@ export function extractEmail(s: string) {
 }
 
 function removeTags(str: string | undefined) { 
-    if (!str) 
-        return false; 
-          
-    // Regular expression to identify HTML tags in  
-    // the input string. Replacing the identified  
-    // HTML tag with a null string. 
-    return str.replace( /(<([^>]+)>)/ig, ''); 
+	if (!str) {
+		return false; 
+	}
+
+	// Regular expression to identify HTML tags in  
+	// the input string. Replacing the identified  
+	// HTML tag with a null string. 
+	return str.replace( /(<([^>]+)>)/ig, ''); 
 } 

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
@@ -52,8 +52,8 @@ export interface IEmail {
 	reference?: string;
 	subject: string;
 	body: string;
+	htmlBody?: string;
 	attachments?: IDataObject[];
-	htmlContent?: boolean;
 }
 
 interface IAttachments {
@@ -261,7 +261,6 @@ export class Gmail implements INodeType {
 					// https://developers.google.com/gmail/api/v1/reference/users/messages/send
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
-					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -325,8 +324,11 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
-						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
+
+					if (this.getNodeParameter('includeHtml', i, false) as boolean === true) {
+						email.htmlBody = this.getNodeParameter('htmlMessage', i) as string;
+					}
 
 					endpoint = '/gmail/v1/users/me/messages/send';
 					method = 'POST';
@@ -342,7 +344,6 @@ export class Gmail implements INodeType {
 					const id = this.getNodeParameter('messageId', i) as string;
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
-					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -422,8 +423,11 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
-						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
+
+					if (this.getNodeParameter('includeHtml', i, false) as boolean === true) {
+						email.htmlBody = this.getNodeParameter('htmlMessage', i) as string;
+					}
 
 					endpoint = '/gmail/v1/users/me/messages/send';
 					method = 'POST';
@@ -558,7 +562,6 @@ export class Gmail implements INodeType {
 					// https://developers.google.com/gmail/api/v1/reference/users/drafts/create
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
-					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -624,8 +627,11 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
-						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
+
+					if (this.getNodeParameter('includeHtml', i, false) as boolean === true) {
+						email.htmlBody = this.getNodeParameter('htmlMessage', i) as string;
+					}
 
 					endpoint = '/gmail/v1/users/me/drafts';
 					method = 'POST';

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
@@ -53,6 +53,7 @@ export interface IEmail {
 	subject: string;
 	body: string;
 	attachments?: IDataObject[];
+	htmlContent?: boolean;
 }
 
 interface IAttachments {
@@ -260,6 +261,7 @@ export class Gmail implements INodeType {
 					// https://developers.google.com/gmail/api/v1/reference/users/messages/send
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -323,6 +325,7 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
+						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
 
 					endpoint = '/gmail/v1/users/me/messages/send';
@@ -339,6 +342,7 @@ export class Gmail implements INodeType {
 					const id = this.getNodeParameter('messageId', i) as string;
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -418,6 +422,7 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
+						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
 
 					endpoint = '/gmail/v1/users/me/messages/send';
@@ -553,6 +558,7 @@ export class Gmail implements INodeType {
 					// https://developers.google.com/gmail/api/v1/reference/users/drafts/create
 
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+					const additionalOptions = this.getNodeParameter('additionalOptions', i) as IDataObject;
 
 					let toStr = '';
 					let ccStr = '';
@@ -618,6 +624,7 @@ export class Gmail implements INodeType {
 						subject: this.getNodeParameter('subject', i) as string,
 						body: this.getNodeParameter('message', i) as string,
 						attachments: attachmentsList,
+						htmlContent: additionalOptions.htmlContent ? true : false,
 					};
 
 					endpoint = '/gmail/v1/users/me/drafts';

--- a/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
@@ -143,7 +143,7 @@ export const messageFields = [
 			},
 		},
 		placeholder: 'Hello World!',
-		description: 'The message body. This can be in HTML.',
+		description: 'The message body. If HTML formatted, then you have to add and activate the option "HTML content" in the "Additional Options" section.',
 	},
 	{
 		displayName: 'To Email',

--- a/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
@@ -126,6 +126,46 @@ export const messageFields = [
 		description: 'The message subject.',
 	},
 	{
+		displayName: 'HTML',
+		name: 'includeHtml',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'send',
+					'reply',
+				],
+			},
+		},
+		default: false,
+		description: 'Switch ON if the message should also be included as HTML.',
+	},
+	{
+		displayName: 'HTML Message',
+		name: 'htmlMessage',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				includeHtml: [
+					true,
+				],
+				resource: [
+					'message',
+				],
+				operation: [
+					'reply',
+					'send',
+				],
+			},
+		},
+		description: 'The HTML message body.',
+	},
+	{
 		displayName: 'Message',
 		name: 'message',
 		type: 'string',
@@ -142,8 +182,7 @@ export const messageFields = [
 				],
 			},
 		},
-		placeholder: 'Hello World!',
-		description: 'The message body. If HTML formatted, then you have to add and activate the option "HTML content" in the "Additional Options" section.',
+		description: 'Plain text message body.',
 	},
 	{
 		displayName: 'To Email',
@@ -236,34 +275,6 @@ export const messageFields = [
 				],
 				default: '',
 				description: 'Array of supported attachments to add to the message.',
-			},
-		],
-	},
-	{
-		displayName: 'Additional Options',
-		name: 'additionalOptions',
-		type: 'collection',
-		displayOptions: {
-			show: {
-				resource: [
-					'message',
-				],
-				operation: [
-					'send',
-					'reply',
-				],
-			},
-		},
-		default: {},
-		description: 'Additional options to the message',
-		placeholder: 'Add Option',
-		options: [
-			{
-				displayName: 'HTML content',
-				name: 'htmlContent',
-				type: 'boolean',
-				default: false,
-				description: 'Switch ON if the message is in HTML format.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/MessageDescription.ts
@@ -240,6 +240,34 @@ export const messageFields = [
 		],
 	},
 	{
+		displayName: 'Additional Options',
+		name: 'additionalOptions',
+		type: 'collection',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'send',
+					'reply',
+				],
+			},
+		},
+		default: {},
+		description: 'Additional options to the message',
+		placeholder: 'Add Option',
+		options: [
+			{
+				displayName: 'HTML content',
+				name: 'htmlContent',
+				type: 'boolean',
+				default: false,
+				description: 'Switch ON if the message is in HTML format.',
+			},
+		],
+	},
+	{
 		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',


### PR DESCRIPTION
Create an optional setting that switches on HTML formatting.
This was done to keep backwards compatibility with previous deployments as it would cause the text to become a single liner.