### PR TITLE
Second alternative to improve node error handling

### DIFF
--- a/packages/core/src/NodeErrors.ts
+++ b/packages/core/src/NodeErrors.ts
@@ -174,22 +174,27 @@ export class NodeApiError extends NodeError {
 }
 
 export class NodeApiMultiError extends NodeApiError {
+	callback: DefaultMultiErrorsCallback = (errorsArray: DefaultMultiErrorsArray) =>
+		errorsArray.map(({ message }) => message).join('|');
+
 	constructor(
 		nodeType: string,
 		error: IErrorObject,
-		callback: NodeApiMultiErrorsCallback,
+		customCallback?: NodeApiMultiErrorsCallback,
 	){
 		super(nodeType, error, {message: ''});
+		if (customCallback) this.callback = customCallback;
+
 		this.httpCode = this.findProperty(error, ERROR_CODE_PROPERTIES, ERROR_NESTING_PROPERTIES);
 		this.setMessage();
 
-		this.description = this.findProperty(error, MULTI_MESSAGE_PROPERTIES, ERROR_NESTING_PROPERTIES, callback);
+		this.description = this.findProperty(error, MULTI_MESSAGE_PROPERTIES, ERROR_NESTING_PROPERTIES, this.callback);
 		console.log(this); // TODO: Delete later
 	}
 }
 
-export type NodeApiMultiErrorsCallback = GoogleMultiErrorsCallback;
+export type NodeApiMultiErrorsCallback = DefaultMultiErrorsCallback;
 
-export type GoogleMultiErrorsCallback = (array: GoogleMultiErrorsArray) => string;
+export type DefaultMultiErrorsCallback = (array: DefaultMultiErrorsArray) => string;
 
-export type GoogleMultiErrorsArray = Array<{ message: string }>;
+export type DefaultMultiErrorsArray = Array<{ message: string }>;

--- a/packages/core/src/NodeErrors.ts
+++ b/packages/core/src/NodeErrors.ts
@@ -57,14 +57,14 @@ abstract class NodeError extends Error {
 		error: IErrorObject,
 		potentialKeys: string[],
 		traversalKeys: string[],
-		callback?: Function,
+		callback?: NodeApiMultiErrorsCallback,
 	): string | null {
 		for(const key of potentialKeys) {
 			if (error[key]) {
 				if (typeof error[key] === 'string') return error[key] as string;
 				if (typeof error[key] === 'number') return error[key]!.toString();
 				if (Array.isArray(error[key]) && callback) {
-					return callback(error[key]);
+					return callback(error[key] as any[]); // tslint:disable-line:no-any
 				}
 			}
 		}
@@ -177,7 +177,7 @@ export class NodeApiMultiError extends NodeApiError {
 	constructor(
 		nodeType: string,
 		error: IErrorObject,
-		callback: Function,
+		callback: NodeApiMultiErrorsCallback,
 	){
 		super(nodeType, error, {message: ''});
 		this.httpCode = this.findProperty(error, ERROR_CODE_PROPERTIES, ERROR_NESTING_PROPERTIES);
@@ -187,3 +187,9 @@ export class NodeApiMultiError extends NodeApiError {
 		console.log(this); // TODO: Delete later
 	}
 }
+
+export type NodeApiMultiErrorsCallback = GoogleMultiErrorsCallback;
+
+export type GoogleMultiErrorsCallback = (array: GoogleMultiErrorsArray) => string;
+
+export type GoogleMultiErrorsArray = Array<{ message: string }>;

--- a/packages/core/src/NodeErrors.ts
+++ b/packages/core/src/NodeErrors.ts
@@ -78,7 +78,7 @@ abstract class NodeError extends Error {
 		return null;
 	}
 
-	protected isTraversableObject(value: any): value is IErrorObject { // tslint:disable-line:no-any
+	protected isTraversableObject(value: unknown): value is IErrorObject {
 		return value && typeof value === 'object' && !Array.isArray(value) && !!Object.keys(value).length;
 	}
 }

--- a/packages/core/src/NodeErrors.ts
+++ b/packages/core/src/NodeErrors.ts
@@ -184,5 +184,6 @@ export class NodeApiMultiError extends NodeApiError {
 		this.setMessage();
 
 		this.description = this.findProperty(error, MULTI_MESSAGE_PROPERTIES, ERROR_NESTING_PROPERTIES, callback);
+		console.log(this); // TODO: Delete later
 	}
 }

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -655,6 +655,7 @@ export class WorkflowExecute {
 							executionError = {
 								message: error.message,
 								stack: error.stack,
+								description: error.description, // TEMP - for displaying new error class in UI
 							};
 						}
 					}

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -82,6 +82,7 @@
 			<span v-if="node && workflowRunData !== null && workflowRunData.hasOwnProperty(node.name)">
 				<div v-if="workflowRunData[node.name][runIndex].error" class="error-display">
 					<div class="error-message">ERROR: {{workflowRunData[node.name][runIndex].error.message}}</div>
+					<pre><code>{{workflowRunData[node.name][runIndex].error.description}}</code></pre>
 					<pre><code>{{workflowRunData[node.name][runIndex].error.stack}}</code></pre>
 				</div>
 				<span v-else>

