### PR TITLE
Spotify infinte return all

### DIFF
--- a/packages/nodes-base/nodes/Interval.node.ts
+++ b/packages/nodes-base/nodes/Interval.node.ts
@@ -84,7 +84,7 @@ export class Interval implements INodeType {
 			throw new Error('The interval value is too large.');
 		}
 
-		const intervalObj = setInterval(executeTrigger, );
+		const intervalObj = setInterval(executeTrigger, intervalValue);
 
 		async function closeFunction() {
 			clearInterval(intervalObj);

--- a/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Spotify/GenericFunctions.ts
@@ -71,7 +71,7 @@ export async function spotifyApiRequestAllItems(this: IHookFunctions | IExecuteF
 		}
 	} while (
 		(responseData['next'] !== null && responseData['next'] !== undefined) ||
-		responseData[propertyName.split('.')[0]].next !== null
+		(responseData[propertyName.split('.')[0]].next !== null || responseData[propertyName.split('.')[0]].next !== undefined)
 	);
 
 	return returnData;


### PR DESCRIPTION
Spotify responsed with undefined "next" field.
Enabling "returnAll" parameter caused infinite loop.

Looks like it closes https://github.com/n8n-io/n8n/pull/2047