### PR TITLE
Remove webhooks deregistration from webhook process

### DIFF
--- a/packages/cli/commands/webhook.ts
+++ b/packages/cli/commands/webhook.ts
@@ -61,17 +61,6 @@ export class Webhook extends Command {
 				process.exit(processExistCode);
 			}, 30000);
 
-			const removePromises = [];
-			if (activeWorkflowRunner !== undefined) {
-				removePromises.push(activeWorkflowRunner.removeAll());
-			}
-
-			// Remove all test webhooks
-			const testWebhooks = TestWebhooks.getInstance();
-			removePromises.push(testWebhooks.removeAll());
-
-			await Promise.all(removePromises);
-
 			// Wait for active workflow executions to finish
 			const activeExecutionsInstance = ActiveExecutions.getInstance();
 			let executingWorkflows = activeExecutionsInstance.getActiveExecutions();


### PR DESCRIPTION
Removed the deregistration process completely from the webhook processes.

This should be done by the main process only and if the `skip` is activated, should only happen when the workflow is deactivated manually.

There is another PR for the same fix: https://github.com/n8n-io/n8n/pull/1746

This all relates to the following issue https://github.com/n8n-io/n8n/issues/1739