### PR TITLE
✨ Add INSERT modifiers support in mySQL node

### DIFF
--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -99,20 +99,6 @@ export class MySql implements INodeType {
 				description: 'Name of the table in which to insert data to.',
 			},
 			{
-				displayName: 'Ignore Errors',
-				name: 'ignoreErrors',
-				type: 'boolean',
-				displayOptions: {
-					show: {
-						operation: [
-							'insert',
-						],
-					},
-				},
-				default: false,
-				description: 'Ignore any ignorable errors that occur while executing the INSERT statement.',
-			},
-			{
 				displayName: 'Columns',
 				name: 'columns',
 				type: 'string',
@@ -126,6 +112,49 @@ export class MySql implements INodeType {
 				default: '',
 				placeholder: 'id,name,description',
 				description: 'Comma separated list of the properties which should used as columns for the new rows.',
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				displayOptions: {
+					show: {
+						operation: [
+							'insert',
+						],
+					},
+				},
+				default: {},
+				placeholder: 'Add modifiers',
+				description: 'Modifiers for INSERT statement.',
+				options: [
+					{
+						displayName: 'Ignore',
+						name: 'ignore',
+						type: 'boolean',
+						default: true,
+						description: 'Ignore any ignorable errors that occur while executing the INSERT statement.',
+					},
+					{
+						displayName: 'Priority',
+						name: 'priority',
+						type: 'options',
+						options: [
+							{
+								name: 'Low Prioirity',
+								value: 'LOW_PRIORITY',
+								description: 'Delays execution of the INSERT until no other clients are reading from the table.',
+							},
+							{
+								name: 'High Priority',
+								value: 'HIGH_PRIORITY',
+								description: 'Overrides the effect of the --low-priority-updates option if the server was started with that option. It also causes concurrent inserts not to be used.',
+							},
+						],
+						default: 'LOW_PRIORITY',
+						description: 'Ignore any ignorable errors that occur while executing the INSERT statement.',
+					},
+				],
 			},
 
 
@@ -230,9 +259,13 @@ export class MySql implements INodeType {
 			const columns = columnString.split(',').map(column => column.trim());
 			const insertItems = copyInputItems(items, columns);
 			const insertPlaceholder = `(${columns.map(column => '?').join(',')})`;
-			const insertIgnore = this.getNodeParameter('ignoreErrors', 0) as boolean;
-			const insertSQL = `INSERT ${insertIgnore ? 'IGNORE' : ''} INTO ${table}(${columnString}) VALUES ${items.map(item => insertPlaceholder).join(',')};`;
+			const options = this.getNodeParameter('options', 0) as IDataObject;
+			const insertIgnore = options.ignore as boolean;
+			const insertPriority = options.priority as string;
+
+			const insertSQL = `INSERT ${insertPriority || ''} ${insertIgnore ? 'IGNORE' : ''} INTO ${table}(${columnString}) VALUES ${items.map(item => insertPlaceholder).join(',')};`;
 			const queryItems = insertItems.reduce((collection, item) => collection.concat(Object.values(item as any)), []); // tslint:disable-line:no-any
+			
 			const queryResult = await connection.query(insertSQL, queryItems);
 
 			returnItems = this.helpers.returnJsonArray(queryResult[0] as IDataObject);

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -47,6 +47,11 @@ export class MySql implements INodeType {
 						description: 'Insert rows in database.',
 					},
 					{
+						name: 'Insert Ignore',
+						value: 'insert ignore',
+						description: 'Insert rows in database, ignoring any errors.',
+					},
+					{
 						name: 'Update',
 						value: 'update',
 						description: 'Update rows in database.',
@@ -106,6 +111,40 @@ export class MySql implements INodeType {
 					show: {
 						operation: [
 							'insert',
+						],
+					},
+				},
+				default: '',
+				placeholder: 'id,name,description',
+				description: 'Comma separated list of the properties which should used as columns for the new rows.',
+			},
+			
+			// ----------------------------------
+			//         insert ignore
+			// ----------------------------------
+			{
+				displayName: 'Table',
+				name: 'table',
+				type: 'string',
+				displayOptions: {
+					show: {
+						operation: [
+							'insert ignore',
+						],
+					},
+				},
+				default: '',
+				required: true,
+				description: 'Name of the table in which to insert data to.',
+			},
+			{
+				displayName: 'Columns',
+				name: 'columns',
+				type: 'string',
+				displayOptions: {
+					show: {
+						operation: [
+							'insert ignore',
 						],
 					},
 				},
@@ -217,6 +256,22 @@ export class MySql implements INodeType {
 			const insertItems = copyInputItems(items, columns);
 			const insertPlaceholder = `(${columns.map(column => '?').join(',')})`;
 			const insertSQL = `INSERT INTO ${table}(${columnString}) VALUES ${items.map(item => insertPlaceholder).join(',')};`;
+			const queryItems = insertItems.reduce((collection, item) => collection.concat(Object.values(item as any)), []); // tslint:disable-line:no-any
+			const queryResult = await connection.query(insertSQL, queryItems);
+
+			returnItems = this.helpers.returnJsonArray(queryResult[0] as IDataObject);
+
+		} else if (operation === 'insert ignore') {
+			// ----------------------------------
+			//         insert
+			// ----------------------------------
+
+			const table = this.getNodeParameter('table', 0) as string;
+			const columnString = this.getNodeParameter('columns', 0) as string;
+			const columns = columnString.split(',').map(column => column.trim());
+			const insertItems = copyInputItems(items, columns);
+			const insertPlaceholder = `(${columns.map(column => '?').join(',')})`;
+			const insertSQL = `INSERT IGNORE INTO ${table}(${columnString}) VALUES ${items.map(item => insertPlaceholder).join(',')};`;
 			const queryItems = insertItems.reduce((collection, item) => collection.concat(Object.values(item as any)), []); // tslint:disable-line:no-any
 			const queryResult = await connection.query(insertSQL, queryItems);
 


### PR DESCRIPTION
Allow for insert ignore - useful if you are wanting to insert data into an already established table with unique ids.