### PR TITLE
✨  Salesforce Case/Lead Owner - Add Queues to Create/Update Owner options

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/CaseDescription.ts
@@ -140,7 +140,7 @@ export const caseFields = [
 				name: 'owner',
 				type: 'options',
 				typeOptions: {
-					loadOptionsMethod: 'getUsers',
+					loadOptionsMethod: 'getCaseOwners',
 				},
 				default: '',
 				description: 'The owner of the case.',
@@ -303,7 +303,7 @@ export const caseFields = [
 				name: 'owner',
 				type: 'options',
 				typeOptions: {
-					loadOptionsMethod: 'getUsers',
+					loadOptionsMethod: 'getCaseOwners',
 				},
 				default: '',
 				description: 'The owner of the case.',

--- a/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
@@ -251,7 +251,7 @@ export const leadFields = [
 				name: 'owner',
 				type: 'options',
 				typeOptions: {
-					loadOptionsMethod: 'getUsers',
+					loadOptionsMethod: 'getLeadOwners',
 				},
 				default: '',
 				description: 'The owner of the lead.',
@@ -509,7 +509,7 @@ export const leadFields = [
 				name: 'owner',
 				type: 'options',
 				typeOptions: {
-					loadOptionsMethod: 'getUsers',
+					loadOptionsMethod: 'getLeadOwners',
 				},
 				default: '',
 				description: 'The owner of the lead.',

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -298,6 +298,70 @@ export class Salesforce implements INodeType {
 				sortOptions(returnData);
 				return returnData;
 			},
+			// Get all the users and case queues to display them to user so that he can
+			// select them easily
+			async getCaseOwners(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const qsQueues = {
+					q: "SELECT Queue.Id, Queue.Name FROM QueuesObject where Queue.Type='Queue' and SobjectType = 'Case'",
+				};
+				const queues = await salesforceApiRequestAllItems.call(this, 'records', 'GET', '/query', {}, qsQueues);
+				for (const queue of queues) {
+					const queueName = queue.Queue.Name;
+					const queueId = queue.Queue.Id;
+					returnData.push({
+						name: `Queue: ${queueName}`,
+						value: queueId,
+					});
+				}
+				const qsUsers = {
+					q: 'SELECT id, Name FROM User',
+				};
+				const users = await salesforceApiRequestAllItems.call(this, 'records', 'GET', '/query', {}, qsUsers);
+				const userPrefix = returnData.length > 0 ? 'User: ' : '';
+				for (const user of users) {
+					const userName = user.Name;
+					const userId = user.Id;
+					returnData.push({
+						name: userPrefix + userName,
+						value: userId,
+					});
+				}
+				sortOptions(returnData);
+				return returnData;
+			},
+			// Get all the users and lead queues to display them to user so that he can
+			// select them easily
+			async getLeadOwners(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const qsQueues = {
+					q: "SELECT Queue.Id, Queue.Name FROM QueuesObject where Queue.Type='Queue' and SobjectType = 'Lead'",
+				};
+				const queues = await salesforceApiRequestAllItems.call(this, 'records', 'GET', '/query', {}, qsQueues);
+				for (const queue of queues) {
+					const queueName = queue.Queue.Name;
+					const queueId = queue.Queue.Id;
+					returnData.push({
+						name: `Queue: ${queueName}`,
+						value: queueId,
+					});
+				}
+				const qsUsers = {
+					q: 'SELECT id, Name FROM User',
+				};
+				const users = await salesforceApiRequestAllItems.call(this, 'records', 'GET', '/query', {}, qsUsers);
+				const userPrefix = returnData.length > 0 ? 'User: ' : '';
+				for (const user of users) {
+					const userName = user.Name;
+					const userId = user.Id;
+					returnData.push({
+						name: userPrefix + userName,
+						value: userId,
+					});
+				}
+				sortOptions(returnData);
+				return returnData;
+			},
 			// Get all the lead sources to display them to user so that he can
 			// select them easily
 			async getLeadSources(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {


### PR DESCRIPTION
Cases and Leads are often assigned to Queues rather than users, with the value placed in the same Owner field.  The provided enhancement looks up the appropriate queues for these object types for the Owner field for create and update operations.  Results are prefixed with "Queue: " in the picklist to differentiate from Users.  If no queues are defined, behavior is unchanged for showing possible Users.  If Queues were defined, then users are also prefixed with "User: ".