### PR TITLE
Allow CLI to import and export decrypted credentials

### DIFF
--- a/packages/cli/commands/export/credentials.ts
+++ b/packages/cli/commands/export/credentials.ts
@@ -4,12 +4,18 @@ import {
 } from '@oclif/command';
 
 import {
+	Credentials,
+	UserSettings,
+} from 'n8n-core';
+
+import {
 	IDataObject
 } from 'n8n-workflow';
 
 import {
 	Db,
 	GenericHelpers,
+	ICredentialsDecryptedDb,
 } from '../../src';
 
 import * as fs from 'fs';
@@ -21,8 +27,9 @@ export class ExportCredentialsCommand extends Command {
 	static examples = [
 		`$ n8n export:credentials --all`,
 		`$ n8n export:credentials --id=5 --output=file.json`,
-		`$ n8n export:credentials --all --output=backups/latest/`,
+		`$ n8n export:credentials --all --output=backups/latest.json`,
 		`$ n8n export:credentials --backup --output=backups/latest/`,
+		`$ n8n export:credentials --all --decrypted --output=backups/decrypted.json`,
 	];
 
 	static flags = {
@@ -45,6 +52,9 @@ export class ExportCredentialsCommand extends Command {
 		}),
 		separate: flags.boolean({
 			description: 'Exports one file per credential (useful for versioning). Must inform a directory via --output.',
+		}),
+		decrypted: flags.boolean({
+			description: 'Exports data decrypted / in plain text. ALL SENSITIVE INFORMATION WILL BE VISIBLE IN THE FILES. Use to migrate from a installation to another that have a different secret key (in the config file).',
 		}),
 	};
 
@@ -107,6 +117,21 @@ export class ExportCredentialsCommand extends Command {
 			}
 
 			const credentials = await Db.collections.Credentials!.find(findQuery);
+
+			if (flags.decrypted) {
+				const encryptionKey = await UserSettings.getEncryptionKey();
+				if (encryptionKey === undefined) {
+					throw new Error('No encryption key got found to decrypt the credentials!');
+				}
+
+				for (let i = 0; i < credentials.length; i++) {
+					const c = credentials[i];
+					const {name, type, nodesAccess, data} = credentials[i];
+					const credential = new Credentials(name, type, nodesAccess, data);
+					const plainData = credential.getData(encryptionKey);
+					(credentials[i] as ICredentialsDecryptedDb).data = plainData;
+				}
+			}
 
 			if (credentials.length === 0) {
 				throw new Error('No credentials found with specified filters.');

--- a/packages/cli/commands/import/credentials.ts
+++ b/packages/cli/commands/import/credentials.ts
@@ -4,6 +4,11 @@ import {
 } from '@oclif/command';
 
 import {
+	Credentials,
+	UserSettings,
+} from 'n8n-core';
+
+import {
 	Db,
 	GenericHelpers,
 } from '../../src';
@@ -64,7 +69,15 @@ export class ImportCredentialsCommand extends Command {
 					throw new Error(`File does not seem to contain credentials.`);
 				}
 
+				const encryptionKey = await UserSettings.getEncryptionKey();
+				if (encryptionKey === undefined) {
+					throw new Error('No encryption key got found to encrypt the credentials!');
+				}
 				for (i = 0; i < fileContents.length; i++) {
+					if (typeof fileContents[i].data === 'object') {
+						// plain data / decrypted input. Should be encrypted first.
+						Credentials.prototype.setData.call(fileContents[i], fileContents[i].data, encryptionKey);
+					}
 					await Db.collections.Credentials!.save(fileContents[i]);
 				}
 			}


### PR DESCRIPTION
As discussed on:

https://community.n8n.io/t/credentials-export-import-bug/4399/3

In the CLI `export:credentials`, add the flag `--decrypted to save the data as plain text.

In the CLI `import:credentials`, support plain data, converting and encrypting them before importing.

### Example
`$ ./packages/cli/bin/n8n export:credentials --pretty --decrypted --id 11 --output 11.json`

```json
[
  {
    "id": 11,
    "name": "FTP Test",
    "data": {
      "username": "anon",
      "password": "secret"
    },
    "type": "ftp",
    "nodesAccess": [],
    "createdAt": "2021-02-18T10:49:41.794Z",
    "updatedAt": "2021-02-18T10:49:41.794Z"
  }
]
```

```sh
$ ./packages/cli/bin/n8n import:credentials --input 11.json
Successfully imported 1 credentials.
```