### PR TITLE
Jira node fixes

### DIFF
--- a/packages/nodes-base/nodes/Jira/IssueDescription.ts
+++ b/packages/nodes-base/nodes/Jira/IssueDescription.ts
@@ -661,7 +661,7 @@ export const issueFields = [
 			{
 				displayName: 'Expand',
 				name: 'expand',
-				type: 'options',
+				type: 'multiOptions',
 				default: '',
 				options: [
 					{

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -594,7 +594,11 @@ export class Jira implements INodeType {
 						body.jql = options.jql as string;
 					}
 					if (options.expand) {
-						body.expand = options.expand as string;
+						if (typeof options.expand === 'string') {
+							body.expand = options.expand.split(',');
+						} else {
+							body.expand = options.expand;
+						}
 					}
 					if (returnAll) {
 						responseData = await jiraSoftwareCloudApiRequestAllItems.call(this, 'issues', `/api/2/search`, 'POST', body);

--- a/packages/nodes-base/nodes/Jira/UserDescription.ts
+++ b/packages/nodes-base/nodes/Jira/UserDescription.ts
@@ -132,7 +132,10 @@ export const userFields = [
 	{
 		displayName: 'Account ID',
 		name: 'accountId',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getUsers',
+		},
 		default: '',
 		description: 'Account ID of the user to delete.',
 		displayOptions: {
@@ -152,7 +155,10 @@ export const userFields = [
 	{
 		displayName: 'Account ID',
 		name: 'accountId',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getUsers',
+		},
 		default: '',
 		description: 'Account ID of the user to retrieve.',
 		displayOptions: {


### PR DESCRIPTION
This PR fixes a bug where using the `expand` option with `getAll` issues would create an invalid request. The `getAll` performs a POST request with a JSON body for parameters, as opposed to the `get` issue request which uses a comma separated query parameter. 
<img width="458" alt="n8n_-_⚠️_My_workflow_2" src="https://user-images.githubusercontent.com/939704/137928263-00d2777e-a8e7-469e-932e-d5a29fa2f514.png">

This change
- changes the `expand` field from `options` to `multiOptions`
- if `expand` is a string it will split it into an array on `,`
- adds load options for some user fields