### PR TITLE
Correct build command call to tmp-promise to create a temporarily file

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -46,8 +46,8 @@ export async function createCustomTsconfig() {
 	tsConfig.include = newIncludeFiles;
 
 	// Write new custom tsconfig file
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	const { fd, path, cleanup } = await file({ dir: process.cwd() });
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call @typescript-eslint/no-unsafe-any
+	const { fd, path, cleanup } = await file();
 	await fsWriteAsync(fd, Buffer.from(JSON.stringify(tsConfig, null, 2), 'utf8'));
 
 	return {


### PR DESCRIPTION
Invoking `file({ 'dir': process.cwd() })` will file due to restrictions on `tmp-promise` that force `dir` to be relative to `/tmp`, using the current working directory (which usually is a project folder, not in `/tmp`), fails triggering this assert check. By removing the current directory option from the call, the build command works properly.

Sample output with the error:
```
~/tmp/n8n-tests ❯ yarn run n8n-node-dev build
yarn run v1.22.10
$ /home/omab/tmp/n8n-tests/node_modules/.bin/n8n-node-dev build

Build credentials and nodes
=========================

GOT ERROR: "dir option must be relative to "/tmp", found "/home/omab/tmp/n8n-tests"."
====================================
Error: dir option must be relative to "/tmp", found "/home/omab/tmp/n8n-tests".
    at _assertIsRelative (/home/omab/tmp/n8n-tests/node_modules/tmp/lib/tmp.js:599:13)
    at _assertAndSanitizeOptions (/home/omab/tmp/n8n-tests/node_modules/tmp/lib/tmp.js:513:5)
    at tmpName (/home/omab/tmp/n8n-tests/node_modules/tmp/lib/tmp.js:65:5)
    at Object.file (/home/omab/tmp/n8n-tests/node_modules/tmp/lib/tmp.js:133:3)
    at /home/omab/tmp/n8n-tests/node_modules/tmp-promise/index.js:9:7
    at internal/util.js:308:30
    at new Promise (<anonymous>)
    at internal/util.js:307:12
    at Object.module.exports.file (/home/omab/tmp/n8n-tests/node_modules/tmp-promise/index.js:13:42)
    at createCustomTsconfig (/home/omab/tmp/n8n-tests/node_modules/n8n-node-dev/dist/src/Build.js:23:55)
Done in 0.44s.
``` 

With the proposed fix:

```
~/tmp/n8n-tests ❯ yarn run n8n-node-dev build
yarn run v1.22.10
$ /home/omab/tmp/n8n-tests/node_modules/.bin/n8n-node-dev build

Build credentials and nodes
=========================
The nodes got build and saved into the following folder:
/home/omab/.n8n/custom
Done in 2.36s.
```

This was on a fresh install that pulled `tmp-promise@3.0.2` and `n8n-node-dev@0.22.0`.