### PR TITLE
Feature: credential testing

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1351,7 +1351,7 @@ class App {
 						| undefined;
 
 					const nodeThatCanTestThisCredential = allNodes.find((node) => {
-						if (incomingData.testWithNode && node.description.name !== incomingData.testWithNode) {
+						if (node.description.name !== incomingData?.nodeToTestWith) {
 							return false;
 						}
 						const credentialTestable = node.description.credentials?.find((credential) => {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1349,9 +1349,11 @@ class App {
 								credential: ICredentialsDecrypted,
 						  ) => Promise<NodeCredentialTestResult>)
 						| undefined;
-
 					const nodeThatCanTestThisCredential = allNodes.find((node) => {
-						if (node.description.name !== incomingData?.nodeToTestWith) {
+						if (
+							incomingData.nodeToTestWith &&
+							node.description.name !== incomingData.nodeToTestWith
+						) {
 							return false;
 						}
 						const credentialTestable = node.description.credentials?.find((credential) => {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -56,6 +56,7 @@ import {
 	Credentials,
 	ICredentialTestFunctions,
 	LoadNodeParameterOptions,
+	NodeExecuteFunctions,
 	UserSettings,
 } from 'n8n-core';
 
@@ -140,7 +141,6 @@ import * as TagHelpers from './TagHelpers';
 import { TagEntity } from './databases/entities/TagEntity';
 import { WorkflowEntity } from './databases/entities/WorkflowEntity';
 import { WorkflowNameRequest } from './WorkflowHelpers';
-import { NodeExecuteFunctions } from 'n8n-core';
 
 require('body-parser-xml')(bodyParser);
 

--- a/packages/core/src/Interfaces.ts
+++ b/packages/core/src/Interfaces.ts
@@ -2,6 +2,7 @@
 import {
 	IAllExecuteFunctions,
 	IBinaryData,
+	ICredentialTestFunctions as ICredentialTestFunctionsBase,
 	ICredentialType,
 	IDataObject,
 	IExecuteFunctions as IExecuteFunctionsBase,
@@ -155,6 +156,12 @@ export interface ILoadOptionsFunctions extends ILoadOptionsFunctionsBase {
 			credentialsType: string,
 			requestOptions: OptionsWithUrl | requestPromise.RequestPromiseOptions,
 		): Promise<any>; // tslint:disable-line:no-any
+	};
+}
+
+export interface ICredentialTestFunctions extends ICredentialTestFunctionsBase {
+	helpers: {
+		request: requestPromise.RequestPromiseAPI;
 	};
 }
 

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -65,6 +65,7 @@ import { lookup } from 'mime-types';
 // eslint-disable-next-line import/no-cycle
 import {
 	BINARY_ENCODING,
+	ICredentialTestFunctions,
 	IHookFunctions,
 	ILoadOptionsFunctions,
 	IResponseError,
@@ -1278,6 +1279,14 @@ export function getExecuteSingleFunctions(
 			},
 		};
 	})(workflow, runExecutionData, connectionInputData, inputData, node, itemIndex);
+}
+
+export function getCredentialTestFunctions(): ICredentialTestFunctions {
+	return {
+		helpers: {
+			request: requestPromiseWithDefaults,
+		},
+	};
 }
 
 /**

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -17,6 +17,7 @@ import {
 	IRun,
 	IRunData,
 	ITaskData,
+	NodeCredentialTestRequest,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
@@ -141,7 +142,7 @@ export interface IRestApi {
 	getWorkflows(filter?: object): Promise<IWorkflowShortResponse[]>;
 	getWorkflowFromUrl(url: string): Promise<IWorkflowDb>;
 	createNewCredentials(sendData: ICredentialsDecrypted): Promise<ICredentialsResponse>;
-	testCredential(sendData: ICredentialsDecrypted): Promise<ICredentialsResponse>;
+	testCredential(sendData: NodeCredentialTestRequest): Promise<ICredentialsResponse>;
 	deleteCredentials(id: string): Promise<void>;
 	updateCredentials(id: string, data: ICredentialsDecrypted): Promise<ICredentialsResponse>;
 	getAllCredentials(filter?: object): Promise<ICredentialsResponse[]>;

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -141,6 +141,7 @@ export interface IRestApi {
 	getWorkflows(filter?: object): Promise<IWorkflowShortResponse[]>;
 	getWorkflowFromUrl(url: string): Promise<IWorkflowDb>;
 	createNewCredentials(sendData: ICredentialsDecrypted): Promise<ICredentialsResponse>;
+	testCredential(sendData: ICredentialsDecrypted): Promise<ICredentialsResponse>;
 	deleteCredentials(id: string): Promise<void>;
 	updateCredentials(id: string, data: ICredentialsDecrypted): Promise<ICredentialsResponse>;
 	getAllCredentials(filter?: object): Promise<ICredentialsResponse[]>;

--- a/packages/editor-ui/src/components/CredentialsInput.vue
+++ b/packages/editor-ui/src/components/CredentialsInput.vue
@@ -144,6 +144,7 @@ import {
 	INodeParameters,
 	INodeProperties,
 	INodeTypeDescription,
+	NodeCredentialTestRequest,
 	NodeHelpers,
 } from 'n8n-workflow';
 
@@ -237,6 +238,10 @@ export default mixins(
 			// eslint-disable-next-line no-console
 			console.log(this.credentialTypeData.name);
 			if (['oAuth1Api', 'oAuth2Api'].includes(this.credentialTypeData.name)) {
+				return false;
+			}
+			const types = this.parentTypes(this.credentialTypeData.name);
+			if(types.includes('oAuth1Api') || types.includes('oAuth2Api')) {
 				return false;
 			}
 			// TODO: Properly detect if credential is testable.
@@ -462,9 +467,13 @@ export default mixins(
 				data: NodeHelpers.getNodeParameters(this.credentialTypeData.properties as INodeProperties[], this.propertyValue as INodeParameters, false, false),
 			} as ICredentialsDecrypted;
 
+			const testRequest = {
+				credentials: newCredentials,
+			} as NodeCredentialTestRequest;
+
 			let result;
 			try {
-				result = await this.restApi().testCredential(newCredentials);
+				result = await this.restApi().testCredential(testRequest);
 			} catch (error) {
 				this.$showError(error, 'Problem Creating Credentials', 'There was a problem creating the credentials:');
 				return 'null';

--- a/packages/editor-ui/src/components/CredentialsInput.vue
+++ b/packages/editor-ui/src/components/CredentialsInput.vue
@@ -249,10 +249,7 @@ export default mixins(
 				if (node.credentials) {
 					// Returns a list of nodes that can test this credentials
 					const eligibleTesters = node.credentials.filter(credential => {
-						if (credential.name === this.credentialTypeData.name && credential.testedBy) {
-							return true;
-						}
-						return false;
+						return credential.name === this.credentialTypeData.name && credential.testedBy;
 					});
 					// If we have any node that can test, return true.
 					if (eligibleTesters.length) {

--- a/packages/editor-ui/src/components/CredentialsInput.vue
+++ b/packages/editor-ui/src/components/CredentialsInput.vue
@@ -235,8 +235,6 @@ export default mixins(
 			return this.credentialDataTemp;
 		},
 		isCredentialTestable (): boolean {
-			// eslint-disable-next-line no-console
-			console.log(this.credentialTypeData.name);
 			if (['oAuth1Api', 'oAuth2Api'].includes(this.credentialTypeData.name)) {
 				return false;
 			}
@@ -244,8 +242,27 @@ export default mixins(
 			if(types.includes('oAuth1Api') || types.includes('oAuth2Api')) {
 				return false;
 			}
-			// TODO: Properly detect if credential is testable.
-			return true;
+
+			// Find all nodes that use this credential.
+			const allNodes = this.$store.getters.allNodeTypes as INodeTypeDescription[];
+			const nodesThatCanTest = allNodes.filter(node => {
+				if (node.credentials) {
+					// Returns a list of nodes that can test this credentials
+					const eligibleTesters = node.credentials.filter(credential => {
+						if (credential.name === this.credentialTypeData.name && credential.testedBy) {
+							return true;
+						}
+						return false;
+					});
+					// If we have any node that can test, return true.
+					if (eligibleTesters.length) {
+						return true;
+					}
+				}
+				return false;
+			});
+			// Means we found at least one node that could test this credential
+			return !!nodesThatCanTest.length;
 			
 		},
 		isGoogleOAuthType (): boolean {

--- a/packages/editor-ui/src/components/mixins/restApi.ts
+++ b/packages/editor-ui/src/components/mixins/restApi.ts
@@ -158,6 +158,10 @@ export const restApi = Vue.extend({
 					return self.restApi().makeRestApiRequest('POST', `/credentials`, sendData);
 				},
 
+				testCredential: (sendData: ICredentialsDecrypted): Promise<ICredentialsResponse> => {
+					return self.restApi().makeRestApiRequest('POST', `/credentials-test`, sendData);
+				},
+
 				// Deletes a credentials
 				deleteCredentials: (id: string): Promise<void> => {
 					return self.restApi().makeRestApiRequest('DELETE', `/credentials/${id}`);

--- a/packages/editor-ui/src/components/mixins/restApi.ts
+++ b/packages/editor-ui/src/components/mixins/restApi.ts
@@ -29,6 +29,7 @@ import {
 	INodeParameters,
 	INodePropertyOptions,
 	INodeTypeDescription,
+	NodeCredentialTestRequest,
 } from 'n8n-workflow';
 import { makeRestApiRequest } from '@/api/helpers';
 
@@ -158,7 +159,7 @@ export const restApi = Vue.extend({
 					return self.restApi().makeRestApiRequest('POST', `/credentials`, sendData);
 				},
 
-				testCredential: (sendData: ICredentialsDecrypted): Promise<ICredentialsResponse> => {
+				testCredential: (sendData: NodeCredentialTestRequest): Promise<ICredentialsResponse> => {
 					return self.restApi().makeRestApiRequest('POST', `/credentials-test`, sendData);
 				},
 

--- a/packages/editor-ui/src/plugins/icons.ts
+++ b/packages/editor-ui/src/plugins/icons.ts
@@ -9,6 +9,7 @@ import {
 	faArrowLeft,
 	faArrowRight,
 	faAt,
+	faBolt,
 	faBook,
 	faBug,
 	faCalendar,
@@ -42,6 +43,7 @@ import {
 	faFilePdf,
 	faFolderOpen,
 	faGift,
+	faHandPointUp,
 	faHdd,
 	faHome,
 	faHourglass,
@@ -93,6 +95,7 @@ library.add(faAngleUp);
 library.add(faArrowLeft);
 library.add(faArrowRight);
 library.add(faAt);
+library.add(faBolt);
 library.add(faBook);
 library.add(faBug);
 library.add(faCalendar);
@@ -126,6 +129,7 @@ library.add(faFileImport);
 library.add(faFilePdf);
 library.add(faFolderOpen);
 library.add(faGift);
+library.add(faHandPointUp);
 library.add(faHdd);
 library.add(faHome);
 library.add(faHourglass);

--- a/packages/nodes-base/credentials/GoogleApi.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleApi.credentials.ts
@@ -15,6 +15,7 @@ export class GoogleApi implements ICredentialType {
 			type: 'string',
 			default: '',
 			description: 'The Google Service account similar to user-808@project.iam.gserviceaccount.com.',
+			required: true,
 
 		},
 		{
@@ -23,6 +24,7 @@ export class GoogleApi implements ICredentialType {
 			type: 'string',
 			default: '',
 			description: 'Use the multiline editor. Make sure there are exactly 3 lines.<br />-----BEGIN PRIVATE KEY-----<br />KEY IN A SINGLE LINE<br />-----END PRIVATE KEY-----',
+			required: true,
 		},
 		{
 			displayName: ' Impersonate a User',

--- a/packages/nodes-base/credentials/SlackApi.credentials.ts
+++ b/packages/nodes-base/credentials/SlackApi.credentials.ts
@@ -14,6 +14,7 @@ export class SlackApi implements ICredentialType {
 			name: 'accessToken',
 			type: 'string',
 			default: '',
+			required: true,
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Google/Sheet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GenericFunctions.ts
@@ -9,6 +9,8 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialDataDecryptedObject,
+	ICredentialTestFunctions,
 	IDataObject, NodeApiError, NodeOperationError,
 } from 'n8n-workflow';
 
@@ -43,7 +45,7 @@ export async function googleApiRequest(this: IExecuteFunctions | IExecuteSingleF
 				throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 			}
 
-			const { access_token } = await getAccessToken.call(this, credentials as IDataObject);
+			const { access_token } = await getAccessToken.call(this, credentials as ICredentialDataDecryptedObject);
 
 			options.headers!.Authorization = `Bearer ${access_token}`;
 			//@ts-ignore
@@ -80,7 +82,7 @@ export async function googleApiRequestAllItems(this: IExecuteFunctions | ILoadOp
 	return returnData;
 }
 
-function getAccessToken(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, credentials: IDataObject): Promise<IDataObject> {
+export function getAccessToken(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | ICredentialTestFunctions, credentials: ICredentialDataDecryptedObject): Promise<IDataObject> {
 	//https://developers.google.com/identity/protocols/oauth2/service-account#httprest
 
 	const scopes = [

--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheets.node.ts
@@ -4,12 +4,15 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
 	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
+	NodeCredentialTestResult,
 	NodeOperationError,
 } from 'n8n-workflow';
 
@@ -23,6 +26,7 @@ import {
 } from './GoogleSheet';
 
 import {
+	getAccessToken,
 	googleApiRequest,
 	hexToRgb,
 } from './GenericFunctions';
@@ -53,6 +57,7 @@ export class GoogleSheets implements INodeType {
 						],
 					},
 				},
+				testedBy: 'googleApiCredentialTest',
 			},
 			{
 				name: 'googleSheetsOAuth2Api',
@@ -1004,6 +1009,30 @@ export class GoogleSheets implements INodeType {
 				}
 
 				return returnData;
+			},
+		},
+		credentialTest: {
+			async googleApiCredentialTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> {
+				try {
+					const tokenRequest = await getAccessToken.call(this, credential.data!);
+					if (!tokenRequest.access_token) {
+						return {
+							status: 'Error',
+							message: 'Could not generate a token from your private key.',
+						};
+					}
+				} catch(err) {
+					return {
+						status: 'Error',
+						message: `Private key validation failed: ${err.message}`,
+					};
+				}
+
+				return {
+					status: 'OK',
+					message: 'Connection successful!',
+				};
+				
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -5,6 +5,7 @@ import {
 
 import {
 	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
@@ -280,12 +281,37 @@ export class Slack implements INodeType {
 			},
 		},
 		credentialTest: {
-			testSlackTokenAuth: async (credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> => {
-				const result = {
+			async testSlackTokenAuth(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> {
+
+				let options = {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json; charset=utf-8',
+						Authorization: `Bearer ${credential.data!.accessToken}`,
+					},
+					uri: 'https://slack.com/api/users.profile.get',
+					json: true,
+				};
+
+				try {
+					const response = await this.helpers.request(options);
+					if (!response.ok) {
+						return {
+							status: 'Error',
+							message: `Unable to authenticate: ${response.error}`,
+						};
+					}
+				} catch(err) {
+					return {
+						status: 'Error',
+						message: `Unable to authenticate: ${err.message}`,
+					};
+				}
+
+				return {
 					status: 'OK',
 					message: 'Connection successful!',
-				} as NodeCredentialTestResult;
-				return Promise.resolve(result);
+				};
 			}
 		}
 	};

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -4,12 +4,14 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialsDecrypted,
 	IDataObject,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
 	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
+	NodeCredentialTestResult,
 	NodeOperationError,
 } from 'n8n-workflow';
 
@@ -126,6 +128,7 @@ export class Slack implements INodeType {
 						],
 					},
 				},
+				testedBy: 'testSlackTokenAuth',
 			},
 			{
 				name: 'slackOAuth2Api',
@@ -276,6 +279,15 @@ export class Slack implements INodeType {
 				return returnData;
 			},
 		},
+		credentialTest: {
+			testSlackTokenAuth: async (credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> => {
+				const result = {
+					status: 'OK',
+					message: 'Connection successful!',
+				} as NodeCredentialTestResult;
+				return Promise.resolve(result);
+			}
+		}
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -298,13 +298,13 @@ export class Slack implements INodeType {
 					if (!response.ok) {
 						return {
 							status: 'Error',
-							message: `Unable to authenticate: ${response.error}`,
+							message: `${response.error}`,
 						};
 					}
 				} catch(err) {
 					return {
 						status: 'Error',
-						message: `Unable to authenticate: ${err.message}`,
+						message: `${err.message}`,
 					};
 				}
 

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -283,7 +283,7 @@ export class Slack implements INodeType {
 		credentialTest: {
 			async testSlackTokenAuth(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> {
 
-				let options = {
+				const options = {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json; charset=utf-8',
@@ -312,8 +312,8 @@ export class Slack implements INodeType {
 					status: 'OK',
 					message: 'Connection successful!',
 				};
-			}
-		}
+			},
+		},
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -3,10 +3,13 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
+	NodeCredentialTestResult,
 	NodeOperationError,
 } from 'n8n-workflow';
 
@@ -35,6 +38,7 @@ export class Telegram implements INodeType {
 			{
 				name: 'telegramApi',
 				required: true,
+				testedBy: 'telegramBotTest',
 			},
 		],
 		properties: [
@@ -1735,6 +1739,38 @@ export class Telegram implements INodeType {
 
 		],
 	};
+
+	methods = {
+		credentialTest: {
+			async telegramBotTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> {
+				const credentials = credential.data;
+				const options = {
+					uri: `https://api.telegram.org/bot${credentials!.accessToken}/getMe`,
+					json: true,
+				};
+				try {
+					const response = await this.helpers.request(options);
+					if (!response.ok) {
+						return {
+							status: 'Error',
+							message: 'Token is not valid.',
+						}
+					}
+				} catch(err) {
+					return {
+						status: 'Error',
+						message: `Token is not valid; ${err.message}`,
+					}
+				}
+
+				return {
+					status: 'OK',
+					message: 'Authentication successful!',
+				}
+				
+			}
+		}
+	}
 
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1754,23 +1754,23 @@ export class Telegram implements INodeType {
 						return {
 							status: 'Error',
 							message: 'Token is not valid.',
-						}
+						};
 					}
 				} catch(err) {
 					return {
 						status: 'Error',
 						message: `Token is not valid; ${err.message}`,
-					}
+					};
 				}
 
 				return {
 					status: 'OK',
 					message: 'Authentication successful!',
-				}
+				};
 				
-			}
-		}
-	}
+			},
+		},
+	};
 
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
+++ b/packages/nodes-base/nodes/Typeform/TypeformTrigger.node.ts
@@ -4,12 +4,15 @@ import {
 } from 'n8n-core';
 
 import {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	INodeType,
 	INodeTypeDescription,
 	IWebhookResponseData,
 	JsonObject,
 	NodeApiError,
+	NodeCredentialTestResult,
 } from 'n8n-workflow';
 
 import {
@@ -46,6 +49,7 @@ export class TypeformTrigger implements INodeType {
 						],
 					},
 				},
+				testedBy: 'testTypeformTokenAuth',
 			},
 			{
 				name: 'typeformOAuth2Api',
@@ -117,6 +121,38 @@ export class TypeformTrigger implements INodeType {
 	methods = {
 		loadOptions: {
 			getForms,
+		},
+		credentialTest: {
+			async testTypeformTokenAuth(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<NodeCredentialTestResult> {
+				const credentials = credential.data;
+
+				const options = {
+					headers: {
+						authorization: `bearer ${credentials!.accessToken}`,
+					},
+					uri: 'https://api.typeform.com/workspaces',
+					json: true,
+				};
+				try {
+					const response = await this.helpers.request(options);
+					if (!response.items) {
+						return {
+							status: 'Error',
+							message: 'Token is not valid.',
+						};
+					}
+				} catch(err) {
+					return {
+						status: 'Error',
+						message: `Token is not valid; ${err.message}`,
+					};
+				}
+
+				return {
+					status: 'OK',
+					message: 'Authentication successful!',
+				};
+			},
 		},
 	};
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -638,6 +638,11 @@ export interface NodeCredentialTestResult {
 	message: string;
 }
 
+export interface NodeCredentialTestRequest {
+	testWithNode?: string; // node name i.e. slack
+	credentials: ICredentialsDecrypted;
+}
+
 export type WebhookSetupMethodNames = 'checkExists' | 'create' | 'delete';
 
 export interface IWebhookSetupMethods {

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -342,6 +342,12 @@ export interface IExecuteWorkflowInfo {
 	id?: string;
 }
 
+export interface ICredentialTestFunctions {
+	helpers: {
+		[key: string]: (...args: any[]) => any;
+	};
+}
+
 export interface ILoadOptionsFunctions {
 	getCredentials(type: string): Promise<ICredentialDataDecryptedObject | undefined>;
 	getNode(): INode;
@@ -617,6 +623,7 @@ export interface INodeType {
 		credentialTest?: {
 			// Contains a group of functins that test credentials.
 			[functionName: string]: (
+				this: ICredentialTestFunctions,
 				credential: ICredentialsDecrypted,
 			) => Promise<NodeCredentialTestResult>;
 		};

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -614,10 +614,21 @@ export interface INodeType {
 		loadOptions?: {
 			[key: string]: (this: ILoadOptionsFunctions) => Promise<INodePropertyOptions[]>;
 		};
+		credentialTest?: {
+			// Contains a group of functins that test credentials.
+			[functionName: string]: (
+				credential: ICredentialsDecrypted,
+			) => Promise<NodeCredentialTestResult>;
+		};
 	};
 	webhookMethods?: {
 		[key: string]: IWebhookSetupMethods;
 	};
+}
+
+export interface NodeCredentialTestResult {
+	status: 'OK' | 'Error';
+	message: string;
 }
 
 export type WebhookSetupMethodNames = 'checkExists' | 'create' | 'delete';
@@ -633,6 +644,7 @@ export interface INodeCredentialDescription {
 	name: string;
 	required?: boolean;
 	displayOptions?: IDisplayOptions;
+	testedBy?: string; // Name of a function inside `loadOptions.credentialTest`
 }
 
 export type INodeIssueTypes = 'credentials' | 'execution' | 'parameters' | 'typeUnknown';

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -639,7 +639,7 @@ export interface NodeCredentialTestResult {
 }
 
 export interface NodeCredentialTestRequest {
-	testWithNode?: string; // node name i.e. slack
+	nodeToTestWith?: string; // node name i.e. slack
 	credentials: ICredentialsDecrypted;
 }
 


### PR DESCRIPTION
This PR relates to ticket N8N-2408 and creates a few important steps:

- Improvements to node interface, stating that a given node can test a few credentials
- A new endpoint that allows you to send credentials for testing. Optionally, you can also specify a node for testing a given credential
- A mock for the frontend with a "Test" button and utility functions for testing discoverability