### PR TITLE
Add trailing slash to webhook urls

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -462,9 +462,9 @@ export function getWebhookBaseUrl() {
 	if (process.env.WEBHOOK_TUNNEL_URL !== undefined || process.env.WEBHOOK_URL !== undefined) {
 		// @ts-ignore
 		urlBaseWebhook = process.env.WEBHOOK_TUNNEL_URL || process.env.WEBHOOK_URL;
-		if (!urlBaseWebhook.endsWith('/')) {
-			urlBaseWebhook += '/';
-		}
+	}
+	if (!urlBaseWebhook.endsWith('/')) {
+		urlBaseWebhook += '/';
 	}
 
 	return urlBaseWebhook;

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -462,6 +462,9 @@ export function getWebhookBaseUrl() {
 	if (process.env.WEBHOOK_TUNNEL_URL !== undefined || process.env.WEBHOOK_URL !== undefined) {
 		// @ts-ignore
 		urlBaseWebhook = process.env.WEBHOOK_TUNNEL_URL || process.env.WEBHOOK_URL;
+		if (!urlBaseWebhook.endsWith('/')) {
+			urlBaseWebhook += '/';
+		}
 	}
 
 	return urlBaseWebhook;


### PR DESCRIPTION
In case it's not present in the settings or env variables, we add it as it's expected it'd be there.

Relates to community issue https://community.n8n.io/t/problem-with-google-calendar-credentials/7232