### PR TITLE
Fix timezone issue on Postgres (issues: #2810  and #2178)

### DIFF
--- a/packages/cli/src/databases/entities/CredentialsEntity.ts
+++ b/packages/cli/src/databases/entities/CredentialsEntity.ts
@@ -5,11 +5,10 @@ import { ICredentialNodeAccess } from 'n8n-workflow';
 import {
 	BeforeUpdate,
 	Column,
-	CreateDateColumn,
+	ColumnOptions,
 	Entity,
 	Index,
 	PrimaryGeneratedColumn,
-	UpdateDateColumn,
 } from 'typeorm';
 
 import config = require('../../../config');
@@ -68,10 +67,15 @@ export class CredentialsEntity implements ICredentialsDb {
 	@Column(resolveDataType('json'))
 	nodesAccess: ICredentialNodeAccess[];
 
-	@CreateDateColumn({ precision: 3, default: () => getTimestampSyntax() })
+	@Column({
+		type: resolveDataType('datetime') as ColumnOptions['type'],
+		precision: 3,
+		default: () => getTimestampSyntax(),
+	})
 	createdAt: Date;
 
-	@UpdateDateColumn({
+	@Column({
+		type: resolveDataType('datetime') as ColumnOptions['type'],
 		precision: 3,
 		default: () => getTimestampSyntax(),
 		onUpdate: getTimestampSyntax(),

--- a/packages/cli/src/databases/entities/WorkflowEntity.ts
+++ b/packages/cli/src/databases/entities/WorkflowEntity.ts
@@ -8,13 +8,11 @@ import {
 	BeforeUpdate,
 	Column,
 	ColumnOptions,
-	CreateDateColumn,
 	Entity,
 	Index,
 	JoinTable,
 	ManyToMany,
 	PrimaryGeneratedColumn,
-	UpdateDateColumn,
 } from 'typeorm';
 
 import config = require('../../../config');
@@ -71,10 +69,15 @@ export class WorkflowEntity implements IWorkflowDb {
 	@Column(resolveDataType('json'))
 	connections: IConnections;
 
-	@CreateDateColumn({ precision: 3, default: () => getTimestampSyntax() })
+	@Column({
+		type: resolveDataType('datetime') as ColumnOptions['type'],
+		precision: 3,
+		default: () => getTimestampSyntax(),
+	})
 	createdAt: Date;
 
-	@UpdateDateColumn({
+	@Column({
+		type: resolveDataType('datetime') as ColumnOptions['type'],
 		precision: 3,
 		default: () => getTimestampSyntax(),
 		onUpdate: getTimestampSyntax(),

--- a/packages/cli/src/databases/postgresdb/migrations/1644709334858-ChangeToTimestampWithTimeZone.ts
+++ b/packages/cli/src/databases/postgresdb/migrations/1644709334858-ChangeToTimestampWithTimeZone.ts
@@ -1,0 +1,51 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+import * as config from '../../../../config';
+
+export class ChangeToTimestampWithTimeZone1644679445231 implements MigrationInterface {
+	name = 'ChangeToTimestampWithTimeZone1644679445231';
+
+	async up(queryRunner: QueryRunner): Promise<void> {
+		let tablePrefix = config.get('database.tablePrefix');
+		const schema = config.get('database.postgresdb.schema');
+		if (schema) {
+			tablePrefix = schema + '.' + tablePrefix;
+		}
+		// You cannot define a TIMESTAMPTZ column with a specific precision for fractional seconds other than 6.
+
+		// CredentialsEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}credentials_entity ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(6)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}credentials_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(6)`);
+		// ExecutionEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "startedAt" TYPE TIMESTAMPTZ`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "stoppedAt" TYPE TIMESTAMPTZ`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "waitTill" TYPE TIMESTAMPTZ`);
+		// TagEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}tag_entity ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(6)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}tag_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(6)`);
+		// WorkflowEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}workflow_entity ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ(6)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}workflow_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ(6)`);
+	}
+
+	async down(queryRunner: QueryRunner): Promise<void> {
+		let tablePrefix = config.get('database.tablePrefix');
+		const schema = config.get('database.postgresdb.schema');
+		if (schema) {
+			tablePrefix = schema + '.' + tablePrefix;
+		}
+		// CredentialsEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}credentials_entity ALTER COLUMN "createdAt" TYPE TIMESTAMP(3)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}credentials_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMP(3)`);
+		// ExecutionEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "startedAt" TYPE TIMESTAMP`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "stoppedAt" TYPE TIMESTAMP`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}execution_entity ALTER COLUMN "waitTill" TYPE TIMESTAMP`);
+		// TagEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}tag_entity ALTER COLUMN "createdAt" TYPE TIMESTAMP(3)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}tag_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMP(3)`);
+		// WorkflowEntity
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}workflow_entity ALTER COLUMN "createdAt" TYPE TIMESTAMP(3)`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}workflow_entity ALTER COLUMN "updatedAt" TYPE TIMESTAMP(3)`);
+	}
+}

--- a/packages/cli/src/databases/postgresdb/migrations/index.ts
+++ b/packages/cli/src/databases/postgresdb/migrations/index.ts
@@ -7,6 +7,7 @@ import { CreateTagEntity1617270242566 } from './1617270242566-CreateTagEntity';
 import { UniqueWorkflowNames1620824779533 } from './1620824779533-UniqueWorkflowNames';
 import { AddwaitTill1626176912946 } from './1626176912946-AddwaitTill';
 import { UpdateWorkflowCredentials1630419189837 } from './1630419189837-UpdateWorkflowCredentials';
+import { ChangeToTimestampWithTimeZone1644679445231 } from './1644709334858-ChangeToTimestampWithTimeZone';
 
 export const postgresMigrations = [
 	InitialMigration1587669153312,
@@ -18,4 +19,5 @@ export const postgresMigrations = [
 	UniqueWorkflowNames1620824779533,
 	AddwaitTill1626176912946,
 	UpdateWorkflowCredentials1630419189837,
+	ChangeToTimestampWithTimeZone1644679445231,
 ];


### PR DESCRIPTION
- Using the datatype `timestamptz` instead of `timestamp` in Postgres.
- For that `createdAt` and `updatedAt` has been switched from `CreateDateColumn` and `UpdateDateColumn` to `Column` so we can set the type to `timestamptz`.
- Adding migration file to alter column types from `timestamp`  to `timestamptz`

(fix for issues: #2810  and #2178)