### PR TITLE
Allowing usage of special characters on SES by encoding the entire message

### DIFF
--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -1091,9 +1091,10 @@ export class AwsSes implements INodeType {
 						];
 
 						if (isBodyHtml) {
-							params.push(`Message.Body.Html.Data=${encodeURI(message)}`);
+							params.push(`Message.Body.Html.Data=${encodeURIComponent(message)}`);
+							params.push(`Message.Body.Html.Charset=UTF-8`);
 						} else {
-							params.push(`Message.Body.Text.Data=${encodeURI(message)}`);
+							params.push(`Message.Body.Text.Data=${encodeURIComponent(message)}`);
 						}
 
 						if (toAddresses.length) {


### PR DESCRIPTION
This PR relates to issue https://github.com/n8n-io/n8n/issues/1442

The previous implementation was skipping encoding parts of the message that corresponded to URLs, like `:`, `/` and `=`.

Switching from `encodeURI` to `encodeURIComponent` fixes the problem as the latter encodes all characters.