### PR TITLE
Zendesk updates

### DIFF
--- a/packages/nodes-base/nodes/Zendesk/SuspendedTicketDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/SuspendedTicketDescription.ts
@@ -1,0 +1,211 @@
+import {
+	INodeProperties,
+ } from 'n8n-workflow';
+
+export const suspendedTicketOperations = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'suspended',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a suspended ticket',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a suspended ticket',
+			},
+			{
+				name: 'Get All',
+				value: 'getAll',
+				description: 'Get all suspended tickets',
+			},
+			{
+				name: 'Recover',
+				value: 'recover',
+				description: 'Recover a suspended ticket',
+			},
+		],
+		default: 'get',
+		description: 'The operation to perform.',
+	},
+] as INodeProperties[];
+
+export const suspendedTicketFields = [
+/* -------------------------------------------------------------------------- */
+/*                                 suspended:get                              */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Suspended Ticket ID',
+		name: 'id',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'suspended',
+				],
+				operation: [
+					'get',
+				],
+			},
+		},
+		description: 'Suspended Ticket ID',
+	},
+/* -------------------------------------------------------------------------- */
+/*                                   suspended:getAll                         */
+/* -------------------------------------------------------------------------- */
+{
+	displayName: 'Return All',
+	name: 'returnAll',
+	type: 'boolean',
+	displayOptions: {
+		show: {
+			resource: [
+				'suspended',
+			],
+			operation: [
+				'getAll',
+			],
+		},
+	},
+	default: false,
+	description: 'If all results should be returned or only up to a given limit.',
+},
+{
+	displayName: 'Limit',
+	name: 'limit',
+	type: 'number',
+	displayOptions: {
+		show: {
+			resource: [
+				'suspended',
+			],
+			operation: [
+				'getAll',
+			],
+			returnAll: [
+				false,
+			],
+		},
+	},
+	typeOptions: {
+		minValue: 1,
+		maxValue: 100,
+	},
+	default: 100,
+	description: 'How many results to return.',
+},
+{
+	displayName: 'Options',
+	name: 'options',
+	type: 'collection',
+	placeholder: 'Add Option',
+	default: {},
+	displayOptions: {
+		show: {
+			resource: [
+				'suspended',
+			],
+			operation: [
+				'getAll',
+			],
+		},
+	},
+	options: [
+		{
+			displayName: 'Sort By',
+			name: 'sortBy',
+			type: 'options',
+			options: [
+				{
+					name: 'Author Email',
+					value: 'author_email',
+				},
+				{
+					name: 'Cause',
+					value: 'cause',
+				},
+				{
+					name: 'Created At',
+					value: 'created_at',
+				},
+				{
+					name: 'Subject',
+					value: 'subject',
+				},
+			],
+			default: 'created_at',
+			description: 'Defaults to sorting by created time',
+		},
+		{
+			displayName: 'Sort Order',
+			name: 'sortOrder',
+			type: 'options',
+			options: [
+				{
+					name: 'Asc',
+					value: 'asc',
+				},
+				{
+					name: 'Desc',
+					value: 'desc',
+				},
+			],
+			default: 'desc',
+			description: 'Sort order',
+		},
+	],
+},
+/* -------------------------------------------------------------------------- */
+/*                                suspended:delete                            */
+/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Suspended Ticket ID',
+		name: 'id',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'suspended',
+				],
+				operation: [
+					'delete',
+				],
+			},
+		},
+	},
+/* -------------------------------------------------------------------------- */
+/*                                suspended:Recover                           */
+/* -------------------------------------------------------------------------- */
+{
+	displayName: 'Suspended Ticket ID',
+	name: 'id',
+	type: 'string',
+	default: '',
+	required: true,
+	displayOptions: {
+		show: {
+			resource: [
+				'suspended',
+			],
+			operation: [
+				'recover',
+			],
+		},
+	},
+},
+] as INodeProperties[];

--- a/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
@@ -36,6 +36,11 @@ export const ticketOperations = [
 				description: 'Get all tickets',
 			},
 			{
+				name: 'Search',
+				value: 'search',
+				description: 'Search tickets',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update a ticket',
@@ -660,4 +665,170 @@ export const ticketFields = [
 		},
 		description: 'Ticket ID',
 	},
