### PR TITLE
Added SSL support to MySQL.credentials and MySQL.node

### DIFF
--- a/packages/nodes-base/credentials/MySql.credentials.ts
+++ b/packages/nodes-base/credentials/MySql.credentials.ts
@@ -56,10 +56,11 @@ export class MySql implements ICredentialType {
 			default: false,
 		},
 		{
-			displayName: 'Server Certificate',
-			name: 'serverCertificate',
+			displayName: 'CA Certificate',
+			name: 'caCertificate',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
+				password: true,
 			},
 			displayOptions: {
 				show: {
@@ -76,6 +77,7 @@ export class MySql implements ICredentialType {
 			name: 'clientPrivateKey',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
+				password: true,
 			},
 			displayOptions: {
 				show: {
@@ -92,6 +94,7 @@ export class MySql implements ICredentialType {
 			name: 'clientCertificate',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
+				password: true,
 			},
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/credentials/MySql.credentials.ts
+++ b/packages/nodes-base/credentials/MySql.credentials.ts
@@ -48,6 +48,60 @@ export class MySql implements ICredentialType {
 			type: 'number' as NodePropertyTypes,
 			default: 10000,
 			description: 'The milliseconds before a timeout occurs during the initial connection to the MySQL server.',
-		},	
+		},
+		{
+			displayName: 'SSL',
+			name: 'ssl',
+			type: 'boolean' as NodePropertyTypes,
+			default: false,
+		},
+		{
+			displayName: 'Server Certificate',
+			name: 'serverCertificate',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+				},
+			},
+			type: 'string' as NodePropertyTypes,
+			default: '',
+		},
+		{
+			displayName: 'Client Private Key',
+			name: 'clientPrivateKey',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+				},
+			},
+			type: 'string' as NodePropertyTypes,
+			default: '',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'clientCertificate',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+				},
+			},
+			type: 'string' as NodePropertyTypes,
+			default: '',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -175,7 +175,30 @@ export class MySql implements INodeType {
 			throw new Error('No credentials got returned!');
 		}
 
-		const connection = await mysql2.createConnection(credentials);
+		// Destructuring SSL configuration
+		const {
+			ssl,
+			serverCertificate,
+			clientCertificate,
+			clientPrivateKey,
+			...baseCredentials
+		} = credentials;
+
+		if (ssl) {
+			baseCredentials.ssl = {};
+
+			if (serverCertificate) {
+				baseCredentials.ssl.ca = serverCertificate;
+			}
+
+			// client certificates might not be required
+			if (clientCertificate || clientPrivateKey) {
+				baseCredentials.ssl.cert = clientCertificate;
+				baseCredentials.ssl.key = clientPrivateKey;
+			}
+		}
+
+		const connection = await mysql2.createConnection(baseCredentials);
 		const items = this.getInputData();
 		const operation = this.getNodeParameter('operation', 0) as string;
 		let returnItems = [];

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -178,7 +178,7 @@ export class MySql implements INodeType {
 		// Destructuring SSL configuration
 		const {
 			ssl,
-			serverCertificate,
+			caCertificate,
 			clientCertificate,
 			clientPrivateKey,
 			...baseCredentials
@@ -187,8 +187,8 @@ export class MySql implements INodeType {
 		if (ssl) {
 			baseCredentials.ssl = {};
 
-			if (serverCertificate) {
-				baseCredentials.ssl.ca = serverCertificate;
+			if (caCertificate) {
+				baseCredentials.ssl.ca = caCertificate;
 			}
 
 			// client certificates might not be required


### PR DESCRIPTION
Added:
- Optional SSL flag on MySQL credentials
- Optional serverCertificate
- Optional clientCertificate & clientPrivateKey
- Support for SSL options in MySQL.node

See related issue https://community.n8n.io/t/support-ssl-connections-with-certificates-in-mysql-credentials/5071