--- a/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
@@ -3,6 +3,7 @@ import {
  } from 'request';
 
 import {
+	GoogleMultiErrorsArray,
 	IExecuteFunctions,
 	IExecuteSingleFunctions,
 	ILoadOptionsFunctions,
@@ -37,9 +38,9 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		return await this.helpers.requestOAuth2.call(this, 'googleCalendarOAuth2Api', options);
 	} catch (error) {
 
-		throw new NodeApiMultiError('Google Calendar', error, (errorArray: any) => { // tslint:disable-line:no-any
-			return errorArray.map((error: any) => error.message).join('|'); // tslint:disable-line:no-any
-		});
+		throw new NodeApiMultiError('Google Calendar', error, (errorsArray: GoogleMultiErrorsArray) =>
+			errorsArray.map(({ message }) => message).join('|'),
+		);
 
 		// if (error.response && error.response.body && error.response.body.error) {
 

--- a/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
@@ -3,7 +3,6 @@ import {
  } from 'request';
 
 import {
-	GoogleMultiErrorsArray,
 	IExecuteFunctions,
 	IExecuteSingleFunctions,
 	ILoadOptionsFunctions,
@@ -38,9 +37,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		return await this.helpers.requestOAuth2.call(this, 'googleCalendarOAuth2Api', options);
 	} catch (error) {
 
-		throw new NodeApiMultiError('Google Calendar', error, (errorsArray: GoogleMultiErrorsArray) =>
-			errorsArray.map(({ message }) => message).join('|'),
-		);
+		throw new NodeApiMultiError('Google Calendar', error);
 
 		// if (error.response && error.response.body && error.response.body.error) {
 

--- a/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
@@ -6,11 +6,14 @@ import {
 	IExecuteFunctions,
 	IExecuteSingleFunctions,
 	ILoadOptionsFunctions,
+	NodeApiMultiError,
 } from 'n8n-core';
 
 import {
 	IDataObject,
 } from 'n8n-workflow';
+
+
 
 export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, headers: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	const options: OptionsWithUri = {
@@ -33,17 +36,22 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		//@ts-ignore
 		return await this.helpers.requestOAuth2.call(this, 'googleCalendarOAuth2Api', options);
 	} catch (error) {
-		if (error.response && error.response.body && error.response.body.error) {
 
-			let errors = error.response.body.error.errors;
+		throw new NodeApiMultiError('Google Calendar', error, (errorArray: any) => { // tslint:disable-line:no-any
+			return errorArray.map((error: any) => error.message).join('|'); // tslint:disable-line:no-any
+		});
 
-			errors = errors.map((e: IDataObject) => e.message);
-			// Try to return the error prettier
-			throw new Error(
-				`Google Calendar error response [${error.statusCode}]: ${errors.join('|')}`,
-			);
-		}
-		throw error;
+		// if (error.response && error.response.body && error.response.body.error) {
+
+		// 	let errors = error.response.body.error.errors;
+
+		// 	errors = errors.map((e: IDataObject) => e.message);
+		// 	// Try to return the error prettier
+		// 	throw new Error(
+		// 		`Google Calendar error response [${error.statusCode}]: ${errors.join('|')}`,
+		// 	);
+		// }
+		// throw error;
 	}
 }
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -34,6 +34,7 @@ export interface IExecutionError {
 	message: string;
 	node?: string;
 	stack?: string;
+	description?: string; // TEMP - for displaying new error class in UI
 }
 
 // Get used to gives nodes access to credentials


### PR DESCRIPTION
For @BHesseldieck

**Pattern 1:** `.errors` → `Array<{ message: string }>`
- Coverage (28): Asana, Box, Discourse, Egoi, Freshdesk, Ghost, Google services (Analytics, Books, Calendar, Cloud Natural Language, Contacts, Drive, Firebase Realtime Database, Gmail, Tasks, YouTube), HelpScout, Hubspot, Mautic, MessageBird, Mindee, PagerDuty, Pushover, SendGrid, Shopify, Twake, Twitter, Vonage
- Implemented: Yes, included in `MULTI_MESSAGE_PROPERTIES`, handled by default callback.

**Pattern 2:** `.messages` → `Array<{ message: string }>`
- Coverage (2): FileMaker, Strapi
- Implemented: Yes, included in `MULTI_MESSAGE_PROPERTIES`, handled by default callback.

**Pattern 3:** `.errors` → `Array<{ code: string, field: string }>`
- Coverage (1): Strava
- Implemented: Not yet. Custom callback to handle this one case.

**Pattern 4:** `.errors` → `errors[key]`
- Coverage (3): Invoice Ninja, Sendy, Shopify
- Implemented: Not yet. More research needed. Possibly with custom callback as well.

**Pattern 5:** `.error` or `.message` or `.errors` or `.messages` or `.errorMessages`
- Coverage (2): Jira, HubSpot
- Implemented: Not yet. Possibly try/catch block using first `NodeApiMultiError` and then `NodeApiError`. More research needed.

**Pattern 6:** (inside try block) `response.success === false` → error manually thrown
- Coverage (3): ActiveCampaign, Slack, SMS77
- Implemented: Not yet. Possibly no special treatment needed, depending on what the error looks like. More research needed.

**"Pattern" 7**: Unknown error shape
- Coverage (13): Hunter, ActiveCampaign, Acuity Scheduling, AgileCRM, CoinGecko, JotForm, Medium, Salesmate, Sentry.io, Taiga, Trello, Upload, Zoom
- Error object needs inspecting, so that it can be categorized.