### PR TITLE
Improve building docker image performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+packages/*/node_modules
+packages/*/dist


### PR DESCRIPTION
To increase the build’s performance, exclude some directories and files like `node_modules` by adding a .dockerignore file to the context directory.