### PR TITLE
Added a global timeout setting for all http requests except for http node

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -51,6 +51,9 @@ import { createHmac } from 'crypto';
 import { fromBuffer } from 'file-type';
 import { lookup } from 'mime-types';
 
+const requestPromiseWithDefaults:requestPromise.RequestPromiseAPI = requestPromise.defaults({
+	timeout: 300000, // 5 minutes
+});
 
 /**
  * Takes a buffer and converts it into the format n8n uses. It encodes the binary data as
@@ -576,7 +579,7 @@ export function getExecutePollFunctions(workflow: Workflow, node: INode, additio
 			},
 			helpers: {
 				prepareBinaryData,
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -642,7 +645,7 @@ export function getExecuteTriggerFunctions(workflow: Workflow, node: INode, addi
 			},
 			helpers: {
 				prepareBinaryData,
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -738,7 +741,7 @@ export function getExecuteFunctions(workflow: Workflow, runExecutionData: IRunEx
 			prepareOutputData: NodeHelpers.prepareOutputData,
 			helpers: {
 				prepareBinaryData,
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -836,7 +839,7 @@ export function getExecuteSingleFunctions(workflow: Workflow, runExecutionData: 
 			},
 			helpers: {
 				prepareBinaryData,
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -892,7 +895,7 @@ export function getLoadOptionsFunctions(workflow: Workflow, node: INode, additio
 				return additionalData.restApiUrl;
 			},
 			helpers: {
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -962,7 +965,7 @@ export function getExecuteHookFunctions(workflow: Workflow, node: INode, additio
 				return workflow.getStaticData(type, node);
 			},
 			helpers: {
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},
@@ -1062,7 +1065,7 @@ export function getExecuteWebhookFunctions(workflow: Workflow, node: INode, addi
 			prepareOutputData: NodeHelpers.prepareOutputData,
 			helpers: {
 				prepareBinaryData,
-				request: requestPromise,
+				request: requestPromiseWithDefaults,
 				requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, oAuth2Options?: IOAuth2Options): Promise<any> { // tslint:disable-line:no-any
 					return requestOAuth2.call(this, credentialsType, requestOptions, node, additionalData, oAuth2Options);
 				},

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -51,7 +51,7 @@ import { createHmac } from 'crypto';
 import { fromBuffer } from 'file-type';
 import { lookup } from 'mime-types';
 
-const requestPromiseWithDefaults:requestPromise.RequestPromiseAPI = requestPromise.defaults({
+const requestPromiseWithDefaults = requestPromise.defaults({
 	timeout: 300000, // 5 minutes
 });
 

--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -688,6 +688,8 @@ export class HttpRequest implements INodeType {
 			}
 			if (options.timeout !== undefined) {
 				requestOptions.timeout = options.timeout as number;
+			} else {
+				requestOptions.timeout = 3600000; // 1 hour
 			}
 
 			if (options.useQueryString === true) {


### PR DESCRIPTION
The http node explicitly sets a timeout that overrides the default value.

This is to prevent behaviors when users were expecting that their requests could take a very long time to execute.

This PR was created by @MedAliMarz and I just made a few minor adjustments.