### PR TITLE
🐛 Fix confusing Item Lists placeholder text

### DIFF
--- a/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
@@ -312,7 +312,7 @@ export class ItemLists implements INodeType {
 				typeOptions: {
 					multipleValues: true,
 				},
-				placeholder: 'Add Field To Exclude',
+				placeholder: 'Add Field To Compare',
 				default: {},
 				displayOptions: {
 					show: {


### PR DESCRIPTION
Update the button text from `Add Field To Exclude` to `Add Field To Compare` for the `fieldsToCompare` action.