### PR TITLE
✨ Add loadOptions for Home Assistant

### DIFF
--- a/packages/nodes-base/nodes/HomeAssistant/CameraProxyDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/CameraProxyDescription.ts
@@ -33,7 +33,10 @@ export const cameraProxyFields = [
 	{
 		displayName: 'Camera Entity ID',
 		name: 'cameraEntityId',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCameraEntities',
+		},
 		default: '',
 		required: true,
 		displayOptions: {

--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -4,7 +4,9 @@ import {
 
 import {
 	IDataObject,
+	ILoadOptionsFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
@@ -49,6 +51,8 @@ import {
 } from './CameraProxyDescription';
 
 import {
+	getHomeAssistantEntities,
+	getHomeAssistantServices,
 	homeAssistantApiRequest,
 } from './GenericFunctions';
 
@@ -131,6 +135,28 @@ export class HomeAssistant implements INodeType {
 			...templateOperations,
 			...templateFields,
 		],
+	};
+
+	methods = {
+		loadOptions: {
+			async getAllEntities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				return await getHomeAssistantEntities.call(this);
+			},
+			async getCameraEntities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				return await getHomeAssistantEntities.call(this, 'camera');
+			},
+			async getDomains(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				return await getHomeAssistantServices.call(this);
+			},
+			async getDomainServices(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const currentDomain = this.getCurrentNodeParameter('domain') as string;
+				if (currentDomain) {
+					return await getHomeAssistantServices.call(this, currentDomain);
+				} else {
+					return [];
+				}
+			},
+		},
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/HomeAssistant/ServiceDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/ServiceDescription.ts
@@ -83,7 +83,10 @@ export const serviceFields = [
 	{
 		displayName: 'Domain',
 		name: 'domain',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getDomains',
+		},
 		default: '',
 		required: true,
 		displayOptions: {
@@ -100,7 +103,13 @@ export const serviceFields = [
 	{
 		displayName: 'Service',
 		name: 'service',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsDependsOn: [
+				'domain',
+			],
+			loadOptionsMethod: 'getDomainServices',
+		},
 		default: '',
 		required: true,
 		displayOptions: {

--- a/packages/nodes-base/nodes/HomeAssistant/StateDescription.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/StateDescription.ts
@@ -43,7 +43,10 @@ export const stateFields = [
 	{
 		displayName: 'Entity ID',
 		name: 'entityId',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getAllEntities',
+		},
 		displayOptions: {
 			show: {
 				operation: [
@@ -110,7 +113,10 @@ export const stateFields = [
 	{
 		displayName: 'Entity ID',
 		name: 'entityId',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getAllEntities',
+		},
 		displayOptions: {
 			show: {
 				operation: [


### PR DESCRIPTION
This PR adds Home Assistant load options functions for:
- Service domains
- Services
- Entities
- Camera entities

I'm not sure if there is, or should be, a practical limit for loadOptions? This functionality could slow down the browser if the Home Assistant instance has a very large number of entities.

Service domains and services:
<img width="744" alt="n8n_io_-_Workflow_Automation" src="https://user-images.githubusercontent.com/939704/137637127-fcdb9634-66da-42d7-9280-ca6190af402b.png">


Entities:
<img width="745" alt="n8n_io_-_Workflow_Automation 2" src="https://user-images.githubusercontent.com/939704/137637129-6d8e93fd-5536-4638-bca5-ddb3d3158b22.png">


Camera entities:
<img width="745" alt="n8n_io_-_Workflow_Automation 1" src="https://user-images.githubusercontent.com/939704/137637098-81f85d02-e9fa-4276-a94f-110b9c968325.png">

