### PR TITLE
N8N-2553 Change node parameter validation behaviour

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -604,6 +604,9 @@ export interface IRootState {
 	lastSelectedNodeOutputIndex: number | null;
 	nodeIndex: Array<string | null>;
 	nodeTypes: INodeTypeDescription[];
+	nodeTouchedParameters: {
+		[key: string]: INodeTouchedParameters;
+	};
 	nodeViewOffsetPosition: XYPositon;
 	nodeViewMoveInProgress: boolean;
 	selectedNodes: INodeUi[];
@@ -613,6 +616,16 @@ export interface IRootState {
 	sidebarMenuItems: IMenuItem[];
 	instanceId: string;
 	telemetry: ITelemetrySettings | null;
+}
+
+export interface INodeTouchedParameters {
+	nodeName: string;
+	isCredentialFieldTouched: boolean;
+	fieldsParameters: FieldsParametersOption;
+}
+
+export interface FieldsParametersOption {
+	[key: string]: string | number | boolean | object | undefined | null;
 }
 
 export interface ICredentialTypeMap {

--- a/packages/editor-ui/src/components/DataDisplay.vue
+++ b/packages/editor-ui/src/components/DataDisplay.vue
@@ -106,6 +106,10 @@ export default mixins(externalHooks, nodeHelpers, workflowHelpers).extend({
 			this.$emit('nodeTypeSelected', nodeTypeName);
 		},
 		close () {
+			// Set that user interacted with all node fields on modal closing
+			this.$store.commit("setNodeTouchedCredentialField", true);
+			this.$store.commit("setNodeTouchedParameters");
+
 			this.$externalHooks().run('dataDisplay.nodeEditingFinished');
 			this.showDocumentHelp = false;
 			this.$store.commit('setActiveNode', null);

--- a/packages/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/editor-ui/src/components/NodeCredentials.vue
@@ -13,7 +13,7 @@
 				</div>
 
 				<div :class="issues.length ? $style.hasIssues : $style.input" v-else >
-					<n8n-select :value="getSelectedId(credentialTypeDescription.name)" @change="(value) => onCredentialSelected(credentialTypeDescription.name, value)" placeholder="Select Credential" size="small">
+					<n8n-select :value="getSelectedId(credentialTypeDescription.name)" @change="(value) => onCredentialSelected(credentialTypeDescription.name, value)" @focus="setFocus" placeholder="Select Credential" size="small">
 						<n8n-option
 							v-for="(item) in credentialOptions[credentialTypeDescription.name]"
 							:key="item.id"
@@ -28,7 +28,7 @@
 						</n8n-option>
 					</n8n-select>
 
-					<div :class="$style.warning" v-if="issues.length">
+					<div :class="$style.warning" v-if="issues.length && getNodeTouchedParameters.isCredentialFieldTouched">
 						<n8n-tooltip placement="top" >
 							<div slot="content" v-html="'Issues:<br />&nbsp;&nbsp;- ' + issues.join('<br />&nbsp;&nbsp;- ')"></div>
 							<font-awesome-icon icon="exclamation-triangle" />
@@ -85,8 +85,9 @@ export default mixins(
 		};
 	},
 	computed: {
-		...mapGetters('credentials', {
-			credentialOptions: 'allCredentialsByType',
+		...mapGetters({
+			credentialOptions: 'credentials/allCredentialsByType',
+			getNodeTouchedParameters: 'getNodeTouchedParameters',
 		}),
 		credentialTypesNode (): string[] {
 			return this.credentialTypesNodeDescription
@@ -160,6 +161,11 @@ export default mixins(
 			});
 		},
 
+		setFocus () {
+			// Set if the user interacted with the credential field on focus
+			this.$store.commit("setNodeTouchedCredentialField", true);
+		},
+
 		stopListeningForNewCredentials() {
 			if (this.newCredentialUnsubscribe) {
 				this.newCredentialUnsubscribe();
@@ -186,6 +192,9 @@ export default mixins(
 		},
 
 		onCredentialSelected (credentialType: string, credentialId: string | null | undefined) {
+			// Set if the user interacted with the credential field on select
+			this.$store.commit("setNodeTouchedCredentialField", true);
+
 			if (credentialId === NEW_CREDENTIALS_TEXT) {
 				this.listenForNewCredentials(credentialType);
 				this.$store.dispatch('ui/openNewCredential', { type: credentialType });

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -167,7 +167,7 @@
 		/>
 	</div>
 
-	<div class="parameter-issues" v-if="getIssues.length">
+	<div class="parameter-issues" v-if="getIssues.length && getNodeTouchedParameters.fieldsParameters[parameter.name]">
 		<n8n-tooltip placement="top" >
 			<div slot="content" v-html="'Issues:<br />&nbsp;&nbsp;- ' + getIssues.join('<br />&nbsp;&nbsp;- ')"></div>
 			<font-awesome-icon icon="exclamation-triangle" />
@@ -215,6 +215,8 @@ import { showMessage } from '@/components/mixins/showMessage';
 import { workflowHelpers } from '@/components/mixins/workflowHelpers';
 
 import mixins from 'vue-typed-mixins';
+
+import { mapGetters } from "vuex";
 
 export default mixins(
 	externalHooks,
@@ -298,6 +300,9 @@ export default mixins(
 			},
 		},
 		computed: {
+			...mapGetters({
+				getNodeTouchedParameters: 'getNodeTouchedParameters',
+			}),
 			showExpressionAsTextInput(): boolean {
 				const types = ['number', 'boolean', 'dateTime', 'options', 'multiOptions'];
 
@@ -633,9 +638,17 @@ export default mixins(
 				}
 			},
 			onBlur () {
+				// Set if the user interacted with the field on blur
+				const fieldParameter = {touched: true, name: this.parameter.name};
+				this.$store.commit("setNodeTouchedSingleFieldParameter", fieldParameter);
+
 				this.$emit('blur');
 			},
 			setFocus () {
+				// Set if the user interacted with the field on focus
+				const fieldParameter = {touched: true, name: this.parameter.name};
+				this.$store.commit("setNodeTouchedSingleFieldParameter", fieldParameter);
+
 				if (this.isValueExpression) {
 					this.expressionEditDialogVisible = true;
 					this.trackExpressionEditOpen();
@@ -679,6 +692,10 @@ export default mixins(
 				return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1) + ((1 << 8) + Math.floor((1-a)*255)).toString(16).slice(1);
 			},
 			onTextInputChange (value: string) {
+				// Set if the user interacted with the field on input change
+				const fieldParameter = {touched: true, name: this.parameter.name};
+				this.$store.commit("setNodeTouchedSingleFieldParameter", fieldParameter);
+
 				const parameterData = {
 					node: this.node !== null ? this.node.name : this.nodeName,
 					name: this.path,

--- a/packages/editor-ui/src/components/mixins/workflowRun.ts
+++ b/packages/editor-ui/src/components/mixins/workflowRun.ts
@@ -72,6 +72,10 @@ export const workflowRun = mixins(
 
 			this.clearAllStickyNotifications();
 
+			// Set that user interacted with all node fields on modal closing
+			this.$store.commit("setNodeTouchedCredentialField", true);
+			this.$store.commit("setNodeTouchedParameters");
+
 			try {
 				// Check first if the workflow has any issues before execute it
 				const issuesExist = this.$store.getters.nodesIssuesExist;

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2002,6 +2002,9 @@ export default mixins(
 					}
 
 					this.$store.commit('addNode', node);
+
+					// Add nodeTouchedParameter when user creating a new node
+					this.$store.commit('addNodeTouchedParameters', node);
 				});
 
 				// Wait for the node to be rendered


### PR DESCRIPTION
Currently, we show validation errors on parameters in the node details view before a user has a chance to interact with the parameter.

Only show validation errors after…

- [x] -User changes the parameter (adds input or focuses and defocuses the input)
- [x] -User attempts to execute the node or WF
- [x] -Closes the node details view (node modal) without interacting with the parameters.