### PR TITLE
Pin libphonenumber in /cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,6 +106,7 @@
     "json-diff": "^0.5.4",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "~1.12.1",
+    "libphonenumber-js": "1.9.7",
     "localtunnel": "^2.0.0",
     "lodash.get": "^4.4.2",
     "mysql2": "~2.3.0",


### PR DESCRIPTION
Pinned `libphonenumber` (transitive dependency of `class-validator`) because its latest version fails to transpile, breaking the build.

@janober 