### PR TITLE
Add suggested node version to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ dependencies are installed and the packages get linked correctly. Here a short g
 
 ### Requirements
 
+#### Node.js
+
+We suggest using the current [Node.js](https://nodejs.org/en/) LTS version (14.18.0 which includes npm 6.14.15) for development purposes.
+
 #### Build tools
 
 The packages which n8n uses depend on a few build tools:


### PR DESCRIPTION
In a recent discussion on the n8n discord server there was some confusion over what Node.js version to use. This PR suggests using the current LTS version which has been confirmed to work fine on Mac, Ubuntu and Windows.