### PR TITLE
Add chat.getPermalink interface in Slack Nodes.

### DIFF
--- a/packages/nodes-base/nodes/Slack/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/MessageDescription.ts
@@ -30,6 +30,11 @@ export const messageOperations = [
 				value: 'update',
 				description: 'Updates a message.',
 			},
+			{
+				name: 'GetPermalink',
+				value: 'getPermalink',
+				description: 'Get Permanent Link of a message',
+			},
 		],
 		default: 'post',
 		description: 'The operation to perform.',
@@ -1630,5 +1635,48 @@ export const messageFields = [
 				],
 			},
 		],
+	},
+
+	/* ----------------------------------------------------------------------- */
+	/*                                 message:getPermaLink
+	/* ----------------------------------------------------------------------- */
+	{
+		displayName: 'Channel',
+		name: 'channelId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+		},
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'getPermalink',
+				],
+			},
+		},
+		description: 'Channel containing the message to be updated.',
+	},
+	{
+		displayName: 'TS',
+		name: 'messageTs',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'message',
+				],
+				operation: [
+					'getPermalink',
+				],
+			},
+		},
+		description: `Timestamp of the message to get permanent link.`,
 	},
 ] as INodeProperties[];

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -795,6 +795,13 @@ export class Slack implements INodeType {
 					Object.assign(body, updateFields);
 					responseData = await slackApiRequest.call(this, 'POST', '/chat.update', body, qs);
 				}
+				//https://api.slack.com/methods/chat.getPermalink
+				if (operation === 'getPermalink') {
+					const channel = this.getNodeParameter('channelId', i) as string;
+					const ts = this.getNodeParameter('messageTs', i) as string;
+				    const qs = { channel: channel, message_ts: ts };
+					responseData = await slackApiRequest.call(this, 'GET', '/chat.getPermalink', {}, qs);
+				}
 			}
 			if (resource === 'reaction') {
 				const channel = this.getNodeParameter('channelId', i) as string;


### PR DESCRIPTION
Add `chat.getPermalink` Slack API 
https://api.slack.com/methods/chat.getPermalink
> Easily exchange a message timestamp and a channel ID for a friendly HTTP-based permalink to that message. Handles message threads and all conversation types.


```
Resource: Message
Operation: GetPermalink
```