### PR TITLE
🐛  Fix bug in Zendesk Trigger node with wrong conditions

### DIFF
--- a/packages/nodes-base/nodes/Zendesk/ZendeskTrigger.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/ZendeskTrigger.node.ts
@@ -441,11 +441,11 @@ export class ZendeskTrigger implements INodeType {
 				const conditionsAll = conditions.all as [IDataObject];
 
 				let endpoint = '';
-				const aux: IDataObject = {};
 				const resultAll = [], resultAny = [];
 
 				if (conditionsAll) {
 					for (const conditionAll of conditionsAll) {
+						const aux: IDataObject = {};
 						aux.field = conditionAll.field;
 						aux.operator = conditionAll.operation;
 						if (conditionAll.operation !== 'changed'
@@ -461,6 +461,7 @@ export class ZendeskTrigger implements INodeType {
 				const conditionsAny = conditions.any as [IDataObject];
 				if (conditionsAny) {
 					for (const conditionAny of conditionsAny) {
+						const aux: IDataObject = {};
 						aux.field = conditionAny.field;
 						aux.operator = conditionAny.operation;
 						if (conditionAny.operation !== 'changed'
@@ -509,7 +510,6 @@ export class ZendeskTrigger implements INodeType {
 				const webhookData = this.getWorkflowStaticData('node');
 				const service = this.getNodeParameter('service') as string;
 				if (service === 'support') {
-					const aux: IDataObject = {};
 					const message: IDataObject = {};
 					const resultAll = [], resultAny = [];
 					const conditions = this.getNodeParameter('conditions') as IDataObject;
@@ -529,6 +529,7 @@ export class ZendeskTrigger implements INodeType {
 					const conditionsAll = conditions.all as [IDataObject];
 					if (conditionsAll) {
 						for (const conditionAll of conditionsAll) {
+							const aux: IDataObject = {};
 							aux.field = conditionAll.field;
 							aux.operator = conditionAll.operation;
 							if (conditionAll.operation !== 'changed'
@@ -543,6 +544,7 @@ export class ZendeskTrigger implements INodeType {
 					const conditionsAny = conditions.any as [IDataObject];
 					if (conditionsAny) {
 						for (const conditionAny of conditionsAny) {
+							const aux: IDataObject = {};
 							aux.field = conditionAny.field;
 							aux.operator = conditionAny.operation;
 							if (conditionAny.operation !== 'changed'


### PR DESCRIPTION
This is my first PR for n8n so if I'm doing something wrong, please let me know. Never too late to learn! 

The conditions for the Zendesk trigger node are populated in the `resultAll` and `resultAny` variables.
While populating these variables, the `const aux: IDataObject = {};` variable from the outer scope is used to create entries for the `resultAll` and `resultAny` variables.

However, the `aux` variable from the outer scope is pushed to the `resultAll` and `resultAny` variables by reference. Therefore, at the second index in the loop, this for example `aux.field = conditionAll.field;` will also update the value of the previously pushed item.

The result is `resultAll` and `resultAny` variable where the entry's are all the same.

Fixed by moving the `aux` variable inside the loop scope.