### PR TITLE
Fix channel select box for post, postEphemeral

### DIFF
--- a/packages/nodes-base/nodes/Slack/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/MessageDescription.ts
@@ -43,8 +43,11 @@ export const messageFields = [
 	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Channel',
-		name: 'channel',
-		type: 'string',
+		name: 'channelId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
 		default: '',
 		placeholder: 'Channel name',
 		displayOptions: {

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -515,7 +515,7 @@ export class Slack implements INodeType {
 			if (resource === 'message') {
 				//https://api.slack.com/methods/chat.postMessage
 				if (['post', 'postEphemeral'].includes(operation)) {
-					const channel = this.getNodeParameter('channel', i) as string;
+					const channel = this.getNodeParameter('channelId', i) as string;
 					const { sendAsUser } = this.getNodeParameter('otherOptions', i) as IDataObject;
 					const text = this.getNodeParameter('text', i) as string;
 					const body: IDataObject = {


### PR DESCRIPTION
in Slack node

```
Resource: Message
Operation: Post or Post(Ephemeral)
```

Actual: The `Channel` Field type is string
Expects:  The `Channel` Field type is options as the same as `Operation: Update`

