### PR TITLE
Improve node discoverability for generic tasks

### DIFF
--- a/packages/nodes-base/nodes/DeepL/DeepL.node.json
+++ b/packages/nodes-base/nodes/DeepL/DeepL.node.json
@@ -5,6 +5,10 @@
 	"categories": [
 		"Utility"
 	],
+	"alias": [
+		"Translate",
+		"Translator"
+	],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.json
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.json
@@ -5,6 +5,10 @@
 	"categories": [
 		"Miscellaneous"
 	],
+	"alias": [
+		"Music",
+		"Song"
+	],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Twilio/Twilio.node.json
+++ b/packages/nodes-base/nodes/Twilio/Twilio.node.json
@@ -6,6 +6,9 @@
 		"Communication",
 		"Development"
 	],
+	"alias": [
+		"SMS"
+	],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Vonage/Vonage.node.json
+++ b/packages/nodes-base/nodes/Vonage/Vonage.node.json
@@ -5,6 +5,9 @@
 	"categories": [
 		"Communication"
 	],
+	"alias": [
+		"SMS"
+	],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Wise/Wise.node.json
+++ b/packages/nodes-base/nodes/Wise/Wise.node.json
@@ -5,6 +5,9 @@
 	"categories": [
 		"Finance & Accounting"
 	],
+	"alias": [
+		"Currency"
+	],
 	"resources": {
 		"credentialDocumentation": [
 			{


### PR DESCRIPTION
Some branded nodes perform tasks that are likely to be desired by users not specifically looking for that brand.

For example, a user may search the node list for "currency", receive no results, and assume currency conversion is not available. It is however already supported by the Wise node.