### PR TITLE
🐛 Fixed path for Supabase credential documentation

### DIFF
--- a/packages/nodes-base/credentials/SupabaseApi.credentials.ts
+++ b/packages/nodes-base/credentials/SupabaseApi.credentials.ts
@@ -6,7 +6,7 @@ import {
 export class SupabaseApi implements ICredentialType {
 	name = 'supabaseApi';
 	displayName = 'Supabase API';
-	documentationUrl = 'superbase';
+	documentationUrl = 'supabase';
 	properties: INodeProperties[] = [
 		{
 			displayName: 'Host',


### PR DESCRIPTION
Supabase credentials link now goes to the correct place.