### PR TITLE
fix importing unknown types with credentials

### DIFF
--- a/packages/editor-ui/src/modules/credentials.ts
+++ b/packages/editor-ui/src/modules/credentials.ts
@@ -98,7 +98,7 @@ const module: Module<ICredentialsState, IRootState> = {
 		},
 		getCredentialsByType: (state: ICredentialsState, getters: any) => { // tslint:disable-line:no-any
 			return (credentialType: string): ICredentialsResponse[] => {
-				return getters.allCredentialsByType[credentialType];
+				return getters.allCredentialsByType[credentialType] || [];
 			};
 		},
 		getNodesWithAccess (state: ICredentialsState, getters: any, rootState: IRootState, rootGetters: any) { // tslint:disable-line:no-any


### PR DESCRIPTION
example workflow to import with this issue 
```
{"id":"21","name":"My workflow 31","active":false,"nodes":[{"parameters":{},"name":"Start","type":"n8n-nodes-base.start","typeVersion":1,"position":[250,300],"notesInFlow":false},{"parameters":{"authentication":"=serviceAccount","boardId":"ties:  - [ ]  The Node (Integration) Name is spelled incorrectly as 'Microsoft Planer' instead of 'Microsoft Planner' (After clicking the 'plus' in the top-right and searching for the node - it won't appear in the search list due to name mismatch). - [ ]  Within the Node Form, The name of the node should be a required entity,          But in the current version, it is possible to edit the name and save it as blank (a nameless node) - later it becomes impossible to rename it as the text box disappears.       ### Naming Conventions:  - [ ]  Change the text case of these Parameter names to Title Case as per Node UX Guide     - Credentials Type     - Card Description     - Make Card Visible     - Simplify output","bucketId":"### Node (Integration) Properties:  - [ ]  The Node (Integration) Name is spelled incorrectly as 'Microsoft Planer' instead of 'Microsoft Planner' (After clicking the 'plus' in the top-right and searching for the node - it won't appear in the search list due to name mismatch). - [ ]  Within the Node Form, The name of the node should be a required entity,          But in the current version, it is possible to edit the name and save it as blank (a nameless node) - later it becomes impossible to rename it as the text box disappears.       ### Naming Conventions:  - [ ]  Change the tels Type   mplify output","cardDescription":"### Node (Integration) Properties:\n\n- [ ]  The Node (Integration) Name is spelled incorrectly as 'Microsoft Planer' instead of 'Microsoft Planner' (After clicking the 'plus' in the top-right and searching for the node - it won't appear in the search list due to name mismatch).\n- [ ]  Within the Node Form, The name of the node should be a required entity,\n    \n    But in the current version, it is possible to edit the name and save it as blank (a nameless node) - later it becomes impossible to rename it as the text box disappears.\n    \n\n### Naming Conventions:\n\n- [ ]  Change the text case of these Parameter names to Title Case as per Node UX Guide\n    - Credentials Type\n    - Card Description\n    - Make Card Visible\n    - Simplify output","cardTitle":"### Node (Integration) Properties:  - [ ]  The Node (Integration) Name is spelled incorrectly as 'Microsoft Planer' instead of 'Microsoft Planner' (After clicking the 'plus' in the top-right and searching for the node - it won't appear in the search list due to name mismatch). - [ ]  Within the Node Form, The name of the node should be a required entity,          But in the current version, it is possible to edit the name and save it as blank (a nameless node) - later it becomes impossible to rename it as the text box disappears.       ### Naming Conventions:  - [ ]  Change the text case of these Parameter names to Title Case as per Node UX Guide     - Credentials Type     - Card Description     - Make Card Visible     - Simplify output","makeCardVisible":"=eafafa aca{{undefined}}{{true}}","simplifyOutput":true,"optionalFields":{"label":"=todo","priority":"1","createdBy":""}},"name":"","type":"n8n-nodes-base.microsoftPlanner","typeVersion":1,"position":[530,60],"notesInFlow":false,"alwaysOutputData":true,"executeOnce":true,"retryOnFail":true,"credentials":{"microsoftPlannerApi":{"id":"27","name":"Service Account dummy 2"}},"notes":"awesfdghj"},{"parameters":{},"name":"g","type":"n8n-nodes-base.function","typeVersion":1,"position":[670,330],"executeOnce":false,"retryOnFail":false,"alwaysOutputData":false,"color":"#544D46"},{"parameters":{"boardId":"dfgchj","bucketId":"fdgcvh  rtzuj createCard","cardDescription":"nb","cardTitle":"={{undefined}} {{undefined}} {{undefined}} {{$node[\"\"].parameter[\"action\"]}} {{$node[\"\"].parameter[\"authentication\"]}} {{undefined}}","makeCardVisible":true,"simplifyOutput":true,"optionalFields":{"label":"inProgress","priority":"1","createdBy":""}},"name":"Microsoft Planner erf","type":"n8n-nodes-base.microsoftPlanner","typeVersion":1,"position":[420,170],"notesInFlow":true,"credentials":{"microsoftPlannerApi":{"id":"27","name":"Service Account dummy 2"}},"notes":"dxfgchjb"},{"parameters":{"authentication":"oAuth2","optionalFields":{"priority":"1"}},"name":"Microsoft Planner","type":"n8n-nodes-base.microsoftPlanner","typeVersion":1,"position":[730,60],"credentials":{"microsoftPlannerOAuth2Api":{"id":"29","name":"Microsoft Planner account"}}}],"connections":{"Start":{"main":[[{"node":"Microsoft Planner erf","type":"main","index":0}]]},"":{"main":[[{"node":"Microsoft Planner","type":"main","index":0}]]}},"createdAt":"2021-10-26T11:42:40.179Z","updatedAt":"2021-10-26T11:42:40.179Z","settings":{},"staticData":null,"tags":[]}
```