### PR TITLE
bugfix(permission): fix permission issue

### DIFF
--- a/docker/images/n8n-custom/docker-entrypoint.sh
+++ b/docker/images/n8n-custom/docker-entrypoint.sh
@@ -6,6 +6,8 @@ if [ -d /root/.n8n ] ; then
   ln -s /root/.n8n /home/node/
 fi
 
+chown -R node /home/node
+
 if [ "$#" -gt 0 ]; then
   # Got started with arguments
   COMMAND=$1;


### PR DESCRIPTION
Fix a permission issue connected to the custom image of n8n.
This fix has already be integrated in the entrypoint for the standard image and was just missing here.