### PR TITLE
:bug: Salesforce Custom Object Get All : Fix TypeError

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -163,7 +163,7 @@ export function getDefaultFields(sobject: string) {
 export function getQuery(options: IDataObject, sobject: string, returnAll: boolean, limit = 0) {
 	const fields: string[] = [];
 	if (options.fields) {
-		fields.push.apply(fields, (options.fields as string).split(','));
+		fields.push.apply(fields, options.fields.toString().split(','));
 	} else {
 		fields.push.apply(fields, (getDefaultFields(sobject) as string || 'id').split(','));
 	}


### PR DESCRIPTION
When attempting to perform Custom Object Get All with Salesforce node and specifying 1 or more fields, the following error is encountered:
  TypeError: options.fields.split is not a function

Fixed bug by using toString on options.fields before attempting split.

![Screen Shot 2021-03-17 at 1 34 29 PM](https://user-images.githubusercontent.com/5472147/111526538-dd893680-872c-11eb-8d13-984c9dcceb20.png)
