### PR TITLE
Changing `data` field from TEXT to MEDIUMTEXT on credentials table

### DIFF
--- a/packages/cli/src/databases/mysqldb/migrations/1620729500000-ChangeCredentialDataSize.ts
+++ b/packages/cli/src/databases/mysqldb/migrations/1620729500000-ChangeCredentialDataSize.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as config from '../../../../config';
+
+export class ChangeCredentialDataSize1620729500000 implements MigrationInterface {
+	name = 'ChangeCredentialDataSize1620729500000';
+
+	async up(queryRunner: QueryRunner): Promise<void> {
+		const tablePrefix = config.get('database.tablePrefix');
+
+		await queryRunner.query('ALTER TABLE `' + tablePrefix + 'credentials_entity` MODIFY COLUMN `data` MEDIUMTEXT NOT NULL');
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		const tablePrefix = config.get('database.tablePrefix');
+
+		await queryRunner.query('ALTER TABLE `' + tablePrefix + 'credentials_entity` MODIFY COLUMN `data` TEXT NOT NULL');
+	}
+}

--- a/packages/cli/src/databases/mysqldb/migrations/index.ts
+++ b/packages/cli/src/databases/mysqldb/migrations/index.ts
@@ -4,6 +4,7 @@ import { CreateIndexStoppedAt1594902918301 } from './1594902918301-CreateIndexSt
 import { AddWebhookId1611149998770 } from './1611149998770-AddWebhookId';
 import { MakeStoppedAtNullable1607431743767 } from './1607431743767-MakeStoppedAtNullable';
 import { ChangeDataSize1615306975123 } from './1615306975123-ChangeDataSize';
+import { ChangeCredentialDataSize1620729500000 } from './1620729500000-ChangeCredentialDataSize';
 
 export const mysqlMigrations = [
 	InitialMigration1588157391238,
@@ -12,4 +13,5 @@ export const mysqlMigrations = [
 	AddWebhookId1611149998770,
 	MakeStoppedAtNullable1607431743767,
 	ChangeDataSize1615306975123,
+	ChangeCredentialDataSize1620729500000,
 ];


### PR DESCRIPTION
This PR relates to issue https://github.com/n8n-io/n8n/issues/1766

Another PR released previously fixed the same issue for the `executions` table. The PR can be found here: https://github.com/n8n-io/n8n/pull/1524

At the time we did not think this could also affect credentials.

I also had a look at other columns but they are using the `json` data type, which is limited to 4gb.