### PR TITLE
Fix hubspotApiRequestAllItems

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
@@ -76,9 +76,7 @@ export async function hubspotApiRequestAllItems(this: IHookFunctions | IExecuteF
 			return returnData;
 		}
 	} while (
-		responseData['has-more'] !== undefined &&
-		responseData['has-more'] !== null &&
-		responseData['has-more'] !== false
+		responseData['hasMore'] || responseData['has-more']
 	);
 	return returnData;
 }


### PR DESCRIPTION
HubSpot API was changed. In some responses has-more property was renamed to hasMore. That's why even if the "Return All" checkbox is selected, the API only returns 250 values