### PR TITLE
[HTTP] add support for Bearer auth

### DIFF
--- a/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
@@ -1,0 +1,23 @@
+import {
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+
+export class HttpBearerAuth implements ICredentialType {
+	name = 'httpBearerAuth';
+	displayName = 'Bearer Auth';
+	documentationUrl = 'httpRequest';
+	icon = 'node:n8n-nodes-base.httpRequest';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Token',
+			name: 'token',
+			type: 'string',
+			default: '',
+			typeOptions: {
+				password: true,
+			},
+		},
+	];
+}

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -48,6 +48,17 @@ export class GraphQL implements INodeType {
 				},
 			},
 			{
+				name: 'httpBearerAuth',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: [
+							'bearerAuth',
+						],
+					},
+				},
+			},
+			{
 				name: 'httpHeaderAuth',
 				required: true,
 				displayOptions: {
@@ -105,6 +116,10 @@ export class GraphQL implements INodeType {
 					{
 						name: 'Digest Auth',
 						value: 'digestAuth',
+					},
+					{
+						name: 'Bearer Auth',
+						value: 'bearerAuth',
 					},
 					{
 						name: 'Header Auth',
@@ -306,6 +321,7 @@ export class GraphQL implements INodeType {
 		const items = this.getInputData();
 		const httpBasicAuth = await this.getCredentials('httpBasicAuth');
 		const httpDigestAuth = await this.getCredentials('httpDigestAuth');
+		const httpBearerAuth = await this.getCredentials('httpBearerAuth');
 		const httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
 		const httpQueryAuth = await this.getCredentials('httpQueryAuth');
 		const oAuth1Api = await this.getCredentials('oAuth1Api');
@@ -359,6 +375,12 @@ export class GraphQL implements INodeType {
 					requestOptions.auth = {
 						user: httpDigestAuth.user as string,
 						pass: httpDigestAuth.password as string,
+						sendImmediately: false,
+					};
+				}
+				if (httpBearerAuth !== undefined) {
+					requestOptions.auth = {
+						bearer: httpBearerAuth.token as string,
 						sendImmediately: false,
 					};
 				}

--- a/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
@@ -62,6 +62,17 @@ export class HttpRequest implements INodeType {
 				},
 			},
 			{
+				name: 'httpBearerAuth',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: [
+							'bearerAuth',
+						],
+					},
+				},
+			},
+			{
 				name: 'httpHeaderAuth',
 				required: true,
 				displayOptions: {
@@ -119,6 +130,10 @@ export class HttpRequest implements INodeType {
 					{
 						name: 'Digest Auth',
 						value: 'digestAuth',
+					},
+					{
+						name: 'Bearer Auth',
+						value: 'bearerAuth',
 					},
 					{
 						name: 'Header Auth',
@@ -654,6 +669,7 @@ export class HttpRequest implements INodeType {
 
 		const httpBasicAuth = await this.getCredentials('httpBasicAuth');
 		const httpDigestAuth = await this.getCredentials('httpDigestAuth');
+		const httpBearerAuth = await this.getCredentials('httpBearerAuth');
 		const httpHeaderAuth = await this.getCredentials('httpHeaderAuth');
 		const httpQueryAuth = await this.getCredentials('httpQueryAuth');
 		const oAuth1Api = await this.getCredentials('oAuth1Api');
@@ -920,6 +936,12 @@ export class HttpRequest implements INodeType {
 				requestOptions.auth = {
 					user: httpDigestAuth.user as string,
 					pass: httpDigestAuth.password as string,
+					sendImmediately: false,
+				};
+			}
+			if (httpBearerAuth !== undefined) {
+				requestOptions.auth = {
+					bearer: httpBearerAuth.token as string,
 					sendImmediately: false,
 				};
 			}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -139,6 +139,7 @@
       "dist/credentials/HomeAssistantApi.credentials.js",
       "dist/credentials/HttpBasicAuth.credentials.js",
       "dist/credentials/HttpDigestAuth.credentials.js",
+      "dist/credentials/HttpBearerAuth.credentials.js",
       "dist/credentials/HttpHeaderAuth.credentials.js",
       "dist/credentials/HttpQueryAuth.credentials.js",
       "dist/credentials/HubspotApi.credentials.js",


### PR DESCRIPTION
`Authorization: Bearer abc` is a commonly used way of authentication.

Tested with HTTP node