### PR TITLE
Fixed the spreadsheet nodes for saving dates

### DIFF
--- a/packages/nodes-base/nodes/SpreadsheetFile.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile.node.ts
@@ -31,6 +31,10 @@ function flattenObject(data: IDataObject) {
 	const returnData: IDataObject = {};
 	for (const key1 of Object.keys(data)) {
 		if (data[key1] !== null && (typeof data[key1]) === 'object') {
+			if (data[key1] instanceof Date) {
+				returnData[key1] = data[key1]?.toString();
+				continue;
+			}
 			const flatObject = flattenObject(data[key1] as IDataObject);
 			for (const key2 in flatObject) {
 				if (flatObject[key2] === undefined) {


### PR DESCRIPTION
As reported on https://github.com/n8n-io/n8n/issues/941, the Spreadsheet node was not saving the `createdAt` mentioned field.

I created a similar structure, setting up a Postgres locally and was able to reproduce the issue. At first, I used a `Set` node to replace the contents of the `createdAt` column and it worked.

Then I started checking and realized that the field, a timestamp in Postgres, was actually being returned as an object. More specifically, a `Date` object. 

This PR fixes the issue by calling `.toString()` on the date object, allowing it to be saved. The format will be saved according to the node settings. On my machine the value saved as "Wed Jul 21 2021 11:59:53 GMT+0200 (Central European Summer Time)"