### PR TITLE
Fixed refresh token to work correctly with Axios

### DIFF
--- a/packages/core/src/Interfaces.ts
+++ b/packages/core/src/Interfaces.ts
@@ -106,11 +106,7 @@ export interface IPollFunctions extends IPollFunctionsBase {
 }
 
 export interface IResponseError extends Error {
-	status?: number; // this is how the request library returns
-	response?: {
-		// this is how Axios returns
-		status: number;
-	};
+	statusCode?: number;
 }
 
 export interface ITriggerFunctions extends ITriggerFunctionsBase {

--- a/packages/core/src/Interfaces.ts
+++ b/packages/core/src/Interfaces.ts
@@ -106,7 +106,11 @@ export interface IPollFunctions extends IPollFunctionsBase {
 }
 
 export interface IResponseError extends Error {
-	statusCode?: number;
+	status?: number; // this is how the request library returns
+	response?: {
+		// this is how Axios returns
+		status: number;
+	};
 }
 
 export interface ITriggerFunctions extends ITriggerFunctionsBase {

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -673,7 +673,7 @@ export async function requestOAuth2(
 				? 401
 				: oAuth2Options?.tokenExpiredStatusCode;
 
-		if (error.statusCode === statusCodeReturned) {
+		if (error.response?.status === statusCodeReturned || error.status === statusCodeReturned) {
 			// Token is probably not valid anymore. So try refresh it.
 
 			const tokenRefreshOptions: IDataObject = {};

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -415,6 +415,7 @@ async function proxyRequestToAxios(
 				}
 			})
 			.catch((error) => {
+				error.statusCode = error.response.status;
 				reject(error);
 			});
 	});
@@ -673,7 +674,7 @@ export async function requestOAuth2(
 				? 401
 				: oAuth2Options?.tokenExpiredStatusCode;
 
-		if (error.response?.status === statusCodeReturned || error.status === statusCodeReturned) {
+		if (error.statusCode === statusCodeReturned) {
 			// Token is probably not valid anymore. So try refresh it.
 
 			const tokenRefreshOptions: IDataObject = {};


### PR DESCRIPTION
Making n8n correctly identify when an OAuth request fails due to refresh token expiration and refresh the token accordingly.