### PR TITLE
Fix #1585 (RabbitMQ connections left open after use)

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -314,6 +314,7 @@ export class RabbitMQ implements INodeType {
 				});
 
 				await channel.close();
+				await channel.connection.close();
 			}
 			else if (mode === 'exchange') {
 				const exchange = this.getNodeParameter('exchange', 0) as string;
@@ -368,6 +369,7 @@ export class RabbitMQ implements INodeType {
 				});
 
 				await channel.close();
+				await channel.connection.close();
 			} else {
 				throw new Error(`The operation "${mode}" is not known!`);
 			}
@@ -377,6 +379,7 @@ export class RabbitMQ implements INodeType {
 		catch (error) {
 			if (channel) {
 				await channel.close();
+				await channel.connection.close();
 			}
 			throw error;
 		}

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
@@ -151,6 +151,7 @@ export class RabbitMQTrigger implements INodeType {
 		// the workflow gets deactivated and can so clean up.
 		async function closeFunction() {
 			await channel.close();
+			await channel.connection.close();
 		}
 
 		// The "manualTriggerFunction" function gets called by n8n


### PR DESCRIPTION
Fix #1585.

Just closing the channels is not enough as the connection stays open forever, until the process is closed.
