### PR TITLE
:zap: Add apiEndpoint to Telegram credentials

### DIFF
--- a/packages/nodes-base/credentials/TelegramApi.credentials.ts
+++ b/packages/nodes-base/credentials/TelegramApi.credentials.ts
@@ -23,7 +23,7 @@ export class TelegramApi implements ICredentialType {
 			default: false,
 		},
 		{
-			displayName: 'APIEndpoint',
+			displayName: 'API Endpoint',
 			name: 'apiEndpoint',
 			type: 'string',
 			displayOptions: {
@@ -37,7 +37,7 @@ export class TelegramApi implements ICredentialType {
 			description: 'API endpoint. Use to redirect Telegram API calls to another server. First \'{0}\' is the \'accessToken\', second \'{1}\' is the endpoint method. See: <a href="https://core.telegram.org/bots">bot api</a>.',
 		},
 		{
-			displayName: 'FileEndpoint',
+			displayName: 'File Endpoint',
 			name: 'fileEndpoint',
 			type: 'string',
 			displayOptions: {

--- a/packages/nodes-base/credentials/TelegramApi.credentials.ts
+++ b/packages/nodes-base/credentials/TelegramApi.credentials.ts
@@ -16,5 +16,39 @@ export class TelegramApi implements ICredentialType {
 			default: '',
 			description: 'Chat with the <a href="https://telegram.me/botfather">bot father</a> to obtain the access token.',
 		},
+		{
+			displayName: 'Advanced',
+			name: 'advanced',
+			type: 'boolean',
+			default: false,
+		},
+		{
+			displayName: 'APIEndpoint',
+			name: 'apiEndpoint',
+			type: 'string',
+			displayOptions: {
+				show: {
+					advanced: [
+						true,
+					],
+				},
+			},
+			default: 'https://api.telegram.org/bot{0}/{1}',
+			description: 'API endpoint. Use to redirect Telegram API calls to another server. First \'{0}\' is the \'accessToken\', second \'{1}\' is the endpoint method. See: <a href="https://core.telegram.org/bots">bot api</a>.',
+		},
+		{
+			displayName: 'FileEndpoint',
+			name: 'fileEndpoint',
+			type: 'string',
+			displayOptions: {
+				show: {
+					advanced: [
+						true,
+					],
+				},
+			},
+			default: 'https://api.telegram.org/file/bot{0}/{1}',
+			description: 'File endpoint. Use to redirect Telegram File API calls to another server. First \'{0}\' is the \'accessToken\', second \'{1}\' is the endpoint method. See: <a href="https://core.telegram.org/bots">bot api</a>.',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -10,6 +10,7 @@ import {
 } from 'request';
 
 import {
+	ICredentialDataDecryptedObject,
 	IDataObject,
 	NodeApiError,
 	NodeOperationError,
@@ -151,12 +152,14 @@ export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoa
 		throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 	}
 
+	const uri = getApiEndpoint(credentials, endpoint);
+
 	query = query || {};
 
 	const options: OptionsWithUri = {
 		headers: {},
 		method,
-		uri: `https://api.telegram.org/bot${credentials.accessToken}/${endpoint}`,
+		uri: uri,
 		body,
 		qs: query,
 		json: true,
@@ -197,4 +200,21 @@ export function getImageBySize(photos: IDataObject[], size: string): IDataObject
 
 export function getPropertyName(operation: string) {
 	return operation.replace('send', '').toLowerCase();
+}
+
+function formatEndpoint(s: string, ...args : string[]): string {
+	return s.replace(/{(\d+)}/g, function(match, number) {
+		return typeof args[number] != 'undefined'
+		  ? args[number]
+		  : match
+		;
+	  });
+}
+
+export function getApiEndpoint(credentials: ICredentialDataDecryptedObject, endpoint: string): string {
+	return credentials.advanced ? formatEndpoint(`${credentials.apiEndpoint}`, `${credentials.accessToken}`, endpoint) : `https://api.telegram.org/bot${credentials.accessToken}/${endpoint}`;
+}
+
+export function getFileEndpoint(credentials: ICredentialDataDecryptedObject, endpoint: string): string {
+	return credentials.advanced ? formatEndpoint(`${credentials.fileEndpoint}`, `${credentials.accessToken}`, endpoint) : `https://api.telegram.org/file/bot${credentials.accessToken}/${endpoint}`;
 }

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -18,6 +18,8 @@ import {
 	addAdditionalFields,
 	apiRequest,
 	getPropertyName,
+	getApiEndpoint,
+	getFileEndpoint,
 } from './GenericFunctions';
 
 
@@ -1816,9 +1818,11 @@ export class Telegram implements INodeType {
 	methods = {
 		credentialTest: {
 			async telegramBotTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
-				const credentials = credential.data;
+				const credentials = credential.data!;
+				const endpoint = 'getMe';
+				const uri = getApiEndpoint(credentials, endpoint);
 				const options = {
-					uri: `https://api.telegram.org/bot${credentials!.accessToken}/getMe`,
+					uri: uri,
 					json: true,
 				};
 				try {
@@ -1840,7 +1844,6 @@ export class Telegram implements INodeType {
 					status: 'OK',
 					message: 'Authentication successful!',
 				};
-
 			},
 		},
 	};
@@ -2196,7 +2199,10 @@ export class Telegram implements INodeType {
 						if (credentials === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No credentials got returned!');
 						}
-						const file = await apiRequest.call(this, 'GET', '', {}, {}, { json: false, encoding: null, uri: `https://api.telegram.org/file/bot${credentials.accessToken}/${filePath}`, resolveWithFullResponse: true });
+
+						const fileUri = getFileEndpoint(credentials, `${filePath}`);
+
+						const file = await apiRequest.call(this, 'GET', '', {}, {}, { json: false, encoding: null, uri: fileUri, resolveWithFullResponse: true });
 
 						const fileName = filePath.split('/').pop();
 						const binaryData = await this.helpers.prepareBinaryData(Buffer.from(file.body as string), fileName);

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1825,6 +1825,12 @@ export class Telegram implements INodeType {
 					uri: uri,
 					json: true,
 				};
+				if (credentials.advanced) {
+					return {
+						status: 'OK',
+						message: 'Credential test disabled when advanced api endpoint enabled.',
+					}
+				}
 				try {
 					const response = await this.helpers.request(options);
 					if (!response.ok) {


### PR DESCRIPTION
Create an advanced option for setting custom Telegram's apiEndpoint.

Inspired by https://github.com/go-telegram-bot-api/telegram-bot-api/blob/3834565c356e9b2d94bd8080555aeaf795bbb0ea/bot.go#L100