### PR TITLE
(fix) fix security vulnerability in the hive node

### DIFF
--- a/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
@@ -30,7 +30,7 @@ export async function theHiveApiRequest(this: IHookFunctions | IExecuteFunctions
 		qs: query,
 		uri: uri || `${credentials.url}/api${resource}`,
 		body,
-		rejectUnauthorized: credentials.allowUnauthorizedCerts as boolean,
+		rejectUnauthorized: !credentials.allowUnauthorizedCerts as boolean,
 		json: true,
 	};
 


### PR DESCRIPTION
This PR fixes a security vulnerabilty in the The Hive node. 

By default the node as it is right now allows unsafe ssl certificates, while suggesting to the user that it rejects them. 

This fix unfortunately also introduces a breaking change for people that rely on setups without valid certificates.