### PR TITLE
Add replyTo feature to Microsoft Teams

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/ChannelMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/ChannelMessageDescription.ts
@@ -24,12 +24,7 @@ export const channelMessageOperations = [
 				name: 'Get All',
 				value: 'getAll',
 				description: 'Get all messages',
-			},
-			{
-				name: 'Reply To',
-				value: 'replyTo',
-				description: 'Reply to a message thread',
-			},
+			}
 		],
 		default: 'create',
 		description: 'The operation to perform.',
@@ -134,6 +129,27 @@ export const channelMessageFields = [
 		default: '',
 		description: 'The content of the item.',
 	},
+	{
+		displayName: 'Reply To ID',
+		name: 'replyToId',
+		required: false,
+		type: 'string',
+		typeOptions: {
+			alwaysOpenEditWindow: false,
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'An optional ID of the message you want to reply to.',
+	},
 	/* -------------------------------------------------------------------------- */
 	/*                                 channelMessage:getAll                      */
 	/* -------------------------------------------------------------------------- */
@@ -221,122 +237,5 @@ export const channelMessageFields = [
 		},
 		default: 100,
 		description: 'How many results to return.',
-	},
-	/* -------------------------------------------------------------------------- */
-	/*                                 channelMessage:replyTo                      */
-	/* -------------------------------------------------------------------------- */
-	{
-		displayName: 'Team ID',
-		name: 'teamId',
-		required: true,
-		type: 'options',
-		typeOptions: {
-			loadOptionsMethod: 'getTeams',
-		},
-		displayOptions: {
-			show: {
-				operation: [
-					'replyTo',
-				],
-				resource: [
-					'channelMessage',
-				],
-			},
-		},
-		default: '',
-		description: 'Team ID',
-	},
-	{
-		displayName: 'Channel ID',
-		name: 'channelId',
-		type: 'options',
-		typeOptions: {
-			loadOptionsMethod: 'getChannels',
-			loadOptionsDependsOn: [
-				'teamId',
-			],
-		},
-		displayOptions: {
-			show: {
-				operation: [
-					'replyTo',
-				],
-				resource: [
-					'channelMessage',
-				],
-			},
-		},
-		default: '',
-		description: 'Channel ID',
-	},
-	{
-		displayName: 'Reply To ID',
-		name: 'replyToId',
-		required: true,
-		type: 'string',
-		typeOptions: {
-			alwaysOpenEditWindow: false,
-		},
-		displayOptions: {
-			show: {
-				operation: [
-					'replyTo',
-				],
-				resource: [
-					'channelMessage',
-				],
-			},
-		},
-		default: '',
-		description: 'The ID of the message you want to reply to.',
-	},
-	{
-		displayName: 'Message Type',
-		name: 'messageType',
-		required: true,
-		type: 'options',
-		options: [
-			{
-				name: 'Text',
-				value: 'text',
-			},
-			{
-				name: 'HTML',
-				value: 'html',
-			},
-		],
-		displayOptions: {
-			show: {
-				operation: [
-					'replyTo',
-				],
-				resource: [
-					'channelMessage',
-				],
-			},
-		},
-		default: '',
-		description: 'The type of the content',
-	},
-	{
-		displayName: 'Message',
-		name: 'message',
-		required: true,
-		type: 'string',
-		typeOptions: {
-			alwaysOpenEditWindow: true,
-		},
-		displayOptions: {
-			show: {
-				operation: [
-					'replyTo',
-				],
-				resource: [
-					'channelMessage',
-				],
-			},
-		},
-		default: '',
-		description: 'The content of the item.',
-	},
+	}
 ] as INodeProperties[];

--- a/packages/nodes-base/nodes/Microsoft/Teams/ChannelMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/ChannelMessageDescription.ts
@@ -25,6 +25,11 @@ export const channelMessageOperations = [
 				value: 'getAll',
 				description: 'Get all messages',
 			},
+			{
+				name: 'Reply To',
+				value: 'replyTo',
+				description: 'Reply to a message thread',
+			},
 		],
 		default: 'create',
 		description: 'The operation to perform.',
@@ -216,5 +221,122 @@ export const channelMessageFields = [
 		},
 		default: 100,
 		description: 'How many results to return.',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                 channelMessage:replyTo                      */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Team ID',
