### PR TITLE
Minor i18n fixes

### DIFF
--- a/packages/editor-ui/src/components/MultipleParameter.vue
+++ b/packages/editor-ui/src/components/MultipleParameter.vue
@@ -65,8 +65,8 @@ export default mixins(genericHelpers)
 		computed: {
 			addButtonText (): string {
 				if (
-					!this.parameter.typeOptions &&
-					!this.parameter.typeOptions.multipleValueButtonText
+					!this.parameter.typeOptions ||
+					(this.parameter.typeOptions && !this.parameter.typeOptions.multipleValueButtonText)
 				) {
 					return this.$locale.baseText('multipleParameter.addItem');
 				}

--- a/packages/editor-ui/src/components/NodeCreator/NoResults.vue
+++ b/packages/editor-ui/src/components/NodeCreator/NoResults.vue
@@ -9,7 +9,7 @@
 			</div>
 			<div class="action">
 				{{ $locale.baseText('nodeCreator.noResults.dontWorryYouCanProbablyDoItWithThe') }}
-				<a @click="selectHttpRequest">{{ $locale.baseText('nodeCreator.noResults.httpRequest') }}</a> or
+				<a @click="selectHttpRequest">{{ $locale.baseText('nodeCreator.noResults.httpRequest') }}</a> {{ $locale.baseText('nodeCreator.noResults.or') }}
 				<a @click="selectWebhook">{{ $locale.baseText('nodeCreator.noResults.webhook') }}</a> {{ $locale.baseText('nodeCreator.noResults.node') }}
 			</div>
 		</div>

--- a/packages/editor-ui/src/components/NodeCreator/SubcategoryItem.vue
+++ b/packages/editor-ui/src/components/NodeCreator/SubcategoryItem.vue
@@ -5,7 +5,7 @@
 				{{ $locale.baseText(`nodeCreator.subcategoryNames.${subcategoryName}`) }}
 			</div>
 			<div v-if="item.properties.description" :class="$style.description">
-				{{ $locale.baseText(`nodeCreator.subcategoryDescriptions.${subcategoryDescription}`) }}
+				{{ $locale.baseText(`nodeCreator.subcategoryDescriptions.${subcategoryName}`) }}
 			</div>
 		</div>
 		<div :class="$style.action">
@@ -23,10 +23,6 @@ export default Vue.extend({
 	computed: {
 		subcategoryName() {
 			return camelcase(this.item.properties.subcategory);
-		},
-		subcategoryDescription() {
-			const subcategory = this.item.key.split('_').pop();
-			return camelcase(subcategory);
 		},
 	},
 });

--- a/packages/editor-ui/src/components/NodeCreator/SubcategoryItem.vue
+++ b/packages/editor-ui/src/components/NodeCreator/SubcategoryItem.vue
@@ -25,8 +25,8 @@ export default Vue.extend({
 			return camelcase(this.item.properties.subcategory);
 		},
 		subcategoryDescription() {
-			const firstWord = this.item.properties.description.split(' ').shift() || '';
-			return firstWord.toLowerCase().replace(/,/g, '');
+			const subcategory = this.item.key.split('_').pop();
+			return camelcase(subcategory);
 		},
 	},
 });

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -422,10 +422,10 @@
 			"searchNodes": "Search nodes..."
 		},
 		"subcategoryDescriptions": {
-			"branches": "Branches, core triggers, merge data",
-			"http": "HTTP Requests (API calls), date and time, scrape HTML",
-			"manipulate": "Manipulate data fields, run code",
-			"work": "Work with CSV, XML, text, images etc."
+			"dataTransformation": "Manipulate data fields, run code",
+			"files": "Work with CSV, XML, text, images etc.",
+			"flow": "Branches, core triggers, merge data",
+			"helpers": "HTTP Requests (API calls), date and time, scrape HTML"
 		},
 		"subcategoryNames": {
 			"dataTransformation": "Data Transformation",

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -413,6 +413,7 @@
 			"dontWorryYouCanProbablyDoItWithThe": "Don’t worry, you can probably do it with the",
 			"httpRequest": "HTTP Request",
 			"node": "node",
+			"or": "or",
 			"requestTheNode": "Request the node",
 			"wantUsToMakeItFaster": "Want us to make it faster?",
 			"weDidntMakeThatYet": "We didn't make that... yet",


### PR DESCRIPTION
- Add missing `or` key.
- Make keys for subcategory descriptions consistent.
- Fix default text for multiple value button.

Note: The [small duplication in the constants](https://github.com/n8n-io/n8n/blob/419c719f90da99840f49d1445ccf3583a1a65800/packages/editor-ui/src/constants.ts#L74-L83) is not trivial to remove without refactoring, so adding it to the backlog for now.