### PR TITLE
Fix performance and crashes with latest updates

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -230,54 +230,63 @@ export function hookFunctionsPreExecute(parentProcessMode?: string): IWorkflowEx
 					return;
 				}
 
-				const execution = await Db.collections.Execution!.findOne(this.executionId);
+				try {
+					const execution = await Db.collections.Execution!.findOne(this.executionId);
+	
+					if (execution === undefined) {
+						// Something went badly wrong if this happens.
+						// This check is here mostly to make typescript happy.
+						return undefined;
+					}
+					const fullExecutionData: IExecutionResponse = ResponseHelper.unflattenExecutionData(execution);
+	
+					if (fullExecutionData.finished) {
+						// We already received ´workflowExecuteAfter´ webhook, so this is just an async call
+						// that was left behind. We skip saving because the other call should have saved everything
+						// so this one is safe to ignore
+						return;
+					}
+	
+	
+					if (fullExecutionData.data === undefined) {
+						fullExecutionData.data = {
+							startData: {
+							},
+							resultData: {
+								runData: {},
+							},
+							executionData: {
+								contextData: {},
+								nodeExecutionStack: [],
+								waitingExecution: {},
+							},
+						};
+					}
+	
+					if (Array.isArray(fullExecutionData.data.resultData.runData[nodeName])) {
+						// Append data if array exists
+						fullExecutionData.data.resultData.runData[nodeName].push(data);
+					} else {
+						// Initialize array and save data
+						fullExecutionData.data.resultData.runData[nodeName] = [data];
+					}
+	
+					fullExecutionData.data.executionData = executionData.executionData;
+	
+					// Set last executed node so that it may resume on failure
+					fullExecutionData.data.resultData.lastNodeExecuted = nodeName;
+	
+					const flattenedExecutionData = ResponseHelper.flattenExecutionData(fullExecutionData);
+	
+					await Db.collections.Execution!.update(this.executionId, flattenedExecutionData as IExecutionFlattedDb);
+				} catch (err) {
+					// Errors here might happen because of database access
+					// For busy machines, we may get "Database is locked" errors.
 
-				if (execution === undefined) {
-					// Something went badly wrong if this happens.
-					// This check is here mostly to make typescript happy.
-					return undefined;
+					// We do this to prevent crashes and executions ending in `unknown` state.
+					console.log(`Failed saving execution progress to database for execution ID ${this.executionId}`, err);
 				}
-				const fullExecutionData: IExecutionResponse = ResponseHelper.unflattenExecutionData(execution);
-
-				if (fullExecutionData.finished) {
-					// We already received ´workflowExecuteAfter´ webhook, so this is just an async call
-					// that was left behind. We skip saving because the other call should have saved everything
-					// so this one is safe to ignore
-					return;
-				}
-
-
-				if (fullExecutionData.data === undefined) {
-					fullExecutionData.data = {
-						startData: {
-						},
-						resultData: {
-							runData: {},
-						},
-						executionData: {
-							contextData: {},
-							nodeExecutionStack: [],
-							waitingExecution: {},
-						},
-					};
-				}
-
-				if (Array.isArray(fullExecutionData.data.resultData.runData[nodeName])) {
-					// Append data if array exists
-					fullExecutionData.data.resultData.runData[nodeName].push(data);
-				} else {
-					// Initialize array and save data
-					fullExecutionData.data.resultData.runData[nodeName] = [data];
-				}
-
-				fullExecutionData.data.executionData = executionData.executionData;
-
-				// Set last executed node so that it may resume on failure
-				fullExecutionData.data.resultData.lastNodeExecuted = nodeName;
-
-				const flattenedExecutionData = ResponseHelper.flattenExecutionData(fullExecutionData);
-
-				await Db.collections.Execution!.update(this.executionId, flattenedExecutionData as IExecutionFlattedDb);
+				
 			},
 		],
 	};

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -232,22 +232,22 @@ export function hookFunctionsPreExecute(parentProcessMode?: string): IWorkflowEx
 
 				try {
 					const execution = await Db.collections.Execution!.findOne(this.executionId);
-	
+
 					if (execution === undefined) {
 						// Something went badly wrong if this happens.
 						// This check is here mostly to make typescript happy.
 						return undefined;
 					}
 					const fullExecutionData: IExecutionResponse = ResponseHelper.unflattenExecutionData(execution);
-	
+
 					if (fullExecutionData.finished) {
 						// We already received ´workflowExecuteAfter´ webhook, so this is just an async call
 						// that was left behind. We skip saving because the other call should have saved everything
 						// so this one is safe to ignore
 						return;
 					}
-	
-	
+
+
 					if (fullExecutionData.data === undefined) {
 						fullExecutionData.data = {
 							startData: {
@@ -262,7 +262,7 @@ export function hookFunctionsPreExecute(parentProcessMode?: string): IWorkflowEx
 							},
 						};
 					}
-	
+
 					if (Array.isArray(fullExecutionData.data.resultData.runData[nodeName])) {
 						// Append data if array exists
 						fullExecutionData.data.resultData.runData[nodeName].push(data);
@@ -270,23 +270,24 @@ export function hookFunctionsPreExecute(parentProcessMode?: string): IWorkflowEx
 						// Initialize array and save data
 						fullExecutionData.data.resultData.runData[nodeName] = [data];
 					}
-	
+
 					fullExecutionData.data.executionData = executionData.executionData;
-	
+
 					// Set last executed node so that it may resume on failure
 					fullExecutionData.data.resultData.lastNodeExecuted = nodeName;
-	
+
 					const flattenedExecutionData = ResponseHelper.flattenExecutionData(fullExecutionData);
-	
+
 					await Db.collections.Execution!.update(this.executionId, flattenedExecutionData as IExecutionFlattedDb);
 				} catch (err) {
+					// TODO: Improve in the future!
 					// Errors here might happen because of database access
 					// For busy machines, we may get "Database is locked" errors.
 
 					// We do this to prevent crashes and executions ending in `unknown` state.
 					console.log(`Failed saving execution progress to database for execution ID ${this.executionId}`, err);
 				}
