### PR TITLE
🐛 PayPal: Fixed Credentials Typo, Updated API URLs

### DIFF
--- a/packages/nodes-base/credentials/PayPalApi.credentials.ts
+++ b/packages/nodes-base/credentials/PayPalApi.credentials.ts
@@ -28,8 +28,8 @@ export class PayPalApi implements ICredentialType {
 			default: 'live',
 			options: [
 				{
-					name: 'Sanbox',
-					value: 'sanbox',
+					name: 'Sandbox',
+					value: 'sandbox',
 				},
 				{
 					name: 'Live',

--- a/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PayPal/GenericFunctions.ts
@@ -38,8 +38,8 @@ export async function payPalApiRequest(this: IHookFunctions | IExecuteFunctions 
 function getEnvironment(env: string): string {
 	// @ts-ignore
 	return {
-		'sanbox': 'https://api.sandbox.paypal.com',
-		'live': 'https://api.paypal.com',
+		'sandbox': 'https://api-m.sandbox.paypal.com',
+		'live': 'https://api-m.paypal.com',
 	}[env];
 }
 


### PR DESCRIPTION
This PR fixes a typo in the PayPal credentials and updates the base URLs used for each environment to the ones documented by PayPal at https://developer.paypal.com/docs/api/overview/#make-rest-api-calls