### PR TITLE
⚡ Slack Node: Check if Channel IDs are array/pass on raw string otherwise

### DIFF
--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -945,7 +945,7 @@ export class Slack implements INodeType {
 						const binaryData = this.getNodeParameter('binaryData', i) as boolean;
 						const body: IDataObject = {};
 						if (options.channelIds) {
-							body.channels = Array.isArray(options.channelIds) ? (options.channelIds as string[]).join(',') : options.channelIds;
+							body.channels = Array.isArray(options.channelIds) ? (options.channelIds as string[]).join(',') : options.channelIds as string;
 						}
 						if (options.fileName) {
 							body.filename = options.fileName as string;

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -945,7 +945,7 @@ export class Slack implements INodeType {
 						const binaryData = this.getNodeParameter('binaryData', i) as boolean;
 						const body: IDataObject = {};
 						if (options.channelIds) {
-							body.channels = (options.channelIds as string[]).join(',');
+							body.channels = Array.isArray(options.channelIds) ? (options.channelIds as string[]).join(',') : options.channelIds;
 						}
 						if (options.fileName) {
 							body.filename = options.fileName as string;


### PR DESCRIPTION
This PR addresses a problem that has been reported through the [community forum](https://community.n8n.io/t/unable-to-see-channel-list-while-uploading-file-using-slack-node/8719?u=mutedjam).

When certain scopes are missing for the corresponding slack app, users are unable to select a channel from the dropdown of the Channels field. They are, however, still able to enter a slack channel identifier manually, but n8n currently throws an error if the field value is not an array of strings.

With this change, the user entered channel identifier is passed on to Slack in such cases and file uploads are successful when a valid channel has been entered by the user.