### PR TITLE
#2590: Add missing gitlab trigger event types

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -16,6 +16,69 @@ import {
 	gitlabApiRequest,
 } from './GenericFunctions';
 
+const GITLAB_EVENTS = [
+	{
+		name: 'Comment',
+		value: 'note',
+		description: 'Triggered when a new comment is made on commits, merge requests, issues, and code snippets.',
+	},
+	{
+		name: 'Confidential Issues',
+		value: 'confidential_issues',
+		description: 'Triggered on confidential issues\' events.',
+	},
+	{
+		name: 'Confidential Comments',
+		value: 'confidential_note',
+		description: 'Triggered when a confidential comment is made.',
+	},
+	{
+		name: 'Deployments',
+		value: 'deployment',
+		description: 'Triggered when a deployment starts/succeeds/fails/is cancelled.',
+	},
+	{
+		name: 'Issue',
+		value: 'issues',
+		description: 'Triggered when a new issue is created or an existing issue was updated/closed/reopened.',
+	},
+	{
+		name: 'Job',
+		value: 'job',
+		description: 'Triggered on status change of a job.',
+	},
+	{
+		name: 'Merge Request',
+		value: 'merge_requests',
+		description: 'Triggered when a new merge request is created, an existing merge request was updated/merged/closed or a commit is added in the source branch.',
+	},
+	{
+		name: 'Pipeline',
+		value: 'pipeline',
+		description: 'Triggered on status change of Pipeline.',
+	},
+	{
+		name: 'Push',
+		value: 'push',
+		description: 'Triggered when you push to the repository except when pushing tags.',
+	},
+	{
+		name: 'Release',
+		value: 'releases',
+		description: 'Release events are triggered when a release is created or updated.',
+	},
+	{
+		name: 'Tag',
+		value: 'tag_push',
+		description: 'Triggered when you create (or delete) tags to the repository.',
+	},
+	{
+		name: 'Wiki Page',
+		value: 'wiki_page',
+		description: 'Triggered when a wiki page is created, updated or deleted.',
+	},
+];
+
 export class GitlabTrigger implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'GitLab Trigger',
@@ -104,50 +167,11 @@ export class GitlabTrigger implements INodeType {
 				name: 'events',
 				type: 'multiOptions',
 				options: [
+					...GITLAB_EVENTS,
 					{
 						name: '*',
 						value: '*',
 						description: 'Any time any event is triggered (Wildcard Event).',
-					},
-					{
-						name: 'Comment',
-						value: 'note',
-						description: 'Triggered when a new comment is made on commits, merge requests, issues, and code snippets.',
-					},
-					{
-						name: 'Issue',
-						value: 'issues',
-						description: 'Triggered when a new issue is created or an existing issue was updated/closed/reopened.',
-					},
-					{
-						name: 'Job',
-						value: 'job',
-						description: 'Triggered on status change of a job.',
-					},
-					{
-						name: 'Merge Request',
-						value: 'merge_requests',
-						description: 'Triggered when a new merge request is created, an existing merge request was updated/merged/closed or a commit is added in the source branch.',
-					},
-					{
-						name: 'Pipeline',
-						value: 'pipeline',
-						description: 'Triggered on status change of Pipeline.',
-					},
-					{
-						name: 'Push',
-						value: 'push',
-						description: 'Triggered when you push to the repository except when pushing tags.',
-					},
-					{
-						name: 'Tag',
-						value: 'tag_push',
-						description: 'Triggered when you create (or delete) tags to the repository.',
-					},
-					{
-						name: 'Wiki Page',
-						value: 'wiki_page',
-						description: 'Triggered when a wiki page is created, updated or deleted.',
 					},
 				],
 				required: true,
@@ -206,7 +230,7 @@ export class GitlabTrigger implements INodeType {
 
 				let eventsArray = this.getNodeParameter('events', []) as string[];
 				if (eventsArray.includes('*')) {
-					eventsArray = ['note', 'issues', 'job', 'merge_requests', 'pipeline', 'push', 'tag_push', 'wiki_page'];
+					eventsArray = GITLAB_EVENTS.map(e => e.value);
 				}
 
 				const events: { [key: string]: boolean } = {};


### PR DESCRIPTION
See issue #2590 

Added types according to:
- https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html
- https://docs.gitlab.com/ee/api/projects.html#list-project-hooks

![Screenshot from 2021-12-22 21-41-11](https://user-images.githubusercontent.com/2084639/147153730-aedb874d-20f5-4b4a-90c8-7ce9408fceca.png)

![Screenshot from 2021-12-22 21-56-24](https://user-images.githubusercontent.com/2084639/147154130-086f7f2e-4363-4426-bff1-86ed34930eba.png)
