### PR TITLE
Fixed n8n's behavior for empty response bodies

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -387,15 +387,31 @@ async function proxyRequestToAxios(
 		axios(axiosConfig)
 			.then((response) => {
 				if (configObject.resolveWithFullResponse === true) {
+					let body = response.data;
+					if (response.data === '') {
+						if (axiosConfig.responseType === 'arraybuffer') {
+							body = Buffer.alloc(0);
+						} else {
+							body = undefined;
+						}
+					}
 					resolve({
-						body: response.data === '' ? undefined : response.data,
+						body,
 						headers: response.headers,
 						statusCode: response.status,
 						statusMessage: response.statusText,
 						request: response.request,
 					});
 				} else {
-					resolve(response.data === '' ? undefined : response.data);
+					let body = response.data;
+					if (response.data === '') {
+						if (axiosConfig.responseType === 'arraybuffer') {
+							body = Buffer.alloc(0);
+						} else {
+							body = undefined;
+						}
+					}
+					resolve(body);
 				}
 			})
 			.catch((error) => {

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -388,14 +388,14 @@ async function proxyRequestToAxios(
 			.then((response) => {
 				if (configObject.resolveWithFullResponse === true) {
 					resolve({
-						body: response.data,
+						body: response.data === '' ? undefined : response.data,
 						headers: response.headers,
 						statusCode: response.status,
 						statusMessage: response.statusText,
 						request: response.request,
 					});
 				} else {
-					resolve(response.data);
+					resolve(response.data === '' ? undefined : response.data);
 				}
 			})
 			.catch((error) => {

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -896,7 +896,11 @@ export class WorkflowExecute {
 					// the `error` property.
 					for (const execution of nodeSuccessData!) {
 						for (const lineResult of execution) {
-							if (lineResult.json.$error !== undefined && lineResult.json.$json !== undefined) {
+							if (
+								lineResult.json !== undefined &&
+								lineResult.json.$error !== undefined &&
+								lineResult.json.$json !== undefined
+							) {
 								lineResult.error = lineResult.json.$error as NodeApiError | NodeOperationError;
 								lineResult.json = {
 									error: (lineResult.json.$error as NodeApiError | NodeOperationError).message,


### PR DESCRIPTION
The deprecated request library used to convert empty response bodies to `undefined`.

Axios simply returns the empty string, so we have to manually change this to undefined.

Also because of this, the error handling part can break as now the `json` property can be an undefined object.