### PR TITLE
Fix workflow ID type on UI download

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -202,7 +202,7 @@ export interface IVariableSelectorOption {
 
 // Simple version of n8n-workflow.Workflow
 export interface IWorkflowData {
-	id?: string;
+	id?: string | number;
 	name?: string;
 	active?: boolean;
 	nodes: INode[];
@@ -212,7 +212,7 @@ export interface IWorkflowData {
 }
 
 export interface IWorkflowDataUpdate {
-	id?: string;
+	id?: string | number;
 	name?: string;
 	nodes?: INode[];
 	connections?: IConnections;

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -408,6 +408,9 @@ export default mixins(
 					const workflowData = await this.getWorkflowDataToSave();
 
 					const {tags, ...data} = workflowData;
+					if (data.id && typeof data.id === 'string') {
+						data.id = parseInt(data.id, 10);
+					}
 					const blob = new Blob([JSON.stringify(data, null, 2)], {
 						type: 'application/json;charset=utf-8',
 					});


### PR DESCRIPTION
This PR sets the workflow `id` type to `number` on UI download, for compatibility with the `import:workflow` CLI command, to close #1955.