### PR TITLE
Load credentials from the database

### DIFF
--- a/packages/cli/commands/execute.ts
+++ b/packages/cli/commands/execute.ts
@@ -155,10 +155,7 @@ export class Execute extends Command {
 		}
 
 		try {
-			const credentials = await WorkflowCredentials(workflowData!.nodes);
-
 			const runData: IWorkflowExecutionDataProcess = {
-				credentials,
 				executionMode: 'cli',
 				startNodes: [startNode.name],
 				workflowData: workflowData!,

--- a/packages/cli/commands/executeBatch.ts
+++ b/packages/cli/commands/executeBatch.ts
@@ -635,10 +635,8 @@ export class ExecuteBatch extends Command {
 
 
 			try {
-				const credentials = await WorkflowCredentials(workflowData!.nodes);
 
 				const runData: IWorkflowExecutionDataProcess = {
-					credentials,
 					executionMode: 'cli',
 					startNodes: [startNode!.name],
 					workflowData: workflowData!,

--- a/packages/cli/commands/worker.ts
+++ b/packages/cli/commands/worker.ts
@@ -148,9 +148,7 @@ export class Worker extends Command {
 
 		const workflow = new Workflow({ id: currentExecutionDb.workflowData.id as string, name: currentExecutionDb.workflowData.name, nodes: currentExecutionDb.workflowData!.nodes, connections: currentExecutionDb.workflowData!.connections, active: currentExecutionDb.workflowData!.active, nodeTypes, staticData, settings: currentExecutionDb.workflowData!.settings });
 
-		const credentials = await WorkflowCredentials(currentExecutionDb.workflowData.nodes);
-
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials, undefined, executionTimeoutTimestamp);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase(undefined, executionTimeoutTimestamp);
 		additionalData.hooks = WorkflowExecuteAdditionalData.getWorkflowHooksWorkerExecuter(currentExecutionDb.mode, job.data.executionId, currentExecutionDb.workflowData, { retryOf: currentExecutionDb.retryOf as string });
 
 		let workflowExecute: WorkflowExecute;

--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -192,9 +192,7 @@ export class ActiveWorkflowRunner {
 		const nodeTypes = NodeTypes();
 		const workflow = new Workflow({ id: webhook.workflowId.toString(), name: workflowData.name, nodes: workflowData.nodes, connections: workflowData.connections, active: workflowData.active, nodeTypes, staticData: workflowData.staticData, settings: workflowData.settings });
 
-		const credentials = await WorkflowCredentials([workflow.getNode(webhook.node as string) as INode]);
-
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase();
 
 		const webhookData = NodeHelpers.getNodeWebhooks(workflow, workflow.getNode(webhook.node as string) as INode, additionalData).filter((webhook) => {
 			return (webhook.httpMethod === httpMethod && webhook.path === path);
@@ -368,8 +366,7 @@ export class ActiveWorkflowRunner {
 
 		const mode = 'internal';
 
-		const credentials = await WorkflowCredentials(workflowData.nodes);
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase();
 
 		const webhooks = WebhookHelpers.getWorkflowWebhooks(workflow, additionalData);
 
@@ -421,7 +418,6 @@ export class ActiveWorkflowRunner {
 
 		// Start the workflow
 		const runData: IWorkflowExecutionDataProcess = {
-			credentials: additionalData.credentials,
 			executionMode: mode,
 			executionData,
 			workflowData,
@@ -508,8 +504,7 @@ export class ActiveWorkflowRunner {
 			}
 
 			const mode = 'trigger';
-			const credentials = await WorkflowCredentials(workflowData.nodes);
-			const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials);
+			const additionalData = await WorkflowExecuteAdditionalData.getBase();
 			const getTriggerFunctions = this.getExecuteTriggerFunctions(workflowData, additionalData, mode, activation);
 			const getPollFunctions = this.getExecutePollFunctions(workflowData, additionalData, mode, activation);
 

--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -48,7 +48,12 @@ export class CredentialsHelper extends ICredentialsHelper {
 	 * @returns {Credentials}
 	 * @memberof CredentialsHelper
 	 */
-	getCredentials(name: string, type: string): Credentials {
+	async getCredentials(name: string, type: string): Promise<Credentials> {
+
+		const credentialsDb = await Db.collections.Credentials?.find({type});
+
+		console.log(credentialsDb);
+
 		if (!this.workflowCredentials[type]) {
 			throw new Error(`No credentials of type "${type}" exist.`);
 		}
@@ -102,8 +107,8 @@ export class CredentialsHelper extends ICredentialsHelper {
 	 * @returns {ICredentialDataDecryptedObject}
 	 * @memberof CredentialsHelper
 	 */
-	getDecrypted(name: string, type: string, mode: WorkflowExecuteMode, raw?: boolean, expressionResolveValues?: ICredentialsExpressionResolveValues): ICredentialDataDecryptedObject {
-		const credentials = this.getCredentials(name, type);
+	async getDecrypted(name: string, type: string, mode: WorkflowExecuteMode, raw?: boolean, expressionResolveValues?: ICredentialsExpressionResolveValues): Promise<ICredentialDataDecryptedObject> {
+		const credentials = await this.getCredentials(name, type);
 
 		const decryptedDataOriginal = credentials.getData(this.encryptionKey);
 

--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -52,17 +52,17 @@ export class CredentialsHelper extends ICredentialsHelper {
 
 		const credentialsDb = await Db.collections.Credentials?.find({type});
 
-		console.log(credentialsDb);
-
-		if (!this.workflowCredentials[type]) {
+		if (credentialsDb === undefined || credentialsDb.length === 0) {
 			throw new Error(`No credentials of type "${type}" exist.`);
 		}
-		if (!this.workflowCredentials[type][name]) {
+
+		const credential = credentialsDb.find(credential => credential.name === name);
+
+		if (credential === undefined) {
 			throw new Error(`No credentials with name "${name}" exist for type "${type}".`);
 		}
-		const credentialData = this.workflowCredentials[type][name];
-
-		return new Credentials(credentialData.name, credentialData.type, credentialData.nodesAccess, credentialData.data);
+		
+		return new Credentials(credential.name, credential.type, credential.nodesAccess, credential.data);
 	}
 
 

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -457,7 +457,6 @@ export interface IProcessMessageDataHook {
 }
 
 export interface IWorkflowExecutionDataProcess {
-	credentials: IWorkflowCredentials;
 	destinationNode?: string;
 	executionMode: WorkflowExecuteMode;
 	executionData?: IRunExecutionData;

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -66,7 +66,6 @@ import {
 	TestWebhooks,
 	WebhookHelpers,
 	WebhookServer,
-	WorkflowCredentials,
 	WorkflowExecuteAdditionalData,
 	WorkflowHelpers,
 	WorkflowRunner,
@@ -79,7 +78,6 @@ import {
 } from 'n8n-core';
 
 import {
-	ICredentialsEncrypted,
 	ICredentialType,
 	IDataObject,
 	INodeCredentials,
@@ -764,8 +762,7 @@ class App {
 
 			// If webhooks nodes exist and are active we have to wait for till we receive a call
 			if (runData === undefined || startNodes === undefined || startNodes.length === 0 || destinationNode === undefined) {
-				const credentials = await WorkflowCredentials(workflowData.nodes);
-				const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials);
+				const additionalData = await WorkflowExecuteAdditionalData.getBase();
 				const nodeTypes = NodeTypes();
 				const workflowInstance = new Workflow({ id: workflowData.id, name: workflowData.name, nodes: workflowData.nodes, connections: workflowData.connections, active: false, nodeTypes, staticData: undefined, settings: workflowData.settings });
 				const needsWebhook = await this.testWebhooks.needsWebhookData(workflowData, workflowInstance, additionalData, executionMode, activationMode, sessionId, destinationNode);
@@ -779,11 +776,8 @@ class App {
 			// For manual testing always set to not active
 			workflowData.active = false;
 
-			const credentials = await WorkflowCredentials(workflowData.nodes);
-
 			// Start the workflow
 			const data: IWorkflowExecutionDataProcess = {
-				credentials,
 				destinationNode,
 				executionMode,
 				runData,
@@ -880,9 +874,7 @@ class App {
 			// @ts-ignore
 			const loadDataInstance = new LoadNodeParameterOptions(nodeType, nodeTypes, path, JSON.parse('' + req.query.currentNodeParameters), credentials!);
 
-			const workflowData = loadDataInstance.getWorkflowData() as IWorkflowBase;
-			const workflowCredentials = await WorkflowCredentials(workflowData.nodes);
-			const additionalData = await WorkflowExecuteAdditionalData.getBase(workflowCredentials, currentNodeParameters);
+			const additionalData = await WorkflowExecuteAdditionalData.getBase(currentNodeParameters);
 
 			return loadDataInstance.getOptions(methodName, additionalData);
 		}));
@@ -1259,15 +1251,9 @@ class App {
 				return '';
 			}
 
-			// Decrypt the currently saved credentials
-			const workflowCredentials: IWorkflowCredentials = {
-				[result.type as string]: {
-					[result.name as string]: result as ICredentialsEncrypted,
-				},
-			};
 			const mode: WorkflowExecuteMode = 'internal';
-			const credentialsHelper = new CredentialsHelper(workflowCredentials, encryptionKey);
-			const decryptedDataOriginal = credentialsHelper.getDecrypted(result.name, result.type, mode, true);
+			const credentialsHelper = new CredentialsHelper(encryptionKey);
+			const decryptedDataOriginal = await credentialsHelper.getDecrypted(result.name, result.type, mode, true);
 			const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(decryptedDataOriginal, result.type, mode);
 
 			const signatureMethod = _.get(oauthCredentials, 'signatureMethod') as string;
@@ -1358,10 +1344,10 @@ class App {
 					},
 				};
 				const mode: WorkflowExecuteMode = 'internal';
-				const credentialsHelper = new CredentialsHelper(workflowCredentials, encryptionKey);
-				const decryptedDataOriginal = credentialsHelper.getDecrypted(result.name, result.type, mode, true);
+				const credentialsHelper = new CredentialsHelper(encryptionKey);
+				const decryptedDataOriginal = await credentialsHelper.getDecrypted(result.name, result.type, mode, true);
 				const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(decryptedDataOriginal, result.type, mode);
-
+	
 				const options: OptionsWithUrl = {
 					method: 'POST',
 					url: _.get(oauthCredentials, 'accessTokenUrl') as string,
@@ -1427,15 +1413,9 @@ class App {
 				return '';
 			}
 
-			// Decrypt the currently saved credentials
-			const workflowCredentials: IWorkflowCredentials = {
-				[result.type as string]: {
-					[result.name as string]: result as ICredentialsEncrypted,
-				},
-			};
 			const mode: WorkflowExecuteMode = 'internal';
-			const credentialsHelper = new CredentialsHelper(workflowCredentials, encryptionKey);
-			const decryptedDataOriginal = credentialsHelper.getDecrypted(result.name, result.type, mode, true);
+			const credentialsHelper = new CredentialsHelper(encryptionKey);
+			const decryptedDataOriginal = await credentialsHelper.getDecrypted(result.name, result.type, mode, true);
 			const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(decryptedDataOriginal, result.type, mode);
 
 			const token = new csrf();
@@ -1534,11 +1514,12 @@ class App {
 						[result.name as string]: result as ICredentialsEncrypted,
 					},
 				};
+	
 				const mode: WorkflowExecuteMode = 'internal';
-				const credentialsHelper = new CredentialsHelper(workflowCredentials, encryptionKey);
-				const decryptedDataOriginal = credentialsHelper.getDecrypted(result.name, result.type, mode, true);
+				const credentialsHelper = new CredentialsHelper(encryptionKey);
+				const decryptedDataOriginal = await credentialsHelper.getDecrypted(result.name, result.type, mode, true);
 				const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(decryptedDataOriginal, result.type, mode);
-
+	
 				const token = new csrf();
 				if (decryptedDataOriginal.csrfSecret === undefined || !token.verify(decryptedDataOriginal.csrfSecret as string, state.token)) {
 					const errorResponse = new ResponseHelper.ResponseError('The OAuth2 callback state is invalid!', undefined, 404);
@@ -1735,13 +1716,10 @@ class App {
 
 			const executionMode = 'retry';
 
-			const credentials = await WorkflowCredentials(fullExecutionData.workflowData.nodes);
-
 			fullExecutionData.workflowData.active = false;
 
 			// Start the workflow
 			const data: IWorkflowExecutionDataProcess = {
-				credentials,
 				executionMode,
 				executionData: fullExecutionData.data,
 				retryOf: req.params.id,

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -78,6 +78,7 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialsEncrypted,
 	ICredentialType,
 	IDataObject,
 	INodeCredentials,
@@ -1336,6 +1337,7 @@ class App {
 					const errorResponse = new ResponseHelper.ResponseError('No encryption key got found to decrypt the credentials!', undefined, 503);
 					return ResponseHelper.sendErrorResponse(res, errorResponse);
 				}
+
 
 				// Decrypt the currently saved credentials
 				const workflowCredentials: IWorkflowCredentials = {

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -129,8 +129,7 @@ export function getWorkflowWebhooksBasic(workflow: Workflow): IWebhookData[] {
 	}
 
 	// Prepare everything that is needed to run the workflow
-	const credentials = await WorkflowCredentials(workflowData.nodes);
-	const additionalData = await WorkflowExecuteAdditionalData.getBase(credentials);
+	const additionalData = await WorkflowExecuteAdditionalData.getBase();
 
 	// Add the Response and Request so that this data can be accessed in the node
 	additionalData.httpRequest = req;
@@ -276,7 +275,6 @@ export function getWorkflowWebhooksBasic(workflow: Workflow): IWebhookData[] {
 		}
 
 		const runData: IWorkflowExecutionDataProcess = {
-			credentials,
 			executionMode,
 			executionData: runExecutionData,
 			sessionId,

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -545,12 +545,7 @@ export async function getRunData(workflowData: IWorkflowBase, inputData?: INodeE
 		},
 	};
 
-	// Get the needed credentials for the current workflow as they will differ to the ones of the
-	// calling workflow.
-	const credentials = await WorkflowCredentials(workflowData!.nodes);
-
 	const runData: IWorkflowExecutionDataProcess = {
-		credentials,
 		executionMode: mode,
 		executionData: runExecutionData,
 		// @ts-ignore
@@ -735,7 +730,7 @@ export function sendMessageToUI(source: string, message: any) { // tslint:disabl
  * @param {INodeParameters} currentNodeParameters
  * @returns {Promise<IWorkflowExecuteAdditionalData>}
  */
-export async function getBase(credentials: IWorkflowCredentials, currentNodeParameters?: INodeParameters, executionTimeoutTimestamp?: number): Promise<IWorkflowExecuteAdditionalData> {
+export async function getBase(currentNodeParameters?: INodeParameters, executionTimeoutTimestamp?: number): Promise<IWorkflowExecuteAdditionalData> {
 	const urlBaseWebhook = WebhookHelpers.getWebhookBaseUrl();
 
 	const timezone = config.get('generic.timezone') as string;
@@ -748,8 +743,7 @@ export async function getBase(credentials: IWorkflowCredentials, currentNodePara
 	}
 
 	return {
-		credentials,
-		credentialsHelper: new CredentialsHelper(credentials, encryptionKey),
+		credentialsHelper: new CredentialsHelper(encryptionKey),
 		encryptionKey,
 		executeWorkflow,
 		restApiUrl: urlBaseWebhook + config.get('endpoints.rest') as string,

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -613,13 +613,9 @@ export async function executeWorkflow(workflowInfo: IExecuteWorkflowInfo, additi
 
 	let data;
 	try {
-		// Get the needed credentials for the current workflow as they will differ to the ones of the
-		// calling workflow.
-		const credentials = await WorkflowCredentials(workflowData!.nodes);
-
 		// Create new additionalData to have different workflow loaded and to call
 		// different webooks
-		const additionalDataIntegrated = await getBase(credentials);
+		const additionalDataIntegrated = await getBase();
 		additionalDataIntegrated.hooks = getWorkflowHooksIntegrated(runData.executionMode, executionId, workflowData!, { parentProcessMode: additionalData.hooks!.mode });
 		// Make sure we pass on the original executeWorkflow function we received
 		// This one already contains changes to talk to parent process

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -144,10 +144,7 @@ export async function executeErrorWorkflow(workflowId: string, workflowErrorData
 			},
 		};
 
-		const credentials = await WorkflowCredentials(workflowData.nodes);
-
 		const runData: IWorkflowExecutionDataProcess = {
-			credentials,
 			executionMode,
 			executionData: runExecutionData,
 			workflowData,

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -430,7 +430,7 @@ export class WorkflowRunner {
 		(data as unknown as IWorkflowExecutionDataProcessWithExecution).executionId = executionId;
 		(data as unknown as IWorkflowExecutionDataProcessWithExecution).nodeTypeData = nodeTypeData;
 		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsOverwrite = this.credentialsOverwrites;
-		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsTypeData = credentialTypes.credentialTypes; // TODO: Still needs correct value
+		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsTypeData = credentialTypes.credentialTypes;
 
 		const workflowHooks = WorkflowExecuteAdditionalData.getWorkflowHooksMain(data, executionId);
 

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -183,7 +183,7 @@ export class WorkflowRunner {
 		}
 
 		const workflow = new Workflow({ id: data.workflowData.id as string | undefined, name: data.workflowData.name, nodes: data.workflowData!.nodes, connections: data.workflowData!.connections, active: data.workflowData!.active, nodeTypes, staticData: data.workflowData!.staticData });
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(data.credentials, undefined, workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase(undefined, workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000);
 
 		// Register the active execution
 		const executionId = await this.activeExecutions.add(data, undefined);
@@ -423,43 +423,14 @@ export class WorkflowRunner {
 		// Register the active execution
 		const executionId = await this.activeExecutions.add(data, subprocess);
 
-		// Check if workflow contains a "executeWorkflow" Node as in this
-		// case we can not know which nodeTypes and credentialTypes will
-		// be needed and so have to load all of them in the workflowRunnerProcess
-		let loadAllNodeTypes = false;
-		for (const node of data.workflowData.nodes) {
-			if (node.type === 'n8n-nodes-base.executeWorkflow') {
-				loadAllNodeTypes = true;
-				break;
-			}
-		}
-
-		let nodeTypeData: ITransferNodeTypes;
-		let credentialTypeData: ICredentialsTypeData;
-		let credentialsOverwrites = this.credentialsOverwrites;
-
-		if (loadAllNodeTypes === true) {
-			// Supply all nodeTypes and credentialTypes
-			nodeTypeData = WorkflowHelpers.getAllNodeTypeData();
-			const credentialTypes = CredentialTypes();
-			credentialTypeData = credentialTypes.credentialTypes;
-		} else {
-			// Supply only nodeTypes, credentialTypes and overwrites that the workflow needs
-			nodeTypeData = WorkflowHelpers.getNodeTypeData(data.workflowData.nodes);
-			credentialTypeData = WorkflowHelpers.getCredentialsData(data.credentials);
-
-			credentialsOverwrites = {};
-			for (const credentialName of Object.keys(credentialTypeData)) {
-				if (this.credentialsOverwrites[credentialName] !== undefined) {
-					credentialsOverwrites[credentialName] = this.credentialsOverwrites[credentialName];
-				}
-			}
-		}
+		// Supply all nodeTypes and credentialTypes
+		const nodeTypeData = WorkflowHelpers.getAllNodeTypeData() as ITransferNodeTypes;
+		const credentialTypes = CredentialTypes();
 
 		(data as unknown as IWorkflowExecutionDataProcessWithExecution).executionId = executionId;
 		(data as unknown as IWorkflowExecutionDataProcessWithExecution).nodeTypeData = nodeTypeData;
-		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsOverwrite = credentialsOverwrites;
-		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsTypeData = credentialTypeData; // TODO: Still needs correct value
+		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsOverwrite = this.credentialsOverwrites;
+		(data as unknown as IWorkflowExecutionDataProcessWithExecution).credentialsTypeData = credentialTypes.credentialTypes; // TODO: Still needs correct value
 
 		const workflowHooks = WorkflowExecuteAdditionalData.getWorkflowHooksMain(data, executionId);
 

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -135,7 +135,7 @@ export class WorkflowRunnerProcess {
 		}
 
 		this.workflow = new Workflow({ id: this.data.workflowData.id as string | undefined, name: this.data.workflowData.name, nodes: this.data.workflowData!.nodes, connections: this.data.workflowData!.connections, active: this.data.workflowData!.active, nodeTypes, staticData: this.data.workflowData!.staticData, settings: this.data.workflowData!.settings });
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(this.data.credentials, undefined, workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase(undefined, workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000);
 		additionalData.hooks = this.getProcessForwardHooks();
 
 		additionalData.sendMessageToUI = async (source: string, message: any) => { // tslint:disable-line:no-any

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -111,9 +111,22 @@ export class WorkflowRunnerProcess {
 		const externalHooks = ExternalHooks();
 		await externalHooks.init();
 
-		// This code has been split into 3 ifs just to make it easier to understand
+		// Credentials should now be loaded from database.
+		// We check if any node uses credentials. If it does, then
+		// init database.
+		let shouldInitializeDb = false;
+		inputData.workflowData.nodes.map(node => {
+			if (Object.keys(node.credentials === undefined ? {} : node.credentials).length > 0) {
+				shouldInitializeDb = true;
+			}
+		});
+
+		// This code has been split into 4 ifs just to make it easier to understand
 		// Can be made smaller but in the end it will make it impossible to read.
-		if (inputData.workflowData.settings !== undefined && inputData.workflowData.settings.saveExecutionProgress === true) {
+		if (shouldInitializeDb) {
+			// initialize db as we need to load credentials
+			await Db.init();
+		} else if (inputData.workflowData.settings !== undefined && inputData.workflowData.settings.saveExecutionProgress === true) {
 			// Workflow settings specifying it should save
 			await Db.init();
 		} else if (inputData.workflowData.settings !== undefined && inputData.workflowData.settings.saveExecutionProgress !== false && config.get('executions.saveExecutionProgress') as boolean) {

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -114,16 +114,16 @@ export class WorkflowRunnerProcess {
 		// Credentials should now be loaded from database.
 		// We check if any node uses credentials. If it does, then
 		// init database.
-		let shouldInitializeDb = false;
+		let shouldInitializaDb = false;
 		inputData.workflowData.nodes.map(node => {
 			if (Object.keys(node.credentials === undefined ? {} : node.credentials).length > 0) {
-				shouldInitializeDb = true;
+				shouldInitializaDb = true;
 			}
 		});
 
 		// This code has been split into 4 ifs just to make it easier to understand
 		// Can be made smaller but in the end it will make it impossible to read.
-		if (shouldInitializeDb) {
+		if (shouldInitializaDb) {
 			// initialize db as we need to load credentials
 			await Db.init();
 		} else if (inputData.workflowData.settings !== undefined && inputData.workflowData.settings.saveExecutionProgress === true) {

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -140,8 +140,8 @@ export async function prepareBinaryData(binaryData: Buffer, filePath?: string, m
  *
  * @returns
  */
-export function requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, node: INode, additionalData: IWorkflowExecuteAdditionalData, oAuth2Options?: IOAuth2Options) {
-	const credentials = this.getCredentials(credentialsType) as ICredentialDataDecryptedObject;
+export async function requestOAuth2(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUri | requestPromise.RequestPromiseOptions, node: INode, additionalData: IWorkflowExecuteAdditionalData, oAuth2Options?: IOAuth2Options) {
+	const credentials = await this.getCredentials(credentialsType) as ICredentialDataDecryptedObject;
 
 	if (credentials === undefined) {
 		throw new Error('No credentials got returned!');
@@ -229,8 +229,8 @@ export function requestOAuth2(this: IAllExecuteFunctions, credentialsType: strin
 * @param {(OptionsWithUrl | requestPromise.RequestPromiseOptions)} requestOptionså
 * @returns
 */
-export function requestOAuth1(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUrl | OptionsWithUri | requestPromise.RequestPromiseOptions) {
-	const credentials = this.getCredentials(credentialsType) as ICredentialDataDecryptedObject;
+export async function requestOAuth1(this: IAllExecuteFunctions, credentialsType: string, requestOptions: OptionsWithUrl | OptionsWithUri | requestPromise.RequestPromiseOptions) {
+	const credentials = await this.getCredentials(credentialsType) as ICredentialDataDecryptedObject;
 
 	if (credentials === undefined) {
 		throw new Error('No credentials got returned!');
@@ -317,7 +317,7 @@ export function returnJsonArray(jsonData: IDataObject | IDataObject[]): INodeExe
  * @param {IWorkflowExecuteAdditionalData} additionalData
  * @returns {(ICredentialDataDecryptedObject | undefined)}
  */
-export function getCredentials(workflow: Workflow, node: INode, type: string, additionalData: IWorkflowExecuteAdditionalData, mode: WorkflowExecuteMode, runExecutionData?: IRunExecutionData | null, runIndex?: number, connectionInputData?: INodeExecutionData[], itemIndex?: number): ICredentialDataDecryptedObject | undefined {
+export async function getCredentials(workflow: Workflow, node: INode, type: string, additionalData: IWorkflowExecuteAdditionalData, mode: WorkflowExecuteMode, runExecutionData?: IRunExecutionData | null, runIndex?: number, connectionInputData?: INodeExecutionData[], itemIndex?: number): Promise<ICredentialDataDecryptedObject | undefined> {
 
 	// Get the NodeType as it has the information if the credentials are required
 	const nodeType = workflow.nodeTypes.getByName(node.type);
@@ -371,7 +371,7 @@ export function getCredentials(workflow: Workflow, node: INode, type: string, ad
 
 	const name = node.credentials[type];
 
-	const decryptedDataObject = additionalData.credentialsHelper.getDecrypted(name, type, mode, false, expressionResolveValues);
+	const decryptedDataObject = await additionalData.credentialsHelper.getDecrypted(name, type, mode, false, expressionResolveValues);
 
 	return decryptedDataObject;
 }
@@ -555,8 +555,8 @@ export function getExecutePollFunctions(workflow: Workflow, node: INode, additio
 			__emit: (data: INodeExecutionData[][]): void => {
 				throw new Error('Overwrite NodeExecuteFunctions.getExecutePullFunctions.__emit function!');
 			},
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode);
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode);
 			},
 			getMode: (): WorkflowExecuteMode => {
 				return mode;
@@ -621,8 +621,8 @@ export function getExecuteTriggerFunctions(workflow: Workflow, node: INode, addi
 			emit: (data: INodeExecutionData[][]): void => {
 				throw new Error('Overwrite NodeExecuteFunctions.getExecuteTriggerFunctions.emit function!');
 			},
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode);
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode);
 			},
 			getNode: () => {
 				return getNode(node);
@@ -699,8 +699,8 @@ export function getExecuteFunctions(workflow: Workflow, runExecutionData: IRunEx
 			getContext(type: string): IContextObject {
 				return NodeHelpers.getContext(runExecutionData, type, node);
 			},
-			getCredentials(type: string, itemIndex?: number): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode, runExecutionData, runIndex, connectionInputData, itemIndex);
+			async getCredentials(type: string, itemIndex?: number): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode, runExecutionData, runIndex, connectionInputData, itemIndex);
 			},
 			getInputData: (inputIndex = 0, inputName = 'main') => {
 
@@ -806,8 +806,8 @@ export function getExecuteSingleFunctions(workflow: Workflow, runExecutionData: 
 			getContext(type: string): IContextObject {
 				return NodeHelpers.getContext(runExecutionData, type, node);
 			},
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode, runExecutionData, runIndex, connectionInputData, itemIndex);
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode, runExecutionData, runIndex, connectionInputData, itemIndex);
 			},
 			getInputData: (inputIndex = 0, inputName = 'main') => {
 				if (!inputData.hasOwnProperty(inputName)) {
@@ -886,8 +886,8 @@ export function getExecuteSingleFunctions(workflow: Workflow, runExecutionData: 
 export function getLoadOptionsFunctions(workflow: Workflow, node: INode, path: string, additionalData: IWorkflowExecuteAdditionalData): ILoadOptionsFunctions {
 	return ((workflow: Workflow, node: INode, path: string) => {
 		const that = {
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, 'internal');
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, 'internal');
 			},
 			getCurrentNodeParameter: (parameterPath: string): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[] | object | undefined => {
 				const nodeParameters = additionalData.currentNodeParameters;
@@ -947,8 +947,8 @@ export function getLoadOptionsFunctions(workflow: Workflow, node: INode, path: s
 export function getExecuteHookFunctions(workflow: Workflow, node: INode, additionalData: IWorkflowExecuteAdditionalData, mode: WorkflowExecuteMode, activation: WorkflowActivateMode, isTest?: boolean, webhookData?: IWebhookData): IHookFunctions {
 	return ((workflow: Workflow, node: INode) => {
 		const that = {
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode);
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode);
 			},
 			getMode: (): WorkflowExecuteMode => {
 				return mode;
@@ -1024,8 +1024,8 @@ export function getExecuteWebhookFunctions(workflow: Workflow, node: INode, addi
 				}
 				return additionalData.httpRequest.body;
 			},
-			getCredentials(type: string): ICredentialDataDecryptedObject | undefined {
-				return getCredentials(workflow, node, type, additionalData, mode);
+			async getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined> {
+				return await getCredentials(workflow, node, type, additionalData, mode);
 			},
 			getHeaderData(): object {
 				if (additionalData.httpRequest === undefined) {

--- a/packages/core/test/Helpers.ts
+++ b/packages/core/test/Helpers.ts
@@ -26,12 +26,14 @@ import {
 
 
 export class CredentialsHelper extends ICredentialsHelper {
-	getDecrypted(name: string, type: string): ICredentialDataDecryptedObject {
-		return {};
+	getDecrypted(name: string, type: string): Promise<ICredentialDataDecryptedObject> {
+		return new Promise(res => res({}));
 	}
 
-	getCredentials(name: string, type: string): Credentials {
-		return new Credentials('', '', [], '');
+	getCredentials(name: string, type: string): Promise<Credentials> {
+		return new Promise(res => {
+			res(new Credentials('', '', [], ''));
+		});
 	}
 
 	async updateCredentials(name: string, type: string, data: ICredentialDataDecryptedObject): Promise<void> {}

--- a/packages/core/test/Helpers.ts
+++ b/packages/core/test/Helpers.ts
@@ -750,8 +750,7 @@ export function WorkflowExecuteAdditionalData(waitPromise: IDeferredPromise<IRun
 	};
 
 	return {
-		credentials: {},
-		credentialsHelper: new CredentialsHelper({}, ''),
+		credentialsHelper: new CredentialsHelper(''),
 		hooks: new WorkflowHooks(hookFunctions, 'trigger', '1', workflowData),
 		executeWorkflow: async (workflowInfo: IExecuteWorkflowInfo): Promise<any> => {}, // tslint:disable-line:no-any
 		sendMessageToUI: (message: string) => {},

--- a/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function actionNetworkApiRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	const credentials = this.getCredentials('actionNetworkApi') as { apiKey: string } | undefined;
+	const credentials = await this.getCredentials('actionNetworkApi') as { apiKey: string } | undefined;
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/ActiveCampaign/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/GenericFunctions.ts
@@ -26,7 +26,7 @@ export interface IProduct {
  * @returns {Promise<any>}
  */
 export async function activeCampaignApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: IDataObject, query?: IDataObject, dataKey?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('activeCampaignApi');
+	const credentials = await this.getCredentials('activeCampaignApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/AcuityScheduling/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function acuitySchedulingApiRequest(this: IHookFunctions | IExecute
 
 	try {
 		if (authenticationMethod === 'apiKey') {
-			const credentials = this.getCredentials('acuitySchedulingApi');
+			const credentials = await this.getCredentials('acuitySchedulingApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Affinity/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Affinity/GenericFunctions.ts
@@ -18,7 +18,7 @@ import {
 
 export async function affinityApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('affinityApi');
+	const credentials = await this.getCredentials('affinityApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/AgileCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/AgileCrm/GenericFunctions.ts
@@ -17,7 +17,7 @@ import { IContactUpdate } from './ContactInterface';
 
 export async function agileCrmApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: any = {}, query: IDataObject = {}, uri?: string): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('agileCrmApi');
+	const credentials = await this.getCredentials('agileCrmApi');
 	const options: OptionsWithUri = {
 		method,
 		headers: {
@@ -46,7 +46,7 @@ export async function agileCrmApiRequest(this: IHookFunctions | IExecuteFunction
 
 export async function agileCrmApiRequestUpdate(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method = 'PUT', endpoint?: string, body: any = {}, query: IDataObject = {}, uri?: string): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('agileCrmApi');
+	const credentials = await this.getCredentials('agileCrmApi');
 	const baseUri = `https://${credentials!.subdomain}.agilecrm.com/dev/`;
 	const options: OptionsWithUri = {
 		method,

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -40,7 +40,7 @@ export interface IRecord {
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions, method: string, endpoint: string, body: object, query?: IDataObject, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('airtableApi');
+	const credentials = await this.getCredentials('airtableApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Amqp/Amqp.node.ts
+++ b/packages/nodes-base/nodes/Amqp/Amqp.node.ts
@@ -98,7 +98,7 @@ export class Amqp implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		try {
-			const credentials = this.getCredentials('amqp');
+			const credentials = await this.getCredentials('amqp');
 			if (!credentials) {
 				throw new NodeOperationError(this.getNode(), 'Credentials are mandatory!');
 			}

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -132,7 +132,7 @@ export class AmqpTrigger implements INodeType {
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
 
-		const credentials = this.getCredentials('amqp');
+		const credentials = await this.getCredentials('amqp');
 		if (!credentials) {
 			throw new NodeOperationError(this.getNode(), 'Credentials are mandatory!');
 		}

--- a/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
@@ -15,7 +15,7 @@ export async function apiTemplateIoApiRequest(
 	qs = {},
 	body = {},
 ) {
-	const { apiKey } = this.getCredentials('apiTemplateIoApi') as { apiKey: string };
+	const { apiKey } = await this.getCredentials('apiTemplateIoApi') as { apiKey: string };
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Asana/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Asana/GenericFunctions.ts
@@ -42,7 +42,7 @@ export async function asanaApiRequest(this: IHookFunctions | IExecuteFunctions |
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('asanaApi');
+			const credentials = await this.getCredentials('asanaApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Automizy/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Automizy/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function automizyApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('automizyApi') as IDataObject;
+	const credentials = await this.getCredentials('automizyApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Autopilot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Autopilot/GenericFunctions.ts
@@ -16,7 +16,7 @@ import {
 
 export async function autopilotApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('autopilotApi') as IDataObject;
+	const credentials = await this.getCredentials('autopilotApi') as IDataObject;
 
 	const apiKey = `${credentials.apiKey}`;
 

--- a/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
@@ -38,7 +38,7 @@ function getEndpointForService(service: string, credentials: ICredentialDataDecr
 }
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
@@ -36,7 +36,7 @@ function getEndpointForService(service: string, credentials: ICredentialDataDecr
 }
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: object | IRequestBody, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new Error('No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/GenericFunctions.ts
@@ -29,7 +29,7 @@ function getEndpointForService(service: string, credentials: ICredentialDataDecr
 }
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -36,7 +36,7 @@ import {
 } from 'change-case';
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string | Buffer | IDataObject, query: IDataObject = {}, headers?: object, option: IDataObject = {}, region?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/S3/AwsS3.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/AwsS3.node.ts
@@ -115,7 +115,7 @@ export class AwsS3 implements INodeType {
 				if (resource === 'bucket') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html
 					if (operation === 'create') {
-						const credentials = this.getCredentials('aws');
+						const credentials = await this.getCredentials('aws');
 						const name = this.getNodeParameter('name', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 						if (additionalFields.acl) {

--- a/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/GenericFunctions.ts
@@ -30,7 +30,7 @@ import {
  } from 'n8n-workflow';
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string | Buffer, query: IDataObject = {}, headers?: object, option: IDataObject = {}, region?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/SES/GenericFunctions.ts
@@ -30,7 +30,7 @@ import {
 } from 'lodash';
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
@@ -41,7 +41,7 @@ function getEndpointForService(service: string, credentials: ICredentialDataDecr
 }
 
 export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, service: string, method: string, path: string, body?: string, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('aws');
+	const credentials = await this.getCredentials('aws');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Bannerbear/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bannerbear/GenericFunctions.ts
@@ -21,7 +21,7 @@ import {
 
 export async function bannerbearApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, headers: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('bannerbearApi');
+	const credentials = await this.getCredentials('bannerbearApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Baserow/Baserow.node.ts
+++ b/packages/nodes-base/nodes/Baserow/Baserow.node.ts
@@ -114,7 +114,7 @@ export class Baserow implements INodeType {
 	methods = {
 		loadOptions: {
 			async getDatabaseIds(this: ILoadOptionsFunctions) {
-				const credentials = this.getCredentials('baserowApi') as BaserowCredentials;
+				const credentials = await this.getCredentials('baserowApi') as BaserowCredentials;
 				const jwtToken = await getJwtToken.call(this, credentials);
 				const endpoint = '/api/applications/';
 				const databases = await baserowApiRequest.call(this, 'GET', endpoint, {}, {}, jwtToken) as LoadedResource[];
@@ -122,7 +122,7 @@ export class Baserow implements INodeType {
 			},
 
 			async getTableIds(this: ILoadOptionsFunctions) {
-				const credentials = this.getCredentials('baserowApi') as BaserowCredentials;
+				const credentials = await this.getCredentials('baserowApi') as BaserowCredentials;
 				const jwtToken = await getJwtToken.call(this, credentials);
 				const databaseId = this.getNodeParameter('databaseId', 0) as string;
 				const endpoint = `/api/database/tables/database/${databaseId}`;
@@ -131,7 +131,7 @@ export class Baserow implements INodeType {
 			},
 
 			async getTableFields(this: ILoadOptionsFunctions) {
-				const credentials = this.getCredentials('baserowApi') as BaserowCredentials;
+				const credentials = await this.getCredentials('baserowApi') as BaserowCredentials;
 				const jwtToken = await getJwtToken.call(this, credentials);
 				const tableId = this.getNodeParameter('tableId', 0) as string;
 				const endpoint = `/api/database/fields/table/${tableId}/`;
@@ -148,7 +148,7 @@ export class Baserow implements INodeType {
 		const operation = this.getNodeParameter('operation', 0) as Operation;
 
 		const tableId = this.getNodeParameter('tableId', 0) as string;
-		const credentials = this.getCredentials('baserowApi') as BaserowCredentials;
+		const credentials = await this.getCredentials('baserowApi') as BaserowCredentials;
 		const jwtToken = await getJwtToken.call(this, credentials);
 		const fields = await mapper.getTableFields.call(this, tableId, jwtToken);
 		mapper.createMappings(fields);

--- a/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
@@ -30,7 +30,7 @@ export async function baserowApiRequest(
 	qs: IDataObject = {},
 	jwtToken: string,
 ) {
-	const credentials = this.getCredentials('baserowApi') as BaserowCredentials;
+	const credentials = await this.getCredentials('baserowApi') as BaserowCredentials;
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
@@ -16,7 +16,7 @@ import {
 } from './GenericFunctions';
 
 export async function createDatapoint(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, data: IDataObject) {
-	const credentials = this.getCredentials('beeminderApi');
+	const credentials = await this.getCredentials('beeminderApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -28,7 +28,7 @@ export async function createDatapoint(this: IExecuteFunctions | IWebhookFunction
 }
 
 export async function getAllDatapoints(this: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions, data: IDataObject) {
-	const credentials = this.getCredentials('beeminderApi');
+	const credentials = await this.getCredentials('beeminderApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -44,7 +44,7 @@ export async function getAllDatapoints(this: IExecuteFunctions | IHookFunctions 
 }
 
 export async function updateDatapoint(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, data: IDataObject) {
-	const credentials = this.getCredentials('beeminderApi');
+	const credentials = await this.getCredentials('beeminderApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -56,7 +56,7 @@ export async function updateDatapoint(this: IExecuteFunctions | IWebhookFunction
 }
 
 export async function deleteDatapoint(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, data: IDataObject) {
-	const credentials = this.getCredentials('beeminderApi');
+	const credentials = await this.getCredentials('beeminderApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
@@ -306,7 +306,7 @@ export class Beeminder implements INodeType {
 			// select them easily
 			async getGoals(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 
-				const credentials = this.getCredentials('beeminderApi');
+				const credentials = await this.getCredentials('beeminderApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
@@ -18,7 +18,7 @@ const BEEMINDER_URI = 'https://www.beeminder.com/api/v1';
 
 export async function beeminderApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: any = {}, query: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('beeminderApi') as IDataObject;
+	const credentials = await this.getCredentials('beeminderApi') as IDataObject;
 
 	Object.assign(body, { auth_token: credentials.authToken });
 

--- a/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
+++ b/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
@@ -221,7 +221,7 @@ export class BitbucketTrigger implements INodeType {
 			// Get all the repositories to display them to user so that he can
 			// select them easily
 			async getRepositories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const credentials = this.getCredentials('bitbucketApi');
+				const credentials = await this.getCredentials('bitbucketApi');
 				const returnData: INodePropertyOptions[] = [];
 				const repositories = await bitbucketApiRequestAllItems.call(this, 'values', 'GET', `/repositories/${credentials!.username}`);
 				for (const repository of repositories) {
@@ -261,7 +261,7 @@ export class BitbucketTrigger implements INodeType {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				let endpoint = '';
-				const credentials = this.getCredentials('bitbucketApi');
+				const credentials = await this.getCredentials('bitbucketApi');
 				const resource = this.getNodeParameter('resource', 0) as string;
 				const webhookData = this.getWorkflowStaticData('node');
 				if (webhookData.webhookId === undefined) {
@@ -292,7 +292,7 @@ export class BitbucketTrigger implements INodeType {
 				const webhookData = this.getWorkflowStaticData('node');
 				const events = this.getNodeParameter('events') as string[];
 				const resource = this.getNodeParameter('resource', 0) as string;
-				const credentials = this.getCredentials('bitbucketApi');
+				const credentials = await this.getCredentials('bitbucketApi');
 
 				if (resource === 'user') {
 					endpoint = `/users/${credentials!.username}/hooks`;
@@ -318,7 +318,7 @@ export class BitbucketTrigger implements INodeType {
 			async delete(this: IHookFunctions): Promise<boolean> {
 				let endpoint = '';
 				const webhookData = this.getWorkflowStaticData('node');
-				const credentials = this.getCredentials('bitbucketApi');
+				const credentials = await this.getCredentials('bitbucketApi');
 				const resource = this.getNodeParameter('resource', 0) as string;
 				if (resource === 'user') {
 					endpoint = `/users/${credentials!.username}/hooks/${webhookData.webhookId}`;

--- a/packages/nodes-base/nodes/Bitbucket/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitbucket/GenericFunctions.ts
@@ -8,7 +8,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function bitbucketApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('bitbucketApi');
+	const credentials = await this.getCredentials('bitbucketApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Bitly/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitly/GenericFunctions.ts
@@ -30,7 +30,7 @@ export async function bitlyApiRequest(this: IHookFunctions | IExecuteFunctions |
 
 	try{
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('bitlyApi');
+			const credentials = await this.getCredentials('bitlyApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -25,6 +25,7 @@ export async function bitwardenApiRequest(
 	token: string,
 ): Promise<any> { // tslint:disable-line:no-any
 
+	const baseUrl = await getBaseUrl.call(this);
 	const options: OptionsWithUri = {
 		headers: {
 			'user-agent': 'n8n',
@@ -34,7 +35,7 @@ export async function bitwardenApiRequest(
 		method,
 		qs,
 		body,
-		uri: `${getBaseUrl.call(this)}${endpoint}`,
+		uri: `${baseUrl}${endpoint}`,
 		json: true,
 	};
 
@@ -60,7 +61,7 @@ export async function getAccessToken(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 ): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('bitwardenApi') as IDataObject;
+	const credentials = await this.getCredentials('bitwardenApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {
@@ -76,7 +77,7 @@ export async function getAccessToken(
 			deviceType: 2, // https://github.com/bitwarden/server/blob/master/src/Core/Enums/DeviceType.cs
 			deviceIdentifier: 'n8n',
 		},
-		uri: getTokenUrl.call(this),
+		uri: await getTokenUrl.call(this),
 		json: true,
 	};
 
@@ -114,8 +115,8 @@ export async function handleGetAll(
 /**
  * Return the access token URL based on the user's environment.
  */
-function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain } = this.getCredentials('bitwardenApi') as IDataObject;
+ async function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
+	const { environment, domain } = await this.getCredentials('bitwardenApi') as IDataObject;
 
 	return environment === 'cloudHosted'
 		? 'https://identity.bitwarden.com/connect/token'
@@ -126,8 +127,8 @@ function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
 /**
  * Return the base API URL based on the user's environment.
  */
-function getBaseUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain } = this.getCredentials('bitwardenApi') as IDataObject;
+async function getBaseUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
+	const { environment, domain } = await this.getCredentials('bitwardenApi') as IDataObject;
 
 	return environment === 'cloudHosted'
 		? 'https://api.bitwarden.com'

--- a/packages/nodes-base/nodes/Brandfetch/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Brandfetch/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function brandfetchApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('brandfetchApi');
+		const credentials = await this.getCredentials('brandfetchApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bubble/GenericFunctions.ts
@@ -24,7 +24,7 @@ export async function bubbleApiRequest(
 	qs: IDataObject,
 ) {
 
-	const { apiToken, appName, domain, environment, hosting } = this.getCredentials('bubbleApi') as {
+	const { apiToken, appName, domain, environment, hosting } = await this.getCredentials('bubbleApi') as {
 		apiToken: string,
 		appName: string,
 		domain: string,

--- a/packages/nodes-base/nodes/Calendly/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Calendly/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function calendlyApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('calendlyApi');
+	const credentials = await this.getCredentials('calendlyApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
+++ b/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
@@ -488,7 +488,7 @@ export class Chargebee implements INodeType {
 		const returnData: IDataObject[] = [];
 		let item: INodeExecutionData;
 
-		const credentials = this.getCredentials('chargebeeApi');
+		const credentials = await this.getCredentials('chargebeeApi');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/CircleCi/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/CircleCi/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function circleciApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('circleCiApi');
+	const credentials = await this.getCredentials('circleCiApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
@@ -8,6 +8,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	IWebhookResponseData,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 import {
@@ -600,7 +601,11 @@ export class CiscoWebexTrigger implements INodeType {
 				const event = this.getNodeParameter('event') as string;
 				const resource = this.getNodeParameter('resource') as string;
 				const filters = this.getNodeParameter('filters', {}) as IDataObject;
-				const secret = getAutomaticSecret(this.getCredentials('ciscoWebexOAuth2Api')!);
+				const credentials = await this.getCredentials('ciscoWebexOAuth2Api');
+				if (credentials === undefined) {
+					throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+				}
+				const secret = getAutomaticSecret(credentials);
 				const filter = [];
 				for (const key of Object.keys(filters)) {
 					if (key !== 'ownedBy') {

--- a/packages/nodes-base/nodes/Clearbit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clearbit/GenericFunctions.ts
@@ -12,7 +12,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function clearbitApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, api: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('clearbitApi');
+	const credentials = await this.getCredentials('clearbitApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ClickUp/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function clickupApiRequest(this: IHookFunctions | IExecuteFunctions
 
 		if (authenticationMethod === 'accessToken') {
 
-			const credentials = this.getCredentials('clickUpApi');
+			const credentials = await this.getCredentials('clickUpApi');
 
 			options.headers!['Authorization'] = credentials?.accessToken;
 			return await this.helpers.request!(options);

--- a/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function clockifyApiRequest(this: ILoadOptionsFunctions | IPollFunctions | IExecuteFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('clockifyApi');
+	const credentials = await this.getCredentials('clockifyApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Cockpit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Cockpit/GenericFunctions.ts
@@ -7,7 +7,7 @@ import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 import { OptionsWithUri } from 'request';
 
 export async function cockpitApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('cockpitApi');
+	const credentials = await this.getCredentials('cockpitApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials available.');

--- a/packages/nodes-base/nodes/Coda/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Coda/GenericFunctions.ts
@@ -7,7 +7,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function codaApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('codaApi');
+	const credentials = await this.getCredentials('codaApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Contentful/Contentful.node.ts
+++ b/packages/nodes-base/nodes/Contentful/Contentful.node.ts
@@ -105,7 +105,7 @@ export class Contentful implements INodeType {
 				if (resource === 'space') {
 					if (operation === 'get') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						responseData = await contentfulApiRequest.call(this, 'GET', `/spaces/${credentials?.spaceId}`);
 					}
@@ -113,7 +113,7 @@ export class Contentful implements INodeType {
 				if (resource === 'contentType') {
 					if (operation === 'get') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const env = this.getNodeParameter('environmentId', 0) as string;
 
@@ -132,7 +132,7 @@ export class Contentful implements INodeType {
 
 					if (operation === 'get') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const env = this.getNodeParameter('environmentId', 0) as string;
 
@@ -147,7 +147,7 @@ export class Contentful implements INodeType {
 						}
 
 					} else if (operation === 'getAll') {
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
 
@@ -214,7 +214,7 @@ export class Contentful implements INodeType {
 				if (resource === 'asset') {
 					if (operation === 'get') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const env = this.getNodeParameter('environmentId', 0) as string;
 
@@ -230,7 +230,7 @@ export class Contentful implements INodeType {
 
 					} else if (operation === 'getAll') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
 
@@ -298,7 +298,7 @@ export class Contentful implements INodeType {
 
 					if (operation === 'getAll') {
 
-						const credentials = this.getCredentials('contentfulApi');
+						const credentials = await this.getCredentials('contentfulApi');
 
 						const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
 

--- a/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function contentfulApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('contentfulApi');
+	const credentials = await this.getCredentials('contentfulApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/ConvertKit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ConvertKit/GenericFunctions.ts
@@ -18,7 +18,7 @@ import {
 export async function convertKitApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IHookFunctions,
 	method: string, endpoint: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('convertKitApi');
+	const credentials = await this.getCredentials('convertKitApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Copper/CopperTrigger.node.ts
+++ b/packages/nodes-base/nodes/Copper/CopperTrigger.node.ts
@@ -133,7 +133,7 @@ export class CopperTrigger implements INodeType {
 					event,
 				};
 
-				const credentials = this.getCredentials('copperApi');
+				const credentials = await this.getCredentials('copperApi');
 				body.secret = {
 					secret: getAutomaticSecret(credentials!),
 				};
@@ -157,7 +157,7 @@ export class CopperTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
-		const credentials = this.getCredentials('copperApi');
+		const credentials = await this.getCredentials('copperApi');
 		const req = this.getRequestObject();
 
 		// Check if the supplied secret matches. If not ignore request.

--- a/packages/nodes-base/nodes/Copper/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Copper/GenericFunctions.ts
@@ -44,7 +44,7 @@ export async function copperApiRequest(
 	uri = '',
 	option: IDataObject = {},
 ) {
-	const credentials = this.getCredentials('copperApi') as { apiKey: string, email: string };
+	const credentials = await this.getCredentials('copperApi') as { apiKey: string, email: string };
 
 	let options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Cortex/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Cortex/GenericFunctions.ts
@@ -23,7 +23,7 @@ import * as moment from 'moment';
 
 export async function cortexApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('cortexApi');
+	const credentials = await this.getCredentials('cortexApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
+++ b/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
@@ -256,7 +256,7 @@ export class CrateDb implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('crateDb');
+		const credentials = await this.getCredentials('crateDb');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
@@ -17,7 +17,7 @@ import {
 } from 'lodash';
 
 export async function customerIoApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: object, baseApi?: string, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('customerIoApi');
+	const credentials = await this.getCredentials('customerIoApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/DeepL/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/DeepL/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function deepLApiRequest(
 	const proApiEndpoint = 'https://api.deepl.com/v2';
 	const freeApiEndpoint = 'https://api-free.deepl.com/v2';
 
-	const credentials = this.getCredentials('deepLApi');
+	const credentials = await this.getCredentials('deepLApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -49,6 +49,12 @@ export async function deepLApiRequest(
 
 		if (Object.keys(body).length === 0) {
 			delete options.body;
+		}
+
+		const credentials = await this.getCredentials('deepLApi');
+
+		if (credentials === undefined) {
+			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}
 
 		options.qs.auth_key = credentials.apiKey;

--- a/packages/nodes-base/nodes/Demio/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Demio/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function demioApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('demioApi');
+		const credentials = await this.getCredentials('demioApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Discourse/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Discourse/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function discourseApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('discourseApi') as IDataObject;
+	const credentials = await this.getCredentials('discourseApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Disqus/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Disqus/GenericFunctions.ts
@@ -16,7 +16,7 @@ export async function disqusApiRequest(
 		option: IDataObject = {},
 	): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('disqusApi') as IDataObject;
+	const credentials = await this.getCredentials('disqusApi') as IDataObject;
 	qs.api_key = credentials.accessToken;
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Drift/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Drift/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function driftApiRequest(this: IExecuteFunctions | IWebhookFunction
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('driftApi');
+			const credentials = await this.getCredentials('driftApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
+++ b/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
@@ -796,7 +796,7 @@ export class Dropbox implements INodeType {
 		let simple = false;
 
 
-		const { accessType } = getCredentials.call(this);
+		const { accessType } = await getCredentials.call(this);
 
 		if (accessType === 'full') {
 			// get the root directory to set it as the default for all operations

--- a/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
@@ -42,7 +42,7 @@ export async function dropboxApiRequest(this: IHookFunctions | IExecuteFunctions
 	try {
 		if (authenticationMethod === 'accessToken') {
 
-			const credentials = this.getCredentials('dropboxApi') as IDataObject;
+			const credentials = await this.getCredentials('dropboxApi') as IDataObject;
 
 			options.headers!['Authorization'] = `Bearer ${credentials.accessToken}`;
 
@@ -101,12 +101,12 @@ export function simplify(data: IDataObject[]) {
 	return results;
 }
 
-export function getCredentials(this: IExecuteFunctions) {
+export async function getCredentials(this: IExecuteFunctions) {
 	const authenticationMethod = this.getNodeParameter('authentication', 0) as string;
 	if (authenticationMethod === 'accessToken') {
-		return this.getCredentials('dropboxApi') as IDataObject;
+		return await this.getCredentials('dropboxApi') as IDataObject;
 	} else {
-		return this.getCredentials('dropboxOAuth2Api') as IDataObject;
+		return await this.getCredentials('dropboxOAuth2Api') as IDataObject;
 	}
 }
 

--- a/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ERPNext/GenericFunctions.ts
@@ -24,7 +24,7 @@ export async function erpNextApiRequest(
 	uri?: string,
 	option: IDataObject = {},
 ) {
-	const credentials = this.getCredentials('erpNextApi') as ERPNextApiCredentials;
+	const credentials = await this.getCredentials('erpNextApi') as ERPNextApiCredentials;
 	const baseUrl = getBaseUrl(credentials);
 
 	if (credentials === undefined) {

--- a/packages/nodes-base/nodes/Egoi/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Egoi/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function getFields(this: IExecuteFunctions, listId: string) {
 
 export async function egoiApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: any = {}, qs: IDataObject = {}, headers?: object): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('egoiApi') as IDataObject;
+	const credentials = await this.getCredentials('egoiApi') as IDataObject;
 
 	const options: OptionsWithUrl = {
 		headers: {

--- a/packages/nodes-base/nodes/Elasticsearch/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Elasticsearch/GenericFunctions.ts
@@ -26,7 +26,7 @@ export async function elasticsearchApiRequest(
 		username,
 		password,
 		baseUrl,
-	} = this.getCredentials('elasticsearchApi') as ElasticsearchApiCredentials;
+	} = await this.getCredentials('elasticsearchApi') as ElasticsearchApiCredentials;
 
 	const token = Buffer.from(`${username}:${password}`).toString('base64');
 

--- a/packages/nodes-base/nodes/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap.node.ts
@@ -177,7 +177,7 @@ export class EmailReadImap implements INodeType {
 
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
-		const credentials = this.getCredentials('imap');
+		const credentials = await this.getCredentials('imap');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/EmailSend.node.ts
+++ b/packages/nodes-base/nodes/EmailSend.node.ts
@@ -147,7 +147,7 @@ export class EmailSend implements INodeType {
 				const attachmentPropertyString = this.getNodeParameter('attachments', itemIndex) as string;
 				const options = this.getNodeParameter('options', itemIndex, {}) as IDataObject;
 
-				const credentials = this.getCredentials('smtp');
+				const credentials = await this.getCredentials('smtp');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Emelia/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Emelia/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function emeliaApiRequest(
 	body: object = {},
 	qs: object = {},
 ) {
-	const { apiKey } = this.getCredentials('emeliaApi') as { apiKey: string };
+	const { apiKey } = await this.getCredentials('emeliaApi') as { apiKey: string };
 
 	const options = {
 		headers: {

--- a/packages/nodes-base/nodes/Eventbrite/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Eventbrite/GenericFunctions.ts
@@ -32,7 +32,7 @@ export async function eventbriteApiRequest(this: IHookFunctions | IExecuteFuncti
 
 	try {
 		if (authenticationMethod === 'privateKey') {
-			const credentials = this.getCredentials('eventbriteApi');
+			const credentials = await this.getCredentials('eventbriteApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -295,7 +295,7 @@ export class FacebookGraphApi implements INodeType {
 		const returnItems: INodeExecutionData[] = [];
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			const graphApiCredentials = this.getCredentials('facebookGraphApi');
+			const graphApiCredentials = await this.getCredentials('facebookGraphApi');
 
 			const hostUrl = this.getNodeParameter('hostUrl', itemIndex) as string;
 			const httpRequestMethod = this.getNodeParameter('httpRequestMethod', itemIndex) as string;

--- a/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookTrigger.node.ts
@@ -248,7 +248,7 @@ export class FacebookTrigger implements INodeType {
 		const res = this.getResponseObject();
 		const req = this.getRequestObject();
 		const headerData = this.getHeaderData() as IDataObject;
-		const credentials = this.getCredentials('facebookGraphAppApi') as IDataObject;
+		const credentials = await this.getCredentials('facebookGraphAppApi') as IDataObject;
 		// Check if we're getting facebook's challenge request (https://developers.facebook.com/docs/graph-api/webhooks/getting-started)
 		if (this.getWebhookName() === 'setup') {
 			if (query['hub.challenge']) {

--- a/packages/nodes-base/nodes/Facebook/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Facebook/GenericFunctions.ts
@@ -23,9 +23,9 @@ export async function facebookApiRequest(this: IHookFunctions | IExecuteFunction
 	let credentials;
 
 	if (this.getNode().name.includes('Trigger')) {
-		credentials = this.getCredentials('facebookGraphAppApi') as IDataObject;
+		credentials = await this.getCredentials('facebookGraphAppApi') as IDataObject;
 	} else {
-		credentials = this.getCredentials('facebookGraphApi') as IDataObject;
+		credentials = await this.getCredentials('facebookGraphApi') as IDataObject;
 	}
 
 	qs.access_token = credentials!.accessToken;

--- a/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
+++ b/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
@@ -773,7 +773,7 @@ export class FileMaker implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const credentials = this.getCredentials('fileMaker');
+		const credentials = await this.getCredentials('fileMaker');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/FileMaker/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FileMaker/GenericFunctions.ts
@@ -39,7 +39,7 @@ interface ScriptObject {
  */
 export async function layoutsApiRequest(this: ILoadOptionsFunctions | IExecuteFunctions | IExecuteSingleFunctions): Promise<INodePropertyOptions[]> { // tslint:disable-line:no-any
 	const token = await getToken.call(this);
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -89,7 +89,7 @@ function parseLayouts(layouts: LayoutObject[]): INodePropertyOptions[] {
  */
 export async function getFields(this: ILoadOptionsFunctions): Promise<any> { // tslint:disable-line:no-any
 	const token = await getToken.call(this);
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 	const layout = this.getCurrentNodeParameter('layout') as string;
 
 	if (credentials === undefined) {
@@ -125,7 +125,7 @@ export async function getFields(this: ILoadOptionsFunctions): Promise<any> { // 
  */
 export async function getPortals(this: ILoadOptionsFunctions): Promise<any> { // tslint:disable-line:no-any
 	const token = await getToken.call(this);
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 	const layout = this.getCurrentNodeParameter('layout') as string;
 
 	if (credentials === undefined) {
@@ -161,7 +161,7 @@ export async function getPortals(this: ILoadOptionsFunctions): Promise<any> { //
  */
 export async function getScripts(this: ILoadOptionsFunctions): Promise<any> { // tslint:disable-line:no-any
 	const token = await getToken.call(this);
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -207,7 +207,7 @@ function parseScriptsList(scripts: ScriptObject[]): INodePropertyOptions[] {
 }
 
 export async function getToken(this: ILoadOptionsFunctions | IExecuteFunctions | IExecuteSingleFunctions): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}
@@ -256,7 +256,7 @@ export async function getToken(this: ILoadOptionsFunctions | IExecuteFunctions |
 }
 
 export async function logout(this: ILoadOptionsFunctions | IExecuteFunctions | IExecuteSingleFunctions, token: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('fileMaker');
+	const credentials = await this.getCredentials('fileMaker');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Flow/Flow.node.ts
+++ b/packages/nodes-base/nodes/Flow/Flow.node.ts
@@ -63,7 +63,7 @@ export class Flow implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('flowApi');
+		const credentials = await this.getCredentials('flowApi');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Flow/FlowTrigger.node.ts
+++ b/packages/nodes-base/nodes/Flow/FlowTrigger.node.ts
@@ -109,7 +109,7 @@ export class FlowTrigger implements INodeType {
 	webhookMethods = {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('flowApi');
+				const credentials = await this.getCredentials('flowApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -143,7 +143,7 @@ export class FlowTrigger implements INodeType {
 				return true;
 			},
 			async create(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('flowApi');
+				const credentials = await this.getCredentials('flowApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -187,7 +187,7 @@ export class FlowTrigger implements INodeType {
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('flowApi');
+				const credentials = await this.getCredentials('flowApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Flow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Flow/GenericFunctions.ts
@@ -8,7 +8,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function flowApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('flowApi');
+	const credentials = await this.getCredentials('flowApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Freshdesk/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshdesk/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function freshdeskApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('freshdeskApi');
+	const credentials = await this.getCredentials('freshdeskApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
@@ -31,7 +31,7 @@ export async function freshworksCrmApiRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	const { apiKey, domain } = this.getCredentials('freshworksCrmApi') as FreshworksCrmApiCredentials;
+	const { apiKey, domain } = await this.getCredentials('freshworksCrmApi') as FreshworksCrmApiCredentials;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp.node.ts
@@ -374,9 +374,9 @@ export class Ftp implements INodeType {
 		const protocol = this.getNodeParameter('protocol', 0) as string;
 
 		if (protocol === 'sftp') {
-			credentials = this.getCredentials('sftp');
+			credentials = await this.getCredentials('sftp');
 		} else {
-			credentials = this.getCredentials('ftp');
+			credentials = await this.getCredentials('ftp');
 		}
 		try {
 

--- a/packages/nodes-base/nodes/GetResponse/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GetResponse/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function getresponseApiRequest(this: IWebhookFunctions | IHookFunct
 		}
 
 		if (authentication === 'apiKey') {
-			const credentials = this.getCredentials('getResponseApi') as IDataObject;
+			const credentials = await this.getCredentials('getResponseApi') as IDataObject;
 			options!.headers!['X-Auth-Token'] = `api-key ${credentials.apiKey}`;
 			//@ts-ignore
 			return await this.helpers.request.call(this, options);

--- a/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
@@ -26,11 +26,11 @@ export async function ghostApiRequest(this: IHookFunctions | IExecuteFunctions |
 	if (source === 'contentApi') {
 		//https://ghost.org/faq/api-versioning/
 		version = 'v3';
-		credentials = this.getCredentials('ghostContentApi') as IDataObject;
+		credentials = await this.getCredentials('ghostContentApi') as IDataObject;
 		query.key = credentials.apiKey as string;
 	} else {
 		version = 'v2';
-		credentials = this.getCredentials('ghostAdminApi') as IDataObject;
+		credentials = await this.getCredentials('ghostAdminApi') as IDataObject;
 		// Create the token (including decoding secret)
 		const [id, secret] = (credentials.apiKey as string).split(':');
 

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -206,11 +206,11 @@ export class Git implements INodeType {
 		const items = this.getInputData();
 
 
-		const prepareRepository = (repositoryPath: string): string => {
+		const prepareRepository = async (repositoryPath: string): Promise<string> => {
 			const authentication = this.getNodeParameter('authentication', 0) as string;
 
 			if (authentication === 'gitPassword') {
-				const gitCredentials = this.getCredentials('gitPassword') as IDataObject;
+				const gitCredentials = await this.getCredentials('gitPassword') as IDataObject;
 
 				const url = new URL(repositoryPath);
 				url.username = gitCredentials.username as string;
@@ -284,7 +284,7 @@ export class Git implements INodeType {
 					// ----------------------------------
 
 					let sourceRepository = this.getNodeParameter('sourceRepository', itemIndex, '') as string;
-					sourceRepository = prepareRepository(sourceRepository);
+					sourceRepository = await prepareRepository(sourceRepository);
 
 					await git.clone(sourceRepository, '.');
 
@@ -348,7 +348,7 @@ export class Git implements INodeType {
 					// ----------------------------------
 
 					if (options.repository) {
-						const targetRepository = prepareRepository(options.targetRepository as string);
+						const targetRepository = await prepareRepository(options.targetRepository as string);
 						await git.push(targetRepository);
 					} else {
 						const authentication = this.getNodeParameter('authentication', 0) as string;
@@ -364,7 +364,7 @@ export class Git implements INodeType {
 								}
 							}
 
-							targetRepository = prepareRepository(targetRepository as string);
+							targetRepository = await prepareRepository(targetRepository as string);
 							await git.push(targetRepository);
 						} else {
 							await git.push();

--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function githubApiRequest(this: IHookFunctions | IExecuteFunctions,
 		const authenticationMethod = this.getNodeParameter('authentication', 0, 'accessToken') as string;
 
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('githubApi');
+			const credentials = await this.getCredentials('githubApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}
@@ -50,7 +50,7 @@ export async function githubApiRequest(this: IHookFunctions | IExecuteFunctions,
 			options.headers!.Authorization = `token ${credentials.accessToken}`;
 			return await this.helpers.request(options);
 		} else {
-			const credentials = this.getCredentials('githubOAuth2Api');
+			const credentials = await this.getCredentials('githubOAuth2Api');
 
 			const baseUrl = credentials!.server || 'https://api.github.com';
 			options.uri = `${baseUrl}${endpoint}`;

--- a/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Gitlab/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions,
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('gitlabApi');
+			const credentials = await this.getCredentials('gitlabApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}
@@ -50,7 +50,7 @@ export async function gitlabApiRequest(this: IHookFunctions | IExecuteFunctions,
 
 			return await this.helpers.request(options);
 		} else {
-			const credentials = this.getCredentials('gitlabOAuth2Api');
+			const credentials = await this.getCredentials('gitlabOAuth2Api');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1101,13 +1101,13 @@ export class Gitlab implements INodeType {
 
 		try {
 			if (authenticationMethod === 'accessToken') {
-				credentials = this.getCredentials('gitlabApi');
+				credentials = await this.getCredentials('gitlabApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 				}
 			} else {
-				credentials = this.getCredentials('gitlabOAuth2Api');
+				credentials = await this.getCredentials('gitlabOAuth2Api');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -137,7 +137,7 @@ export async function handleGetAll(
 }
 
 export async function loadWebinars(this: ILoadOptionsFunctions) {
-	const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+	const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 		oauthTokenData: { account_key: string }
 	};
 
@@ -163,7 +163,7 @@ export async function loadWebinars(this: ILoadOptionsFunctions) {
 }
 
 export async function loadWebinarSessions(this: ILoadOptionsFunctions) {
-	const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+	const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 		oauthTokenData: { organizer_key: string }
 	};
 
@@ -186,7 +186,7 @@ export async function loadWebinarSessions(this: ILoadOptionsFunctions) {
 }
 
 export async function loadRegistranSimpleQuestions(this: ILoadOptionsFunctions) {
-	const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+	const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 		oauthTokenData: { organizer_key: string }
 	};
 
@@ -211,7 +211,7 @@ export async function loadRegistranSimpleQuestions(this: ILoadOptionsFunctions) 
 }
 
 export async function loadAnswers(this: ILoadOptionsFunctions) {
-	const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+	const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 		oauthTokenData: { organizer_key: string }
 	};
 
@@ -240,7 +240,7 @@ export async function loadAnswers(this: ILoadOptionsFunctions) {
 }
 
 export async function loadRegistranMultiChoiceQuestions(this: ILoadOptionsFunctions) {
-	const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+	const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 		oauthTokenData: { organizer_key: string }
 	};
 

--- a/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
@@ -158,7 +158,7 @@ export class GoToWebinar implements INodeType {
 		let responseData;
 		const returnData: IDataObject[] = [];
 
-		const { oauthTokenData } = this.getCredentials('goToWebinarOAuth2Api') as {
+		const { oauthTokenData } = await this.getCredentials('goToWebinarOAuth2Api') as {
 			oauthTokenData: { account_key: string, organizer_key: string }
 		};
 

--- a/packages/nodes-base/nodes/Google/Books/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Books/GenericFunctions.ts
@@ -37,7 +37,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Docs/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Docs/GenericFunctions.ts
@@ -44,7 +44,7 @@ export async function googleApiRequest(
 	try {
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Drive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GenericFunctions.ts
@@ -36,7 +36,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDriveTrigger.node.ts
@@ -98,7 +98,7 @@
 
 // 				const resourceId = this.getNodeParameter('resourceId') as string;
 
-// 				const credentials = this.getCredentials('googleApi');
+// 				const credentials = await this.getCredentials('googleApi');
 
 // 				if (credentials === undefined) {
 // 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -190,7 +190,7 @@
 
 // 				const resourceId = this.getNodeParameter('resourceId') as string;
 
-// 				const credentials = this.getCredentials('googleApi');
+// 				const credentials = await this.getCredentials('googleApi');
 
 // 				if (credentials === undefined) {
 // 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -57,7 +57,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Sheet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GenericFunctions.ts
@@ -37,7 +37,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Google/Slides/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Slides/GenericFunctions.ts
@@ -45,7 +45,7 @@ export async function googleApiRequest(
 
 	try {
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi') as { access_token: string, email: string, privateKey: string };
+			const credentials = await this.getCredentials('googleApi') as { access_token: string, email: string, privateKey: string };
 			const { access_token } = await getAccessToken.call(this, credentials);
 			options.headers.Authorization = `Bearer ${access_token}`;
 			return await this.helpers.request!(options);

--- a/packages/nodes-base/nodes/Google/Translate/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Translate/GenericFunctions.ts
@@ -37,7 +37,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (authenticationMethod === 'serviceAccount') {
-			const credentials = this.getCredentials('googleApi');
+			const credentials = await this.getCredentials('googleApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Gotify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Gotify/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function gotifyApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, uri?: string | undefined, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('gotifyApi') as IDataObject;
+	const credentials = await this.getCredentials('gotifyApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		method,

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -230,7 +230,7 @@ export class GraphQL implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 
 		const items = this.getInputData();
-		const httpHeaderAuth = this.getCredentials('httpHeaderAuth');
+		const httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
 
 		let requestOptions: OptionsWithUri & RequestPromiseOptions;
 

--- a/packages/nodes-base/nodes/Gumroad/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Gumroad/GenericFunctions.ts
@@ -9,7 +9,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function gumroadApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('gumroadApi');
+	const credentials = await this.getCredentials('gumroadApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Harvest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Harvest/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function harvestApiRequest(this: IHookFunctions | IExecuteFunctions
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('harvestApi') as IDataObject;
+			const credentials = await this.getCredentials('harvestApi') as IDataObject;
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/HomeAssistant/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 } from 'n8n-workflow';
 
 export async function homeAssistantApiRequest(this: IExecuteFunctions, method: string, resource: string, body: IDataObject = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}) {
-	const credentials = this.getCredentials('homeAssistantApi');
+	const credentials = await this.getCredentials('homeAssistantApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -640,11 +640,11 @@ export class HttpRequest implements INodeType {
 		const parametersAreJson = this.getNodeParameter('jsonParameters', 0) as boolean;
 		const responseFormat = this.getNodeParameter('responseFormat', 0) as string;
 
-		const httpBasicAuth = this.getCredentials('httpBasicAuth');
-		const httpDigestAuth = this.getCredentials('httpDigestAuth');
-		const httpHeaderAuth = this.getCredentials('httpHeaderAuth');
-		const oAuth1Api = this.getCredentials('oAuth1Api');
-		const oAuth2Api = this.getCredentials('oAuth2Api');
+		const httpBasicAuth = await this.getCredentials('httpBasicAuth');
+		const httpDigestAuth = await this.getCredentials('httpDigestAuth');
+		const httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
+		const oAuth1Api = await this.getCredentials('oAuth1Api');
+		const oAuth2Api = await this.getCredentials('oAuth2Api');
 
 		let requestOptions: OptionsWithUri;
 		let setUiParameter: IDataObject;

--- a/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
@@ -33,13 +33,13 @@ export async function hubspotApiRequest(this: IHookFunctions | IExecuteFunctions
 
 	try {
 		if (authenticationMethod === 'apiKey') {
-			const credentials = this.getCredentials('hubspotApi');
+			const credentials = await this.getCredentials('hubspotApi');
 
 			options.qs.hapikey = credentials!.apiKey as string;
 
 			return await this.helpers.request!(options);
 		} else if (authenticationMethod === 'developerApi') {
-			const credentials = this.getCredentials('hubspotDeveloperApi');
+			const credentials = await this.getCredentials('hubspotDeveloperApi');
 
 			options.qs.hapikey = credentials!.apiKey as string;
 			return await this.helpers.request!(options);

--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -277,7 +277,7 @@ export class HubspotTrigger implements INodeType {
 				// Check all the webhooks which exist already if it is identical to the
 				// one that is supposed to get created.
 				const currentWebhookUrl = this.getNodeWebhookUrl('default') as string;
-				const { appId } = this.getCredentials('hubspotDeveloperApi') as IDataObject;
+				const { appId } = await this.getCredentials('hubspotDeveloperApi') as IDataObject;
 
 				try {
 					const { targetUrl } = await hubspotApiRequest.call(this, 'GET', `/webhooks/v3/${appId}/settings`, {});
@@ -304,7 +304,7 @@ export class HubspotTrigger implements INodeType {
 			},
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
-				const { appId } = this.getCredentials('hubspotDeveloperApi') as IDataObject;
+				const { appId } = await this.getCredentials('hubspotDeveloperApi') as IDataObject;
 				const events = (this.getNodeParameter('eventsUi') as IDataObject || {}).eventValues as IDataObject[] || [];
 				const additionalFields = this.getNodeParameter('additionalFields') as IDataObject;
 				let endpoint = `/webhooks/v3/${appId}/settings`;
@@ -336,7 +336,7 @@ export class HubspotTrigger implements INodeType {
 				return true;
 			},
 			async delete(this: IHookFunctions): Promise<boolean> {
-				const { appId } = this.getCredentials('hubspotDeveloperApi') as IDataObject;
+				const { appId } = await this.getCredentials('hubspotDeveloperApi') as IDataObject;
 
 				const { results: subscriptions } = await hubspotApiRequest.call(this, 'GET', `/webhooks/v3/${appId}/subscriptions`, {});
 
@@ -356,7 +356,7 @@ export class HubspotTrigger implements INodeType {
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 
-		const credentials = this.getCredentials('hubspotDeveloperApi') as IDataObject;
+		const credentials = await this.getCredentials('hubspotDeveloperApi') as IDataObject;
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials found!');

--- a/packages/nodes-base/nodes/HumanticAI/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HumanticAI/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function humanticAiApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('humanticAiApi');
+		const credentials = await this.getCredentials('humanticAiApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
@@ -8,7 +8,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function hunterApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('hunterApi');
+	const credentials = await this.getCredentials('hunterApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
@@ -12,7 +12,7 @@ import {
 } from 'n8n-workflow';
 
 export async function intercomApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, endpoint: string, method: string, body: any = {}, query?: IDataObject, uri?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('intercomApi');
+	const credentials = await this.getCredentials('intercomApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/InvoiceNinja/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/GenericFunctions.ts
@@ -18,7 +18,7 @@ import {
 } from 'lodash';
 
 export async function invoiceNinjaApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: any = {}, query?: IDataObject, uri?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('invoiceNinjaApi');
+	const credentials = await this.getCredentials('invoiceNinjaApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Iterable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Iterable/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function iterableApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, headers: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('iterableApi') as IDataObject;
+	const credentials = await this.getCredentials('iterableApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Jira/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jira/GenericFunctions.ts
@@ -23,9 +23,9 @@ export async function jiraSoftwareCloudApiRequest(this: IHookFunctions | IExecut
 
 	let jiraCredentials: ICredentialDataDecryptedObject | undefined;
 	if (jiraVersion === 'server') {
-		jiraCredentials = this.getCredentials('jiraSoftwareServerApi');
+		jiraCredentials = await this.getCredentials('jiraSoftwareServerApi');
 	} else {
-		jiraCredentials = this.getCredentials('jiraSoftwareCloudApi');
+		jiraCredentials = await this.getCredentials('jiraSoftwareCloudApi');
 	}
 
 	if (jiraCredentials === undefined) {

--- a/packages/nodes-base/nodes/JotForm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/JotForm/GenericFunctions.ts
@@ -9,7 +9,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function jotformApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('jotFormApi');
+	const credentials = await this.getCredentials('jotFormApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -181,7 +181,7 @@ export class Kafka implements INodeType {
 				compression = CompressionTypes.GZIP;
 			}
 
-			const credentials = this.getCredentials('kafka') as IDataObject;
+			const credentials = await this.getCredentials('kafka') as IDataObject;
 
 			const brokers = (credentials.brokers as string || '').split(',').map(item => item.trim()) as string[];
 

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -116,7 +116,7 @@ export class KafkaTrigger implements INodeType {
 
 		const groupId = this.getNodeParameter('groupId') as string;
 
-		const credentials = this.getCredentials('kafka') as IDataObject;
+		const credentials = await this.getCredentials('kafka') as IDataObject;
 
 		const brokers = (credentials.brokers as string || '').split(',').map(item => item.trim()) as string[];
 

--- a/packages/nodes-base/nodes/Kitemaker/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Kitemaker/GenericFunctions.ts
@@ -13,7 +13,7 @@ export async function kitemakerRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 	body: IDataObject = {},
 ) {
-	const { personalAccessToken } = this.getCredentials('kitemakerApi') as { personalAccessToken: string };
+	const { personalAccessToken } = await this.getCredentials('kitemakerApi') as { personalAccessToken: string };
 
 	const options = {
 		headers: {

--- a/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function lemlistApiRequest(
 	option: IDataObject = {},
 ) {
 
-	const { apiKey } = this.getCredentials('lemlistApi') as {
+	const { apiKey } = await this.getCredentials('lemlistApi') as {
 		apiKey: string,
 	};
 

--- a/packages/nodes-base/nodes/LingvaNex/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/LingvaNex/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function lingvaNexApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('lingvaNexApi');
+		const credentials = await this.getCredentials('lingvaNexApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
+++ b/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
@@ -111,7 +111,7 @@ export class Mqtt implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const length = (items.length as unknown) as number;
-		const credentials = this.getCredentials('mqtt') as IDataObject;
+		const credentials = await this.getCredentials('mqtt') as IDataObject;
 
 		const protocol = credentials.protocol as string || 'mqtt';
 		const host = credentials.host as string;

--- a/packages/nodes-base/nodes/MQTT/MqttTrigger.node.ts
+++ b/packages/nodes-base/nodes/MQTT/MqttTrigger.node.ts
@@ -75,7 +75,7 @@ export class MqttTrigger implements INodeType {
 
 	async trigger(this: ITriggerFunctions): Promise<ITriggerResponse> {
 
-		const credentials = this.getCredentials('mqtt');
+		const credentials = await this.getCredentials('mqtt');
 
 		if (!credentials) {
 			throw new NodeOperationError(this.getNode(), 'Credentials are mandatory!');

--- a/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function mailCheckApiRequest(this: IWebhookFunctions | IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, headers: IDataObject = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('mailcheckApi') as IDataObject;
+	const credentials = await this.getCredentials('mailcheckApi') as IDataObject;
 
 	let options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Mailchimp/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailchimp/GenericFunctions.ts
@@ -35,7 +35,7 @@ export async function mailchimpApiRequest(this: IHookFunctions | IExecuteFunctio
 
 	try {
 		if (authenticationMethod === 'apiKey') {
-			const credentials = this.getCredentials('mailchimpApi');
+			const credentials = await this.getCredentials('mailchimpApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -52,7 +52,7 @@ export async function mailchimpApiRequest(this: IHookFunctions | IExecuteFunctio
 
 			return await this.helpers.request!(options);
 		} else {
-			const credentials = this.getCredentials('mailchimpOAuth2Api') as IDataObject;
+			const credentials = await this.getCredentials('mailchimpOAuth2Api') as IDataObject;
 
 			const { api_endpoint } = await getMetadata.call(this, credentials.oauthTokenData as IDataObject);
 
@@ -95,8 +95,8 @@ export function validateJSON(json: string | undefined): any { // tslint:disable-
 	return result;
 }
 
-function getMetadata(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, oauthTokenData: IDataObject) {
-	const credentials = this.getCredentials('mailchimpOAuth2Api') as IDataObject;
+async function getMetadata(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, oauthTokenData: IDataObject) {
+	const credentials = await this.getCredentials('mailchimpOAuth2Api') as IDataObject;
 	const options: OptionsWithUrl = {
 		headers: {
 			'Accept': 'application/json',

--- a/packages/nodes-base/nodes/MailerLite/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MailerLite/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function mailerliteApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IHookFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('mailerLiteApi') as IDataObject;
+	const credentials = await this.getCredentials('mailerLiteApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
+++ b/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
@@ -127,7 +127,7 @@ export class Mailgun implements INodeType {
 				const html = this.getNodeParameter('html', itemIndex) as string;
 				const attachmentPropertyString = this.getNodeParameter('attachments', itemIndex) as string;
 
-				const credentials = this.getCredentials('mailgunApi');
+				const credentials = await this.getCredentials('mailgunApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 } from 'n8n-workflow';
 
 export async function mailjetApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const emailApiCredentials = this.getCredentials('mailjetEmailApi');
+	const emailApiCredentials = await this.getCredentials('mailjetEmailApi');
 	let options: OptionsWithUri = {
 		headers: {
 			Accept: 'application/json',
@@ -35,7 +35,7 @@ export async function mailjetApiRequest(this: IExecuteFunctions | IExecuteSingle
 		const base64Credentials = Buffer.from(`${emailApiCredentials.apiKey}:${emailApiCredentials.secretKey}`).toString('base64');
 		options.headers!['Authorization'] = `Basic ${base64Credentials}`;
 	} else {
-		const smsApiCredentials = this.getCredentials('mailjetSmsApi');
+		const smsApiCredentials = await this.getCredentials('mailjetSmsApi');
 		options.headers!['Authorization'] = `Bearer ${smsApiCredentials!.token}`;
 	}
 	try {

--- a/packages/nodes-base/nodes/Mandrill/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mandrill/GenericFunctions.ts
@@ -12,7 +12,7 @@ import * as _ from 'lodash';
 import { NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function mandrillApiRequest(this: IExecuteFunctions | IHookFunctions | ILoadOptionsFunctions, resource: string, method: string, action: string, body: any = {}, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('mandrillApi');
+	const credentials = await this.getCredentials('mandrillApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Marketstack/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Marketstack/GenericFunctions.ts
@@ -19,7 +19,7 @@ export async function marketstackApiRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	const credentials = this.getCredentials('marketstackApi') as IDataObject;
+	const credentials = await this.getCredentials('marketstackApi') as IDataObject;
 	const protocol = credentials.useHttps ? 'https' : 'http'; // Free API does not support HTTPS
 
 	const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -50,7 +50,7 @@ export async function matrixApiRequest(this: IExecuteFunctions | IExecuteSingleF
 
 		let response: any; // tslint:disable-line:no-any
 
-		const credentials = this.getCredentials('matrixApi');
+		const credentials = await this.getCredentials('matrixApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Mattermost/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mattermost/GenericFunctions.ts
@@ -31,7 +31,7 @@ export interface IAttachment {
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: object, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('mattermostApi');
+	const credentials = await this.getCredentials('mattermostApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Mattermost/Mattermost.node.ts
+++ b/packages/nodes-base/nodes/Mattermost/Mattermost.node.ts
@@ -1940,7 +1940,7 @@ export class Mattermost implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const credentials = this.getCredentials('mattermostApi');
+		const credentials = await this.getCredentials('mattermostApi');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Mautic/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mautic/GenericFunctions.ts
@@ -30,7 +30,7 @@ export async function mauticApiRequest(this: IHookFunctions | IExecuteFunctions 
 		let returnData;
 
 		if (authenticationMethod === 'credentials') {
-			const credentials = this.getCredentials('mauticApi') as IDataObject;
+			const credentials = await this.getCredentials('mauticApi') as IDataObject;
 
 			const base64Key = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64');
 
@@ -41,7 +41,7 @@ export async function mauticApiRequest(this: IHookFunctions | IExecuteFunctions 
 			//@ts-ignore
 			returnData = await this.helpers.request(options);
 		} else {
-			const credentials = this.getCredentials('mauticOAuth2Api') as IDataObject;
+			const credentials = await this.getCredentials('mauticOAuth2Api') as IDataObject;
 
 			options.uri = `${credentials.url}${options.uri}`;
 			//@ts-ignore

--- a/packages/nodes-base/nodes/Medium/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Medium/GenericFunctions.ts
@@ -32,7 +32,7 @@ export async function mediumApiRequest(this: IHookFunctions | IExecuteFunctions 
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('mediumApi');
+			const credentials = await this.getCredentials('mediumApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/MessageBird/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MessageBird/GenericFunctions.ts
@@ -27,7 +27,7 @@ export async function messageBirdApiRequest(
 	body: IDataObject,
 	query: IDataObject = {},
 ): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('messageBirdApi');
+	const credentials = await this.getCredentials('messageBirdApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials returned!');
 	}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 } from 'n8n-workflow';
 
 export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, headers: IDataObject = {}, option: IDataObject = { json: true }): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('microsoftOutlookOAuth2Api');
+	const credentials = await this.getCredentials('microsoftOutlookOAuth2Api');
 
 	let apiUrl = `https://graph.microsoft.com/v1.0/me${resource}`;
 	// If accessing shared mailbox

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -214,7 +214,7 @@ export class MicrosoftSql implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('microsoftSql');
+		const credentials = await this.getCredentials('microsoftSql');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Mindee/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mindee/GenericFunctions.ts
@@ -19,9 +19,9 @@ export async function mindeeApiRequest(this: IExecuteFunctions | IExecuteSingleF
 	let credentials;
 
 	if (resource === 'receipt') {
-		credentials = this.getCredentials('mindeeReceiptApi') as IDataObject;
+		credentials = await this.getCredentials('mindeeReceiptApi') as IDataObject;
 	} else {
-		credentials = this.getCredentials('mindeeInvoiceApi') as IDataObject;
+		credentials = await this.getCredentials('mindeeInvoiceApi') as IDataObject;
 	}
 
 	const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/Mocean/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mocean/GenericFunctions.ts
@@ -17,7 +17,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function moceanApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, body: IDataObject, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('moceanApi');
+	const credentials = await this.getCredentials('moceanApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
@@ -37,7 +37,7 @@ export async function mondayComApiRequest(this: IExecuteFunctions | IWebhookFunc
 	options = Object.assign({}, options, option);
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('mondayComApi') as IDataObject;
+			const credentials = await this.getCredentials('mondayComApi') as IDataObject;
 
 			options.headers = { Authorization: `Bearer ${credentials.apiToken}` };
 

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -31,7 +31,7 @@ export class MongoDb implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const { database, connectionString } = validateAndResolveMongoCredentials(
 			this,
-			this.getCredentials('mongoDb'),
+			await this.getCredentials('mongoDb'),
 		);
 
 		const client: MongoClient = await MongoClient.connect(connectionString, {

--- a/packages/nodes-base/nodes/MonicaCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function monicaCrmApiRequest(
 	body: IDataObject = {},
 	qs: IDataObject = {},
 ) {
-	const credentials = this.getCredentials('monicaCrmApi') as { apiToken: string, environment: string, domain: string };
+	const credentials = await this.getCredentials('monicaCrmApi') as { apiToken: string, environment: string, domain: string };
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Msg91/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Msg91/GenericFunctions.ts
@@ -17,7 +17,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function msg91ApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, body: IDataObject, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('msg91Api');
+	const credentials = await this.getCredentials('msg91Api');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -213,7 +213,7 @@ export class MySql implements INodeType {
 
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('mySql');
+		const credentials = await this.getCredentials('mySql');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Nasa/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Nasa/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 
 export async function nasaApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, qs: IDataObject, option: IDataObject = {}, uri?: string | undefined): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('nasaApi') as IDataObject;
+	const credentials = await this.getCredentials('nasaApi') as IDataObject;
 
 	qs.api_key = credentials['api_key'] as string;
 

--- a/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
@@ -38,7 +38,7 @@ export async function nextCloudApiRequest(this: IHookFunctions | IExecuteFunctio
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('nextCloudApi');
+			const credentials = await this.getCredentials('nextCloudApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}
@@ -55,7 +55,7 @@ export async function nextCloudApiRequest(this: IHookFunctions | IExecuteFunctio
 			}
 			return await this.helpers.request(options);
 		} else {
-			const credentials = this.getCredentials('nextCloudOAuth2Api');
+			const credentials = await this.getCredentials('nextCloudOAuth2Api');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
+++ b/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
@@ -785,9 +785,9 @@ export class NextCloud implements INodeType {
 		let credentials;
 
 		if (authenticationMethod === 'accessToken') {
-			credentials = this.getCredentials('nextCloudApi');
+			credentials = await this.getCredentials('nextCloudApi');
 		} else {
-			credentials = this.getCredentials('nextCloudOAuth2Api');
+			credentials = await this.getCredentials('nextCloudOAuth2Api');
 		}
 
 		if (credentials === undefined) {

--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -35,7 +35,7 @@ interface IAttachment {
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions, method: string, endpoint: string, body: object, query?: IDataObject, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('nocoDb');
+	const credentials = await this.getCredentials('nocoDb');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -41,7 +41,7 @@ export async function notionApiRequest(this: IHookFunctions | IExecuteFunctions 
 		};
 
 		options = Object.assign({}, options, option);
-		const credentials = this.getCredentials('notionApi') as IDataObject;
+		const credentials = await this.getCredentials('notionApi') as IDataObject;
 		options!.headers!['Authorization'] = `Bearer ${credentials.apiKey}`;
 		return this.helpers.request!(options);
 

--- a/packages/nodes-base/nodes/OpenWeatherMap.node.ts
+++ b/packages/nodes-base/nodes/OpenWeatherMap.node.ts
@@ -208,7 +208,7 @@ export class OpenWeatherMap implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const credentials = this.getCredentials('openWeatherMapApi');
+		const credentials = await this.getCredentials('openWeatherMapApi');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Orbit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Orbit/GenericFunctions.ts
@@ -19,7 +19,7 @@ import {
 
 export async function orbitApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('orbitApi');
+		const credentials = await this.getCredentials('orbitApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Oura/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Oura/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function ouraApiRequest(
 	option: IDataObject = {},
 ) {
 
-	const credentials = this.getCredentials('ouraApi');
+	const credentials = await this.getCredentials('ouraApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Paddle/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Paddle/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 } from 'n8n-workflow';
 
 export async function paddleApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, endpoint: string, method: string, body: any = {}, query?: IDataObject, uri?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('paddleApi');
+	const credentials = await this.getCredentials('paddleApi');
 	const productionUrl = 'https://vendors.paddle.com/api';
 	const sandboxUrl = 'https://sandbox-vendors.paddle.com/api';
 

--- a/packages/nodes-base/nodes/PagerDuty/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PagerDuty/GenericFunctions.ts
@@ -48,7 +48,7 @@ export async function pagerDutyApiRequest(this: IExecuteFunctions | IWebhookFunc
 
 	try {
 		if (authenticationMethod === 'apiToken') {
-			const credentials = this.getCredentials('pagerDutyApi');
+			const credentials = await this.getCredentials('pagerDutyApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function payPalApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, endpoint: string, method: string, body: any = {}, query?: IDataObject, uri?: string): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('payPalApi');
+	const credentials = await this.getCredentials('payPalApi');
 	const env = getEnvironment(credentials!.env as string);
 	const tokenInfo =  await getAccessToken.call(this);
 	const headerWithAuthentication = Object.assign({ },
@@ -44,7 +44,7 @@ function getEnvironment(env: string): string {
 }
 
 async function getAccessToken(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('payPalApi');
+	const credentials = await this.getCredentials('payPalApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Peekalink/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Peekalink/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function peekalinkApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('peekalinkApi');
+		const credentials = await this.getCredentials('peekalinkApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Phantombuster/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Phantombuster/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function phantombusterApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('phantombusterApi') as IDataObject;
+	const credentials = await this.getCredentials('phantombusterApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Pipedrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pipedrive/GenericFunctions.ts
@@ -71,7 +71,7 @@ export async function pipedriveApiRequest(this: IHookFunctions | IExecuteFunctio
 	try {
 		if (authenticationMethod === 'basicAuth' || authenticationMethod === 'apiToken' || authenticationMethod === 'none') {
 
-			const credentials = this.getCredentials('pipedriveApi');
+			const credentials = await this.getCredentials('pipedriveApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Pipedrive/PipedriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/PipedriveTrigger.node.ts
@@ -268,7 +268,7 @@ export class PipedriveTrigger implements INodeType {
 				};
 
 				if (incomingAuthentication === 'basicAuth') {
-					const httpBasicAuth = this.getCredentials('httpBasicAuth');
+					const httpBasicAuth = await this.getCredentials('httpBasicAuth');
 
 					if (httpBasicAuth === undefined || !httpBasicAuth.user || !httpBasicAuth.password) {
 						// Data is not defined on node so can not authenticate
@@ -324,7 +324,7 @@ export class PipedriveTrigger implements INodeType {
 
 		if (incomingAuthentication === 'basicAuth') {
 			// Basic authorization is needed to call webhook
-			const httpBasicAuth = this.getCredentials('httpBasicAuth');
+			const httpBasicAuth = await this.getCredentials('httpBasicAuth');
 
 			if (httpBasicAuth === undefined || !httpBasicAuth.user || !httpBasicAuth.password) {
 				// Data is not defined on node so can not authenticate

--- a/packages/nodes-base/nodes/Plivo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Plivo/GenericFunctions.ts
@@ -26,7 +26,7 @@ export async function plivoApiRequest(
 	qs: IDataObject = {},
 ) {
 
-	const credentials = this.getCredentials('plivoApi') as { authId: string, authToken: string };
+	const credentials = await this.getCredentials('plivoApi') as { authId: string, authToken: string };
 
 	if (!credentials) {
 		throw new NodeOperationError(this.getNode(), 'No credentials returned!');

--- a/packages/nodes-base/nodes/PostHog/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PostHog/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 
 export async function posthogApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('postHogApi') as IDataObject;
+	const credentials = await this.getCredentials('postHogApi') as IDataObject;
 
 	const base = credentials.url as string;
 

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -253,7 +253,7 @@ export class Postgres implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('postgres');
+		const credentials = await this.getCredentials('postgres');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Postmark/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Postmark/GenericFunctions.ts
@@ -17,7 +17,7 @@ import {
 
 
 export async function postmarkApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method : string, endpoint : string, body: any = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('postmarkApi');
+	const credentials = await this.getCredentials('postmarkApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/ProfitWell/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ProfitWell/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function profitWellApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 	try {
-		const credentials = this.getCredentials('profitWellApi');
+		const credentials = await this.getCredentials('profitWellApi');
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 		}

--- a/packages/nodes-base/nodes/Pushcut/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pushcut/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function pushcutApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, uri?: string | undefined, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('pushcutApi') as IDataObject;
+	const credentials = await this.getCredentials('pushcutApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Pushover/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pushover/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function pushoverApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('pushoverApi') as IDataObject;
+	const credentials = await this.getCredentials('pushoverApi') as IDataObject;
 
 	if (method === 'GET') {
 		qs.token = credentials.apiKey;

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -210,7 +210,7 @@ export class QuestDb implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('questDb');
+		const credentials = await this.getCredentials('questDb');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBase/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function quickbaseApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('quickbaseApi') as IDataObject;
+	const credentials = await this.getCredentials('quickbaseApi') as IDataObject;
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -61,7 +61,7 @@ export async function quickBooksApiRequest(
 	const productionUrl = 'https://quickbooks.api.intuit.com';
 	const sandboxUrl = 'https://sandbox-quickbooks.api.intuit.com';
 
-	const credentials = this.getCredentials('quickBooksOAuth2Api') as QuickBooksOAuth2Credentials;
+	const credentials = await this.getCredentials('quickBooksOAuth2Api') as QuickBooksOAuth2Credentials;
 
 	const options: OptionsWithUri = {
 		headers: {
@@ -267,7 +267,7 @@ export async function loadResource(
 		query: `SELECT * FROM ${resource}`,
 	} as IDataObject;
 
-	const { oauthTokenData: { callbackQueryString: { realmId } } } = this.getCredentials('quickBooksOAuth2Api') as { oauthTokenData: { callbackQueryString: { realmId: string } } };
+	const { oauthTokenData: { callbackQueryString: { realmId } } } = await this.getCredentials('quickBooksOAuth2Api') as { oauthTokenData: { callbackQueryString: { realmId: string } } };
 	const endpoint = `/v3/company/${realmId}/query`;
 
 	const resourceItems = await quickBooksApiRequestAllItems.call(this, 'GET', endpoint, qs, {}, resource);

--- a/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
+++ b/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
@@ -200,8 +200,7 @@ export class QuickBooks implements INodeType {
 		let responseData;
 		const returnData: IDataObject[] = [];
 
-		const { oauthTokenData } = this.getCredentials('quickBooksOAuth2Api') as QuickBooksOAuth2Credentials;
-
+		const { oauthTokenData } = await this.getCredentials('quickBooksOAuth2Api') as QuickBooksOAuth2Credentials;
 		const companyId = oauthTokenData.callbackQueryString.realmId;
 
 		for (let i = 0; i < items.length; i++) {

--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -7,7 +7,7 @@ import {
 const amqplib = require('amqplib');
 
 export async function rabbitmqConnect(this: IExecuteFunctions | ITriggerFunctions, options: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('rabbitmq') as IDataObject;
+	const credentials = await this.getCredentials('rabbitmq') as IDataObject;
 
 	const credentialKeys = [
 		'hostname',

--- a/packages/nodes-base/nodes/Redis/Redis.node.ts
+++ b/packages/nodes-base/nodes/Redis/Redis.node.ts
@@ -480,12 +480,12 @@ export class Redis implements INodeType {
 		};
 
 
-		return new Promise((resolve, reject) => {
+		return new Promise(async (resolve, reject) => {
 			// TODO: For array and object fields it should not have a "value" field it should
 			//       have a parameter field for a path. Because it is not possible to set
 			//       array, object via parameter directly (should maybe be possible?!?!)
 			//       Should maybe have a parameter which is JSON.
-			const credentials = this.getCredentials('redis');
+			const credentials = await this.getCredentials('redis');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
@@ -10,7 +10,7 @@ import {
 import { NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function rocketchatApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions, resource: string, method: string, operation: string, body: any = {}, headers?: object): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('rocketchatApi');
+	const credentials = await this.getCredentials('rocketchatApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/S3/GenericFunctions.ts
@@ -31,7 +31,7 @@ export async function s3ApiRequest(this: IHookFunctions | IExecuteFunctions | IL
 
 	let credentials;
 
-	credentials = this.getCredentials('s3');
+	credentials = await this.getCredentials('s3');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -120,7 +120,7 @@ export class S3 implements INodeType {
 						let credentials;
 
 						try {
-							credentials = this.getCredentials('s3');
+							credentials = await this.getCredentials('s3');
 						} catch (error) {
 							throw new NodeApiError(this.getNode(), error);
 						}

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -28,7 +28,7 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 		if (authenticationMethod === 'jwt') {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=5
 			const credentialsType = 'salesforceJwtApi';
-			const credentials = this.getCredentials(credentialsType);
+			const credentials = await this.getCredentials(credentialsType);
 			const response = await getAccessToken.call(this, credentials as IDataObject);
 			const { instance_url, access_token } = response;
 			const options = getOptions.call(this, method, (uri || endpoint), body, qs, instance_url as string);
@@ -40,7 +40,7 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 		} else {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
 			const credentialsType = 'salesforceOAuth2Api';
-			const credentials = this.getCredentials(credentialsType) as { oauthTokenData: { instance_url: string } };
+			const credentials = await this.getCredentials(credentialsType) as { oauthTokenData: { instance_url: string } };
 			const options = getOptions.call(this, method, (uri || endpoint), body, qs, credentials.oauthTokenData.instance_url);
 			Logger.debug(`Authentication for "Salesforce" node is using "OAuth2". Invoking URI ${options.uri}`);
 			Object.assign(options, option);

--- a/packages/nodes-base/nodes/Salesmate/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesmate/GenericFunctions.ts
@@ -9,7 +9,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function salesmateApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('salesmateApi');
+	const credentials = await this.getCredentials('salesmateApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/SecurityScorecard/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SecurityScorecard/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 } from 'n8n-workflow';
 
 export async function scorecardApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('securityScorecardApi');
+	const credentials = await this.getCredentials('securityScorecardApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Segment/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Segment/GenericFunctions.ts
@@ -9,7 +9,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function segmentApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('segmentApi');
+	const credentials = await this.getCredentials('segmentApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function sendGridApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, endpoint: string, method: string, body: any = {}, qs: IDataObject = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('sendGridApi') as IDataObject;
+	const credentials = await this.getCredentials('sendGridApi') as IDataObject;
 
 	const host = 'api.sendgrid.com/v3';
 

--- a/packages/nodes-base/nodes/Sendy/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Sendy/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 
 export async function sendyApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('sendyApi') as IDataObject;
+	const credentials = await this.getCredentials('sendyApi') as IDataObject;
 
 	body.api_key = credentials.apiKey;
 

--- a/packages/nodes-base/nodes/SentryIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SentryIo/GenericFunctions.ts
@@ -50,7 +50,7 @@ export async function sentryIoApiRequest(this: IHookFunctions | IExecuteFunction
 				credentialName = 'sentryIoServerApi';
 			}
 
-			const credentials = this.getCredentials(credentialName);
+			const credentials = await this.getCredentials(credentialName);
 
 			if (credentials?.url) {
 				options.uri = `${credentials?.url}${resource}`;

--- a/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ServiceNow/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function serviceNowApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('serviceNowOAuth2Api');
+	const credentials = await this.getCredentials('serviceNowOAuth2Api');
 
 	const options: OptionsWithUri = {
 		headers: {},

--- a/packages/nodes-base/nodes/Shopify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Shopify/GenericFunctions.ts
@@ -19,7 +19,7 @@ import {
 } from 'change-case';
 
 export async function shopifyApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('shopifyApi');
+	const credentials = await this.getCredentials('shopifyApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Shopify/ShopifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Shopify/ShopifyTrigger.node.ts
@@ -358,7 +358,7 @@ export class ShopifyTrigger implements INodeType {
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const headerData = this.getHeaderData() as IDataObject;
 		const req = this.getRequestObject();
-		const credentials = this.getCredentials('shopifyApi') as IDataObject;
+		const credentials = await this.getCredentials('shopifyApi') as IDataObject;
 		const topic = this.getNodeParameter('topic') as string;
 		if (headerData['x-shopify-topic'] !== undefined
 			&& headerData['x-shopify-hmac-sha256'] !== undefined

--- a/packages/nodes-base/nodes/Signl4/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Signl4/GenericFunctions.ts
@@ -25,7 +25,7 @@ import {
  */
 
 export async function SIGNL4ApiRequest(this: IExecuteFunctions, method: string, body: string, query: IDataObject = {}, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('signl4Api');
+	const credentials = await this.getCredentials('signl4Api');
 
 	const teamSecret = credentials?.teamSecret as string;
 

--- a/packages/nodes-base/nodes/Slack/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/GenericFunctions.ts
@@ -40,7 +40,7 @@ export async function slackApiRequest(this: IExecuteFunctions | IExecuteSingleFu
 		let response: any; // tslint:disable-line:no-any
 
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('slackApi');
+			const credentials = await this.getCredentials('slackApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Sms77/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Sms77/GenericFunctions.ts
@@ -21,7 +21,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function sms77ApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, form: IDataObject, qs?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('sms77Api');
+	const credentials = await this.getCredentials('sms77Api');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -176,7 +176,7 @@ export class Snowflake implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('snowflake') as unknown as snowflake.ConnectionOptions;
+		const credentials = await this.getCredentials('snowflake') as unknown as snowflake.ConnectionOptions;
 		const returnData: IDataObject[] = [];
 		let responseData;
 

--- a/packages/nodes-base/nodes/Spontit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Spontit/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function spontitApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('spontitApi') as IDataObject;
+	const credentials = await this.getCredentials('spontitApi') as IDataObject;
 
 	try {
 		const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -296,7 +296,7 @@ export class Ssh implements INodeType {
 		try {
 			if (authentication === 'password') {
 
-				const credentials = this.getCredentials('sshPassword') as IDataObject;
+				const credentials = await this.getCredentials('sshPassword') as IDataObject;
 
 				await ssh.connect({
 					host: credentials.host as string,
@@ -307,7 +307,7 @@ export class Ssh implements INodeType {
 
 			} else if (authentication === 'privateKey') {
 
-				const credentials = this.getCredentials('sshPrivateKey') as IDataObject;
+				const credentials = await this.getCredentials('sshPrivateKey') as IDataObject;
 
 				const { path, } = await file({ prefix: 'n8n-ssh-' });
 				temporaryFiles.push(path);

--- a/packages/nodes-base/nodes/Stackby/GenericFunction.ts
+++ b/packages/nodes-base/nodes/Stackby/GenericFunction.ts
@@ -24,7 +24,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions, method: string, endpoint: string, body: IDataObject, query?: IDataObject, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('stackbyApi') as IDataObject;
+	const credentials = await this.getCredentials('stackbyApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Storyblok/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Storyblok/GenericFunctions.ts
@@ -34,13 +34,13 @@ export async function storyblokApiRequest(this: IHookFunctions | IExecuteFunctio
 	}
 
 	if (authenticationMethod === 'contentApi') {
-		const credentials = this.getCredentials('storyblokContentApi') as IDataObject;
+		const credentials = await this.getCredentials('storyblokContentApi') as IDataObject;
 
 		options.uri = `https://api.storyblok.com${resource}`;
 
 		Object.assign(options.qs, { token: credentials.apiKey });
 	} else {
-		const credentials = this.getCredentials('storyblokManagementApi') as IDataObject;
+		const credentials = await this.getCredentials('storyblokManagementApi') as IDataObject;
 
 		options.uri = `https://mapi.storyblok.com${resource}`;
 

--- a/packages/nodes-base/nodes/Strapi/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strapi/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function strapiApiRequest(this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, headers: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('strapiApi') as IDataObject;
+	const credentials = await this.getCredentials('strapiApi') as IDataObject;
 
 	try {
 		const options: OptionsWithUri = {
@@ -41,7 +41,7 @@ export async function strapiApiRequest(this: IExecuteFunctions | ILoadOptionsFun
 }
 
 export async function getToken(this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions | IWebhookFunctions): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('strapiApi') as IDataObject;
+	const credentials = await this.getCredentials('strapiApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Strava/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strava/GenericFunctions.ts
@@ -32,7 +32,7 @@ export async function stravaApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		}
 
 		if (this.getNode().type.includes('Trigger') && resource.includes('/push_subscriptions')) {
-			const credentials = this.getCredentials('stravaOAuth2Api') as IDataObject;
+			const credentials = await this.getCredentials('stravaOAuth2Api') as IDataObject;
 			if (method === 'GET') {
 				qs.client_id = credentials.clientId;
 				qs.client_secret = credentials.clientSecret;

--- a/packages/nodes-base/nodes/Stripe/helpers.ts
+++ b/packages/nodes-base/nodes/Stripe/helpers.ts
@@ -36,7 +36,7 @@ export async function stripeApiRequest(
 	body: object,
 	query?: object,
 ) {
-	const credentials = this.getCredentials('stripeApi');
+	const credentials = await this.getCredentials('stripeApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/SurveyMonkey/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SurveyMonkey/GenericFunctions.ts
@@ -41,7 +41,7 @@ export async function surveyMonkeyApiRequest(this: IExecuteFunctions | IWebhookF
 
 	try {
 		if ( authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('surveyMonkeyApi');
+			const credentials = await this.getCredentials('surveyMonkeyApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
+++ b/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
@@ -497,9 +497,9 @@ export class SurveyMonkeyTrigger implements INodeType {
 		const webhookName = this.getWebhookName();
 
 		if (authenticationMethod === 'accessToken') {
-			credentials = this.getCredentials('surveyMonkeyApi') as IDataObject;
+			credentials = await this.getCredentials('surveyMonkeyApi') as IDataObject;
 		} else {
-			credentials = this.getCredentials('surveyMonkeyOAuth2Api') as IDataObject;
+			credentials = await this.getCredentials('surveyMonkeyOAuth2Api') as IDataObject;
 		}
 
 		if (webhookName === 'setup') {

--- a/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
@@ -60,7 +60,7 @@ export async function taigaApiRequest(
 	uri?: string | undefined,
 	option = {},
 ): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('taigaApi') as ICredentialDataDecryptedObject;
+	const credentials = await this.getCredentials('taigaApi') as ICredentialDataDecryptedObject;
 
 	const authToken = await getAuthorization.call(this, credentials);
 

--- a/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Taiga/TaigaTrigger.node.ts
@@ -176,7 +176,7 @@ export class TaigaTrigger implements INodeType {
 				return false;
 			},
 			async create(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('taigaApi') as ICredentialDataDecryptedObject;
+				const credentials = await this.getCredentials('taigaApi') as ICredentialDataDecryptedObject;
 
 				const webhookUrl = this.getNodeWebhookUrl('default') as string;
 

--- a/packages/nodes-base/nodes/Tapfiliate/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Tapfiliate/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function tapfiliateApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: any = {}, qs: IDataObject = {}, uri?: string | undefined, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('tapfiliateApi') as IDataObject;
+	const credentials = await this.getCredentials('tapfiliateApi') as IDataObject;
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -143,7 +143,7 @@ export function addAdditionalFields(this: IExecuteFunctions, body: IDataObject, 
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, endpoint: string, body: object, query?: IDataObject, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('telegramApi');
+	const credentials = await this.getCredentials('telegramApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2062,7 +2062,7 @@ export class Telegram implements INodeType {
 					if (this.getNodeParameter('download', i, false) as boolean === true) {
 						const filePath = responseData.result.file_path;
 
-						const credentials = this.getCredentials('telegramApi');
+						const credentials = await this.getCredentials('telegramApi');
 
 						if (credentials === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -210,7 +210,7 @@ export class TelegramTrigger implements INodeType {
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 
-		const credentials = this.getCredentials('telegramApi') as IDataObject;
+		const credentials = await this.getCredentials('telegramApi') as IDataObject;
 
 		const bodyData = this.getBodyData() as IEvent;
 

--- a/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
@@ -16,7 +16,7 @@ import * as moment from 'moment';
 import { Eq } from './QueryFunctions';
 
 export async function theHiveApiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('theHiveApi');
+	const credentials = await this.getCredentials('theHiveApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -112,7 +112,11 @@ export async function prepareCustomFields(this: IHookFunctions | IExecuteFunctio
 		}
 	} else if (additionalFields.customFieldsUi) {
 		// Get Custom Field Types from TheHive
-		const version = this.getCredentials('theHiveApi')?.apiVersion;
+		const credentials = await this.getCredentials('theHiveApi');
+		if (credentials === undefined) {
+			throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+		}
+		const version = credentials.apiVersion;
 		const endpoint = version === 'v1' ? '/customField' : '/list/custom_fields';
 
 		const requestResult = await theHiveApiRequest.call(

--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -183,7 +183,11 @@ export class TheHive implements INodeType {
 				return returnData;
 			},
 			async loadCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const credentials = await this.getCredentials('theHiveApi');
+				if (credentials === undefined) {
+					throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+				}
+				const version = credentials.apiVersion;
 				const endpoint = version === 'v1' ? '/customField' : '/list/custom_fields';
 
 				const requestResult = await theHiveApiRequest.call(
@@ -209,7 +213,7 @@ export class TheHive implements INodeType {
 			},
 			async loadObservableOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				// if v1 is not used we remove 'count' option
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const version = (await this.getCredentials('theHiveApi'))?.apiVersion;
 
 				const options = [
 					...(version === 'v1') ? [{ name: 'Count', value: 'count', description: 'Count observables' }] : [],
@@ -224,7 +228,7 @@ export class TheHive implements INodeType {
 				return options;
 			},
 			async loadObservableTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const version = (await this.getCredentials('theHiveApi'))?.apiVersion;
 				const endpoint = version === 'v1' ? '/observable/type?range=all' : '/list/list_artifactDataType';
 
 				const dataTypes = await theHiveApiRequest.call(
@@ -268,7 +272,11 @@ export class TheHive implements INodeType {
 				return returnData;
 			},
 			async loadTaskOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const credentials = await this.getCredentials('theHiveApi');
+				if (credentials === undefined) {
+					throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+				}
+				const version = credentials.apiVersion;
 				const options = [
 					...(version === 'v1') ? [{ name: 'Count', value: 'count', description: 'Count tasks' }] : [],
 					{ name: 'Create', value: 'create', description: 'Create a task' },
@@ -281,7 +289,11 @@ export class TheHive implements INodeType {
 				return options;
 			},
 			async loadAlertOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const credentials = await this.getCredentials('theHiveApi');
+				if (credentials === undefined) {
+					throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+				}
+				const version = credentials.apiVersion;
 				const options = [
 					...(version === 'v1') ? [{ name: 'Count', value: 'count', description: 'Count alerts' }] : [],
 					{ name: 'Create', value: 'create', description: 'Create alert' },
@@ -297,7 +309,11 @@ export class TheHive implements INodeType {
 				return options;
 			},
 			async loadCaseOptions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const version = this.getCredentials('theHiveApi')?.apiVersion;
+				const credentials = await this.getCredentials('theHiveApi');
+				if (credentials === undefined) {
+					throw new NodeOperationError(this.getNode(), 'Credentials could not be obtained');
+				}
+				const version = credentials.apiVersion;
 				const options = [
 					...(version === 'v1') ? [{ name: 'Count', value: 'count', description: 'Count a case' }] : [],
 					{ name: 'Create', value: 'create', description: 'Create a case' },
@@ -529,9 +545,8 @@ export class TheHive implements INodeType {
 							{},
 						);
 					}
-
 					if (operation === 'getAll') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -961,7 +976,7 @@ export class TheHive implements INodeType {
 					if (operation === 'get') {
 						const observableId = this.getNodeParameter('id', i) as string;
 
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const version = credentials.apiVersion;
 
@@ -1006,7 +1021,7 @@ export class TheHive implements INodeType {
 					}
 
 					if (operation === 'getAll') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -1079,7 +1094,7 @@ export class TheHive implements INodeType {
 					}
 
 					if (operation === 'search') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -1343,7 +1358,7 @@ export class TheHive implements INodeType {
 					if (operation === 'get') {
 						const caseId = this.getNodeParameter('id', i) as string;
 
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const version = credentials.apiVersion;
 
@@ -1388,7 +1403,7 @@ export class TheHive implements INodeType {
 					}
 
 					if (operation === 'getAll') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -1632,7 +1647,7 @@ export class TheHive implements INodeType {
 					if (operation === 'get') {
 						const taskId = this.getNodeParameter('id', i) as string;
 
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const version = credentials.apiVersion;
 
@@ -1676,7 +1691,7 @@ export class TheHive implements INodeType {
 
 					if (operation === 'getAll') {
 						// get all require a case id (it retursn all tasks for a specific case)
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -1751,7 +1766,7 @@ export class TheHive implements INodeType {
 					}
 
 					if (operation === 'search') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 
@@ -1973,7 +1988,7 @@ export class TheHive implements INodeType {
 					if (operation === 'get') {
 						const logId = this.getNodeParameter('id', i) as string;
 
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const version = credentials.apiVersion;
 
@@ -2017,7 +2032,7 @@ export class TheHive implements INodeType {
 					}
 
 					if (operation === 'getAll') {
-						const credentials = this.getCredentials('theHiveApi') as IDataObject;
+						const credentials = await this.getCredentials('theHiveApi') as IDataObject;
 
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -274,7 +274,7 @@ export class TimescaleDb implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = this.getCredentials('timescaleDb');
+		const credentials = await this.getCredentials('timescaleDb');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Todoist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Todoist/GenericFunctions.ts
@@ -40,7 +40,7 @@ export async function todoistApiRequest(
 
 	try {
 		if (authentication === 'apiKey') {
-			const credentials = this.getCredentials('todoistApi') as IDataObject;
+			const credentials = await this.getCredentials('todoistApi') as IDataObject;
 
 			//@ts-ignore
 			options.headers['Authorization'] = `Bearer ${credentials.apiKey}`;

--- a/packages/nodes-base/nodes/Toggl/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Toggl/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function togglApiRequest(this: ITriggerFunctions | IPollFunctions | IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query?: IDataObject, uri?: string): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('togglApi');
+	const credentials = await this.getCredentials('togglApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/TravisCi/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/TravisCi/GenericFunctions.ts
@@ -20,7 +20,7 @@ import {
 import * as querystring from 'querystring';
 
 export async function travisciApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('travisCiApi');
+	const credentials = await this.getCredentials('travisCiApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Trello/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Trello/GenericFunctions.ts
@@ -22,7 +22,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: object, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('trelloApi');
+	const credentials = await this.getCredentials('trelloApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Trello/TrelloTrigger.node.ts
+++ b/packages/nodes-base/nodes/Trello/TrelloTrigger.node.ts
@@ -69,7 +69,7 @@ export class TrelloTrigger implements INodeType {
 	webhookMethods = {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('trelloApi');
+				const credentials = await this.getCredentials('trelloApi');
 
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -98,7 +98,7 @@ export class TrelloTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 
-				const credentials = this.getCredentials('trelloApi');
+				const credentials = await this.getCredentials('trelloApi');
 				if (credentials === undefined) {
 					throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 				}
@@ -129,7 +129,7 @@ export class TrelloTrigger implements INodeType {
 				const webhookData = this.getWorkflowStaticData('node');
 
 				if (webhookData.webhookId !== undefined) {
-					const credentials = this.getCredentials('trelloApi');
+					const credentials = await this.getCredentials('trelloApi');
 					if (credentials === undefined) {
 						throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 					}
@@ -170,7 +170,7 @@ export class TrelloTrigger implements INodeType {
 
 		const bodyData = this.getBodyData();
 
-		const credentials = this.getCredentials('trelloApi');
+		const credentials = await this.getCredentials('trelloApi');
 
 		if (credentials === undefined) {
 			throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Twake/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twake/GenericFunctions.ts
@@ -34,11 +34,11 @@ export async function twakeApiRequest(this: IHookFunctions | IExecuteFunctions |
 
 
 	// if (authenticationMethod === 'cloud') {
-		const credentials = this.getCredentials('twakeCloudApi');
+		const credentials = await this.getCredentials('twakeCloudApi');
 		options.headers!.Authorization = `Bearer ${credentials!.workspaceKey}`;
 
 	// } else {
-	// 	const credentials = this.getCredentials('twakeServerApi');
+	// 	const credentials = await this.getCredentials('twakeServerApi');
 	// 	options.auth = { user: credentials!.publicId as string, pass: credentials!.privateApiKey as string };
 	// 	options.uri = `${credentials!.hostUrl}/api/v1${resource}`;
 	// }

--- a/packages/nodes-base/nodes/Twilio/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twilio/GenericFunctions.ts
@@ -21,7 +21,7 @@ import {
  * @returns {Promise<any>}
  */
 export async function twilioApiRequest(this: IHookFunctions | IExecuteFunctions, method: string, endpoint: string, body: IDataObject, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('twilioApi') as {
+	const credentials = await this.getCredentials('twilioApi') as {
 		accountSid: string;
 		authType: 'authToken' | 'apiKey';
 		authToken: string;

--- a/packages/nodes-base/nodes/Typeform/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Typeform/GenericFunctions.ts
@@ -65,7 +65,7 @@ export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoa
 	try {
 		if (authenticationMethod === 'accessToken') {
 
-			const credentials = this.getCredentials('typeformApi');
+			const credentials = await this.getCredentials('typeformApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/UProc/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UProc/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function uprocApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('uprocApi');
+	const credentials = await this.getCredentials('uprocApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.ts
@@ -40,7 +40,7 @@ export async function unleashedApiRequest(this: IHookFunctions | IExecuteFunctio
 		delete options.body;
 	}
 
-	const credentials = this.getCredentials('unleashedSoftwareApi');
+	const credentials = await this.getCredentials('unleashedSoftwareApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Uplead/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Uplead/GenericFunctions.ts
@@ -8,7 +8,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function upleadApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('upleadApi');
+	const credentials = await this.getCredentials('upleadApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/UptimeRobot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UptimeRobot/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 } from 'n8n-workflow';
 
 export async function uptimeRobotApiRequest(this: IExecuteFunctions, method: string, resource: string, body: IDataObject = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}) {
-	const credentials = this.getCredentials('uptimeRobotApi');
+	const credentials = await this.getCredentials('uptimeRobotApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Vero/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Vero/GenericFunctions.ts
@@ -7,7 +7,7 @@ import {
 import { IDataObject, NodeApiError, NodeOperationError, } from 'n8n-workflow';
 
 export async function veroApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('veroApi');
+	const credentials = await this.getCredentials('veroApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Vonage/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Vonage/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function vonageApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, path: string, body: any = {}, qs: IDataObject = {}, option = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('vonageApi') as IDataObject;
+	const credentials = await this.getCredentials('vonageApi') as IDataObject;
 
 	body.api_key = credentials.apiKey as string;
 

--- a/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
@@ -47,7 +47,7 @@ export async function webflowApiRequest(
 	}
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('webflowApi');
+			const credentials = await this.getCredentials('webflowApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook.node.ts
@@ -369,7 +369,7 @@ export class Webhook implements INodeType {
 
 		if (authentication === 'basicAuth') {
 			// Basic authorization is needed to call webhook
-			const httpBasicAuth = this.getCredentials('httpBasicAuth');
+			const httpBasicAuth = await this.getCredentials('httpBasicAuth');
 
 			if (httpBasicAuth === undefined || !httpBasicAuth.user || !httpBasicAuth.password) {
 				// Data is not defined on node so can not authenticate
@@ -389,7 +389,7 @@ export class Webhook implements INodeType {
 			}
 		} else if (authentication === 'headerAuth') {
 			// Special header with value is needed to call webhook
-			const httpHeaderAuth = this.getCredentials('httpHeaderAuth');
+			const httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
 
 			if (httpHeaderAuth === undefined || !httpHeaderAuth.name || !httpHeaderAuth.value) {
 				// Data is not defined on node so can not authenticate

--- a/packages/nodes-base/nodes/Wekan/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wekan/GenericFunctions.ts
@@ -46,7 +46,7 @@ export async function getAuthorization(
 }
 
 export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, method: string, endpoint: string, body: object, query?: IDataObject): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('wekanApi');
+	const credentials = await this.getCredentials('wekanApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Wise/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wise/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function wiseApiRequest(
 	qs: IDataObject = {},
 	option: IDataObject = {},
 ) {
-	const { apiToken, environment } = this.getCredentials('wiseApi') as {
+	const { apiToken, environment } = await this.getCredentials('wiseApi') as {
 		apiToken: string,
 		environment: 'live' | 'test',
 	};

--- a/packages/nodes-base/nodes/Wise/Wise.node.ts
+++ b/packages/nodes-base/nodes/Wise/Wise.node.ts
@@ -426,7 +426,7 @@ export class Wise implements INodeType {
 
 						// in sandbox, simulate transfer completion so that PDF receipt can be downloaded
 
-						const { environment } = this.getCredentials('wiseApi') as IDataObject;
+						const { environment } = await this.getCredentials('wiseApi') as IDataObject;
 
 						if (environment === 'test') {
 							for (const endpoint of ['processing', 'funds_converted', 'outgoing_payment_sent']) {

--- a/packages/nodes-base/nodes/Wise/WiseTrigger.node.ts
+++ b/packages/nodes-base/nodes/Wise/WiseTrigger.node.ts
@@ -154,7 +154,7 @@ export class WiseTrigger implements INodeType {
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const req = this.getRequestObject();
 		const headers = this.getHeaderData() as IDataObject;
-		const credentials = this.getCredentials('wiseApi') as IDataObject;
+		const credentials = await this.getCredentials('wiseApi') as IDataObject;
 
 		if (headers['x-test-notification'] === 'true') {
 			const res = this.getResponseObject();

--- a/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
@@ -37,7 +37,7 @@ import {
 } from 'lodash';
 
 export async function woocommerceApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IWebhookFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('wooCommerceApi');
+	const credentials = await this.getCredentials('wooCommerceApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/WooCommerce/WooCommerceTrigger.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerceTrigger.node.ts
@@ -132,7 +132,7 @@ export class WooCommerceTrigger implements INodeType {
 				return false;
 			},
 			async create(this: IHookFunctions): Promise<boolean> {
-				const credentials = this.getCredentials('wooCommerceApi');
+				const credentials = await this.getCredentials('wooCommerceApi');
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const event = this.getNodeParameter('event') as string;

--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -13,7 +13,7 @@ import {
 } from 'n8n-workflow';
 
 export async function wordpressApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('wordpressApi');
+	const credentials = await this.getCredentials('wordpressApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 } from 'n8n-workflow';
 
 export async function wufooApiRequest(this: IHookFunctions | IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credentials = this.getCredentials('wufooApi');
+	const credentials = await this.getCredentials('wufooApi');
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}

--- a/packages/nodes-base/nodes/Yourls/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Yourls/GenericFunctions.ts
@@ -14,7 +14,7 @@ import {
 
 export async function yourlsApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, body: any = {}, qs: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('yourlsApi') as IDataObject;
+	const credentials = await this.getCredentials('yourlsApi') as IDataObject;
 
 	qs.signature = credentials.signature as string;
 	qs.format = 'json';

--- a/packages/nodes-base/nodes/Zendesk/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zendesk/GenericFunctions.ts
@@ -36,7 +36,7 @@ export async function zendeskApiRequest(this: IHookFunctions | IExecuteFunctions
 
 	try {
 		if (authenticationMethod === 'apiToken') {
-			const credentials = this.getCredentials('zendeskApi');
+			const credentials = await this.getCredentials('zendeskApi');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
@@ -48,7 +48,7 @@ export async function zendeskApiRequest(this: IHookFunctions | IExecuteFunctions
 
 			return await this.helpers.request!(options);
 		} else {
-			const credentials = this.getCredentials('zendeskOAuth2Api');
+			const credentials = await this.getCredentials('zendeskOAuth2Api');
 
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Zoho/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zoho/GenericFunctions.ts
@@ -43,7 +43,7 @@ export async function zohoApiRequest(
 	qs: IDataObject = {},
 	uri?: string,
 ) {
-	const { oauthTokenData } = this.getCredentials('zohoOAuth2Api') as ZohoOAuth2ApiCredentials;
+	const { oauthTokenData } = await this.getCredentials('zohoOAuth2Api') as ZohoOAuth2ApiCredentials;
 
 	const options: OptionsWithUri = {
 		body: {

--- a/packages/nodes-base/nodes/Zoom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zoom/GenericFunctions.ts
@@ -36,7 +36,7 @@ export async function zoomApiRequest(this: IExecuteFunctions | IExecuteSingleFun
 
 	try {
 		if (authenticationMethod === 'accessToken') {
-			const credentials = this.getCredentials('zoomApi');
+			const credentials = await this.getCredentials('zoomApi');
 			if (credentials === undefined) {
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}

--- a/packages/nodes-base/nodes/Zulip/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zulip/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 
 export async function zulipApiRequest(this: IExecuteFunctions | IWebhookFunctions | IHookFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, query: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
 
-	const credentials = this.getCredentials('zulipApi');
+	const credentials = await this.getCredentials('zulipApi');
 
 	if (credentials === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');

--- a/packages/nodes-base/nodes/Zulip/Zulip.node.ts
+++ b/packages/nodes-base/nodes/Zulip/Zulip.node.ts
@@ -209,7 +209,7 @@ export class Zulip implements INodeType {
 					}
 					//https://zulipchat.com/api/upload-file
 					if (operation === 'updateFile') {
-						const credentials = this.getCredentials('zulipApi');
+						const credentials = await this.getCredentials('zulipApi');
 						const binaryProperty = this.getNodeParameter('dataBinaryProperty', i) as string;
 						if (items[i].binary === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No binary data exists on item!');

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -102,8 +102,8 @@ export abstract class ICredentialsHelper {
 		this.workflowCredentials = workflowCredentials;
 	}
 
-	abstract getCredentials(name: string, type: string): ICredentials;
-	abstract getDecrypted(name: string, type: string, mode: WorkflowExecuteMode, raw?: boolean, expressionResolveValues?: ICredentialsExpressionResolveValues): ICredentialDataDecryptedObject;
+	abstract getCredentials(name: string, type: string): Promise<ICredentials>;
+	abstract getDecrypted(name: string, type: string, mode: WorkflowExecuteMode, raw?: boolean, expressionResolveValues?: ICredentialsExpressionResolveValues): Promise<ICredentialDataDecryptedObject>;
 	abstract updateCredentials(name: string, type: string, data: ICredentialDataDecryptedObject): Promise<void>;
 }
 
@@ -212,7 +212,7 @@ export interface IExecuteFunctions {
 	evaluateExpression(expression: string, itemIndex: number): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[];
 	executeWorkflow(workflowInfo: IExecuteWorkflowInfo, inputData?: INodeExecutionData[]): Promise<any>; // tslint:disable-line:no-any
 	getContext(type: string): IContextObject;
-	getCredentials(type: string, itemIndex?: number): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string, itemIndex?: number): Promise<ICredentialDataDecryptedObject | undefined>;
 	getInputData(inputIndex?: number, inputName?: string): INodeExecutionData[];
 	getMode(): WorkflowExecuteMode;
 	getNode(): INode;
@@ -234,7 +234,7 @@ export interface IExecuteSingleFunctions {
 	continueOnFail(): boolean;
 	evaluateExpression(expression: string, itemIndex: number | undefined): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[];
 	getContext(type: string): IContextObject;
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getInputData(inputIndex?: number, inputName?: string): INodeExecutionData;
 	getMode(): WorkflowExecuteMode;
 	getNode(): INode;
@@ -255,7 +255,7 @@ export interface IExecuteWorkflowInfo {
 }
 
 export interface ILoadOptionsFunctions {
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getNode(): INode;
 	getNodeParameter(parameterName: string, fallbackValue?: any): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[] | object; //tslint:disable-line:no-any
 	getCurrentNodeParameter(parameterName: string): NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[] | object | undefined;
@@ -268,7 +268,7 @@ export interface ILoadOptionsFunctions {
 }
 
 export interface IHookFunctions {
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getMode(): WorkflowExecuteMode;
 	getActivationMode(): WorkflowActivateMode;
 	getNode(): INode;
@@ -286,7 +286,7 @@ export interface IHookFunctions {
 
 export interface IPollFunctions {
 	__emit(data: INodeExecutionData[][]): void;
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getMode(): WorkflowExecuteMode;
 	getActivationMode(): WorkflowActivateMode;
 	getNode(): INode;
@@ -302,7 +302,7 @@ export interface IPollFunctions {
 
 export interface ITriggerFunctions {
 	emit(data: INodeExecutionData[][]): void;
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getMode(): WorkflowExecuteMode;
 	getActivationMode(): WorkflowActivateMode;
 	getNode(): INode;
@@ -318,7 +318,7 @@ export interface ITriggerFunctions {
 
 export interface IWebhookFunctions {
 	getBodyData(): IDataObject;
-	getCredentials(type: string): ICredentialDataDecryptedObject | undefined;
+	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getHeaderData(): object;
 	getMode(): WorkflowExecuteMode;
 	getNode(): INode;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -95,11 +95,9 @@ export interface ICredentialsExpressionResolveValues {
 
 export abstract class ICredentialsHelper {
 	encryptionKey: string;
-	workflowCredentials: IWorkflowCredentials;
 
-	constructor(workflowCredentials: IWorkflowCredentials, encryptionKey: string) {
+	constructor(encryptionKey: string) {
 		this.encryptionKey = encryptionKey;
-		this.workflowCredentials = workflowCredentials;
 	}
 
 	abstract getCredentials(name: string, type: string): Promise<ICredentials>;
@@ -739,7 +737,6 @@ export interface IWorkflowExecuteHooks {
 }
 
 export interface IWorkflowExecuteAdditionalData {
-	credentials: IWorkflowCredentials;
 	credentialsHelper: ICredentialsHelper;
 	encryptionKey: string;
 	executeWorkflow: (workflowInfo: IExecuteWorkflowInfo, additionalData: IWorkflowExecuteAdditionalData, inputData?: INodeExecutionData[], parentExecutionId?: string, loadedWorkflowData?: IWorkflowBase, loadedRunData?: any) => Promise<any>; // tslint:disable-line:no-any


### PR DESCRIPTION
This pull request relates to issue https://github.com/n8n-io/n8n/issues/1695

We changed the way n8n uses credentials for nodes by loading them from database on demand always.

This change was made because OAuth access tokens expire eventually and by keeping tokens in memory n8n refreshes tokens too many times.

Tests that were done to certify nothing broke:
- Trigger, webhook and poll nodes
- Main, own and queue modes
- OAuth2 app connection (had side effect from the changes)


Please feel free to share ideas for other tests that should be done.