### PR TITLE
Allow ItemList to Extract a path from Object

### DIFF
--- a/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
@@ -699,61 +699,61 @@ return 0;`,
 						arrayToSplit = [arrayToSplit];
 					}
 
-					for (const element of arrayToSplit) {
-						let newItem = {};
+						for (const element of arrayToSplit) {
+							let newItem = {};
 
-						if (include === 'selectedOtherFields') {
+							if (include === 'selectedOtherFields') {
 
-							const fieldsToInclude = (this.getNodeParameter('fieldsToInclude.fields', i, []) as [{ fieldName: string }]).map(field => field.fieldName);
+								const fieldsToInclude = (this.getNodeParameter('fieldsToInclude.fields', i, []) as [{ fieldName: string }]).map(field => field.fieldName);
 
-							if (!fieldsToInclude.length) {
-								throw new NodeOperationError(this.getNode(), 'No fields specified', { description: 'Please add a field to include' });
+								if (!fieldsToInclude.length) {
+									throw new NodeOperationError(this.getNode(), 'No fields specified', { description: 'Please add a field to include' });
+								}
+
+								newItem = {
+									...fieldsToInclude.reduce((prev, field) => {
+										if (field === fieldToSplitOut) {
+											return prev;
+										}
+										let value;
+										if (disableDotNotation === false) {
+											value = get(items[i].json, field);
+										} else {
+											value = items[i].json[field as string];
+										}
+										prev = { ...prev, [field as string]: value, };
+										return prev;
+									}, {}),
+								};
+
+							} else if (include === 'allOtherFields') {
+
+								const keys = Object.keys(items[i].json);
+
+								newItem = {
+									...keys.reduce((prev, field) => {
+										let value;
+										if (disableDotNotation === false) {
+											value = get(items[i].json, field);
+										} else {
+											value = items[i].json[field as string];
+										}
+										prev = { ...prev, [field as string]: value, };
+										return prev;
+									}, {}),
+								};
+
+								unset(newItem, fieldToSplitOut);
 							}
 
-							newItem = {
-								...fieldsToInclude.reduce((prev, field) => {
-									if (field === fieldToSplitOut) {
-										return prev;
-									}
-									let value;
-									if (disableDotNotation === false) {
-										value = get(items[i].json, field);
-									} else {
-										value = items[i].json[field as string];
-									}
-									prev = { ...prev, [field as string]: value, };
-									return prev;
-								}, {}),
-							};
+							if (typeof element === 'object' && include === 'noOtherFields' && destinationFieldName === '') {
+								newItem = { ...newItem, ...element };
+							} else {
+								newItem = { ...newItem, [destinationFieldName as string || fieldToSplitOut as string]: element };
+							}
 
-						} else if (include === 'allOtherFields') {
-
-							const keys = Object.keys(items[i].json);
-
-							newItem = {
-								...keys.reduce((prev, field) => {
-									let value;
-									if (disableDotNotation === false) {
-										value = get(items[i].json, field);
-									} else {
-										value = items[i].json[field as string];
-									}
-									prev = { ...prev, [field as string]: value, };
-									return prev;
-								}, {}),
-							};
-
-							unset(newItem, fieldToSplitOut);
+							returnData.push({ json: newItem });
 						}
-
-						if (typeof element === 'object' && include === 'noOtherFields' && destinationFieldName === '') {
-							newItem = { ...newItem, ...element };
-						} else {
-							newItem = { ...newItem, [destinationFieldName as string || fieldToSplitOut as string]: element };
-						}
-
-						returnData.push({ json: newItem });
-					}
 				}
 
 				return this.prepareOutputData(returnData);

--- a/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
@@ -696,64 +696,63 @@ return 0;`,
 					}
 
 					if (!Array.isArray(arrayToSplit)) {
-						throw new NodeOperationError(this.getNode(), `The provided field '${fieldToSplitOut}' is not an array`);
-					} else {
+						arrayToSplit = [arrayToSplit];
+					}
 
