### PR TITLE
Updating toggl API URL as previous one deprecated

### DIFF
--- a/packages/nodes-base/nodes/Toggl/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Toggl/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function togglApiRequest(this: ITriggerFunctions | IPollFunctions |
 		headers: headerWithAuthentication,
 		method,
 		qs: query,
-		uri: uri || `https://www.toggl.com/api/v8${resource}`,
+		uri: uri || `https://api.track.toggl.com/api/v8${resource}`,
 		body,
 		json: true,
 	};


### PR DESCRIPTION
Updating API URL as per https://support.toggl.com/en/articles/5708431-why-did-my-integration-stop-working

#2417