### PR TITLE
Add skipWebhookDeregistration option to webhook

### DIFF
--- a/packages/cli/commands/webhook.ts
+++ b/packages/cli/commands/webhook.ts
@@ -67,7 +67,7 @@ export class Webhook extends Command {
 			if (activeWorkflowRunner !== undefined && skipWebhookDeregistration !== true) {
 				removePromises.push(activeWorkflowRunner.removeAll());
 			}
-			
+
 			// Remove all test webhooks
 			const testWebhooks = TestWebhooks.getInstance();
 			removePromises.push(testWebhooks.removeAll());

--- a/packages/cli/commands/webhook.ts
+++ b/packages/cli/commands/webhook.ts
@@ -61,11 +61,13 @@ export class Webhook extends Command {
 				process.exit(processExistCode);
 			}, 30000);
 
+			const skipWebhookDeregistration = config.get('endpoints.skipWebhoooksDeregistrationOnShutdown') as boolean;
+
 			const removePromises = [];
-			if (activeWorkflowRunner !== undefined) {
+			if (activeWorkflowRunner !== undefined && skipWebhookDeregistration !== true) {
 				removePromises.push(activeWorkflowRunner.removeAll());
 			}
-
+			
 			// Remove all test webhooks
 			const testWebhooks = TestWebhooks.getInstance();
 			removePromises.push(testWebhooks.removeAll());


### PR DESCRIPTION
skipWebhookDeregistration is only available to webapp service. On webhook restart we get the error: `The requested webhook \"POST xxxxx-xxxxx-xxxx-xxx-xxx \" is not registered` even if N8N_SKIP_WEBHOOK_DEREGISTRATION is true