### PR TITLE
Unpin libphonenumber-js

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,7 +106,6 @@
     "json-diff": "^0.5.4",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "~1.12.1",
-    "libphonenumber-js": "1.9.7",
     "localtunnel": "^2.0.0",
     "lodash.get": "^4.4.2",
     "mysql2": "~2.3.0",


### PR DESCRIPTION
#2193 pinned an older version of `libphonenumber-js` (transitive dependency of `class-validator`) because v1.9.32 had a typo that crashed the TS compiler. This was later [resolved in v1.9.34](https://gitlab.com/catamphetamine/libphonenumber-js/-/issues/48). The project builds again with the latest so this dep can be unpinned.