### PR TITLE
Fix Istanbul timezone label

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -2460,6 +2460,7 @@ class App {
 		this.app.get(
 			`/${this.restEndpoint}/options/timezones`,
 			ResponseHelper.send(async (req: express.Request, res: express.Response): Promise<object> => {
+				timezones['Europe/Istanbul'] = '(GMT+03:00) Istanbul';
 				return timezones;
 			}),
 		);


### PR DESCRIPTION
This PR fixes the Istanbul timezone label, which is [hardcoded to a wrong value](https://github.com/sanohin/google-timezones-json/blob/bc6b8f5e50a4174626182f6aad4be33bea25d15e/timezones.json#L145) in the underlying lib. See [community post](https://community.n8n.io/t/istanbul-timezone-is-incorrect/7633).