### PR TITLE
✨ Add operation to list Github files

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -2182,6 +2182,9 @@ export class Github implements INodeType {
 					const asBinaryProperty = this.getNodeParameter('asBinaryProperty', i);
 
 					if (asBinaryProperty === true) {
+						if (Array.isArray(responseData)) {
+							throw new NodeOperationError(this.getNode(), 'File Path is a folder, not a file.');
+						}
 						// Add the returned data to the item as binary property
 						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
 

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -193,7 +193,12 @@ export class Github implements INodeType {
 					{
 						name: 'Get',
 						value: 'get',
-						description: 'Get the data of a single issue.',
+						description: 'Get the data of a single file.',
+					},
+					{
+						name: 'List',
+						value: 'list',
+						description: 'List contents of a folder.',
 					},
 				],
 				default: 'create',
@@ -413,9 +418,37 @@ export class Github implements INodeType {
 							'file',
 						],
 					},
+					hide: {
+						operation: [
+							'list',
+						],
+					},
 				},
 				placeholder: 'docs/README.md',
 				description: 'The file path of the file. Has to contain the full path.',
+			},
+
+			// ----------------------------------
+			//         file:list
+			// ----------------------------------
+			{
+				displayName: 'Path',
+				name: 'filePath',
+				type: 'string',
+				default: '',
+				required: false,
+				displayOptions: {
+					show: {
+						resource: [
+							'file',
+						],
+						operation: [
+							'list',
+						],
+					},
+				},
+				placeholder: 'docs/',
+				description: 'The path of the folder to list.',
 			},
 
 			// ----------------------------------
@@ -1774,6 +1807,7 @@ export class Github implements INodeType {
 		// Operations which overwrite the returned data and return arrays
 		// and has so to be merged with the data of other items
 		const overwriteDataOperationsArray = [
+			'file:list',
 			'repository:getIssues',
 			'repository:listPopularPaths',
 			'repository:listReferrers',
@@ -1891,7 +1925,7 @@ export class Github implements INodeType {
 						body.sha = await getFileSha.call(this, owner, repository, filePath, body.branch as string | undefined);
 
 						endpoint = `/repos/${owner}/${repository}/contents/${encodeURI(filePath)}`;
-					} else if (operation === 'get') {
+					} else if (operation === 'get' || operation === 'list') {
 						requestMethod = 'GET';
 
 						const filePath = this.getNodeParameter('filePath', i) as string;


### PR DESCRIPTION
This PR adds an option to the Github node to list files in a folder.

This was previously possible but unintended with the `get` operation. However that returns a single item as an array which can be difficult to deal with (#2751). It also throws a non-obvious error when `asBinaryProperty` is true.

Before using `get`:
<img width="703" alt="n8n_-_▶️_Github_List_Files" src="https://user-images.githubusercontent.com/939704/152151165-beb59be3-6cd2-411f-bddd-b4bec04e9791.png">

After:
<img width="703" alt="n8n_-_▶️_Github_List_Files" src="https://user-images.githubusercontent.com/939704/152151095-d30b48db-f5cd-451a-ac13-d8c936eb5de1.png">