### PR TITLE
Fix #1596 (RabbitMQ AMPQS support)

### DIFF
--- a/packages/nodes-base/credentials/RabbitMQ.credentials.ts
+++ b/packages/nodes-base/credentials/RabbitMQ.credentials.ts
@@ -1,5 +1,6 @@
 import {
 	ICredentialType,
+	IDisplayOptions,
 	NodePropertyTypes,
 } from 'n8n-workflow';
 
@@ -71,10 +72,6 @@ export class RabbitMQ implements ICredentialType {
 			typeOptions: {
 				password: true,
 			},
-			// typeOptions: {
-			// 	multipleValues: true,
-			// 	multipleValueButtonText: 'Add Certificate',
-			// },
 			displayOptions: {
 				show: {
 					ssl: [
@@ -97,11 +94,11 @@ export class RabbitMQ implements ICredentialType {
 					ssl: [
 						true,
 					],
-					// passwordless: [
-					// 	true,
-					// ],
+					passwordless: [
+						true,
+					],
 				},
-			},
+			} as IDisplayOptions,
 			default: '',
 			description: 'SSL Client Certificate to use.',
 		},
@@ -117,9 +114,9 @@ export class RabbitMQ implements ICredentialType {
 					ssl: [
 						true,
 					],
-					// passwordless: [
-					// 	true,
-					// ],
+					passwordless: [
+						true,
+					],
 				},
 			},
 			default: '',
@@ -137,9 +134,9 @@ export class RabbitMQ implements ICredentialType {
 					ssl: [
 						true,
 					],
-					// passwordless: [
-					// 	true,
-					// ],
+					passwordless: [
+						true,
+					],
 				},
 			},
 			default: '',

--- a/packages/nodes-base/credentials/RabbitMQ.credentials.ts
+++ b/packages/nodes-base/credentials/RabbitMQ.credentials.ts
@@ -51,12 +51,9 @@ export class RabbitMQ implements ICredentialType {
 			default: false,
 		},
 		{
-			displayName: 'Client Certificate',
-			name: 'cert',
-			type: 'string' as NodePropertyTypes,
-			typeOptions: {
-				password: true,
-			},
+			displayName: 'Passwordless',
+			name: 'passwordless',
+			type: 'boolean' as NodePropertyTypes,
 			displayOptions: {
 				show: {
 					ssl: [
@@ -64,42 +61,8 @@ export class RabbitMQ implements ICredentialType {
 					],
 				},
 			},
-			default: '',
-			description: 'SSL Client Certificate to use.',
-		},
-		{
-			displayName: 'Client Key',
-			name: 'key',
-			type: 'string' as NodePropertyTypes,
-			typeOptions: {
-				password: true,
-			},
-			displayOptions: {
-				show: {
-					ssl: [
-						true,
-					],
-				},
-			},
-			default: '',
-			description: 'SSL Client Key to use.',
-		},
-		{
-			displayName: 'Passphrase',
-			name: 'passphrase',
-			type: 'string' as NodePropertyTypes,
-			typeOptions: {
-				password: true,
-			},
-			displayOptions: {
-				show: {
-					ssl: [
-						true,
-					],
-				},
-			},
-			default: '',
-			description: 'SSL passphrase to use.',
+			default: false,
+			description: 'Passwordless connection with certificates (SASL mechanism EXTERNAL)',
 		},
 		{
 			displayName: 'CA Certificates',
@@ -121,6 +84,66 @@ export class RabbitMQ implements ICredentialType {
 			},
 			default: '',
 			description: 'SSL CA Certificates to use.',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'cert',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					// passwordless: [
+					// 	true,
+					// ],
+				},
+			},
+			default: '',
+			description: 'SSL Client Certificate to use.',
+		},
+		{
+			displayName: 'Client Key',
+			name: 'key',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					// passwordless: [
+					// 	true,
+					// ],
+				},
+			},
+			default: '',
+			description: 'SSL Client Key to use.',
+		},
+		{
+			displayName: 'Passphrase',
+			name: 'passphrase',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					// passwordless: [
+					// 	true,
+					// ],
+				},
+			},
+			default: '',
+			description: 'SSL passphrase to use.',
 		},
 		// {
 		// 	displayName: 'Client ID',

--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -26,11 +26,13 @@ export async function rabbitmqConnect(this: IExecuteFunctions | ITriggerFunction
 	if (credentials.ssl === true) {
 		credentialData.protocol = 'amqps';
 
-		optsData.cert = credentials.cert === '' ? undefined : Buffer.from(credentials.cert as string);
-		optsData.key = credentials.key === '' ? undefined : Buffer.from(credentials.key as string);
-		optsData.passphrase = credentials.passphrase === '' ? undefined : credentials.passphrase;
 		optsData.ca = credentials.ca === '' ? undefined : [Buffer.from(credentials.ca as string)];
-		optsData.credentials = amqplib.credentials.external();
+		if (credentials.passwordless === true) {
+			optsData.cert = credentials.cert === '' ? undefined : Buffer.from(credentials.cert as string);
+			optsData.key = credentials.key === '' ? undefined : Buffer.from(credentials.key as string);
+			optsData.passphrase = credentials.passphrase === '' ? undefined : credentials.passphrase;
+			optsData.credentials = amqplib.credentials.external();
+		}
 	}
 
 


### PR DESCRIPTION
This is a WIP fix for #1596.

It works and can be merged already.

But there is a minor issue in the credentials properties: many fields open in the SSL only make sense with the passwordless options. But in the `displayOptions.show` of these properties fails if I add or change anything.

For example, in this option: 
```ts
{
	displayName: 'Client Key',
	name: 'key',
	type: 'string' as NodePropertyTypes,
	typeOptions: {
		password: true,
	},
	displayOptions: {
		show: {
			ssl: [
				true,
			],
		},
	},
	default: '',
	description: 'SSL Client Key to use.',
},
```

if I change the display options to:
```ts
displayOptions: {
	show: {
		ssl: [
			true,
		],
		passwordless: [
			true,
		],
	},
},
```
or
```ts
displayOptions: {
	show: {
		passwordless: [
			true,
		],
	},
},
```
they will fail to compile. But if you change the property name of `ssl` to something else, it compiles (but generates a weird error on runtime).

So, I have no idea why, and it may not happen outside my computer, but if anyone could help to fix this, that would be great.
For now, the fix can be merged and the improvement in the UI can be sorted later.