### PR TITLE
Add sandbox option to Salesforce OAuth2 credentials

### DIFF
--- a/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
@@ -31,15 +31,15 @@ export class SalesforceOAuth2Api implements ICredentialType {
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',
-			default: 'https://login.salesforce.com/services/oauth2/authorize',
 			required: true,
+			default: '={{ $self["environment"] === "sandbox" ? "https://test.salesforce.com/services/oauth2/authorize" : "https://login.salesforce.com/services/oauth2/authorize" }}',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
-			type: 'string',
-			default: 'https://yourcompany.salesforce.com/services/oauth2/token',
+			type: 'hidden',
 			required: true,
+			default: '={{ $self["environment"] === "sandbox" ? "https://test.salesforce.com/services/oauth2/token" : "https://login.salesforce.com/services/oauth2/token" }}',
 		},
 		{
 			displayName: 'Scope',

--- a/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SalesforceOAuth2Api.credentials.ts
@@ -12,6 +12,22 @@ export class SalesforceOAuth2Api implements ICredentialType {
 	documentationUrl = 'salesforce';
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Environment Type',
+			name: 'environment',
+			type: 'options',
+			options: [
+				{
+					name: 'Production',
+					value: 'production',
+				},
+				{
+					name: 'Sandbox',
+					value: 'sandbox',
+				},
+			],
+			default: 'production',
+		},
+		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -40,9 +40,8 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 		} else {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
 			const credentialsType = 'salesforceOAuth2Api';
-			const credentials = this.getCredentials(credentialsType);
-			const subdomain = ((credentials!.accessTokenUrl as string).match(/https:\/\/(.+).salesforce\.com/) || [])[1];
-			const options = getOptions.call(this, method, (uri || endpoint), body, qs, `https://${subdomain}.salesforce.com`);
+			const credentials = this.getCredentials(credentialsType) as { oauthTokenData: { instance_url: string } };
+			const options = getOptions.call(this, method, (uri || endpoint), body, qs, credentials.oauthTokenData.instance_url);
 			Logger.debug(`Authentication for "Salesforce" node is using "OAuth2". Invoking URI ${options.uri}`);
 			//@ts-ignore
 			return await this.helpers.requestOAuth2.call(this, credentialsType, options);

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -42,7 +42,8 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 			const credentialsType = 'salesforceOAuth2Api';
 			const credentials = this.getCredentials(credentialsType);
 			const subdomain = ((credentials!.accessTokenUrl as string).match(/https:\/\/(.+).salesforce\.com/) || [])[1];
-			const options = getOptions.call(this, method, (uri || endpoint), body, qs, `https://${subdomain}.salesforce.com`);
+			const url = credentials!.environment === 'sandbox' ? 'https://test.salesforce.com' : `https://${subdomain}.salesforce.com`;
+			const options = getOptions.call(this, method, (uri || endpoint), body, qs, url);
 			Logger.debug(`Authentication for "Salesforce" node is using "OAuth2". Invoking URI ${options.uri}`);
 			//@ts-ignore
 			return await this.helpers.requestOAuth2.call(this, credentialsType, options);

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -42,8 +42,7 @@ export async function salesforceApiRequest(this: IExecuteFunctions | IExecuteSin
 			const credentialsType = 'salesforceOAuth2Api';
 			const credentials = this.getCredentials(credentialsType);
 			const subdomain = ((credentials!.accessTokenUrl as string).match(/https:\/\/(.+).salesforce\.com/) || [])[1];
-			const url = credentials!.environment === 'sandbox' ? 'https://test.salesforce.com' : `https://${subdomain}.salesforce.com`;
-			const options = getOptions.call(this, method, (uri || endpoint), body, qs, url);
+			const options = getOptions.call(this, method, (uri || endpoint), body, qs, `https://${subdomain}.salesforce.com`);
 			Logger.debug(`Authentication for "Salesforce" node is using "OAuth2". Invoking URI ${options.uri}`);
 			//@ts-ignore
 			return await this.helpers.requestOAuth2.call(this, credentialsType, options);


### PR DESCRIPTION
This PR adds the sandbox option to the OAuth2 credentials in the Salesforce node.