### PR TITLE
N8N-2551 - Fixed Expression Renaming Bug

### DIFF
--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -416,7 +416,7 @@ export class Workflow {
 
 					parameterValue = parameterValue.replace(
 						// eslint-disable-next-line no-useless-escape
-            new RegExp(`(\\$node(\.|\\["|\\[\'))${currentNameEscaped}((\s/g|"\\]|\'\\]))`, 'g'),
+						new RegExp(`(\\$node(\.|\\["|\\[\'))${currentNameEscaped}((\s/g|"\\]|\'\\]))`, 'g'),
 						`$1${newName}$3`,
 					);
 				}

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -416,7 +416,7 @@ export class Workflow {
 
 					parameterValue = parameterValue.replace(
 						// eslint-disable-next-line no-useless-escape
-						new RegExp(`(\\$node(\.|\\["|\\[\'))${currentNameEscaped}((\.|"\\]|\'\\]))`, 'g'),
+            new RegExp(`(\\$node(\.|\\["|\\[\'))${currentNameEscaped}((\s/g|"\\]|\'\\]))`, 'g'),
 						`$1${newName}$3`,
 					);
 				}


### PR DESCRIPTION
###Description
When a user renames a node, there is a function that updates any expression reference to that node name. It currently does a simple regex check that has flawed logic:

-Node is called Set and user renames to My node
-Any node containing string fragment Set will be incorrectly updated.
-So an unrelated Set1 node would inadvertently be renamed to My node1

Therefore, when a user renames a node, it causing a problem with the names of the other nodes that are present in the workflow.

###Reported:
This bug firstly is reported by community member here: https://community.n8n.io/t/renaming-node-bug/8302/2

###Proof
Reproduced bug could be find on this video: https://www.loom.com/share/f49bf29dcfbb44509ba23271d5243d7d

###Solution
When a user renames a node, there is a function that updates any expression reference to that node name. The currently regex match exactly the string between [ and ], then the '.' (dot) after currentNameEscape is causing it to match anything that is that string plus 1 char. 

Therefore, if we have nodes like the sample below, and we want only to change the name of the Set 1 to 'New', the current regex will change the names of both items.
"$node['Set 1']"
"$node['Set 2']"

To prevent this, I replaced the '.' (dot) after currentNameEscape with '\s/g' to match the all whitspace in the string.  This way, it will updated only the exact node name.
