### PR TITLE
fix credentials modal spacing issue when no tooltip

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -53,7 +53,7 @@
 		/>
 
 		<CredentialInputs
-			v-if="credentialType && credentialProperties.length"
+			v-if="credentialType"
 			:credentialData="credentialData"
 			:credentialProperties="credentialProperties"
 			:documentationUrl="documentationUrl"

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -53,7 +53,7 @@
 		/>
 
 		<CredentialInputs
-			v-if="credentialType"
+			v-if="credentialType && credentialProperties.length"
 			:credentialData="credentialData"
 			:credentialProperties="credentialProperties"
 			:documentationUrl="documentationUrl"

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
@@ -1,5 +1,5 @@
 <template>
-	<div @keydown.stop :class="$style.container">
+	<div @keydown.stop :class="$style.container" v-if="credentialProperties.length">
 		<div v-for="parameter in credentialProperties" :key="parameter.name">
 			<ParameterInputExpanded
 				:parameter="parameter"


### PR DESCRIPTION
Fix issue with spacing when there are no inputs
<img width="1077" alt="82f0e30b-ce34-4d03-aa8d-d2d414008bfc" src="https://user-images.githubusercontent.com/4711238/134300668-89e131e4-bac3-4614-87dd-de900079a870.png">
e 