### PR TITLE
Fix settings in AWS Transcribe node

### DIFF
--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -426,7 +426,7 @@ export class AwsTranscribe implements INodeType {
 							Media: {
 								MediaFileUri: mediaFileUri,
 							},
-							Settings: {}
+							Settings: {},
 						};
 
 						if (detectLang) {

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -441,13 +441,14 @@ export class AwsTranscribe implements INodeType {
 
 						if (options.maxAlternatives) {
 							Object.assign(body.Settings, {
+								ShowAlternatives: true,
 								MaxAlternatives: options.maxAlternatives,
 							});
-						}
+						} 
 
-						if (options.showSpeakerLabels) {
+						if (options.maxSpeakerLabels) {
 							Object.assign(body.Settings, {
-								ShowSpeakerLabels: options.showSpeakerLabels,
+								ShowSpeakerLabels: true,
 								MaxSpeakerLabels: options.maxSpeakerLabels,
 							});
 						}

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -441,7 +441,6 @@ export class AwsTranscribe implements INodeType {
 
 						if (options.maxAlternatives) {
 							Object.assign(body.Settings, {
-								ShowAlternatives: options.maxAlternatives,
 								MaxAlternatives: options.maxAlternatives,
 							});
 						}

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -439,7 +439,7 @@ export class AwsTranscribe implements INodeType {
 							Object.assign(body.Settings, { ChannelIdentification: options.channelIdentification });
 						}
 
-						if (options.MaxAlternatives) {
+						if (options.maxAlternatives) {
 							Object.assign(body.Settings, {
 								ShowAlternatives: options.maxAlternatives,
 								MaxAlternatives: options.maxAlternatives,

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -426,6 +426,7 @@ export class AwsTranscribe implements INodeType {
 							Media: {
 								MediaFileUri: mediaFileUri,
 							},
+							Settings: {}
 						};
 
 						if (detectLang) {


### PR DESCRIPTION
This PR initializes the `Settings` object, fixes `maxAlternatives` and removes `showAlternatives` in the AWS Transcribe node.

Building on the community contribution at #1858.