### PR TITLE
Add field AccountNumber to Create/Update operation

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/AccountDescription.ts
@@ -146,6 +146,13 @@ export const accountFields: INodeProperties[] = [
 		},
 		options: [
 			{
+				displayName: 'Account Number',
+				name: 'accountNumber',
+				type: 'string',
+				default: '',
+				description: 'Account number assigned to this account (not the unique ID). Maximum size is 40 characters.',
+			},
+			{
 				displayName: 'Account Source',
 				name: 'accountSource',
 				type: 'options',
@@ -410,6 +417,13 @@ export const accountFields: INodeProperties[] = [
 			},
 		},
 		options: [
+			{
+				displayName: 'Account Number',
+				name: 'accountNumber',
+				type: 'string',
+				default: '',
+				description: 'Account number assigned to this account (not the unique ID). Maximum size is 40 characters.',
+			},
 			{
 				displayName: 'Account Source',
 				name: 'accountSource',

--- a/packages/nodes-base/nodes/Salesforce/AccountInterface.ts
+++ b/packages/nodes-base/nodes/Salesforce/AccountInterface.ts
@@ -16,6 +16,7 @@ export interface IAccount {
 	BillingState?: string;
 	ShippingStreet?: string;
 	ShippingCity?: string;
+	AccountNumber?: string;
 	AccountSource?: string;
 	AnnualRevenue?: number;
 	BillingStreet?: string;

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1956,6 +1956,9 @@ export class Salesforce implements INodeType {
 						if (additionalFields.shippingCity !== undefined) {
 							body.ShippingCity = additionalFields.shippingCity as string;
 						}
+						if (additionalFields.accountNumber !== undefined) {
+							body.AccountNumber = additionalFields.accountNumber as string;
+						}
 						if (additionalFields.accountSource !== undefined) {
 							body.AccountSource = additionalFields.accountSource as string;
 						}
@@ -2063,6 +2066,9 @@ export class Salesforce implements INodeType {
 						}
 						if (updateFields.shippingCity !== undefined) {
 							body.ShippingCity = updateFields.shippingCity as string;
+						}
+						if (updateFields.accountNumber !== undefined) {
+							body.AccountNumber = updateFields.accountNumber as string;
 						}
 						if (updateFields.accountSource !== undefined) {
 							body.AccountSource = updateFields.accountSource as string;


### PR DESCRIPTION
This is the update based on the community thread:
https://community.n8n.io/t/salesforce-accountnumber-field-missing/10376