### PR TITLE
Update flag because of deprecation notice

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -229,6 +229,7 @@ export class MicrosoftSql implements INodeType {
 			connectTimeout: credentials.connectTimeout as number,
 			options: {
 				encrypt: credentials.tls as boolean,
+				enableArithAbort: false,
 			},
 		};
 


### PR DESCRIPTION
The library used by us is emitting a warning notice saying that this flag will change its default value in the future, asking us to explicitly set it.

This PR does this to avoid problems with future updates.