### PR TITLE
Fix number suffix in duplicate node

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -396,7 +396,7 @@ export default mixins(
 					if (nameIndex) {
 						index = parseInt(nameIndex, 10);
 					}
-					baseName = uniqueName = originalName;
+					baseName = uniqueName = found;
 				} else {
 					const nameMatch = originalName.match(/(.*\D+)(\d*)/);
 
@@ -411,7 +411,7 @@ export default mixins(
 						if (nameIndex !== '') {
 							index = parseInt(nameIndex, 10);
 						}
-						uniqueName = baseName = originalName;
+						uniqueName = baseName;
 					}
 				}
 
@@ -1954,6 +1954,10 @@ export default mixins(
 				// Deep copy the data so that data on lower levels of the node-properties do
 				// not share objects
 				const newNodeData = JSON.parse(JSON.stringify(this.getNodeDataToSave(node)));
+
+				// here
+
+				console.log(newNodeData.name);
 
 				// Check if node-name is unique else find one that is
 				newNodeData.name = this.getUniqueNodeName({

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1955,10 +1955,6 @@ export default mixins(
 				// not share objects
 				const newNodeData = JSON.parse(JSON.stringify(this.getNodeDataToSave(node)));
 
-				// here
-
-				console.log(newNodeData.name);
-
 				// Check if node-name is unique else find one that is
 				newNodeData.name = this.getUniqueNodeName({
 					originalName: newNodeData.name,


### PR DESCRIPTION
To close #2600

To test: 
- Add three Set nodes from the nodes panel
- Add a Set node from the nodes panel and duplicate twice
- Add three AWS S3 nodes from the nodes panel
- Add an AWS S3 node from the nodes panel and duplicate twice

Expected:
```
Set, Set1, Set2
AWS S3, AWS S31, AWS S32
```