### PR TITLE
Stripe node: fix metadata field

### DIFF
--- a/packages/nodes-base/nodes/Stripe/helpers.ts
+++ b/packages/nodes-base/nodes/Stripe/helpers.ts
@@ -102,10 +102,10 @@ export function adjustMetadata(
 ) {
 	if (!fields.metadata || isEmpty(fields.metadata)) return fields;
 
-	let adjustedMetadata = {};
+	const adjustedMetadata: Record<string, string> = {};
 
 	fields.metadata.metadataProperties.forEach(pair => {
-		adjustedMetadata = { ...adjustedMetadata, ...pair };
+		adjustedMetadata[pair.key] = pair.value;
 	});
 
 	return {

--- a/packages/nodes-base/test/nodes/Stripe/helpers.test.js
+++ b/packages/nodes-base/test/nodes/Stripe/helpers.test.js
@@ -1,0 +1,30 @@
+const helpers = require("../../../nodes/Stripe/helpers");
+
+describe('adjustMetadata', () => {
+	it('it should adjust multiple metadata values', async () => {
+		const additionalFieldsValues = {
+			metadata: {
+				metadataProperties: [
+					{
+						key: "keyA",
+						value: "valueA"
+					},
+					{
+						key: "keyB",
+						value: "valueB"
+					},
+				],
+			},
+		}
+
+		const adjustedMetadata = helpers.adjustMetadata(additionalFieldsValues)
+
+		const expectedAdjustedMetadata = {
+			metadata: {
+				keyA: "valueA",
+				keyB: "valueB"
+			}
+		}
+		expect(adjustedMetadata).toStrictEqual(expectedAdjustedMetadata)
+	});
+});


### PR DESCRIPTION
In the Stripe node, Metadata values are not correctly adjusted for the Stripe API.

# Example of current behavior

## Input

When sending 2 metadata values like:
- keyA=valueA
- keyB=valueB

![metadata-input](https://user-images.githubusercontent.com/3189335/139819063-3144e3bd-172f-4777-b939-ce7e7d103f15.png)

## Current result

Currently the `key` and `value` words are used as metadata keys, and the last metadata key and value are used as values:

![bad-metadata-values](https://user-images.githubusercontent.com/3189335/139819067-ef1995b4-493a-4c5b-b6c3-6569d1bdede0.png)

# Example of fixed behavior

This PR fixes the behavior, passing the correct metadata keys and values to the Stripe API. Using the previous input, with the fixed behavior we get the following results:

![fixed-metadata-values](https://user-images.githubusercontent.com/3189335/139819066-16247605-a856-4c9f-9a89-8986d535c842.png)
