### PR TITLE
🐛 fix for same name rename

### DIFF
--- a/packages/nodes-base/nodes/RenameKeys.node.ts
+++ b/packages/nodes-base/nodes/RenameKeys.node.ts
@@ -96,8 +96,8 @@ export class RenameKeys implements INodeType {
 			}
 
 			renameKeys.forEach((renameKey) => {
-				if (renameKey.currentKey === '' || renameKey.newKey === '') {
-					// Ignore all which do not have all the values set
+				if (renameKey.currentKey === '' || renameKey.newKey === '' || renameKey.currentKey === renameKey.newKey) {
+					// Ignore all which do not have all the values set or if the new key is equal to the current key
 					return;
 				}
 				value = get(item.json, renameKey.currentKey as string);


### PR DESCRIPTION
If you rename to the same name, it just gets removed. This should not be the case.