### PR TITLE
✨ Add Jira raw JSON field for advanced users

### DIFF
--- a/packages/nodes-base/nodes/Jira/IssueDescription.ts
+++ b/packages/nodes-base/nodes/Jira/IssueDescription.ts
@@ -254,6 +254,13 @@ export const issueFields = [
 				description: 'Priority',
 			},
 			{
+				displayName: 'Raw JSON',
+				name: 'rawJson',
+				type: 'string',
+				default: '',
+				description: 'A JSON object to be merged with the existing request object',
+			},
+			{
 				displayName: 'Reporter',
 				name: 'reporter',
 				type: 'options',
@@ -424,6 +431,13 @@ export const issueFields = [
 				},
 				default: '',
 				description: 'Priority',
+			},
+			{
+				displayName: 'Raw JSON',
+				name: 'rawJson',
+				type: 'string',
+				default: '',
+				description: 'A JSON object to be merged with the existing request object',
 			},
 			{
 				displayName: 'Reporter',

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -55,6 +55,10 @@ import {
 	userOperations,
 } from './UserDescription';
 
+import {
+	merge,
+} from 'lodash';
+
 export class Jira implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Jira Software',
@@ -517,6 +521,9 @@ export class Jira implements INodeType {
 						};
 					}
 					body.fields = fields;
+					if (additionalFields.rawJson) {
+						merge(body, JSON.parse(additionalFields.rawJson as string));
+					}
 					responseData = await jiraSoftwareCloudApiRequest.call(this, '/api/2/issue', 'POST', body);
 					returnData.push(responseData);
 				}
@@ -591,7 +598,9 @@ export class Jira implements INodeType {
 						};
 					}
 					body.fields = fields;
-
+					if (updateFields.rawJson) {
+						merge(body, JSON.parse(updateFields.rawJson as string));
+					}
 					if (updateFields.statusId) {
 						responseData = await jiraSoftwareCloudApiRequest.call(this, `/api/2/issue/${issueKey}/transitions`, 'POST', { transition: { id: updateFields.statusId } });
 					}


### PR DESCRIPTION
This PR adds the ability to manually define/merge the request JSON body for create and update operations. This can allow advanced users to support setting additional custom fields that aren't strings. This is in lieu of providing this dynamically in the front end which needs some thought.

In this example we're setting an options custom field with an ID we've pulled:
<img width="381" alt="n8n_-_▶️_Jira_test" src="https://user-images.githubusercontent.com/939704/141792294-4ca1707d-43cb-4a3e-9333-f654e522e065.png">

This could probably do with a documentation update, not sure where that exists to submit a PR?
 