### PR TITLE
Throw Error Node

### DIFF
--- a/packages/nodes-base/nodes/ThrowError.node.json
+++ b/packages/nodes-base/nodes/ThrowError.node.json
@@ -1,0 +1,25 @@
+{
+	"node": "n8n-nodes-base.throw",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": [
+		"Core Nodes"
+	],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/nodes/n8n-nodes-base.throw/"
+			}
+		]
+	},
+	"alias": [
+		"error",
+		"throw",
+		"exception"
+	],
+	"subcategories": {
+		"Core Nodes": [
+			"Flow"
+		]
+	}
+}

--- a/packages/nodes-base/nodes/ThrowError.node.ts
+++ b/packages/nodes-base/nodes/ThrowError.node.ts
@@ -1,0 +1,39 @@
+import { IExecuteFunctions } from 'n8n-core';
+import {
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+
+
+export class ThrowError implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Throw Error',
+		name: 'throw',
+		icon: 'fa:exclamation-triangle',
+		group: ['input'],
+		version: 1,
+		description: 'Throws an Error in the Workflow',
+		maxNodes: 1,
+		defaults: {
+			name: 'Throw Error',
+			color: '#ff0000',
+		},
+		inputs: ['main'],
+		outputs: [],
+		properties: [{
+			displayName: 'Error Message',
+			name: 'error_message',
+			type: 'string',
+			default: 'An error occured',
+			description: 'The message to pass to the Error',
+		}
+		],
+	};
+
+	execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const message = this.getNodeParameter('error_message', 0) as string;
+
+		throw new Error(message);
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -527,6 +527,7 @@
       "dist/nodes/TheHive/TheHive.node.js",
       "dist/nodes/TheHive/TheHiveTrigger.node.js",
       "dist/nodes/TimescaleDb/TimescaleDb.node.js",
+      "dist/nodes/ThrowError.node.js",
       "dist/nodes/Todoist/Todoist.node.js",
       "dist/nodes/Toggl/TogglTrigger.node.js",
       "dist/nodes/TravisCi/TravisCi.node.js",


### PR DESCRIPTION
I was searching a way to throw Errors from n8n if some information in the workflow is missing or is wrong. 

So this realy small Node can help to throw a User Exception and trigger eventual set ErrorWorkflows.

Hope it is helpfull for someone.

To be done: Document the Node and change the documentation of the ErrorTrigger (https://docs.n8n.io/nodes/n8n-nodes-base.errorTrigger/#how-do-we-call-the-error-workflow-manually)