### PR TITLE
[BREAKING CHANGE] Typeform trigger fix for variables

### DIFF
--- a/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
+++ b/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
@@ -217,7 +217,7 @@ export class TypeformTrigger implements INodeType {
 			// Create a dictionary to get the field title by its ID
 			const defintitionsById: { [key: string]: string; } = {};
 			for (const field of definition.fields) {
-				defintitionsById[field.id] = field.title;
+				defintitionsById[field.id] = field.title.replace(/\{\{/g, "[").replace(/\}\}/g, "]");
 			}
 
 			// Convert the answers to key -> value pair


### PR DESCRIPTION
Typeform trigger node now translates double curly brackets to single square brackets on variables.

This might break previous deployments that reference the previously used names.

This issue was described in this video: https://www.loom.com/share/0f9a1011863440d88e9df9596fbd6343