+/* -------------------------------------------------------------------------- */
+/*                                 ticket:search                              */
+/* -------------------------------------------------------------------------- */
+{
+	displayName: 'Query',
+	name: 'query',
+	type: 'string',
+	default: '',
+	required: false,
+	displayOptions: {
+		show: {
+			resource: [
+				'ticket',
+			],
+			operation: [
+				'search',
+			],
+		},
+	},
+	description: 'Search query to use',
+},
+{
+	displayName: 'Return All',
+	name: 'returnAll',
+	type: 'boolean',
+	displayOptions: {
+		show: {
+			resource: [
+				'ticket',
+			],
+			operation: [
+				'search',
+			],
+		},
+	},
+	default: false,
+	description: 'If all results should be returned or only up to a given limit.',
+},
+{
+	displayName: 'Limit',
+	name: 'limit',
+	type: 'number',
+	displayOptions: {
+		show: {
+			resource: [
+				'ticket',
+			],
+			operation: [
+				'search',
+			],
+			returnAll: [
+				false,
+			],
+		},
+	},
+	typeOptions: {
+		minValue: 1,
+		maxValue: 100,
+	},
+	default: 100,
+	description: 'How many results to return.',
+},
+{
+	displayName: 'Options',
+	name: 'options',
+	type: 'collection',
+	placeholder: 'Add Option',
+	default: {},
+	displayOptions: {
+		show: {
+			resource: [
+				'ticket',
+			],
+			operation: [
+				'search',
+			],
+		},
+	},
+	options: [
+		{
+			displayName: 'Group',
+			name: 'group',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getGroups',
+			},
+			default: '',
+			description: 'The group to search',
+		},
+		{
+			displayName: 'Status',
+			name: 'status',
+			type: 'options',
+			options: [
+				{
+					name: 'Open',
+					value: 'open',
+				},
+				{
+					name: 'New',
+					value: 'new',
+				},
+				{
+					name: 'Pending',
+					value: 'pending',
+				},
+				{
+					name: 'Solved',
+					value: 'solved',
+				},
+				{
+					name: 'Closed',
+					value: 'closed',
+				},
+			],
+			default: '',
+			description: 'The state of the ticket',
+		},
+		{
+			displayName: 'Sort By',
+			name: 'sortBy',
+			type: 'options',
+			options: [
+				{
+					name: 'Updated At',
+					value: 'updated_at',
+				},
+				{
+					name: 'Created At',
+					value: 'created_at',
+				},
+				{
+					name: 'Priority',
+					value: 'priority',
+				},
+				{
+					name: 'Status',
+					value: 'status',
+				},
+				{
+					name: 'Ticket Type',
+					value: 'ticket_type',
+				},
+			],
+			default: 'updated_at',
+			description: 'Defaults to sorting by updated at',
+		},
+		{
+			displayName: 'Sort Order',
+			name: 'sortOrder',
+			type: 'options',
+			options: [
+				{
+					name: 'Asc',
+					value: 'asc',
+				},
+				{
+					name: 'Desc',
+					value: 'desc',
+				},
+			],
+			default: 'desc',
+			description: 'Sort order',
+		},
+	],
+},
 ] as INodeProperties[];

