### PR TITLE
Fix unique node name creation for natively number suffixed names

### DIFF
--- a/packages/editor-ui/src/store.ts
+++ b/packages/editor-ui/src/store.ts
@@ -808,6 +808,21 @@ export const store = new Vuex.Store({
 		allNodeTypes: (state): INodeTypeDescription[] => {
 			return state.nodeTypes;
 		},
+
+		/**
+		 * Getter for node default names ending with a number: `'S3'`, `'Magento 2'`, etc.
+		 */
+		nativelyNumberSuffixedDefaults: (_, getters): string[] => {
+			const { allNodeTypes } = getters as {
+				allNodeTypes: Array<INodeTypeDescription & { defaults: { name: string } }>;
+			};
+
+			return allNodeTypes.reduce<string[]>((acc, cur) => {
+				if (/\d$/.test(cur.defaults.name)) acc.push(cur.defaults.name);
+				return acc;
+			}, []);
+		},
+
 		nodeType: (state, getters) => (nodeType: string, typeVersion?: number): INodeTypeDescription | null => {
 			const foundType = state.nodeTypes.find(typeData => {
 				return typeData.name === nodeType && typeData.version === (typeVersion || typeData.defaultVersion || DEFAULT_NODETYPE_VERSION);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -243,6 +243,7 @@ export default mixins(
 			...mapGetters('ui', [
 				'sidebarMenuCollapsed',
 			]),
+			...mapGetters(['nativelyNumberSuffixedDefaults']),
 			activeNode (): INodeUi | null {
 				return this.$store.getters.activeNode;
 			},
@@ -1183,7 +1184,7 @@ export default mixins(
 				newNodeData.name = CanvasHelpers.getUniqueNodeName({
 					nodes: this.$store.getters.allNodes,
 					originalName: newNodeData.name,
-					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+					nativelyNumberSuffixed: this.nativelyNumberSuffixedDefaults,
 				});
 
 				if (nodeTypeData.webhooks && nodeTypeData.webhooks.length) {
@@ -1760,7 +1761,7 @@ export default mixins(
 				newNodeData.name = CanvasHelpers.getUniqueNodeName({
 					nodes: this.$store.getters.allNodes,
 					originalName: newNodeData.name,
-					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+					nativelyNumberSuffixed: this.nativelyNumberSuffixedDefaults,
 				});
 
 				newNodeData.position = CanvasHelpers.getNewNodePosition(
@@ -2004,7 +2005,7 @@ export default mixins(
 				newName = CanvasHelpers.getUniqueNodeName({
 					nodes: this.$store.getters.allNodes,
 					originalName: newName,
-					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+					nativelyNumberSuffixed: this.nativelyNumberSuffixedDefaults,
 				});
 
 				// Rename the node and update the connections
@@ -2218,7 +2219,7 @@ export default mixins(
 						nodes: this.$store.getters.allNodes,
 						originalName: node.name,
 						additionalUsedNames: newNodeNames,
-						nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+						nativelyNumberSuffixed: this.nativelyNumberSuffixedDefaults,
 					});
 
 					newNodeNames.push(newName);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1180,7 +1180,11 @@ export default mixins(
 				}
 
 				// Check if node-name is unique else find one that is
-				newNodeData.name = CanvasHelpers.getUniqueNodeName(this.$store.getters.allNodes, newNodeData.name);
+				newNodeData.name = CanvasHelpers.getUniqueNodeName({
+					nodes: this.$store.getters.allNodes,
+					originalName: newNodeData.name,
+					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+				});
 
 				if (nodeTypeData.webhooks && nodeTypeData.webhooks.length) {
 					newNodeData.webhookId = uuidv4();
@@ -1753,7 +1757,11 @@ export default mixins(
 				const newNodeData = JSON.parse(JSON.stringify(this.getNodeDataToSave(node)));
 
 				// Check if node-name is unique else find one that is
-				newNodeData.name = CanvasHelpers.getUniqueNodeName(this.$store.getters.allNodes, newNodeData.name);
+				newNodeData.name = CanvasHelpers.getUniqueNodeName({
+					nodes: this.$store.getters.allNodes,
+					originalName: newNodeData.name,
+					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+				});
 
 				newNodeData.position = CanvasHelpers.getNewNodePosition(
 					this.nodes,
@@ -1993,7 +2001,11 @@ export default mixins(
 					return;
 				}
 				// Check if node-name is unique else find one that is
-				newName = CanvasHelpers.getUniqueNodeName(this.$store.getters.allNodes, newName);
+				newName = CanvasHelpers.getUniqueNodeName({
+					nodes: this.$store.getters.allNodes,
+					originalName: newName,
+					nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+				});
 
 				// Rename the node and update the connections
 				const workflow = this.getWorkflow(undefined, undefined, true);
@@ -2202,7 +2214,12 @@ export default mixins(
 					}
 
 					oldName = node.name;
-					newName = CanvasHelpers.getUniqueNodeName(this.$store.getters.allNodes, node.name, newNodeNames);
+					newName = CanvasHelpers.getUniqueNodeName({
+						nodes: this.$store.getters.allNodes,
+						originalName: node.name,
+						additionalUsedNames: newNodeNames,
+						nativelyNumberSuffixed: this.$store.getters.nativelyNumberSuffixedDefaults,
+					});
 
 					newNodeNames.push(newName);
 					nodeNameTable[oldName] = newName;

--- a/packages/editor-ui/src/views/canvasHelpers.ts
+++ b/packages/editor-ui/src/views/canvasHelpers.ts
@@ -640,7 +640,9 @@ export const getUniqueNodeName = ({
 
 	if (found) {
 		nameIndex = originalName.split(found).pop();
-		if (nameIndex) index = parseInt(nameIndex, 10);
+		if (nameIndex) {
+			index = parseInt(nameIndex, 10);
+		}
 		baseName = uniqueName = found;
 	} else {
 		const nameMatch = originalName.match(/(.*\D+)(\d*)/);

--- a/packages/editor-ui/src/views/canvasHelpers.ts
+++ b/packages/editor-ui/src/views/canvasHelpers.ts
@@ -609,9 +609,19 @@ export const getZoomToFit = (nodes: INodeUi[]): {offset: XYPosition, zoomLevel: 
 	};
 };
 
-export const getUniqueNodeName = (nodes: INodeUi[], originalName: string, additinalUsedNames?: string[]) => {
+export const getUniqueNodeName = ({
+	nodes,
+	originalName,
+	additionalUsedNames,
+	nativelyNumberSuffixed,
+} : {
+	nodes: INodeUi[],
+	originalName: string,
+	additionalUsedNames?: string[],
+	nativelyNumberSuffixed: string[],
+}) => {
 	// Check if node-name is unique else find one that is
-	additinalUsedNames = additinalUsedNames || [];
+	additionalUsedNames = additionalUsedNames || [];
 
 	// Get all the names of the current nodes
 	const nodeNames = nodes.map((node: INodeUi) => {
@@ -619,31 +629,40 @@ export const getUniqueNodeName = (nodes: INodeUi[], originalName: string, additi
 	});
 
 	// Check first if the current name is already unique
-	if (!nodeNames.includes(originalName) && !additinalUsedNames.includes(originalName)) {
+	if (!nodeNames.includes(originalName) && !additionalUsedNames.includes(originalName)) {
 		return originalName;
 	}
 
-	const nameMatch = originalName.match(/(.*\D+)(\d*)/);
+	const found = nativelyNumberSuffixed.find((n) => originalName.startsWith(n));
+
 	let ignore, baseName, nameIndex, uniqueName;
 	let index = 1;
 
-	if (nameMatch === null) {
-		// Name is only a number
-		index = parseInt(originalName, 10);
-		baseName = '';
-		uniqueName = baseName + index;
+	if (found) {
+		nameIndex = originalName.split(found).pop();
+		if (nameIndex) index = parseInt(nameIndex, 10);
+		baseName = uniqueName = found;
 	} else {
-		// Name is string or string/number combination
-		[ignore, baseName, nameIndex] = nameMatch;
-		if (nameIndex !== '') {
-			index = parseInt(nameIndex, 10);
+		const nameMatch = originalName.match(/(.*\D+)(\d*)/);
+
+		if (nameMatch === null) {
+			// Name is only a number
+			index = parseInt(originalName, 10);
+			baseName = '';
+			uniqueName = baseName + index;
+		} else {
+			// Name is string or string/number combination
+			[ignore, baseName, nameIndex] = nameMatch;
+			if (nameIndex !== '') {
+				index = parseInt(nameIndex, 10);
+			}
+			uniqueName = baseName;
 		}
-		uniqueName = baseName;
 	}
 
 	while (
 		nodeNames.includes(uniqueName) ||
-		additinalUsedNames.includes(uniqueName)
+		additionalUsedNames.includes(uniqueName)
 	) {
 		uniqueName = baseName + (index++);
 	}


### PR DESCRIPTION
Unique node name creation was failing for: `Magento 2`, `Msg91`, `S3`, `SIGNL4`, `Sms77`, `AWS S3`. Tested with addition, duplication, renaming.

<img src="https://user-images.githubusercontent.com/44588767/143859072-2dba71c3-35ea-4b4c-bbbc-63c633afdd3e.png" width="300">
