### PR TITLE
AWS DynamoDB: Scan data

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -312,15 +312,17 @@ export class AwsDynamoDB implements INodeType {
 						const {
 							indexName,
 							projectionExpression,
+							filterExpression,
 						} = this.getNodeParameter('options', i) as {
 							indexName: string;
 							projectionExpression: string;
+							filterExpression: string;
 						};
 
 						const expressionAttributeName = adjustExpressionAttributeName(eanUi);
 
 						if (Object.keys(expressionAttributeName).length) {
-							body.expressionAttributeNames = expressionAttributeName;
+							body.ExpressionAttributeNames = expressionAttributeName;
 						}
 
 						if (indexName) {
@@ -329,6 +331,10 @@ export class AwsDynamoDB implements INodeType {
 
 						if (projectionExpression && select !== 'COUNT') {
 							body.ProjectionExpression = projectionExpression;
+						}
+
+						if (filterExpression) {
+							body.FilterExpression = filterExpression;
 						}
 
 						if (select) {

--- a/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/ItemDescription.ts
@@ -35,6 +35,11 @@ export const itemOperations = [
 				value: 'getAll',
 				description: 'Get all items',
 			},
+			{
+				name: 'Scan',
+				value: 'scan',
+				description: 'Scan database',
+			},
 		],
 		default: 'upsert',
 	},
@@ -883,6 +888,245 @@ export const itemFields = [
 				type: 'string',
 				default: '',
 				description: 'Text that contains conditions that DynamoDB applies after the Query operation,<br>but before the data is returned. Items that do not satisfy the FilterExpression criteria</br>are not returned',
+			},
+			{
+				displayName: 'Expression Attribute Names',
+				name: 'eanUi',
+				placeholder: 'Add Expression',
+				type: 'fixedCollection',
+				default: '',
+				typeOptions: {
+					multipleValues: true,
+				},
+				options: [
+					{
+						name: 'eanValues',
+						displayName: 'Expression',
+						values: [
+							{
+								displayName: 'Key',
+								name: 'key',
+								type: 'string',
+								default: '',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+				],
+				description: 'One or more substitution tokens for attribute names in an expression. Check <a target="_blank" href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html">Info</a>',
+			},
+		],
+	},
+
+
+	// ----------------------------------
+	//              Scan
+	// ----------------------------------
+	{
+		displayName: 'Filter Expression',
+		name: 'filterExpression',
+		type: 'string',
+		default: '',
+		description: 'Text that contains conditions that DynamoDB applies after the Query operation,<br>but before the data is returned. Items that do not satisfy the FilterExpression criteria</br>are not returned',
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+			},
+		},
+	},
+	{
+		displayName: 'Expression Attribute Values',
+		name: 'eavUi',
+		description: 'Substitution tokens for attribute names in an expression',
+		placeholder: 'Add Attribute Value',
+		type: 'fixedCollection',
+		default: '',
+		typeOptions: {
+			multipleValues: true,
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'eavValues',
+				displayName: 'Expression Attribute Vaue',
+				values: [
+					{
+						displayName: 'Attribute',
+						name: 'attribute',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{
+								name: 'Number',
+								value: 'N',
+							},
+							{
+								name: 'String',
+								value: 'S',
+							},
+						],
+						default: 'S',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				operation: [
+					'scan',
+				],
+				returnAll: [
+					false,
+				],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 100,
+		},
+		default: 50,
+		description: 'How many results to return',
+	},
+	{
+		displayName: 'Select',
+		name: 'select',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'All Attributes',
+				value: 'ALL_ATTRIBUTES',
+			},
+			{
+				name: 'All Projected Attributes',
+				value: 'ALL_PROJECTED_ATTRIBUTES',
+			},
+			{
+				name: 'Count',
+				value: 'COUNT',
+			},
+			{
+				name: 'Specific Attributes',
+				value: 'SPECIFIC_ATTRIBUTES',
+				description: 'Select them in Attributes to Select under Additional Fields',
+			},
+		],
+		default: 'ALL_ATTRIBUTES',
+	},
+	{
+		displayName: 'Simple',
+		name: 'simple',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+				select: [
+					'ALL_PROJECTED_ATTRIBUTES',
+					'ALL_ATTRIBUTES',
+					'SPECIFIC_ATTRIBUTES',
+				],
+			},
+		},
+		default: true,
+		description: 'Whether to return a simplified version of the response instead of the raw data',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: [
+					'item',
+				],
+				operation: [
+					'scan',
+				],
+			},
+		},
+		options: [
+			{
+				displayName: 'Index Name',
+				name: 'indexName',
+				description: 'Name of the index to query. It can be any <br>secondary local or global index on the table.',
+				type: 'string',
+				default: '',
+			},
+			{
+				displayName: 'Attributes to Select',
+				name: 'projectionExpression',
+				type: 'string',
+				default: '',
+				description: 'Text that identifies one or more attributes to retrieve from the table.<br>These attributes can include scalars, sets, or elements of a JSON document. The attributes<br>in the expression must be separated by commas',
 			},
 			{
 				displayName: 'Expression Attribute Names',


### PR DESCRIPTION
Hey, thanks for finally merging #1602! 
Looking into 0.130.0, it looks awesome, but after refactoring, one operation was gone: [Scan](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html). For me it's somehow mandatory to explore data easily.

I re-added it, by using the dynamodb-code you built. Hopefully this gets merged faster than last time :grinning: 

Thanks for all your work! n8n is awesome!