### PR TITLE
538 add support for casting types in postgres

### DIFF
--- a/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
@@ -109,21 +109,36 @@ export async function pgUpdate(
 	const updateKey = getNodeParam('updateKey', 0) as string;
 	const columnString = getNodeParam('columns', 0) as string;
 
-	const columns = columnString.split(',').map(column => column.trim());
+	const updateColumnParts = updateKey.split(':');
+	const updateColumn = {
+		name: updateColumnParts[0],
+		cast: updateColumnParts[1]
+	};
+
+	const columns = columnString.split(',')
+		.map(column => column.trim().split(':'))
+		.map(([name, cast]) => ({name, cast}));
 
 	const te = new pgp.helpers.TableName({ table, schema });
 
 	// Make sure that the updateKey does also get queried
-	if (!columns.includes(updateKey)) {
-		columns.unshift(updateKey);
+	const targetCol = columns.find((column) => column.name === updateColumn.name);
+	if (!targetCol) {
+		columns.unshift(updateColumn);
+	}
+	else if (!targetCol.cast) {
+		targetCol.cast = updateColumn.cast || targetCol.cast;
 	}
 
 	// Prepare the data to update and copy it to be returned
-	const updateItems = getItemCopy(items, columns);
+	const columnNames = columns.map(column => column.name);
+	const updateItems = getItemCopy(items, columnNames);
+
+	const columnSet = new pgp.helpers.ColumnSet(columns);
 
 	// Generate the multi-row update query
 	const query =
-		pgp.helpers.update(updateItems, columns, te) + ' WHERE v.' + updateKey + ' = t.' + updateKey;
+		pgp.helpers.update(updateItems, columnSet, te) + ' WHERE v.' + updateColumn.name + ' = t.' + updateColumn.name;
 
 	// Executing the query to update the data
 	await db.none(query);

--- a/packages/nodes-base/test/nodes/Postgres/Postgres.node.functions.test.js
+++ b/packages/nodes-base/test/nodes/Postgres/Postgres.node.functions.test.js
@@ -1,0 +1,104 @@
+const PostgresFun = require('../../../nodes/Postgres/Postgres.node.functions')
+const pgPromise = require('pg-promise');
+
+describe('pgUpdate', () => {
+	it('runs query to update db', async () => {
+		const updateItem = {id: 1234, name: 'test'};
+		const nodeParams = {
+			table: 'mytable',
+			schema: 'myschema',
+			updateKey: 'id',
+			columns: 'id,name'
+		};
+		const getNodeParam = (key) => nodeParams[key];
+		const pgp = pgPromise();
+		const none = jest.fn();
+		const db = {none};
+
+		const items = [
+			{
+				json: updateItem
+			}
+		];
+
+		const results = await PostgresFun.pgUpdate(getNodeParam, pgp, db, items)
+
+		expect(db.none).toHaveBeenCalledWith(`update \"myschema\".\"mytable\" as t set \"id\"=v.\"id\",\"name\"=v.\"name\" from (values(1234,'test')) as v(\"id\",\"name\") WHERE v.id = t.id`);
+		expect(results).toEqual([updateItem]);
+	});
+
+	it('runs query to update db if updateKey is not in columns', async () => {
+		const updateItem = {id: 1234, name: 'test'};
+		const nodeParams = {
+			table: 'mytable',
+			schema: 'myschema',
+			updateKey: 'id',
+			columns: 'name'
+		};
+		const getNodeParam = (key) => nodeParams[key];
+		const pgp = pgPromise();
+		const none = jest.fn();
+		const db = {none};
+
+		const items = [
+			{
+				json: updateItem
+			}
+		];
+
+		const results = await PostgresFun.pgUpdate(getNodeParam, pgp, db, items)
+
+		expect(db.none).toHaveBeenCalledWith(`update \"myschema\".\"mytable\" as t set \"id\"=v.\"id\",\"name\"=v.\"name\" from (values(1234,'test')) as v(\"id\",\"name\") WHERE v.id = t.id`);
+		expect(results).toEqual([updateItem]);
+	});
+
+	it('runs query to update db with cast as updateKey', async () => {
+		const updateItem = {id: '1234', name: 'test'};
+		const nodeParams = {
+			table: 'mytable',
+			schema: 'myschema',
+			updateKey: 'id:uuid',
+			columns: 'name'
+		};
+		const getNodeParam = (key) => nodeParams[key];
+		const pgp = pgPromise();
+		const none = jest.fn();
+		const db = {none};
+
+		const items = [
+			{
+				json: updateItem
+			}
+		];
+
+		const results = await PostgresFun.pgUpdate(getNodeParam, pgp, db, items)
+
+		expect(db.none).toHaveBeenCalledWith(`update \"myschema\".\"mytable\" as t set \"id\"=v.\"id\",\"name\"=v.\"name\" from (values('1234'::uuid,'test')) as v(\"id\",\"name\") WHERE v.id = t.id`);
+		expect(results).toEqual([updateItem]);
+	});
+
+	it('runs query to update db with cast in target columns', async () => {
+		const updateItem = {id: '1234', name: 'test'};
+		const nodeParams = {
+			table: 'mytable',
+			schema: 'myschema',
+			updateKey: 'id',
+			columns: 'id:uuid,name'
+		};
+		const getNodeParam = (key) => nodeParams[key];
+		const pgp = pgPromise();
+		const none = jest.fn();
+		const db = {none};
+
+		const items = [
+			{
+				json: updateItem
+			}
+		];
+
+		const results = await PostgresFun.pgUpdate(getNodeParam, pgp, db, items)
+
+		expect(db.none).toHaveBeenCalledWith(`update \"myschema\".\"mytable\" as t set \"id\"=v.\"id\",\"name\"=v.\"name\" from (values('1234'::uuid,'test')) as v(\"id\",\"name\") WHERE v.id = t.id`);
+		expect(results).toEqual([updateItem]);
+	});
+});


### PR DESCRIPTION
- this is POC to add type casting to columns in Postgres node (as such it's WIP)
- supports casting any Postgres supported data types in both updateKey and target columns
- logs error if type is unknown
- backward compatible 
- add tests to verify previous behavior and new behavior (in JS, struggled to mock effectively with typescript 😞 still looking into this) 
- if you guys like this approach, I can continue to add type casting to insert query as well and update documentation. Feel free to provide any feedback.

<img width="785" alt="Screen Shot 2021-01-01 at 5 49 45 PM" src="https://user-images.githubusercontent.com/4711238/103442023-0b48fe00-4c5b-11eb-84e2-29f2180b5f09.png">
<img width="1280" alt="Screen Shot 2021-01-01 at 5 51 25 PM" src="https://user-images.githubusercontent.com/4711238/103441996-d76dd880-4c5a-11eb-914f-18ff0f09884c.png">


example workflow tested against
```
{
  "name": "",
  "nodes": [
    {
      "parameters": {},
      "name": "Start",
      "type": "n8n-nodes-base.start",
      "typeVersion": 1,
      "position": [
        250,
        300
      ]
    },
    {
      "parameters": {
        "values": {
          "string": [
            {
              "name": "name",
              "value": "hello"
            },
            {
              "name": "id",
              "value": "666693d8-8aae-4e0a-a25e-1c98cbb5cded"
            }
          ]
        },
        "options": {}
      },
      "name": "Set",
      "type": "n8n-nodes-base.set",
      "typeVersion": 1,
      "position": [
        450,
        300
      ]
    },
    {
      "parameters": {
        "operation": "update",
        "table": "test1",
        "updateKey": "id:uuid",
        "columns": "name"
      },
      "name": "Postgres",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 1,
      "position": [
        650,
        300
      ],
      "credentials": {
        "postgres": "postgresdb"
      }
    }
  ],
  "connections": {
    "Start": {
      "main": [
        [
          {
            "node": "Set",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Set": {
      "main": [
        [
          {
            "node": "Postgres",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "active": false,
  "settings": {}
}
```