### PR TITLE
Pipedrive Improvments

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -228,6 +228,11 @@ export class Pipedrive implements INodeType {
 						value: 'update',
 						description: 'Update a deal',
 					},
+					{
+						name: 'Search',
+						value: 'search',
+						description: 'Search a deal',
+					},
 				],
 				default: 'create',
 				description: 'The operation to perform.',
@@ -1281,7 +1286,109 @@ export class Pipedrive implements INodeType {
 					},
 				],
 			},
-
+			// ----------------------------------
+			//         deal:search
+			// ----------------------------------
+			{
+				displayName: 'Term',
+				name: 'term',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: [
+							'search',
+						],
+						resource: [
+							'deal',
+						],
+					},
+				},
+				default: '',
+				description: 'The search term to look for. Minimum 2 characters (or 1 if using exact_match).',
+			},
+			{
+				displayName: 'Exact Match',
+				name: 'exactMatch',
+				type: 'boolean',
+				default: false,
+				description: 'When enabled, only full exact matches against the given term are returned. It is not case sensitive.',
+			},
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						operation: [
+							'search',
+						],
+						resource: [
+							'deal',
+						],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Fields',
+						name: 'fields',
+						type: 'string',
+						default: '',
+						description: 'A comma-separated string array. The fields to perform the search from. Defaults to all of them.',
+					},
+					{
+						displayName: 'Include Fields',
+						name: 'includeFields',
+						type: 'string',
+						default: '',
+						description: 'Supports including optional fields in the results which are not provided by default.',
+					},
+					{
+						displayName: 'Organization ID',
+						name: 'organizationId',
+						type: 'string',
+						default: '',
+						description: 'Will filter Deals by the provided Organization ID.',
+					},
+					{
+						displayName: 'Person ID',
+						name: 'personId',
+						type: 'string',
+						default: '',
+						description: 'Will filter Deals by the provided Person ID.',
+					},
+					{
+						displayName: 'Status',
+						name: 'status',
+						type: 'options',
+						options: [
+							{
+								name: 'Open',
+								value: 'open',
+							},
+							{
+								name: 'Won',
+								value: 'won',
+							},
+							{
+								name: 'Lost',
+								value: 'lost',
+							}
+						],
+						default: 'open',
+						description: 'The status of the deal. If not provided it will automatically be set to "open".',
+					},
+					{
+						displayName: 'RAW Data',
+						name: 'rawData',
+						type: 'boolean',
+						default: false,
+						description: `Returns the data exactly in the way it got received from the API.`,
+					},
+				],
+			},
 
 
 			// ----------------------------------
