### PR TITLE
[Notion] Adds possibility to return blocks as an array

### DIFF
--- a/packages/nodes-base/nodes/Notion/BlockDescription.ts
+++ b/packages/nodes-base/nodes/Notion/BlockDescription.ts
@@ -120,4 +120,21 @@ export const blockFields = [
 		default: 50,
 		description: 'How many results to return',
 	},
+	{
+		displayName: 'Return as Array',
+		name: 'returnAsArray',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'block',
+				],
+				operation: [
+					'getAll',
+				],
+			},
+		},
+		default: false,
+		description: 'If each all results should be returned as an array in one item',
+	},
 ] as INodeProperties[];

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -240,6 +240,7 @@ export class NotionV2 implements INodeType {
 			if (operation === 'getAll') {
 				for (let i = 0; i < length; i++) {
 					const blockId = extractPageId(this.getNodeParameter('blockId', i) as string);
+					const returnAsArray = this.getNodeParameter('returnAsArray', i) as boolean;
 					const returnAll = this.getNodeParameter('returnAll', i) as boolean;
 					if (returnAll) {
 						responseData = await notionApiRequestAllItems.call(this, 'results', 'GET', `/blocks/${blockId}/children`, {});
@@ -248,7 +249,12 @@ export class NotionV2 implements INodeType {
 						responseData = await notionApiRequest.call(this, 'GET', `/blocks/${blockId}/children`, {}, qs);
 						responseData = responseData.results;
 					}
-					returnData.push.apply(returnData, responseData);
+					if(returnAsArray) {
+						returnData.push(responseData);
+					}
+					else {
+						returnData.push.apply(returnData, responseData);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
With the current Notion node implementation the `getAll` functionality returns each block as an item.
That is ok when the node runs only for one page but if there are multiple pages we want to get blocks from (e.g. from a Node trigger), it makes it impossible to know which blocks comes from each page.
This adds an option to return all blocks from a call into an array in one item per call.

PS: I'm not great at naming 😅 so feel free to propose something better for the option and the description.