### PR TITLE
Downgrade @types/aws4 to ~1.5.1

### DIFF
--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -637,7 +637,7 @@
     ]
   },
   "devDependencies": {
-    "@types/aws4": "^1.5.1",
+    "@types/aws4": "~1.5.1",
     "@types/basic-auth": "^1.1.2",
     "@types/cheerio": "^0.22.15",
     "@types/cron": "~1.7.1",


### PR DESCRIPTION
@types/aws4 updated to 1.11.1 and it breaks all the AWS nodes significantly

I tried fixing it, but I was touching a lot of code, and a few changes were potentially changing behavior so I stopped.