### PR TITLE
🐛 Fixes icalendar node month out by one

### DIFF
--- a/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
+++ b/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
@@ -313,14 +313,19 @@ export class ICalendar implements INodeType {
 				const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 				let fileName = 'event.ics';
 
+				let eventStart = moment(start).toArray().splice(0, (allDay) ? 3 : 6) as ics.DateArray;
+				eventStart[1]++;
+				let eventEnd = moment(end).toArray().splice(0, (allDay) ? 3 : 6) as ics.DateArray;
+				eventEnd[1]++;
+
 				if (additionalFields.fileName) {
 					fileName = additionalFields.fileName as string;
 				}
 
 				const data: ics.EventAttributes = {
 					title,
-					start: (moment(start).toArray().splice(0, (allDay) ? 3 : 6) as ics.DateArray),
-					end: (moment(end).toArray().splice(0, (allDay) ? 3 : 6) as ics.DateArray),
+					start: eventStart,
+					end: eventEnd,
 					startInputType: 'utc',
 					endInputType: 'utc',
 				};


### PR DESCRIPTION
This fixes the month being out by one issue in the icalendar node.

**Linked issues:**
https://github.com/n8n-io/n8n/issues/2627
https://community.n8n.io/t/icalendar-event-date-is-for-1-month-before-the-actual-event-date/7298
https://community.n8n.io/t/month-shifting-with-icalendar-node/6587

This will break any workflows where a user has already worked around the issue by using the Date & Time node to increment the month by one.