### PR TITLE
Add execution ID to queue processes for clarification

### DIFF
--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -357,7 +357,7 @@ export class WorkflowRunner {
 		try {
 			job = await this.jobQueue.add(jobData, jobOptions);
 
-			console.log(`Started with ID: ${job.id.toString()}`);
+			console.log(`Started with job ID: ${job.id.toString()}; execution ID: ${restartExecutionId}`);
 
 			hooks = WorkflowExecuteAdditionalData.getWorkflowHooksWorkerMain(
 				data.executionMode,

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -357,7 +357,7 @@ export class WorkflowRunner {
 		try {
 			job = await this.jobQueue.add(jobData, jobOptions);
 
-			console.log(`Started with job ID: ${job.id.toString()}; execution ID: ${restartExecutionId}`);
+			console.log(`Started with job ID: ${job.id.toString()} (Execution ID: ${executionId})`);
 
 			hooks = WorkflowExecuteAdditionalData.getWorkflowHooksWorkerMain(
 				data.executionMode,


### PR DESCRIPTION
Added clarification information so that it's easier to understand what is happening on queue mode.

This PR relates to https://community.n8n.io/t/main-proccess-randomly-starting-webhook-jobs/7560/3