--- a/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/TicketDescription.ts
@@ -364,6 +364,27 @@ export const ticketFields = [
 				],
 			},
 			{
+				displayName: 'Assignee Email',
+				name: 'assigneeEmail',
+				type: 'string',
+				default: '',
+				description: 'The e-mail address of the assignee',
+			},
+			{
+				displayName: 'Public Reply',
+				name: 'publicReply',
+				type: 'string',
+				default: '',
+				description: 'Public ticket reply',
+			},
+			{
+				displayName: 'Internal Note',
+				name: 'internalNote',
+				type: 'string',
+				default: '',
+				description: 'Internal Ticket Note (Accepts HTML)',
+			},
+			{
 				displayName: 'External ID',
 				name: 'externalId',
 				type: 'string',

--- a/packages/nodes-base/nodes/Zendesk/TicketInterface.ts
+++ b/packages/nodes-base/nodes/Zendesk/TicketInterface.ts
@@ -4,6 +4,8 @@ import {
 
  export interface IComment {
 	body?: string;
+	html_body?: string;
+	public?: boolean;
 }
 
 export interface ITicket {
@@ -16,4 +18,5 @@ export interface ITicket {
 	status?: string;
 	recipient?: string;
 	custom_fields?: IDataObject[];
+	assignee_email?: string;
 }

--- a/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
@@ -395,6 +395,25 @@ export class Zendesk implements INodeType {
 							if (updateFields.customFieldsUi) {
 								body.custom_fields = (updateFields.customFieldsUi as IDataObject).customFieldsValues as IDataObject[];
 							}
+							if (updateFields.assigneeEmail) {
+								body.assignee_email = updateFields.assigneeEmail as string;
+							}
+							if (updateFields.internalNote) {
+								const comment: IComment = {
+									html_body: updateFields.internalNote as string,
+									public: false,
+								};
+								body.comment = comment;
+							}
+
+							if (updateFields.publicReply) {
+								const comment: IComment = {
+									body: updateFields.publicReply as string,
+									public: true,
+								};
+								body.comment = comment;
+							}
+
 						}
 						responseData = await zendeskApiRequest.call(this, 'PUT', `/tickets/${ticketId}`, { ticket: body });
 						responseData = responseData.ticket;

--- a/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
@@ -104,7 +104,7 @@ export class Zendesk implements INodeType {
 					},
 				],
 				default: 'apiToken',
-				description: 'The resource to operate on.',
+				description: 'The resource to operate on',
 			},
 			{
 				displayName: 'Resource',
@@ -114,12 +114,12 @@ export class Zendesk implements INodeType {
 					{
 						name: 'Ticket (Active)',
 						value: 'ticket',
-						description: 'Tickets are the means through which your end users (customers) communicate with agents in Zendesk Support.',
+						description: 'Tickets are the means through which your end users (customers) communicate with agents in Zendesk Support',
 					},
 					{
 						name: 'Ticket (Suspended)',
 						value: 'suspended',
-						description: 'Manage suspended tickets.',
+						description: 'Manage suspended tickets',
 					},
 					{
 						name: 'Ticket Field',
@@ -138,7 +138,7 @@ export class Zendesk implements INodeType {
 					},
 				],
 				default: 'ticket',
-				description: 'Resource to consume.',
+				description: 'Resource to consume',
 			},
 			// TICKET
 			...ticketOperations,
@@ -435,6 +435,34 @@ export class Zendesk implements INodeType {
 							responseData = await zendeskApiRequest.call(this, 'DELETE', `/tickets/${ticketId}`, {});
 						} catch (error) {
 							throw new NodeApiError(this.getNode(), error);
+						}
+					}
+					//https://developer.zendesk.com/rest_api/docs/support/search#list-search-results
+					if (operation === 'search') {
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+						const options = this.getNodeParameter('options', i) as IDataObject;
+						const query = this.getNodeParameter('query', i) as string;
+						qs.query = 'type:ticket';
+						qs.query += ` ${query}`;
+						if (options.status) {
+							qs.query += ` status:${options.status}`;
+						}
+						if (options.group) {
+							qs.query += ` group:${options.group}`;
+						}
+						if (options.sortBy) {
+							qs.sort_by = options.sortBy;
+						}
+						if (options.sortOrder) {
+							qs.sort_order = options.sortOrder;
+						}
+						if (returnAll) {
+							responseData = await zendeskApiRequestAllItems.call(this, 'results', 'GET', `/search`, {}, qs);
+						} else {
+							const limit = this.getNodeParameter('limit', i) as number;
+							qs.per_page = limit;
+							responseData = await zendeskApiRequest.call(this, 'GET', `/search`, {}, qs);
+							responseData = responseData.results;
 						}
 					}
 				}


### PR DESCRIPTION
Few more updates to the Zendesk node to support our workflows a bit more...

Added Suspended Tickets options (Delete, List, Get, Recover) this is displayed as Ticket (Suspended).

Updated the display name for Ticket to Ticket (Active), Kept the internal value the same to prevent breaking existing workflows.

Added a search option to Ticket (Active) this supports any of the normal search queries so group:xxx assignee:yyyy status:zzzz I have also added helper options for Group and Status so you can now in one query get a list of all open tickets for a sales team with no assignee.

Added Public Reply, Internal Note and Assignee Email options to Ticket > Update, Internal Notes support HTML, The option is there so in the future we could toggle the HTML option for both public replies and internal notes.