### PR TITLE
🐛 Fix Philips Hue API Connection

### DIFF
--- a/packages/nodes-base/credentials/PhilipsHueOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/PhilipsHueOAuth2Api.credentials.ts
@@ -21,13 +21,13 @@ export class PhilipsHueOAuth2Api implements ICredentialType {
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',
-			default: 'https://api.meethue.com/oauth2/auth',
+			default: 'https://api.meethue.com/v2/oauth2/authorize',
 		},
 		{
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
 			type: 'hidden',
-			default: 'https://api.meethue.com/oauth2/token',
+			default: 'https://api.meethue.com/v2/oauth2/token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',

--- a/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
@@ -19,7 +19,7 @@ export async function philipsHueApiRequest(this: IExecuteFunctions | ILoadOption
 		method,
 		body,
 		qs,
-		uri: uri || `https://api.meethue.com${resource}`,
+		uri: uri || `https://api.meethue.com/route${resource}`,
 		json: true,
 	};
 	try {
@@ -36,14 +36,15 @@ export async function philipsHueApiRequest(this: IExecuteFunctions | ILoadOption
 		}
 
 		//@ts-ignore
-		return await this.helpers.requestOAuth2.call(this, 'philipsHueOAuth2Api', options, { tokenType: 'Bearer' });
+		const response = await this.helpers.requestOAuth2.call(this, 'philipsHueOAuth2Api', options, { tokenType: 'Bearer' });
+		return response;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error);
 	}
 }
 
 export async function getUser(this: IExecuteFunctions | ILoadOptionsFunctions): Promise<any> { // tslint:disable-line:no-any
-	const { whitelist } = await philipsHueApiRequest.call(this, 'GET', '/bridge/0/config', {}, {});
+	const { whitelist } = await philipsHueApiRequest.call(this, 'GET', '/api/0/config', {}, {});
 	//check if there is a n8n user
 	for (const user of Object.keys(whitelist)) {
 		if (whitelist[user].name === 'n8n') {
@@ -51,7 +52,7 @@ export async function getUser(this: IExecuteFunctions | ILoadOptionsFunctions): 
 		}
 	}
 	// n8n user was not fount then create the user
-	await philipsHueApiRequest.call(this, 'PUT', '/bridge/0/config', { linkbutton: true });
-	const { success } = await philipsHueApiRequest.call(this, 'POST', '/bridge', { devicetype: 'n8n' });
+	await philipsHueApiRequest.call(this, 'PUT', '/api/0/config', { linkbutton: true });
+	const { success } = await philipsHueApiRequest.call(this, 'POST', '/api', { devicetype: 'n8n' });
 	return success.username;
 }

--- a/packages/nodes-base/nodes/PhilipsHue/LightDescription.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/LightDescription.ts
@@ -33,7 +33,7 @@ export const lightOperations: INodeProperties[] = [
 			{
 				name: 'Update',
 				value: 'update',
-				description: 'Update an light',
+				description: 'Update a light',
 			},
 		],
 		default: 'update',

--- a/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
@@ -74,13 +74,13 @@ export class PhilipsHue implements INodeType {
 				const lights = await philipsHueApiRequest.call(
 					this,
 					'GET',
-					`/bridge/${user}/lights`,
+					`/api/${user}/lights`,
 				);
 
 				const groups = await philipsHueApiRequest.call(
 					this,
 					'GET',
-					`/bridge/${user}/groups`,
+					`/api/${user}/groups`,
 				);
 
 				for (const light of Object.keys(lights)) {
@@ -144,7 +144,7 @@ export class PhilipsHue implements INodeType {
 					const data = await philipsHueApiRequest.call(
 						this,
 						'PUT',
-						`/bridge/${user}/lights/${lightId}/state`,
+						`/api/${user}/lights/${lightId}/state`,
 						body,
 					);
 
@@ -161,7 +161,7 @@ export class PhilipsHue implements INodeType {
 
 					const user = await getUser.call(this);
 
-					responseData = await philipsHueApiRequest.call(this, 'DELETE', `/bridge/${user}/lights/${lightId}`);
+					responseData = await philipsHueApiRequest.call(this, 'DELETE', `/api/${user}/lights/${lightId}`);
 
 				}
 				if (operation === 'getAll') {
@@ -169,7 +169,7 @@ export class PhilipsHue implements INodeType {
 
 					const user = await getUser.call(this);
 
-					const lights = await philipsHueApiRequest.call(this, 'GET', `/bridge/${user}/lights`);
+					const lights = await philipsHueApiRequest.call(this, 'GET', `/api/${user}/lights`);
 
 					responseData = Object.values(lights);
 
@@ -183,7 +183,7 @@ export class PhilipsHue implements INodeType {
 
 					const user = await getUser.call(this);
 
-					responseData = await philipsHueApiRequest.call(this, 'GET', `/bridge/${user}/lights/${lightId}`);
+					responseData = await philipsHueApiRequest.call(this, 'GET', `/api/${user}/lights/${lightId}`);
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes the problem reported in the forum at https://community.n8n.io/t/cannot-link-with-philips-hue-the-requested-permission-could-not-be-verified/10024?u=mutedjam

Philips uses new OAuth2 URLs as per https://developers.meethue.com/develop/hue-api/remote-authentication-oauth/ which have been added to the credentials.

As per https://developers.meethue.com/develop/hue-api/remote-api-quick-start-guide/, the remote API endpoints have also been updated:

> From now on the Remote API calls are same as local API calls. Just the base URL is different: https://api.meethue.com/route/api/<whitelist_identifier>instead of http://<ip-address.of.the.bridge>/api/<whitelist_identifier>

This PR reflects this change as well and sets the base URL to `https://api.meethue.com/route`, with the endpoints used in the `PhilipsHue.node.ts` file now reflecting the ones listed in the Lights API documentation from https://developers.meethue.com/develop/hue-api/lights-api/. 

This has been tested against my personal Philips Hue setup, all operations worked fine.
