### PR TITLE
Add workflowOpen > filterWorkflows locale string

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -943,6 +943,7 @@
 		"created": "Created",
 		"name": "@:reusableBaseText.name",
 		"openWorkflow": "Open Workflow",
+		"filterWorkflows": "Filter by tag(s)",
 		"searchWorkflows": "Search workflows...",
 		"showError": {
 			"message": "There was a problem loading the workflows",


### PR DESCRIPTION
Adding `filterWorkflows` locale for use in `workflowOpen` modal, instead of previously used `openWorkflow`, which did not indicate the tag filter possibility