-				
+
 			},
 		],
 	};

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -174,8 +174,8 @@ export class WorkflowRunnerProcess {
 				},
 			],
 			nodeExecuteAfter: [
-				async (nodeName: string, data: ITaskData, executionData: IRunExecutionData): Promise<void> => {
-					this.sendHookToParentProcess('nodeExecuteAfter', [nodeName, data, executionData]);
+				async (nodeName: string, data: ITaskData): Promise<void> => {
+					this.sendHookToParentProcess('nodeExecuteAfter', [nodeName, data]);
 				},
 			],
 			workflowExecuteBefore: [

--- a/packages/cli/src/databases/mysqldb/migrations/1615306975123-ChangeDataSize.ts
+++ b/packages/cli/src/databases/mysqldb/migrations/1615306975123-ChangeDataSize.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+import * as config from '../../../../config';
+
+export class ChangeDataSize1615306975123 implements MigrationInterface {
+	name = 'ChangeDataSize1615306975123';
+
+	async up(queryRunner: QueryRunner): Promise<void> {
+		const tablePrefix = config.get('database.tablePrefix');
+
+		await queryRunner.query('ALTER TABLE `' + tablePrefix + 'execution_entity` MODIFY COLUMN `data` MEDIUMTEXT NOT NULL');
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		const tablePrefix = config.get('database.tablePrefix');
+
+		await queryRunner.query('ALTER TABLE `' + tablePrefix + 'execution_entity` MODIFY COLUMN `data` TEXT NOT NULL');
+	}
+}

--- a/packages/cli/src/databases/mysqldb/migrations/1615306975123-ChangeDataSize.ts
+++ b/packages/cli/src/databases/mysqldb/migrations/1615306975123-ChangeDataSize.ts
@@ -1,4 +1,4 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 import * as config from '../../../../config';
 
 export class ChangeDataSize1615306975123 implements MigrationInterface {

--- a/packages/cli/src/databases/mysqldb/migrations/index.ts
+++ b/packages/cli/src/databases/mysqldb/migrations/index.ts
@@ -3,6 +3,7 @@ import { WebhookModel1592447867632 } from './1592447867632-WebhookModel';
 import { CreateIndexStoppedAt1594902918301 } from './1594902918301-CreateIndexStoppedAt';
 import { AddWebhookId1611149998770 } from './1611149998770-AddWebhookId';
 import { MakeStoppedAtNullable1607431743767 } from './1607431743767-MakeStoppedAtNullable';
+import { ChangeDataSize1615306975123 } from './1615306975123-ChangeDataSize';
 
 export const mysqlMigrations = [
 	InitialMigration1588157391238,
@@ -10,4 +11,5 @@ export const mysqlMigrations = [
 	CreateIndexStoppedAt1594902918301,
 	AddWebhookId1611149998770,
 	MakeStoppedAtNullable1607431743767,
+	ChangeDataSize1615306975123,
 ];


### PR DESCRIPTION
This pull request fixes a few issues we found out:

- Problem with data being transferred from child process to main that was not necessary; removed to improve performance
- Issue with workflows crashing and remaining with status `Unknown` in execution list
- Crashes that might happen with MySQL while saving execution data when `data` field had over 64KB. The change causes this field to occupy 1 more by than previously but allows data up to 16MB.