### PR TITLE
Fix uninitialized object when settings enabled for AWS Transcribe node

### DIFF
--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -426,6 +426,7 @@ export class AwsTranscribe implements INodeType {
 							Media: {
 								MediaFileUri: mediaFileUri,
 							},
+							Settings: {}
 						};
 
 						if (detectLang) {


### PR DESCRIPTION
Fixes this bug when settings are enabled for a job because an Object is not initialized.

```
TypeError: Cannot convert undefined or null to object
    at Function.assign (<anonymous>)
    at Object.execute (/usr/local/lib/node_modules/n8n/node_modules/n8n-nodes-base/dist/nodes/Aws/Transcribe/AwsTranscribe.node.js:419:36)
    at Workflow.runNode (/usr/local/lib/node_modules/n8n/node_modules/n8n-workflow/dist/src/Workflow.js:492:37)
    at /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/src/WorkflowExecute.js:424:62
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```