### PR TITLE
N8n 2249 nodes panel reactivity bug

### DIFF
--- a/packages/editor-ui/src/components/NodeCreator/ItemIterator.vue
+++ b/packages/editor-ui/src/components/NodeCreator/ItemIterator.vue
@@ -8,7 +8,7 @@
 			@before-leave="beforeLeave"
 			@leave="leave"
 		>
-			<div v-for="(item, index) in elements" :key="item.key" :class="item.type">
+			<div v-for="(item, index) in elements" :key="item.key" :class="item.type" :data-key="item.key">
 				<CreatorItem
 					:item="item"
 					:active="activeIndex === index && !disabled"

--- a/packages/editor-ui/src/components/NodeCreator/NodeCreator.vue
+++ b/packages/editor-ui/src/components/NodeCreator/NodeCreator.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
 			if (prevList.length === 0) {
 				this.allNodeTypes = newList;
 			}
-		}
+		},
 	},
 });
 </script>

--- a/packages/editor-ui/src/components/NodeCreator/NodeCreator.vue
+++ b/packages/editor-ui/src/components/NodeCreator/NodeCreator.vue
@@ -29,9 +29,17 @@ export default Vue.extend({
 	props: [
 		'active',
 	],
+	data() {
+		return {
+			allNodeTypes: [],
+		};
+	},
 	computed: {
+		nodeTypes(): INodeTypeDescription[] {
+			return this.$store.getters.allNodeTypes;
+		},
 		visibleNodeTypes(): INodeTypeDescription[] {
-			return this.$store.getters.allNodeTypes
+			return this.allNodeTypes
 				.filter((nodeType: INodeTypeDescription) => {
 					return !HIDDEN_NODES.includes(nodeType.name);
 				});
@@ -72,6 +80,13 @@ export default Vue.extend({
 		nodeTypeSelected (nodeTypeName: string) {
 			this.$emit('nodeTypeSelected', nodeTypeName);
 		},
+	},
+	watch: {
+		nodeTypes(newList, prevList) {
+			if (prevList.length === 0) {
+				this.allNodeTypes = newList;
+			}
+		}
 	},
 });
 </script>


### PR DESCRIPTION
- vue reactivity causing list to rerender with different sort order after inserting an item, fixed by setting nodes panel data only once when data is available
- add unique key for each element in list