### PR TITLE
WooCommerce - Fixed wrong postcode field name in orders

### DIFF
--- a/packages/nodes-base/nodes/WooCommerce/OrderDescription.ts
+++ b/packages/nodes-base/nodes/WooCommerce/OrderDescription.ts
@@ -232,7 +232,7 @@ export const orderFields = [
 					},
 					{
 						displayName: 'Postal Code',
-						name: 'postalCode',
+						name: 'postcode',
 						type: 'string',
 						default: '',
 					},
@@ -645,7 +645,7 @@ export const orderFields = [
 					},
 					{
 						displayName: 'Postal Code',
-						name: 'postalCode',
+						name: 'postcode',
 						type: 'string',
 						default: '',
 					},


### PR DESCRIPTION
The WC REST-API expects the ZIP code/post code to be submitted in a field named 'postcode'. The WooCommerce node used the field name 'postal_code'.