### PR TITLE
Changing "name" to "id" in label and description of Airtable nodes

### DIFF
--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -83,7 +83,7 @@ export class Airtable implements INodeType {
 				description: 'The ID of the base to access.',
 			},
 			{
-				displayName: 'Table',
+				displayName: 'Table ID',
 				name: 'table',
 				type: 'string',
 				default: '',

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -89,7 +89,7 @@ export class Airtable implements INodeType {
 				default: '',
 				placeholder: 'Stories',
 				required: true,
-				description: 'The name of table to access.',
+				description: 'The ID of the table to access.',
 			},
 
 			// ----------------------------------

--- a/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
+++ b/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
@@ -52,7 +52,7 @@ export class AirtableTrigger implements INodeType {
 				name: 'tableId',
 				type: 'string',
 				default: '',
-				description: 'The name of table to access.',
+				description: 'The ID of the table to access.',
 				required: true,
 			},
 			{

--- a/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
+++ b/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
@@ -48,7 +48,7 @@ export class AirtableTrigger implements INodeType {
 				description: 'The ID of this base.',
 			},
 			{
-				displayName: 'Table',
+				displayName: 'Table ID',
 				name: 'tableId',
 				type: 'string',
 				default: '',


### PR DESCRIPTION
The airtable node & airtable trigger node use the `table ID` to fetch information. Status quo:

> Label: "Table"
> Description: "The name of table to access."

Change request:

> Label: "Table ID"
> Description: "The ID of the table to access."

This way, the label and description reflect the needed input. Also it is consistent with the label and description of the "Base ID" inputs.
