### PR TITLE
:zap: Always stringify data of Function-Nodes

### DIFF
--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -1,5 +1,6 @@
 import { IExecuteFunctions } from 'n8n-core';
 import {
+	IDataObject,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
@@ -57,6 +58,21 @@ return items;`,
 
 		// Copy the items as they may get changed in the functions
 		items = JSON.parse(JSON.stringify(items));
+
+		const cleanupData = (inputData: IDataObject): IDataObject => {
+			Object.keys(inputData).map(key => {
+				if (inputData[key] !== null && typeof inputData[key] === 'object') {
+					if (inputData[key]!.constructor.name === 'Object') {
+						// Is regular node.js object so check its data
+						inputData[key] = cleanupData(inputData[key] as IDataObject);
+					} else {
+						// Is some special object like a Date so stringify
+						inputData[key] = JSON.stringify(inputData[key]);
+					}
+				}
+			});
+			return inputData;
+		}
 
 		// Define the global objects for the custom function
 		const sandbox = {
@@ -117,6 +133,9 @@ return items;`,
 				if (typeof item.json !== 'object') {
 					throw new NodeOperationError(this.getNode(), 'The json-property has to be an object!');
 				}
+
+				item.json = cleanupData(item.json);
+
 				if (item.binary !== undefined) {
 					if (Array.isArray(item.binary) || typeof item.binary !== 'object') {
 						throw new NodeOperationError(this.getNode(), 'The binary-property has to be an object!');
@@ -142,9 +161,6 @@ return items;`,
 				return Promise.reject(error);
 			}
 		}
-
-
-
 
 		return this.prepareOutputData(items);
 	}

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -67,12 +67,12 @@ return items;`,
 						inputData[key] = cleanupData(inputData[key] as IDataObject);
 					} else {
 						// Is some special object like a Date so stringify
-						inputData[key] = JSON.stringify(inputData[key]);
+						inputData[key] = JSON.parse(JSON.stringify(inputData[key]));
 					}
 				}
 			});
 			return inputData;
-		}
+		};
 
 		// Define the global objects for the custom function
 		const sandbox = {

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -58,6 +58,21 @@ return item;`,
 		const length = items.length as unknown as number;
 		let item: INodeExecutionData;
 
+		const cleanupData = (inputData: IDataObject): IDataObject => {
+			Object.keys(inputData).map(key => {
+				if (inputData[key] !== null && typeof inputData[key] === 'object') {
+					if (inputData[key]!.constructor.name === 'Object') {
+						// Is regular node.js object so check its data
+						inputData[key] = cleanupData(inputData[key] as IDataObject);
+					} else {
+						// Is some special object like a Date so stringify
+						inputData[key] = JSON.stringify(inputData[key]);
+					}
+				}
+			});
+			return inputData;
+		}
+
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
 			try {
 				item = items[itemIndex];
@@ -145,7 +160,7 @@ return item;`,
 				}
 
 				const returnItem: INodeExecutionData = {
-					json: jsonData,
+					json: cleanupData(jsonData),
 				};
 
 				if (item.binary) {

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -66,12 +66,12 @@ return item;`,
 						inputData[key] = cleanupData(inputData[key] as IDataObject);
 					} else {
 						// Is some special object like a Date so stringify
-						inputData[key] = JSON.stringify(inputData[key]);
+						inputData[key] = JSON.parse(JSON.stringify(inputData[key]));
 					}
 				}
 			});
 			return inputData;
-		}
+		};
 
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
 			try {


### PR DESCRIPTION
Makes sure that Function-Nodes can not return illegal data like for example Data-Objects.

More information about the issue that this fices can be found in this post:
https://community.n8n.io/t/scenario-behaves-differently-when-run-step-by-step/10195/2

Example workflow:
```json
{
  "nodes": [
    {
      "parameters": {
        "functionCode": "// Code here will run only once, no matter how many input items there are.\n// More info and help: https://docs.n8n.io/nodes/n8n-nodes-base.function\n\n// Loop over inputs and add a new field called 'myNewField' to the JSON of each one\nfor (item of items) {\n  item.json.dateObject = new Date();\n}\n\n// You can write logs to the browser console\nconsole.log('Done!');\n\nreturn items;"
      },
      "name": "Function",
      "type": "n8n-nodes-base.function",
      "typeVersion": 1,
      "position": [
        460,
        300
      ]
    },
    {
      "parameters": {
        "keepOnlySet": true,
        "values": {
          "string": [
            {
              "name": "resultOnSet",
              "value": "={{$json[\"dateObject\"]}} [{{ typeof $json[\"dateObject\"]}}]"
            }
          ]
        },
        "options": {}
      },
      "name": "Set",
      "type": "n8n-nodes-base.set",
      "typeVersion": 1,
      "position": [
        680,
        300
      ]
    }
  ],
  "connections": {
    "Function": {
      "main": [
        [
          {
            "node": "Set",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
```