### PR TITLE
Support Application permissions in OAuth2

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -13,18 +13,18 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 	properties: INodeProperties[] = [
 		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
-			displayName: 'Subdomain',
-			name: 'subdomain',
+			displayName: 'Url',
+			name: 'url',
 			type: 'string',
 			required: true,
-			placeholder: 'organization',
+			placeholder: 'Url to Microsoft Dynamics',
 			default: '',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '=openid offline_access https://{{$self.subdomain}}.crm.dynamics.com/.default',
+			default: '=openid offline_access https://{{$self.url}}/.default',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/OAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/OAuth2Api.credentials.ts
@@ -73,5 +73,24 @@ export class OAuth2Api implements ICredentialType {
 			default: 'header',
 			description: 'Resource to consume.',
 		},
+		{
+			displayName: 'Delegated or Application permission',
+			name: 'permissionType',
+			type: 'options',
+			options: [
+				{
+					name: 'Delegated',
+					value: 'delegated',
+					description: 'Delegated permissions are used by apps that have a signed-in user present. For these apps, either the user or an administrator consents to the permissions that the app requests. The app is delegated with the permission to act as a signed-in user when it makes calls to the target resource.'
+				},
+				{
+					name: 'Application',
+					value: 'application',
+					description: 'Application permissions are used by apps that run without a signed-in user present, for example, apps that run as background services or daemons. Only an administrator can consent to application permissions.'
+				}
+			],
+			default: 'delegated',
+			description: 'Use delegated or application permission'
+		}
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -15,7 +15,7 @@ import {
 } from 'n8n-workflow';
 
 export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credenitals = await this.getCredentials('microsoftDynamicsOAuth2Api') as { subdomain: string };
+	const credentials = await this.getCredentials('microsoftDynamicsOAuth2Api') as { url: string };
 
 	let options: OptionsWithUri = {
 		headers: {
@@ -26,7 +26,7 @@ export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSing
 		method,
 		body,
 		qs,
-		uri: uri || `https://${credenitals.subdomain}.crm.dynamics.com/api/data/v9.2${resource}`,
+		uri: uri || `https://${credentials.url}/api/data/v9.2${resource}`,
 		json: true,
 	};
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#permission-types

Client credentials flow are used for applications: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow