### PR TITLE
Retrieve liked tracks and remove track from playlist in Spotify node

### DIFF
--- a/packages/nodes-base/credentials/SpotifyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SpotifyOAuth2Api.credentials.ts
@@ -36,7 +36,7 @@ export class SpotifyOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden' as NodePropertyTypes,
-			default: 'user-read-playback-state playlist-read-collaborative user-modify-playback-state playlist-modify-public user-read-currently-playing playlist-read-private user-read-recently-played playlist-modify-private',
+			default: 'user-read-playback-state playlist-read-collaborative user-modify-playback-state playlist-modify-public user-read-currently-playing playlist-read-private user-read-recently-played playlist-modify-private user-library-read',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -58,6 +58,10 @@ export class Spotify implements INodeType {
 						value: 'artist',
 					},
 					{
+						name: 'Library',
+						value: 'library',
+					},
+					{
 						name: 'Player',
 						value: 'player',
 					},
@@ -487,6 +491,30 @@ export class Spotify implements INodeType {
 				placeholder: 'spotify:track:0xE4LEFzSNGsz1F6kvXsHU',
 				description: `The track's Spotify URI or ID.`,
 			},
+			// --------------------------------------------------------------------------------------------------------
+			//         Library Operations
+			//		   Get saved tracks
+			// --------------------------------------------------------------------------------------------------------
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				displayOptions: {
+					show: {
+						resource: [
+							'library',
+						],
+					},
+				},
+				options: [
+					{
+						name: 'Get Saved Tracks',
+						value: 'getUserTracks',
+						description: `Get the user's saved tracks.`,
+					},
+				],
+				default: 'getUserTracks',
+			},
 			{
 				displayName: 'Return All',
 				name: 'returnAll',
@@ -498,6 +526,7 @@ export class Spotify implements INodeType {
 						resource: [
 							'album',
 							'artist',
+							'library',
 							'playlist',
 						],
 						operation: [
@@ -505,6 +534,7 @@ export class Spotify implements INodeType {
 							'getAlbums',
 							'getUserPlaylists',
 							'getNewReleases',
+							'getUserTracks',
 						],
 					},
 				},
@@ -521,6 +551,7 @@ export class Spotify implements INodeType {
 						resource: [
 							'album',
 							'artist',
+							'library',
 							'playlist',
 						],
 						operation: [
@@ -528,6 +559,7 @@ export class Spotify implements INodeType {
 							'getAlbums',
 							'getUserPlaylists',
 							'getNewReleases',
+							'getUserTracks',
 						],
 						returnAll: [
 							false,
@@ -939,6 +971,31 @@ export class Spotify implements INodeType {
 				}
 
 				responseData = await spotifyApiRequest.call(this, requestMethod, endpoint, body, qs);
+			// -----------------------------
+			//      Library Operations
+			// -----------------------------
+			} else if( resource === 'library') {
+				if(operation === 'getUserTracks') {
+					requestMethod = 'GET';
+
+					endpoint = '/me/tracks';
+
+					returnAll = this.getNodeParameter('returnAll', i) as boolean;
+
+					propertyName = 'items';
+
+					if(!returnAll) {
+						const limit = this.getNodeParameter('limit', i) as number;
+
+						qs = {
+							limit,
+						};
+
+						responseData = await spotifyApiRequest.call(this, requestMethod, endpoint, body, qs);
+
+						responseData = responseData.items;
+					}
+				}
 			}
 
 			if (returnAll) {

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -867,7 +867,6 @@ export class Spotify implements INodeType {
 						body.tracks = [
 							{
 								uri: `${trackId}`,
-								positions: [0],
 							},
 						];
 

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -493,7 +493,7 @@ export class Spotify implements INodeType {
 			},
 			// --------------------------------------------------------------------------------------------------------
 			//         Library Operations
-			//		   Get saved tracks
+			//		   Get liked tracks
 			// --------------------------------------------------------------------------------------------------------
 			{
 				displayName: 'Operation',
@@ -508,12 +508,12 @@ export class Spotify implements INodeType {
 				},
 				options: [
 					{
-						name: 'Get Saved Tracks',
-						value: 'getUserTracks',
-						description: `Get the user's saved tracks.`,
+						name: 'Get Liked Tracks',
+						value: 'getLikedTracks',
+						description: `Get the user's liked tracks.`,
 					},
 				],
-				default: 'getUserTracks',
+				default: 'getLikedTracks',
 			},
 			{
 				displayName: 'Return All',
@@ -534,7 +534,7 @@ export class Spotify implements INodeType {
 							'getAlbums',
 							'getUserPlaylists',
 							'getNewReleases',
-							'getUserTracks',
+							'getLikedTracks',
 						],
 					},
 				},
@@ -559,7 +559,7 @@ export class Spotify implements INodeType {
 							'getAlbums',
 							'getUserPlaylists',
 							'getNewReleases',
-							'getUserTracks',
+							'getLikedTracks',
 						],
 						returnAll: [
 							false,
@@ -652,10 +652,12 @@ export class Spotify implements INodeType {
 		returnAll = false;
 
 		for (let i = 0; i < items.length; i++) {
-			// -----------------------------
-			//      Player Operations
-			// -----------------------------
 			if (resource === 'player') {
+
+				// -----------------------------
+				//      Player Operations
+				// -----------------------------
+
 				if (operation === 'pause') {
 					requestMethod = 'PUT';
 
@@ -733,10 +735,12 @@ export class Spotify implements INodeType {
 
 					responseData = { success: true };
 				}
+
+			} else if (resource === 'album') {
+
 				// -----------------------------
 				//      Album Operations
 				// -----------------------------
-			} else if (resource === 'album') {
 
 				if (operation === 'get') {
 					const uri = this.getNodeParameter('id', i) as string;
@@ -795,10 +799,13 @@ export class Spotify implements INodeType {
 						responseData = responseData.items;
 					}
 				}
+
+			} else if (resource === 'artist') {
+
 				// -----------------------------
 				//      Artist Operations
 				// -----------------------------
-			} else if (resource === 'artist') {
+
 				const uri = this.getNodeParameter('id', i) as string;
 
 				const id = uri.replace('spotify:artist:', '');
@@ -822,6 +829,7 @@ export class Spotify implements INodeType {
 
 						responseData = responseData.items;
 					}
+
 				} else if (operation === 'getRelatedArtists') {
 
 					endpoint = `/artists/${id}/related-artists`;
@@ -851,10 +859,13 @@ export class Spotify implements INodeType {
 
 					responseData = await spotifyApiRequest.call(this, requestMethod, endpoint, body, qs);
 				}
+
+			} else if (resource === 'playlist') {
+
 				// -----------------------------
 				//      Playlist Operations
 				// -----------------------------
-			} else if (resource === 'playlist') {
+
 				if (['delete', 'get', 'getTracks', 'add'].includes(operation)) {
 					const uri = this.getNodeParameter('id', i) as string;
 
@@ -866,7 +877,7 @@ export class Spotify implements INodeType {
 
 						body.tracks = [
 							{
-								uri: `${trackId}`,
+								uri: trackId,
 							},
 						];
 
@@ -953,10 +964,12 @@ export class Spotify implements INodeType {
 					responseData = await spotifyApiRequest.call(this, 'POST', '/me/playlists', body, qs);
 				}
 
+			} else if (resource === 'track') {
+
 				// -----------------------------
 				//      Track Operations
 				// -----------------------------
-			} else if (resource === 'track') {
+
 				const uri = this.getNodeParameter('id', i) as string;
 
 				const id = uri.replace('spotify:track:', '');
@@ -970,11 +983,14 @@ export class Spotify implements INodeType {
 				}
 
 				responseData = await spotifyApiRequest.call(this, requestMethod, endpoint, body, qs);
-			// -----------------------------
-			//      Library Operations
-			// -----------------------------
-			} else if( resource === 'library') {
-				if(operation === 'getUserTracks') {
+
+			} else if (resource === 'library') {
+
+				// -----------------------------
+				//      Library Operations
+				// -----------------------------
+
+				if (operation === 'getLikedTracks') {
 					requestMethod = 'GET';
 
 					endpoint = '/me/tracks';
@@ -983,7 +999,7 @@ export class Spotify implements INodeType {
 
 					propertyName = 'items';
 
-					if(!returnAll) {
+					if (!returnAll) {
 						const limit = this.getNodeParameter('limit', i) as number;
 
 						qs = {


### PR DESCRIPTION
This PR adds `library:getLikedTracks` and fixes `playlist:delete` in the Spotify node, based on #1472.