### PR TITLE
onedrive folders hierarchy creation support

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/FolderDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/FolderDescription.ts
@@ -67,7 +67,7 @@ export const folderFields = [
 			},
 		},
 		default: '',
-		description: `Folder's name`,
+		description: `Folder's name, or a folders slash (/) separated hierarchy`,
 	},
 	{
 		displayName: 'Options',

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -209,17 +209,24 @@ export class MicrosoftOneDrive implements INodeType {
 				if (resource === 'folder') {
 					//https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_post_children?view=odsp-graph-online
 					if (operation === 'create') {
-						const name = this.getNodeParameter('name', i) as string;
+						const names = (this.getNodeParameter('name', i) as string).split("/").filter( s => s.trim() != "" );
 						const options = this.getNodeParameter('options', i) as IDataObject;
-						const body: IDataObject = {
-							name,
-							folder: {},
-						};
-						let endpoint = '/drive/root/children';
-						if (options.parentFolderId) {
-							endpoint = `/drive/items/${options.parentFolderId}/children`;
+						let parentFolderId = options.parentFolderId ? options.parentFolderId : null;
+						for( let name of names ) {
+							let body: IDataObject = {
+								name,
+								folder: {},
+							};
+							let endpoint = '/drive/root/children';
+							if (parentFolderId) {
+								endpoint = `/drive/items/${parentFolderId}/children`;
+							}
+							responseData = await microsoftApiRequest.call(this, 'POST', endpoint, body);
+							if( !responseData.id ) {
+								break;
+							}
+							parentFolderId = responseData.id;
 						}
-						responseData = await microsoftApiRequest.call(this, 'POST', endpoint, body);
 						returnData.push(responseData);
 					}
 					//https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_delete?view=odsp-graph-online


### PR DESCRIPTION
Extends Microsoft OneDrive node folder creation feature by allowing the creation of a hierarchy of folders at once.

To create a folder with a hierarchy of ancestors folders, the `name` folder can be filled with a slash (`/`) separated folders hierarchy. For example, the following name:
```
name: my-folder/my-subfolder/my-sub-subfolder
```
will create on root the folder _my-folder_, a subfolder named _my-subfolder_, and a sub-subfolder named _my-sub-subfolder_.

As with a single folder, it is also possible to set a root folder different from the drive root, by using the `Parent Folder ID` property. In this case the entire hierarchy willl begin from the given folder.