### PR TITLE
Feat: Add an 'Header Row' option to the SpreadsheetFile node

### DIFF
--- a/packages/nodes-base/nodes/SpreadsheetFile.node.json
+++ b/packages/nodes-base/nodes/SpreadsheetFile.node.json
@@ -1,7 +1,7 @@
 {
 	"node": "n8n-nodes-base.spreadsheetFile",
-	"nodeVersion": "1.0",
-	"codexVersion": "1.0",
+	"nodeVersion": "1.1",
+	"codexVersion": "1.1",
 	"categories": [
 		"Data & Storage",
 		"Core Nodes"


### PR DESCRIPTION
Hi all, I needed support for spreadsheets without headers for a project

---

When this new *Header Row* option is false the first row of the spreadsheet file is considered a data row and each row is parsed as an array in `item.json.row`.

The node previous behavior is preserved as the options is `true` by default.

:heavy_check_mark: `npm run tslint`
:heavy_check_mark: `npm run test`
:heavy_check_mark: `npm run dev` + *Header Row* = `false` test