### PR TITLE
Fixed an issue with current executing workflows when using queues

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1647,6 +1647,10 @@ class App {
 
 				const currentlyRunningExecutionIds = currentJobs.map(job => job.data.executionId);
 
+				if (currentlyRunningExecutionIds.length === 0) {
+					return [];
+				}
+
 				const resultsQuery = await Db.collections.Execution!
 					.createQueryBuilder("execution")
 					.select([


### PR DESCRIPTION
When running n8n in queue mode, the query to search for currently running workflows would fail on Postgres but work fine with SQLite and MySQL / MariaDB. This fix makes it work fine for all RDBMS.