### PR TITLE
🐛 Handle Wise SCA requests

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -729,6 +729,10 @@ function convertN8nRequestToAxios(n8nRequest: IHttpRequestOptions): AxiosRequest
 		axiosRequest.headers['User-Agent'] = 'n8n';
 	}
 
+	if (n8nRequest.ignoreHttpStatusErrors) {
+		axiosRequest.validateStatus = () => true;
+	}
+
 	return axiosRequest;
 }
 

--- a/packages/nodes-base/credentials/WiseApi.credentials.ts
+++ b/packages/nodes-base/credentials/WiseApi.credentials.ts
@@ -30,5 +30,15 @@ export class WiseApi implements ICredentialType {
 				},
 			],
 		},
+		{
+			displayName: 'Private Key (Optional)',
+			name: 'privateKey',
+			type: 'string',
+			default: '',
+			description: 'Optional private key used for Strong Customer Authentication (SCA). Only needed to retrieve statements, and execute transfers.',
+			typeOptions: {
+				alwaysOpenEditWindow: true,
+			},
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Wise/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wise/GenericFunctions.ts
@@ -1,49 +1,53 @@
 import {
+	createSign,
+} from 'crypto';
+
+import {
 	IExecuteFunctions,
 	IHookFunctions,
 } from 'n8n-core';
 
 import {
 	IDataObject,
+	IHttpRequestOptions,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
 	NodeApiError,
 } from 'n8n-workflow';
-
-import {
-	OptionsWithUri,
-} from 'request';
 
 /**
  * Make an authenticated API request to Wise.
  */
 export async function wiseApiRequest(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
-	method: string,
+	method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'PATCH',
 	endpoint: string,
 	body: IDataObject = {},
 	qs: IDataObject = {},
 	option: IDataObject = {},
 ) {
-	const { apiToken, environment } = await this.getCredentials('wiseApi') as {
+	const { apiToken, environment, privateKey } = await this.getCredentials('wiseApi') as {
 		apiToken: string,
 		environment: 'live' | 'test',
+		privateKey?: string,
 	};
 
 	const rootUrl = environment === 'live'
 		? 'https://api.transferwise.com/'
 		: 'https://api.sandbox.transferwise.tech/';
 
-	const options: OptionsWithUri = {
+	const options: IHttpRequestOptions = {
 		headers: {
 			'user-agent': 'n8n',
 			'Authorization': `Bearer ${apiToken}`,
 		},
 		method,
-		uri: `${rootUrl}${endpoint}`,
+		url: `${rootUrl}${endpoint}`,
 		qs,
 		body,
 		json: true,
+		returnFullResponse: true,
+		ignoreHttpStatusErrors: true,
 	};
 
 	if (!Object.keys(body).length) {
@@ -58,10 +62,53 @@ export async function wiseApiRequest(
 		Object.assign(options, option);
 	}
 
+	let response;
 	try {
-		return await this.helpers.request!(options);
+		response = await this.helpers.httpRequest!(options);
 	} catch (error) {
+		delete error.config;
 		throw new NodeApiError(this.getNode(), error);
+	}
+
+	if (response.statusCode === 200) {
+		return response.body;
+	}
+
+	// Request requires SCA approval
+	if (response.statusCode === 403 && response.headers['x-2fa-approval']) {
+		if (!privateKey) {
+			throw new NodeApiError(this.getNode(), {
+				message: 'This request requires Strong Customer Authentication (SCA). Please add a key pair to your account and n8n credentials. See https://api-docs.transferwise.com/#strong-customer-authentication-personal-token',
+				headers: response.headers,
+				body: response.body,
+			});
+		}
+		// Sign the x-2fa-approval
+		const oneTimeToken = response.headers['x-2fa-approval'] as string;
+		const signerObject = createSign('RSA-SHA256').update(oneTimeToken);
+		try {
+			const signature = signerObject.sign(
+				privateKey,
+				'base64',
+			);
+			delete option.ignoreHttpStatusErrors;
+			options.headers = {
+				...options.headers,
+				'X-Signature': signature,
+				'x-2fa-approval': oneTimeToken,
+			};
+		} catch (error) {
+			throw new NodeApiError(this.getNode(), {message: 'Error signing SCA request, check your private key', ...error});
+		}
+		// Retry the request with signed token
+		try {
+			response = await this.helpers.httpRequest!(options);
+			return response.body;
+		} catch (error) {
+			throw new NodeApiError(this.getNode(), {message: 'SCA request failed, check your private key is valid'});
+		}
+	} else {
+		throw new NodeApiError(this.getNode(), {headers: response.headers, body: response.body},);
 	}
 }
 
@@ -113,8 +160,12 @@ export type Profile = {
 };
 
 export type Recipient = {
+	active: boolean,
 	id: number,
-	accountHolderName: string
+	accountHolderName: string,
+	country: string | null,
+	currency: string,
+	type: string,
 };
 
 export type StatementAdditionalFields = {

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -316,6 +316,7 @@ export interface IHttpRequestOptions {
 	encoding?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
 	skipSslCertificateValidation?: boolean;
 	returnFullResponse?: boolean;
+	ignoreHttpStatusErrors?: boolean;
 	proxy?: {
 		host: string;
 		port: number;


### PR DESCRIPTION
Fixes #2144

This PR adds [Strong Customer Authentication (SCA)](https://api-docs.transferwise.com/#strong-customer-authentication) to the Wise node and extra context to recipients that could previously be hard to distinguish.

SCA is only required on getStatements, and Funds transfer request. It is disabled when using test endpoints which makes it difficult to test.

To support SCA we need to:

- get back a 403 response
- extract a one-time token from the headers `X-2FA-Approval`
- create a SHA256 signature with an RSA key
- resend the request with new headers `X-2FA-Approval` and `X-Signature`

### 🚧 403/error responses
By default all of the request helpers treat non-success codes as errors. To get back the error response with headers I needed to add the Axios `validateStatus` option to the `IHttpRequestOptions`. In developing nodes I've sometimes wondered if I could get all responses and decide what constitutes a failure condition. Is this something I've missed that is already possible?

### 🔑 Handle one-time tokens
To enable signing a token I've added a `privateKey` to the Wise credentials. The basic instructions for configuring this are

1. Generate an RSA key pair 
  ```shell
  openssl genrsa -out wise-n8n.pem 2048
  openssl rsa -pubout -in wise-n8n.pem -out wise-n8n-public.pem
  ```
2. In the `API token` section of your [profile](https://wise.com/settings/) go to `Manage your public keys`
3. Upload the `wise-n8n-public.pem` public key
4. Add the contents of `wise-n8n.pem` to the `Private Key (Optional)` credential field.

### 👩‍💻 Recipient display
This PR also updates the recipient loadOptions to filter for active accounts, and show more context around the account, like country and currency.

Before (first 6 options are the same name):
<img width="173" alt="n8n_io_-_Workflow_Automation" src="https://user-images.githubusercontent.com/939704/151661381-e7bb6b7f-0fe1-495c-99ed-fba4d6ac4050.png">

After (shows currency, country, and account type):
<img width="170" alt="n8n_-_▶️_My_workflow_4" src="https://user-images.githubusercontent.com/939704/151661524-8fa7f34b-4704-4fec-9052-8c935fdc8e9b.png">

