### PR TITLE
Fixed execute commands after binary data release

### DIFF
--- a/packages/cli/commands/execute.ts
+++ b/packages/cli/commands/execute.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import { promises as fs } from 'fs';
 import { Command, flags } from '@oclif/command';
-import { UserSettings } from 'n8n-core';
+import { BinaryDataManager, IBinaryDataConfig, UserSettings } from 'n8n-core';
 import { INode, LoggerProxy } from 'n8n-workflow';
 
 import {
@@ -22,6 +22,7 @@ import {
 } from '../src';
 
 import { getLogger } from '../src/Logger';
+import config = require('../config');
 
 export class Execute extends Command {
 	static description = '\nExecutes a given workflow';
@@ -45,6 +46,8 @@ export class Execute extends Command {
 	async run() {
 		const logger = getLogger();
 		LoggerProxy.init(logger);
+		const binaryDataConfig = config.get('binaryDataManager') as IBinaryDataConfig;
+		await BinaryDataManager.init(binaryDataConfig, true);
 
 		// eslint-disable-next-line @typescript-eslint/no-shadow
 		const { flags } = this.parse(Execute);

--- a/packages/cli/commands/executeBatch.ts
+++ b/packages/cli/commands/executeBatch.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import { Command, flags } from '@oclif/command';
 
-import { UserSettings } from 'n8n-core';
+import { BinaryDataManager, IBinaryDataConfig, UserSettings } from 'n8n-core';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { INode, ITaskData, LoggerProxy } from 'n8n-workflow';
@@ -36,6 +36,7 @@ import {
 	NodeTypes,
 	WorkflowRunner,
 } from '../src';
+import config = require('../config');
 
 export class ExecuteBatch extends Command {
 	static description = '\nExecutes multiple workflows once';
@@ -190,6 +191,8 @@ export class ExecuteBatch extends Command {
 
 		const logger = getLogger();
 		LoggerProxy.init(logger);
+		const binaryDataConfig = config.get('binaryDataManager') as IBinaryDataConfig;
+		await BinaryDataManager.init(binaryDataConfig, true);
 
 		// eslint-disable-next-line @typescript-eslint/no-shadow
 		const { flags } = this.parse(ExecuteBatch);


### PR DESCRIPTION
With the release of binary data management, the execute commands broke.

This PR fixes the binary data handler initialization so these commands can continue working.