### PR TITLE
Add XML parsing to NodeApiError constructor

### DIFF
--- a/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
@@ -158,9 +158,7 @@ export class AwsLambda implements INodeType {
 				Qualifier: this.getNodeParameter('qualifier', i) as string,
 			};
 
-			let responseData;
-
-			responseData = await awsApiRequestREST.call(
+			const responseData = await awsApiRequestREST.call(
 				this,
 				'lambda',
 				'POST',

--- a/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
@@ -134,11 +134,8 @@ export class AwsLambda implements INodeType {
 				const returnData: INodePropertyOptions[] = [];
 
 				let data;
-				try {
-					data = await awsApiRequestREST.call(this, 'lambda', 'GET', '/2015-03-31/functions/');
-				} catch (error) {
-					throw new NodeApiError(this.getNode(), error);
-				}
+
+				data = await awsApiRequestREST.call(this, 'lambda', 'GET', '/2015-03-31/functions/');
 
 				for (const func of data.Functions!) {
 					returnData.push({
@@ -165,21 +162,18 @@ export class AwsLambda implements INodeType {
 			};
 
 			let responseData;
-			try {
-				responseData = await awsApiRequestREST.call(
-					this,
-					'lambda',
-					'POST',
-					`/2015-03-31/functions/${params.FunctionName}/invocations?Qualifier=${params.Qualifier}`,
-					params.Payload,
-					{
-						'X-Amz-Invocation-Type': params.InvocationType,
-						'Content-Type': 'application/x-amz-json-1.0',
-					},
-				);
-			} catch (err) {
-				throw new NodeOperationError(this.getNode(), `AWS Error: ${err}`);
-			}
+
+			responseData = await awsApiRequestREST.call(
+				this,
+				'lambda',
+				'POST',
+				`/2015-03-31/functions/${params.FunctionName}/invocations?Qualifier=${params.Qualifier}`,
+				params.Payload,
+				{
+					'X-Amz-Invocation-Type': params.InvocationType,
+					'Content-Type': 'application/x-amz-json-1.0',
+				},
+			);
 
 			if (responseData !== null && responseData.errorMessage !== undefined) {
 				let errorMessage = responseData.errorMessage;

--- a/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
@@ -132,10 +132,7 @@ export class AwsLambda implements INodeType {
 		loadOptions: {
 			async getFunctions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-
-				let data;
-
-				data = await awsApiRequestREST.call(this, 'lambda', 'GET', '/2015-03-31/functions/');
+				const data = await awsApiRequestREST.call(this, 'lambda', 'GET', '/2015-03-31/functions/');
 
 				for (const func of data.Functions!) {
 					returnData.push({

--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -109,9 +109,7 @@ export class AwsSns implements INodeType {
 			// select them easily
 			async getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				let data;
-
-				data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
+				const data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
 
 				let topics = data.ListTopicsResponse.ListTopicsResult.Topics.member;
 

--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -110,11 +110,8 @@ export class AwsSns implements INodeType {
 			async getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				let data;
-				try {
-					data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
-				} catch (error) {
-					throw new NodeApiError(this.getNode(), error);
-				}
+
+				data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
 
 				let topics = data.ListTopicsResponse.ListTopicsResult.Topics.member;
 

--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -146,12 +146,8 @@ export class AwsSns implements INodeType {
 				'Message=' + this.getNodeParameter('message', i) as string,
 			];
 
-			let responseData;
-			try {
-				responseData = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=Publish&' + params.join('&'));
-			} catch (err) {
-				throw new NodeOperationError(this.getNode(), `AWS Error: ${err}`);
-			}
+
+			const	responseData = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=Publish&' + params.join('&'));
 			returnData.push({MessageId: responseData.PublishResponse.PublishResult.MessageId} as IDataObject);
 		}
 

--- a/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
@@ -71,11 +71,8 @@ export class AwsSnsTrigger implements INodeType {
 			async getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				let data;
-				try {
-					data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
-				} catch (error) {
-					throw new NodeApiError(this.getNode(), error);
-				}
+
+				data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
 
 				let topics = data.ListTopicsResponse.ListTopicsResult.Topics.member;
 

--- a/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
@@ -70,9 +70,7 @@ export class AwsSnsTrigger implements INodeType {
 			// select them easily
 			async getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				let data;
-
-				data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
+				const data = await awsApiRequestSOAP.call(this, 'sns', 'GET', '/?Action=ListTopics');
 
 				let topics = data.ListTopicsResponse.ListTopicsResult.Topics.member;
 

--- a/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
@@ -61,7 +61,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error);
+		throw new NodeApiError(this.getNode(), error); // no XML parsing needed
 	}
 }
 

--- a/packages/nodes-base/nodes/Aws/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/GenericFunctions.ts
@@ -1,7 +1,7 @@
 import { URL } from 'url';
 import { sign } from 'aws4';
 import { OptionsWithUri } from 'request';
-import { parseString } from 'xml2js';
+import { parseString as parseXml } from 'xml2js';
 
 import {
 	IExecuteFunctions,
@@ -50,7 +50,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error);
+		throw new NodeApiError(this.getNode(), error, { parseXml: true });
 	}
 }
 
@@ -67,7 +67,7 @@ export async function awsApiRequestSOAP(this: IHookFunctions | IExecuteFunctions
 	const response = await awsApiRequest.call(this, service, method, path, body, headers);
 	try {
 		return await new Promise((resolve, reject) => {
-			parseString(response, { explicitArray: false }, (err, data) => {
+			parseXml(response, { explicitArray: false }, (err, data) => {
 				if (err) {
 					return reject(err);
 				}

--- a/packages/nodes-base/nodes/Aws/Rekognition/AwsRekognition.node.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/AwsRekognition.node.ts
@@ -496,11 +496,9 @@ export class AwsRekognition implements INodeType {
 								body.Image.S3Object.Version = additionalFields.version as string;
 							}
 						}
-						try {
-							responseData = await awsApiRequestREST.call(this, 'rekognition', 'POST', '', JSON.stringify(body), {}, { 'X-Amz-Target': action, 'Content-Type': 'application/x-amz-json-1.1' });
-						} catch (error) {
-							throw new NodeApiError(this.getNode(), error);
-						}
+
+						responseData = await awsApiRequestREST.call(this, 'rekognition', 'POST', '', JSON.stringify(body), {}, { 'X-Amz-Target': action, 'Content-Type': 'application/x-amz-json-1.1' });
+
 					}
 				}
 			}

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -27,6 +27,7 @@ import {
 
 import {
 	IDataObject,
+	NodeApiError,
 	NodeOperationError,
  } from 'n8n-workflow';
 
@@ -60,17 +61,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		const errorMessage = (error.response && error.response.body.message) || (error.response && error.response.body.Message) || error.message;
-
-		if (error.statusCode === 403) {
-			if (errorMessage === 'The security token included in the request is invalid.') {
-				throw new NodeOperationError(this.getNode(), 'The AWS credentials are not valid!');
-			} else if (errorMessage.startsWith('The request signature we calculated does not match the signature you provided')) {
-				throw new NodeOperationError(this.getNode(), 'The AWS credentials are not valid!');
-			}
-		}
-
-		throw new NodeOperationError(this.getNode(), `AWS error response [${error.statusCode}]: ${errorMessage}`);
+		throw new NodeApiError(this.getNode(), error);
 	}
 }
 

--- a/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
@@ -57,7 +57,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error);
+		throw new NodeApiError(this.getNode(), error, { parseXml: true });
 	}
 }
 

--- a/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
@@ -52,7 +52,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	try {
 		return await this.helpers.request!(options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error);
+		throw new NodeApiError(this.getNode(), error, { parseXml: true });
 	}
 }
 

--- a/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
@@ -161,8 +161,8 @@ export class StravaTrigger implements INodeType {
 
 				try {
 					responseData = await stravaApiRequest.call(this, 'POST', endpoint, body);
-				} catch (error: NodeApiError) {
-					const apiErrorResponse = error.cause.response
+				} catch (error) {
+					const apiErrorResponse = error.cause.response;
 					if (apiErrorResponse?.body?.errors) {
 						const errors = apiErrorResponse.body.errors;
 						for (error of errors) {

--- a/packages/workflow/src/NodeErrors.ts
+++ b/packages/workflow/src/NodeErrors.ts
@@ -179,7 +179,7 @@ export class NodeApiError extends NodeError {
 	constructor(
 		node: INode,
 		error: IRawErrorObject,
-		{ message, description, httpCode, parseXml }: { message?: string, description?: string, httpCode?: string, parseXml?: boolean } = { message: '' },
+		{ message, description, httpCode, parseXml }: { message?: string, description?: string, httpCode?: string, parseXml?: boolean } = {},
 	) {
 		super(node, error);
 		if (message) {
@@ -193,16 +193,15 @@ export class NodeApiError extends NodeError {
 		this.setMessage();
 
 		if (parseXml) {
-			// @ts-ignore
-			this.setDescriptionFromXml(this.cause.error);
-		} else {
-			this.description = this.findProperty(error, ERROR_MESSAGE_PROPERTIES, ERROR_NESTING_PROPERTIES);
+			this.setDescriptionFromXml(error.error as string);
+			return;
 		}
+
+		this.description = this.findProperty(error, ERROR_MESSAGE_PROPERTIES, ERROR_NESTING_PROPERTIES);
 	}
 
-	setDescriptionFromXml(xml: string) {
-		parseString(xml, { explicitArray: false }, (parsingError, result) => {
-			if (parsingError) throw new NodeOperationError(this.node, 'Failed to parse XML');
+	private setDescriptionFromXml(xml: string) {
+		parseString(xml, { explicitArray: false }, (_, result) => {
 			this.description = result;
 		});
 	}

--- a/packages/workflow/src/NodeErrors.ts
+++ b/packages/workflow/src/NodeErrors.ts
@@ -5,6 +5,7 @@ import { parseString } from 'xml2js';
  * Top-level properties where an error message can be found in an API response.
  */
 const ERROR_MESSAGE_PROPERTIES = [
+	'error',
 	'message',
 	'Message',
 	'msg',
@@ -25,7 +26,6 @@ const ERROR_MESSAGE_PROPERTIES = [
 	'title',
 	'text',
 	'field',
-	'error',
 	'err',
 	'type',
 ];
@@ -202,7 +202,10 @@ export class NodeApiError extends NodeError {
 
 	private setDescriptionFromXml(xml: string) {
 		parseString(xml, { explicitArray: false }, (_, result) => {
-			this.description = result;
+			if (!result) return;
+
+			const topLevelKey = Object.keys(result)[0];
+			this.description = this.findProperty(result[topLevelKey], ERROR_MESSAGE_PROPERTIES, ['Error'].concat(ERROR_NESTING_PROPERTIES));
 		});
 	}
 


### PR DESCRIPTION
This PR
- adds an optional `parseXml` flag to the `NodeApiError` constructor,
- refactors to remove an illegal type annotation,
- refactors to simplify the call sites, and
- removes unneeded try/catch blocks,

![image](https://user-images.githubusercontent.com/44588767/113844335-aab6e900-9794-11eb-9874-71e9276d2968.png)

Pending:
- [x] Remove the need for `@ts-ignore` when passing the error object to the XML parser.

Notes: 
- There is considerable duplication among the `GenericFunctions.ts` of the AWS nodes, and even among `awsApiRequestREST` and `awsApiRequestSOAP` inside a single `GenericFunctions.ts` file, but this PR is limited to adding XML parsing. This larger refactoring should ideally be done separately.
- The AWS Rekognition node is broken, since the API call only happens in `detectText` type operations. This problem should ideally be fixed separately.