### PR TITLE
:zap: Add extra large size option - Telegram trigger

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -10,7 +10,9 @@ import {
 } from 'request';
 
 import {
-	IBinaryData, IDataObject, NodeApiError, NodeOperationError,
+	IDataObject,
+	NodeApiError,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 // Interface in n8n
@@ -185,6 +187,7 @@ export function getImageBySize(photos: IDataObject[], size: string): IDataObject
 		'small': 0,
 		'medium': 1,
 		'large': 2,
+		'extraLarge': 3,
 	} as IDataObject;
 
 	const index = sizes[size] as number;

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -121,7 +121,7 @@ export class TelegramTrigger implements INodeType {
 						name: 'download',
 						type: 'boolean',
 						default: false,
-						description: `Telegram delivers the image in 3 sizes. By default, just the larger image would be downloaded. If you want to change the size, set the field 'Image Size'.`,
+						description: `Telegram delivers the image in multiple sizes. By default, just the large image would be downloaded. If you want to change the size, set the field 'Image Size'.`,
 					},
 					{
 						displayName: 'Image Size',
@@ -146,6 +146,10 @@ export class TelegramTrigger implements INodeType {
 							{
 								name: 'Large',
 								value: 'large',
+							},
+							{
+								name: 'Extra Large',
+								value: 'extraLarge',
 							},
 						],
 						default: 'large',


### PR DESCRIPTION
Community: https://community.n8n.io/t/telegram-trigger-returns-smaller-image-than-sent-in-compressed-mode/11453/4