### PR TITLE
Add expression callback tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38477,9 +38477,8 @@
 			}
 		},
 		"riot-tmpl": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/riot-tmpl/-/riot-tmpl-3.0.8.tgz",
-			"integrity": "sha1-3WVOcqOhUgywCcvvcMc4Vt7VhKY=",
+			"version": "git+https://github.com/n8n-io/tmpl.git#e8ff65539440564b0e0d949ede63e799c10734b3",
+			"from": "git+https://github.com/n8n-io/tmpl.git#support-anonymous-and-arrow-callbacks",
 			"requires": {
 				"eslint-config-riot": "^1.0.0"
 			}

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -51,7 +51,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "lodash.set": "^4.3.2",
-    "riot-tmpl": "^3.0.8",
+    "riot-tmpl": "git+https://github.com/n8n-io/tmpl.git#support-anonymous-and-arrow-callbacks",
     "xml2js": "^0.4.23"
   },
   "jest": {

--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -119,8 +119,8 @@ export class Expression {
 
 		// Execute the expression
 		try {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-			const returnValue = tmpl.tmpl(parameterValue, data);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+			const returnValue = tmpl.tmpl(parameterValue, data) as any;
 			if (typeof returnValue === 'function') {
 				throw new Error('Expression resolved to a function. Please add "()"');
 			} else if (returnValue !== null && typeof returnValue === 'object') {

--- a/packages/workflow/test/Expression.test.ts
+++ b/packages/workflow/test/Expression.test.ts
@@ -1,0 +1,49 @@
+import * as tmpl from 'riot-tmpl';
+
+describe('Expression', () => {
+	beforeAll(() => {
+		tmpl.brackets.set('{{ }}');
+	});
+
+	test('evaluate sum of integers', () => {
+		const evaluated = tmpl.tmpl('{{ 1 + 2 }}');
+		expect(evaluated).toEqual(3);
+	});
+
+	test('evaluate array method with same-line anonymous callback', () => {
+		const evaluated = tmpl.tmpl('{{ [1, 2, 3].filter(function (v) { return v > 2 }) }}');
+		expect(evaluated).toEqual([3]);
+	});
+
+	test('evaluate array method with single-line anonymous callback', () => {
+		const evaluated = tmpl.tmpl(`{{ [1, 2, 3].filter(function (v) {
+			return v > 2
+		}) }}`);
+		expect(evaluated).toEqual([3]);
+	});
+
+	test('evaluate array method with multi-line anonymous callback', () => {
+		const evaluated = tmpl.tmpl(`{{ [1, 2, 3].filter(function (v) {
+			const a = 1;
+			return v > 2
+		}) }}`);
+		expect(evaluated).toEqual([3]);
+	});
+
+	test('evaluate array method with same-line arrow callback, unbracketed return', () => {
+		const evaluated = tmpl.tmpl('{{ [1, 2, 3].filter((v) => v > 2) }}');
+		expect(evaluated).toEqual([3]);
+	});
+
+	test('evaluate array method with single-line anonymous callback, bracketed return', () => {
+		const evaluated = tmpl.tmpl(`{{ [1, 2, 3].filter((v) => { return v > 2 }) }}`);
+		expect(evaluated).toEqual([3]);
+	});
+
+	test('evaluate array method with single-line arrow callback', () => {
+		const evaluated = tmpl.tmpl(`{{ [1, 2, 3].filter((v) => {
+			return v > 2
+		}) }}`);
+		expect(evaluated).toEqual([3]);
+	});
+});

--- a/packages/workflow/types.d.ts
+++ b/packages/workflow/types.d.ts
@@ -1,0 +1,20 @@
+declare module 'riot-tmpl' {
+	export const brackets: {
+		/**
+		 * Set expression brackets other than the default `{ ... }`
+		 */
+		set: (brackets: string) => void;
+	};
+
+	export const tmpl: {
+		/**
+		 * Evaluate a `tmpl` expression.
+		 */
+		(expression: string, data?: object): unknown;
+
+		/**
+		 * Handle an error from evaluating a `tmpl` expression.
+		 */
+		errorHandler: () => void;
+	};
+}


### PR DESCRIPTION
Add expression callback tests for https://github.com/n8n-io/tmpl/pull/1

To test in this repo, replace `node_modules/riot-tmpl/dist/tmpl.js` L494-506 with the fork fix.

Do not merge this until fork fix is merged and `riot-tmpl` source is switched to fork.

To close #1492