### PR TITLE
Zendesk node: fix User External ID option name

### DIFF
--- a/packages/nodes-base/nodes/Zendesk/UserDescription.ts
+++ b/packages/nodes-base/nodes/Zendesk/UserDescription.ts
@@ -130,7 +130,7 @@ export const userFields = [
 			},
 			{
 				displayName: 'External ID',
-				name: 'externalId',
+				name: 'external_id',
 				type: 'string',
 				default: '',
 				description: 'A unique identifier from another system',
@@ -387,7 +387,7 @@ export const userFields = [
 			},
 			{
 				displayName: 'External ID',
-				name: 'externalId',
+				name: 'external_id',
 				type: 'string',
 				default: '',
 				description: 'A unique identifier from another system',


### PR DESCRIPTION
Incorrect name of the `External ID` option prevents the `external_id` property from being correctly valued on Zendesk.