### PR TITLE
Fix console error on node deletion

### DIFF
--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -86,7 +86,7 @@
     "vue-router": "^3.0.6",
     "vue-template-compiler": "^2.5.17",
     "vue-typed-mixins": "^0.2.0",
-    "vue2-touch-events": "^2.3.2",
+    "vue2-touch-events": "^3.0.0",
     "vuex": "^3.1.1"
   }
 }

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -86,7 +86,7 @@
     "vue-router": "^3.0.6",
     "vue-template-compiler": "^2.5.17",
     "vue-typed-mixins": "^0.2.0",
-    "vue2-touch-events": "^3.0.0",
+    "vue2-touch-events": "^3.2.1",
     "vuex": "^3.1.1"
   }
 }


### PR DESCRIPTION
Deleting a node from the canvas causes `TypeError: i is undefined`. See [recording](https://cdn.discordapp.com/attachments/732676898177417278/856466291643777075/bug.gif).

Fixed by updating the `vue2-touch-events` lib. (The fix is in v3.0.0 but this update is to the latest.) See [lib changelog](https://github.com/jerrybendy/vue-touch-events/releases).

Tested on desktop and tablet and no relevant error logged. See [full report](https://n8n.atlassian.net/browse/PROD-1086?focusedCommentId=13932).

Thanks @krynble for helping to test. 