### PR TITLE
fix keyboard shortcut issues

### DIFF
--- a/packages/editor-ui/src/modules/ui.ts
+++ b/packages/editor-ui/src/modules/ui.ts
@@ -31,9 +31,6 @@ const module: Module<IUiState, IRootState> = {
 		isModalActive: (state: IUiState) => {
 			return (name: string) => state.modalStack.length > 0 && name === state.modalStack[0];
 		},
-		anyModalsOpen: (state: IUiState) => {
-			return state.modalStack.length > 0;
-		},
 		sidebarMenuCollapsed: (state: IUiState): boolean => state.sidebarMenuCollapsed,
 	},
 	mutations: {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -509,14 +509,13 @@ export default mixins(
 				// else which should ignore the default keybindings
 				for (let index = 0; index < path.length; index++) {
 					if (path[index].className && typeof path[index].className === 'string' && (
-						path[index].className.includes('el-message-box') ||
 						path[index].className.includes('ignore-key-press')
 					)) {
 						return;
 					}
 				}
 
-				// el-dialog element is open
+				// el-dialog or el-message-box element is open
 				if (window.document.body.classList.contains('el-popup-parent--hidden')) {
 					return;
 				}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -510,7 +510,6 @@ export default mixins(
 				for (let index = 0; index < path.length; index++) {
 					if (path[index].className && typeof path[index].className === 'string' && (
 						path[index].className.includes('el-message-box') ||
-						path[index].className.includes('el-select') ||
 						path[index].className.includes('ignore-key-press')
 					)) {
 						return;
@@ -521,6 +520,26 @@ export default mixins(
 					return;
 				}
 
+				// el-dialog element is open
+				if (window.document.body.classList.contains('el-popup-parent--hidden')) {
+					return;
+				}
+
+				if (e.key === 'Escape') {
+					this.createNodeActive = false;
+					if (this.activeNode) {
+						this.$externalHooks().run('dataDisplay.nodeEditingFinished');
+						this.$store.commit('setActiveNode', null);
+					}
+
+					return;
+				}
+
+				// node modal is open
+				if (this.activeNode) {
+					return;
+				}
+
 				if (e.key === 'd') {
 					this.callDebounced('deactivateSelectedNode', 350);
 				} else if (e.key === 'Delete') {
@@ -528,15 +547,12 @@ export default mixins(
 					e.preventDefault();
 
 					this.callDebounced('deleteSelectedNodes', 500);
-				} else if (e.key === 'Escape') {
-					this.$externalHooks().run('dataDisplay.nodeEditingFinished');
-					this.createNodeActive = false;
-					this.$store.commit('setActiveNode', null);
+
 				} else if (e.key === 'Tab') {
 					this.createNodeActive = !this.createNodeActive && !this.isReadOnly;
 				} else if (e.key === this.controlKeyCode) {
 					this.ctrlKeyPressed = true;
-				} else if (e.key === 'F2') {
+				} else if (e.key === 'F2' && !this.isReadOnly) {
 					const lastSelectedNode = this.lastSelectedNode;
 					if (lastSelectedNode !== null) {
 						this.callDebounced('renameNodePrompt', 1500, lastSelectedNode.name);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -515,10 +515,6 @@ export default mixins(
 						return;
 					}
 				}
-				const anyModalsOpen = this.$store.getters['ui/anyModalsOpen'];
-				if (anyModalsOpen) {
-					return;
-				}
 
 				// el-dialog element is open
 				if (window.document.body.classList.contains('el-popup-parent--hidden')) {


### PR DESCRIPTION
- prevent node panel from opening when a modal is open
- prevent any canvas actions (zooming in/out, selection...) when a modal is open
- prevent renaming a node on execution page
- prevent opening another modal like workflows lists while another modal is open