### PR TITLE
Fixing concurrency issues with subworkflows

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -557,7 +557,7 @@ export class WorkflowExecute {
 					executionData = this.runExecutionData.executionData!.nodeExecutionStack.shift() as IExecuteData;
 					executionNode = executionData.node;
 
-					this.executeHook('nodeExecuteBefore', [executionNode.name]);
+					await this.executeHook('nodeExecuteBefore', [executionNode.name]);
 
 					// Get the index of the current run
 					runIndex = 0;
@@ -722,7 +722,7 @@ export class WorkflowExecute {
 							// Add the execution data again so that it can get restarted
 							this.runExecutionData.executionData!.nodeExecutionStack.unshift(executionData);
 
-							this.executeHook('nodeExecuteAfter', [executionNode.name, taskData, this.runExecutionData]);
+							await this.executeHook('nodeExecuteAfter', [executionNode.name, taskData, this.runExecutionData]);
 
 							break;
 						}


### PR DESCRIPTION
Hooks were happening out of order, making the execution list inconsistent.

We were processing the `workflowExecuteAfter` hook before the `nodeExecuteAfter`.

The end result is that the final execution on database had `finished: false` and would display status as `Unknown` in the execution list.

This PR fixes this and also makes the `nodeExecuteBefore` sync (was not necessary, but it is best so the behavior is consistent) by adding `await` to these calls.