### PR TITLE
Hubspot OAuth2 Credentials: Use granular scopes

### DIFF
--- a/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
@@ -4,7 +4,12 @@ import {
 } from 'n8n-workflow';
 
 const scopes = [
-	'contacts',
+	'crm.objects.contacts.read',
+	'crm.schemas.contacts.read',
+	'crm.objects.companies.read',
+	'crm.schemas.companies.read',
+	'crm.objects.deals.read',
+	'crm.schemas.deals.read'
 ];
 
 export class HubspotDeveloperApi implements ICredentialType {


### PR DESCRIPTION
This PR addresses the issue reported [here in the community forum](https://community.n8n.io/t/scope-error-using-hubspot-trigger/9317): Currently, new users trying to authenticate with Hubspot will see an error message `Insufficient scopes were provided. Please contact the app developer` coming from Hubspot. This appears to be caused by n8n requesting a `contacts` scope (which [while documented](https://developers.hubspot.com/docs/api/working-with-oauth#scopes) is no longer available to new apps).

Note: The scopes selected in the respective Hubspot app's Auth settings need to match the scopes requested by n8n (`oauth` needs to be selected separately):
![image](https://user-images.githubusercontent.com/19203795/142872970-189e190d-f75d-4461-be9c-1a9337629ba9.png)

⚠️ This is most likely a breaking change for existing users of the Hubspot Trigger node/Hubspot Developer API credentials. These users would need to:
1. Update their Hubspot app to use the scopes from the above screenshot (`oauth`, `crm.objects.contacts.read`, `crm.schemas.contacts.read`, `crm.objects.companies.read`, `crm.objects.deals.read`, `crm.schemas.companies.read`, `crm.schemas.deals.read`).
2. Reconnect their Hubspot account.