### PR TITLE
⚡ Add support of array in querystring

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -797,8 +797,22 @@ export class HttpRequest implements INodeType {
 						// @ts-ignore
 						requestOptions[optionName] = {};
 						for (const parameterData of setUiParameter!.parameter as IDataObject[]) {
-							// @ts-ignore
-							requestOptions[optionName][parameterData!.name as string] = parameterData!.value;
+							const parameterDataName = parameterData!.name as string;
+							const newValue = parameterData!.value;
+							if (optionName === 'qs') {
+								const requestOption = requestOptions[optionName];
+								const oldValue = requestOption[parameterDataName];
+								if (typeof oldValue === 'string') {
+									requestOption[parameterDataName] = [oldValue, newValue];
+								} else if (Array.isArray(oldValue)) {
+									oldValue.push(parameterData!.value)
+								} else {
+									requestOption[parameterDataName] = newValue;
+								}
+							} else {
+								// @ts-ignore
+								requestOptions[optionName][parameterDataName] = newValue;
+							}
 						}
 					}
 				}

--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -800,15 +800,16 @@ export class HttpRequest implements INodeType {
 							const parameterDataName = parameterData!.name as string;
 							const newValue = parameterData!.value;
 							if (optionName === 'qs') {
-								const requestOption = requestOptions[optionName];
-								const oldValue = requestOption[parameterDataName];
-								if (typeof oldValue === 'string') {
-									requestOption[parameterDataName] = [oldValue, newValue];
-								} else if (Array.isArray(oldValue)) {
-									oldValue.push(parameterData!.value)
-								} else {
-									requestOption[parameterDataName] = newValue;
-								}
+								const computeNewValue = (oldValue: unknown) => {
+									if (typeof oldValue === 'string') {
+										return [oldValue, newValue];
+									} else if (Array.isArray(oldValue)) {
+										return [...oldValue, newValue];
+									} else {
+										return newValue;
+									}
+								};
+								requestOptions[optionName][parameterDataName] = computeNewValue(requestOptions[optionName][parameterDataName]);
 							} else {
 								// @ts-ignore
 								requestOptions[optionName][parameterDataName] = newValue;


### PR DESCRIPTION
## Overview

In the HTTP Request node, a parameter that appeared multiple times with the same name will be converted into an array.
Any parameters that appeared only once will be kept in the form of a string for backward compatibility.

## Use case
I want to use this feature with [Atlassian Marketplace API](https://developer.atlassian.com/platform/marketplace/rest/v2/api-group-reporting/#api-vendors-vendorid-reporting-licenses-get).
Our needs require the following form of the query string.

`https://marketplace.atlassian.com/rest/2/vendors/{vendorId}/reporting/licenses?licenseType=commercial&licenseType=evaluation`

In this query string, `licenseType` appears multiple times and I believe this is one of the popular ways to express an array in the query string. (Another way is the PHP style of `licenseType[]=a&licenseType[]=b`).