### PR TITLE
🐛 Google Tasks: Fix due field

### DIFF
--- a/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
+++ b/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
@@ -124,7 +124,7 @@ export class GoogleTasks implements INodeType {
 							body.notes = additionalFields.notes as string;
 						}
 						if (additionalFields.dueDate) {
-							body.dueDate = additionalFields.dueDate as string;
+							body.due = additionalFields.dueDate as string;
 						}
 
 						if (additionalFields.completed) {
@@ -249,7 +249,7 @@ export class GoogleTasks implements INodeType {
 						}
 
 						if (updateFields.dueDate) {
-							body.dueDate = updateFields.dueDate as string;
+							body.due = updateFields.dueDate as string;
 						}
 
 						if (updateFields.completed) {

--- a/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
@@ -448,6 +448,13 @@ export const taskFields = [
 				description: 'Flag indicating whether the task has been deleted.',
 			},
 			{
+				displayName: 'Due Date',
+				name: 'dueDate',
+				type: 'dateTime',
+				default: '',
+				description: 'Due date of the task.',
+			},
+			{
 				displayName: 'Notes',
 				name: 'notes',
 				type: 'string',


### PR DESCRIPTION
This PR addresses a bug reported [by the community](https://community.n8n.io/t/cant-get-due-date-working-for-google-tasks/9049?u=mutedjam) where the Due Date field of the Google Tasks node had no effect (when creating a task) or was completely unavailable (when updating a task).

n8n was sending a `dueDate` key whereas the expected key would be `due` as per the [respective API documentation](https://developers.google.com/tasks/reference/rest/v1/tasks#Task). 