### PR TITLE
Fix load of n8n-nodes-* packages when n8n is installed globally.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,6 +104,7 @@
     "flatted": "^2.0.0",
     "google-timezones-json": "^1.0.2",
     "inquirer": "^7.0.1",
+    "is-installed-globally": "^0.4.0",
     "json-diff": "^0.5.4",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "~1.12.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -102,6 +102,7 @@
     "express": "^4.16.4",
     "fast-glob": "^3.2.5",
     "flatted": "^2.0.0",
+    "global-dirs": "^3.0.0",
     "google-timezones-json": "^1.0.2",
     "inquirer": "^7.0.1",
     "is-installed-globally": "^0.4.0",

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -9,8 +9,8 @@
 /* eslint-disable no-continue */
 /* eslint-disable no-restricted-syntax */
 import * as glob from 'fast-glob';
-import isInstalledGlobally = require('is-installed-globally');
-import globalDirs = require('global-dirs');
+import * as isInstalledGlobally from 'is-installed-globally';
+import * as globalDirs from 'global-dirs';
 import {
 	access as fsAccess,
 	readdir as fsReaddir,
@@ -83,9 +83,7 @@ class LoadNodesAndCredentialsClass {
 		if (isInstalledGlobally) {
 			this.nodeModulesPaths.push(globalDirs.npm.packages);
 			this.logger.info(
-				`n8n is installed globally, add global "node_modules" path: ${
-					globalDirs.npm.packages || ''
-				}`,
+				`n8n is installed globally, add global "node_modules" path: ${globalDirs.npm.packages}`,
 			);
 		}
 

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -9,14 +9,14 @@
 /* eslint-disable no-continue */
 /* eslint-disable no-restricted-syntax */
 import * as glob from 'fast-glob';
-import * as isInstalledGlobally from 'is-installed-globally';
-import * as globalDirs from 'global-dirs';
 import {
 	access as fsAccess,
 	readdir as fsReaddir,
 	readFile as fsReadFile,
 	stat as fsStat,
 } from 'fs/promises';
+import * as isInstalledGlobally from 'is-installed-globally';
+import * as globalDirs from 'global-dirs';
 import { CUSTOM_EXTENSION_ENV, UserSettings } from 'n8n-core';
 import {
 	CodexData,
@@ -81,9 +81,10 @@ class LoadNodesAndCredentialsClass {
 		}
 
 		if (isInstalledGlobally) {
-			this.nodeModulesPaths.push(globalDirs.npm.packages);
+			const globalNodeModules: string = globalDirs.npm.packages;
+			this.nodeModulesPaths.push(globalNodeModules);
 			this.logger.info(
-				`n8n is installed globally, add global "node_modules" path: ${globalDirs.npm.packages}`,
+				`n8n is installed globally, add global "node_modules" path: ${globalNodeModules}`,
 			);
 		}
 


### PR DESCRIPTION
The [guide to create your own custom n8n module](https://docs.n8n.io/nodes/creating-nodes/node-dev-cli.html#create-own-custom-n8n-nodes-module) shows that you can create a custom node package and install it alongside your local n8n installation. However that approach does not work if both n8n and your custom package are installed globally on your machine.
The main reason for such behaviour is that when installed globally, n8n scan only the "node_modules" folder underneath its main folder, but does not take into account the global "node_modules" folder.

This PR fix that by checking if n8n is installed globally at runtime; if that is the case, the global "node_modules" folder will be scan in addition to the previous one.