### PR TITLE
Fixed typo that prevented opportunity amount from being saved

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1744,8 +1744,8 @@ export class Salesforce implements INodeType {
 						if (additionalFields.type !== undefined) {
 							body.Type = additionalFields.type as string;
 						}
-						if (additionalFields.ammount !== undefined) {
-							body.Amount = additionalFields.ammount as number;
+						if (additionalFields.amount !== undefined) {
+							body.Amount = additionalFields.amount as number;
 						}
 						if (additionalFields.owner !== undefined) {
 							body.OwnerId = additionalFields.owner as string;
@@ -1813,8 +1813,8 @@ export class Salesforce implements INodeType {
 						if (updateFields.type !== undefined) {
 							body.Type = updateFields.type as string;
 						}
-						if (updateFields.ammount !== undefined) {
-							body.Amount = updateFields.ammount as number;
+						if (updateFields.amount !== undefined) {
+							body.Amount = updateFields.amount as number;
 						}
 						if (updateFields.owner !== undefined) {
 							body.OwnerId = updateFields.owner as string;


### PR DESCRIPTION
"amount" was typed "ammount" on 4 occurrences. That prevented the amount from being saved at all.