### PR TITLE
⚡ Add a Bot user option to Slack credentials

### DIFF
--- a/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
@@ -4,7 +4,7 @@ import {
 } from 'n8n-workflow';
 
 //https://api.slack.com/authentication/oauth-v2
-const userScopes = [
+const scopes = [
 	'chat:write',
 	'files:read',
 	'files:write',
@@ -13,9 +13,13 @@ const userScopes = [
 	'mpim:read',
 	'reactions:read',
 	'reactions:write',
+	'users.profile:read',
+];
+
+const userScopes = [
+	...scopes,
 	'stars:read',
 	'stars:write',
-	'users.profile:read',
 	'users.profile:write',
 ];
 
@@ -27,6 +31,25 @@ export class SlackOAuth2Api implements ICredentialType {
 	displayName = 'Slack OAuth2 API';
 	documentationUrl = 'slack';
 	properties: INodeProperties[] = [
+		{
+			displayName: 'Token Type',
+			name: 'authQueryParameters',
+			type: 'options',
+			options: [
+				{
+					name: 'Bot Token',
+					value: `scope=${scopes.join(',')}`,
+					description: 'Authorize as a bot',
+				},
+				{
+					name: 'User Token',
+					value: `user_scope=${userScopes.join(' ')}`,
+					description: 'Authorize as an user',
+				},
+			],
+			default: `user_scope=${userScopes.join(' ')}`,
+			description: 'Bot Token is recommended.',
+		},
 		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
@@ -45,12 +68,6 @@ export class SlackOAuth2Api implements ICredentialType {
 			name: 'scope',
 			type: 'hidden',
 			default: 'chat:write',
-		},
-		{
-			displayName: 'Auth URI Query Parameters',
-			name: 'authQueryParameters',
-			type: 'hidden',
-			default: `user_scope=${userScopes.join(' ')}`,
 		},
 		{
 			displayName: 'Authentication',


### PR DESCRIPTION
Slack recommends New Slack apps use a Bot token.
https://api.slack.com/authentication/basics#scopes

It also fixes the icon problem posted on the forum.
https://community.n8n.io/t/slack-send-message-as-bot/4830/11
