### PR TITLE
Microsoft Dynamics Node: Adjust to support all regions urls

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -13,18 +13,18 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
-			displayName: 'Subdomain',
-			name: 'subdomain',
+			displayName: 'Url',
+			name: 'url',
 			type: 'string',
 			required: true,
-			placeholder: 'organization',
+			placeholder: 'Url to Microsoft Dynamics',
 			default: '',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '=openid offline_access https://{{$self.subdomain}}.crm.dynamics.com/.default',
+			default: '=openid offline_access https://{{$self.url}}/.default',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 } from 'n8n-workflow';
 
 export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credenitals = await this.getCredentials('microsoftDynamicsOAuth2Api') as { subdomain: string };
+	const credentials = await this.getCredentials('microsoftDynamicsOAuth2Api') as { url: string };
 
 	let options: OptionsWithUri = {
 		headers: {
@@ -26,7 +26,7 @@ export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSing
 		method,
 		body,
 		qs,
-		uri: uri || `https://${credenitals.subdomain}.crm.dynamics.com/api/data/v9.2${resource}`,
+		uri: uri || `https://${credentials.url}/api/data/v9.2${resource}`,
 		json: true,
 	};
 


### PR DESCRIPTION
The Microsoft Dynamics URL depends on the region that the instance is hosted, e.g. the european data center has uses crm4.dynamics.com instead of just crm.dynamics.com. The german has an entirely different one.
This change will allow to paste the entirely url supporting all regions as listed here:
https://docs.microsoft.com/en-us/power-platform/admin/new-datacenter-regions