### PR TITLE
🐛 Google Tasks: Fix Show Completed [N8N-2898]

### DIFF
--- a/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
+++ b/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
@@ -171,7 +171,7 @@ export class GoogleTasks implements INodeType {
 						//https://developers.google.com/tasks/v1/reference/tasks/list
 						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 						const taskListId = this.getNodeParameter('task', i) as string;
-						const options = this.getNodeParameter(
+						const { showCompleted = true, showDeleted = false, showHidden = false, ...options } = this.getNodeParameter(
 							'additionalFields',
 							i,
 						) as IDataObject;
@@ -187,13 +187,11 @@ export class GoogleTasks implements INodeType {
 						if (options.dueMax) {
 							qs.dueMax = options.dueMax as string;
 						}
-						qs.showCompleted = options.showCompleted as boolean;
-						if (options.showDeleted) {
-							qs.showDeleted = options.showDeleted as boolean;
-						}
-						if (options.showHidden) {
-							qs.showHidden = options.showHidden as boolean;
-						}
+
+						qs.showCompleted = showCompleted;
+						qs.showDeleted = showDeleted;
+						qs.showHidden = showHidden;
+
 						if (options.updatedMin) {
 							qs.updatedMin = options.updatedMin as string;
 						}

--- a/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
+++ b/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
@@ -187,9 +187,7 @@ export class GoogleTasks implements INodeType {
 						if (options.dueMax) {
 							qs.dueMax = options.dueMax as string;
 						}
-						if (options.showCompleted) {
-							qs.showCompleted = options.showCompleted as boolean;
-						}
+						qs.showCompleted = options.showCompleted as boolean;
 						if (options.showDeleted) {
 							qs.showDeleted = options.showDeleted as boolean;
 						}

--- a/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
+++ b/packages/nodes-base/nodes/Google/Task/TaskDescription.ts
@@ -76,6 +76,16 @@ export const taskFields: INodeProperties[] = [
 		type: 'string',
 		default: '',
 		description: 'Title of the task.',
+		displayOptions: {
+			show: {
+				operation: [
+					'create',
+				],
+				resource: [
+					'task',
+				],
+			},
+		},
 	},
 	{
 		displayName: 'Additional Fields',
@@ -350,21 +360,21 @@ export const taskFields: INodeProperties[] = [
 				name: 'showCompleted',
 				type: 'boolean',
 				default: true,
-				description: 'Flag indicating whether completed tasks are returned in the result',
+				description: 'Flag indicating whether completed tasks are returned in the result. <strong>Show Hidden</strong> must also be True to show tasks completed in first party clients such as the web UI or Google\'s mobile apps.',
 			},
 			{
 				displayName: 'Show Deleted',
 				name: 'showDeleted',
 				type: 'boolean',
 				default: false,
-				description: 'Flag indicating whether deleted tasks are returned in the result',
+				description: 'Flag indicating whether deleted tasks are returned in the result.',
 			},
 			{
 				displayName: 'Show Hidden',
 				name: 'showHidden',
 				type: 'boolean',
 				default: false,
-				description: 'Flag indicating whether hidden tasks are returned in the result',
+				description: 'Flag indicating whether hidden tasks are returned in the result.',
 			},
 			{
 				displayName: 'Updated Min',


### PR DESCRIPTION
This PR fixes a bug [reported via Discord](https://discord.com/channels/832547762716278804/920610924098883594/937660504749514783):

Adding/disabling the Show Completed option in the Google Tasks node has no effect because it would simply remove that option from the parameters used to query Google's Tasks API. The API would use a default value of TRUE in this case, even though this is contrary to the settings made on the node.

This PR also includes a bit of cleaning up and
- hides the title field for operations ignoring it to avoid confusing users
- clarifies that enabling the _Show Hidden_ option is required for the _Fix Show_ option to take effect
- standardizes the spelling of the additional field descriptions by making sure they all end with a full stop (instead of having just some of them end with a full stop)