### PR TITLE
Adding an optional database field to redis

### DIFF
--- a/packages/nodes-base/credentials/Redis.credentials.ts
+++ b/packages/nodes-base/credentials/Redis.credentials.ts
@@ -30,5 +30,11 @@ export class Redis implements ICredentialType {
 			type: 'number',
 			default: 6379,
 		},
+		{
+			displayName: 'Database',
+			name: 'database',
+			type: 'number',
+			default: 0,
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Redis/Redis.node.ts
+++ b/packages/nodes-base/nodes/Redis/Redis.node.ts
@@ -507,6 +507,7 @@ export class Redis implements INodeType {
 			});
 
 			client.on('ready', async (err: Error | null) => {
+				client.select(credentials.database as number);
 				try {
 					if (operation === 'info') {
 						const clientInfo = util.promisify(client.info).bind(client);


### PR DESCRIPTION
Hello, this is a tiny patch to add an optional field `database` to Redis credentials. It will allow users to select a different database for their operations instead of the default 0.

It defaults on `0` as in not to break any current implementations. The `select` operation will be run regardless the field is set or not, so maybe I can add a condition `if (database !== 0)` if necessary, but I think it is better to be explicit.

Looking forward to some feedback.