### PR TITLE
🐛 Fix custom fields for Jira Server

### DIFF
--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -378,7 +378,7 @@ export class Jira implements INodeType {
 					if (field.schema && Object.keys(field.schema).includes('customId')) {
 							returnData.push({
 								name: field.name,
-								value: field.key,
+								value: field.key || field.fieldId,
 							});
 					}
 				}


### PR DESCRIPTION
When using Jira Server, custom fields populated, but weren't selectable because the function wasn't returning a `value`, only a `key`.

This is because Server returns the custom field id in a `fieldId` field instead of `key` for cloud.
