### PR TITLE
Fix default value for Send Notification Email option in Google Drive node

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -979,7 +979,7 @@ export class GoogleDrive implements INodeType {
 								],
 							},
 						},
-						default: '',
+						default: false,
 						description: 'Whether to send a notification email when sharing to users or groups',
 					},
 					{


### PR DESCRIPTION
PR for #1354.

Re: feature request, `allowFileDiscovery` is already implemented but only visible for permission types `domain` and `anyone`.

> allowFileDiscovery boolean Whether the permission allows the file to be discovered through search. This is only applicable for permissions of type domain or anyone. [Source](https://developers.google.com/drive/api/v3/reference/permissions)

![image](https://user-images.githubusercontent.com/44588767/105070157-a61a4880-5a61-11eb-8154-27c9f0a3f092.png)
