### PR TITLE
:bug: fix saving credentials id as string

### DIFF
--- a/packages/cli/src/databases/sqlite/migrations/1630330987096-UpdateWorkflowCredentials.ts
+++ b/packages/cli/src/databases/sqlite/migrations/1630330987096-UpdateWorkflowCredentials.ts
@@ -39,7 +39,7 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 									// @ts-ignore
 									(credentials) => credentials.name === name && credentials.type === type,
 								);
-								node.credentials[type] = { id: matchingCredentials?.id || null, name };
+								node.credentials[type] = { id: matchingCredentials?.id.toString() || null, name };
 								credentialsUpdated = true;
 							}
 						}
@@ -82,7 +82,7 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 									// @ts-ignore
 									(credentials) => credentials.name === name && credentials.type === type,
 								);
-								node.credentials[type] = { id: matchingCredentials?.id || null, name };
+								node.credentials[type] = { id: matchingCredentials?.id.toString() || null, name };
 								credentialsUpdated = true;
 							}
 						}
@@ -126,7 +126,7 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 								// @ts-ignore
 								(credentials) => credentials.name === name && credentials.type === type,
 							);
-							node.credentials[type] = { id: matchingCredentials?.id || null, name };
+							node.credentials[type] = { id: matchingCredentials?.id.toString() || null, name };
 							credentialsUpdated = true;
 						}
 					}
@@ -176,8 +176,8 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 						for (const [type, creds] of allNodeCredentials) {
 							if (typeof creds === 'object') {
 								const matchingCredentials = credentialsEntities.find(
-									// @ts-ignore
-									(credentials) => credentials.id === creds.id && credentials.type === type,
+									// @ts-ignore double-equals because creds.id can be string or number
+									(credentials) => credentials.id == creds.id && credentials.type === type,
 								);
 								if (matchingCredentials) {
 									node.credentials[type] = matchingCredentials.name;
@@ -226,8 +226,8 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 						for (const [type, creds] of allNodeCredentials) {
 							if (typeof creds === 'object') {
 								const matchingCredentials = credentialsEntities.find(
-									// @ts-ignore
-									(credentials) => credentials.id === creds.id && credentials.type === type,
+									// @ts-ignore double-equals because creds.id can be string or number
+									(credentials) => credentials.id == creds.id && credentials.type === type,
 								);
 								if (matchingCredentials) {
 									node.credentials[type] = matchingCredentials.name;
@@ -276,8 +276,8 @@ export class UpdateWorkflowCredentials1630330987096 implements MigrationInterfac
 					for (const [type, creds] of allNodeCredentials) {
 						if (typeof creds === 'object') {
 							const matchingCredentials = credentialsEntities.find(
-								// @ts-ignore
-								(credentials) => credentials.id === creds.id && credentials.type === type,
+								// @ts-ignore double-equals because creds.id can be string or number
+								(credentials) => credentials.id == creds.id && credentials.type === type,
 							);
 							if (matchingCredentials) {
 								node.credentials[type] = matchingCredentials.name;

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1917,10 +1917,13 @@ export default mixins(
 
 					if (nodeCredentials.id) {
 						// Check whether the id is matching with a credential
-						const credentialsForId = credentialOptions.find((optionData: ICredentialsResponse) => optionData.id === nodeCredentials.id);
+						const credentialsId = nodeCredentials.id.toString(); // due to a fixed bug in the migration UpdateWorkflowCredentials (just sqlite) we have to cast to string and check later if it has been a number
+						const credentialsForId = credentialOptions.find((optionData: ICredentialsResponse) =>
+							optionData.id === credentialsId,
+						);
 						if (credentialsForId) {
-							if (credentialsForId.name !== nodeCredentials.name) {
-								node.credentials![nodeCredentialType].name = credentialsForId.name;
+							if (credentialsForId.name !== nodeCredentials.name || typeof nodeCredentials.id === 'number') {
+								node.credentials![nodeCredentialType] = { id: credentialsForId.id, name: credentialsForId.name };
 								this.credentialsUpdated = true;
 							}
 							return;


### PR DESCRIPTION
⚠️ only relevant for sqlite ⚠️ 

unfortunately have credentials' ids been saved as numbers instead of strings at the replacement.

This created a bug in the UI: falsely indicating that the credential cannot be selected with certainty (if multiple exist of the same name) although it can via the id (which doesn't work because of type inequality)

Has no impact on running activated workflows, since TypeORM does type-coercion.