### PR TITLE
Postgres/ Choose output format

### DIFF
--- a/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
+++ b/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
@@ -217,7 +217,7 @@ export class CrateDb implements INodeType {
 
 			const queryResult = await pgQuery(this.getNodeParameter, pgp, db, items);
 
-			returnItems = this.helpers.returnJsonArray(queryResult as IDataObject[]);
+			returnItems = this.helpers.returnJsonArray(queryResult[0] as IDataObject[]);
 		} else if (operation === 'insert') {
 			// ----------------------------------
 			//         insert

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
@@ -40,13 +40,15 @@ export function pgQuery(
 	pgp: pgPromise.IMain<{}, pg.IClient>,
 	db: pgPromise.IDatabase<{}, pg.IClient>,
 	input: INodeExecutionData[],
-): Promise<object[]> {
-	const queries: string[] = [];
-	for (let i = 0; i < input.length; i++) {
-		queries.push(getNodeParam('query', i) as string);
-	}
-
-	return db.any(pgp.helpers.concat(queries));
+): Promise<object[][]> {
+	return db.tx(async (t) => {
+		const results: object[][] = [];
+		for (let i = 0; i < input.length; i++) {
+			const query = getNodeParam('query', i) as string;
+			results.push(await db.any(query));
+		}
+		return results;
+	});
 }
 
 /**

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -60,6 +60,25 @@ export class Postgres implements INodeType {
 			//         executeQuery
 			// ----------------------------------
 			{
+				displayName: 'Output format',
+				name: 'outputFormat',
+				type: 'options',
+				options: [
+					{
+						name: 'All of first input',
+						value: 'allOfFirst',
+						description: 'The output array is the results of the first query.',
+					},
+					{
+						name: 'One per input',
+						value: 'onePerInput',
+						description: 'The output array is composed of the first results of each query.',
+					},
+				],
+				default: 'allOfFirst',
+				description: 'How query results are outputted.',
+			},
+			{
 				displayName: 'Query',
 				name: 'query',
 				type: 'string',
@@ -230,10 +249,12 @@ export class Postgres implements INodeType {
 			// ----------------------------------
 			//         executeQuery
 			// ----------------------------------
-
-			const queryResult = await pgQuery(this.getNodeParameter, pgp, db, items);
-
-			returnItems = this.helpers.returnJsonArray(queryResult as IDataObject[]);
+			const queryResults = await pgQuery(this.getNodeParameter, pgp, db, items);
+			const outputFormat = this.getNodeParameter('outputFormat', 0) as string;
+			const results = outputFormat === 'allOfFirst' ?
+				queryResults[0] :
+				queryResults.map(queryResult => queryResult[0] ?? {});
+			returnItems = this.helpers.returnJsonArray(results as IDataObject[]);
 		} else if (operation === 'insert') {
 			// ----------------------------------
 			//         insert

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -173,7 +173,7 @@ export class QuestDb implements INodeType {
 
 			const queryResult = await pgQuery(this.getNodeParameter, pgp, db, items);
 
-			returnItems = this.helpers.returnJsonArray(queryResult as IDataObject[]);
+			returnItems = this.helpers.returnJsonArray(queryResult[0] as IDataObject[]);
 		} else if (operation === 'insert') {
 			// ----------------------------------
 			//         insert

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -252,7 +252,7 @@ export class TimescaleDb implements INodeType {
 
 			const queryResult = await pgQuery(this.getNodeParameter, pgp, db, items);
 
-			returnItems = this.helpers.returnJsonArray(queryResult as IDataObject[]);
+			returnItems = this.helpers.returnJsonArray(queryResult[0] as IDataObject[]);
 		} else if (operation === 'insert') {
 			// ----------------------------------
 			//         insert


### PR DESCRIPTION
This pull request allow selection of one output format among several when executing an "Execute Query" Postgres operation. It adds one format in addition to the existing one.

**Formats:**

1. _All of first input_: the output array is the results of the first query.

It's the current format and now the one used by default.

2. _One per input_: the output array is composed of the first results of each query.

This mode aims to produce one result per query when executing multiple selections. It is also useful for continuing the workflow after updates or inserts.