### PR TITLE
Fixed ignore response code flag to work properly with return full response

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -438,17 +438,17 @@ async function proxyRequestToAxios(
 				}
 			})
 			.catch((error) => {
-				if (configObject.simple === true && error.response) {
-					resolve({
-						body: error.response.data,
-						headers: error.response.headers,
-						statusCode: error.response.status,
-						statusMessage: error.response.statusText,
-					});
-					return;
-				}
 				if (configObject.simple === false && error.response) {
-					resolve(error.response.data);
+					if (configObject.resolveWithFullResponse) {
+						resolve({
+							body: error.response.data,
+							headers: error.response.headers,
+							statusCode: error.response.status,
+							statusMessage: error.response.statusText,
+						});
+					} else {
+						resolve(error.response.data);
+					}
 					return;
 				}
 


### PR DESCRIPTION
This PR now correctly fixes the issue reported in [this community post](https://community.n8n.io/t/get-cookie-after-login/7842/14).

Behavior works as intended. Tested using https://beeceptor.com/ to mock api requests properly.