### PR TITLE
N8n 2918 support telemetry page

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -409,6 +409,7 @@ export interface IN8nUISettings {
 	telemetry: ITelemetrySettings;
 	personalizationSurvey: IPersonalizationSurvey;
 	defaultLocale: string;
+	logLevel: 'info' | 'debug' | 'warn' | 'error' | 'verbose';
 }
 
 export interface IPersonalizationSurveyAnswers {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -288,6 +288,7 @@ class App {
 				shouldShow: false,
 			},
 			defaultLocale: config.get('defaultLocale'),
+			logLevel: config.get('logs.level'),
 		};
 	}
 

--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -22,6 +22,9 @@ export default Vue.extend({
 	components: {
 		Telemetry,
 	},
+	mounted() {
+		this.$telemetry.page('Editor', this.$route.name);
+	},
 	watch: {
 		'$route'(route) {
 			this.$telemetry.page('Editor', route.name);

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -719,7 +719,7 @@ export interface IUiState {
 	isPageLoading: boolean;
 }
 
-export type ILogLevel = 'debug' | 'info' | 'warn' | 'vebose';
+export type ILogLevel = 'info' | 'debug' | 'warn' | 'error' | 'verbose';
 
 export interface ISettingsState {
 	settings: IN8nUISettings;

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -536,6 +536,7 @@ export interface IN8nUISettings {
 	personalizationSurvey?: IPersonalizationSurvey;
 	telemetry: ITelemetrySettings;
 	defaultLocale: string;
+	logLevel: ILogLevel;
 }
 
 export interface IWorkflowSettings extends IWorkflowSettingsWorkflow {
@@ -717,6 +718,8 @@ export interface IUiState {
 	};
 	isPageLoading: boolean;
 }
+
+export type ILogLevel = 'debug' | 'info' | 'warn' | 'vebose';
 
 export interface ISettingsState {
 	settings: IN8nUISettings;

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -681,7 +681,6 @@ export interface IRootState {
 	workflow: IWorkflowDb;
 	sidebarMenuItems: IMenuItem[];
 	instanceId: string;
-	telemetry: ITelemetrySettings | null;
 }
 
 export interface ICredentialTypeMap {

--- a/packages/editor-ui/src/components/Telemetry.vue
+++ b/packages/editor-ui/src/components/Telemetry.vue
@@ -10,12 +10,12 @@ import { mapGetters } from 'vuex';
 export default Vue.extend({
 	name: 'Telemetry',
 	computed: {
-		...mapGetters(['telemetry']),
+		...mapGetters('settings', ['telemetry']),
 	},
 	watch: {
 		telemetry(opts) {
-			if (opts.enabled) {
-				this.$telemetry.init(opts, this.$store.getters.instanceId);
+			if (opts && opts.enabled) {
+				this.$telemetry.init(opts, this.$store.getters.instanceId, this.$store.getters['settings/logLevel']);
 			}
 		},
 	},

--- a/packages/editor-ui/src/modules/settings.ts
+++ b/packages/editor-ui/src/modules/settings.ts
@@ -1,5 +1,6 @@
 import {  ActionContext, Module } from 'vuex';
 import {
+	ILogLevel,
 	IN8nPrompts,
 	IN8nUISettings,
 	IN8nValueSurveyData,
@@ -11,6 +12,7 @@ import { getPromptsData, getSettings, submitValueSurvey, submitPersonalizationSu
 import Vue from 'vue';
 import { getPersonalizedNodeTypes } from './helper';
 import { CONTACT_PROMPT_MODAL_KEY, PERSONALIZATION_MODAL_KEY, VALUE_SURVEY_MODAL_KEY } from '@/constants';
+import { ITelemetrySettings } from 'n8n-workflow';
 
 const module: Module<ISettingsState, IRootState> = {
 	namespaced: true,
@@ -29,6 +31,15 @@ const module: Module<ISettingsState, IRootState> = {
 		},
 		getPromptsData(state: ISettingsState) {
 			return state.promptsData;
+		},
+		telemetry: (state): ITelemetrySettings | null => {
+			return state.settings.telemetry;
+		},
+		logLevel: (state): ILogLevel | null => {
+			return state.settings.logLevel;
+		},
+		isTelemetryEnabled: (state) => {
+			return state.settings.telemetry && state.settings.telemetry.enabled;
 		},
 	},
 	mutations: {
@@ -66,7 +77,6 @@ const module: Module<ISettingsState, IRootState> = {
 			context.commit('setN8nMetadata', settings.n8nMetadata || {}, {root: true});
 			context.commit('setDefaultLocale', settings.defaultLocale, {root: true});
 			context.commit('versions/setVersionNotificationSettings', settings.versionNotifications, {root: true});
-			context.commit('setTelemetry', settings.telemetry, {root: true});
 
 			const showPersonalizationsModal = settings.personalizationSurvey && settings.personalizationSurvey.shouldShow && !settings.personalizationSurvey.answers;
 
@@ -81,7 +91,7 @@ const module: Module<ISettingsState, IRootState> = {
 			context.commit('setPersonalizationAnswers', results);
 		},
 		async fetchPromptsData(context: ActionContext<ISettingsState, IRootState>) {
-			if (!context.rootGetters.isTelemetryEnabled) {
+			if (!context.getters.isTelemetryEnabled) {
 				return;
 			}
 

--- a/packages/editor-ui/src/modules/settings.ts
+++ b/packages/editor-ui/src/modules/settings.ts
@@ -32,10 +32,10 @@ const module: Module<ISettingsState, IRootState> = {
 		getPromptsData(state: ISettingsState) {
 			return state.promptsData;
 		},
-		telemetry: (state): ITelemetrySettings | null => {
+		telemetry: (state): ITelemetrySettings => {
 			return state.settings.telemetry;
 		},
-		logLevel: (state): ILogLevel | null => {
+		logLevel: (state): ILogLevel => {
 			return state.settings.logLevel;
 		},
 		isTelemetryEnabled: (state) => {

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -3,7 +3,7 @@ import {
 	ITelemetrySettings,
 	IDataObject,
 } from 'n8n-workflow';
-import { INodeCreateElement } from "@/Interface";
+import { ILogLevel, INodeCreateElement } from "@/Interface";
 
 declare module 'vue/types/vue' {
 	interface Vue {
@@ -55,13 +55,14 @@ class Telemetry {
 		this.pageEventQueue = [];
 	}
 
-	init(options: ITelemetrySettings, instanceId: string) {
+	init(options: ITelemetrySettings, instanceId: string, logLevel?: ILogLevel) {
 		if (options.enabled && !this.telemetry) {
 			if(!options.config) {
 				return;
 			}
 
-			this.loadTelemetryLibrary(options.config.key, options.config.url, { integrations: { All: false }, loadIntegration: false });
+			const logging = logLevel === 'debug' ? { logLevel: 'DEBUG'} : {};
+			this.loadTelemetryLibrary(options.config.key, options.config.url, { integrations: { All: false }, loadIntegration: false, ...logging});
 			this.telemetry.identify(instanceId);
 		}
 	}

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -64,6 +64,7 @@ class Telemetry {
 			const logging = logLevel === 'debug' ? { logLevel: 'DEBUG'} : {};
 			this.loadTelemetryLibrary(options.config.key, options.config.url, { integrations: { All: false }, loadIntegration: false, ...logging});
 			this.telemetry.identify(instanceId);
+			this.flushPageEvents();
 		}
 	}
 
@@ -196,6 +197,5 @@ class Telemetry {
 		};
 		this.telemetry.loadJS();
 		this.telemetry.load(key, url, options);
-		this.flushPageEvents();
 	}
 }

--- a/packages/editor-ui/src/store.ts
+++ b/packages/editor-ui/src/store.ts
@@ -12,7 +12,6 @@ import {
 	INodeIssueData,
 	INodeTypeDescription,
 	IRunData,
-	ITelemetrySettings,
 	ITaskData,
 	IWorkflowSettings,
 } from 'n8n-workflow';
@@ -89,7 +88,6 @@ const state: IRootState = {
 	},
 	sidebarMenuItems: [],
 	instanceId: '',
-	telemetry: null,
 };
 
 const modules = {
@@ -545,9 +543,6 @@ export const store = new Vuex.Store({
 		setInstanceId(state, instanceId: string) {
 			Vue.set(state, 'instanceId', instanceId);
 		},
-		setTelemetry(state, telemetry: ITelemetrySettings) {
-			Vue.set(state, 'telemetry', telemetry);
-		},
 		setOauthCallbackUrls(state, urls: IDataObject) {
 			Vue.set(state, 'oauthCallbackUrls', urls);
 		},
@@ -659,10 +654,6 @@ export const store = new Vuex.Store({
 			return state.workflow.id === PLACEHOLDER_EMPTY_WORKFLOW_ID;
 		},
 
-		isTelemetryEnabled: (state) => {
-			return state.telemetry && state.telemetry.enabled;
-		},
-
 		currentWorkflowHasWebhookNode: (state: IRootState): boolean => {
 			return !!state.workflow.nodes.find((node: INodeUi) => !!node.webhookId);
 		},
@@ -729,9 +720,6 @@ export const store = new Vuex.Store({
 		},
 		versionCli: (state): string => {
 			return state.versionCli;
-		},
-		telemetry: (state): ITelemetrySettings | null => {
-			return state.telemetry;
 		},
 		oauthCallbackUrls: (state): object => {
 			return state.oauthCallbackUrls;

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2752,7 +2752,6 @@ export default mixins(
 			});
 
 			this.$externalHooks().run('nodeView.mount');
-			this.$telemetry.page('Editor', this.$route.name);
 		},
 
 		destroyed () {


### PR DESCRIPTION
* support page events before telemetry is initialised (paving the way for new views, i.e. UM, Templates)
* add debug logging to telemetry based on env debug level
* refactor telemetry from main store to settings store