### PR TITLE
Add RabbitMQ Exchange's Header parameter

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/DefaultOptions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/DefaultOptions.ts
@@ -37,6 +37,37 @@ export const rabbitDefaultOptions: Array<INodePropertyOptions | INodeProperties 
 		],
 	},
 	{
+		displayName: 'Headers',
+		name: 'headers',
+		placeholder: 'Add Header',
+		description: 'Headers to add.',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'header',
+				displayName: 'Header',
+				values: [
+					{
+						displayName: 'Key',
+						name: 'key',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
+	},
+	{
 		displayName: 'Auto Delete',
 		name: 'autoDelete',
 		type: 'boolean',

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -353,13 +353,15 @@ export class RabbitMQ implements INodeType {
 
 				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 
-				let headers : object | undefined  = undefined;
-				if (options.headers?.header != null) {
-					headers = options.headers?.header.reduce((map, obj) => {
-						map[obj.key] = obj.value;
-						return map;
-					}, {});
+				let headers : IDataObject = {};
+				if (options.headers && ((options.headers as IDataObject).header! as IDataObject[]).length) {
+					const additionalArguments: IDataObject = {};
+					((options.headers as IDataObject).header as IDataObject[]).forEach((header: IDataObject) => {
+						additionalArguments[header.key as string] = header.value;
+					});
+					headers = additionalArguments;
 				}
+				console.log(headers);
 
 				channel = await rabbitmqConnectExchange.call(this, exchange, type, options);
 

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -355,13 +355,12 @@ export class RabbitMQ implements INodeType {
 
 				let headers : IDataObject = {};
 				if (options.headers && ((options.headers as IDataObject).header! as IDataObject[]).length) {
-					const additionalArguments: IDataObject = {};
+					const additionalHeaders: IDataObject = {};
 					((options.headers as IDataObject).header as IDataObject[]).forEach((header: IDataObject) => {
-						additionalArguments[header.key as string] = header.value;
+						additionalHeaders[header.key as string] = header.value;
 					});
-					headers = additionalArguments;
+					headers = additionalHeaders;
 				}
-				console.log(headers);
 
 				channel = await rabbitmqConnectExchange.call(this, exchange, type, options);
 

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -209,6 +209,37 @@ export class RabbitMQ implements INodeType {
 						],
 					},
 					{
+						displayName: 'Headers',
+						name: 'headers',
+						placeholder: 'Add Header',
+						description: 'Headers to add.',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								name: 'header',
+								displayName: 'Header',
+								values: [
+									{
+										displayName: 'Key',
+										name: 'key',
+										type: 'string',
+										default: '',
+									},
+									{
+										displayName: 'Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+									},
+								],
+							},
+						],
+					},
+					{
 						displayName: 'Auto Delete',
 						name: 'autoDelete',
 						type: 'boolean',
@@ -322,6 +353,14 @@ export class RabbitMQ implements INodeType {
 
 				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 
+				let headers : object | undefined  = undefined;
+				if (options.headers?.header != null) {
+					headers = options.headers?.header.reduce((map, obj) => {
+						map[obj.key] = obj.value;
+						return map;
+					}, {});
+				}
+
 				channel = await rabbitmqConnectExchange.call(this, exchange, type, options);
 
 				const sendInputData = this.getNodeParameter('sendInputData', 0) as boolean;
@@ -336,7 +375,7 @@ export class RabbitMQ implements INodeType {
 						message = this.getNodeParameter('message', i) as string;
 					}
 
-					exchangePromises.push(channel.publish(exchange, routingKey, Buffer.from(message)));
+					exchangePromises.push(channel.publish(exchange, routingKey, Buffer.from(message), {headers}));
 				}
 
 				// @ts-ignore


### PR DESCRIPTION
This PR includes changes to RabbitMQ node to support:
- Custom Header options in exchange mode 


the below workflow can be used to test the added option.
```
{
  "nodes": [
    {
      "parameters": {},
      "name": "Start",
      "type": "n8n-nodes-base.start",
      "typeVersion": 1,
      "position": [
        250,
        300
      ]
    },
    {
      "parameters": {
        "mode": "exchange",
        "exchange": "direct",
        "exchangeType": "=x-delayed-message",
        "options": {
          "argumen": {
            "argument": []
          },
          "headers": {
            "header": [
              {
                "key": "x-delay",
                "value": "1001"
              }
            ]
          }
        }
      },
      "name": "RabbitMQ",
      "type": "n8n-nodes-base.rabbitmq",
      "typeVersion": 1,
      "position": [
        780,
        290
      ],
      "credentials": {
        "rabbitmq": "rabbitmq"
      }
    },
    {
      "parameters": {
        "functionCode": "items[0].json.timestamp = new Date().toString();\nreturn items;"
      },
      "name": "Function",
      "type": "n8n-nodes-base.function",
      "typeVersion": 1,
      "position": [
        470,
        290
      ]
    }
  ],
  "connections": {
    "Function": {
      "main": [
        [
          {
            "node": "RabbitMQ",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
```

