### PR TITLE
fix: use correct publicPath instead of wrong basePath

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -15,7 +15,7 @@
 
 				<el-menu-item index="logo" class="logo-item">
 					<a href="https://n8n.io" target="_blank" class="logo">
-						<img :src="basePath + 'n8n-icon-small.png'" class="icon" alt="n8n.io"/>
+						<img :src="publicPath + 'n8n-icon-small.png'" class="icon" alt="n8n.io"/>
 						<span class="logo-text" slot="title">n8n.io</span>
 					</a>
 				</el-menu-item>
@@ -227,8 +227,7 @@ export default mixins(
 		data () {
 			return {
 				aboutDialogVisible: false,
-				// @ts-ignore
-				basePath: this.$store.getters.getBaseUrl,
+				publicPath: process.env.VUE_APP_PUBLIC_PATH || '/',
 				credentialNewDialogVisible: false,
 				credentialOpenDialogVisible: false,
 				executionsListDialogVisible: false,


### PR DESCRIPTION
After user has set publicPath, the logo will be missing.