### PR TITLE
🐛 WooCommerce: Fix pagination for getAll product operation

### DIFF
--- a/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
@@ -53,7 +53,6 @@ export async function woocommerceApiRequest(this: IHookFunctions | IExecuteFunct
 		uri: uri || `${credentials.url}/wp-json/wc/v3${resource}`,
 		json: true,
 	};
-
 	if (credentials.includeCredentialsInQuery === true) {
 		delete options.auth;
 		Object.assign(qs, { consumer_key: credentials.consumerKey, consumer_secret: credentials.consumerSecret });
@@ -79,7 +78,11 @@ export async function woocommerceApiRequestAllItems(this: IExecuteFunctions | IL
 	query.per_page = 100;
 	do {
 		responseData = await woocommerceApiRequest.call(this, method, endpoint, body, query, uri, { resolveWithFullResponse: true });
-		uri = responseData.headers['link'].split(';')[0].replace('<', '').replace('>', '');
+		const links = responseData.headers.link.split(',');
+		const nextLink = links.find((link: string) => link.indexOf('rel="next"') !== -1);
+		if (nextLink) {
+			uri = nextLink.split(';')[0].replace(/<(.*)>/, '$1');
+		}
 		returnData.push.apply(returnData, responseData.body);
 	} while (
 		responseData.headers['link'] !== undefined &&
@@ -156,7 +159,7 @@ export function setFields(fieldsToSet: IDataObject, body: IDataObject) {
 		} else {
 			body[snakeCase(fields.toString())] = fieldsToSet[fields];
 		}
-		
+
 	}
 }
 


### PR DESCRIPTION
This PR addresses a problem [raised in our community](https://community.n8n.io/t/problem-with-woocommerce-node-fails-on-product-get-all/9607) by member Alejandro_Bonnin.

When enabling the *Return All* option on the *Get All* operation of the *Product* resource, WooCommerce can respond with a `link` header in which the `rel="prev"` URL appears before the `rel="next"` URL. Previously, n8n would always use the first URL from the `link` header. With this change, n8n searches for the correct `rel="next"` URL regardless of its position.