### PR TITLE
Fix sheet name param in Spreadsheet File node

### DIFF
--- a/packages/nodes-base/nodes/SpreadsheetFile.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile.node.ts
@@ -293,7 +293,7 @@ export class SpreadsheetFile implements INodeType {
 					},
 					{
 						displayName: 'Sheet Name',
-						name: 'sheetName',
+						name: 'sheetNameTo',
 						type: 'string',
 						displayOptions: {
 							show: {
@@ -440,7 +440,7 @@ export class SpreadsheetFile implements INodeType {
 			}
 
 			// Convert the data in the correct format
-			const sheetName = options.sheetName as string || 'Sheet';
+			const sheetName = options.sheetNameTo as string || 'Sheet';
 			const wb: WorkBook = {
 				SheetNames: [sheetName],
 				Sheets: {


### PR DESCRIPTION
This PR fixes the `sheetName` param in the Spreadsheet File node for the file write operation, to close #1808.