### PR TITLE
✨  Salesforce Case - Access custom fields create/update

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
@@ -112,6 +112,42 @@ export const caseFields = [
 				description: 'ID of the associated Contact.',
 			},
 			{
+				displayName: 'Custom Fields',
+				name: 'customFieldsUi',
+				placeholder: 'Add Custom Field',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				description: 'Filter by custom fields ',
+				default: {},
+				options: [
+					{
+						name: 'customFieldsValues',
+						displayName: 'Custom Field',
+						values: [
+							{
+								displayName: 'Field ID',
+								name: 'fieldId',
+								type: 'options',
+								typeOptions: {
+									loadOptionsMethod: 'getCustomFields',
+								},
+								default: '',
+								description: 'The ID of the field to add custom field to.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The value to set on custom field.',
+							},
+						],
+					},
+				],
+			},
+			{
 				displayName: 'Description',
 				name: 'description',
 				type: 'string',
@@ -259,14 +295,68 @@ export const caseFields = [
 		},
 		options: [
 			{
-				displayName: 'Type',
-				name: 'type',
-				type: 'options',
-				typeOptions: {
-					loadOptionsMethod: 'getCaseTypes',
-				},
+				displayName: 'Account ID',
+				name: 'accountId',
+				type: 'string',
 				default: '',
-				description: 'The type of case',
+				description: 'ID of the account associated with this case.',
+			},
+			{
+				displayName: 'Contact ID',
+				name: 'contactId',
+				type: 'string',
+				default: '',
+				description: 'ID of the associated Contact.',
+			},
+			{
+				displayName: 'Custom Fields',
+				name: 'customFieldsUi',
+				placeholder: 'Add Custom Field',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				description: 'Filter by custom fields ',
+				default: {},
+				options: [
+					{
+						name: 'customFieldsValues',
+						displayName: 'Custom Field',
+						values: [
+							{
+								displayName: 'Field ID',
+								name: 'fieldId',
+								type: 'options',
+								typeOptions: {
+									loadOptionsMethod: 'getCustomFields',
+								},
+								default: '',
+								description: 'The ID of the field to add custom field to.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The value to set on custom field.',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description: 'A text description of the case. Limit: 32 KB.',
+			},
+			{
+				displayName: 'Is Escalated',
+				name: 'isEscalated',
+				type: 'boolean',
+				default: false,
+				description: 'Indicates whether the case has been escalated (true) or not.',
 			},
 			{
 				displayName: 'Origin',
@@ -277,6 +367,33 @@ export const caseFields = [
 				},
 				default: '',
 				description: 'The source of the case, such as Email, Phone, or Web. Label is Case Origin.',
+			},
+			{
+				displayName: 'Owner',
+				name: 'owner',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getUsers',
+				},
+				default: '',
+				description: 'The owner of the case.',
+			},
+			{
+				displayName: 'Parent ID',
+				name: 'ParentId',
+				type: 'string',
+				default: '',
+				description: 'The ID of the parent case in the hierarchy. The label is Parent Case.',
+			},
+			{
+				displayName: 'Priority',
+				name: 'priority',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getCasePriorities',
+				},
+				default: '',
+				description: 'The importance or urgency of the case, such as High, Medium, or Low.',
 			},
 			{
 				displayName: 'Reason',
@@ -299,16 +416,6 @@ export const caseFields = [
 				description: 'The status of the case, such as “New,” “Closed,” or “Escalated.” This field directly controls the IsClosed flag',
 			},
 			{
-				displayName: 'Owner',
-				name: 'owner',
-				type: 'options',
-				typeOptions: {
-					loadOptionsMethod: 'getUsers',
-				},
-				default: '',
-				description: 'The owner of the case.',
-			},
-			{
 				displayName: 'Subject',
 				name: 'subject',
 				type: 'string',
@@ -316,56 +423,11 @@ export const caseFields = [
 				description: 'The subject of the case. Limit: 255 characters.',
 			},
 			{
-				displayName: 'Parent ID',
-				name: 'ParentId',
+				displayName: 'Supplied Company',
+				name: 'suppliedCompany',
 				type: 'string',
 				default: '',
-				description: 'The ID of the parent case in the hierarchy. The label is Parent Case.',
-			},
-			{
-				displayName: 'Priority',
-				name: 'priority',
-				type: 'options',
-				typeOptions: {
-					loadOptionsMethod: 'getCasePriorities',
-				},
-				default: '',
-				description: 'The importance or urgency of the case, such as High, Medium, or Low.',
-			},
-			{
-				displayName: 'Account ID',
-				name: 'accountId',
-				type: 'string',
-				default: '',
-				description: 'ID of the account associated with this case.',
-			},
-			{
-				displayName: 'Contact ID',
-				name: 'contactId',
-				type: 'string',
-				default: '',
-				description: 'ID of the associated Contact.',
-			},
-			{
-				displayName: 'Description',
-				name: 'description',
-				type: 'string',
-				default: '',
-				description: 'A text description of the case. Limit: 32 KB.',
-			},
-			{
-				displayName: 'Is Escalated',
-				name: 'isEscalated',
-				type: 'boolean',
-				default: false,
-				description: 'Indicates whether the case has been escalated (true) or not.',
-			},
-			{
-				displayName: 'Supplied Name',
-				name: 'suppliedName',
-				type: 'string',
-				default: '',
-				description: `The name that was entered when the case was created. This field can't be updated after the case has been created`,
+				description: `The company name that was entered when the case was created. This field can't be updated after the case has been created..`,
 			},
 			{
 				displayName: 'Supplied Email',
@@ -375,6 +437,13 @@ export const caseFields = [
 				description: `The email address that was entered when the case was created. This field can't be updated after the case has been created.`,
 			},
 			{
+				displayName: 'Supplied Name',
+				name: 'suppliedName',
+				type: 'string',
+				default: '',
+				description: `The name that was entered when the case was created. This field can't be updated after the case has been created`,
+			},
+			{
 				displayName: 'Supplied Phone',
 				name: 'suppliedPhone',
 				type: 'string',
@@ -382,11 +451,14 @@ export const caseFields = [
 				description: `The phone number that was entered when the case was created. This field can't be updated after the case has been created.`,
 			},
 			{
-				displayName: 'Supplied Company',
-				name: 'suppliedCompany',
-				type: 'string',
+				displayName: 'Type',
+				name: 'type',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getCaseTypes',
+				},
 				default: '',
-				description: `The company name that was entered when the case was created. This field can't be updated after the case has been created..`,
+				description: 'The type of case',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1918,6 +1918,15 @@ export class Salesforce implements INodeType {
 					if (additionalFields.suppliedCompany !== undefined) {
 						body.SuppliedCompany = additionalFields.suppliedCompany as string;
 					}
+					if (additionalFields.customFieldsUi) {
+						const customFields = (additionalFields.customFieldsUi as IDataObject).customFieldsValues as IDataObject[];
+						if (customFields) {
+							for (const customField of customFields) {
+								//@ts-ignore
+								body[customField.fieldId] = customField.value;
+							}
+						}
+					}
 					responseData = await salesforceApiRequest.call(this, 'POST', '/sobjects/case', body);
 				}
 				//https://developer.salesforce.com/docs/api-explorer/sobject/Case/patch-case-id
@@ -1969,6 +1978,15 @@ export class Salesforce implements INodeType {
 					}
 					if (updateFields.suppliedCompany !== undefined) {
 						body.SuppliedCompany = updateFields.suppliedCompany as string;
+					}
+					if (updateFields.customFieldsUi) {
+						const customFields = (updateFields.customFieldsUi as IDataObject).customFieldsValues as IDataObject[];
+						if (customFields) {
+							for (const customField of customFields) {
+								//@ts-ignore
+								body[customField.fieldId] = customField.value;
+							}
+						}
 					}
 					responseData = await salesforceApiRequest.call(this, 'PATCH', `/sobjects/case/${caseId}`, body);
 				}


### PR DESCRIPTION
Salesforce Account, Lead, etc. allowed for including custom fields during create and update operations.  Applied same pattern to the standard Case object.  Also alphabetized fields in update section to match pattern of other object types.