### PR TITLE
Simplify property types in credentials classes

### DIFF
--- a/packages/nodes-base/credentials/ActiveCampaignApi.credentials.ts
+++ b/packages/nodes-base/credentials/ActiveCampaignApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class ActiveCampaignApi implements ICredentialType {
 	name = 'activeCampaignApi';
 	displayName = 'ActiveCampaign API';
 	documentationUrl = 'activeCampaign';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API URL',
 			name: 'apiUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
+++ b/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AcuitySchedulingApi implements ICredentialType {
 	name = 'acuitySchedulingApi';
 	displayName = 'Acuity Scheduling API';
 	documentationUrl = 'acuityScheduling';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User ID',
 			name: 'userId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AcuitySchedulingOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/AcuitySchedulingOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,38 +11,38 @@ export class AcuitySchedulingOAuth2Api implements ICredentialType {
 	];
 	displayName = 'AcuityScheduling OAuth2 API';
 	documentationUrl = 'acuityScheduling';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://acuityscheduling.com/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://acuityscheduling.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'api-v1',
 			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/AffinityApi.credentials.ts
+++ b/packages/nodes-base/credentials/AffinityApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AffinityApi implements ICredentialType {
 	name = 'affinityApi';
 	displayName = 'Affinity API';
 	documentationUrl = 'affinity';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AgileCrmApi.credentials.ts
+++ b/packages/nodes-base/credentials/AgileCrmApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AgileCrmApi implements ICredentialType {
 	name = 'agileCrmApi';
 	displayName = 'AgileCRM API';
 	documentationUrl = 'agileCrm';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'example',
 			description: 'If the domain is https://example.agilecrm.com "example" would have to be entered.',

--- a/packages/nodes-base/credentials/AirtableApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtableApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class AirtableApi implements ICredentialType {
 	name = 'airtableApi';
 	displayName = 'Airtable API';
 	documentationUrl = 'airtable';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Amqp.credentials.ts
+++ b/packages/nodes-base/credentials/Amqp.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,29 +8,29 @@ export class Amqp implements ICredentialType {
 	name = 'amqp';
 	displayName = 'AMQP';
 	documentationUrl = 'amqp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Hostname',
 			name: 'hostname',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 5672,
 		},
 		{
 			displayName: 'User',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -39,7 +39,7 @@ export class Amqp implements ICredentialType {
 		{
 			displayName: 'Transport Type',
 			name: 'transportType',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Optional Transport Type to use.',
 		},

--- a/packages/nodes-base/credentials/ApiTemplateIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/ApiTemplateIoApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ApiTemplateIoApi implements ICredentialType {
 	name = 'apiTemplateIoApi';
 	displayName = 'APITemplate.io API';
 	documentationUrl = 'apiTemplateIo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AsanaApi.credentials.ts
+++ b/packages/nodes-base/credentials/AsanaApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AsanaApi implements ICredentialType {
 	name = 'asanaApi';
 	displayName = 'Asana API';
 	documentationUrl = 'asana';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AsanaOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/AsanaOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AsanaOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class AsanaOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Asana OAuth2 API';
 	documentationUrl = 'asana';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.asana.com/-/oauth_authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.asana.com/-/oauth_token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/AutomizyApi.credentials.ts
+++ b/packages/nodes-base/credentials/AutomizyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AutomizyApi implements ICredentialType {
 	name = 'automizyApi';
 	displayName = 'Automizy API';
 	documentationUrl = 'automizy';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/AutopilotApi.credentials.ts
+++ b/packages/nodes-base/credentials/AutopilotApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class AutopilotApi implements ICredentialType {
 	name = 'autopilotApi';
 	displayName = 'Autopilot API';
 	documentationUrl = 'autopilot';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,23 +8,23 @@ export class Aws implements ICredentialType {
 	name = 'aws';
 	displayName = 'AWS';
 	documentationUrl = 'aws';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Region',
 			name: 'region',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'us-east-1',
 		},
 		{
 			displayName: 'Access Key Id',
 			name: 'accessKeyId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Secret Access Key',
 			name: 'secretAccessKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			typeOptions: {
 				password: true,
@@ -33,14 +33,14 @@ export class Aws implements ICredentialType {
 		{
 			displayName: 'Custom Endpoints',
 			name: 'customEndpoints',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
 			displayName: 'Rekognition Endpoint',
 			name: 'rekognitionEndpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and Rekognition using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [
@@ -55,7 +55,7 @@ export class Aws implements ICredentialType {
 			displayName: 'Lambda Endpoint',
 			name: 'lambdaEndpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and Lambda using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [
@@ -70,7 +70,7 @@ export class Aws implements ICredentialType {
 			displayName: 'SNS Endpoint',
 			name: 'snsEndpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SNS using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [
@@ -85,7 +85,7 @@ export class Aws implements ICredentialType {
 			displayName: 'SES Endpoint',
 			name: 'sesEndpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SES using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [
@@ -100,7 +100,7 @@ export class Aws implements ICredentialType {
 			displayName: 'SQS Endpoint',
 			name: 'sqsEndpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and SQS using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [
@@ -115,7 +115,7 @@ export class Aws implements ICredentialType {
 			displayName: 'S3 Endpoint',
 			name: 's3Endpoint',
 			description: 'If you use Amazon VPC to host n8n, you can establish a connection between your VPC and S3 using a VPC endpoint. Leave blank to use the default endpoint.',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					customEndpoints: [

--- a/packages/nodes-base/credentials/BannerbearApi.credentials.ts
+++ b/packages/nodes-base/credentials/BannerbearApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BannerbearApi implements ICredentialType {
 	name = 'bannerbearApi';
 	displayName = 'Bannerbear API';
 	documentationUrl = 'bannerbear';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Project API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/BeeminderApi.credentials.ts
+++ b/packages/nodes-base/credentials/BeeminderApi.credentials.ts
@@ -1,22 +1,22 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BeeminderApi implements ICredentialType {
 	name = 'beeminderApi';
 	displayName = 'Beeminder API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Auth Token',
 			name: 'authToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/BitbucketApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitbucketApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BitbucketApi implements ICredentialType {
 	name = 'bitbucketApi';
 	displayName = 'Bitbucket API';
 	documentationUrl = 'bitbucket';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'App Password',
 			name: 'appPassword',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/BitlyApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitlyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BitlyApi implements ICredentialType {
 	name = 'bitlyApi';
 	displayName = 'Bitly API';
 	documentationUrl = 'bitly';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/BitlyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/BitlyOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,32 +11,32 @@ export class BitlyOAuth2Api implements ICredentialType {
 	extends = [
 		'oAuth2Api',
 	];
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://bitly.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api-ssl.bitly.com/oauth/access_token',
 			required: true,
 		},
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -46,13 +46,13 @@ export class BitlyOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 			description: 'For some services additional query parameters have to be set which can be defined here.',
 			placeholder: '',
@@ -60,7 +60,7 @@ export class BitlyOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/BitwardenApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitwardenApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 // https://bitwarden.com/help/article/public-api/#authentication
@@ -9,23 +9,23 @@ export class BitwardenApi implements ICredentialType {
 	name = 'bitwardenApi';
 	displayName = 'Bitwarden API';
 	documentationUrl = 'bitwarden';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Environment',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'cloudHosted',
 			options: [
 				{
@@ -41,7 +41,7 @@ export class BitwardenApi implements ICredentialType {
 		{
 			displayName: 'Self-hosted domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://www.mydomain.com',
 			displayOptions: {

--- a/packages/nodes-base/credentials/BoxOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/BoxOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BoxOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class BoxOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Box OAuth2 API';
 	documentationUrl = 'box';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://account.box.com/api/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.box.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/BrandfetchApi.credentials.ts
+++ b/packages/nodes-base/credentials/BrandfetchApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BrandfetchApi implements ICredentialType {
 	name = 'brandfetchApi';
 	displayName = 'Brandfetch API';
 	documentationUrl = 'brandfetch';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/BubbleApi.credentials.ts
+++ b/packages/nodes-base/credentials/BubbleApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class BubbleApi implements ICredentialType {
 	name = 'bubbleApi';
 	displayName = 'Bubble API';
 	documentationUrl = 'bubble';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'App Name',
 			name: 'appName',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Environment',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'live',
 			options: [
 				{
@@ -39,7 +39,7 @@ export class BubbleApi implements ICredentialType {
 		{
 			displayName: 'Hosting',
 			name: 'hosting',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'bubbleHosted',
 			options: [
 				{
@@ -55,7 +55,7 @@ export class BubbleApi implements ICredentialType {
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			placeholder: 'mydomain.com',
 			default: '',
 			displayOptions: {

--- a/packages/nodes-base/credentials/CalendlyApi.credentials.ts
+++ b/packages/nodes-base/credentials/CalendlyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class CalendlyApi implements ICredentialType {
 	name = 'calendlyApi';
 	displayName = 'Calendly API';
 	documentationUrl = 'calendly';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ChargebeeApi.credentials.ts
+++ b/packages/nodes-base/credentials/ChargebeeApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class ChargebeeApi implements ICredentialType {
 	name = 'chargebeeApi';
 	displayName = 'Chargebee API';
 	documentationUrl = 'chargebee';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Account Name',
 			name: 'accountName',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Api Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/CircleCiApi.credentials.ts
+++ b/packages/nodes-base/credentials/CircleCiApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class CircleCiApi implements ICredentialType {
 	name = 'circleCiApi';
 	displayName = 'CircleCI API';
 	documentationUrl = 'circleCi';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Personal API Token',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ClearbitApi.credentials.ts
+++ b/packages/nodes-base/credentials/ClearbitApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ClearbitApi implements ICredentialType {
 	name = 'clearbitApi';
 	displayName = 'Clearbit API';
 	documentationUrl = 'clearbit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ClickUpApi.credentials.ts
+++ b/packages/nodes-base/credentials/ClickUpApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ClickUpApi implements ICredentialType {
 	name = 'clickUpApi';
 	displayName = 'ClickUp API';
 	documentationUrl = 'clickUp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ClickUpOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ClickUpOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ClickUpOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class ClickUpOAuth2Api implements ICredentialType {
 	];
 	displayName = 'ClickUp OAuth2 API';
 	documentationUrl = 'clickUp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.clickup.com/api',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.clickup.com/api/v2/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/ClockifyApi.credentials.ts
+++ b/packages/nodes-base/credentials/ClockifyApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,14 +8,14 @@ export class ClockifyApi implements ICredentialType {
 	name = 'clockifyApi';
 	displayName = 'Clockify API';
 	documentationUrl = 'clockify';
-	properties = [
+	properties: INodeProperties[] = [
 		// The credentials to get from user and save encrypted.
 		// Properties can be defined exactly in the same way
 		// as node properties.
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/CockpitApi.credentials.ts
+++ b/packages/nodes-base/credentials/CockpitApi.credentials.ts
@@ -1,24 +1,24 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class CockpitApi implements ICredentialType {
 	name = 'cockpitApi';
 	displayName = 'Cockpit API';
 	documentationUrl = 'cockpit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Cockpit URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.com',
 		},
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/CodaApi.credentials.ts
+++ b/packages/nodes-base/credentials/CodaApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class CodaApi implements ICredentialType {
 	name = 'codaApi';
 	displayName = 'Coda API';
 	documentationUrl = 'coda';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ContentfulApi.credentials.ts
+++ b/packages/nodes-base/credentials/ContentfulApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 //https://www.contentful.com/developers/docs/references/authentication/
@@ -8,11 +8,11 @@ export class ContentfulApi implements ICredentialType {
 	name = 'contentfulApi';
 	displayName = 'Contenful API';
 	documentationUrl = 'contentful';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Space ID',
 			name: 'spaceId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 			description: 'The id for the Contentful space.',
@@ -20,14 +20,14 @@ export class ContentfulApi implements ICredentialType {
 		{
 			displayName: 'Content Delivery API Access token',
 			name: 'ContentDeliveryaccessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Access token that has access to the space. Can be left empty if only Delivery API should be used.',
 		},
 		{
 			displayName: 'Content Preview API Access token',
 			name: 'ContentPreviewaccessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Access token that has access to the space. Can be left empty if only Preview API should be used.',
 		},

--- a/packages/nodes-base/credentials/ConvertKitApi.credentials.ts
+++ b/packages/nodes-base/credentials/ConvertKitApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class ConvertKitApi implements ICredentialType {
 	name = 'convertKitApi';
 	displayName = 'ConvertKit API';
 	documentationUrl = 'convertKit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Secret',
 			name: 'apiSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			typeOptions: {
 				password: true,

--- a/packages/nodes-base/credentials/CopperApi.credentials.ts
+++ b/packages/nodes-base/credentials/CopperApi.credentials.ts
@@ -1,25 +1,25 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class CopperApi implements ICredentialType {
 	name = 'copperApi';
 	displayName = 'Copper API';
 	documentationUrl = 'copper';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Email',
 			name: 'email',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/CortexApi.credentials.ts
+++ b/packages/nodes-base/credentials/CortexApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class CortexApi implements ICredentialType {
 	name = 'cortexApi';
 	displayName = 'Cortex API';
 	documentationUrl = 'cortex';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'cortexApiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Cortex Instance',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			description: 'The URL of the Cortex instance',
 			default: '',
 			placeholder: 'https://localhost:9001',

--- a/packages/nodes-base/credentials/CrateDb.credentials.ts
+++ b/packages/nodes-base/credentials/CrateDb.credentials.ts
@@ -1,32 +1,32 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class CrateDb implements ICredentialType {
 	name = 'crateDb';
 	displayName = 'CrateDB';
 	documentationUrl = 'crateDb';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'doc',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'crate',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -35,7 +35,7 @@ export class CrateDb implements ICredentialType {
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'disable',
@@ -63,7 +63,7 @@ export class CrateDb implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 5432,
 		},
 	];

--- a/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class CustomerIoApi implements ICredentialType {
 	name = 'customerIoApi';
 	displayName = 'Customer.io API';
 	documentationUrl = 'customerIo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Tracking API Key',
 			name: 'trackingApiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Required for tracking API.',
 			required: true,
@@ -20,14 +20,14 @@ export class CustomerIoApi implements ICredentialType {
 		{
 			displayName: 'Tracking Site ID',
 			name: 'trackingSiteId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Required for tracking API.',
 		},
 		{
 			displayName: 'App API Key',
 			name: 'appApiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Required for App API.',
 		},

--- a/packages/nodes-base/credentials/DeepLApi.credentials.ts
+++ b/packages/nodes-base/credentials/DeepLApi.credentials.ts
@@ -1,20 +1,20 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class DeepLApi implements ICredentialType {
 	name = 'deepLApi';
 	displayName = 'DeepL API';
 	documentationUrl = 'deepL';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Plan',
 			name: 'apiPlan',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'Pro Plan',

--- a/packages/nodes-base/credentials/DemioApi.credentials.ts
+++ b/packages/nodes-base/credentials/DemioApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class DemioApi implements ICredentialType {
 	name = 'demioApi';
 	displayName = 'Demio API';
 	documentationUrl = 'demio';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Secret',
 			name: 'apiSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/DiscourseApi.credentials.ts
+++ b/packages/nodes-base/credentials/DiscourseApi.credentials.ts
@@ -1,32 +1,32 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class DiscourseApi implements ICredentialType {
 	name = 'discourseApi';
 	displayName = 'Discourse API';
 	documentationUrl = 'discourse';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/DisqusApi.credentials.ts
+++ b/packages/nodes-base/credentials/DisqusApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class DisqusApi implements ICredentialType {
 	name = 'disqusApi';
 	displayName = 'Disqus API';
 	documentationUrl = 'disqus';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Visit your account details page, and grab the Access Token. See <a href="https://disqus.com/api/docs/auth/">Disqus auth</a>.',
 		},

--- a/packages/nodes-base/credentials/DriftApi.credentials.ts
+++ b/packages/nodes-base/credentials/DriftApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class DriftApi implements ICredentialType {
 	name = 'driftApi';
 	displayName = 'Drift API';
 	documentationUrl = 'drift';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Personal Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Visit your account details page, and grab the Access Token. See <a href="https://devdocs.drift.com/docs/quick-start">Drift auth</a>.',
 		},

--- a/packages/nodes-base/credentials/DriftOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DriftOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,37 +11,37 @@ export class DriftOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Drift OAuth2 API';
 	documentationUrl = 'drift';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://dev.drift.com/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://driftapi.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/DropboxApi.credentials.ts
+++ b/packages/nodes-base/credentials/DropboxApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class DropboxApi implements ICredentialType {
 	name = 'dropboxApi';
 	displayName = 'Dropbox API';
 	documentationUrl = 'dropbox';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'APP Access Type',
 			name: 'accessType',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'App Folder',

--- a/packages/nodes-base/credentials/DropboxOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DropboxOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -17,43 +17,43 @@ export class DropboxOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Dropbox OAuth2 API';
 	documentationUrl = 'dropbox';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.dropbox.com/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.dropboxapi.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'token_access_type=offline&force_reapprove=true',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 		{
 			displayName: 'APP Access Type',
 			name: 'accessType',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'App Folder',

--- a/packages/nodes-base/credentials/ERPNextApi.credentials.ts
+++ b/packages/nodes-base/credentials/ERPNextApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ERPNextApi implements ICredentialType {
 	name = 'erpNextApi';
 	displayName = 'ERPNext API';
 	documentationUrl = 'erpnext';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Secret',
 			name: 'apiSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Environment',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'cloudHosted',
 			options: [
 				{
@@ -39,7 +39,7 @@ export class ERPNextApi implements ICredentialType {
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'n8n',
 			description: 'Subdomain of cloud-hosted ERPNext instance. For example, "n8n" is the subdomain in: <code>https://n8n.erpnext.com</code>',
@@ -54,7 +54,7 @@ export class ERPNextApi implements ICredentialType {
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://www.mydomain.com',
 			description: 'Fully qualified domain name of self-hosted ERPNext instance.',

--- a/packages/nodes-base/credentials/EgoiApi.credentials.ts
+++ b/packages/nodes-base/credentials/EgoiApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,14 +8,14 @@ export class EgoiApi implements ICredentialType {
 	name = 'egoiApi';
 	displayName = 'E-goi API';
 	documentationUrl = 'egoi';
-	properties = [
+	properties: INodeProperties[] = [
 		// The credentials to get from user and save encrypted.
 		// Properties can be defined exactly in the same way
 		// as node properties.
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/EmeliaApi.credentials.ts
+++ b/packages/nodes-base/credentials/EmeliaApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class EmeliaApi implements ICredentialType {
 	name = 'emeliaApi';
 	displayName = 'Emelia API';
 	documentationUrl = 'emelia';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/EventbriteApi.credentials.ts
+++ b/packages/nodes-base/credentials/EventbriteApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class EventbriteApi implements ICredentialType {
 	name = 'eventbriteApi';
 	displayName = 'Eventbrite API';
 	documentationUrl = 'eventbrite';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Private Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/EventbriteOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/EventbriteOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,37 +11,37 @@ export class EventbriteOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Eventbrite OAuth2 API';
 	documentationUrl = 'eventbrite';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.eventbrite.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.eventbrite.com/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/FacebookGraphApi.credentials.ts
+++ b/packages/nodes-base/credentials/FacebookGraphApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class FacebookGraphApi implements ICredentialType {
 	name = 'facebookGraphApi';
 	displayName = 'Facebook Graph API';
 	documentationUrl = 'facebookGraph';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/FacebookGraphAppApi.credentials.ts
+++ b/packages/nodes-base/credentials/FacebookGraphAppApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class FacebookGraphAppApi implements ICredentialType {
@@ -10,11 +10,11 @@ export class FacebookGraphAppApi implements ICredentialType {
 	extends = [
 		'facebookGraphApi',
 	];
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'App Secret',
 			name: 'appSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: '(Optional) When the app secret is set the node will verify this signature to validate the integrity and origin of the payload.',
 		},

--- a/packages/nodes-base/credentials/FileMaker.credentials.ts
+++ b/packages/nodes-base/credentials/FileMaker.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,29 +8,29 @@ export class FileMaker implements ICredentialType {
 	name = 'fileMaker';
 	displayName = 'FileMaker API';
 	documentationUrl = 'fileMaker';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Database',
 			name: 'db',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Login',
 			name: 'login',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/FlowApi.credentials.ts
+++ b/packages/nodes-base/credentials/FlowApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class FlowApi implements ICredentialType {
 	name = 'flowApi';
 	displayName = 'Flow API';
 	documentationUrl = 'flow';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Organization ID',
 			name: 'organizationId',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 0,
 		},
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/FreshdeskApi.credentials.ts
+++ b/packages/nodes-base/credentials/FreshdeskApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class FreshdeskApi implements ICredentialType {
 	name = 'freshdeskApi';
 	displayName = 'Freshdesk API';
 	documentationUrl = 'freshdesk';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			placeholder: 'company',
 			description: 'If the URL you get displayed on Freshdesk is "https://company.freshdesk.com" enter "company"',
 			default: '',

--- a/packages/nodes-base/credentials/Ftp.credentials.ts
+++ b/packages/nodes-base/credentials/Ftp.credentials.ts
@@ -1,18 +1,18 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Ftp implements ICredentialType {
 	name = 'ftp';
 	displayName = 'FTP';
 	documentationUrl = 'ftp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'localhost',
 		},
@@ -20,19 +20,19 @@ export class Ftp implements ICredentialType {
 			displayName: 'Port',
 			name: 'port',
 			required: true,
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 21,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/GSuiteAdminOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GSuiteAdminOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -17,11 +17,11 @@ export class GSuiteAdminOAuth2Api implements ICredentialType {
 	];
 	displayName = 'G Suite Admin OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GetResponseApi.credentials.ts
+++ b/packages/nodes-base/credentials/GetResponseApi.credentials.ts
@@ -1,16 +1,16 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GetResponseApi implements ICredentialType {
 	name = 'getResponseApi';
 	displayName = 'GetResponse API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/GetResponseOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GetResponseOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GetResponseOAuth2Api implements ICredentialType {
@@ -9,37 +9,37 @@ export class GetResponseOAuth2Api implements ICredentialType {
 		'oAuth2Api',
 	];
 	displayName = 'GetResponse OAuth2 API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.getresponse.com/oauth2_authorize.html',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.getresponse.com/v3/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/GhostAdminApi.credentials.ts
+++ b/packages/nodes-base/credentials/GhostAdminApi.credentials.ts
@@ -1,24 +1,24 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GhostAdminApi implements ICredentialType {
 	name = 'ghostAdminApi';
 	displayName = 'Ghost Admin API';
 	documentationUrl = 'ghost';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'http://localhost:3001',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/GhostContentApi.credentials.ts
+++ b/packages/nodes-base/credentials/GhostContentApi.credentials.ts
@@ -1,24 +1,24 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GhostContentApi implements ICredentialType {
 	name = 'ghostContentApi';
 	displayName = 'Ghost Content API';
 	documentationUrl = 'ghost';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'http://localhost:3001',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/GitPassword.credentials.ts
+++ b/packages/nodes-base/credentials/GitPassword.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GitPassword implements ICredentialType {
 	name = 'gitPassword';
 	displayName = 'Git';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
-			decription: 'The username to authenticate with.',
+			description: 'The username to authenticate with.',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/GithubApi.credentials.ts
+++ b/packages/nodes-base/credentials/GithubApi.credentials.ts
@@ -1,30 +1,30 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GithubApi implements ICredentialType {
 	name = 'githubApi';
 	displayName = 'Github API';
 	documentationUrl = 'github';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Github Server',
 			name: 'server',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://api.github.com',
 			description: 'The server to connect to. Does only have to get changed if Github Enterprise gets used.',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/GithubOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GithubOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,44 +11,44 @@ export class GithubOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Github OAuth2 API';
 	documentationUrl = 'github';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Github Server',
 			name: 'server',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://api.github.com',
 			description: 'The server to connect to. Does only have to get changed if Github Enterprise gets used.',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["server"] === "https://api.github.com" ? "https://github.com" : $self["server"]}}/login/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["server"] === "https://api.github.com" ? "https://github.com" : $self["server"]}}/login/oauth/access_token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'repo,admin:repo_hook,admin:org,admin:org_hook,gist,notifications,user,write:packages,read:packages,delete:packages,worfklow',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/GitlabApi.credentials.ts
+++ b/packages/nodes-base/credentials/GitlabApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class GitlabApi implements ICredentialType {
 	name = 'gitlabApi';
 	displayName = 'Gitlab API';
 	documentationUrl = 'gitlab';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Gitlab Server',
 			name: 'server',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://gitlab.com',
 		},
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/GitlabOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GitlabOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,43 +11,43 @@ export class GitlabOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Gitlab OAuth2 API';
 	documentationUrl = 'gitlab';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Gitlab Server',
 			name: 'server',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://gitlab.com',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["server"]}}/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["server"]}}/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'api',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/GmailOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GmailOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -20,11 +20,11 @@ export class GmailOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Gmail OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoToWebinarOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoToWebinarOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GoToWebinarOAuth2Api implements ICredentialType {
@@ -10,35 +10,35 @@ export class GoToWebinarOAuth2Api implements ICredentialType {
 	];
 	displayName = 'GoToWebinar OAuth2 API';
 	documentationUrl = 'goToWebinar';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.getgo.com/oauth/v2/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.getgo.com/oauth/v2/token',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '', // set when creating the OAuth client
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleAnalyticsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleAnalyticsOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -16,11 +16,11 @@ export class GoogleAnalyticsOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Analytics OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class GoogleApi implements ICredentialType {
 	name = 'googleApi';
 	displayName = 'Google API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Service Account Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'The Google Service account similar to user-808@project.iam.gserviceaccount.com.',
 
@@ -20,21 +20,22 @@ export class GoogleApi implements ICredentialType {
 		{
 			displayName: 'Private Key',
 			name: 'privateKey',
+			// @ts-ignore
 			lines: 5,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Use the multiline editor. Make sure there are exactly 3 lines.<br />-----BEGIN PRIVATE KEY-----<br />KEY IN A SINGLE LINE<br />-----END PRIVATE KEY-----',
 		},
 		{
 			displayName: ' Impersonate a User',
 			name: 'inpersonate',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
 			displayName: 'Email',
 			name: 'delegatedEmail',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/credentials/GoogleBigQueryOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleBigQueryOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -14,11 +14,11 @@ export class GoogleBigQueryOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google BigQuery OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleBooksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleBooksOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -14,11 +14,11 @@ export class GoogleBooksOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Books OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleCalendarOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleCalendarOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class GoogleCalendarOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Calendar OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleCloudNaturalLanguageOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleCloudNaturalLanguageOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class GoogleCloudNaturalLanguageOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Cloud Natural Language OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleContactsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleContactsOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -14,11 +14,11 @@ export class GoogleContactsOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Contacts OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleDriveOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleDriveOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -16,11 +16,11 @@ export class GoogleDriveOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Drive OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleFirebaseCloudFirestoreOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleFirebaseCloudFirestoreOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class GoogleFirebaseCloudFirestoreOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Firebase Cloud Firestore OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleFirebaseRealtimeDatabaseOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleFirebaseRealtimeDatabaseOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -16,11 +16,11 @@ export class GoogleFirebaseRealtimeDatabaseOAuth2Api implements ICredentialType 
 	];
 	displayName = 'Google Firebase Realtime Database OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GoogleOAuth2Api implements ICredentialType {
@@ -10,29 +10,29 @@ export class GoogleOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://accounts.google.com/o/oauth2/v2/auth',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://oauth2.googleapis.com/token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'access_type=offline&prompt=consent',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class GoogleSheetsOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Sheets OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleSlidesOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleSlidesOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class GoogleSlidesOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Slides OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleTasksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleTasksOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -12,11 +12,11 @@ export class GoogleTasksOAuth2Api implements ICredentialType {
 	extends = ['googleOAuth2Api'];
 	displayName = 'Google Tasks OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GoogleTranslateOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleTranslateOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -14,11 +14,11 @@ export class GoogleTranslateOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Google Translate OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/GotifyApi.credentials.ts
+++ b/packages/nodes-base/credentials/GotifyApi.credentials.ts
@@ -1,31 +1,31 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GotifyApi implements ICredentialType {
 	name = 'gotifyApi';
 	displayName = 'Gotify API';
 	documentationUrl = 'gotify';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'App API Token',
 			name: 'appApiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: '(Optional) Needed for message creation.',
 		},
 		{
 			displayName: 'Client API Token',
 			name: 'clientApiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: '(Optional) Needed for everything (delete, getAll) but message creation.',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'The URL of the Gotify host.',
 		},

--- a/packages/nodes-base/credentials/GumroadApi.credentials.ts
+++ b/packages/nodes-base/credentials/GumroadApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class GumroadApi implements ICredentialType {
 	name = 'gumroadApi';
 	displayName = 'Gumroad API';
 	documentationUrl = 'gumroad';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/HarvestApi.credentials.ts
+++ b/packages/nodes-base/credentials/HarvestApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HarvestApi implements ICredentialType {
 	name = 'harvestApi';
 	displayName = 'Harvest API';
 	documentationUrl = 'harvest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Visit your account details page, and grab the Access Token. See <a href="https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/">Harvest Personal Access Tokens</a>.',
 		},

--- a/packages/nodes-base/credentials/HarvestOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/HarvestOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -10,37 +10,37 @@ export class HarvestOAuth2Api implements ICredentialType {
 		'oAuth2Api',
 	];
 	displayName = 'Harvest OAuth2 API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://id.getharvest.com/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://id.getharvest.com/api/v2/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'all',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/HelpScoutOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/HelpScoutOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HelpScoutOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class HelpScoutOAuth2Api implements ICredentialType {
 	];
 	displayName = 'HelpScout OAuth2 API';
 	documentationUrl = 'helpScout';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://secure.helpscout.net/authentication/authorizeClientApplication',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.helpscout.net/v2/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/HttpBasicAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpBasicAuth.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class HttpBasicAuth implements ICredentialType {
 	name = 'httpBasicAuth';
 	displayName = 'Basic Auth';
 	documentationUrl = 'httpRequest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/HttpDigestAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpDigestAuth.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class HttpDigestAuth implements ICredentialType {
 	name = 'httpDigestAuth';
 	displayName = 'Digest Auth';
 	documentationUrl = 'httpRequest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/HttpHeaderAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpHeaderAuth.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class HttpHeaderAuth implements ICredentialType {
 	name = 'httpHeaderAuth';
 	displayName = 'Header Auth';
 	documentationUrl = 'httpRequest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Name',
 			name: 'name',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 
 		},
 		{
 			displayName: 'Value',
 			name: 'value',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/HubspotApi.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HubspotApi implements ICredentialType {
 	name = 'hubspotApi';
 	displayName = 'Hubspot API';
 	documentationUrl = 'hubspot';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HubspotDeveloperApi implements ICredentialType {
 	name = 'hubspotDeveloperApi';
 	displayName = 'Hubspot Developer API';
 	documentationUrl = 'hubspot';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Developer API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'App ID',
 			name: 'appId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			required: true,
 			default: '',
 			description: 'The App ID',

--- a/packages/nodes-base/credentials/HubspotOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -16,37 +16,37 @@ export class HubspotOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Hubspot OAuth2 API';
 	documentationUrl = 'hubspot';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.hubspot.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.hubapi.com/oauth/v1/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'grant_type=authorization_code',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/HumanticAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/HumanticAiApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HumanticAiApi implements ICredentialType {
 	name = 'humanticAiApi';
 	displayName = 'Humantic AI API';
 	documentationUrl = 'humanticAi';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/HunterApi.credentials.ts
+++ b/packages/nodes-base/credentials/HunterApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class HunterApi implements ICredentialType {
 	name = 'hunterApi';
 	displayName = 'Hunter API';
 	documentationUrl = 'hunter';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Imap.credentials.ts
+++ b/packages/nodes-base/credentials/Imap.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class Imap implements ICredentialType {
 	name = 'imap';
 	displayName = 'IMAP';
 	documentationUrl = 'imap';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -28,19 +28,19 @@ export class Imap implements ICredentialType {
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 993,
 		},
 		{
 			displayName: 'SSL/TLS',
 			name: 'secure',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 		},
 	];

--- a/packages/nodes-base/credentials/IntercomApi.credentials.ts
+++ b/packages/nodes-base/credentials/IntercomApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class IntercomApi implements ICredentialType {
 	name = 'intercomApi';
 	displayName = 'Intercom API';
 	documentationUrl = 'intercom';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/InvoiceNinjaApi.credentials.ts
+++ b/packages/nodes-base/credentials/InvoiceNinjaApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class InvoiceNinjaApi implements ICredentialType {
 	name = 'invoiceNinjaApi';
 	displayName = 'Invoice Ninja API';
 	documentationUrl = 'invoiceNinja';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://app.invoiceninja.com',
 		},
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/IterableApi.credentials.ts
+++ b/packages/nodes-base/credentials/IterableApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class IterableApi implements ICredentialType {
 	name = 'iterableApi';
 	displayName = 'Iterable API';
 	documentationUrl = 'iterable';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/JiraSoftwareCloudApi.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareCloudApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class JiraSoftwareCloudApi implements ICredentialType {
 	name = 'jiraSoftwareCloudApi';
 	displayName = 'Jira SW Cloud API';
 	documentationUrl = 'jira';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.atlassian.net',
 		},

--- a/packages/nodes-base/credentials/JiraSoftwareServerApi.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareServerApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class JiraSoftwareServerApi implements ICredentialType {
 	name = 'jiraSoftwareServerApi';
 	displayName = 'Jira SW Server API';
 	documentationUrl = 'jira';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
@@ -20,13 +20,13 @@ export class JiraSoftwareServerApi implements ICredentialType {
 			typeOptions: {
 				password: true,
 			},
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.com',
 		},

--- a/packages/nodes-base/credentials/JotFormApi.credentials.ts
+++ b/packages/nodes-base/credentials/JotFormApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class JotFormApi implements ICredentialType {
 	name = 'jotFormApi';
 	displayName = 'JotForm API';
 	documentationUrl = 'jotForm';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Domain',
 			name: 'apiDomain',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'api.jotform.com',

--- a/packages/nodes-base/credentials/Kafka.credentials.ts
+++ b/packages/nodes-base/credentials/Kafka.credentials.ts
@@ -1,43 +1,43 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Kafka implements ICredentialType {
 	name = 'kafka';
 	displayName = 'Kafka';
 	documentationUrl = 'kafka';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'my-app',
 		},
 		{
 			displayName: 'Brokers',
 			name: 'brokers',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'kafka1:9092,kafka2:9092',
 		},
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					authentication: [
@@ -51,7 +51,7 @@ export class Kafka implements ICredentialType {
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					authentication: [
@@ -68,7 +68,7 @@ export class Kafka implements ICredentialType {
 		{
 			displayName: 'SASL mechanism',
 			name: 'saslMechanism',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			displayOptions: {
 				show: {
 					authentication: [

--- a/packages/nodes-base/credentials/KeapOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/KeapOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -14,35 +14,35 @@ export class KeapOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Keap OAuth2 API';
 	documentationUrl = 'keap';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://signin.infusionsoft.com/app/oauth/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.infusionsoft.com/token',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/KitemakerApi.credentials.ts
+++ b/packages/nodes-base/credentials/KitemakerApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class KitemakerApi implements ICredentialType {
 	name = 'kitemakerApi';
 	displayName = 'Kitemaker API';
 	documentationUrl = 'kitemaker';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Personal Access Token',
 			name: 'personalAccessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/LemlistApi.credentials.ts
+++ b/packages/nodes-base/credentials/LemlistApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class LemlistApi implements ICredentialType {
 	name = 'lemlistApi';
 	displayName = 'Lemlist API';
 	documentationUrl = 'lemlist';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/LineNotifyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/LineNotifyOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class LineNotifyOAuth2Api implements ICredentialType {
@@ -10,38 +10,38 @@ export class LineNotifyOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Line Notify OAuth2 API';
 	documentationUrl = 'line';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://notify-bot.line.me/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://notify-bot.line.me/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'notify',
 			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/LingvaNexApi.credentials.ts
+++ b/packages/nodes-base/credentials/LingvaNexApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class LingvaNexApi implements ICredentialType {
 	name = 'lingvaNexApi';
 	displayName = 'LingvaNex API';
 	documentationUrl = 'lingvaNex';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/LinkedInOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/LinkedInOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,45 +11,45 @@ export class LinkedInOAuth2Api implements ICredentialType {
 	];
 	displayName = 'LinkedIn OAuth2 API';
 	documentationUrl = 'linkedIn';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Organization Support',
 			name: 'organizationSupport',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 			description: 'Request permissions to post as an orgaization.',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.linkedin.com/oauth/v2/authorization',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.linkedin.com/oauth/v2/accessToken',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '=r_liteprofile,r_emailaddress,w_member_social{{$self["organizationSupport"] === true ? ",w_organization_social":""}}',
 			description: 'Standard scopes for posting on behalf of a user or organization. See <a href="https://docs.microsoft.com/en-us/linkedin/marketing/getting-started#available-permissions"> this resource </a>.',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MailcheckApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailcheckApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MailcheckApi implements ICredentialType {
 	name = 'mailcheckApi';
 	displayName = 'Mailcheck API';
 	documentationUrl = 'mailcheck';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MailchimpApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailchimpApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MailchimpApi implements ICredentialType {
 	name = 'mailchimpApi';
 	displayName = 'Mailchimp API';
 	documentationUrl = 'mailchimp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MailchimpOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MailchimpOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,44 +11,44 @@ export class MailchimpOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Mailchimp OAuth2 API';
 	documentationUrl = 'mailchimp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://login.mailchimp.com/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://login.mailchimp.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Metadata',
 			name: 'metadataUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://login.mailchimp.com/oauth2/metadata',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MailerLiteApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailerLiteApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MailerLiteApi implements ICredentialType {
 	name = 'mailerLiteApi';
 	displayName = 'Mailer Lite API';
 	documentationUrl = 'mailerLite';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MailgunApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailgunApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class MailgunApi implements ICredentialType {
 	name = 'mailgunApi';
 	displayName = 'Mailgun API';
 	documentationUrl = 'mailgun';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Domain',
 			name: 'apiDomain',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'api.eu.mailgun.net',
@@ -29,14 +29,14 @@ export class MailgunApi implements ICredentialType {
 		{
 			displayName: 'Email Domain',
 			name: 'emailDomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: '.',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MailjetEmailApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailjetEmailApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MailjetEmailApi implements ICredentialType {
 	name = 'mailjetEmailApi';
 	displayName = 'Mailjet Email API';
 	documentationUrl = 'mailjet';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Secret Key',
 			name: 'secretKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MailjetSmsApi.credentials.ts
+++ b/packages/nodes-base/credentials/MailjetSmsApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MailjetSmsApi implements ICredentialType {
 	name = 'mailjetSmsApi';
 	displayName = 'Mailjet SMS API';
 	documentationUrl = 'mailjet';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Token',
 			name: 'token',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MandrillApi.credentials.ts
+++ b/packages/nodes-base/credentials/MandrillApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class MandrillApi implements ICredentialType {
 	name = 'mandrillApi';
 	displayName = 'Mandrill API';
 	documentationUrl = 'mandrill';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MatrixApi.credentials.ts
+++ b/packages/nodes-base/credentials/MatrixApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class MatrixApi implements ICredentialType {
 	name = 'matrixApi';
 	displayName = 'Matrix API';
 	documentationUrl = 'matrix';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Homeserver URL',
 			name: 'homeserverUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://matrix-client.matrix.org',
 		},
 	];

--- a/packages/nodes-base/credentials/MattermostApi.credentials.ts
+++ b/packages/nodes-base/credentials/MattermostApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class MattermostApi implements ICredentialType {
 	name = 'mattermostApi';
 	displayName = 'Mattermost API';
 	documentationUrl = 'mattermost';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Base URL',
 			name: 'baseUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MauticApi.credentials.ts
+++ b/packages/nodes-base/credentials/MauticApi.credentials.ts
@@ -1,30 +1,30 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MauticApi implements ICredentialType {
 	name = 'mauticApi';
 	displayName = 'Mautic API';
 	documentationUrl = 'mautic';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://name.mautic.net',
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/MauticOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MauticOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MauticOAuth2Api implements ICredentialType {
@@ -10,44 +10,44 @@ export class MauticOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Mautic OAuth2 API';
 	documentationUrl = 'mautic';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://name.mautic.net',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["url"]}}/oauth/v2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{$self["url"]}}/oauth/v2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MediumApi.credentials.ts
+++ b/packages/nodes-base/credentials/MediumApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MediumApi implements ICredentialType {
 	name = 'mediumApi';
 	displayName = 'Medium API';
 	documentationUrl = 'medium';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MediumOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MediumOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MediumOAuth2Api implements ICredentialType {
@@ -10,51 +10,51 @@ export class MediumOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Medium OAuth2 API';
 	documentationUrl = 'medium';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://medium.com/m/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://medium.com/v1/tokens',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'basicProfile,publishPost,listPublications',
 		},
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MessageBirdApi.credentials.ts
+++ b/packages/nodes-base/credentials/MessageBirdApi.credentials.ts
@@ -1,14 +1,14 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class MessageBirdApi implements ICredentialType {
 	name = 'messageBirdApi';
 	displayName = 'MessageBird API';
 	documentationUrl = 'messageBird';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'accessKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MicrosoftExcelOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftExcelOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftExcelOAuth2Api implements ICredentialType {
@@ -10,12 +10,12 @@ export class MicrosoftExcelOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft Excel OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'openid offline_access Files.ReadWrite',
 		},
 	];

--- a/packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftOAuth2Api implements ICredentialType {
@@ -10,31 +10,31 @@ export class MicrosoftOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//info about the tenantID
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'response_mode=query',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MicrosoftOneDriveOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOneDriveOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftOneDriveOAuth2Api implements ICredentialType {
@@ -10,12 +10,12 @@ export class MicrosoftOneDriveOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft Drive OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'openid offline_access Files.ReadWrite.All',
 		},
 	];

--- a/packages/nodes-base/credentials/MicrosoftOutlookOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftOutlookOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftOutlookOAuth2Api implements ICredentialType {
@@ -10,25 +10,25 @@ export class MicrosoftOutlookOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft Outlook OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'openid offline_access Mail.ReadWrite Mail.ReadWrite.Shared Mail.Send Mail.Send.Shared MailboxSettings.Read',
 		},
 		{
 			displayName: 'Use Shared Mailbox',
 			name: 'useShared',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
 			displayName: 'User Principal Name',
 			name: 'userPrincipalName',
 			description: 'Target user\'s UPN or ID',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftSql.credentials.ts
@@ -1,32 +1,32 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class MicrosoftSql implements ICredentialType {
 	name = 'microsoftSql';
 	displayName = 'Microsoft SQL';
 	documentationUrl = 'microsoftSql';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Server',
 			name: 'server',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'master',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'sa',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -35,25 +35,25 @@ export class MicrosoftSql implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 1433,
 		},
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'TLS',
 			name: 'tls',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 		},
 		{
 			displayName: 'Connect Timeout',
 			name: 'connectTimeout',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 15000,
 			description: 'Connection timeout in ms.',
 		},

--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftTeamsOAuth2Api implements ICredentialType {
@@ -10,12 +10,12 @@ export class MicrosoftTeamsOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft Teams OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'openid offline_access User.ReadWrite.All Group.ReadWrite.All',
 		},
 	];

--- a/packages/nodes-base/credentials/MicrosoftToDoOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftToDoOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MicrosoftToDoOAuth2Api implements ICredentialType {
@@ -10,12 +10,12 @@ export class MicrosoftToDoOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Microsoft To Do OAuth2 API';
 	documentationUrl = 'microsoft';
-	properties = [
+	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'openid offline_access Tasks.ReadWrite',
 		},
 	];

--- a/packages/nodes-base/credentials/MindeeInvoiceApi.credentials.ts
+++ b/packages/nodes-base/credentials/MindeeInvoiceApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MindeeInvoiceApi implements ICredentialType {
 	name = 'mindeeInvoiceApi';
 	displayName = 'Mindee Invoice API';
 	documentationUrl = 'mindee';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MindeeReceiptApi.credentials.ts
+++ b/packages/nodes-base/credentials/MindeeReceiptApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MindeeReceiptApi implements ICredentialType {
 	name = 'mindeeReceiptApi';
 	displayName = 'Mindee Receipt API';
 	documentationUrl = 'mindee';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MoceanApi.credentials.ts
+++ b/packages/nodes-base/credentials/MoceanApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,20 +8,20 @@ export class MoceanApi implements ICredentialType {
 	name = 'moceanApi';
 	displayName = 'Mocean Api';
 	documentationUrl = 'mocean';
-	properties = [
+	properties: INodeProperties[] = [
 		// The credentials to get from user and save encrypted.
 		// Properties can be defined exactly in the same way
 		// as node properties.
 		{
 			displayName: 'API Key',
 			name: 'mocean-api-key',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Secret',
 			name: 'mocean-api-secret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MondayComApi.credentials.ts
+++ b/packages/nodes-base/credentials/MondayComApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class MondayComApi implements ICredentialType {
 	name = 'mondayComApi';
 	displayName = 'Monday.com API';
 	documentationUrl = 'mondayCom';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Token V2',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MondayComOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MondayComOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,37 +15,37 @@ export class MondayComOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Monday.com OAuth2 API';
 	documentationUrl = 'monday';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://auth.monday.com/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://auth.monday.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/MongoDb.credentials.ts
+++ b/packages/nodes-base/credentials/MongoDb.credentials.ts
@@ -1,14 +1,14 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class MongoDb implements ICredentialType {
 	name = 'mongoDb';
 	displayName = 'MongoDB';
 	documentationUrl = 'mongoDb';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Configuration Type',
 			name: 'configurationType',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'Connection String',
@@ -27,7 +27,7 @@ export class MongoDb implements ICredentialType {
 		{
 			displayName: 'Connection String',
 			name: 'connectionString',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					configurationType: [
@@ -44,7 +44,7 @@ export class MongoDb implements ICredentialType {
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					configurationType: [
@@ -57,14 +57,14 @@ export class MongoDb implements ICredentialType {
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Note: the database should still be provided even if using an override connection string',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			displayOptions: {
 				show: {
 					configurationType: [
@@ -77,7 +77,7 @@ export class MongoDb implements ICredentialType {
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -93,7 +93,7 @@ export class MongoDb implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			displayOptions: {
 				show: {
 					configurationType: [

--- a/packages/nodes-base/credentials/Mqtt.credentials.ts
+++ b/packages/nodes-base/credentials/Mqtt.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Mqtt implements ICredentialType {
 	name = 'mqtt';
 	displayName = 'MQTT';
 	documentationUrl = 'mqtt';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Protocol',
 			name: 'protocol',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'mqtt',
@@ -27,25 +27,25 @@ export class Mqtt implements ICredentialType {
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 1883,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -54,14 +54,14 @@ export class Mqtt implements ICredentialType {
 		{
 			displayName: 'Clean Session',
 			name: 'clean',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 			description: `Set to false to receive QoS 1 and 2 messages while offline.`,
 		},
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Client ID. If left empty, one is autogenrated for you',
 		},

--- a/packages/nodes-base/credentials/Msg91Api.credentials.ts
+++ b/packages/nodes-base/credentials/Msg91Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,12 +8,12 @@ export class Msg91Api implements ICredentialType {
 	name = 'msg91Api';
 	displayName = 'Msg91 Api';
 	documentationUrl = 'msg91';
-	properties = [
+	properties: INodeProperties[] = [
 		// User authentication key
 		{
 			displayName: 'Authentication Key',
 			name: 'authkey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/MySql.credentials.ts
+++ b/packages/nodes-base/credentials/MySql.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,29 +8,29 @@ export class MySql implements ICredentialType {
 	name = 'mySql';
 	displayName = 'MySQL';
 	documentationUrl = 'mySql';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'mysql',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'mysql',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -39,20 +39,20 @@ export class MySql implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 3306,
 		},
 		{
 			displayName: 'Connect Timeout',
 			name: 'connectTimeout',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 10000,
 			description: 'The milliseconds before a timeout occurs during the initial connection to the MySQL server.',
 		},
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
@@ -69,7 +69,7 @@ export class MySql implements ICredentialType {
 					],
 				},
 			},
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
@@ -86,7 +86,7 @@ export class MySql implements ICredentialType {
 					],
 				},
 			},
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
@@ -103,7 +103,7 @@ export class MySql implements ICredentialType {
 					],
 				},
 			},
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/NasaApi.credentials.ts
+++ b/packages/nodes-base/credentials/NasaApi.credentials.ts
@@ -1,16 +1,16 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class NasaApi implements ICredentialType {
 	name = 'nasaApi';
 	displayName = 'NASA API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'api_key',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/NextCloudApi.credentials.ts
+++ b/packages/nodes-base/credentials/NextCloudApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,24 +8,24 @@ export class NextCloudApi implements ICredentialType {
 	name = 'nextCloudApi';
 	displayName = 'NextCloud API';
 	documentationUrl = 'nextCloud';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Web DAV URL',
 			name: 'webDavUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			placeholder: 'https://nextcloud.example.com/remote.php/webdav',
 			default: '',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/NextCloudOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/NextCloudOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,44 +11,44 @@ export class NextCloudOAuth2Api implements ICredentialType {
 	];
 	displayName = 'NextCloud OAuth2 API';
 	documentationUrl = 'nextCloud';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Web DAV URL',
 			name: 'webDavUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			placeholder: 'https://nextcloud.example.com/remote.php/webdav',
 			default: '',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://nextcloud.example.com/apps/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://nextcloud.example.com/apps/oauth2/api/v1/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/NotionApi.credentials.ts
+++ b/packages/nodes-base/credentials/NotionApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class NotionApi implements ICredentialType {
 	name = 'notionApi';
 	displayName = 'Notion API';
 	documentationUrl = 'notion';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/NotionOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/NotionOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class NotionOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class NotionOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Notion OAuth2 API';
 	documentationUrl = 'notion';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.notion.com/v1/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.notion.com/v1/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/OAuth1Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth1Api.credentials.ts
@@ -1,52 +1,52 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class OAuth1Api implements ICredentialType {
 	name = 'oAuth1Api';
 	displayName = 'OAuth1 API';
 	documentationUrl = 'httpRequest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Consumer Key',
 			name: 'consumerKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Consumer Secret',
 			name: 'consumerSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Request Token URL',
 			name: 'requestTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Signature Method',
 			name: 'signatureMethod',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'HMAC-SHA1',

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,32 +8,32 @@ export class OAuth2Api implements ICredentialType {
 	name = 'oAuth2Api';
 	displayName = 'OAuth2 API';
 	documentationUrl = 'httpRequest';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -43,13 +43,13 @@ export class OAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'For some services additional query parameters have to be set which can be defined here.',
 			placeholder: 'access_type=offline',
@@ -57,7 +57,7 @@ export class OAuth2Api implements ICredentialType {
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'Body',

--- a/packages/nodes-base/credentials/OpenWeatherMapApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenWeatherMapApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class OpenWeatherMapApi implements ICredentialType {
 	name = 'openWeatherMapApi';
 	displayName = 'OpenWeatherMap API';
 	documentationUrl = 'openWeatherMap';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/OrbitApi.credentials.ts
+++ b/packages/nodes-base/credentials/OrbitApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class OrbitApi implements ICredentialType {
 	name = 'orbitApi';
 	displayName = 'Orbit API';
 	documentationUrl = 'orbit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/OuraApi.credentials.ts
+++ b/packages/nodes-base/credentials/OuraApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class OuraApi implements ICredentialType {
 	name = 'ouraApi';
 	displayName = 'Oura API';
 	documentationUrl = 'oura';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Personal Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PaddleApi.credentials.ts
+++ b/packages/nodes-base/credentials/PaddleApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PaddleApi implements ICredentialType {
 	name = 'paddleApi';
 	displayName = 'Paddle API';
 	documentationUrl = 'paddle';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Vendor Auth Code',
 			name: 'vendorAuthCode',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Vendor ID',
 			name: 'vendorId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Use Sandbox environment API',
 			name: 'sandbox',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 	];

--- a/packages/nodes-base/credentials/PagerDutyApi.credentials.ts
+++ b/packages/nodes-base/credentials/PagerDutyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PagerDutyApi implements ICredentialType {
 	name = 'pagerDutyApi';
 	displayName = 'PagerDuty API';
 	documentationUrl = 'pagerDuty';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PagerDutyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/PagerDutyOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PagerDutyOAuth2Api implements ICredentialType {
@@ -10,35 +10,35 @@ export class PagerDutyOAuth2Api implements ICredentialType {
 	];
 	displayName = 'PagerDuty OAuth2 API';
 	documentationUrl = 'pagerDuty';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.pagerduty.com/oauth/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://app.pagerduty.com/oauth/token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 			description: 'Method of authentication.',
 		},

--- a/packages/nodes-base/credentials/PayPalApi.credentials.ts
+++ b/packages/nodes-base/credentials/PayPalApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,23 +8,23 @@ export class PayPalApi implements ICredentialType {
 	name = 'payPalApi';
 	displayName = 'PayPal API';
 	documentationUrl = 'payPal';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Secret',
 			name: 'secret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Environment',
 			name: 'env',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'live',
 			options: [
 				{

--- a/packages/nodes-base/credentials/PeekalinkApi.credentials.ts
+++ b/packages/nodes-base/credentials/PeekalinkApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PeekalinkApi implements ICredentialType {
 	name = 'peekalinkApi';
 	displayName = 'Peekalink API';
 	documentationUrl = 'peekalink';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PhantombusterApi.credentials.ts
+++ b/packages/nodes-base/credentials/PhantombusterApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PhantombusterApi implements ICredentialType {
 	name = 'phantombusterApi';
 	displayName = 'Phantombuster API';
 	documentationUrl = 'phantombuster';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PhilipsHueOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/PhilipsHueOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PhilipsHueOAuth2Api implements ICredentialType {
@@ -10,41 +10,41 @@ export class PhilipsHueOAuth2Api implements ICredentialType {
 	];
 	displayName = 'PhilipHue OAuth2 API';
 	documentationUrl = 'philipsHue';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'APP ID',
 			name: 'appId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.meethue.com/oauth2/auth',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.meethue.com/oauth2/token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '={{"appid="+$self["appId"]}}',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 			description: 'Method of authentication.',
 		},

--- a/packages/nodes-base/credentials/PipedriveApi.credentials.ts
+++ b/packages/nodes-base/credentials/PipedriveApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class PipedriveApi implements ICredentialType {
 	name = 'pipedriveApi';
 	displayName = 'Pipedrive API';
 	documentationUrl = 'pipedrive';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PipedriveOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/PipedriveOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PipedriveOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class PipedriveOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Pipedrive OAuth2 API';
 	documentationUrl = 'pipedrive';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://oauth.pipedrive.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://oauth.pipedrive.com/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/PlivoApi.credentials.ts
+++ b/packages/nodes-base/credentials/PlivoApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PlivoApi implements ICredentialType {
 	name = 'plivoApi';
 	displayName = 'Plivo API';
 	documentationUrl = 'plivo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Auth ID',
 			name: 'authId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Auth Token',
 			name: 'authToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PostHogApi.credentials.ts
+++ b/packages/nodes-base/credentials/PostHogApi.credentials.ts
@@ -1,22 +1,22 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PostHogApi implements ICredentialType {
 	name = 'postHogApi';
 	displayName = 'PostHog API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://app.posthog.com',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,29 +8,29 @@ export class Postgres implements ICredentialType {
 	name = 'postgres';
 	displayName = 'Postgres';
 	documentationUrl = 'postgres';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'postgres',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'postgres',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -39,14 +39,14 @@ export class Postgres implements ICredentialType {
 		{
 			displayName: 'Ignore SSL Issues',
 			name: 'allowUnauthorizedCerts',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 			description: 'Connect even if SSL certificate validation is not possible.',
 		},
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			displayOptions: {
 				show: {
 					allowUnauthorizedCerts: [
@@ -81,7 +81,7 @@ export class Postgres implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 5432,
 		},
 	];

--- a/packages/nodes-base/credentials/PostmarkApi.credentials.ts
+++ b/packages/nodes-base/credentials/PostmarkApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class PostmarkApi implements ICredentialType {
 	name = 'postmarkApi';
 	displayName = 'Postmark API';
 	documentationUrl = 'postmark';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Server API Token',
 			name: 'serverToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ProfitWellApi.credentials.ts
+++ b/packages/nodes-base/credentials/ProfitWellApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ProfitWellApi implements ICredentialType {
 	name = 'profitWellApi';
 	displayName = 'ProfitWell API';
 	documentationUrl = 'profitWell';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Your Private Token',
 		},

--- a/packages/nodes-base/credentials/PushbulletOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/PushbulletOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PushbulletOAuth2Api implements ICredentialType {
@@ -9,37 +9,37 @@ export class PushbulletOAuth2Api implements ICredentialType {
 		'oAuth2Api',
 	];
 	displayName = 'Pushbullet OAuth2 API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.pushbullet.com/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.pushbullet.com/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/PushcutApi.credentials.ts
+++ b/packages/nodes-base/credentials/PushcutApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PushcutApi implements ICredentialType {
 	name = 'pushcutApi';
 	displayName = 'Pushcut API';
 	documentationUrl = 'pushcut';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/PushoverApi.credentials.ts
+++ b/packages/nodes-base/credentials/PushoverApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class PushoverApi implements ICredentialType {
 	name = 'pushoverApi';
 	displayName = 'Pushover API';
 	documentationUrl = 'pushover';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/QuestDb.credentials.ts
+++ b/packages/nodes-base/credentials/QuestDb.credentials.ts
@@ -1,32 +1,32 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class QuestDb implements ICredentialType {
 	name = 'questDb';
 	displayName = 'QuestDB';
 	documentationUrl = 'questDb';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'qdb',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'admin',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -35,7 +35,7 @@ export class QuestDb implements ICredentialType {
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'disable',
@@ -63,7 +63,7 @@ export class QuestDb implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 8812,
 		},
 	];

--- a/packages/nodes-base/credentials/QuickBaseApi.credentials.ts
+++ b/packages/nodes-base/credentials/QuickBaseApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class QuickBaseApi implements ICredentialType {
 	name = 'quickbaseApi';
 	displayName = 'Quick Base API';
 	documentationUrl = 'quickbase';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Hostname',
 			name: 'hostname',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 			placeholder: 'demo.quickbase.com',
@@ -19,7 +19,7 @@ export class QuickBaseApi implements ICredentialType {
 		{
 			displayName: 'User Token',
 			name: 'userToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},

--- a/packages/nodes-base/credentials/QuickBooksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/QuickBooksOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -17,41 +17,41 @@ export class QuickBooksOAuth2Api implements ICredentialType {
 	];
 	displayName = 'QuickBooks OAuth2 API';
 	documentationUrl = 'quickbooks';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://appcenter.intuit.com/connect/oauth2',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 		{
 			displayName: 'Environment',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'production',
 			options: [
 				{

--- a/packages/nodes-base/credentials/RabbitMQ.credentials.ts
+++ b/packages/nodes-base/credentials/RabbitMQ.credentials.ts
@@ -1,38 +1,38 @@
 import {
 	ICredentialType,
 	IDisplayOptions,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class RabbitMQ implements ICredentialType {
 	name = 'rabbitmq';
 	displayName = 'RabbitMQ';
 	documentationUrl = 'rabbitmq';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Hostname',
 			name: 'hostname',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'localhost',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 5672,
 		},
 		{
 			displayName: 'User',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'guest',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -42,19 +42,19 @@ export class RabbitMQ implements ICredentialType {
 		{
 			displayName: 'Vhost',
 			name: 'vhost',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '/',
 		},
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 		{
 			displayName: 'Passwordless',
 			name: 'passwordless',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			displayOptions: {
 				show: {
 					ssl: [
@@ -68,7 +68,7 @@ export class RabbitMQ implements ICredentialType {
 		{
 			displayName: 'CA Certificates',
 			name: 'ca',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -85,7 +85,7 @@ export class RabbitMQ implements ICredentialType {
 		{
 			displayName: 'Client Certificate',
 			name: 'cert',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -105,7 +105,7 @@ export class RabbitMQ implements ICredentialType {
 		{
 			displayName: 'Client Key',
 			name: 'key',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -125,7 +125,7 @@ export class RabbitMQ implements ICredentialType {
 		{
 			displayName: 'Passphrase',
 			name: 'passphrase',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -145,28 +145,28 @@ export class RabbitMQ implements ICredentialType {
 		// {
 		// 	displayName: 'Client ID',
 		// 	name: 'clientId',
-		// 	type: 'string' as NodePropertyTypes,
+		// 	type: 'string',
 		// 	default: '',
 		// 	placeholder: 'my-app',
 		// },
 		// {
 		// 	displayName: 'Brokers',
 		// 	name: 'brokers',
-		// 	type: 'string' as NodePropertyTypes,
+		// 	type: 'string',
 		// 	default: '',
 		// 	placeholder: 'kafka1:9092,kafka2:9092',
 		// },
 		// {
 		// 	displayName: 'Username',
 		// 	name: 'username',
-		// 	type: 'string' as NodePropertyTypes,
+		// 	type: 'string',
 		// 	default: '',
 		// 	description: 'Optional username if authenticated is required.',
 		// },
 		// {
 		// 	displayName: 'Password',
 		// 	name: 'password',
-		// 	type: 'string' as NodePropertyTypes,
+		// 	type: 'string',
 		// 	typeOptions: {
 		// 		password: true,
 		// 	},

--- a/packages/nodes-base/credentials/RaindropOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/RaindropOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 // https://developer.raindrop.io/v1/authentication
@@ -12,35 +12,35 @@ export class RaindropOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Raindrop OAuth2 API';
 	documentationUrl = 'raindrop';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://raindrop.io/oauth/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://raindrop.io/oauth/access_token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/RedditOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/RedditOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -22,47 +22,47 @@ export class RedditOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Reddit OAuth2 API';
 	documentationUrl = 'reddit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'response_type=code',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'grant_type=authorization_code',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'duration=permanent',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.reddit.com/api/v1/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.reddit.com/api/v1/access_token',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/Redis.credentials.ts
+++ b/packages/nodes-base/credentials/Redis.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class Redis implements ICredentialType {
 	name = 'redis';
 	displayName = 'Redis';
 	documentationUrl = 'redis';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -21,13 +21,13 @@ export class Redis implements ICredentialType {
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 6379,
 		},
 	];

--- a/packages/nodes-base/credentials/RocketchatApi.credentials.ts
+++ b/packages/nodes-base/credentials/RocketchatApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,23 +8,23 @@ export class RocketchatApi implements ICredentialType {
 	name = 'rocketchatApi';
 	displayName = 'Rocket API';
 	documentationUrl = 'rocketchat';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User Id',
 			name: 'userId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Auth Key',
 			name: 'authKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Domain',
 			name: 'domain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://n8n.rocket.chat',
 		},

--- a/packages/nodes-base/credentials/RundeckApi.credentials.ts
+++ b/packages/nodes-base/credentials/RundeckApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class RundeckApi implements ICredentialType {
 	name = 'rundeckApi';
 	displayName = 'Rundeck API';
 	documentationUrl = 'rundeck';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Url',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'http://127.0.0.1:4440',
 		},
 		{
 			displayName: 'Token',
 			name: 'token',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/S3.credentials.ts
+++ b/packages/nodes-base/credentials/S3.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,29 +8,29 @@ export class S3 implements ICredentialType {
 	name = 's3';
 	displayName = 'S3';
 	documentationUrl = 's3';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'S3 endpoint',
 			name: 'endpoint',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Region',
 			name: 'region',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'us-east-1',
 		},
 		{
 			displayName: 'Access Key Id',
 			name: 'accessKeyId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Secret Access Key',
 			name: 'secretAccessKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			typeOptions: {
 				password: true,
@@ -39,7 +39,7 @@ export class S3 implements ICredentialType {
 		{
 			displayName: 'Force path style',
 			name: 'forcePathStyle',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 	];

--- a/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceJwtApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SalesforceJwtApi implements ICredentialType {
 	name = 'salesforceJwtApi';
 	displayName = 'Salesforce JWT API';
 	documentationUrl = 'salesforce';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Environment Type',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'Production',
@@ -27,7 +27,7 @@ export class SalesforceJwtApi implements ICredentialType {
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 			description: 'Consumer Key from Salesforce Connected App.',
@@ -35,14 +35,14 @@ export class SalesforceJwtApi implements ICredentialType {
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Private Key',
 			name: 'privateKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SalesforceOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class SalesforceOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Salesforce OAuth2 API';
 	documentationUrl = 'salesforce';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://login.salesforce.com/services/oauth2/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'https://yourcompany.salesforce.com/services/oauth2/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'full refresh_token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 			description: 'Method of authentication.',
 		},

--- a/packages/nodes-base/credentials/SalesmateApi.credentials.ts
+++ b/packages/nodes-base/credentials/SalesmateApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SalesmateApi implements ICredentialType {
 	name = 'salesmateApi';
 	displayName = 'Salesmate API';
 	documentationUrl = 'salesmate';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Session Token',
 			name: 'sessionToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'n8n.salesmate.io',
 		},

--- a/packages/nodes-base/credentials/SecurityScorecardApi.credentials.ts
+++ b/packages/nodes-base/credentials/SecurityScorecardApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SecurityScorecardApi implements ICredentialType {
 	name = 'securityScorecardApi';
 	displayName = 'SecurityScorecard API';
 	documentationUrl = 'securityScorecard';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},

--- a/packages/nodes-base/credentials/SegmentApi.credentials.ts
+++ b/packages/nodes-base/credentials/SegmentApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SegmentApi implements ICredentialType {
 	name = 'segmentApi';
 	displayName = 'Segment API';
 	documentationUrl = 'segment';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Write Key',
 			name: 'writekey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SendGridApi.credentials.ts
+++ b/packages/nodes-base/credentials/SendGridApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SendGridApi implements ICredentialType {
 	name = 'sendGridApi';
 	displayName = 'SendGrid API';
 	documentationUrl = 'sendgrid';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SendyApi.credentials.ts
+++ b/packages/nodes-base/credentials/SendyApi.credentials.ts
@@ -1,24 +1,24 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SendyApi implements ICredentialType {
 	name = 'sendyApi';
 	displayName = 'Sendy API';
 	documentationUrl = 'sendy';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://yourdomain.com',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SentryIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/SentryIoApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SentryIoApi implements ICredentialType {
 	name = 'sentryIoApi';
 	displayName = 'Sentry.io API';
 	documentationUrl = 'sentryIo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Token',
 			name: 'token',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SentryIoOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SentryIoOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SentryIoOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class SentryIoOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Sentry.io OAuth2 API';
 	documentationUrl = 'sentryIo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://sentry.io/oauth/authorize/',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://sentry.io/oauth/token/',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'event:admin event:read org:read project:read project:releases team:read event:write org:admin project:write team:write project:admin team:admin',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/SentryIoServerApi.credentials.ts
+++ b/packages/nodes-base/credentials/SentryIoServerApi.credentials.ts
@@ -1,22 +1,22 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SentryIoServerApi implements ICredentialType {
 	name = 'sentryIoServerApi';
 	displayName = 'Sentry.io Server API';
 	documentationUrl = 'sentryIo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Token',
 			name: 'token',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.com',
 		},

--- a/packages/nodes-base/credentials/Sftp.credentials.ts
+++ b/packages/nodes-base/credentials/Sftp.credentials.ts
@@ -1,38 +1,38 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Sftp implements ICredentialType {
 	name = 'sftp';
 	displayName = 'SFTP';
 	documentationUrl = 'ftp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
 			required: true,
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 22,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -41,7 +41,7 @@ export class Sftp implements ICredentialType {
 		{
 			displayName: 'Private Key',
 			name: 'privateKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
 			},
@@ -54,7 +54,7 @@ export class Sftp implements ICredentialType {
 			typeOptions: {
 				password: true,
 			},
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'For an encrypted private key, this is the passphrase used to decrypt it.',
 		},

--- a/packages/nodes-base/credentials/ShopifyApi.credentials.ts
+++ b/packages/nodes-base/credentials/ShopifyApi.credentials.ts
@@ -1,39 +1,39 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ShopifyApi implements ICredentialType {
 	name = 'shopifyApi';
 	displayName = 'Shopify API';
 	documentationUrl = 'shopify';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Shop Subdomain',
 			name: 'shopSubdomain',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Only the subdomain without .myshopify.com',
 		},
 		{
 			displayName: 'Shared Secret',
 			name: 'sharedSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Signl4Api.credentials.ts
+++ b/packages/nodes-base/credentials/Signl4Api.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Signl4Api implements ICredentialType {
 	name = 'signl4Api';
 	displayName = 'SIGNL4 Webhook';
 	documentationUrl = 'signl4';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Team Secret',
 			name: 'teamSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'The team secret is the last part of your SIGNL4 webhook URL.',
 		},

--- a/packages/nodes-base/credentials/SlackApi.credentials.ts
+++ b/packages/nodes-base/credentials/SlackApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class SlackApi implements ICredentialType {
 	name = 'slackApi';
 	displayName = 'Slack API';
 	documentationUrl = 'slack';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 //https://api.slack.com/authentication/oauth-v2
@@ -26,36 +26,36 @@ export class SlackOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Slack OAuth2 API';
 	documentationUrl = 'slack';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://slack.com/oauth/v2/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://slack.com/api/oauth.v2.access',
 		},
 		//https://api.slack.com/scopes
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'chat:write',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: `user_scope=${userScopes.join(' ')}`,
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/Sms77Api.credentials.ts
+++ b/packages/nodes-base/credentials/Sms77Api.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Sms77Api implements ICredentialType {
 	name = 'sms77Api';
 	displayName = 'Sms77 API';
 	documentationUrl = 'sms77';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/Smtp.credentials.ts
+++ b/packages/nodes-base/credentials/Smtp.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,18 +8,18 @@ export class Smtp implements ICredentialType {
 	name = 'smtp';
 	displayName = 'SMTP';
 	documentationUrl = 'smtp';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -28,19 +28,19 @@ export class Smtp implements ICredentialType {
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 465,
 		},
 		{
 			displayName: 'SSL/TLS',
 			name: 'secure',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: true,
 		},
 	];

--- a/packages/nodes-base/credentials/Snowflake.credentials.ts
+++ b/packages/nodes-base/credentials/Snowflake.credentials.ts
@@ -1,44 +1,44 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class Snowflake implements ICredentialType {
 	name = 'snowflake';
 	displayName = 'Snowflake';
 	documentationUrl = 'snowflake';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Account',
 			name: 'account',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Enter the name of your Snowflake account.',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Specify the database you want to use after creating the connection.',
 		},
 		{
 			displayName: 'Warehouse',
 			name: 'warehouse',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'The default virtual warehouse to use for the session after connecting. Used for performing queries, loading data, etc.',
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -47,21 +47,21 @@ export class Snowflake implements ICredentialType {
 		{
 			displayName: 'Schema',
 			name: 'schema',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Enter the schema you want to use after creating the connection',
 		},
 		{
 			displayName: 'Role',
 			name: 'role',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Enter the security role you want to use after creating the connection',
 		},
 		{
 			displayName: 'Client Session Keep Alive',
 			name: 'clientSessionKeepAlive',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 			description: `By default, client connections typically time out approximately 3-4 hours after the most recent query was executed.<br>
 			If the parameter clientSessionKeepAlive is set to true, the client’s connection to the server will be kept alive indefinitely, even if no queries are executed.`,

--- a/packages/nodes-base/credentials/SpontitApi.credentials.ts
+++ b/packages/nodes-base/credentials/SpontitApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SpontitApi implements ICredentialType {
 	name = 'spontitApi';
 	displayName = 'Spontit API';
 	documentationUrl = 'spontit';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SpotifyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SpotifyOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -11,43 +11,43 @@ export class SpotifyOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Spotify OAuth2 API';
 	documentationUrl = 'spotify';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Spotify Server',
 			name: 'server',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.spotify.com/',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://accounts.spotify.com/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://accounts.spotify.com/api/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'user-read-playback-state playlist-read-collaborative user-modify-playback-state playlist-modify-public user-read-currently-playing playlist-read-private user-read-recently-played playlist-modify-private user-library-read user-follow-read',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/SshPassword.credentials.ts
+++ b/packages/nodes-base/credentials/SshPassword.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SshPassword implements ICredentialType {
 	name = 'sshPassword';
 	displayName = 'SSH';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'localhost',
 		},
@@ -19,19 +19,19 @@ export class SshPassword implements ICredentialType {
 			displayName: 'Port',
 			name: 'port',
 			required: true,
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 22,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/SshPrivateKey.credentials.ts
+++ b/packages/nodes-base/credentials/SshPrivateKey.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SshPrivateKey implements ICredentialType {
 	name = 'sshPrivateKey';
 	displayName = 'SSH';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'localhost',
 		},
@@ -19,19 +19,19 @@ export class SshPrivateKey implements ICredentialType {
 			displayName: 'Port',
 			name: 'port',
 			required: true,
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 22,
 		},
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Private Key',
 			name: 'privateKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				rows: 4,
 			},
@@ -40,7 +40,7 @@ export class SshPrivateKey implements ICredentialType {
 		{
 			displayName: 'Passphrase',
 			name: 'passphrase',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Passphase used to create the key, if no passphase was used leave empty',
 		},

--- a/packages/nodes-base/credentials/StackbyApi.credentials.ts
+++ b/packages/nodes-base/credentials/StackbyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class StackbyApi implements ICredentialType {
 	name = 'stackbyApi';
 	displayName = 'Stackby API';
 	documentationUrl = 'stackby';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/StoryblokContentApi.credentials.ts
+++ b/packages/nodes-base/credentials/StoryblokContentApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class StoryblokContentApi implements ICredentialType {
 	name = 'storyblokContentApi';
 	displayName = 'Storyblok Content API';
 	documentationUrl = 'storyblok';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/StoryblokManagementApi.credentials.ts
+++ b/packages/nodes-base/credentials/StoryblokManagementApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class StoryblokManagementApi implements ICredentialType {
 	name = 'storyblokManagementApi';
 	displayName = 'Storyblok Management API';
 	documentationUrl = 'storyblok';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Personal Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/StrapiApi.credentials.ts
+++ b/packages/nodes-base/credentials/StrapiApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class StrapiApi implements ICredentialType {
 	name = 'strapiApi';
 	displayName = 'Strapi API';
 	documentationUrl = 'strapi';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -26,7 +26,7 @@ export class StrapiApi implements ICredentialType {
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://api.example.com',
 		},

--- a/packages/nodes-base/credentials/StravaOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/StravaOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class StravaOAuth2Api implements ICredentialType {
@@ -10,38 +10,38 @@ export class StravaOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Strava OAuth2 API';
 	documentationUrl = 'strava';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.strava.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://www.strava.com/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'activity:read_all,activity:write',
 			required: true,
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/StripeApi.credentials.ts
+++ b/packages/nodes-base/credentials/StripeApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,14 +8,14 @@ export class StripeApi implements ICredentialType {
 	name = 'stripeApi';
 	displayName = 'Stripe Api';
 	documentationUrl = 'stripe';
-	properties = [
+	properties: INodeProperties[] = [
 		// The credentials to get from user and save encrypted.
 		// Properties can be defined exactly in the same way
 		// as node properties.
 		{
 			displayName: 'Secret Key',
 			name: 'secretKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SurveyMonkeyApi.credentials.ts
+++ b/packages/nodes-base/credentials/SurveyMonkeyApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class SurveyMonkeyApi implements ICredentialType {
 	name = 'surveyMonkeyApi';
 	displayName = 'SurveyMonkey API';
 	documentationUrl = 'surveyMonkey';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: `The access token must have the following scopes:</br />
 			- Create/modify webhooks</br />
@@ -24,13 +24,13 @@ export class SurveyMonkeyApi implements ICredentialType {
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/SurveyMonkeyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SurveyMonkeyOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -19,37 +19,37 @@ export class SurveyMonkeyOAuth2Api implements ICredentialType {
 	];
 	displayName = 'SurveyMonkey OAuth2 API';
 	documentationUrl = 'surveyMonkey';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.surveymonkey.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.surveymonkey.com/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(','),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/TaigaCloudApi.credentials.ts
+++ b/packages/nodes-base/credentials/TaigaCloudApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TaigaCloudApi implements ICredentialType {
 	name = 'taigaCloudApi';
 	displayName = 'Taiga Cloud API';
 	documentationUrl = 'taiga';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TaigaServerApi.credentials.ts
+++ b/packages/nodes-base/credentials/TaigaServerApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TaigaServerApi implements ICredentialType {
 	name = 'taigaServerApi';
 	displayName = 'Taiga Server API';
 	documentationUrl = 'taiga';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://taiga.yourdomain.com',
 		},

--- a/packages/nodes-base/credentials/TapfiliateApi.credentials.ts
+++ b/packages/nodes-base/credentials/TapfiliateApi.credentials.ts
@@ -1,18 +1,18 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TapfiliateApi implements ICredentialType {
 	name = 'tapfiliateApi';
 	displayName = 'Tapfiliate API';
 	documentationUrl = 'tapfiliate';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
 			required: true,
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TelegramApi.credentials.ts
+++ b/packages/nodes-base/credentials/TelegramApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class TelegramApi implements ICredentialType {
 	name = 'telegramApi';
 	displayName = 'Telegram API';
 	documentationUrl = 'telegram';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			description: 'Chat with the <a href="https://telegram.me/botfather">bot father</a> to obtain the access token.',
 		},

--- a/packages/nodes-base/credentials/TheHiveApi.credentials.ts
+++ b/packages/nodes-base/credentials/TheHiveApi.credentials.ts
@@ -1,24 +1,24 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TheHiveApi implements ICredentialType {
 	name = 'theHiveApi';
 	displayName = 'The Hive API';
 	documentationUrl = 'theHive';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'ApiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
 			default: '',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			description: 'The URL of TheHive instance',
 			placeholder: 'https://localhost:9000',
 		},
@@ -26,7 +26,7 @@ export class TheHiveApi implements ICredentialType {
 			displayName: 'API Version',
 			name: 'apiVersion',
 			default: '',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			description: 'The version of api to be used',
 			options: [
 				{
@@ -44,7 +44,7 @@ export class TheHiveApi implements ICredentialType {
 		{
 			displayName: 'Ignore SSL Issues',
 			name: 'allowUnauthorizedCerts',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 		},
 	];

--- a/packages/nodes-base/credentials/TimescaleDb.credentials.ts
+++ b/packages/nodes-base/credentials/TimescaleDb.credentials.ts
@@ -1,35 +1,35 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TimescaleDb implements ICredentialType {
 	name = 'timescaleDb';
 	displayName = 'TimescaleDB';
 	documentationUrl = 'timescaleDb';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',
 			name: 'host',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'localhost',
 		},
 		{
 			displayName: 'Database',
 			name: 'database',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'postgres',
 		},
 		{
 			displayName: 'User',
 			name: 'user',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: 'postgres',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},
@@ -38,14 +38,14 @@ export class TimescaleDb implements ICredentialType {
 		{
 			displayName: 'Ignore SSL Issues',
 			name: 'allowUnauthorizedCerts',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 			description: 'Connect even if SSL certificate validation is not possible.',
 		},
 		{
 			displayName: 'SSL',
 			name: 'ssl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			displayOptions: {
 				show: {
 					allowUnauthorizedCerts: [
@@ -80,7 +80,7 @@ export class TimescaleDb implements ICredentialType {
 		{
 			displayName: 'Port',
 			name: 'port',
-			type: 'number' as NodePropertyTypes,
+			type: 'number',
 			default: 5432,
 		},
 	];

--- a/packages/nodes-base/credentials/TodoistApi.credentials.ts
+++ b/packages/nodes-base/credentials/TodoistApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class TodoistApi implements ICredentialType {
 	name = 'todoistApi';
 	displayName = 'Todoist API';
 	documentationUrl = 'todoist';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TodoistOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TodoistOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TodoistOAuth2Api implements ICredentialType {
@@ -10,37 +10,37 @@ export class TodoistOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Todoist OAuth2 API';
 	documentationUrl = 'todoist';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://todoist.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://todoist.com/oauth/access_token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'data:read_write,data:delete',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/TogglApi.credentials.ts
+++ b/packages/nodes-base/credentials/TogglApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,17 +8,17 @@ export class TogglApi implements ICredentialType {
 	name = 'togglApi';
 	displayName = 'Toggl API';
 	documentationUrl = 'toggl';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TravisCiApi.credentials.ts
+++ b/packages/nodes-base/credentials/TravisCiApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TravisCiApi implements ICredentialType {
 	name = 'travisCiApi';
 	displayName = 'Travis API';
 	documentationUrl = 'travisCi';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TrelloApi.credentials.ts
+++ b/packages/nodes-base/credentials/TrelloApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,23 +8,23 @@ export class TrelloApi implements ICredentialType {
 	name = 'trelloApi';
 	displayName = 'Trello API';
 	documentationUrl = 'trello';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'OAuth Secret',
 			name: 'oauthSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TwakeCloudApi.credentials.ts
+++ b/packages/nodes-base/credentials/TwakeCloudApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TwakeCloudApi implements ICredentialType {
 	name = 'twakeCloudApi';
 	displayName = 'Twake API';
 	documentationUrl = 'twake';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Workspace Key',
 			name: 'workspaceKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TwakeServerApi.credentials.ts
+++ b/packages/nodes-base/credentials/TwakeServerApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TwakeServerApi implements ICredentialType {
 	name = 'twakeServerApi';
 	displayName = 'Twake API';
 	documentationUrl = 'twake';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Host URL',
 			name: 'hostUrl',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Public ID',
 			name: 'publicId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Private API Key',
 			name: 'privateApiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TwilioApi.credentials.ts
+++ b/packages/nodes-base/credentials/TwilioApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class TwilioApi implements ICredentialType {
 	name = 'twilioApi';
 	displayName = 'Twilio API';
 	documentationUrl = 'twilio';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Auth Type',
 			name: 'authType',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'authToken',
 			options: [
 				{
@@ -28,13 +28,13 @@ export class TwilioApi implements ICredentialType {
 		{
 			displayName: 'Account SID',
 			name: 'accountSid',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Auth Token',
 			name: 'authToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			displayOptions: {
 				show: {
@@ -47,7 +47,7 @@ export class TwilioApi implements ICredentialType {
 		{
 			displayName: 'API Key SID',
 			name: 'apiKeySid',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			displayOptions: {
 				show: {
@@ -60,7 +60,7 @@ export class TwilioApi implements ICredentialType {
 		{
 			displayName: 'API Key Secret',
 			name: 'apiKeySecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			typeOptions: {
 				password: true,
 			},

--- a/packages/nodes-base/credentials/TwistOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TwistOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -19,37 +19,37 @@ export class TwistOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Twist OAuth2 API';
 	documentationUrl = 'twist';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://twist.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://twist.com/oauth/access_token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(','),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/TwitterOAuth1Api.credentials.ts
+++ b/packages/nodes-base/credentials/TwitterOAuth1Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class TwitterOAuth1Api implements ICredentialType {
@@ -10,29 +10,29 @@ export class TwitterOAuth1Api implements ICredentialType {
 	];
 	displayName = 'Twitter OAuth API';
 	documentationUrl = 'twitter';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Request Token URL',
 			name: 'requestTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.twitter.com/oauth/request_token',
 		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.twitter.com/oauth/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.twitter.com/oauth/access_token',
 		},
 		{
 			displayName: 'Signature Method',
 			name: 'signatureMethod',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'HMAC-SHA1',
 		},
 	];

--- a/packages/nodes-base/credentials/TypeformApi.credentials.ts
+++ b/packages/nodes-base/credentials/TypeformApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class TypeformApi implements ICredentialType {
 	name = 'typeformApi';
 	displayName = 'Typeform API';
 	documentationUrl = 'typeform';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/TypeformOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TypeformOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -16,37 +16,37 @@ export class TypeformOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Typeform OAuth2 API';
 	documentationUrl = 'typeform';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.typeform.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.typeform.com/oauth/token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/UProcApi.credentials.ts
+++ b/packages/nodes-base/credentials/UProcApi.credentials.ts
@@ -1,22 +1,22 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class UProcApi implements ICredentialType {
 	name = 'uprocApi';
 	displayName = 'uProc API';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/UnleashedSoftwareApi.credentials.ts
+++ b/packages/nodes-base/credentials/UnleashedSoftwareApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class UnleashedSoftwareApi implements ICredentialType {
 	name = 'unleashedSoftwareApi';
 	displayName = 'Unleashed API';
 	documentationUrl = 'unleashedSoftware';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API ID',
 			name: 'apiId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			typeOptions: {
 				password: true,

--- a/packages/nodes-base/credentials/UpleadApi.credentials.ts
+++ b/packages/nodes-base/credentials/UpleadApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class UpleadApi implements ICredentialType {
 	name = 'upleadApi';
 	displayName = 'Uplead API';
 	documentationUrl = 'uplead';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/UptimeRobotApi.credentials.ts
+++ b/packages/nodes-base/credentials/UptimeRobotApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class UptimeRobotApi implements ICredentialType {
 	name = 'uptimeRobotApi';
 	displayName = 'Uptime Robot API';
 	documentationUrl = 'uptimeRobot';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/VeroApi.credentials.ts
+++ b/packages/nodes-base/credentials/VeroApi.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 
@@ -8,11 +8,11 @@ export class VeroApi implements ICredentialType {
 	name = 'veroApi';
 	displayName = 'Vero API';
 	documentationUrl = 'vero';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Auth Token',
 			name: 'authToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/VonageApi.credentials.ts
+++ b/packages/nodes-base/credentials/VonageApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class VonageApi implements ICredentialType {
 	name = 'vonageApi';
 	displayName = 'Vonage API';
 	documentationUrl = 'vonage';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Secret',
 			name: 'apiSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/WebflowApi.credentials.ts
+++ b/packages/nodes-base/credentials/WebflowApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WebflowApi implements ICredentialType {
 	name = 'webflowApi';
 	displayName = 'Webflow API';
 	documentationUrl = 'webflow';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Access Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/WebflowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/WebflowOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WebflowOAuth2Api implements ICredentialType {
@@ -10,31 +10,31 @@ export class WebflowOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Webflow OAuth2 API';
 	documentationUrl = 'webflow';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://webflow.com/oauth/authorize',
 			required: true,
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://api.webflow.com/oauth/access_token',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 			description: 'For some services additional query parameters have to be set which can be defined here.',
 			placeholder: '',
@@ -42,7 +42,7 @@ export class WebflowOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: '',
 		},

--- a/packages/nodes-base/credentials/WekanApi.credentials.ts
+++ b/packages/nodes-base/credentials/WekanApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WekanApi implements ICredentialType {
 	name = 'wekanApi';
 	displayName = 'Wekan API';
 	documentationUrl = 'wekan';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://wekan.yourdomain.com',
 		},

--- a/packages/nodes-base/credentials/WiseApi.credentials.ts
+++ b/packages/nodes-base/credentials/WiseApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WiseApi implements ICredentialType {
 	name = 'wiseApi';
 	displayName = 'Wise API';
 	documentationUrl = 'wise';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Environment',
 			name: 'environment',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			default: 'live',
 			options: [
 				{

--- a/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
+++ b/packages/nodes-base/credentials/WooCommerceApi.credentials.ts
@@ -1,36 +1,36 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WooCommerceApi implements ICredentialType {
 	name = 'wooCommerceApi';
 	displayName = 'WooCommerce API';
 	documentationUrl = 'wooCommerce';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Consumer Key',
 			name: 'consumerKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Consumer Secret',
 			name: 'consumerSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'WooCommerce URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.com',
 		},
 		{
 			displayName: 'Include Credentials in Query',
 			name: 'includeCredentialsInQuery',
-			type: 'boolean' as NodePropertyTypes,
+			type: 'boolean',
 			default: false,
 			description: `Occasionally, some servers may not parse the Authorization header correctly</br>
 			(if you see a “Consumer key is missing” error when authenticating over SSL, you have a server issue).</br>

--- a/packages/nodes-base/credentials/WordpressApi.credentials.ts
+++ b/packages/nodes-base/credentials/WordpressApi.credentials.ts
@@ -1,29 +1,29 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WordpressApi implements ICredentialType {
 	name = 'wordpressApi';
 	displayName = 'Wordpress API';
 	documentationUrl = 'wordpress';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Username',
 			name: 'username',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Password',
 			name: 'password',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Wordpress URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://example.com',
 		},

--- a/packages/nodes-base/credentials/WufooApi.credentials.ts
+++ b/packages/nodes-base/credentials/WufooApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class WufooApi implements ICredentialType {
 	name = 'wufooApi';
 	displayName = 'Wufoo API';
 	documentationUrl = 'wufoo';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -17,35 +17,35 @@ export class XeroOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Xero OAuth2 API';
 	documentationUrl = 'xero';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://login.xero.com/identity/connect/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://identity.xero.com/connect/token',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/YouTubeOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/YouTubeOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 //https://developers.google.com/youtube/v3/guides/auth/client-side-web-apps#identify-access-scopes
@@ -19,11 +19,11 @@ export class YouTubeOAuth2Api implements ICredentialType {
 	];
 	displayName = 'YouTube OAuth2 API';
 	documentationUrl = 'google';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 	];

--- a/packages/nodes-base/credentials/YourlsApi.credentials.ts
+++ b/packages/nodes-base/credentials/YourlsApi.credentials.ts
@@ -1,23 +1,23 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class YourlsApi implements ICredentialType {
 	name = 'yourlsApi';
 	displayName = 'Yourls API';
 	documentationUrl = 'yourls';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Signature',
 			name: 'signature',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'http://localhost:8080',
 		},

--- a/packages/nodes-base/credentials/ZendeskApi.credentials.ts
+++ b/packages/nodes-base/credentials/ZendeskApi.credentials.ts
@@ -1,17 +1,17 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ZendeskApi implements ICredentialType {
 	name = 'zendeskApi';
 	displayName = 'Zendesk API';
 	documentationUrl = 'zendesk';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			description: 'The subdomain of your Zendesk work environment.',
 			placeholder: 'company',
 			default: '',
@@ -19,13 +19,13 @@ export class ZendeskApi implements ICredentialType {
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Token',
 			name: 'apiToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 const scopes = [
@@ -15,11 +15,11 @@ export class ZendeskOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Zendesk OAuth2 API';
 	documentationUrl = 'zendesk';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'n8n',
 			description: 'The subdomain of your Zendesk work environment.',
@@ -28,7 +28,7 @@ export class ZendeskOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '=https://{{$self["subdomain"]}}.zendesk.com/oauth/authorizations/new',
 			description: 'URL to get authorization code. Replace {SUBDOMAIN_HERE} with your subdomain.',
 			required: true,
@@ -36,7 +36,7 @@ export class ZendeskOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '=https://{{$self["subdomain"]}}.zendesk.com/oauth/tokens',
 			description: 'URL to get access token. Replace {SUBDOMAIN_HERE} with your subdomain.',
 			required: true,
@@ -44,27 +44,27 @@ export class ZendeskOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Client ID',
 			name: 'clientId',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			required: true,
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: scopes.join(' '),
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 			description: 'For some services additional query parameters have to be set which can be defined here.',
 			placeholder: '',
@@ -72,7 +72,7 @@ export class ZendeskOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 			description: 'Resource to consume.',
 		},

--- a/packages/nodes-base/credentials/ZohoOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ZohoOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ZohoOAuth2Api implements ICredentialType {
@@ -10,11 +10,11 @@ export class ZohoOAuth2Api implements ICredentialType {
 	];
 	displayName = 'Zoho OAuth2 API';
 	documentationUrl = 'zoho';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'https://accounts.zoho.com/oauth/v2/auth',
@@ -33,7 +33,7 @@ export class ZohoOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'options' as NodePropertyTypes,
+			type: 'options',
 			options: [
 				{
 					name: 'US - https://accounts.zoho.com/oauth/v2/token',
@@ -62,19 +62,19 @@ export class ZohoOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'ZohoCRM.modules.ALL,ZohoCRM.settings.all,ZohoCRM.users.all',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'access_type=offline',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'body',
 		},
 	];

--- a/packages/nodes-base/credentials/ZoomApi.credentials.ts
+++ b/packages/nodes-base/credentials/ZoomApi.credentials.ts
@@ -1,14 +1,14 @@
-import { ICredentialType, NodePropertyTypes } from 'n8n-workflow';
+import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class ZoomApi implements ICredentialType {
 	name = 'zoomApi';
 	displayName = 'Zoom API';
 	documentationUrl = 'zoom';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'JWT Token',
 			name: 'accessToken',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];

--- a/packages/nodes-base/credentials/ZoomOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ZoomOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ZoomOAuth2Api implements ICredentialType {
@@ -8,35 +8,35 @@ export class ZoomOAuth2Api implements ICredentialType {
 	extends = ['oAuth2Api'];
 	displayName = 'Zoom OAuth2 API';
 	documentationUrl = 'zoom';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://zoom.us/oauth/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'https://zoom.us/oauth/token',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: '',
 		},
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
-			type: 'hidden' as NodePropertyTypes,
+			type: 'hidden',
 			default: 'header',
 		},
 	];

--- a/packages/nodes-base/credentials/ZulipApi.credentials.ts
+++ b/packages/nodes-base/credentials/ZulipApi.credentials.ts
@@ -1,30 +1,30 @@
 import {
 	ICredentialType,
-	NodePropertyTypes,
+	INodeProperties,
 } from 'n8n-workflow';
 
 export class ZulipApi implements ICredentialType {
 	name = 'zulipApi';
 	displayName = 'Zulip API';
 	documentationUrl = 'zulip';
-	properties = [
+	properties: INodeProperties[] = [
 		{
 			displayName: 'URL',
 			name: 'url',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 			placeholder: 'https://yourZulipDomain.zulipchat.com',
 		},
 		{
 			displayName: 'Email',
 			name: 'email',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 		{
 			displayName: 'API Key',
 			name: 'apiKey',
-			type: 'string' as NodePropertyTypes,
+			type: 'string',
 			default: '',
 		},
 	];


### PR DESCRIPTION
This PR types the `properties` field in all credentials classes, allowing us to remove ~700 castings in individual credential properties. The `properties` field was defaulting to `any[]`, causing TS to infer `string` where a union was expected. 

This also surfaced that
- `GitPassword.credentials.ts` contained the misspelled key `decription`, which was fixed, and
- `GoogleApi.credentials.ts` contains an unspecified key `lines`, ignored for now.