### PR TITLE
Fix nodelinter config file extension in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ _START_PACKAGE
 .idea
 .prettierrc.js
 vetur.config.js
-nodelinter.config.js
+nodelinter.config.json


### PR DESCRIPTION
The [custom config](https://github.com/n8n-io/nodelinter#custom-config) should be `.json`.