### PR TITLE
Fix issue with path separators on Windows in import:credentials command

### DIFF
--- a/packages/cli/commands/import/credentials.ts
+++ b/packages/cli/commands/import/credentials.ts
@@ -66,9 +66,12 @@ export class ImportCredentialsCommand extends Command {
 			}
 
 			if (flags.separate) {
-				const files = await glob(
-					`${flags.input.endsWith(path.sep) ? flags.input : flags.input + path.sep}*.json`,
-				);
+				let inputPath = flags.input;
+				if (process.platform === 'win32') {
+					inputPath = inputPath.replace(/\\/g, '/');
+				}
+				inputPath = inputPath.replace(/\/$/g, '');
+				const files = await glob(`${inputPath}/*.json`);
 				for (i = 0; i < files.length; i++) {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 					const credential = JSON.parse(fs.readFileSync(files[i], { encoding: 'utf8' }));


### PR DESCRIPTION
I went looking for the cause of #2804 and found some inconsistencies between importing workflows and credentials in how it handles the 'separate' argument. So I copied this lines from https://github.com/n8n-io/n8n/blob/master/packages/cli/commands/import/workflow.ts#L88-L93 and it turns out that fixes the issue.

**Glob-path before:** `backups/latest/\*.json`
**Glob-path after:** `backups/latest/*.json`

Resolves #2804