+		name: 'teamId',
+		required: true,
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getTeams',
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'replyTo',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'Team ID',
+	},
+	{
+		displayName: 'Channel ID',
+		name: 'channelId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChannels',
+			loadOptionsDependsOn: [
+				'teamId',
+			],
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'replyTo',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'Channel ID',
+	},
+	{
+		displayName: 'Reply To ID',
+		name: 'replyToId',
+		required: true,
+		type: 'string',
+		typeOptions: {
+			alwaysOpenEditWindow: false,
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'replyTo',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'The ID of the message you want to reply to.',
+	},
+	{
+		displayName: 'Message Type',
+		name: 'messageType',
+		required: true,
+		type: 'options',
+		options: [
+			{
+				name: 'Text',
+				value: 'text',
+			},
+			{
+				name: 'HTML',
+				value: 'html',
+			},
+		],
+		displayOptions: {
+			show: {
+				operation: [
+					'replyTo',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'The type of the content',
+	},
+	{
+		displayName: 'Message',
+		name: 'message',
+		required: true,
+		type: 'string',
+		typeOptions: {
+			alwaysOpenEditWindow: true,
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'replyTo',
+				],
+				resource: [
+					'channelMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'The content of the item.',
 	},
 ] as INodeProperties[];

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
@@ -262,18 +262,26 @@ export class MicrosoftTeams implements INodeType {
 			}
 			if (resource === 'channelMessage') {
 				//https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-beta&tabs=http
+				//https://docs.microsoft.com/en-us/graph/api/channel-post-messagereply?view=graph-rest-beta&tabs=http
 				if (operation === 'create') {
 					const teamId = this.getNodeParameter('teamId', i) as string;
 					const channelId = this.getNodeParameter('channelId', i) as string;
 					const messageType = this.getNodeParameter('messageType', i) as string;
 					const message = this.getNodeParameter('message', i) as string;
+					// optional replyToId
+					const replyToId = this.getNodeParameter('replyToId', i) as string;
+
 					const body: IDataObject = {
 						body: {
 							contentType: messageType,
 							content: message,
 						},
 					};
-					responseData = await microsoftApiRequest.call(this, 'POST', `/beta/teams/${teamId}/channels/${channelId}/messages`, body);
+
+					if (replyToId)
+						responseData = await microsoftApiRequest.call(this, 'POST', `/beta/teams/${teamId}/channels/${channelId}/messages/${replyToId}/replies`, body);
+					else
+						responseData = await microsoftApiRequest.call(this, 'POST', `/beta/teams/${teamId}/channels/${channelId}/messages`, body);
 				}
 				//https://docs.microsoft.com/en-us/graph/api/channel-list-messages?view=graph-rest-beta&tabs=http
 				if (operation === 'getAll') {
@@ -287,21 +295,6 @@ export class MicrosoftTeams implements INodeType {
 						responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', `/beta/teams/${teamId}/channels/${channelId}/messages`, {});
 						responseData = responseData.splice(0, qs.limit);
 					}
-				}
-				//https://docs.microsoft.com/en-us/graph/api/channel-post-messagereply?view=graph-rest-beta&tabs=http
-				if (operation === 'replyTo') {
-					const teamId = this.getNodeParameter('teamId', i) as string;
-					const channelId = this.getNodeParameter('channelId', i) as string;
-					const replyToId = this.getNodeParameter('replyToId', i) as string;
-					const messageType = this.getNodeParameter('messageType', i) as string;
-					const message = this.getNodeParameter('message', i) as string;
-					const body: IDataObject = {
-						body: {
-							contentType: messageType,
-							content: message,
-						},
-					};
-					responseData = await microsoftApiRequest.call(this, 'POST', `/beta/teams/${teamId}/channels/${channelId}/messages/${replyToId}/replies`, body);
 				}
 			}
 			if (resource === 'task') {

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
@@ -288,6 +288,21 @@ export class MicrosoftTeams implements INodeType {
 						responseData = responseData.splice(0, qs.limit);
 					}
 				}
+				//https://docs.microsoft.com/en-us/graph/api/channel-post-messagereply?view=graph-rest-beta&tabs=http
+				if (operation === 'replyTo') {
+					const teamId = this.getNodeParameter('teamId', i) as string;
+					const channelId = this.getNodeParameter('channelId', i) as string;
+					const replyToId = this.getNodeParameter('replyToId', i) as string;
+					const messageType = this.getNodeParameter('messageType', i) as string;
+					const message = this.getNodeParameter('message', i) as string;
+					const body: IDataObject = {
+						body: {
+							contentType: messageType,
+							content: message,
+						},
+					};
+					responseData = await microsoftApiRequest.call(this, 'POST', `/beta/teams/${teamId}/channels/${channelId}/messages/${replyToId}/replies`, body);
+				}
 			}
 			if (resource === 'task') {
 				//https://docs.microsoft.com/en-us/graph/api/planner-post-tasks?view=graph-rest-1.0&tabs=http


### PR DESCRIPTION
With a Message ID from `createMessage` or `getAll` one is now able to reply to a message in a threaded manner:
![image](https://user-images.githubusercontent.com/4921147/108032997-9a577d00-7033-11eb-8b54-b39d9f9f8118.png)
