### PR TITLE
Fixes #1364 - Incorrect mouse selection when zoomed in or out

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2139,6 +2139,7 @@ export default mixins(
 	position: relative;
 	width: 100%;
 	height: 100%;
+	transform-origin: 0 0;
 }
 
 .node-view-background {


### PR DESCRIPTION
Prior to this change, the mouse selection box had a fixed position on the page. Nodes have absolute
position within `NodeView`. This inconsistency in positioning caused issues when calculating
if a node was positioned within the mouse selection. This solution makes both nodes
and mouse selection have consistent positioning, along with correctly calculating the
mouse click position within `NodeView` when making a selection.