### PR TITLE
Fix #1595 (MongoDB node left connection open)

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -143,6 +143,7 @@ export class MongoDb implements INodeType {
 			throw new Error(`The operation "${operation}" is not supported!`);
 		}
 
+		client.close();
 		return this.prepareOutputData(returnItems);
 	}
 }


### PR DESCRIPTION
The MongoDB node didn't close the connection after it opens, leaving it open and unused forever.

