### PR TITLE
Fix typo in baserow create operation parameters to match Operation description

### DIFF
--- a/packages/nodes-base/nodes/Baserow/Baserow.node.ts
+++ b/packages/nodes-base/nodes/Baserow/Baserow.node.ts
@@ -222,12 +222,11 @@ export class Baserow implements INodeType {
 
 					const body: IDataObject = {};
 
-					const dataToSend = this.getNodeParameter('dataToSend', 0) as 'defineBelow' | 'autoMapColumns';
+					const dataToSend = this.getNodeParameter('dataToSend', 0) as 'defineBelow' | 'autoMapInputData';
 
-					if (dataToSend === 'autoMapColumns') {
-
+					if (dataToSend === 'autoMapInputData') {
 						const incomingKeys = Object.keys(items[i].json);
-						const rawInputsToIgnore = this.getNodeParameter('inputDataToIgnore', i) as string;
+						const rawInputsToIgnore = this.getNodeParameter('inputsToIgnore', i) as string;
 						const inputDataToIgnore = rawInputsToIgnore.split(',').map(c => c.trim());
 
 						for (const key of incomingKeys) {


### PR DESCRIPTION
Baserow node is inserting `null` value on create operation. It is caused by parameters not matching what is set in `OperationDescriptions.ts`