### PR TITLE
Fix/gmail label filters

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -41,6 +41,9 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		body,
 		qs,
 		uri: uri || `https://www.googleapis.com${endpoint}`,
+		qsStringifyOptions:{
+			arrayFormat:'repeat'
+		},
 		json: true,
 	};
 

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -42,7 +42,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		qs,
 		uri: uri || `https://www.googleapis.com${endpoint}`,
 		qsStringifyOptions:{
-			arrayFormat:'repeat'
+			arrayFormat: 'repeat',
 		},
 		json: true,
 	};


### PR DESCRIPTION
This pr fixes the [issue](https://community.n8n.io/t/reading-gmail-emails-by-label/4521) mentioned in the community forum.
It adds an option to stringify the labels array into multiple query params `?arrayName=value1&arrayName=value2` instead of using `?arrayName[0]=value1&..`