### PR TITLE
:zap: Fix pagination in Slack-Node

### DIFF
--- a/packages/nodes-base/nodes/Slack/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/GenericFunctions.ts
@@ -71,15 +71,15 @@ export async function slackApiRequestAllItems(this: IExecuteFunctions | ILoadOpt
 	const returnData: IDataObject[] = [];
 	let responseData;
 	query.page = 1;
-	query.count = 100;
+	query.limit = query.limit || 100;
 	do {
 		responseData = await slackApiRequest.call(this, method, endpoint, body, query);
-		query.cursor = encodeURIComponent(_.get(responseData, 'response_metadata.next_cursor'));
+		query.cursor = _.get(responseData, 'response_metadata.next_cursor');
 		query.page++;
 		returnData.push.apply(returnData, responseData[propertyName]);
 	} while (
 		(responseData.response_metadata !== undefined &&
-			responseData.response_metadata.mext_cursor !== undefined &&
+			responseData.response_metadata.next_cursor !== undefined &&
 			responseData.response_metadata.next_cursor !== '' &&
 			responseData.response_metadata.next_cursor !== null) ||
 		(responseData.paging !== undefined &&


### PR DESCRIPTION
Previously, if you had more than 1k channels, only the first 1k would be loaded. Now with pagination, the limit is ~40k (due to rate limiting, which this doesn't handle well)