### PR TITLE
Add support for Todoist task descriptions

### DIFF
--- a/packages/nodes-base/nodes/Todoist/Todoist.node.ts
+++ b/packages/nodes-base/nodes/Todoist/Todoist.node.ts
@@ -17,6 +17,7 @@ import {
 
 interface IBodyCreateTask {
 	content: string;
+	description?: string;
 	project_id?: number;
 	section_id?: number;
 	parent?: number;
@@ -248,6 +249,13 @@ export class Todoist implements INodeType {
 					},
 				},
 				options: [
+					{
+						displayName: 'Description',
+						name: 'description',
+						type: 'string',
+						default: '',
+						description: 'A description for the task.',
+					},
 					{
 						displayName: 'Due Date Time',
 						name: 'dueDateTime',
@@ -482,6 +490,10 @@ export class Todoist implements INodeType {
 						project_id: projectId,
 						priority: (options.priority!) ? parseInt(options.priority as string, 10) : 1,
 					};
+
+					if (options.description) {
+						body.description = options.description as string;
+					}
 
 					if (options.dueDateTime) {
 						body.due_datetime = options.dueDateTime as string;


### PR DESCRIPTION
This PR adds support for task descriptions when creating Todoist tasks.

It's basically a new optional text field in the API, so the implementation is pretty straightforward 🙂