### PR TITLE
Fixing an isue where manual executions could not be stopped with queues

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1709,6 +1709,20 @@ class App {
 		// Forces the execution to stop
 		this.app.post(`/${this.restEndpoint}/executions-current/:id/stop`, ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<IExecutionsStopData> => {
 			if (config.get('executions.mode') === 'queue') {
+				// Manual executions should still be stoppable, so
+				// try notifying the `activeExecutions` to stop it.
+				const result = await this.activeExecutionsInstance.stopExecution(req.params.id);
+				if (result !== undefined) {
+					const returnData: IExecutionsStopData = {
+						mode: result.mode,
+						startedAt: new Date(result.startedAt),
+						stoppedAt: result.stoppedAt ?  new Date(result.stoppedAt) : undefined,
+						finished: result.finished,
+					};
+	
+					return returnData;
+				}
+
 				const currentJobs = await Queue.getInstance().getJobs(['active', 'waiting']);
 
 				const job = currentJobs.find(job => job.data.executionId.toString() === req.params.id);


### PR DESCRIPTION
When running with queues, we now check if the execution can be stopped from the current instance (main process) first before checking the queue.

For manual executions, this would be the correct behavior.

No harm for queue running executions as these are not registered in the `activeExecutions` instance and therefore simply return `undefined` in this case.