### PR TITLE
Changed the place where output format is made

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts
@@ -26,9 +26,6 @@ export class MattermostV1 implements INodeType {
 	methods = { loadOptions };
 
 	async execute(this: IExecuteFunctions) {
-		// Router returns INodeExecutionData[]
-		// We need to output INodeExecutionData[][]
-		// So we wrap in []
-		return [await router.call(this)];
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/router.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/router.ts
@@ -12,7 +12,7 @@ import * as reaction from './reaction';
 import * as user from './user';
 import { Mattermost } from './Interfaces';
 
-export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
+export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
 	const operationResult: INodeExecutionData[] = [];
 
@@ -49,5 +49,5 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 		}
 	}
 
-	return operationResult;
+	return [operationResult];
 }


### PR DESCRIPTION
The router file now correctly returns a `INodeExecutionData[][]` instead of a simple `INodeExecutionData[]` forcing the main node file to correct this.