### PR TITLE
Remove Node 12 CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This PR removes Node 12 CI tests, since 0.118.0 requires at minimum Node 14.