### PR TITLE
Expose pleaseParse-functionality in n8n interface

### DIFF
--- a/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
+++ b/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
@@ -216,7 +216,10 @@ export class Raindrop implements INodeType {
 							};
 							delete updateFields.collectionId;
 						}
-
+						if (updateFields.pleaseParse === true) {
+							body.pleaseParse = {};
+							delete updateFields.pleaseParse;
+						}
 						if (updateFields.tags) {
 							body.tags = (updateFields.tags as string).split(',').map(tag => tag.trim()) as string[];
 						}

--- a/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
+++ b/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
@@ -107,6 +107,13 @@ export const bookmarkFields: INodeProperties[] = [
 				description: 'Whether this bookmark is marked as favorite.',
 			},
 			{
+					displayName: 'Fetch Cover/Description/HTML for URL',
+					name: 'pleaseParse',
+					type: 'boolean',
+					default: false,
+					description: 'Whether Raindrop should load cover, description and HTML for the URL',
+			},
+			{
 				displayName: 'Order',
 				name: 'order',
 				type: 'number',

--- a/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
+++ b/packages/nodes-base/nodes/Raindrop/descriptions/BookmarkDescription.ts
@@ -302,6 +302,13 @@ export const bookmarkFields: INodeProperties[] = [
 				description: 'Whether this bookmark is marked as favorite.',
 			},
 			{
+				displayName: 'Please Parse',
+				name: 'pleaseParse',
+				type: 'boolean',
+				default: false,
+				description: 'Whether Raindrop should reload cover, description and HTML for the URL',
+			},
+			{
 				displayName: 'Order',
 				name: 'order',
 				type: 'number',


### PR DESCRIPTION
This functionality has been present in https://github.com/n8n-io/n8n/blob/cbe2fc2210abac4d81ed84b4f463a22fc6fe8541/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts#L143 for over 5 months, but was not exposed in the UI. This change for the description just makes the option available in the UI.

I found this https://github.com/n8n-io/n8n/pull/1464/commits/f2d521da12ed4e5c4075fe5e8e5a9de83bf2906a to have removed the option in the UI, but I don't see why. I verified it to being working. Perhaps @ivov can help?

Would be awesome to have this functionality available.