### PR TITLE
MQTT node: Add SSL/TLS support

### DIFF
--- a/packages/nodes-base/credentials/Mqtt.credentials.ts
+++ b/packages/nodes-base/credentials/Mqtt.credentials.ts
@@ -1,5 +1,6 @@
 import {
 	ICredentialType,
+	IDisplayOptions,
 	NodePropertyTypes,
 } from 'n8n-workflow';
 
@@ -16,6 +17,10 @@ export class Mqtt implements ICredentialType {
 				{
 					name: 'mqtt',
 					value: 'mqtt',
+				},
+				{
+					name: 'mqtts (SSL/TLS)',
+					value: 'mqtts',
 				},
 				{
 					name: 'ws',
@@ -64,6 +69,100 @@ export class Mqtt implements ICredentialType {
 			type: 'string' as NodePropertyTypes,
 			default: '',
 			description: 'Client ID. If left empty, one is autogenrated for you',
+		},
+		{
+			displayName: 'SSL',
+			name: 'ssl',
+			type: 'boolean' as NodePropertyTypes,
+			default: false,
+		},
+		{
+			displayName: 'Passwordless',
+			name: 'passwordless',
+			type: 'boolean' as NodePropertyTypes,
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+				},
+			},
+			default: true,
+			description: 'Passwordless connection with certificates (SASL mechanism EXTERNAL)',
+		},
+		{
+			displayName: 'CA Certificates',
+			name: 'ca',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+				},
+			},
+			default: '',
+			description: 'SSL CA Certificates to use.',
+		},
+		{
+			displayName: 'Reject Unauthorized Certificate',
+			name: 'rejectUnauthorized',
+			type: 'boolean' as NodePropertyTypes,			
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					passwordless: [
+						true,
+					],
+				},
+			} as IDisplayOptions,
+			default: '',
+			description: 'Validate Certificate.',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'cert',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					passwordless: [
+						true,
+					],
+				},
+			} as IDisplayOptions,
+			default: '',
+			description: 'SSL Client Certificate to use.',
+		},
+		{
+			displayName: 'Client Key',
+			name: 'key',
+			type: 'string' as NodePropertyTypes,
+			typeOptions: {
+				password: true,
+			},
+			displayOptions: {
+				show: {
+					ssl: [
+						true,
+					],
+					passwordless: [
+						true,
+					],
+				},
+			},
+			default: '',
+			description: 'SSL Client Key to use.',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
+++ b/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
@@ -119,19 +119,46 @@ export class Mqtt implements INodeType {
 		const port = credentials.port as number || 1883;
 		const clientId = credentials.clientId as string || `mqttjs_${Math.random().toString(16).substr(2, 8)}`;
 		const clean = credentials.clean as boolean;
+		const ssl = credentials.ssl as boolean;
+		const ca = credentials.ca as string;
+		const cert = credentials.cert as string;
+		const key = credentials.key as string;
+		const rejectUnauthorized = credentials.rejectUnauthorized as boolean;
 
-		const clientOptions: IClientOptions = {
-			port,
-			clean,
-			clientId,
-		};
+		let client: mqtt.MqttClient;
 
-		if (credentials.username && credentials.password) {
-			clientOptions.username = credentials.username as string;
-			clientOptions.password = credentials.password as string;
+		if (ssl === false) {
+			const clientOptions: IClientOptions = {
+				port,
+				clean,
+				clientId,
+			};
+
+			if (credentials.username && credentials.password) {
+					clientOptions.username = credentials.username as string;
+					clientOptions.password = credentials.password as string;
+			}
+
+			 client = mqtt.connect(brokerUrl, clientOptions);
 		}
+		else {
+			const clientOptions: IClientOptions = {
+				port,
+				clean,
+				clientId,
+				ca,
+				cert,
+				key,
+				rejectUnauthorized,	
+			};
+			if (credentials.username && credentials.password) {
+				clientOptions.username = credentials.username as string;
+				clientOptions.password = credentials.password as string;
+			}
 
-		const client = mqtt.connect(brokerUrl, clientOptions);
+			 client = mqtt.connect(brokerUrl, clientOptions);
+		}
+		
 		const sendInputData = this.getNodeParameter('sendInputData', 0) as boolean;
 
 		// tslint:disable-next-line: no-any

--- a/packages/nodes-base/nodes/MQTT/MqttTrigger.node.ts
+++ b/packages/nodes-base/nodes/MQTT/MqttTrigger.node.ts
@@ -102,19 +102,45 @@ export class MqttTrigger implements INodeType {
 		const port = credentials.port as number || 1883;
 		const clientId = credentials.clientId as string || `mqttjs_${Math.random().toString(16).substr(2, 8)}`;
 		const clean = credentials.clean as boolean;
+		const ssl = credentials.ssl as boolean;
+		const ca = credentials.ca as string;
+		const cert = credentials.cert as string;
+		const key = credentials.key as string;
+		const rejectUnauthorized = credentials.rejectUnauthorized as boolean;
 
-		const clientOptions: IClientOptions = {
-			port,
-			clean,
-			clientId,
-		};
+		let client: mqtt.MqttClient;
 
-		if (credentials.username && credentials.password) {
-			clientOptions.username = credentials.username as string;
-			clientOptions.password = credentials.password as string;
+		if (ssl === false) {
+			const clientOptions: IClientOptions = {
+				port,
+				clean,
+				clientId,
+			};
+
+			if (credentials.username && credentials.password) {
+					clientOptions.username = credentials.username as string;
+					clientOptions.password = credentials.password as string;
+			}
+
+			 client = mqtt.connect(brokerUrl, clientOptions);
 		}
+		else {
+			const clientOptions: IClientOptions = {
+				port,
+				clean,
+				clientId,
+				ca,
+				cert,
+				key,
+				rejectUnauthorized,	
+			};
+			if (credentials.username && credentials.password) {
+				clientOptions.username = credentials.username as string;
+				clientOptions.password = credentials.password as string;
+			}
 
-		const client = mqtt.connect(brokerUrl, clientOptions);
+			 client = mqtt.connect(brokerUrl, clientOptions);
+		}
 
 		const self = this;
 


### PR DESCRIPTION
I need to encrypt my mqtt data between my ESP32 and n8n.
I am not a JS/TS dev, but I did my best to add SSL/TLS cert support.

I tested my modifications and Regular and Triggers MQTT n8n run very well with my SSL certififcates..
The network traffic is correctly encrypted