### PR TITLE
Update description of 'Keep Source' toggle

### DIFF
--- a/packages/nodes-base/nodes/MoveBinaryData.node.ts
+++ b/packages/nodes-base/nodes/MoveBinaryData.node.ts
@@ -299,7 +299,7 @@ export class MoveBinaryData implements INodeType {
 						name: 'keepSource',
 						type: 'boolean',
 						default: false,
-						description: 'If the source key should be kept. By default does it get deleted.',
+						description: 'If the source key should be kept. By default it will be deleted.',
 					},
 					{
 						displayName: 'Keep As Base64',


### PR DESCRIPTION
Fixed some improper grammar in the 'Keep Source' toggle of the Move Binary Data node in order to improve readability