### PR TITLE
Integrate nodelinter into n8n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _START_PACKAGE
 .idea
 .prettierrc.js
 vetur.config.js
+nodelinter.config.js

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -19,6 +19,7 @@
     "build": "tsc && gulp",
     "tslint": "tslint -p tsconfig.json -c tslint.json",
     "tslintfix": "tslint --fix -p tsconfig.json -c tslint.json",
+    "nodelinter": "nodelinter",
     "watch": "tsc --watch",
     "test": "jest"
   },
@@ -634,6 +635,7 @@
     "gulp": "^4.0.0",
     "jest": "^26.4.2",
     "n8n-workflow": "~0.64.0",
+    "nodelinter": "^0.1.9",
     "ts-jest": "^26.3.0",
     "tslint": "^6.1.2",
     "typescript": "~3.9.7"


### PR DESCRIPTION
This PR adds [nodelinter](https://github.com/n8n-io/nodelinter) as a dev dependency of the `nodes-base` package.

To install:

```
lerna bootstrap --hoist && npm run build
```

To run:

```
cd packages/nodes-base
npm run nodelinter -- --target=./nodes/ActionNetwork
```

To override default settings, add a `nodelinter.config.json` at `/nodes-base`. See [custom config details](https://github.com/n8n-io/nodelinter#custom-config).