### PR TITLE
Extend GCNL node

### DIFF
--- a/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
+++ b/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
@@ -121,7 +121,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 							'analyzeEntities',
 							'analyzeEntitySentiment',
 							'analyzeSyntax',
-							'classifyText'
+							'classifyText',
 						],
 					},
 				},
@@ -140,7 +140,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 							'analyzeEntities',
 							'analyzeEntitySentiment',
 							'analyzeSyntax',
-							'classifyText'
+							'classifyText',
 						],
 						source: [
 							'content',
@@ -162,7 +162,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 							'analyzeEntities',
 							'analyzeEntitySentiment',
 							'analyzeSyntax',
-							'classifyText'
+							'classifyText',
 						],
 						source: [
 							'gcsContentUri',
@@ -181,7 +181,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 							'analyzeEntities',
 							'analyzeEntitySentiment',
 							'analyzeSyntax',
-							'classifyText'
+							'classifyText',
 						],
 					},
 				},
@@ -371,9 +371,8 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					if (options.language) {
 						body.document.language = options.language as string;
 					}
-
 					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeEntities`, body);
-					responseData.push(response);
+					responseData.push.apply(responseData, response.entities);
 				}
 				if (operation === 'analyzeEntitySentiment') {
 					const source = this.getNodeParameter('source', i) as string;
@@ -401,7 +400,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					}
 
 					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeEntitySentiment`, body);
-					responseData.push(response);
+					responseData.push.apply(responseData, response.entities);
 				}
 				if (operation === 'analyzeSyntax') {
 					const source = this.getNodeParameter('source', i) as string;
@@ -439,7 +438,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					const body: IData = {
 						document: {
 							type: documentType,
-						}
+						},
 					};
 
 					if (source === 'content') {
@@ -455,7 +454,7 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					}
 
 					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:classifyText`, body);
-					responseData.push(response);
+					responseData.push.apply(responseData, response.categories);
 				}
 			}
 		}

--- a/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
+++ b/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
@@ -70,6 +70,26 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 						value: 'analyzeSentiment',
 						description: 'Analyze Sentiment',
 					},
+					{
+						name: 'Analyze Entities',
+						value: 'analyzeEntities',
+						description: 'Analyze Entities',
+					},
+					{
+						name: 'Analyze Entity Sentiment',
+						value: 'analyzeEntitySentiment',
+						description: 'Analyze Entity Sentiment',
+					},
+					{
+						name: 'Analyze Syntax',
+						value: 'analyzeSyntax',
+						description: 'Analyze Syntax',
+					},
+					{
+						name: 'Classify Text',
+						value: 'classifyText',
+						description: 'Classify Text',
+					},
 				],
 				default: 'analyzeSentiment',
 				description: 'The operation to perform',
@@ -98,6 +118,10 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					show: {
 						operation: [
 							'analyzeSentiment',
+							'analyzeEntities',
+							'analyzeEntitySentiment',
+							'analyzeSyntax',
+							'classifyText'
 						],
 					},
 				},
@@ -113,6 +137,10 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					show: {
 						operation: [
 							'analyzeSentiment',
+							'analyzeEntities',
+							'analyzeEntitySentiment',
+							'analyzeSyntax',
+							'classifyText'
 						],
 						source: [
 							'content',
@@ -131,6 +159,10 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					show: {
 						operation: [
 							'analyzeSentiment',
+							'analyzeEntities',
+							'analyzeEntitySentiment',
+							'analyzeSyntax',
+							'classifyText'
 						],
 						source: [
 							'gcsContentUri',
@@ -146,6 +178,10 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					show: {
 						operation: [
 							'analyzeSentiment',
+							'analyzeEntities',
+							'analyzeEntitySentiment',
+							'analyzeSyntax',
+							'classifyText'
 						],
 					},
 				},
@@ -309,6 +345,116 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 					}
 
 					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeSentiment`, body);
