### PR TITLE
Add .npmrc for building with npm v7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
The project does not build with npm v7, which [blocks package installation](https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies) when there is a dependency conflict. This is a source of friction for new users.

This `.npmrc` overrides that behavior. 

To test:

```sh
npm i npm@latest -g
git reset --hard && git clean -dffx
lerna clean -y && lerna bootstrap --hoist && npm run build
```

The build should succeed with npm v7.

**Warning:** `git clean` with `-x` will remove any ignored files, to ensure a full re-install. [Do a dry run first](https://git-scm.com/docs/git-clean#Documentation/git-clean.txt---dry-run) if you have important ignored files.

To close #1693