### PR TITLE
Add last name to contact:update in Salesforce node

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/ContactDescription.ts
@@ -571,6 +571,13 @@ export const contactFields = [
 				If a contact has a value in this field, it means that a contact was imported as a contact from Data.com.`,
 			},
 			{
+				displayName: 'Last Name',
+				name: 'lastName',
+				type: 'string',
+				default: '',
+				description: 'Last name of the contact. Limited to 80 characters.',
+			},
+			{
 				displayName: 'Lead Source',
 				name: 'leadSource',
 				type: 'options',

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1337,6 +1337,9 @@ export class Salesforce implements INodeType {
 					if (!Object.keys(updateFields).length) {
 						throw new NodeOperationError(this.getNode(), 'You must add at least one update field');
 					}
+					if (updateFields.lastName !== undefined) {
+						body.LastName = updateFields.lastName as string;
+					}
 					if (updateFields.fax !== undefined) {
 						body.Fax = updateFields.fax as string;
 					}


### PR DESCRIPTION
This PR adds the last name field to `contact:update` operation in the Salesforce node.