### PR TITLE
Fixing issues with subworkflows not finishing

### DIFF
--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -121,7 +121,15 @@ export class WorkflowRunnerProcess {
 					resolve(executionId);
 				};
 			});
-			const result: IRun = await executeWorkflowFunction(workflowInfo, additionalData, inputData, executionId, workflowData, runData);
+			let result: IRun;
+			try {
+				result = await executeWorkflowFunction(workflowInfo, additionalData, inputData, executionId, workflowData, runData);
+			} catch (e) {
+				await sendToParentProcess('finishExecution', { executionId });
+				// Throw same error we had 
+				throw e;	
+			}
+			
 			await sendToParentProcess('finishExecution', { executionId, result });
 
 			const returnData = WorkflowHelpers.getDataLastExecutedNodeData(result);


### PR DESCRIPTION
When using subworkflows in a separate process (the default setting), in case the subworkflow terminates with an error, this was bypassing the call from the subprocess to main process requesting the termination of the execution.

What is happening under the hood is that the execution was correctly saved to the database and ended, but the main process' `ActiveExecutions` class wasn't aware of this.

This was causing n8n's main process to hang on termination saying `Waiting for n executions to finish`.

This was now fixed.