### PR TITLE
Fix SendGrid dynamic field generation

### DIFF
--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -361,10 +361,9 @@ export class SendGrid implements INodeType {
 						};
 
 						if (fields) {
+							body.personalizations[0].dynamic_template_data = {}
 							fields.forEach(field => {
-								body.personalizations[0].dynamic_template_data = {
-									[field.key]: field.value,
-								};
+								body.personalizations[0].dynamic_template_data![field.key] = field.value;
 							});
 						}
 


### PR DESCRIPTION
Bug: only the last field would be sent to SendGrid.
Fix: now all of them are sent.

Didn't find a test case for it but tested manually to confirm it works.