### PR TITLE
Exclude packages from linting and formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+packages/nodes-base
+packages/editor-ui

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 packages/nodes-base
 packages/editor-ui
+packages/design-system

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+packages/nodes-base
+packages/editor-ui

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 packages/nodes-base
 packages/editor-ui
+packages/design-system


### PR DESCRIPTION
This PR introduces ignore files to exclude the `/nodes-base` and `/editor-ui` packages from detection by ESLint and Prettier VSCode extensions. Ignore files to be removed once these packages are linted and formatted.