### PR TITLE
Change placeholder text for tags dropdown in Open Workflow Modal

### DIFF
--- a/packages/editor-ui/src/components/WorkflowOpen.vue
+++ b/packages/editor-ui/src/components/WorkflowOpen.vue
@@ -12,7 +12,7 @@
 					</n8n-heading>
 					<div class="tags-filter">
 						<TagsDropdown
-							:placeholder="$locale.baseText('workflowOpen.openWorkflow')"
+							:placeholder="$locale.baseText('workflowOpen.filterWorkflows')"
 							:currentTagIds="filterTagIds"
 							:createEnabled="false"
 							@update="updateTagsFilter"


### PR DESCRIPTION
Changing placeholder text for tags dropdown to indicate tag filtering possibility.