### PR TITLE
:bug: fix rabbitMQ AMPQS Support PR 1598

### DIFF
--- a/packages/nodes-base/credentials/RabbitMQ.credentials.ts
+++ b/packages/nodes-base/credentials/RabbitMQ.credentials.ts
@@ -62,7 +62,7 @@ export class RabbitMQ implements ICredentialType {
 					],
 				},
 			},
-			default: false,
+			default: true,
 			description: 'Passwordless connection with certificates (SASL mechanism EXTERNAL)',
 		},
 		{


### PR DESCRIPTION
Backward compatibility for rabbit credentials created before AMPQS support