### PR TITLE
Render empty array in variable selector

### DIFF
--- a/packages/editor-ui/src/components/VariableSelector.vue
+++ b/packages/editor-ui/src/components/VariableSelector.vue
@@ -114,6 +114,9 @@ export default mixins(
 						// Has still options left so return
 						inputData.options = this.sortOptions(newOptions);
 						return inputData;
+					} else if (Array.isArray(newOptions) && newOptions.length === 0) {
+						delete inputData.options;
+						return inputData;
 					}
 					// Has no options left so remove
 					return null;


### PR DESCRIPTION
This PR restores rendering for a property pointing to an empty array in the variable selector, as [reported](https://community.n8n.io/t/empty-json-properties/4737/4) in the community.

![image](https://user-images.githubusercontent.com/44588767/110936661-0023e580-8310-11eb-89ea-689bd61c8458.png)


