### PR TITLE
Add description option to NodeOperationError

### DIFF
--- a/packages/workflow/src/NodeErrors.ts
+++ b/packages/workflow/src/NodeErrors.ts
@@ -202,11 +202,15 @@ abstract class NodeError extends Error {
  * Class for instantiating an operational error, e.g. an invalid credentials error.
  */
 export class NodeOperationError extends NodeError {
-	constructor(node: INode, error: Error | string) {
+	constructor(node: INode, error: Error | string, options?: { description: string }) {
 		if (typeof error === 'string') {
 			error = new Error(error);
 		}
 		super(node, error);
+
+		if (options?.description) {
+			this.description = options.description;
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds an option to specify a description in `NodeOperationError`

```ts
throw new NodeOperationError(this.getNode(), 'My title', { description: 'My description' });
```

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/44588767/131324541-b7810a9a-58f9-4166-99ae-f89904fb4c61.png">