### PR TITLE
Fixed default for url when missing

### DIFF
--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -36,7 +36,7 @@ function getEndpointForService(service: string, credentials: ICredentialDataDecr
 	} else if (service === 'sns' && credentials.snsEndpoint) {
 		endpoint = credentials.snsEndpoint;
 	} else {
-		endpoint = `https://${service}.${credentials.region}.amazonaws.com`;
+		endpoint = `https://${service}.${credentials.region || 'us-east-1'}.amazonaws.com`;
 	}
 	return (endpoint as string).replace('{region}', credentials.region as string);
 }
@@ -69,7 +69,7 @@ export async function awsApiRequest(this: IHookFunctions | IExecuteFunctions | I
 			const errorMessage = error?.response?.data || error?.response?.body;
 			if (errorMessage.includes('AccessDeniedException')) {
 				const user = JSON.parse(errorMessage).Message.split(' ')[1];
-				throw new NodeApiError(this.getNode(), error, { 
+				throw new NodeApiError(this.getNode(), error, {
 					message: 'Unauthorized — please check your AWS policy configuration',
 					description: `Make sure an identity-based policy allows user ${user} to perform textract:AnalyzeExpense` });
 			}


### PR DESCRIPTION
@RicardoE105 I believe this fixes the issue n8n-2544 from Linear.

It seems the URL was being malformed because if you don't change the region from `us-east-1` then the URL will be formed with `undefined` causing an authentication issue.

Could you please confirm if it works well for you now?