### PR TITLE
Fix validation on deactivation at PATCH /workfows/:id

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -964,10 +964,10 @@ class App {
 					}
 				}
 
-				// required due to atomic update
-				updateData.updatedAt = this.getCurrentDate();
-
-				await validateEntity(updateData);
+				if (Object.keys(updateData).length > 1) {
+					updateData.updatedAt = this.getCurrentDate(); // required due to atomic update
+					await validateEntity(updateData);
+				}
 
 				await Db.collections.Workflow!.update(workflowId, updateData);
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -964,7 +964,7 @@ class App {
 					}
 				}
 
-				if (Object.keys(updateData).length > 1) {
+				if (Object.keys(updateData).length > 1 || updateData.active === undefined) {
 					updateData.updatedAt = this.getCurrentDate(); // required due to atomic update
 					await validateEntity(updateData);
 				}


### PR DESCRIPTION
Deactivating a workflow sends an `{ active: false }` payload to `PATCH /workflows/:id`, which incorrectly triggers a validation error for the workflow entity.