### PR TITLE
Removing default headers for PUT and PATCH

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -87,6 +87,8 @@ import {
 axios.defaults.timeout = 300000;
 // Prevent axios from adding x-form-www-urlencoded headers by default
 axios.defaults.headers.post = {};
+axios.defaults.headers.put = {};
+axios.defaults.headers.patch = {};
 axios.defaults.paramsSerializer = (params) => {
 	if (params instanceof URLSearchParams) {
 		return params.toString();


### PR DESCRIPTION
As can be seen in the previous lline, we already removed the default headers for POST.

This is due to Axios' default behavior to add these headers.

It can be seen here: https://github.com/axios/axios/blob/c5fe05bdff82e0fa4ace9a832e75052e1ee297f0/lib/defaults.js#L130