### PR TITLE
Fixing get profile operation to send additional data correctly

### DIFF
--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -1035,11 +1035,11 @@ export class Slack implements INodeType {
 				if (operation === 'get') {
 					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 
-					const body: IDataObject = {};
+					const qs: IDataObject = {};
 
-					Object.assign(body, additionalFields);
+					Object.assign(qs, additionalFields);
 
-					responseData = await slackApiRequest.call(this, 'POST', '/users.profile.get', body);
+					responseData = await slackApiRequest.call(this, 'POST', '/users.profile.get', undefined, qs);
 
 					responseData = responseData.profile;
 				}


### PR DESCRIPTION
The user.profile.get endpoint on Slack receives `user` and `include_labels` parameters via query string and not as request body.

Testing the method in the `Tester` tab shows how the request is made.

This PR relates to issue https://github.com/n8n-io/n8n/issues/1198