### PR TITLE
Fixed url params serializing for OAuth1 requests

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -86,6 +86,12 @@ import {
 axios.defaults.timeout = 300000;
 // Prevent axios from adding x-form-www-urlencoded headers by default
 axios.defaults.headers.post = {};
+axios.defaults.paramsSerializer = (params) => {
+	if (params instanceof URLSearchParams) {
+		return params.toString();
+	}
+	return stringify(params, { arrayFormat: 'indices' });
+};
 
 const requestPromiseWithDefaults = requestPromise.defaults({
 	timeout: 300000, // 5 minutes
@@ -357,6 +363,7 @@ async function parseRequestObject(requestObject: IDataObject) {
 	if (
 		requestObject.json !== false &&
 		axiosConfig.data !== undefined &&
+		axiosConfig.data !== '' &&
 		!(axiosConfig.data instanceof Buffer) &&
 		!allHeaders.some((headerKey) => headerKey.toLowerCase() === 'content-type')
 	) {
@@ -405,6 +412,11 @@ async function proxyRequestToAxios(
 	}
 
 	axiosConfig = Object.assign(axiosConfig, await parseRequestObject(configObject));
+
+	Logger.debug('Proxying request to axios', {
+		originalConfig: configObject,
+		parsedConfig: axiosConfig,
+	});
 
 	return new Promise((resolve, reject) => {
 		axios(axiosConfig)


### PR DESCRIPTION
This PR sets up a default formatter for arrays that is safe to use. Request lib uses indices to serialize arrays and this was breaking a few workflows as well as having problems to sign OAuth1 requests that had special characters.

Using this default formatters fixes both problems: array serialization in query strings and special characters.