### PR TITLE
⚡Fetch observable data types from TheHive API

### DIFF
--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -195,6 +195,50 @@ export class TheHive implements INodeType {
 				];
 				return options;
 			},
+			async loadObservableTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const endpoint = version === 'v1' ? '/observable/type?range=all' : '/list/list_artifactDataType';
+
+				const dataTypes = await theHiveApiRequest.call(
+					this,
+					'GET',
+					endpoint as string,
+				);
+				
+				let returnData: INodePropertyOptions[] = [];
+
+				if (version === 'v1') {
+					returnData = dataTypes.map((dataType: IDataObject) => {
+						return {
+							name: dataType.name as string,
+							value: dataType.name as string,
+						};
+					});
+				}
+				else {
+					returnData = Object.keys(dataTypes).map(key => {
+						const dataType = dataTypes[key] as string;
+						
+						return {
+							name: dataType,
+							value: dataType,
+						};
+					});
+				}
+
+				// Sort the array by option name
+				returnData.sort((a, b) => {
+					if (a.name < b.name) {
+						return -1;
+					}
+					if (a.name > b.name) {
+						return 1;
+					}
+					return 0;
+				});
+
+				return returnData;
+			},
 			async loadTaskOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const version = this.getCredentials('theHiveApi')?.apiVersion;
 				const options = [

--- a/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/AlertDescription.ts
@@ -385,21 +385,10 @@ export const alertFields = [
 						name: 'dataType',
 						type: 'options',
 						default: '',
-						options: [
-							{
-								name: 'IP',
-								value: 'ip',
-							},
-							{
-								name: 'Domain',
-								value: 'domain',
-							},
-							{
-								name: 'File',
-								value: 'file',
-							},
-						],
-						description: '',
+						typeOptions: {
+							loadOptionsMethod: 'loadObservableTypes',
+						},
+						description: 'Type of the observable',
 					},
 					{
 						displayName: 'Data',
@@ -543,20 +532,10 @@ export const alertFields = [
 								name: 'dataType',
 								type: 'options',
 								default: '',
-								options: [
-									{
-										name: 'IP',
-										value: 'ip',
-									},
-									{
-										name: 'Domain',
-										value: 'domain',
-									},
-									{
-										name: 'File',
-										value: 'file',
-									},
-								],
+								typeOptions: {
+									loadOptionsMethod: 'loadObservableTypes',
+								},
+								description: 'Type of the observable',
 							},
 							{
 								displayName: 'Data',

--- a/packages/nodes-base/nodes/TheHive/descriptions/ObservableDescription.ts
+++ b/packages/nodes-base/nodes/TheHive/descriptions/ObservableDescription.ts
@@ -120,64 +120,9 @@ export const observableFields = [
 		type: 'options',
 		required: true,
 		default: '',
-		options: [
-			{
-				name: 'domain',
-				value: 'domain',
-			},
-			{
-				name: 'file',
-				value: 'file',
-			},
-			{
-				name: 'filename',
-				value: 'filename',
-			},
-			{
-				name: 'fqdn',
-				value: 'fqdn',
-			},
-			{
-				name: 'hash',
-				value: 'hash',
-			},
-			{
-				name: 'ip',
-				value: 'ip',
-			},
-			{
-				name: 'mail',
-				value: 'mail',
-			},
-			{
-				name: 'mail_subject',
-				value: 'mail_subject',
-			},
-			{
-				name: 'other',
-				value: 'other',
-			},
-			{
-				name: 'regexp',
-				value: 'regexp',
-			},
-			{
-				name: 'registry',
-				value: 'registry',
-			},
-			{
-				name: 'uri_path',
-				value: 'uri_path',
-			},
-			{
-				name: 'url',
-				value: 'url',
-			},
-			{
-				name: 'user-agent',
-				value: 'user-agent',
-			},
-		],
+		typeOptions: {
+			loadOptionsMethod: 'loadObservableTypes',
+		},
 		displayOptions: {
 			show: {
 				resource: [
@@ -604,64 +549,9 @@ export const observableFields = [
 				name: 'dataType',
 				type: 'multiOptions',
 				default: [],
-				options: [
-					{
-						name: 'domain',
-						value: 'domain',
-					},
-					{
-						name: 'file',
-						value: 'file',
-					},
-					{
-						name: 'filename',
-						value: 'filename',
-					},
-					{
-						name: 'fqdn',
-						value: 'fqdn',
-					},
-					{
-						name: 'hash',
-						value: 'hash',
-					},
-					{
-						name: 'ip',
-						value: 'ip',
-					},
-					{
-						name: 'mail',
-						value: 'mail',
-					},
-					{
-						name: 'mail_subject',
-						value: 'mail_subject',
-					},
-					{
-						name: 'other',
-						value: 'other',
-					},
-					{
-						name: 'regexp',
-						value: 'regexp',
-					},
-					{
-						name: 'registry',
-						value: 'registry',
-					},
-					{
-						name: 'uri_path',
-						value: 'uri_path',
-					},
-					{
-						name: 'url',
-						value: 'url',
-					},
-					{
-						name: 'user-agent',
-						value: 'user-agent',
-					},
-				],
+				typeOptions: {
+					loadOptionsMethod: 'loadObservableTypes',
+				},
 				description: 'Type of the observable',
 			},
 			{


### PR DESCRIPTION
This pull request makes the TheHive node load observable data types from the TheHive API. Users can create (and delete) observable data types in TheHive, so this is the best way to show them in the options menu. Fixes #1225 