### PR TITLE
Fix parsing issues in Firestore node

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -109,14 +109,13 @@ export function fullDocumentToJson(data: IDataObject): IDataObject {
 
 export function documentToJson(fields: IDataObject): IDataObject {
 	if (fields === undefined) return {};
-
 	const result = {};
 	for (const f of Object.keys(fields)) {
 		const key = f, value = fields[f],
 			isDocumentType = ['stringValue', 'booleanValue', 'doubleValue',
-				'integerValue', 'timestampValue', 'mapValue', 'arrayValue', 'nullValue'].find(t => t === key);
+				'integerValue', 'timestampValue', 'mapValue', 'arrayValue', 'nullValue', 'geoPointValue'].find(t => t === key);
 		if (isDocumentType) {
-			const item = ['stringValue', 'booleanValue', 'doubleValue', 'integerValue', 'timestampValue', 'nullValue']
+			const item = ['stringValue', 'booleanValue', 'doubleValue', 'integerValue', 'timestampValue', 'nullValue', 'geoPointValue']
 				.find(t => t === key);
 			if (item) {
 				return value as IDataObject;

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -60,7 +60,7 @@ export async function googleApiRequestAllItems(this: IExecuteFunctions | ILoadOp
 	return returnData;
 }
 
-const isValidDate = (str: string) => moment(str, 'YYYY-MM-DD HH:mm:ss Z', true).isValid();
+const isValidDate = (str: string) => moment(str, ['YYYY-MM-DD HH:mm:ss Z', moment.ISO_8601], true).isValid();
 
 // Both functions below were taken from Stack Overflow jsonToDocument was fixed as it was unable to handle null values correctly
 // https://stackoverflow.com/questions/62246410/how-to-convert-a-firestore-document-to-plain-json-and-vice-versa

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -108,6 +108,8 @@ export function fullDocumentToJson(data: IDataObject): IDataObject {
 
 
 export function documentToJson(fields: IDataObject): IDataObject {
+	if (fields === undefined) return {};
+
 	const result = {};
 	for (const f of Object.keys(fields)) {
 		const key = f, value = fields[f],

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -12,6 +12,8 @@ import {
 	IDataObject, NodeApiError,
 } from 'n8n-workflow';
 
+import * as moment from 'moment-timezone';
+
 export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri: string | null = null): Promise<any> { // tslint:disable-line:no-any
 
 	const options: OptionsWithUri = {
@@ -31,7 +33,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		if (Object.keys(body).length === 0) {
 			delete options.body;
 		}
-
+		// console.log(options.body);
 		//@ts-ignore
 		return await this.helpers.requestOAuth2.call(this, 'googleFirebaseCloudFirestoreOAuth2Api', options);
 	} catch (error) {
@@ -58,6 +60,7 @@ export async function googleApiRequestAllItems(this: IExecuteFunctions | ILoadOp
 	return returnData;
 }
 
+const isValidDate = (str: string) => moment(str, 'YYYY-MM-DD HH:mm:ss Z', true).isValid();
 
 // Both functions below were taken from Stack Overflow jsonToDocument was fixed as it was unable to handle null values correctly
 // https://stackoverflow.com/questions/62246410/how-to-convert-a-firestore-document-to-plain-json-and-vice-versa
@@ -73,7 +76,7 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 		} else {
 			return { 'integerValue': value };
 		}
-	} else if (Date.parse(value as string)) {
+	} else if (isValidDate(value as string)) {
 		const date = new Date(Date.parse(value as string));
 		return { 'timestampValue': date.toISOString() };
 	} else if (typeof value === 'string') {

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -33,7 +33,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 		if (Object.keys(body).length === 0) {
 			delete options.body;
 		}
-		// console.log(options.body);
+
 		//@ts-ignore
 		return await this.helpers.requestOAuth2.call(this, 'googleFirebaseCloudFirestoreOAuth2Api', options);
 	} catch (error) {


### PR DESCRIPTION
- Fix parsing for [empty document](https://github.com/n8n-io/n8n/pull/1749#discussion_r628238125)
- Fix parsing for [geopoint](https://github.com/n8n-io/n8n/pull/1749#discussion_r628243690)
- Fix detection for timestamp to close #1718

Regarding the third fix:

Both `Date.parse(str)` and `moment(str).isValid()` return a date for `"TEST SM UPDATED 2"`, `"TEST SM UPDATED-2"` and `"TEST SM UPDATED/2"`. Same with standalone strings `"1"` to `"12"`, and `"32"` and above. To prevent date misdetection, the parser now strictly requires a specific format with `moment(str, 'YYYY-MM-DD HH:mm:ss Z', true)` to create a Firestore timestamp value. See [Moment.js time tokens reference](https://momentjs.com/docs/#/parsing/string-format/).