### PR TITLE
Updated HTTP Request Node to use proxies and added a couple of options

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest.node.ts
@@ -1,3 +1,4 @@
+import { request } from 'http';
 import {
 	BINARY_ENCODING,
 	IExecuteFunctions,
@@ -351,8 +352,33 @@ export class HttpRequest implements INodeType {
 						name: 'proxy',
 						type: 'string',
 						default: '',
-						placeholder: 'http://myproxy:3128',
+						placeholder: 'myproxy:3128',
 						description: 'HTTP proxy to use.',
+					},
+					{
+						displayName: 'Proxy Type',
+						name: 'proxyType',
+						type: 'options',
+						options: [
+							{
+								name: 'HTTP',
+								value: 'http',
+							},
+							{
+								name: 'HTTPS',
+								value: 'https',
+							},
+						],
+						default: 'https',
+						description: '',
+					},
+					{
+						displayName: 'Proxy Credentials',
+						name: 'proxyCredentials',
+						type: 'string',
+						default: '',
+						placeholder: 'user:password',
+						description: 'Credentials for the proxy',
 					},
 					{
 						displayName: 'Split Into Items',
@@ -712,7 +738,28 @@ export class HttpRequest implements INodeType {
 				requestOptions.simple = false;
 			}
 			if (options.proxy !== undefined) {
-				requestOptions.proxy = options.proxy as string;
+				const proxyOptions = {};
+				let proxy = (options.proxy as string).split(":");
+				// @ts-ignore
+				proxyOptions.host = proxy[0];
+				// @ts-ignore
+				proxyOptions.port = parseInt(proxy[1]);
+
+				if (options.proxyType !== undefined) {
+					// @ts-ignore
+					proxyOptions.protocol = options.proxyType as string;
+				}
+
+				if (options.proxyCredentials !== undefined) {
+					// @ts-ignore
+					proxyOptions.auth = {};
+					let credentials = (options.proxyCredentials as string).split(":");
+					// @ts-ignore
+					proxyOptions.auth.username = credentials[0];
+					// @ts-ignore
+					proxyOptions.auth.password = credentials[1];
+				}
+				requestOptions.proxy = proxyOptions;
 			}
 			if (options.timeout !== undefined) {
 				requestOptions.timeout = options.timeout as number;


### PR DESCRIPTION
This is for https://community.n8n.io/t/http-request-via-proxy-connect-econnrefused-127-0-0-1-80/8469/12

I have updated the HTTP Request Node to use the Axios proxy object, I have also added 2 new fields Proxy Type (HTTP / HTTPS) which could be handy if anyone wants to look at implementing SOCKS support in the future and also a Credentials field which takes the username and password using a : to split the values.

It is not perfect but it is a start if anyone wants to run with it.