### PR TITLE
Xero Node: Allow Searching / Finding Contacts

### DIFF
--- a/packages/nodes-base/nodes/Xero/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Xero/ContactDescription.ts
@@ -31,6 +31,11 @@ export const contactOperations = [
 				description: 'Get all contacts',
 			},
 			{
+				name: 'Find',
+				value: 'find',
+				description: 'Find contacts based on query.',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update a contact',
@@ -392,6 +397,76 @@ export const contactFields = [
 			},
 		},
 		required: true,
+	},
+/* -------------------------------------------------------------------------- */
+/*                                 contact:find                                */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getTenants',
+		},
+		default: '',
+		displayOptions: {
+			show: {
+				resource: [
+					'contact',
+				],
+				operation: [
+					'find',
+				],
+			},
+		},
+		required: true,
+	},
+	{
+		displayName: 'Lookup Field',
+		name: 'contactLookupField',
+		type: 'options',
+		default: 'EmailAddress',
+		options: [
+			{
+				name: 'Name',
+				value: 'Name',
+			},
+			{
+				name: 'Email Address',
+				value: 'EmailAddress',
+			},
+			{
+				name: 'Account Number',
+				value: 'AccountNumber',
+			},
+		],
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'contact',
+				],
+				operation: [
+					'find',
+				],
+			},
+		},
+	},
+	{
+		displayName: 'Lookup Value',
+		name: 'contactLookupValue',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'contact',
+				],
+				operation: [
+					'find',
+				],
+			},
+		},
 	},
 /* -------------------------------------------------------------------------- */
 /*                                   contact:getAll                           */

--- a/packages/nodes-base/nodes/Xero/Xero.node.ts
+++ b/packages/nodes-base/nodes/Xero/Xero.node.ts
@@ -566,6 +566,14 @@ export class Xero implements INodeType {
 					}
 
 				}
+				if (operation === 'find') {
+					const organizationId = this.getNodeParameter('organizationId', i) as string;
+					const lookupField = this.getNodeParameter('contactLookupField', i) as string;
+					const lookupValue = this.getNodeParameter('contactLookupValue', i) as string;
+					const where = `${lookupField}="${lookupValue}"`;
+					responseData = await xeroApiRequest.call(this, 'GET', `/Contacts`, { organizationId }, { where });
+					responseData = responseData.Contacts;
+				}
 				if (operation === 'update') {
 					const organizationId = this.getNodeParameter('organizationId', i) as string;
 					const contactId = this.getNodeParameter('contactId', i) as string;


### PR DESCRIPTION
This PR adds Contact Searching / Finding Capability in the Xero Node. Contacts can be found using their Email Address, Account ID, or Account Name. These three parameters are mentioned as the most optimal, in the [Developer Documentation of Xero](https://developer.xero.com/documentation/api/contacts).

Would highly appreciate if you folks considered this PR. Good job done with n8n!