### PR TITLE
Export and Import Workflow Tags

### DIFF
--- a/packages/cli/commands/export/workflow.ts
+++ b/packages/cli/commands/export/workflow.ts
@@ -111,7 +111,10 @@ export class ExportWorkflowsCommand extends Command {
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const workflows = await Db.collections.Workflow!.find(findQuery);
+			const workflows = await Db.collections.Workflow!.find({
+				where: findQuery,
+				relations: ['tags'],
+			});
 
 			if (workflows.length === 0) {
 				throw new Error('No workflows found with specified filters.');

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -705,6 +705,8 @@ export interface ITag {
 	id: string;
 	name: string;
 	usageCount?: number;
+	createdAt?: string;
+	updatedAt?: string;
 }
 
 export interface ITagRow {

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -501,9 +501,22 @@ export default mixins(
 					if (data.id && typeof data.id === 'string') {
 						data.id = parseInt(data.id, 10);
 					}
-					const blob = new Blob([JSON.stringify(data, null, 2)], {
+
+					// Add tag info
+					const exportData: IWorkflowDataUpdate = {
+						...data,
+						tags: (tags||[]).map(tagId => {
+							return {
+								...this.$store.getters["tags/getTagById"](tagId),
+								usageCount: undefined,
+							};
+						}),
+					};
+
+					const blob = new Blob([JSON.stringify(exportData, null, 2)], {
 						type: 'application/json;charset=utf-8',
 					});
+
 
 					let workflowName = this.$store.getters.workflowName || 'unsaved_workflow';
 

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -177,6 +177,8 @@ import {
 
 import '../plugins/N8nCustomConnectorType';
 import '../plugins/PlusEndpointType';
+import { setTagsForImport } from "n8n-workflow/dist/src/WorkflowHelpers";
+import { createTag, getTags } from "@/api/tags";
 
 export default mixins(
 	copyPaste,
@@ -1213,6 +1215,17 @@ export default mixins(
 							this.nodeSelectedByName(node.name);
 						});
 					});
+
+					if (workflowData.tags) {
+						await setTagsForImport(workflowData as { tags: ITag[] }, await getTags(this.$store.getters.getRestApiContext), (name: string) => {
+							return createTag(this.$store.getters.getRestApiContext, {
+								name,
+							});
+						});
+						const tagIds = workflowData.tags.map((tag) => typeof tag === "string" ? tag : tag.id);
+						this.$store.commit('setWorkflowTagIds', tagIds || []);
+					}
+
 				} catch (error) {
 					this.$showError(
 						error,

--- a/packages/workflow/src/WorkflowHelpers.ts
+++ b/packages/workflow/src/WorkflowHelpers.ts
@@ -1,0 +1,53 @@
+// Supports both database entries and frontend api responses
+export interface ITag {
+	id: string | number;
+	name: string;
+	createdAt?: string | Date;
+	updatedAt?: string | Date;
+}
+
+// Set tag ids to use existing tags, creates a new tag if no matching tag could be found
+export async function setTagsForImport(
+	workflow: { tags: ITag[] },
+	tagsEntities: ITag[],
+	createTag: (name: string) => Promise<ITag>,
+): Promise<void> {
+	const findOrCreateTag = async (importTag: ITag) => {
+		// Assume tag is identical if createdAt date is the same to preserve a changed tag name
+		const identicalMatch = tagsEntities.find(
+			(existingTag) =>
+				existingTag.id.toString() === importTag.id.toString() &&
+				existingTag.createdAt &&
+				importTag.createdAt &&
+				new Date(existingTag.createdAt) === new Date(importTag.createdAt),
+		);
+		if (identicalMatch) {
+			return identicalMatch;
+		}
+
+		// Find tag with identical name
+		const nameMatch = tagsEntities.find((existingTag) => existingTag.name === importTag.name);
+		if (nameMatch) {
+			return nameMatch;
+		}
+
+		// Create new Tag
+		const createdTag = await createTag(importTag.name);
+		// add new tag to available tags
+		tagsEntities.push(createdTag);
+		return createdTag;
+	};
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+	const workflowTags = workflow.tags;
+	if (!workflowTags || !Array.isArray(workflowTags) || workflowTags.length === 0) {
+		return;
+	}
+	for (let i = 0; i < workflowTags.length; i++) {
+		// eslint-disable-next-line no-await-in-loop
+		const tag = await findOrCreateTag(workflowTags[i]);
+		workflowTags[i] = {
+			id: tag.id,
+			name: tag.name,
+		};
+	}
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -13,4 +13,5 @@ export * from './Workflow';
 export * from './WorkflowDataProxy';
 export * from './WorkflowErrors';
 export * from './WorkflowHooks';
+export * from './WorkflowHelpers';
 export { LoggerProxy, NodeHelpers, ObservableObject };


### PR DESCRIPTION
Support exporting and importing tags of workflows via frontend and cli.

On export, all tag data is included in the json.
- id
- name
- updatedAt
- createdAt

When importing a workflow json to n8n we:
- first check if a tag with the same id and createdAt date exists in the
  database, then we can assume the tag is identical. Changes on the name
  of the tag are now preserved.
- check if a tag with the same name exists on the database.
- create a new tag with the given name.