+					responseData.push(response);
+				}
+				if (operation === 'analyzeEntities') {
+					const source = this.getNodeParameter('source', i) as string;
+					const options = this.getNodeParameter('options', i) as IDataObject;
+					const encodingType = (options.encodingType as string | undefined) || 'UTF16';
+					const documentType = (options.documentType as string | undefined) || 'PLAIN_TEXT';
+
+					const body: IData = {
+						document: {
+							type: documentType,
+						},
+						encodingType,
+					};
+
+					if (source === 'content') {
+						const content = this.getNodeParameter('content', i) as string;
+						body.document.content = content;
+					} else {
+						const gcsContentUri = this.getNodeParameter('gcsContentUri', i) as string;
+						body.document.gcsContentUri = gcsContentUri;
+					}
+
+					if (options.language) {
+						body.document.language = options.language as string;
+					}
+
+					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeEntities`, body);
+					responseData.push(response);
+				}
+				if (operation === 'analyzeEntitySentiment') {
+					const source = this.getNodeParameter('source', i) as string;
+					const options = this.getNodeParameter('options', i) as IDataObject;
+					const encodingType = (options.encodingType as string | undefined) || 'UTF16';
+					const documentType = (options.documentType as string | undefined) || 'PLAIN_TEXT';
+
+					const body: IData = {
+						document: {
+							type: documentType,
+						},
+						encodingType,
+					};
+
+					if (source === 'content') {
+						const content = this.getNodeParameter('content', i) as string;
+						body.document.content = content;
+					} else {
+						const gcsContentUri = this.getNodeParameter('gcsContentUri', i) as string;
+						body.document.gcsContentUri = gcsContentUri;
+					}
+
+					if (options.language) {
+						body.document.language = options.language as string;
+					}
+
+					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeEntitySentiment`, body);
+					responseData.push(response);
+				}
+				if (operation === 'analyzeSyntax') {
+					const source = this.getNodeParameter('source', i) as string;
+					const options = this.getNodeParameter('options', i) as IDataObject;
+					const encodingType = (options.encodingType as string | undefined) || 'UTF16';
+					const documentType = (options.documentType as string | undefined) || 'PLAIN_TEXT';
+
+					const body: IData = {
+						document: {
+							type: documentType,
+						},
+						encodingType,
+					};
+
+					if (source === 'content') {
+						const content = this.getNodeParameter('content', i) as string;
+						body.document.content = content;
+					} else {
+						const gcsContentUri = this.getNodeParameter('gcsContentUri', i) as string;
+						body.document.gcsContentUri = gcsContentUri;
+					}
+
+					if (options.language) {
+						body.document.language = options.language as string;
+					}
+
+					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:analyzeSyntax`, body);
+					responseData.push(response);
+				}
+				if (operation === 'classifyText') {
+					const source = this.getNodeParameter('source', i) as string;
+					const options = this.getNodeParameter('options', i) as IDataObject;
+					const documentType = (options.documentType as string | undefined) || 'PLAIN_TEXT';
+
+					const body: IData = {
+						document: {
+							type: documentType,
+						}
+					};
+
+					if (source === 'content') {
+						const content = this.getNodeParameter('content', i) as string;
+						body.document.content = content;
+					} else {
+						const gcsContentUri = this.getNodeParameter('gcsContentUri', i) as string;
+						body.document.gcsContentUri = gcsContentUri;
+					}
+
+					if (options.language) {
+						body.document.language = options.language as string;
+					}
+
+					const response = await googleApiRequest.call(this, 'POST', `/v1/documents:classifyText`, body);
 					responseData.push(response);
 				}
 			}

--- a/packages/nodes-base/nodes/Google/CloudNaturalLanguage/Interface.ts
+++ b/packages/nodes-base/nodes/Google/CloudNaturalLanguage/Interface.ts
@@ -1,6 +1,6 @@
 export interface IData {
 	document: IDocument;
-	encodingType: string;
+	encodingType?: string;
 }
 
 export interface IDocument {


### PR DESCRIPTION
I added four new operations to the Google Cloud Natural Language node: analyze entities, analyze entity sentiment, analyze syntax, and classify text. 