### PR TITLE
⚡ Add N8N_BASEURL

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -370,6 +370,12 @@ const config = convict({
 		env: 'N8N_SSL_CERT',
 		doc: 'SSL Cert for HTTPS Protocol',
 	},
+	baseurl: {
+		format: String,
+		default: '',
+		env: 'N8N_BASEURL',
+		doc: 'Base URL n8n can be reached (Optional)'
+	},
 
 	security: {
 		excludeEndpoints: {

--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -16,12 +16,15 @@ let versionCache: IPackageVersions | undefined;
  * @returns {string}
  */
 export function getBaseUrl(): string {
+	const baseurl = config.get('baseurl');
 	const protocol = config.get('protocol') as string;
 	const host = config.get('host') as string;
 	const port = config.get('port') as number;
 	const path = config.get('path') as string;
 
-	if (protocol === 'http' && port === 80 || protocol === 'https' && port === 443) {
+	if (!!baseurl) {
+		return baseurl;
+	} else if (protocol === 'http' && port === 80 || protocol === 'https' && port === 443) {
 		return `${protocol}://${host}${path}`;
 	}
 	return `${protocol}://${host}:${port}${path}`;


### PR DESCRIPTION
When n8n is behind a reverse proxy, n8n cannot know its base URL from its configuration.
Providing the base URL decided by the reverse proxy solves this problem.