### PR TITLE
Fix RAW request issue

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -337,6 +337,7 @@ async function parseRequestObject(requestObject: IDataObject) {
 		axiosConfig.headers = Object.assign(axiosConfig.headers || {}, { accept: '*/*' });
 	}
 	if (
+		requestObject.json !== false &&
 		axiosConfig.data !== undefined &&
 		!(axiosConfig.data instanceof Buffer) &&
 		!allHeaders.some((headerKey) => headerKey.toLowerCase() === 'content-type')


### PR DESCRIPTION
Fixes the issue that if non-JSON requests break as always the JSON headers get added even if they should not.

Related to this community topic:
https://community.n8n.io/t/http-post-now-has-error-after-upgrade-to-1-141-1/8254/13