### PR TITLE
Add Variables JSON to Mailjet Batch send

### DIFF
--- a/packages/nodes-base/nodes/Mailjet/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Mailjet/EmailDescription.ts
@@ -445,4 +445,11 @@ export const emailFields: INodeProperties[] = [
 			},
 		],
 	},
+    {
+      displayName: 'Variables (JSON)',
+      name: 'variables',
+      type: 'json',
+      default: '',
+      description: "Template variables in JSON"
+    }
 ];

--- a/packages/nodes-base/nodes/Mailjet/Mailjet.node.ts
+++ b/packages/nodes-base/nodes/Mailjet/Mailjet.node.ts
@@ -203,6 +203,7 @@ export class Mailjet implements INodeType {
 						const templateId = parseInt(this.getNodeParameter('templateId', i) as string, 10);
 						const subject = this.getNodeParameter('subject', i) as string;
 						const variables = (this.getNodeParameter('variablesUi', i) as IDataObject).variablesValues as IDataObject[];
+						const variablesJson = this.getNodeParameter('variables', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 						const toEmail = (this.getNodeParameter('toEmail', i) as string).split(',') as string[];
 
@@ -223,6 +224,12 @@ export class Mailjet implements INodeType {
 								Email: email,
 							});
 						}
+
+						if (variablesJson) {
+							const v = JSON.parse(variablesJson);
+							Object.assign(body.Variables!, v);
+						}
+
 						if (variables) {
 							for (const variable of variables) {
 								body.Variables![variable.name as string] = variable.value;


### PR DESCRIPTION
Hey N8N!
Thank you for creating such an AWESOME tool and releasing it under FLOSS license.

We wanted to send emails with Mailjet but pass all the variables instead of adding them by hand in the UI one by one - so we added this new parameter to pass variables JSON, and it will be sent as-is.

Would that be something to add to upstream?
 