### PR TITLE
Add Vetur config file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _START_PACKAGE
 .vscode
 .idea
 .prettierrc.js
+vetur.config.js


### PR DESCRIPTION
Vetur, the VSCode extension we are using to work on Vue files in `/editor-ui`, cannot parse file paths with aliases in multi-root workspaces. Vetur by default tries to find the `tsconfig.json` file in the project root, but we need Vetur to search in the `/editor-ui` package root. This bug causes VSCode to report non-errors, disables the ability to rename when refactoring, and does not bring type data from those files.

Per the docs, this can be solved with a `vetur.config.js` in the n8n project root:

```
module.exports = {
  projects: [
    './packages/editor-ui',
  ]
}
```

This PR only adds this file to the root `.gitignore` to keep the project editor-agnostic.