### PR TITLE
Fix Google Drive delete and share

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -2067,7 +2067,8 @@ export class GoogleDrive implements INodeType {
 
 					returnData.push(response as IDataObject);
 				}
-			} else if (['file', 'folder'].includes(resource)) {
+			}
+			if (['file', 'folder'].includes(resource)) {
 				if (operation === 'delete') {
 					// ----------------------------------
 					//         delete

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -530,10 +530,10 @@ export class GoogleDrive implements INodeType {
 					show: {
 						resource: [
 							'file',
+							'folder',
 						],
 						operation: [
 							'share',
-							'folder',
 						],
 					},
 				},


### PR DESCRIPTION
This PR fixes: 
- delete and share for files and folders, which fail silently, and
- share for folders, which lack permissions.

See [this comment](https://github.com/n8n-io/n8n/issues/1354#issuecomment-767931389).