### PR TITLE
:bug: Fix autocomplete API uri

### DIFF
--- a/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
+++ b/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
@@ -109,7 +109,7 @@ export class Clearbit implements INodeType {
 					if (additionalFields.facebook) {
 						qs.facebook = additionalFields.facebook as string;
 					}
-					responseData = await clearbitApiRequest.call(this, 'GET', resource, '/v2/people/find', {}, qs);
+					responseData = await clearbitApiRequest.call(this, 'GET', `${resource}-stream`, '/v2/people/find', {}, qs);
 				}
 			}
 			if (resource === 'company') {
@@ -129,7 +129,7 @@ export class Clearbit implements INodeType {
 					if (additionalFields.facebook) {
 						qs.facebook = additionalFields.facebook as string;
 					}
-					responseData = await clearbitApiRequest.call(this, 'GET', resource, '/v2/companies/find', {}, qs);
+					responseData = await clearbitApiRequest.call(this, 'GET', `${resource}-stream`, '/v2/companies/find', {}, qs);
 				}
 				if (operation === 'autocomplete') {
 					const name = this.getNodeParameter('name', i) as string;

--- a/packages/nodes-base/nodes/Clearbit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clearbit/GenericFunctions.ts
@@ -17,7 +17,7 @@ export async function clearbitApiRequest(this: IHookFunctions | IExecuteFunction
 		method,
 		qs,
 		body,
-		uri: uri ||`https://${api}-stream.clearbit.com${resource}`,
+		uri: uri ||`https://${api}.clearbit.com${resource}`,
 		json: true,
 	};
 	options = Object.assign({}, options, option);


### PR DESCRIPTION
This pr include a small fix for the API subdomain as mentioned in [docs](https://dashboard.clearbit.com/docs#autocomplete-api), it changes the subdomain from `autocomplete-stream` to `autocomplete`