### PR TITLE
fix(GoogleDrive): missing permissions field

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -522,7 +522,7 @@ export class GoogleDrive implements INodeType {
 				name: 'permissionsUi',
 				placeholder: 'Add Permission',
 				type: 'fixedCollection',
-				default: '',
+				default: {},
 				typeOptions: {
 					multipleValues: false,
 				},


### PR DESCRIPTION
When the default value for `fixedCollection` is `''` this field on UI is missing