### PR TITLE
n8n-2297 Fix UI behavior in delete workflow (with changes)

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -395,6 +395,7 @@ export default mixins(
 						this.$showError(error, 'Problem deleting the workflow', 'There was a problem deleting the workflow:');
 						return;
 					}
+					this.$store.commit('setStateDirty', false);
 					// Reset tab title since workflow is deleted.
 					this.$titleReset();
 					this.$showMessage({


### PR DESCRIPTION
This PR adds changes to correct the dirty state after deleting a workflow in order to avoid a second confirmation message