### PR TITLE
Fix activity type in post operation

### DIFF
--- a/packages/nodes-base/nodes/Orbit/Orbit.node.ts
+++ b/packages/nodes-base/nodes/Orbit/Orbit.node.ts
@@ -414,10 +414,12 @@ export class Orbit implements INodeType {
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 					const body: IDataObject = {
 						type: 'post',
+						activity_type: 'post',
 						url,
 					};
 					if (additionalFields.publishedAt) {
 						body.occurred_at = additionalFields.publishedAt as string;
+						delete body.publishedAt;
 					}
 
 					responseData = await orbitApiRequest.call(this, 'POST', `/${workspaceId}/members/${memberId}/activities/`, body);


### PR DESCRIPTION
This PR appends an 'activity_type' field to the request body in `create:Post` operation, as it seems that the API changed after fixing the same issue in a previous [PR](https://github.com/n8n-io/n8n/pull/1699)