### PR TITLE
🐛 [N8N-2887] Wordpress: Add Status option to Get All operation of Posts resource

### DIFF
--- a/packages/nodes-base/credentials/WordpressApi.credentials.ts
+++ b/packages/nodes-base/credentials/WordpressApi.credentials.ts
@@ -18,6 +18,9 @@ export class WordpressApi implements ICredentialType {
 			displayName: 'Password',
 			name: 'password',
 			type: 'string',
+			typeOptions: {
+				password: true,
+			},
 			default: '',
 		},
 		{

--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -60,6 +60,7 @@ export async function wordpressApiRequestAllItems(this: IExecuteFunctions | ILoa
 		returnData.push.apply(returnData, responseData.body);
 	} while (
 		responseData.headers['x-wp-totalpages'] !== undefined &&
+		responseData.headers['x-wp-totalpages'] !== '0' &&
 		parseInt(responseData.headers['x-wp-totalpages'], 10) !== query.page
 	);
 

--- a/packages/nodes-base/nodes/Wordpress/PostDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PostDescription.ts
@@ -609,6 +609,40 @@ export const postFields: INodeProperties[] = [
 		},
 		options: [
 			{
+				displayName: 'After',
+				name: 'after',
+				type: 'dateTime',
+				default: '',
+				description: 'Limit response to posts published after a given ISO8601 compliant date.',
+			},
+			{
+				displayName: 'Author',
+				name: 'author',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getAuthors',
+				},
+				description: 'Limit result set to posts assigned to specific authors.',
+			},
+			{
+				displayName: 'Before',
+				name: 'before',
+				type: 'dateTime',
+				default: '',
+				description: 'Limit response to posts published before a given ISO8601 compliant date.',
+			},
+			{
+				displayName: 'Categories',
+				name: 'categories',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getCategories',
+				},
+				description: 'Limit result set to all items that have the specified term assigned in the categories taxonomy.',
+			},
+			{
 				displayName: 'Context',
 				name: 'context',
 				type: 'options',
@@ -628,6 +662,43 @@ export const postFields: INodeProperties[] = [
 				],
 				default: 'view',
 				description: 'Scope under which the request is made; determines fields present in response.',
+			},
+			{
+				displayName: 'Exclude Categories',
+				name: 'excludedCategories',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getCategories',
+				},
+				description: 'Limit result set to all items except those that have the specified term assigned in the categories taxonomy.',
+			},
+			{
+				displayName: 'Exclude Tags',
+				name: 'excludedTags',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getTags',
+				},
+				description: 'Limit result set to all items except those that have the specified term assigned in the tags taxonomy.',
+			},
+			{
+				displayName: 'Order',
+				name: 'order',
+				type: 'options',
+				options: [
+					{
+						name: 'ASC',
+						value: 'asc',
+					},
+					{
+						name: 'DESC',
+						value: 'desc',
+					},
+				],
+				default: 'desc',
+				description: 'Order sort attribute ascending or descending.',
 			},
 			{
 				displayName: 'Order By',
@@ -679,99 +750,11 @@ export const postFields: INodeProperties[] = [
 				description: 'Sort collection by object attribute.',
 			},
 			{
-				displayName: 'Order',
-				name: 'order',
-				type: 'options',
-				options: [
-					{
-						name: 'ASC',
-						value: 'asc',
-					},
-					{
-						name: 'DESC',
-						value: 'desc',
-					},
-				],
-				default: 'desc',
-				description: 'Order sort attribute ascending or descending.',
-			},
-			{
 				displayName: 'Search',
 				name: 'search',
 				type: 'string',
 				default: '',
 				description: 'Limit results to those matching a string.',
-			},
-			{
-				displayName: 'After',
-				name: 'after',
-				type: 'dateTime',
-				default: '',
-				description: 'Limit response to posts published after a given ISO8601 compliant date.',
-			},
-			{
-				displayName: 'Before',
-				name: 'before',
-				type: 'dateTime',
-				default: '',
-				description: 'Limit response to posts published before a given ISO8601 compliant date.',
-			},
-			{
-				displayName: 'Author',
-				name: 'author',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getAuthors',
-				},
-				description: 'Limit result set to posts assigned to specific authors.',
-			},
-			{
-				displayName: 'Categories',
-				name: 'categories',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				description: 'Limit result set to all items that have the specified term assigned in the categories taxonomy.',
-			},
-			{
-				displayName: 'Exclude Categories',
-				name: 'excludedCategories',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				description: 'Limit result set to all items except those that have the specified term assigned in the categories taxonomy.',
-			},
-			{
-				displayName: 'Tags',
-				name: 'tags',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				description: 'Limit result set to all items that have the specified term assigned in the tags taxonomy.',
-			},
-			{
-				displayName: 'Exclude Tags',
-				name: 'excludedTags',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				description: 'Limit result set to all items except those that have the specified term assigned in the tags taxonomy.',
-			},
-			{
-				displayName: 'Sticky',
-				name: 'sticky',
-				type: 'boolean',
-				default: false,
-				description: 'Limit result set to items that are sticky.',
 			},
 			{
 				displayName: 'Status',
@@ -801,7 +784,24 @@ export const postFields: INodeProperties[] = [
 				],
 				default: 'publish',
 				description: 'The status of the post.',
-			}
+			},
+			{
+				displayName: 'Sticky',
+				name: 'sticky',
+				type: 'boolean',
+				default: false,
+				description: 'Limit result set to items that are sticky.',
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'multiOptions',
+				default: [],
+				typeOptions: {
+					loadOptionsMethod: 'getTags',
+				},
+				description: 'Limit result set to all items that have the specified term assigned in the tags taxonomy.',
+			},
 		],
 	},
 /* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Wordpress/PostDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PostDescription.ts
@@ -773,7 +773,35 @@ export const postFields: INodeProperties[] = [
 				default: false,
 				description: 'Limit result set to items that are sticky.',
 			},
-
+			{
+				displayName: 'Status',
+				name: 'status',
+				type: 'options',
+				options: [
+					{
+						name: 'Draft',
+						value: 'draft',
+					},
+					{
+						name: 'Future',
+						value: 'future',
+					},
+					{
+						name: 'Pending',
+						value: 'pending',
+					},
+					{
+						name: 'Private',
+						value: 'private',
+					},
+					{
+						name: 'Publish',
+						value: 'publish',
+					},
+				],
+				default: 'publish',
+				description: 'The status of the post.',
+			}
 		],
 	},
 /* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -276,6 +276,9 @@ export class Wordpress implements INodeType {
 						if (options.sticky) {
 							qs.sticky = options.sticky as boolean;
 						}
+						if (options.status) {
+							qs.publish = options.status as string;
+						}
 						if (returnAll === true) {
 							responseData = await wordpressApiRequestAllItems.call(this, 'GET', '/posts', {}, qs);
 						} else {

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -277,7 +277,7 @@ export class Wordpress implements INodeType {
 							qs.sticky = options.sticky as boolean;
 						}
 						if (options.status) {
-							qs.publish = options.status as string;
+							qs.status = options.status as string;
 						}
 						if (returnAll === true) {
 							responseData = await wordpressApiRequestAllItems.call(this, 'GET', '/posts', {}, qs);


### PR DESCRIPTION
This PR addresses a [problem](https://community.n8n.io/t/wordpress-node-returns-only-published-posts/10882?u=mutedjam) reported by community member bartv and also implements a [related feature request](https://community.n8n.io/t/wordpress-node-filter-by-post-status/10881/) by bartv by letting users specify the status when listing posts.

I have also sorted the available options alphabetically since it got a bit hard to find the right one.

https://community.n8n.io/t/wordpress-node-returns-only-published-posts/10882?u=mutedjam
https://community.n8n.io/t/wordpress-node-filter-by-post-status/10881/