-						for (const element of arrayToSplit) {
-							let newItem = {};
+					for (const element of arrayToSplit) {
+						let newItem = {};
 
-							if (include === 'selectedOtherFields') {
+						if (include === 'selectedOtherFields') {
 
-								const fieldsToInclude = (this.getNodeParameter('fieldsToInclude.fields', i, []) as [{ fieldName: string }]).map(field => field.fieldName);
+							const fieldsToInclude = (this.getNodeParameter('fieldsToInclude.fields', i, []) as [{ fieldName: string }]).map(field => field.fieldName);
 
-								if (!fieldsToInclude.length) {
-									throw new NodeOperationError(this.getNode(), 'No fields specified', { description: 'Please add a field to include' });
-								}
-
-								newItem = {
-									...fieldsToInclude.reduce((prev, field) => {
-										if (field === fieldToSplitOut) {
-											return prev;
-										}
-										let value;
-										if (disableDotNotation === false) {
-											value = get(items[i].json, field);
-										} else {
-											value = items[i].json[field as string];
-										}
-										prev = { ...prev, [field as string]: value, };
-										return prev;
-									}, {}),
-								};
-
-							} else if (include === 'allOtherFields') {
-
-								const keys = Object.keys(items[i].json);
-
-								newItem = {
-									...keys.reduce((prev, field) => {
-										let value;
-										if (disableDotNotation === false) {
-											value = get(items[i].json, field);
-										} else {
-											value = items[i].json[field as string];
-										}
-										prev = { ...prev, [field as string]: value, };
-										return prev;
-									}, {}),
-								};
-
-								unset(newItem, fieldToSplitOut);
+							if (!fieldsToInclude.length) {
+								throw new NodeOperationError(this.getNode(), 'No fields specified', { description: 'Please add a field to include' });
 							}
 
-							if (typeof element === 'object' && include === 'noOtherFields' && destinationFieldName === '') {
-								newItem = { ...newItem, ...element };
-							} else {
-								newItem = { ...newItem, [destinationFieldName as string || fieldToSplitOut as string]: element };
-							}
+							newItem = {
+								...fieldsToInclude.reduce((prev, field) => {
+									if (field === fieldToSplitOut) {
+										return prev;
+									}
+									let value;
+									if (disableDotNotation === false) {
+										value = get(items[i].json, field);
+									} else {
+										value = items[i].json[field as string];
+									}
+									prev = { ...prev, [field as string]: value, };
+									return prev;
+								}, {}),
+							};
 
-							returnData.push({ json: newItem });
+						} else if (include === 'allOtherFields') {
+
+							const keys = Object.keys(items[i].json);
+
+							newItem = {
+								...keys.reduce((prev, field) => {
+									let value;
+									if (disableDotNotation === false) {
+										value = get(items[i].json, field);
+									} else {
+										value = items[i].json[field as string];
+									}
+									prev = { ...prev, [field as string]: value, };
+									return prev;
+								}, {}),
+							};
+
+							unset(newItem, fieldToSplitOut);
 						}
+
+						if (typeof element === 'object' && include === 'noOtherFields' && destinationFieldName === '') {
+							newItem = { ...newItem, ...element };
+						} else {
+							newItem = { ...newItem, [destinationFieldName as string || fieldToSplitOut as string]: element };
+						}
+
+						returnData.push({ json: newItem });
 					}
 				}
 
@@ -986,7 +985,7 @@ return 0;`,
 						fieldName: string;
 						order: 'ascending' | 'descending'
 					}>;
-				
+
 
 					if (!sortFields || !sortFields.length) {
 						throw new NodeOperationError(this.getNode(), 'No sorting specified. Please add a field to sort by');


### PR DESCRIPTION
Given a nested JavaScript object, the goal is to extract the object from a certain depth (path), without having to use the function node (a low-code form) and place it at the root:

For example, node Webhook always returns data like this:

![image-a](https://user-images.githubusercontent.com/257004/144551020-5c6ea37e-eb67-428c-9732-49b5f2da64b3.png)

If we only want to use the body, we have to use the node function (which is a problem for non-devs).

If using ItemList to extract the body, it actually throws an exception:

![image-b](https://user-images.githubusercontent.com/257004/144551186-dc8c6e50-3ae5-4593-9553-a9a663034084.png)

If we use Set, the result will put the items in a property (the goal is to put them at the root):

![image-d](https://user-images.githubusercontent.com/257004/144599477-dfbc0918-43c4-4b61-86bf-eb4771ff7ce0.png)

This pull request allows the ItemList to pull data from the given path from both arrays and objects by placing at the root (without a parent property):

![image-c](https://user-images.githubusercontent.com/257004/144551352-c0022155-eb77-4e66-a2f8-93319ccba399.png)

