### PR TITLE
Fix `TypeError: s is undefined` in nodes panel text selection

### DIFF
--- a/packages/editor-ui/src/components/NodeCreator/MainPanel.vue
+++ b/packages/editor-ui/src/components/NodeCreator/MainPanel.vue
@@ -214,11 +214,11 @@ export default mixins(externalHooks).extend({
 				this.activeIndex = Math.max(this.activeIndex, 0);
 			} else if (e.key === 'Enter' && activeNodeType) {
 				this.selected(activeNodeType);
-			} else if (e.key === 'ArrowRight' && activeNodeType.type === 'subcategory') {
+			} else if (e.key === 'ArrowRight' && activeNodeType && activeNodeType.type === 'subcategory') {
 				this.selected(activeNodeType);
-			} else if (e.key === 'ArrowRight' && activeNodeType.type === 'category' && !activeNodeType.properties.expanded) {
+			} else if (e.key === 'ArrowRight' && activeNodeType && activeNodeType.type === 'category' && !activeNodeType.properties.expanded) {
 				this.selected(activeNodeType);
-			} else if (e.key === 'ArrowLeft' && activeNodeType.type === 'category' && activeNodeType.properties.expanded) {
+			} else if (e.key === 'ArrowLeft' && activeNodeType && activeNodeType.type === 'category' && activeNodeType.properties.expanded) {
 				this.selected(activeNodeType);
 			}
 		},


### PR DESCRIPTION
To fix the console error `TypeError: s is undefined` triggered in latest FF when typing into the nodes panel trigger and selecting the text with shift+cmd+left and shift+cmd+right.