### PR TITLE
Fixed batch sizing to work when batchSize = 1

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -656,7 +656,7 @@ export class HttpRequest implements INodeType {
 			if (itemIndex > 0 && options.batchSize as number >= 0 && options.batchInterval as number > 0) {
 				// defaults batch size to 1 of it's set to 0
 				const batchSize: number = options.batchSize as number > 0 ? options.batchSize as number : 1;
-				if (itemIndex % batchSize === 1) {
+				if (itemIndex % batchSize === 0) {
 					await new Promise(resolve => setTimeout(resolve, options.batchInterval as number));
 				}
 			}


### PR DESCRIPTION
This PR solves a bug reported by issue https://github.com/n8n-io/n8n/issues/1308

Tested with batch sizes of 0 (overriden to 1), 1, 3 and 5. All working fine. Correctness was assessed using webhook.site.

For batchSize 0 or 1 it would fire all requests at once (immediately). This PR fixes this.