### PR TITLE
Add codex search properties to node types

### DIFF
--- a/packages/cli/src/NodeTypes.ts
+++ b/packages/cli/src/NodeTypes.ts
@@ -1,4 +1,5 @@
 import {
+	CodexSearchProperties,
 	INodeType,
 	INodeTypeData,
 	INodeTypes,
@@ -25,7 +26,15 @@ class NodeTypesClass implements INodeTypes {
 	}
 
 	getAll(): INodeType[] {
-		return Object.values(this.nodeTypes).map((data) => data.type);
+		return Object.values(this.nodeTypes).map((data) => {
+			try {
+				data.type.description.codex = this.getCodexSearchProperties(data.sourcePath);
+			} catch (error) {
+				console.error(`No codex available for: ${data.sourcePath.split('/').pop()}`);
+			}
+
+			return data.type;
+		});
 	}
 
 	getByName(nodeType: string): INodeType | undefined {
@@ -33,6 +42,15 @@ class NodeTypesClass implements INodeTypes {
 			throw new Error(`The node-type "${nodeType}" is not known!`);
 		}
 		return this.nodeTypes[nodeType].type;
+	}
+
+	getCodexSearchProperties(fullNodePath: string): CodexSearchProperties {
+		const codex = require(`${fullNodePath}on`); // .js to .json
+
+		return {
+			categories: codex.categories ?? [],
+			alias: codex.alias ?? [],
+		};
 	}
 }
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -441,7 +441,6 @@ class App {
 		// Healthcheck
 		// ----------------------------------------
 
-
 		// Does very basic health check
 		this.app.get('/healthz', async (req: express.Request, res: express.Response) => {
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -566,6 +566,7 @@ export interface INodeTypeDescription {
 		deactivate?: INodeHookDescription[];
 	};
 	webhooks?: IWebhookDescription[];
+	codex?: CodexSearchProperties;
 }
 
 export interface INodeHookDescription {
@@ -781,3 +782,8 @@ export interface IRawErrorObject {
 export interface IStatusCodeMessages {
 	[key: string]: string;
 }
+
+export type CodexSearchProperties = {
+	categories: string[];
+	alias: string[];
+};


### PR DESCRIPTION
This PR adds codex search properties to the response of `/node-types` for the nodes panel revamp.

```
{ 
  "data": [
    {
      "displayName": "Compression",
      "name": "n8n-nodes-base.compression",
      "icon": "fa:file-archive",
      "group": [
        "transform"
      ],
      "subtitle": "={{$parameter[\"operation\"]}}",
      "version": 1,
      "description": "Compress and uncompress files",
      "defaults": {
        "name": "Compression",
        "color": "#408000"
      },
      "inputs": [
        "main"
      ],
      "outputs": [
        "main"
      ],
      "codex": {
        "categories": [
          "Core Nodes",
          "Data & Storage"
        ],
        "alias": [
          "Zip",
          "Gzip",
          "uncompress"
        ]
      }
    },
    // ...
  ]
}
```