### PR TITLE
Fix Clockify Trigger bug

### DIFF
--- a/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
@@ -116,6 +116,9 @@ export class ClockifyTrigger implements INodeType {
 		result = await clockifyApiRequest.call(this, 'GET', resource, {}, qs);
 		webhookData.lastTimeChecked = qs.end;
 
-		return [ this.helpers.returnJsonArray(result) ];
+		if (Array.isArray(result) && result.length !== 0) {
+			return [ this.helpers.returnJsonArray(result) ];
+		}
+		return null;
 	}
 }

--- a/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
@@ -24,7 +24,7 @@ export class ClockifyTrigger implements INodeType {
 		displayName: 'Clockify Trigger',
 		icon: 'file:clockify.png',
 		name: 'clockifyTrigger',
-		group: ['trigger'],
+		group: [ 'trigger' ],
 		version: 1,
 		description: 'Watches Clockify For Events',
 		defaults: {
@@ -32,7 +32,7 @@ export class ClockifyTrigger implements INodeType {
 			color: '#000000',
 		},
 		inputs: [],
-		outputs: ['main'],
+		outputs: [ 'main' ],
 		credentials: [
 			{
 				name: 'clockifyApi',
@@ -109,16 +109,13 @@ export class ClockifyTrigger implements INodeType {
 				qs.start = webhookData.lastTimeChecked;
 				qs.end = moment().tz(workflowTimezone).format('YYYY-MM-DDTHH:mm:ss') + 'Z';
 				qs.hydrated = true;
-				qs['in-progress'] = false;
+				qs[ 'in-progress' ] = false;
 				break;
 		}
 
 		result = await clockifyApiRequest.call(this, 'GET', resource, {}, qs);
 		webhookData.lastTimeChecked = qs.end;
 
-		if (Array.isArray(result) && result.length !== 0) {
-			result = [this.helpers.returnJsonArray(result)];
-		}
-		return result;
+		return [ this.helpers.returnJsonArray(result) ];
 	}
 }


### PR DESCRIPTION
This PR fix a bug that occurs when _Clockify Trigger_ node return an empty array (in case of empty time entries result)
worth mentioning, that the user must change the workflow timezone settings to avoid any conflicts as mentioned in this [Docs PR](https://github.com/n8n-io/n8n-docs/pull/516)