### PR TITLE
Added await statement for hooks

### DIFF
--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -194,9 +194,9 @@ export class WorkflowRunnerProcess {
 	 * @param {any[]} parameters
 	 * @memberof WorkflowRunnerProcess
 	 */
-	sendHookToParentProcess(hook: string, parameters: any[]) { // tslint:disable-line:no-any
+	async sendHookToParentProcess(hook: string, parameters: any[]) { // tslint:disable-line:no-any
 		try {
-			sendToParentProcess('processHook', {
+			await sendToParentProcess('processHook', {
 				hook,
 				parameters,
 			});
@@ -217,22 +217,22 @@ export class WorkflowRunnerProcess {
 		const hookFunctions: IWorkflowExecuteHooks = {
 			nodeExecuteBefore: [
 				async (nodeName: string): Promise<void> => {
-					this.sendHookToParentProcess('nodeExecuteBefore', [nodeName]);
+					await this.sendHookToParentProcess('nodeExecuteBefore', [nodeName]);
 				},
 			],
 			nodeExecuteAfter: [
 				async (nodeName: string, data: ITaskData): Promise<void> => {
-					this.sendHookToParentProcess('nodeExecuteAfter', [nodeName, data]);
+					await this.sendHookToParentProcess('nodeExecuteAfter', [nodeName, data]);
 				},
 			],
 			workflowExecuteBefore: [
 				async (): Promise<void> => {
-					this.sendHookToParentProcess('workflowExecuteBefore', []);
+					await this.sendHookToParentProcess('workflowExecuteBefore', []);
 				},
 			],
 			workflowExecuteAfter: [
 				async (fullRunData: IRun, newStaticData?: IDataObject): Promise<void> => {
-					this.sendHookToParentProcess('workflowExecuteAfter', [fullRunData, newStaticData]);
+					await this.sendHookToParentProcess('workflowExecuteAfter', [fullRunData, newStaticData]);
 				},
 			],
 		};


### PR DESCRIPTION
This PR relates to https://github.com/n8n-io/n8n/issues/1764, https://github.com/n8n-io/n8n/issues/1591 and https://community.n8n.io/t/workflow-executions-with-status-unknown/5706/3

The changes are an attempt to fix the issue happening with `Unknown` status in workflows.

Considering I was unable to reproduce the error with 100% certainty in my setup but I was able to actually reproduce it by adding a delay to hooks (by using `setTimeout`) and get an inconsistent state, this change should fix the problem.