### PR TITLE
Hue Node: Add Room/Group Name to Light Name

### DIFF
--- a/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
@@ -77,9 +77,23 @@ export class PhilipsHue implements INodeType {
 					'GET',
 					`/bridge/${user}/lights`,
 				);
+				
+				const groups = await philipsHueApiRequest.call(
+					this,
+					'GET',
+					`/bridge/${user}/groups`,
+				);
+
 				for (const light of Object.keys(lights)) {
-					const lightName = lights[light].name;
+					let lightName = lights[light].name;
 					const lightId = light;
+					
+					for (const groupId of Object.keys(groups)) {
+						if(groups[groupId].type == "Room" && groups[groupId].lights.includes(lightId)) {
+							lightName = groups[groupId].name + ": " + lightName
+						}
+					}
+					
 					returnData.push({
 						name: lightName,
 						value: lightId,


### PR DESCRIPTION
To easier identify lights in the dropdown it is useful to know to which group (room) they belong, especially if they have the same name.
While lights can be added to multiple zones, they can only ever belong to one room.

Example:
<img src="https://user-images.githubusercontent.com/19166967/103444306-93cd9b80-4c67-11eb-8906-7fea1d8d7497.png" height="200">