### PR TITLE
Updates webhook UUIDs to a new one when duplicating

### DIFF
--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -44,8 +44,6 @@ import { workflowHelpers } from "@/components/mixins/workflowHelpers";
 import { showMessage } from "@/components/mixins/showMessage";
 import TagsDropdown from "@/components/TagsDropdown.vue";
 import Modal from "./Modal.vue";
-import { v4 as uuidv4} from 'uuid';
-import { INodeUi } from "../Interface";
 
 export default mixins(showMessage, workflowHelpers).extend({
 	components: { TagsDropdown, Modal },
@@ -109,16 +107,9 @@ export default mixins(showMessage, workflowHelpers).extend({
 				return;
 			}
 
-			const allNodes = this.$store.getters.allNodes;
-			allNodes.forEach((node: INodeUi) => {
-				if (node.webhookId) {
-					node.webhookId = uuidv4();
-				}
-			});
-
 			this.$data.isSaving = true;
 
-			const saved = await this.saveAsNewWorkflow({name, tags: this.currentTagIds});
+			const saved = await this.saveAsNewWorkflow({name, tags: this.currentTagIds, updateWebhookUrls: true});
 
 			if (saved) {
 				this.closeDialog();

--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -44,6 +44,8 @@ import { workflowHelpers } from "@/components/mixins/workflowHelpers";
 import { showMessage } from "@/components/mixins/showMessage";
 import TagsDropdown from "@/components/TagsDropdown.vue";
 import Modal from "./Modal.vue";
+import { v4 as uuidv4} from 'uuid';
+import { INodeUi } from "../Interface";
 
 export default mixins(showMessage, workflowHelpers).extend({
 	components: { TagsDropdown, Modal },
@@ -106,6 +108,13 @@ export default mixins(showMessage, workflowHelpers).extend({
 
 				return;
 			}
+
+			const allNodes = this.$store.getters.allNodes;
+			allNodes.forEach((node: INodeUi) => {
+				if (node.webhookId) {
+					node.webhookId = uuidv4();
+				}
+			});
 
 			this.$data.isSaving = true;
 

--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -109,7 +109,7 @@ export default mixins(showMessage, workflowHelpers).extend({
 
 			this.$data.isSaving = true;
 
-			const saved = await this.saveAsNewWorkflow({name, tags: this.currentTagIds, updateWebhookUrls: true});
+			const saved = await this.saveAsNewWorkflow({name, tags: this.currentTagIds, resetWebhookUrls: true});
 
 			if (saved) {
 				this.closeDialog();

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -436,18 +436,19 @@ export const workflowHelpers = mixins(
 				}
 			},
 
-			async saveAsNewWorkflow ({name, tags, updateWebhookUrls}: {name?: string, tags?: string[], updateWebhookUrls?: boolean} = {}): Promise<boolean> {
+			async saveAsNewWorkflow ({name, tags, resetWebhookUrls}: {name?: string, tags?: string[], resetWebhookUrls?: boolean} = {}): Promise<boolean> {
 				try {
 					this.$store.commit('addActiveAction', 'workflowSaving');
 
 					const workflowDataRequest: IWorkflowDataUpdate = await this.getWorkflowDataToSave();
 					// make sure that the new ones are not active
 					workflowDataRequest.active = false;
-					if (updateWebhookUrls) {
-						workflowDataRequest.nodes!.forEach(node => {
+					if (resetWebhookUrls) {
+						workflowDataRequest.nodes = workflowDataRequest.nodes!.map(node => {
 							if (node.webhookId) {
 								node.webhookId = uuidv4();
 							}
+							return node;
 						});
 					}
 


### PR DESCRIPTION
This PR fixes the issue mentioned https://github.com/n8n-io/n8n/issues/1967

Before duplicating the workflows, after the user confirms to save, we iterate over all nodes and check if they contain the `webhookId` property. In case they do, we replace it by a new one.

I am not 100% sure if this is the best approach (maybe I should've dispatched something to the store) but this worked.