### PR TITLE
Fix typos in Salesforce param descriptions

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/OpportunityDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/OpportunityDescription.ts
@@ -538,11 +538,11 @@ export const opportunityFields = [
 				options: [
 					{
 						name: 'Business',
-						valie: 'Business',
+						value: 'Business',
 					},
 					{
 						name: 'New Business',
-						valie: 'New Business',
+						value: 'New Business',
 					},
 				],
 				description: 'Type of opportunity. For example, Existing Business or New Business. Label is Opportunity Type.',


### PR DESCRIPTION
Follow-up to #2500