### PR TITLE
Support for JWT Cookies and EC-signed JWT Tokens, and JWT Auth Performance Improvements

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -463,11 +463,23 @@ const config = convict({
 				env: 'N8N_JWT_AUTH_HEADER_VALUE_PREFIX',
 				doc: 'The request header value prefix to strip (optional)',
 			},
+			jwtCookie: {
+				format: String,
+				default: '',
+				env: 'N8N_JWT_AUTH_COOKIE',
+				doc: 'The request cookie containing a signed JWT',
+			},
 			jwksUri: {
 				format: String,
 				default: '',
 				env: 'N8N_JWKS_URI',
 				doc: 'The URI to fetch JWK Set for JWT authentication',
+			},
+			jwksEllipticCurve: {
+				format: 'Boolean',
+				default: false,
+				env: 'N8N_JWKS_USE_EC',
+				doc: 'If the keys used for the JWT are Elliptic Curve signed keys',
 			},
 			jwtIssuer: {
 				format: String,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -108,6 +108,7 @@
     "inquirer": "^7.0.1",
     "json-diff": "^0.5.4",
     "jsonwebtoken": "^8.5.1",
+    "jwks-ec": "^1.0.3",
     "jwks-rsa": "~1.12.1",
     "localtunnel": "^2.0.0",
     "lodash.get": "^4.4.2",

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -511,7 +511,7 @@ class App {
 					token = token.replace(`${jwtHeaderValuePrefix} `, '').trimLeft();
 				}
 				// eslint-disable-next-line no-inner-declarations, @typescript-eslint/ban-types
-				function getKey(header: any, callback: Function): void {
+				function getKey(header: any, callback: Function) {
 					jwkClient.getSigningKey(header.kid, (err: Error, key: any) => {
 						// eslint-disable-next-line @typescript-eslint/no-throw-literal
 						if (err) throw ResponseHelper.jwtAuthAuthorizationError(res, err.message);
@@ -3062,7 +3062,4 @@ async function getExecutionsCount(
 
 	const count = await Db.collections.Execution!.count(countFilter);
 	return { count, estimate: false };
-}
-function res(res: any, message: string) {
-	throw new Error('Function not implemented.');
 }


### PR DESCRIPTION
Hi there, first time doing any kind of pull-request/enhancement to existing software so please let me know what I can do better. Here are my list of changes:

1. JWT Cookie Support
I noticed that n8n supported JWT authorization tokens, but only if it's passed as a header. Depending on the OAuth service, some products pass the JWT token as a cookie so this would allow n8n to work with those products too. You can define the cookie name with the following environment variable:
`N8N_JWT_AUTH_COOKIE`
I've designed the code to allow either the Header name or Cookie name to be defined, but not both. Having both seems redundant in my opinion and probably not a valid use-case.

2. EC-signed JWT Tokens
I also noticed that n8n did not support EC-signed JWT tokens, which is increasingly becoming an industry standard. Including the "jwks-ec" module helps solve this issue. I've included code that sets the jwksClient to use the "jwks-rsa" module by default, or "jwks-ec" if EC-signed tokens are going to be used. You can tell n8n to use "jwks-ec" by setting the following environment variable to true:
`N8N_JWKS_USE_EC`

3. Updating isTenantAllowed Function
Originally, the isTenantAllowed function would return a blanket true if the `N8N_JWT_NAMESPACE`, `N8N_JWT_ALLOWED_TENANT_KEY`, and `N8N_JWT_ALLOWED_TENANT` were not all defined in some manner. This seemed restrictive since tokens might not be multi-tenant. By only checking if the Tenant Key and Tenant ID are defined, n8n can parse through the decoded Token looking for any key-value pair that the user wants to allow. For example, most companies will place a user's account name in the "sub" key of a token, which could be a useful intermediary for authenticated user management. If a namespace is defined, the function will act as normal.

4. JWT Authentication Performance Improvement
Finally, I think I've improved the performance of n8n when doing JWT token based authentication. I noticed that n8n seemed to take 3-4x longer to load when using tokens. I think this was because the jwksClient was making a call to my JWKS server to grab the signing keys for every operation (GET, POST, etc). Typically, the jwksClient will want to cache those keys so that it's not making repetitive calls to the JWKS server - but by defining the  jwksClient variable inside the middleware layer,  it would continually be re-created and the keys weren't cached so it would have to wait for the server. By moving the definition of the jwksClient outside of the authentication middleware layer, it remains persistent across all middleware operations, using those cached keys.

Regardless, if the maintainers of n8n decide that Updates 1, 2, and 3 are not something they'd like to support, I think option 4 should be heavily considered as a modification to n8n.

Please let me know if you have any questions. Thanks!
