### PR TITLE
Introduce virtual host setting to override inferred host

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -364,6 +364,12 @@ const config = convict({
 		env: 'N8N_PROTOCOL',
 		doc: 'HTTP Protocol via which n8n can be reached',
 	},
+	virtualHost: {
+		doc: 'N8N host override',
+		format: String,
+		default: '',
+		env: 'N8N_VIRTUAL_HOST',
+	},
 	ssl_key: {
 		format: String,
 		default: '',

--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -27,10 +27,16 @@ let versionCache: IPackageVersions | undefined;
  * @returns {string}
  */
 export function getBaseUrl(): string {
+	const virtualHost = config.get('virtualHost');
+	const path = config.get('path');
+
+	if (virtualHost) {
+		return `${virtualHost}${path}`;
+	}
+
 	const protocol = config.get('protocol');
 	const host = config.get('host');
 	const port = config.get('port');
-	const path = config.get('path');
 
 	if ((protocol === 'http' && port === 80) || (protocol === 'https' && port === 443)) {
 		return `${protocol}://${host}${path}`;


### PR DESCRIPTION
This PR introduces the `virtualHost` setting that can be defined through `N8N_VIRTUAL_HOST` environment var.

With this setting it's possible to override the inferred URL generated from `protocol`, `host` and `port` settings which are problematic to use when N8N sits behind a proxy or load-balancer, specially in environments ran with Docker where the official image can't bind on ports below 1024 due to privileges (which is OK IMO).

Another option to consider is to propagate and respect the `X-Forwarded-for` header and family (proto, etc), that seems more involved as a change today.