@@ -2870,6 +2977,47 @@ export class Pipedrive implements INodeType {
 					if (body.label === 'null') {
 						body.label = null;
 					}
+				} else if (operation === 'search') {
+					// ----------------------------------
+					//         deal:search
+					// ----------------------------------
+
+					requestMethod = 'GET';
+
+					qs.term = this.getNodeParameter('term', i) as string;
+					returnAll = this.getNodeParameter('returnAll', i) as boolean;
+					qs.exact_match = this.getNodeParameter('exactMatch', i) as boolean;
+					if (returnAll === false) {
+						qs.limit = this.getNodeParameter('limit', i) as number;
+					}
+
+					const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+
+					if (additionalFields.fields) {
+						qs.fields = additionalFields.fields as string;
+					}
+
+					// if (additionalFields.exactMatch) {
+					// 	qs.exact_match = additionalFields.exactMatch as boolean;
+					// }
+
+					if (additionalFields.organizationId) {
+						qs.organization_id = parseInt(additionalFields.organizationId as string, 10);
+					}
+
+					if (additionalFields.includeFields) {
+						qs.include_fields = additionalFields.includeFields as string;
+					}
+
+					if(additionalFields.personId){
+						qs.person_id = parseInt(additionalFields.personId as string, 10);
+					}
+					if (additionalFields.status) {
+						qs.status = additionalFields.status as string;
+					}
+
+					endpoint = `/deals/search`;
+
 				}
 			} else if (resource === 'file') {
 				if (operation === 'create') {

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -531,6 +531,13 @@ export class Pipedrive implements INodeType {
 						description: 'ID of the deal this activity will be associated with',
 					},
 					{
+						displayName: 'Due Date',
+						name: 'due_date',
+						type: 'dateTime',
+						default: '',
+						description: 'Due Date to activity be done YYYY-MM-DD',
+					},
+					{
 						displayName: 'Note',
 						name: 'note',
 						type: 'string',
@@ -544,8 +551,11 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds'
+						},
+						default: '',
 						description: 'ID of the organization this activity will be associated with',
 					},
 					{
@@ -558,9 +568,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'User ID',
 						name: 'user_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getUserIds'
+						},
+						default: '',
+						description: 'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
 					},
 					{
 						displayName: 'Custom Properties',
@@ -689,6 +702,13 @@ export class Pipedrive implements INodeType {
 						description: 'ID of the deal this activity will be associated with',
 					},
 					{
+						displayName: 'Due Date',
+						name: 'due_date',
+						type: 'dateTime',
+						default: '',
+						description: 'Due Date to activity be done YYYY-MM-DD',
+					},
+					{
 						displayName: 'Done',
 						name: 'done',
 						type: 'options',
@@ -720,8 +740,11 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
+						type: 'options',
+						typeOptions:{
+							loadOptionsMethod: 'getOrganizationIds'
+						},
+						default: '',
 						description: 'ID of the organization this activity will be associated with',
 					},
 					{
@@ -749,9 +772,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'User ID',
 						name: 'user_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getUserIds'
+						},
+						default: '',
+						description: 'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
 					},
 					{
 						displayName: 'Custom Properties',
@@ -892,8 +918,11 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
 						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
@@ -917,9 +946,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Stage ID',
 						name: 'stage_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getStageIds'
+						},
+						default: '',
+						description: 'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE)',
 					},
 					{
 						displayName: 'Status',
@@ -949,9 +981,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'User ID',
 						name: 'user_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the user who will be marked as the owner of this deal. If omitted, the authorized user ID will be used.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getUserIds'
+						},
+						default: '',
+						description: 'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
 					},
 					{
 						displayName: 'Value',
@@ -1125,6 +1160,16 @@ export class Pipedrive implements INodeType {
 						],
 					},
 					{
+						displayName: 'User ID',
+						name: 'user_id',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getUserIds'
+						},
+						default: '',
+						description: 'ID of the active user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.',
+					},
+					{
 						displayName: 'Label',
 						name: 'label',
 						type: 'options',
@@ -1143,8 +1188,11 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
 						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
@@ -1168,9 +1216,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Stage ID',
 						name: 'stage_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getStageIds'
+						},
+						default: '',
+						description: 'ID of the stage this deal will be placed in a pipeline. If omitted, the deal will be placed in the first stage of the default pipeline. (PIPELINE > STAGE)',
 					},
 					{
 						displayName: 'Status',
@@ -1294,9 +1345,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this file will be associated with.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Person ID',
@@ -1457,9 +1511,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this note will be associated with.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Person ID',
@@ -1573,9 +1630,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this note will be associated with.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Person ID',
@@ -1950,9 +2010,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this person will belong to.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Phone',
@@ -2129,9 +2192,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this person will belong to.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Phone',
@@ -2397,9 +2463,12 @@ export class Pipedrive implements INodeType {
 					{
 						displayName: 'Organization ID',
 						name: 'org_id',
-						type: 'number',
-						default: 0,
-						description: 'ID of the organization this note will be associated with.',
+						type: 'options',
+						typeOptions: {
+							loadOptionsMethod: 'getOrganizationIds',
+						},
+						default: '',
+						description: 'ID of the organization this deal will be associated with.',
 					},
 					{
 						displayName: 'Person ID',
@@ -2415,6 +2484,112 @@ export class Pipedrive implements INodeType {
 
 	methods = {
 		loadOptions: {
+			// Get all Organizations to display them to user so that he can
+			// select them easily
+			async getOrganizationIds(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/organizations', {});
+				for (const org of data) {
+					
+					returnData.push({
+						name: org.name,
+						value: org.id,
+					});
+							
+				}
+				
+				return returnData;
+			},
+			// Get all Organizations to display them to user so that he can
+			// select them easily
+			async getUserIds(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/users', {});
+				for (const user of data) {
+					if(user.active_flag === true){
+						returnData.push({
+							name: user.name,
+							value: user.id,
+						});
+					}
+							
+				}
+				
+				return returnData;
+			},
+			// Get all Stages to display them to user so that he can
+			// select them easily
+			async getStageIds(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/stages', {});
+				for (const stage of data) {
+					
+					returnData.push({
+						name: `${stage.pipeline_name} > ${stage.name}`,
+						value: stage.id,
+					});
+							
+				}
+				
+				return returnData;
+			},
+			// Get all the Organization Custom Fields to display them to user so that he can
+			// select them easily
+			async getOrganizationCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/organizationFields', {});
+				for (const field of data) {
+					if (field.key.length == 40) {
+						
+						returnData.push({
+							name: field.name,
+							value: field.id,
+						});
+					}
+				}
+				
+				return returnData;
+			},
+			// Get all the Deal Custom Fields to display them to user so that he can
+			// select them easily
+			async getDealCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/dealFields', {});
+				for (const field of data) {
+					if (field.key.length == 40) {
+						
+						returnData.push({
+							name: field.name,
+							value: field.id,
+						});
+					}
+				}
+				
+				return returnData;
+			},
+			// Get all the Person Custom Fields to display them to user so that he can
+			// select them easily
+			async getPersonCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const operation = this.getCurrentNodeParameter('operation') as string;
+				const { data } = await pipedriveApiRequest.call(this, 'GET', '/personFields', {});
+				for (const field of data) {
+					if (field.key.length == 40) {
+						
+						returnData.push({
+							name: field.name,
+							value: field.id,
+						});
+					}
+				}
+				
+				return returnData;
+			},
 			// Get all the filters to display them to user so that he can
 			// select them easily
 			async getFilters(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -38,7 +38,11 @@ function addAdditionalFields(body: IDataObject, additionalFields: IDataObject) {
 			for (const customProperty of (additionalFields.customProperties as IDataObject)!.property! as CustomProperty[]) {
 				body[customProperty.name] = customProperty.value;
 			}
-		} else {
+		} else if (key === 'customFields' && (additionalFields.customFields as IDataObject).property !== undefined) {
+			for (const customProperty of (additionalFields.customFields as IDataObject)!.property! as CustomProperty[]) {
+				body[customProperty.name] = customProperty.value;
+			}
+		}  else {
 			body[key] = additionalFields[key];
 		}
 	}
@@ -872,6 +876,45 @@ export class Pipedrive implements INodeType {
 						description: 'Currency of the deal. Accepts a 3-character currency code. Like EUR, USD, ...',
 					},
 					{
+						displayName: 'Custom Fields',
+						name: 'customFields',
+						placeholder: 'Add Custom Field',
+						description: 'Adds a custom field to set also values which have not been predefined.',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								name: 'property',
+								displayName: 'Custom Field',
+								typeOptions: {
+									multipleValueButtonText: 'Add Cutom Field'
+								},
+								values: [
+									{
+										displayName: 'Property Name',
+										name: 'name',
+										type: 'options',
+										typeOptions: {
+											loadOptionsMethod: 'getDealCustomFields'
+										},
+										default: '',
+										description: 'Name of the custom field to set.',
+									},
+									{
+										displayName: 'Property Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+										description: 'Value of the property to set.',
+									},
+								],
+							},
+						],
+					},
+					{
 						displayName: 'Custom Properties',
 						name: 'customProperties',
 						placeholder: 'Add Custom Property',
@@ -1130,6 +1173,45 @@ export class Pipedrive implements INodeType {
 						type: 'string',
 						default: 'USD',
 						description: 'Currency of the deal. Accepts a 3-character currency code. Like EUR, USD, ...',
+					},
+					{
+						displayName: 'Custom Fields',
+						name: 'customFields',
+						placeholder: 'Add Custom Field',
+						description: 'Adds a custom field to set also values which have not been predefined.',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								name: 'property',
+								displayName: 'Custom Field',
+								typeOptions: {
+									multipleValueButtonText: 'Add Cutom Field'
+								},
+								values: [
+									{
+										displayName: 'Property Name',
+										name: 'name',
+										type: 'options',
+										typeOptions: {
+											loadOptionsMethod: 'getDealCustomFields'
+										},
+										default: '',
+										description: 'Name of the custom field to set.',
+									},
+									{
+										displayName: 'Property Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+										description: 'Value of the property to set.',
+									},
+								],
+							},
+						],
 					},
 					{
 						displayName: 'Custom Properties',
@@ -2063,6 +2145,45 @@ export class Pipedrive implements INodeType {
 				default: {},
 				options: [
 					{
+						displayName: 'Custom Fields',
+						name: 'customFields',
+						placeholder: 'Add Custom Field',
+						description: 'Adds a custom field to set also values which have not been predefined.',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								name: 'property',
+								displayName: 'Custom Field',
+								typeOptions: {
+									multipleValueButtonText: 'Add Cutom Field'
+								},
+								values: [
+									{
+										displayName: 'Property Name',
+										name: 'name',
+										type: 'options',
+										typeOptions: {
+											loadOptionsMethod: 'getPersonCustomFields'
+										},
+										default: '',
+										description: 'Name of the custom field to set.',
+									},
+									{
+										displayName: 'Property Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+										description: 'Value of the property to set.',
+									},
+								],
+							},
+						],
+					},
+					{
 						displayName: 'Custom Properties',
 						name: 'customProperties',
 						placeholder: 'Add Custom Property',
@@ -2237,6 +2358,45 @@ export class Pipedrive implements INodeType {
 				},
 				default: {},
 				options: [
+					{
+						displayName: 'Custom Fields',
+						name: 'customFields',
+						placeholder: 'Add Custom Field',
+						description: 'Adds a custom field to set also values which have not been predefined.',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						options: [
+							{
+								name: 'property',
+								displayName: 'Custom Field',
+								typeOptions: {
+									multipleValueButtonText: 'Add Cutom Field'
+								},
+								values: [
+									{
+										displayName: 'Property Name',
+										name: 'name',
+										type: 'options',
+										typeOptions: {
+											loadOptionsMethod: 'getPersonCustomFields'
+										},
+										default: '',
+										description: 'Name of the custom field to set.',
+									},
+									{
+										displayName: 'Property Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+										description: 'Value of the property to set.',
+									},
+								],
+							},
+						],
+					},
 					{
 						displayName: 'Custom Properties',
 						name: 'customProperties',
@@ -2654,7 +2814,7 @@ export class Pipedrive implements INodeType {
 						
 						returnData.push({
 							name: field.name,
-							value: field.id,
+							value: field.key,
 						});
 					}
 				}
@@ -2672,7 +2832,7 @@ export class Pipedrive implements INodeType {
 						
 						returnData.push({
 							name: field.name,
-							value: field.id,
+							value: field.key,
 						});
 					}
 				}
@@ -2690,7 +2850,7 @@ export class Pipedrive implements INodeType {
 						
 						returnData.push({
 							name: field.name,
-							value: field.id,
+							value: field.key,
 						});
 					}
 				}


### PR DESCRIPTION
I did some modifications on pipedrive node that I think that will speed up workflows creation that use this nodes.

 - Change the way that we select optional fields. Pipedrive uses Id to send to API, but getting API by Pipe interface is a little annoying some times, so I changed the current way to use a dropdown menu to select options.
 - Create an operation in Deal resource to SEARCH deals like it was implemented in Person resource.
 - For Custom Fields Pipedrive uses a key with 40 characters length so I put available to select this custom fields by name with a dropdown.

So if you have any question or if you could review the code. Thanks a lot this is a great project that you're doing.