### PR TITLE
🐛 CLI: Add windows support to import:workflow --separate

### DIFF
--- a/packages/cli/commands/import/workflow.ts
+++ b/packages/cli/commands/import/workflow.ts
@@ -86,9 +86,12 @@ export class ImportWorkflowsCommand extends Command {
 			const credentialsEntities = (await Db.collections.Credentials?.find()) ?? [];
 			let i;
 			if (flags.separate) {
-				const files = await glob(
-					`${flags.input.endsWith(path.sep) ? flags.input : flags.input + path.sep}*.json`,
-				);
+				let inputPath = flags.input;
+				if (process.platform === 'win32') {
+					inputPath = inputPath.replace(/\\/g, '/');
+				}
+				inputPath = inputPath.replace(/\/$/g, '');
+				const files = await glob(`${inputPath}/*.json`);
 				for (i = 0; i < files.length; i++) {
 					const workflow = JSON.parse(fs.readFileSync(files[i], { encoding: 'utf8' }));
 					if (credentialsEntities.length > 0) {


### PR DESCRIPTION
This PR addresses a bug [reported in the community](https://community.n8n.io/t/cant-see-any-change-after-i-import-workflow-from-file/9014/21?u=mutedjam). The CLI command `n8n import:workflow --separate` would fail on Windows because the [fast-glob](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) package requires forward-slashes for patterns (while Windows uses backslashes in paths).

This PR introduces a quick check for `process.platform === 'win32'` and converts backslashes accordingly if true.

It also removes potentially trailing slashes from the path since one will be appended as part of the pattern (I only did this because the linter complained about the old format).

Tested this on Windows 11 using:

```
.\packages\cli\bin\n8n import:workflow --separate --input=C:\Users\Tom\Desktop\test
.\packages\cli\bin\n8n import:workflow --separate --input=C:\Users\Tom\Desktop\test\
```

Workflows were imported in both cases. Also tested this on Ubuntu 20.04 using:

```
./packages/cli/bin/n8n import:workflow --separate --input=/mnt/c/Users/Tom/Desktop/test
./packages/cli/bin/n8n import:workflow --separate --input=/mnt/c/Users/Tom/Desktop/test/
```

Again workflows were imported in both cases.