### PR TITLE
⚡ Use faster bcrypt implementation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
     "@types/basic-auth": "^1.1.2",
-    "@types/bcryptjs": "^2.4.1",
     "@types/bull": "^3.3.10",
     "@types/compression": "1.0.1",
     "@types/connect-history-api-fallback": "^1.3.1",
@@ -80,11 +79,11 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
+    "@node-rs/bcrypt": "^1.2.0",
     "@oclif/command": "^1.5.18",
     "@oclif/errors": "^1.2.2",
     "@types/jsonwebtoken": "^8.3.4",
     "basic-auth": "^2.0.1",
-    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "body-parser-xml": "^1.1.0",
     "bull": "^3.19.0",

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -22,7 +22,7 @@ import { RequestOptions } from 'oauth-1.0a';
 import * as csrf from 'csrf';
 import * as requestPromise from 'request-promise-native';
 import { createHmac } from 'crypto';
-import { compare } from 'bcryptjs';
+import { compare } from '@node-rs/bcrypt';
 import * as promClient from 'prom-client';
 
 import {


### PR DESCRIPTION
@node-rs/bcrypt is faster, and the Installation is as easy as bcryptjs, see https://github.com/napi-rs/node-rs/tree/main/packages/bcrypt