### PR TITLE
[fix] Functions are listed recursively if the number of functions exceeds 50

### DIFF
--- a/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsLambda.node.ts
@@ -140,6 +140,27 @@ export class AwsLambda implements INodeType {
 						value: func.FunctionArn as string,
 					});
 				}
+
+				if (data.NextMarker) {
+					let marker: string = data.NextMarker;
+					while (true) {
+						const dataLoop = await awsApiRequestREST.call(this, 'lambda', 'GET', `/2015-03-31/functions/?MaxItems=50&Marker=${encodeURIComponent(marker)}`);
+				
+						for (const func of dataLoop.Functions!) {
+							returnData.push({
+								name: func.FunctionName as string,
+								value: func.FunctionArn as string,
+							});
+						}
+	
+						if (dataLoop.NextMarker) {
+							marker = dataLoop.NextMarker;
+						} else {
+							break;
+						}
+					}
+				}
+				
 				return returnData;
 			},
 		},


### PR DESCRIPTION
This problem affects those who have over 50 lambda functions because the current version cannot list all of them (i.e. only the first 50). I changed it a bit to list all functions recursively.

https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html