### PR TITLE
Add metrics endpoint

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -446,6 +446,20 @@ const config = convict({
 	},
 
 	endpoints: {
+		metrics: {
+			enable: {
+				format: 'Boolean',
+				default: false,
+				env: 'N8N_ENABLE_METRICS',
+				doc: 'Enable metrics endpoint',
+			},
+			prefix: {
+				format: String,
+				default: 'n8n_',
+				env: 'N8N_METRICS_PREFIX',
+				doc: 'An optional prefix for metric names. Default: n8n_',
+			},
+		},
 		rest: {
 			format: String,
 			default: 'rest',
@@ -471,7 +485,7 @@ const config = convict({
 			doc: 'Disable production webhooks from main process. This helps ensures no http traffic load to main process when using webhook-specific processes.',
 		},
 		skipWebhoooksDeregistrationOnShutdown: {
-			/** 
+			/**
 			 * Longer explanation: n8n deregisters webhooks on shutdown / deactivation
 			 * and registers on startup / activation. If we skip
 			 * deactivation on shutdown, webhooks will remain active on 3rd party services.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -111,6 +111,7 @@
         "oauth-1.0a": "^2.2.6",
         "open": "^7.0.0",
         "pg": "^8.3.0",
+        "prom-client": "^13.1.0",
         "request-promise-native": "^1.0.7",
         "sqlite3": "^5.0.1",
         "sse-channel": "^3.1.1",


### PR DESCRIPTION
_Related discussion:_ https://community.n8n.io/t/prometheus-metrics-integration/1641

This commit adds the new package prom-client in order to expose metrics to Prometheus as well as the endpoint `/metrics` and its configuration.

### Configuration

The endpoint `/metrics` is disabled by default to expose this capability it requires setting up the env var `N8N_ENABLE_METRICS` as true

This is also possible to set up the prefix of the metrics by adding the `N8N_METRICS_PREFIX` env var, the default is `n8n_`

### Out of scope:
It is not the intention of this pull request to add metrics for webhooks
