### PR TITLE
Strava node: adding getStreams operation

### DIFF
--- a/packages/nodes-base/nodes/Strava/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Strava/ActivityDescription.ts
@@ -47,6 +47,11 @@ export const activityOperations: INodeProperties[] = [
 				description: 'Get all activity laps',
 			},
 			{
+				name: 'Get Streams',
+				value: 'getStreams',
+				description: 'Get activity streams',
+			},
+			{
 				name: 'Get Zones',
 				value: 'getZones',
 				description: 'Get all activity zones',
@@ -316,6 +321,7 @@ export const activityFields: INodeProperties[] = [
 					'getLaps',
 					'getKudos',
 					'getZones',
+					'getStreams',
 				],
 			},
 		},
@@ -368,6 +374,24 @@ export const activityFields: INodeProperties[] = [
 		},
 		default: 50,
 		description: 'How many results to return.',
+	},
+	{
+		displayName: 'Keys',
+		name: 'keys',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'activity',
+				],
+				operation: [
+					'getStreams',
+				],
+			},
+		},
+		default: 'time,distance',
+		description: 'Desired stream types (comma separated). Possible stream sets: time, distance, latlng, altitude, velocity_smooth, heartrate, cadence, watts, temp, moving, grade_smooth.',
 	},
 
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Strava/ActivityDescription.ts
+++ b/packages/nodes-base/nodes/Strava/ActivityDescription.ts
@@ -378,8 +378,53 @@ export const activityFields: INodeProperties[] = [
 	{
 		displayName: 'Keys',
 		name: 'keys',
-		type: 'string',
-		required: true,
+		type: 'multiOptions',
+		options: [
+			{
+				name: 'Altitude',
+				value: 'altitude',
+			},
+			{
+				name: 'Cadence',
+				value: 'cadence',
+			},
+			{
+				name: 'Distance',
+				value: 'distance',
+			},
+			{
+				name: 'Gradient',
+				value: 'grade_smooth',
+			},
+			{
+				name: 'Heartrate',
+				value: 'heartrate',
+			},
+			{
+				name: 'Latitude / Longitude',
+				value: 'latlng',
+			},
+			{
+				name: 'Moving',
+				value: 'moving',
+			},
+			{
+				name: 'Temperature',
+				value: 'temp',
+			},
+			{
+				name: 'Time',
+				value: 'time',
+			},
+			{
+				name: 'Velocity',
+				value: 'velocity_smooth',
+			},
+			{
+				name: 'Watts',
+				value: 'watts',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: [
@@ -390,10 +435,10 @@ export const activityFields: INodeProperties[] = [
 				],
 			},
 		},
-		default: 'time,distance',
-		description: 'Desired stream types (comma separated). Possible stream sets: time, distance, latlng, altitude, velocity_smooth, heartrate, cadence, watts, temp, moving, grade_smooth.',
+		required: true,
+		default: [],
+		description: 'Desired stream types to return',
 	},
-
 	/* -------------------------------------------------------------------------- */
 	/*                                  activity:getAll                           */
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Strava/Strava.node.ts
+++ b/packages/nodes-base/nodes/Strava/Strava.node.ts
@@ -130,6 +130,15 @@ export class Strava implements INodeType {
 							responseData = responseData.splice(0, limit);
 						}
 					}
+					//https://developers.strava.com/docs/reference/#api-Streams-getActivityStreams
+					if (operation === 'getStreams') {
+						const activityId = this.getNodeParameter('activityId', i) as string;
+
+						qs.keys = this.getNodeParameter('keys', i) as string;
+						qs.key_by_type = true;
+
+						responseData = await stravaApiRequest.call(this, 'GET', `/activities/${activityId}/streams`, {}, qs);
+					}
 					//https://developers.mailerlite.com/reference#subscribers
 					if (operation === 'getAll') {
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;

--- a/packages/nodes-base/nodes/Strava/Strava.node.ts
+++ b/packages/nodes-base/nodes/Strava/Strava.node.ts
@@ -133,8 +133,8 @@ export class Strava implements INodeType {
 					//https://developers.strava.com/docs/reference/#api-Streams-getActivityStreams
 					if (operation === 'getStreams') {
 						const activityId = this.getNodeParameter('activityId', i) as string;
-
-						qs.keys = this.getNodeParameter('keys', i) as string;
+						const keys = this.getNodeParameter('keys', i) as string[];
+						qs.keys = keys.toString();
 						qs.key_by_type = true;
 
 						responseData = await stravaApiRequest.call(this, 'GET', `/activities/${activityId}/streams`, {}, qs);


### PR DESCRIPTION
This PR adds support to Activity [Streams endpoint](https://developers.strava.com/docs/reference/#api-Streams-getActivityStreams) from Strava.

This endpoint returns the data streams of an activity such as time, distance or heart rate data points.