### PR TITLE
Feature/n8n 2835 handle error workflows correctly

### DIFF
--- a/packages/cli/commands/execute.ts
+++ b/packages/cli/commands/execute.ts
@@ -22,6 +22,7 @@ import {
 } from '../src';
 
 import { getLogger } from '../src/Logger';
+import { getInstanceowner } from '../src/UserManagement/UserManagementHelper';
 
 export class Execute extends Command {
 	static description = '\nExecutes a given workflow';
@@ -165,6 +166,7 @@ export class Execute extends Command {
 				startNodes: [startNode.name],
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				workflowData: workflowData!,
+				user: await getInstanceowner(),
 			};
 
 			const workflowRunner = new WorkflowRunner();

--- a/packages/cli/commands/executeBatch.ts
+++ b/packages/cli/commands/executeBatch.ts
@@ -36,6 +36,8 @@ import {
 	NodeTypes,
 	WorkflowRunner,
 } from '../src';
+import { User } from '../src/databases/entities/User';
+import { getInstanceowner } from '../src/UserManagement/UserManagementHelper';
 
 export class ExecuteBatch extends Command {
 	static description = '\nExecutes multiple workflows once';
@@ -55,6 +57,8 @@ export class ExecuteBatch extends Command {
 	static debug = false;
 
 	static executionTimeout = 3 * 60 * 1000;
+
+	static instanceOwner: User;
 
 	static examples = [
 		`$ n8n executeBatch`,
@@ -275,6 +279,8 @@ export class ExecuteBatch extends Command {
 
 		// Wait till the database is ready
 		await startDbInitPromise;
+
+		ExecuteBatch.instanceOwner = await getInstanceowner();
 
 		let allWorkflows;
 
@@ -663,6 +669,7 @@ export class ExecuteBatch extends Command {
 					executionMode: 'cli',
 					startNodes: [startNode!.name],
 					workflowData,
+					user: ExecuteBatch.instanceOwner,
 				};
 
 				const workflowRunner = new WorkflowRunner();

--- a/packages/cli/commands/worker.ts
+++ b/packages/cli/commands/worker.ts
@@ -39,6 +39,7 @@ import { getLogger } from '../src/Logger';
 
 import * as config from '../config';
 import * as Queue from '../src/Queue';
+import { getWorkflowOwner } from '../src/UserManagement/UserManagementHelper';
 
 export class Worker extends Command {
 	static description = '\nStarts a n8n worker';
@@ -121,6 +122,8 @@ export class Worker extends Command {
 			`Start job: ${job.id} (Workflow ID: ${currentExecutionDb.workflowData.id} | Execution: ${jobData.executionId})`,
 		);
 
+		const workflowOwner = await getWorkflowOwner(currentExecutionDb.workflowData.id!.toString());
+
 		let { staticData } = currentExecutionDb.workflowData;
 		if (jobData.loadStaticData) {
 			const findOptions = {
@@ -165,6 +168,7 @@ export class Worker extends Command {
 		});
 
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
+			workflowOwner,
 			undefined,
 			executionTimeoutTimestamp,
 		);

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -15,6 +15,7 @@ import {
 	ITaskData,
 	ITelemetrySettings,
 	IWorkflowBase as IWorkflowBaseWorkflow,
+	N8nUserData,
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
@@ -575,7 +576,7 @@ export interface IWorkflowExecutionDataProcess {
 	sessionId?: string;
 	startNodes?: string[];
 	workflowData: IWorkflowBase;
-	userId?: string;
+	user: N8nUserData;
 }
 
 export interface IWorkflowExecutionDataProcessWithExecution extends IWorkflowExecutionDataProcess {
@@ -583,6 +584,7 @@ export interface IWorkflowExecutionDataProcessWithExecution extends IWorkflowExe
 	credentialsTypeData: ICredentialsTypeData;
 	executionId: string;
 	nodeTypeData: ITransferNodeTypes;
+	user: User;
 }
 
 export interface IWorkflowExecuteProcess {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1034,7 +1034,7 @@ class App {
 						startNodes.length === 0 ||
 						destinationNode === undefined
 					) {
-						const additionalData = await WorkflowExecuteAdditionalData.getBase();
+						const additionalData = await WorkflowExecuteAdditionalData.getBase(req.user as User);
 						if (this.isUserManagementEnabled) {
 							// TODO UM: test this.
 							// TODO: test this.
@@ -1079,11 +1079,8 @@ class App {
 						sessionId,
 						startNodes,
 						workflowData,
+						user: req.user as User,
 					};
-					if (this.isUserManagementEnabled) {
-						// TODO UM: test this.
-						data.userId = req.body.userId;
-					}
 					const workflowRunner = new WorkflowRunner();
 					const executionId = await workflowRunner.run(data);
 
@@ -1224,9 +1221,12 @@ class App {
 						credentials,
 					);
 
-					const additionalData = await WorkflowExecuteAdditionalData.getBase(currentNodeParameters);
+					const additionalData = await WorkflowExecuteAdditionalData.getBase(
+						req.user as User,
+						currentNodeParameters,
+					);
 					// TODO UM: restrict user access to credentials he cannot use.
-					additionalData.userId = (req.user as User).id;
+					additionalData.user = req.user as User;
 
 					return loadDataInstance.getOptions(methodName, additionalData);
 				},
@@ -1913,6 +1913,7 @@ class App {
 					result as INodeCredentialsDetails,
 					result.type,
 					mode,
+					req.user as User,
 					true,
 				);
 				const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(
@@ -2040,6 +2041,7 @@ class App {
 						result as INodeCredentialsDetails,
 						result.type,
 						mode,
+						req.user as User,
 						true,
 					);
 					const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(
@@ -2135,6 +2137,7 @@ class App {
 					result as INodeCredentialsDetails,
 					result.type,
 					mode,
+					req.user as User,
 					true,
 				);
 				const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(
@@ -2272,6 +2275,7 @@ class App {
 						result as INodeCredentialsDetails,
 						result.type,
 						mode,
+						req.user as User,
 						true,
 					);
 					const oauthCredentials = credentialsHelper.applyDefaultsAndOverwrites(
@@ -2556,6 +2560,7 @@ class App {
 					executionData: fullExecutionData.data,
 					retryOf: req.params.id,
 					workflowData: fullExecutionData.workflowData,
+					user: req.user as User,
 				};
 
 				const { lastNodeExecuted } = data.executionData!.resultData;

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -45,6 +45,23 @@ export async function saveCredentialOwnership(
 	})) as SharedCredentials;
 }
 
+export async function getWorkflowOwner(workflowId: string) {
+	const workflowDb = await Db.collections.Workflow!.findOneOrFail(workflowId, {
+		relations: ['shared', 'shared.user', 'shared.user.globalRole'],
+	});
+
+	return workflowDb.shared[0].user;
+}
+
+export async function getInstanceowner() {
+	const qb = Db.collections.User!.createQueryBuilder('u');
+	qb.innerJoin('u.globalRole', 'gr');
+	qb.andWhere('gr.name = :name and gr.scope = :scope', { name: 'owner', scope: 'global' });
+
+	const owner = await qb.getOneOrFail();
+	return owner;
+}
+
 export function isEmailSetup(): boolean {
 	const emailMode = config.get('userManagement.emails.mode') as string;
 	return !!emailMode;

--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -24,6 +24,7 @@ import {
 	WorkflowCredentials,
 	WorkflowRunner,
 } from '.';
+import { getWorkflowOwner } from './UserManagement/UserManagementHelper';
 
 export class WaitTrackerClass {
 	activeExecutionsInstance: ActiveExecutions.ActiveExecutions;
@@ -157,10 +158,16 @@ export class WaitTrackerClass {
 				throw new Error('The execution did succeed and can so not be started again.');
 			}
 
+			if (!fullExecutionData.workflowData.id) {
+				throw new Error('Only saved workflows can be resumed.');
+			}
+			const user = await getWorkflowOwner(fullExecutionData.workflowData.id.toString());
+
 			const data: IWorkflowExecutionDataProcess = {
 				executionMode: fullExecutionData.mode,
 				executionData: fullExecutionData.data,
 				workflowData: fullExecutionData.workflowData,
+				user,
 			};
 
 			// Start the execution again

--- a/packages/cli/src/WaitingWebhooks.ts
+++ b/packages/cli/src/WaitingWebhooks.ts
@@ -26,6 +26,7 @@ import {
 	WorkflowCredentials,
 	WorkflowExecuteAdditionalData,
 } from '.';
+import { getWorkflowOwner } from './UserManagement/UserManagementHelper';
 
 export class WaitingWebhooks {
 	async executeWebhook(
@@ -111,7 +112,14 @@ export class WaitingWebhooks {
 			settings: workflowData.settings,
 		});
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase();
+		let workflowOwner;
+		try {
+			workflowOwner = await getWorkflowOwner(workflowData.id!.toString());
+		} catch (error) {
+			throw new ResponseHelper.ResponseError('Could not find workflow', 404, 404);
+		}
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase(workflowOwner);
 
 		const webhookData = NodeHelpers.getNodeWebhooks(
 			workflow,

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -40,6 +41,7 @@ import {
 import * as config from '../config';
 // eslint-disable-next-line import/no-cycle
 import { WorkflowEntity } from './databases/entities/WorkflowEntity';
+import { getWorkflowOwner } from './UserManagement/UserManagementHelper';
 
 const ERROR_TRIGGER_TYPE = config.get('nodes.errorTriggerType') as string;
 
@@ -110,6 +112,8 @@ export async function executeErrorWorkflow(
 			return;
 		}
 
+		const user = await getWorkflowOwner(workflowId);
+
 		const executionMode = 'error';
 		const nodeTypes = NodeTypes();
 
@@ -173,6 +177,7 @@ export async function executeErrorWorkflow(
 			executionMode,
 			executionData: runExecutionData,
 			workflowData,
+			user,
 		};
 
 		const workflowRunner = new WorkflowRunner();

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -100,7 +100,28 @@ export async function executeErrorWorkflow(
 ): Promise<void> {
 	// Wrap everything in try/catch to make sure that no errors bubble up and all get caught here
 	try {
-		const workflowData = await Db.collections.Workflow!.findOne({ id: Number(workflowId) });
+		let workflowData;
+		if (workflowId.toString() !== workflowErrorData.workflow.id?.toString()) {
+			// To make this code easier to understand, we split it in 2 parts:
+			// 1) Fetch the owner of the errored workflows and then
+			// 2) if now instance owner, then check if the user has access to the
+			//    triggered workflow.
+
+			const user = await getWorkflowOwner(workflowErrorData.workflow.id!);
+
+			if (user.globalRole.name === 'owner') {
+				workflowData = await Db.collections.Workflow!.findOne({ id: Number(workflowId) });
+			} else {
+				const { id } = user;
+				const qb = Db.collections.Workflow!.createQueryBuilder('w');
+				qb.innerJoin('w.shared', 'shared');
+				qb.andWhere('shared.user = :id', { id });
+				qb.andWhere('w.id = :workflowId', { workflowId });
+				workflowData = await qb.getOne();
+			}
+		} else {
+			workflowData = await Db.collections.Workflow!.findOne({ id: Number(workflowId) });
+		}
 
 		if (workflowData === undefined) {
 			// The error workflow could not be found

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -246,13 +246,10 @@ export class WorkflowRunner {
 			staticData: data.workflowData.staticData,
 		});
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
+			data.user,
 			undefined,
 			workflowTimeout <= 0 ? undefined : Date.now() + workflowTimeout * 1000,
 		);
-		if (data.userId) {
-			// @ts-ignore
-			additionalData.userId = data.userId;
-		}
 
 		// Register the active execution
 		const executionId = await this.activeExecutions.add(data, undefined, restartExecutionId);

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -860,6 +860,7 @@ export async function requestOAuth2(
 				nodeCredentials,
 				credentialsType,
 				credentials,
+				additionalData.user,
 			);
 
 			Logger.debug(
@@ -1090,9 +1091,9 @@ export async function getCredentials(
 		nodeCredentials,
 		type,
 		mode,
+		additionalData.user,
 		false,
 		expressionResolveValues,
-		additionalData.userId,
 	);
 
 	return decryptedDataObject;

--- a/packages/core/test/Helpers.ts
+++ b/packages/core/test/Helpers.ts
@@ -783,5 +783,12 @@ export function WorkflowExecuteAdditionalData(
 		webhookBaseUrl: 'webhook',
 		webhookWaitingBaseUrl: 'webhook-waiting',
 		webhookTestBaseUrl: 'webhook-test',
+		user: {
+			id: '123',
+			globalRole: {
+				name: 'owner',
+				scope: 'global',
+			}
+		}
 	};
 }

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -138,21 +138,23 @@ export abstract class ICredentialsHelper {
 	abstract getCredentials(
 		nodeCredentials: INodeCredentialsDetails,
 		type: string,
+		user: N8nUserData,
 	): Promise<ICredentials>;
 
 	abstract getDecrypted(
 		nodeCredentials: INodeCredentialsDetails,
 		type: string,
 		mode: WorkflowExecuteMode,
+		user: N8nUserData,
 		raw?: boolean,
 		expressionResolveValues?: ICredentialsExpressionResolveValues,
-		userId?: string,
 	): Promise<ICredentialDataDecryptedObject>;
 
 	abstract updateCredentials(
 		nodeCredentials: INodeCredentialsDetails,
 		type: string,
 		data: ICredentialDataDecryptedObject,
+		user: N8nUserData,
 	): Promise<void>;
 }
 
@@ -1017,7 +1019,7 @@ export interface IWorkflowExecuteAdditionalData {
 	webhookTestBaseUrl: string;
 	currentNodeParameters?: INodeParameters;
 	executionTimeoutTimestamp?: number;
-	userId?: string; // this is a UUID - used to firewall actions in user management
+	user: N8nUserData;
 }
 
 export type WorkflowExecuteMode =
@@ -1118,4 +1120,17 @@ export interface ITelemetryClientConfig {
 export interface ITelemetrySettings {
 	enabled: boolean;
 	config?: ITelemetryClientConfig;
+}
+
+export interface N8nUserData {
+	id: string;
+	email?: string;
+	firstName?: string;
+	lastName?: string;
+	globalRole: N8nRoleData;
+}
+
+export interface N8nRoleData {
+	name: string;
+	scope: string;
 }


### PR DESCRIPTION
This PR needs to be merged AFTER https://github.com/n8n-io/n8n/pull/2697 as it relies on many changes made by it.

- Adds runtime checks for the `Error workflow` feature, where you can select another workflow to be executed upon a workflow error.

This can happen in two different ways:

1) Select another workflow from the current workflow settings to be executed on error. This secondary workflow needs to contain the `Error trigger` node
2) A single workflow contains a trigger path and also the `Error trigger` node in itself, like self-healing.

The checks were implemented only for situation (1) as (2) doesn't make sense to check ownership for the workflow itself. Also, instance owners bypass this check.