### PR TITLE
fixed #1233 #1240 EACCES: permission denied

### DIFF
--- a/docker/images/n8n-rpi/Dockerfile
+++ b/docker/images/n8n-rpi/Dockerfile
@@ -15,6 +15,5 @@ ENV NODE_ENV production
 
 WORKDIR /data
 
-USER node
-
-CMD n8n
+CMD chown -R node:node /home/node/.n8n \
+&& gosu node n8n


### PR DESCRIPTION
This problem happens when the user is not the first user (uid=1000). When using raspberry pi, we often don't use the default user `pi` due to security reason, so we got 1001 or other uid.  
The work around 1 is running as root inside container. However I respect that you want to run it as non-root user, so here's work around 2:  
Change the permission when the container first run, and run n8n as user node.  
  
It would be a little bit weird for the permissions of the mount folder for host(1000:1000). But users don't have to do extra steps before deploying the docker container (`sudo chown -R 1000:1000 ~/.n8n` or something like that).