### PR TITLE
:bug: Fix NodeViewNew navigation handling

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -432,8 +432,6 @@ export default mixins(
 						if (importConfirm === true) {
 							this.$store.commit('setStateDirty', false);
 							if (this.$router.currentRoute.name === 'NodeViewNew') {
-								// using event emitter pattern
-								// to avoid duplicate navigation issue
 								this.$root.$emit('newWorkflow');
 							} else {
 								this.$router.push({ name: 'NodeViewNew' });

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -431,7 +431,14 @@ export default mixins(
 						const importConfirm = await this.confirmMessage(`When you switch workflows your current workflow changes will be lost.`, 'Save your Changes?', 'warning', 'Yes, switch workflows and forget changes');
 						if (importConfirm === true) {
 							this.$store.commit('setStateDirty', false);
-							this.$router.push({ name: 'NodeViewNew' });
+							if (this.$router.currentRoute.name === 'NodeViewNew') {
+								// the default router mode is : Hash
+								// HACK; so changing the query will make the route seems different
+								// the added query attribute can be used in the NodeViewNew for extra behavior
+								this.$router.push({ name: 'NodeViewNew', query: {ref:'NodeViewNew'} });
+							} else {
+								this.$router.push({ name: 'NodeViewNew' });
+							}
 
 							this.$showMessage({
 								title: 'Workflow created',
@@ -440,7 +447,9 @@ export default mixins(
 							});
 						}
 					} else {
-						this.$router.push({ name: 'NodeViewNew' });
+						if (this.$router.currentRoute.name !== 'NodeViewNew') {
+							this.$router.push({ name: 'NodeViewNew' });
+						}
 
 						this.$showMessage({
 							title: 'Workflow created',

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -432,10 +432,9 @@ export default mixins(
 						if (importConfirm === true) {
 							this.$store.commit('setStateDirty', false);
 							if (this.$router.currentRoute.name === 'NodeViewNew') {
-								// the default router mode is : Hash
-								// HACK; so changing the query will make the route seems different
-								// the added query attribute can be used in the NodeViewNew for extra behavior
-								this.$router.push({ name: 'NodeViewNew', query: {ref:'NodeViewNew'} });
+								// using event emitter pattern
+								// to avoid duplicate navigation issue
+								this.$root.$emit('newWorkflow');
 							} else {
 								this.$router.push({ name: 'NodeViewNew' });
 							}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -495,10 +495,14 @@ export default mixins(
 					e.stopPropagation();
 					e.preventDefault();
 
-					this.$router.push({ name: 'NodeViewNew' });
+					if (this.$router.currentRoute.name === 'NodeViewNew') {
+						this.$root.$emit('newWorkflow');
+					} else {
+						this.$router.push({ name: 'NodeViewNew' });
+					}
 
 					this.$showMessage({
-						title: 'Created',
+						title: 'Workflow created',
 						message: 'A new workflow got created!',
 						type: 'success',
 					});

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2063,6 +2063,10 @@ export default mixins(
 				const resData = await this.importWorkflowData(data.data as IWorkflowDataUpdate);
 			});
 
+			this.$root.$on('newWorkflow', async () => {
+				await this.newWorkflow();
+			});
+
 			this.$root.$on('importWorkflowUrl', async (data: IDataObject) => {
 				const workflowData = await this.getWorkflowDataFromUrl(data.url as string);
 				if (workflowData !== undefined) {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2063,9 +2063,7 @@ export default mixins(
 				const resData = await this.importWorkflowData(data.data as IWorkflowDataUpdate);
 			});
 
-			this.$root.$on('newWorkflow', () => {
-				this.newWorkflow();
-			});
+			this.$root.$on('newWorkflow', this.newWorkflow);
 
 			this.$root.$on('importWorkflowUrl', async (data: IDataObject) => {
 				const workflowData = await this.getWorkflowDataFromUrl(data.url as string);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2063,8 +2063,8 @@ export default mixins(
 				const resData = await this.importWorkflowData(data.data as IWorkflowDataUpdate);
 			});
 
-			this.$root.$on('newWorkflow', async () => {
-				await this.newWorkflow();
+			this.$root.$on('newWorkflow', () => {
+				this.newWorkflow();
 			});
 
 			this.$root.$on('importWorkflowUrl', async (data: IDataObject) => {


### PR DESCRIPTION
This PR address bugs related when creating a new workflow while having an unsaved workflow:

- The editor doesn't clean the workflow data (including node, connection etc) after initiating the new workflow
- The refresh behavior wasn't handled correctly
- Console errors out

The changes include: 
- Navigating to NodeViewNew component if the previous route is different.
- Navigating to NodeViewNew with query attributes if the previous route is the same.