### PR TITLE
Correcting paging parameter name

### DIFF
--- a/packages/nodes-base/nodes/Strava/Strava.node.ts
+++ b/packages/nodes-base/nodes/Strava/Strava.node.ts
@@ -137,7 +137,7 @@ export class Strava implements INodeType {
 
 						responseData = await stravaApiRequestAllItems.call(this, 'GET', `/activities`, {}, qs);
 					} else {
-						qs.limit = this.getNodeParameter('limit', i) as number;
+						qs.per_page = this.getNodeParameter('limit', i) as number;
 
 						responseData = await stravaApiRequest.call(this, 'GET', `/activities`, {}, qs);
 					}


### PR DESCRIPTION
We should be using `per_page` instead of `limit` to limit the number of activities returned. Previously Strava was limiting to it's default 30 items, ignoring what the user entered.