### PR TITLE
run a new external hook once active workflows have been initialized

### DIFF
--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -45,6 +45,7 @@ import {
 	WorkflowExecuteAdditionalData,
 	WorkflowHelpers,
 	WorkflowRunner,
+	ExternalHooks,
 } from '.';
 import config = require('../config');
 
@@ -112,6 +113,8 @@ export class ActiveWorkflowRunner {
 			}
 			Logger.verbose('Finished initializing active workflows (startup)');
 		}
+		const externalHooks = ExternalHooks();
+		await externalHooks.run('activeWorkflows.initialized', []);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
I need to run a code when all existing active workflows are initialized. I added a new external hook. Let me know if there is any specific consideration or if I need to change it.