### PR TITLE
Fix an issue with the regex that detects node names

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -964,7 +964,7 @@ export default mixins(
 					return originalName;
 				}
 
-				const nameMatch = originalName.match(/(.*[a-zA-Z])(\d*)/);
+				const nameMatch = originalName.match(/(.*\D+)(\d*)/);
 				let ignore, baseName, nameIndex, uniqueName;
 				let index = 1;
 


### PR DESCRIPTION
 This should now work with all languages. Tested with arabic and russian characters.

Solves issue https://github.com/n8n-io/n8n/issues/917