### PR TITLE
🐛 Fix Google Sheet to handle 0 correctly 

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
@@ -486,8 +486,9 @@ export class GoogleSheet {
 		inputData.forEach((item) => {
 			rowData = [];
 			keyColumnOrder.forEach((key) => {
-				if (item.hasOwnProperty(key) && item[key]) {
-					rowData.push(item[key]!.toString());
+				const data = item[key];
+				if (item.hasOwnProperty(key) && data !== null && typeof data !== 'undefined') {
+					rowData.push(data.toString())
 				} else {
 					rowData.push('');
 				}

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheet.ts
@@ -488,7 +488,7 @@ export class GoogleSheet {
 			keyColumnOrder.forEach((key) => {
 				const data = item[key];
 				if (item.hasOwnProperty(key) && data !== null && typeof data !== 'undefined') {
-					rowData.push(data.toString())
+					rowData.push(data.toString());
 				} else {
 					rowData.push('');
 				}


### PR DESCRIPTION
`if (condition) { statement }` will not be executed if the `condition` is `0` (number) so that appending 0 to Google Sheets results in an empty cell.
Checking if the value is `null` or `undefined` is enough to guarantee that `toString` is callable.