### PR TITLE
Add data-node-name to node item

### DIFF
--- a/packages/editor-ui/src/components/NodeCreateItem.vue
+++ b/packages/editor-ui/src/components/NodeCreateItem.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="node-item clickable" :class="{active: active}" @click="nodeTypeSelected(nodeType)">
+	<div class="node-item clickable" :class="{active: active}" :data-node-name="nodeName" @click="nodeTypeSelected(nodeType)">
 		<NodeIcon class="node-icon" :nodeType="nodeType" :style="nodeIconStyle" />
 		<div class="name">
 			{{nodeType.displayName}}
@@ -32,6 +32,9 @@ export default Vue.extend({
 			return {
 				color: this.nodeType.defaults.color,
 			};
+		},
+		nodeName (): string {
+			return this.nodeType.name.replace("n8n-nodes-base.", "");
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/NodeCreateItem.vue
+++ b/packages/editor-ui/src/components/NodeCreateItem.vue
@@ -34,7 +34,7 @@ export default Vue.extend({
 			};
 		},
 		nodeName (): string {
-			return this.nodeType.name.replace("n8n-nodes-base.", "");
+			return this.nodeType.name;
 		},
 	},
 	methods: {


### PR DESCRIPTION
This PR adds a unique `data-node-name` attribute to each `.node-item` in the right-hand nodes panel, so that we can attach a tooltip to this unique element in Appcues flows.