### PR TITLE
Allow strapi node to use custom endpoints

### DIFF
--- a/packages/nodes-base/nodes/Strapi/EntryDescription.ts
+++ b/packages/nodes-base/nodes/Strapi/EntryDescription.ts
@@ -40,6 +40,11 @@ export const entryOperations: INodeProperties[] = [
 				value: 'update',
 				description: 'Update an entry',
 			},
+			{
+				name: 'Custom',
+				value: 'custom',
+				description: 'Custom endpoint',
+			},
 		],
 		default: 'get',
 		description: 'The operation to perform.',
@@ -344,5 +349,62 @@ export const entryFields: INodeProperties[] = [
 		default: '',
 		placeholder: 'id,name,description',
 		description: 'Comma separated list of the properties which should used as columns for the new rows.',
+	},
+
+		/* -------------------------------------------------------------------------- */
+	/*                                entry:custom                                */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Columns',
+		name: 'columns',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: [
+					'entry',
+				],
+				operation: [
+					'custom',
+				],
+			},
+		},
+		default: '',
+		placeholder: 'id,name,description',
+		description: 'Comma separated list of the properties which should used as columns for the new rows.',
+	},
+	{
+		displayName: 'Method',
+		name: 'method',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: [
+					'entry',
+				],
+				operation: [
+					'custom',
+				],
+			},
+		},
+		default: 'PATCH',
+		description: 'REST method to use on this path.',
+	},
+	{
+		displayName: 'Path',
+		name: 'path',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: [
+					'entry',
+				],
+				operation: [
+					'custom',
+				],
+			},
+		},
+		placeholder: '/custom-path',
+		default: '',
+		description: 'Path to custom endpoint without initial /.',
 	},
 ];

--- a/packages/nodes-base/nodes/Strapi/Strapi.node.ts
+++ b/packages/nodes-base/nodes/Strapi/Strapi.node.ts
@@ -177,6 +177,28 @@ export class Strapi implements INodeType {
 
 						returnData.push(responseData);
 					}
+
+					if (operation === 'custom') {
+
+						const body: IDataObject = {};
+
+						const path = this.getNodeParameter('path', i) as string;
+
+						const columns = this.getNodeParameter('columns', i) as string;
+
+						const method = this.getNodeParameter('method', i) as string;
+
+						const columnList = columns.split(',').map(column => column.trim());
+
+						for (const key of Object.keys(items[i].json)) {
+							if (columnList.includes(key)) {
+								body[key] = items[i].json[key];
+							}
+						}
+						responseData = await strapiApiRequest.call(this, method, `/${path}`, body, qs, undefined, headers);
+
+						returnData.push(responseData);
+					}
 				}
 			} catch (error) {
 				if (this.continueOnFail()) {


### PR DESCRIPTION
Hi! I've been working with n8n to interact mainly with a strapi application.
One of the main problems we had was that as the project grew we developed custom endpoints into our strapi project, and to interact with them from n8n we couln't use the strapi node. 
We had a workaround using the HTTP request node, first login then store the jwt and then adding headers. So we made this light modification to the strapi node to allow use of any method to any endpoint. 
I hope i didn't miss anything, if so let me know as we plan to keep creating PRs with solutions we implement to our needs. 