### PR TITLE
Adding support to ParameterizedQuery on Postgres Node

### DIFF
--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -72,9 +72,23 @@ export class Postgres implements INodeType {
 					},
 				},
 				default: '',
-				placeholder: 'SELECT id, name FROM product WHERE id < 40',
+				placeholder: 'SELECT id, name FROM product WHERE qty > $1 AND price <= $2',
 				required: true,
 				description: 'The SQL query to execute.',
+			},
+			{
+				displayName: 'Properties',
+				name: 'properties',
+				type: 'string',
+				displayOptions: {
+					show: {
+						operation: ['executeQuery'],
+					},
+				},
+				default: '',
+				placeholder: 'qty,price',
+				description:
+					'Comma separated list of properties which should be used as query parameters.',
 			},
 
 			// ----------------------------------


### PR DESCRIPTION
This PR provides support to [ParameterizedQuery](https://vitaly-t.github.io/pg-promise/ParameterizedQuery.html), which allows correct type management and content escaping when creating complex queries.

This solution is backward compatible and you're able to create new queries following the driver syntax:

```sql
SELECT id, name FROM product WHERE qty > $1 AND price <= $2
```

Those parameters `$1` and `$2` will be read from a comma-separated list, similar to the **Insert Operation**.

This approach shines when you need to run `INSERT ... ON CONFLICT` syntax, which can be cumbersome to interpolate string and it is error prone if not properly escaped.

```sql
INSERT INTO tbl(id, description, price)
VALUES($1, $2, $3)
ON CONFLICT (id) DO
UPDATE SET
  description = EXCLUDED.description,
  price = EXCLUDED.price
RETURNING *;
```

The editor will receive a new field `properties` which maps item fields to their relative position on the query, ie: price on the list is the $2 in the SQL query:

![image](https://user-images.githubusercontent.com/194210/108584119-8191e480-731d-11eb-97fb-4c04fbc0b3d9.png)


This is a more robust solution for this discussion: https://community.n8n.io/t/postgres-node-effective-way-to-upsert-insert-or-update/4315

This is my first PR to the project, feedback is very appreciated. If this PR is approved I intend to update the node documentation accordingly.