### PR TITLE
✨ Add option to ignore requests from bots

### DIFF
--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 
 import * as formidable from 'formidable';
 
+import * as isbot from 'isbot';
 
 function authorizationError(resp: Response, realm: string, responseCode: number, message?: string) {
 	if (message === undefined) {
@@ -627,6 +628,13 @@ export class Wait implements INodeType {
 						placeholder: 'webhook',
 						description: 'This suffix path will be appended to the restart URL. Helpful when using multiple wait nodes. Note: Does not support expressions.',
 					},
+					{
+						displayName: 'Ignore Bots',
+						name: 'ignoreBots',
+						type: 'boolean',
+						default: false,
+						description: 'Set to true to ignore requests from bots like link previewers and web crawlers',
+					},
 					// {
 					// 	displayName: 'Raw Body',
 					// 	name: 'rawBody',
@@ -655,6 +663,11 @@ export class Wait implements INodeType {
 		const resp = this.getResponseObject();
 		const headers = this.getHeaderData();
 		const realm = 'Webhook';
+
+		const ignoreBots = options.ignoreBots as boolean;
+		if (ignoreBots && isbot((headers as IDataObject)['user-agent'] as string)) {
+			return authorizationError(resp, realm, 403);
+		}
 
 		if (incomingAuthentication === 'basicAuth') {
 			// Basic authorization is needed to call webhook

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -20,6 +20,8 @@ import * as fs from 'fs';
 
 import * as formidable from 'formidable';
 
+import * as isbot from 'isbot';
+
 function authorizationError(resp: Response, realm: string, responseCode: number, message?: string) {
 	if (message === undefined) {
 		message = 'Authorization problem!';
@@ -379,6 +381,13 @@ export class Webhook implements INodeType {
 						default: false,
 						description: 'Raw body (binary)',
 					},
+					{
+						displayName: 'Ignore Bots',
+						name: 'ignoreBots',
+						type: 'boolean',
+						default: false,
+						description: 'Set to true to ignore requests from bots like link previewers and web crawlers',
+					},
 				],
 			},
 		],
@@ -391,6 +400,11 @@ export class Webhook implements INodeType {
 		const resp = this.getResponseObject();
 		const headers = this.getHeaderData();
 		const realm = 'Webhook';
+
+		const ignoreBots = options.ignoreBots as boolean;
+		if (ignoreBots && isbot((headers as IDataObject)['user-agent'] as string)) {
+			return authorizationError(resp, realm, 403);
+		}
 
 		if (authentication === 'basicAuth') {
 			// Basic authorization is needed to call webhook

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -702,6 +702,7 @@
     "iconv-lite": "^0.6.2",
     "ics": "^2.27.0",
     "imap-simple": "^4.3.0",
+    "isbot": "^3.3.4",  
     "iso-639-1": "^2.1.3",
     "jsonwebtoken": "^8.5.1",
     "kafkajs": "^1.14.0",


### PR DESCRIPTION
I noticed when trying to create an approval workflow my workflows would get resumed before I'd had a chance to click the link. It turns out link previewers and URL detonation/link scanners were completing my workflows for me 🤦‍♂️.

To avoid this I had to add a loop to detect various bots, Telegram, Signal, Whatsapp, Teams, Darktrace Antigena, O365 etc. 
![image](https://user-images.githubusercontent.com/939704/145403311-88b4d8e9-abb4-4dd4-bcf1-8dd3e9fca49b.png)

This PR avoids this issue by offering a toggle to ignore bot requests. It's based on isbot which uses up-to-date lists of known crawlers and bots.

![image](https://user-images.githubusercontent.com/939704/145403879-f4682cfd-dbdb-4700-87fb-dcba5b7a9a54.png)

