### PR TITLE
✨ Add chat messages to MS Teams node

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts
@@ -16,7 +16,7 @@ export class MicrosoftTeamsOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: 'openid offline_access User.ReadWrite.All Group.ReadWrite.All',
+			default: 'openid offline_access User.ReadWrite.All Group.ReadWrite.All Chat.ReadWrite',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/ChatMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/ChatMessageDescription.ts
@@ -1,0 +1,174 @@
+import {
+	INodeProperties,
+} from 'n8n-workflow';
+
+export const chatMessageOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a message',
+			},
+			{
+				name: 'Get All',
+				value: 'getAll',
+				description: 'Get all messages',
+			},
+		],
+		default: 'create',
+		description: 'The operation to perform.',
+	},
+];
+
+export const chatMessageFields: INodeProperties[] = [
+
+	/* -------------------------------------------------------------------------- */
+	/*                                 chatMessage:create                      */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Chat ID',
+		name: 'chatId',
+		required: true,
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChats',
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'Chat ID',
+	},
+	{
+		displayName: 'Message Type',
+		name: 'messageType',
+		required: true,
+		type: 'options',
+		options: [
+			{
+				name: 'Text',
+				value: 'text',
+			},
+			{
+				name: 'HTML',
+				value: 'html',
+			},
+		],
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'The type of the content',
+	},
+	{
+		displayName: 'Message',
+		name: 'message',
+		required: true,
+		type: 'string',
+		typeOptions: {
+			alwaysOpenEditWindow: true,
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'The content of the item.',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                 chatMessage:getAll                      */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Chat ID',
+		name: 'chatId',
+		required: true,
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getChats',
+		},
+		displayOptions: {
+			show: {
+				operation: [
+					'getAll',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: '',
+		description: 'Chat ID',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: [
+					'getAll',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: false,
+		description: 'If all results should be returned or only up to a given limit.',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				operation: [
+					'getAll',
+				],
+				resource: [
+					'chatMessage',
+				],
+				returnAll: [
+					false,
+				],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 500,
+		},
+		default: 100,
+		description: 'How many results to return.',
+	},
+];

--- a/packages/nodes-base/nodes/Microsoft/Teams/ChatMessageDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/ChatMessageDescription.ts
@@ -21,6 +21,11 @@ export const chatMessageOperations: INodeProperties[] = [
 				description: 'Create a message',
 			},
 			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a message',
+			},
+			{
 				name: 'Get All',
 				value: 'getAll',
 				description: 'Get all messages',
@@ -34,7 +39,7 @@ export const chatMessageOperations: INodeProperties[] = [
 export const chatMessageFields: INodeProperties[] = [
 
 	/* -------------------------------------------------------------------------- */
-	/*                                 chatMessage:create                      */
+	/*                                 chatMessage:create                         */
 	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Chat ID',
@@ -48,6 +53,7 @@ export const chatMessageFields: INodeProperties[] = [
 			show: {
 				operation: [
 					'create',
+					'get',
 				],
 				resource: [
 					'chatMessage',
@@ -106,8 +112,29 @@ export const chatMessageFields: INodeProperties[] = [
 		default: '',
 		description: 'The content of the item.',
 	},
+
 	/* -------------------------------------------------------------------------- */
-	/*                                 chatMessage:getAll                      */
+	/*                                 chatMessage:get                            */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Message ID',
+		name: 'messageId',
+		required: true,
+		type: 'string',
+		displayOptions: {
+			show: {
+				operation: [
+					'get',
+				],
+				resource: [
+					'chatMessage',
+				],
+			},
+		},
+		default: '',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                 chatMessage:getAll                         */
 	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Chat ID',

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
@@ -27,6 +27,11 @@ import {
 } from './ChannelMessageDescription';
 
 import {
+	chatMessageFields,
+	chatMessageOperations,
+} from './ChatMessageDescription';
+
+import {
 	taskFields,
 	taskOperations,
 } from './TaskDescription';
@@ -66,6 +71,10 @@ export class MicrosoftTeams implements INodeType {
 						value: 'channelMessage',
 					},
 					{
+						name: 'Chat Message',
+						value: 'chatMessage',
+					},
+					{
 						name: 'Task',
 						value: 'task',
 					},
@@ -79,6 +88,8 @@ export class MicrosoftTeams implements INodeType {
 			/// MESSAGE
 			...channelMessageOperations,
 			...channelMessageFields,
+			...chatMessageOperations,
+			...chatMessageFields,
 			///TASK
 			...taskOperations,
 			...taskFields,
@@ -189,6 +200,32 @@ export class MicrosoftTeams implements INodeType {
 				}
 				return returnData;
 			},
+			// Get all the chats to display them to user so that they can
+			// select them easily
+			async getChats(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const qs: IDataObject = {
+					$expand: 'members',
+				};
+				const { value } = await microsoftApiRequest.call(this, 'GET', '/v1.0/chats', {}, qs);
+				const chats = value
+								.filter((a: IDataObject) => a.createdDateTime)
+								.sort((a: IDataObject, b: IDataObject) => new Date(a.lastUpdatedDateTime as string) > new Date(b.lastUpdatedDateTime as string) ? 1 : -1);
+				for (const chat of value) {
+					if (!chat.topic) {
+						chat.topic = chat.members
+										.filter((member: IDataObject) => member.displayName)
+										.map((member: IDataObject) => member.displayName).join(', ');
+					}
+					const chatName = `${chat.topic || '(no title) - ' + chat.id} (${chat.chatType})`;
+					const chatId = chat.id;
+					returnData.push({
+						name: chatName,
+						value: chatId,
+					});
+				}
+				return returnData;
+			},
 		},
 	};
 
@@ -294,6 +331,34 @@ export class MicrosoftTeams implements INodeType {
 						} else {
 							qs.limit = this.getNodeParameter('limit', i) as number;
 							responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', `/beta/teams/${teamId}/channels/${channelId}/messages`, {});
+							responseData = responseData.splice(0, qs.limit);
+						}
+					}
+				}
+				if (resource === 'chatMessage') {
+					// https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http
+					if (operation === 'create') {
+						const chatId = this.getNodeParameter('chatId', i) as string;
+						const messageType = this.getNodeParameter('messageType', i) as string;
+						const message = this.getNodeParameter('message', i) as string;
+						const body: IDataObject = {
+							body: {
+								contentType: messageType,
+								content: message,
+							},
+						};
+						responseData = await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
+					}
+
+					// https://docs.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http
+					if (operation === 'getAll') {
+						const chatId = this.getNodeParameter('chatId', i) as string;
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+						if (returnAll) {
+							responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', `/v1.0/chats/${chatId}/messages`);
+						} else {
+							qs.limit = this.getNodeParameter('limit', i) as number;
+							responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', `/v1.0/chats/${chatId}/messages`, {});
 							responseData = responseData.splice(0, qs.limit);
 						}
 					}

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
@@ -208,9 +208,6 @@ export class MicrosoftTeams implements INodeType {
 					$expand: 'members',
 				};
 				const { value } = await microsoftApiRequest.call(this, 'GET', '/v1.0/chats', {}, qs);
-				const chats = value
-								.filter((a: IDataObject) => a.createdDateTime)
-								.sort((a: IDataObject, b: IDataObject) => new Date(a.lastUpdatedDateTime as string) > new Date(b.lastUpdatedDateTime as string) ? 1 : -1);
 				for (const chat of value) {
 					if (!chat.topic) {
 						chat.topic = chat.members
@@ -349,7 +346,12 @@ export class MicrosoftTeams implements INodeType {
 						};
 						responseData = await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
 					}
-
+					// https://docs.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http
+					if (operation === 'get') {
+						const chatId = this.getNodeParameter('chatId', i) as string;
+						const messageId = this.getNodeParameter('messageId', i) as string;
+						responseData = await microsoftApiRequest.call(this, 'GET', `/v1.0/chats/${chatId}/messages/${messageId}`);
+					}
 					// https://docs.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http
 					if (operation === 'getAll') {
 						const chatId = this.getNodeParameter('chatId', i) as string;


### PR DESCRIPTION
This PR adds the ability to get and create messages in oneOnOne, meeting, and other Teams chats.

* Add load options for available chats
* Uses API version 1.0, which may require one of `Chat.Read` or `Chat.ReadWrite` permissions.

<img width="252" alt="n8n_-_▶️_MS_Teams" src="https://user-images.githubusercontent.com/939704/148203943-0805ff1c-a011-42e9-a9bf-586ddf6ddebe.png">

Side note: I've noticed `beta` endpoints sometimes ignore required permissions on delegated access, e.g. the same endpoint for retrieving channel messages works on the beta version, but requires `ChannelMessage.Read.All` on `v1.0`. Updating the `channelMessage` endpoint will likely be a breaking change if users haven't added the correct permissions.