### PR TITLE
Fix #1583 Redis node's memory leak due connection being kept open

### DIFF
--- a/packages/nodes-base/nodes/Redis/Redis.node.ts
+++ b/packages/nodes-base/nodes/Redis/Redis.node.ts
@@ -445,6 +445,7 @@ export class Redis implements INodeType {
 			const operation = this.getNodeParameter('operation', 0) as string;
 
 			client.on('error', (err: Error) => {
+				client.quit();
 				reject(err);
 			});
 
@@ -518,6 +519,7 @@ export class Redis implements INodeType {
 						}
 					}
 
+					client.quit();
 					resolve(this.prepareOutputData(returnItems));
 				}
 			});


### PR DESCRIPTION
Fixes and closes #1583.

Do like in the info command, and after the execution of the other commands, close the connection, otherwise, it will be kept open and cause a connection and memory leak.

Also, as to close in case of error, just in case.