### PR TITLE
Templates Bugs / Fixed Various Bugs / Multiply Api Request, Carousel Gradient, Core Nodes Filters

### DIFF
--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -198,6 +198,8 @@ export default {
 		padding: var(--spacing-s);
 		color: #555555;
 		background-color: #f2f4f8;
+		text-overflow: ellipsis;
+    overflow: hidden;
 	}
 
 	.label {

--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -199,7 +199,7 @@ export default {
 		color: #555555;
 		background-color: #f2f4f8;
 		text-overflow: ellipsis;
-    overflow: hidden;
+		overflow: hidden;
 	}
 
 	.label {

--- a/packages/design-system/theme/src/skeleton.scss
+++ b/packages/design-system/theme/src/skeleton.scss
@@ -32,7 +32,7 @@
 
 .el-skeleton__image {
   width: unset;
-  height: 607px !important;
+  height: 500px !important;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;

--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -27,6 +27,11 @@ export default mixins(showMessage).extend({
 		Modals,
 		Telemetry,
 	},
+	computed: {
+		isTemplatesEnabled() {
+			return this.$store.getters['settings/isTemplatesEnabled'];
+		},
+	},
 	data() {
 		return {
 			loading: true,
@@ -51,6 +56,13 @@ export default mixins(showMessage).extend({
 	},
 	async mounted() {
 		await this.initialize();
+
+		if (this.isTemplatesEnabled && this.$route.path === '/') {
+			this.$router.replace({ name: 'TemplatesView'});
+		} else if (this.$route.path === '/') {
+			this.$router.replace({ name: 'NodeViewNew'});
+		}
+
 		this.$store.commit('ui/setCurrentPage', this.$route.name);
 		this.$telemetry.page('Editor', this.$route.name);
 	},

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -651,6 +651,7 @@ export interface ITemplateNode {
 	};
 	name: string;
 	typeVersion: number;
+	categories: ITemplateCategories[];
 }
 
 export interface ITimeoutHMS {

--- a/packages/editor-ui/src/components/CollectionsCarousel.vue
+++ b/packages/editor-ui/src/components/CollectionsCarousel.vue
@@ -101,7 +101,7 @@ export default mixins(genericHelpers).extend({
 				const scrollWidth = list.scrollWidth;
 				const scrollLeft = this.carouselScrollPosition;
 
-				if (scrollWidth - width <= scrollLeft + 10) {
+				if (scrollWidth - width <= scrollLeft + 7) {
 					this.scrollEnd = true;
 				} else {
 					this.scrollEnd = false;
@@ -166,17 +166,16 @@ export default mixins(genericHelpers).extend({
 	background-color: #fbfcfe;
 	opacity: 1;
 	cursor: pointer;
-	z-index: 2;
 
 	&:nth-child(1) {
-		left: var(--spacing-2xs);
+		left: -30px;
 
 		&:after {
 			content: '';
 			width: 40px;
 			height: 140px;
 			top: -54px;
-			left: -23px;
+			left: 27px;
 			position: absolute;
 			position: absolute;
 			background: linear-gradient(270deg, rgba(255, 255, 255, 0.25) 0%, rgba(248, 249, 251, 1) 86%);
@@ -185,15 +184,14 @@ export default mixins(genericHelpers).extend({
 	}
 
 	&:nth-child(2) {
-		right: var(--spacing-2xs);
+		right: -30px;
 
 		&:after {
 			content: '';
 			width: 40px;
 			height: 140px;
 			top: -54px;
-			right: -23px;
-			position: absolute;
+			right: 27px;
 			position: absolute;
 			background: linear-gradient(
 				270deg,

--- a/packages/editor-ui/src/components/CollectionsCarousel.vue
+++ b/packages/editor-ui/src/components/CollectionsCarousel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="$style.container">
-		<div :class="$style.header">
+		<div v-if="collections.length || loading" :class="$style.header">
 			<n8n-heading :bold="true" size="medium" color="text-light">
 				{{ $locale.baseText('templates.collections') }}
 				<span v-if="!loading" v-text="`(${collections.length})`" />
@@ -40,10 +40,6 @@
 					<font-awesome-icon icon="chevron-right" />
 				</button>
 			</div>
-		</div>
-
-		<div v-else :class="$style.text">
-			<n8n-text color="text-base">{{ $locale.baseText('templates.collectionNotFound') }}</n8n-text>
 		</div>
 	</div>
 </template>

--- a/packages/editor-ui/src/components/CollectionsCarousel.vue
+++ b/packages/editor-ui/src/components/CollectionsCarousel.vue
@@ -76,6 +76,7 @@ export default mixins(genericHelpers).extend({
 				const width = list.clientWidth;
 				const collectionsWidth = collections.length * (this.carouselWidth + collections.length * 2);
 				this.scrollEnd = collectionsWidth < width;
+				list.addEventListener('scroll', this.handleCarouselScroll);
 			}
 		},
 	},

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -560,6 +560,7 @@ export default mixins(
 <style lang="scss">
 .sidebar-popper{
 	.el-menu-item {
+		padding-left: 30px!important;
 		font-size: 0.9em;
 		height: 35px;
 		line-height: 35px;

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -32,7 +32,7 @@
 					</n8n-menu-item>
 					<n8n-menu-item v-if="isTemplatesEnabled" index="template-new">
 						<template slot="title">
-							<font-awesome-icon icon="shapes"/>&nbsp;
+							<font-awesome-icon icon="box-open"/>&nbsp;
 							<span slot="title" class="item-title">{{ $locale.baseText('mainSidebar.newTemplate') }}</span>
 						</template>
 					</n8n-menu-item>
@@ -87,7 +87,7 @@
 				</el-submenu>
 
 				<n8n-menu-item v-if="isTemplatesEnabled" index="templates">
-					<font-awesome-icon icon="shapes"/>&nbsp;
+					<font-awesome-icon icon="box-open"/>&nbsp;
 					<span slot="title" class="item-title-root">{{ $locale.baseText('mainSidebar.templates') }}</span>
 				</n8n-menu-item>
 

--- a/packages/editor-ui/src/components/NodeList.vue
+++ b/packages/editor-ui/src/components/NodeList.vue
@@ -5,11 +5,7 @@
 			:class="$style.container"
 			:key="node.name"
 		>
-			<TemplateNodeIcon
-				:nodeType="node"
-				:size="nodeSize"
-				:title="node.name"
-			/>
+			<TemplateNodeIcon :nodeType="node" :size="nodeSize" :title="node.name" />
 		</div>
 		<div :class="$style.button" v-if="filteredCoreNodes.length > nodesToBeShown + 1">
 			+{{ filteredCoreNodes.length - countNodesToBeSliced(filteredCoreNodes) }}
@@ -61,16 +57,19 @@ export default mixins(genericHelpers).extend({
 	},
 	computed: {
 		filteredCoreNodes() {
-			return this.nodes.filter((elem) => {
+			const result = this.nodes.filter((elem) => {
 				const node = elem as INode;
 				if (node.categories) {
-					return node.categories.some((category: ITemplateCategories) => {
-						return category.name !== 'Core Nodes';
-					});
+					const found = node.categories.some(
+						(category: ITemplateCategories) => category.name === 'Core Nodes',
+					);
+					if (!found) return node;
+					else return;
 				} else {
-					return node;
+					return;
 				}
 			});
+			return result.length > 0 ? result : this.nodes;
 		},
 	},
 	methods: {
@@ -86,44 +85,44 @@ export default mixins(genericHelpers).extend({
 </script>
 
 <style lang="scss" module>
-  .list {
-  	max-width: 100px;
-  	height: 20px;
-  	display: flex;
-  	flex-direction: row;
-  	justify-content: flex-end;
-  	align-items: center;
+.list {
+	max-width: 100px;
+	height: 20px;
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	align-items: center;
 
-  	.container {
-  		width: 18px;
-  		height: 18px;
-  		margin-left: var(--spacing-2xs);
-  		position: relative;
-  		display: block;
+	.container {
+		width: 18px;
+		height: 18px;
+		margin-left: var(--spacing-2xs);
+		position: relative;
+		display: block;
 
-  		.image {
-  			width: 18px;
-  			height: 18px;
-  			display: block;
-  		}
-  	}
+		.image {
+			width: 18px;
+			height: 18px;
+			display: block;
+		}
+	}
 
-  	.button {
-  		width: 20px;
-  		min-width: 20px;
-  		height: 20px;
-  		margin-left: var(--spacing-2xs);
-  		top: 0px;
-  		position: relative;
-  		display: flex;
-  		justify-content: center;
-  		align-items: center;
-  		background: var(--color-background-light);
-  		border: $--version-card-border;
-  		border-radius: var(--border-radius-base);
-  		font-size: 10px;
-  		font-weight: var(--font-weight-bold);
-  		color: var(--color-text-base);
-  	}
-  }
+	.button {
+		width: 20px;
+		min-width: 20px;
+		height: 20px;
+		margin-left: var(--spacing-2xs);
+		top: 0px;
+		position: relative;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		background: var(--color-background-light);
+		border: $--version-card-border;
+		border-radius: var(--border-radius-base);
+		font-size: 10px;
+		font-weight: var(--font-weight-bold);
+		color: var(--color-text-base);
+	}
+}
 </style>

--- a/packages/editor-ui/src/components/NodeList.vue
+++ b/packages/editor-ui/src/components/NodeList.vue
@@ -18,6 +18,8 @@ import TemplateNodeIcon from '@/components/TemplateNodeIcon.vue';
 
 import { genericHelpers } from '@/components/mixins/genericHelpers';
 import { ITemplateCategories } from '@/Interface';
+import { TEMPLATES_NODES_FILTER } from '@/constants';
+
 
 interface INode {
 	displayName: string;
@@ -57,19 +59,26 @@ export default mixins(genericHelpers).extend({
 	},
 	computed: {
 		filteredCoreNodes() {
-			const result = this.nodes.filter((elem) => {
+			const notCoreNodes = this.nodes.filter((elem) => {
 				const node = elem as INode;
 				if (node.categories) {
 					const found = node.categories.some(
 						(category: ITemplateCategories) => category.name === 'Core Nodes',
 					);
-					if (!found) return node;
+					if (!found) return !TEMPLATES_NODES_FILTER.includes(node.name);
 					else return;
 				} else {
 					return;
 				}
 			});
-			return result.length > 0 ? result : this.nodes;
+
+			if (notCoreNodes.length) return notCoreNodes;
+			else {
+				return this.nodes.filter((elem) => {
+					const node = elem as INode;
+					return !TEMPLATES_NODES_FILTER.includes(node.name);
+				});
+			}
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/NodeList.vue
+++ b/packages/editor-ui/src/components/NodeList.vue
@@ -127,7 +127,7 @@ export default mixins(genericHelpers).extend({
 		justify-content: center;
 		align-items: center;
 		background: var(--color-background-light);
-		border: $--version-card-border;
+		border: 1px var(--color-foreground-base) solid;
 		border-radius: var(--border-radius-base);
 		font-size: 10px;
 		font-weight: var(--font-weight-bold);

--- a/packages/editor-ui/src/components/NodeList.vue
+++ b/packages/editor-ui/src/components/NodeList.vue
@@ -17,26 +17,10 @@
 import TemplateNodeIcon from '@/components/TemplateNodeIcon.vue';
 
 import { genericHelpers } from '@/components/mixins/genericHelpers';
-import { ITemplateCategories } from '@/Interface';
-import { TEMPLATES_NODES_FILTER } from '@/constants';
-
-
-interface INode {
-	displayName: string;
-	defaults: {
-		color: string;
-	};
-	categories: ITemplateCategories[];
-	icon: string;
-	iconData?: {
-		fileBuffer?: string;
-		type?: string;
-	};
-	name: string;
-	typeVersion: number;
-}
+import { ITemplateNode } from '@/Interface';
 
 import mixins from 'vue-typed-mixins';
+import { filterTemplateNodes } from './helpers';
 
 export default mixins(genericHelpers).extend({
 	name: 'NodeList',
@@ -59,26 +43,7 @@ export default mixins(genericHelpers).extend({
 	},
 	computed: {
 		filteredCoreNodes() {
-			const notCoreNodes = this.nodes.filter((elem) => {
-				const node = elem as INode;
-				if (node.categories) {
-					const found = node.categories.some(
-						(category: ITemplateCategories) => category.name === 'Core Nodes',
-					);
-					if (!found) return !TEMPLATES_NODES_FILTER.includes(node.name);
-					else return;
-				} else {
-					return;
-				}
-			});
-
-			if (notCoreNodes.length) return notCoreNodes;
-			else {
-				return this.nodes.filter((elem) => {
-					const node = elem as INode;
-					return !TEMPLATES_NODES_FILTER.includes(node.name);
-				});
-			}
+			return filterTemplateNodes(this.nodes as ITemplateNode[]);
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/TemplateDetails.vue
+++ b/packages/editor-ui/src/components/TemplateDetails.vue
@@ -61,9 +61,8 @@ import Vue from 'vue';
 import TemplateBlock from '@/components/TemplateBlock.vue';
 import TemplateNodeIcon from '@/components/TemplateNodeIcon.vue';
 
-import { abbreviateNumber } from '@/components/helpers';
-import { ITemplateCategories } from '@/Interface';
-import { TEMPLATES_NODES_FILTER } from '@/constants';
+import { abbreviateNumber, filterTemplateNodes } from '@/components/helpers';
+import { ITemplateCategories, ITemplateNode } from '@/Interface';
 
 interface INode {
 	displayName: string;
@@ -108,22 +107,8 @@ export default Vue.extend({
 	},
 	methods: {
 		abbreviateNumber,
-		filterCoreNodes(nodes: []) {
-			const notCoreNodes = nodes.filter((elem) => {
-				const node = elem as INode;
-				if (node.categories) {
-					const found = node.categories.some(
-						(category: ITemplateCategories) => category.name === 'Core Nodes',
-					);
-					if (!found) return !TEMPLATES_NODES_FILTER.includes(node.name);
-					else return;
-				} else {
-					return;
-				}
-			});
-			return notCoreNodes.length > 0
-				? notCoreNodes
-				: nodes.filter((elem: INode) => !TEMPLATES_NODES_FILTER.includes(elem.name));
+		filterCoreNodes(nodes: ITemplateNode[]) {
+			return filterTemplateNodes(nodes);
 		},
 		redirectToCategory(tag: ITag) {
 			this.$router.push(`/templates?categories=${tag.id}`);

--- a/packages/editor-ui/src/components/TemplateDetails.vue
+++ b/packages/editor-ui/src/components/TemplateDetails.vue
@@ -63,6 +63,7 @@ import TemplateNodeIcon from '@/components/TemplateNodeIcon.vue';
 
 import { abbreviateNumber } from '@/components/helpers';
 import { ITemplateCategories } from '@/Interface';
+import { TEMPLATES_NODES_FILTER } from '@/constants';
 
 interface INode {
 	displayName: string;
@@ -108,19 +109,21 @@ export default Vue.extend({
 	methods: {
 		abbreviateNumber,
 		filterCoreNodes(nodes: []) {
-			const result = nodes.filter((elem) => {
+			const notCoreNodes = nodes.filter((elem) => {
 				const node = elem as INode;
 				if (node.categories) {
 					const found = node.categories.some(
 						(category: ITemplateCategories) => category.name === 'Core Nodes',
 					);
-					if (!found) return node;
+					if (!found) return !TEMPLATES_NODES_FILTER.includes(node.name);
 					else return;
 				} else {
 					return;
 				}
 			});
-			return result.length > 0 ? result : nodes;
+			return notCoreNodes.length > 0
+				? notCoreNodes
+				: nodes.filter((elem: INode) => !TEMPLATES_NODES_FILTER.includes(elem.name));
 		},
 		redirectToCategory(tag: ITag) {
 			this.$router.push(`/templates?categories=${tag.id}`);

--- a/packages/editor-ui/src/components/TemplateDetails.vue
+++ b/packages/editor-ui/src/components/TemplateDetails.vue
@@ -4,7 +4,7 @@
 
 		<template-block
 			v-if="!loading && template.nodes.length > 0"
-			:title="$locale.baseText('template.details.appsInTheWorkflow')"
+			:title="blockTitle"
 		>
 			<template v-slot:content>
 				<div :class="$style.icons">
@@ -91,6 +91,9 @@ interface INode {
 export default Vue.extend({
 	name: 'TemplateDetails',
 	props: {
+		blockTitle: {
+			type: String,
+		},
 		loading: {
 			type: Boolean,
 		},
@@ -105,16 +108,19 @@ export default Vue.extend({
 	methods: {
 		abbreviateNumber,
 		filterCoreNodes(nodes: []) {
-			return nodes.filter((elem) => {
+			const result = nodes.filter((elem) => {
 				const node = elem as INode;
 				if (node.categories) {
-					return node.categories.some((category: ITemplateCategories) => {
-						return category.name !== 'Core Nodes';
-					});
+					const found = node.categories.some(
+						(category: ITemplateCategories) => category.name === 'Core Nodes',
+					);
+					if (!found) return node;
+					else return;
 				} else {
-					return node;
+					return;
 				}
 			});
+			return result.length > 0 ? result : nodes;
 		},
 		redirectToCategory(tag: ITag) {
 			this.$router.push(`/templates?categories=${tag.id}`);

--- a/packages/editor-ui/src/components/TemplateFilters.vue
+++ b/packages/editor-ui/src/components/TemplateFilters.vue
@@ -189,7 +189,14 @@ export default mixins(genericHelpers).extend({
 
 <style lang="scss">
 .template-filters {
+	.el-checkbox {
+		display: flex;
+		white-space: unset;
+	}
+
 	.el-checkbox__label {
+		top: -3px;
+		position: relative;
 		font-size: var(--font-size-2xs);
 		color: var(--color-text-dark);
 		padding-left: var(--spacing-2xs);

--- a/packages/editor-ui/src/components/TemplateList.vue
+++ b/packages/editor-ui/src/components/TemplateList.vue
@@ -318,7 +318,7 @@ export default mixins(genericHelpers).extend({
 	justify-content: center;
 	align-items: center;
 	background: var(--color-background-light);
-	border: $--version-card-border;
+	border: 1px var(--color-foreground-base) solid;
 	border-radius: var(--border-radius-base);
 	font-size: 10px;
 	font-weight: var(--font-weight-bold);

--- a/packages/editor-ui/src/components/TemplateList.vue
+++ b/packages/editor-ui/src/components/TemplateList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="$style.list">
-		<div v-if="workflows.length || loading" :class="$style.header">
+		<div v-if="(workflows && workflows.length) || loading" :class="$style.header">
 			<n8n-heading :bold="true" size="medium" color="text-light">
 				{{ $locale.baseText('templates.workflows') }}
 				<span v-if="!loading && totalWorkflows" v-text="`(${totalWorkflows})`" />

--- a/packages/editor-ui/src/components/TemplateList.vue
+++ b/packages/editor-ui/src/components/TemplateList.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="$style.list">
-		<div :class="$style.header">
+		<div v-if="workflows.length || loading" :class="$style.header">
 			<n8n-heading :bold="true" size="medium" color="text-light">
 				{{ $locale.baseText('templates.workflows') }}
 				<span v-if="!loading && totalWorkflows" v-text="`(${totalWorkflows})`" />
@@ -83,9 +83,6 @@
 					<span v-html="$locale.baseText('templates.endResult')" />
 				</n8n-text>
 			</div>
-		</div>
-		<div v-else>
-			<n8n-text color="text-base">{{ $locale.baseText('templates.workflowsNotFound') }}</n8n-text>
 		</div>
 	</div>
 </template>

--- a/packages/editor-ui/src/components/TemplateList.vue
+++ b/packages/editor-ui/src/components/TemplateList.vue
@@ -61,12 +61,12 @@
 						</template>
 					</TemplateCard>
 				</div>
-				<div v-if="infinityScroll && searchFinished" v-infocus />
-				<div v-if="infinityScroll && shouldShowLoadingState && !searchFinished">
+				<div v-if="infiniteScrollEnabled && searchFinished" v-infocus />
+				<div v-if="infiniteScrollEnabled && shouldShowLoadingState && !searchFinished">
 					<TemplateCard v-for="n in 4" :key="'index-' + n" :loading="true" />
 				</div>
 			</div>
-			<div v-if="infinityScroll && !shouldShowLoadingState" :class="$style.text">
+			<div v-if="infiniteScrollEnabled && !shouldShowLoadingState" :class="$style.text">
 				<n8n-text size="medium" color="text-base">
 					<span v-html="$locale.baseText('templates.endResult')" />
 				</n8n-text>
@@ -110,7 +110,7 @@ export default mixins(genericHelpers).extend({
 		categories: {
 			type: Array,
 		},
-		infinityScroll: {
+		infiniteScrollEnabled: {
 			type: Boolean,
 			default: false,
 		},
@@ -158,8 +158,7 @@ export default mixins(genericHelpers).extend({
 				const f = () => {
 					if (vnode.context) {
 						if (
-							vnode.context.$props.infinityScroll &&
-							vnode.context.$route.name === 'TemplatesView' &&
+							vnode.context.$props.infiniteScrollEnabled &&
 							vnode.context.$data.searchFinished
 						) {
 							const rect = el.getBoundingClientRect();

--- a/packages/editor-ui/src/components/TemplateList.vue
+++ b/packages/editor-ui/src/components/TemplateList.vue
@@ -92,24 +92,9 @@ import TemplateNodeIcon from '@/components/TemplateNodeIcon.vue';
 import TemplateCard from '@/components/TemplateCard.vue';
 
 import { genericHelpers } from '@/components/mixins/genericHelpers';
-import { ITemplateCategories } from '@/Interface';
-import { TEMPLATES_NODES_FILTER } from '@/constants';
+import { ITemplateNode } from '@/Interface';
 import mixins from 'vue-typed-mixins';
-
-interface INode {
-	displayName: string;
-	defaults: {
-		color: string;
-	};
-	categories: ITemplateCategories[];
-	icon: string;
-	iconData?: {
-		fileBuffer?: string;
-		type?: string;
-	};
-	name: string;
-	typeVersion: number;
-}
+import { filterTemplateNodes } from './helpers';
 
 export default mixins(genericHelpers).extend({
 	name: 'TemplateList',
@@ -231,19 +216,8 @@ export default mixins(genericHelpers).extend({
 				return this.nodesToBeShown;
 			}
 		},
-		filterCoreNodes(nodes: []) {
-			const notCoreNodes = nodes.filter((elem) => {
-				const node = elem as INode;
-				const found = node.categories.some(
-					(category: ITemplateCategories) => category.name === 'Core Nodes',
-				);
-				if (!found) return !TEMPLATES_NODES_FILTER.includes(node.name);
-				else return;
-			});
-
-			return notCoreNodes.length > 0
-				? notCoreNodes
-				: nodes.filter((elem: INode) => !TEMPLATES_NODES_FILTER.includes(elem.name));
+		filterCoreNodes(nodes: ITemplateNode[]) {
+			return filterTemplateNodes(nodes);
 		},
 	},
 });

--- a/packages/editor-ui/src/components/WorkflowPreview.vue
+++ b/packages/editor-ui/src/components/WorkflowPreview.vue
@@ -114,7 +114,7 @@ export default mixins(showMessage).extend({
 <style lang="scss" module>
 .workflow {
 	width: 100%;
-	height: 607px;
+	height: 500px;
 	border: var(--border-base);
 	border-radius: var(--border-radius-large);
 }

--- a/packages/editor-ui/src/components/helpers.ts
+++ b/packages/editor-ui/src/components/helpers.ts
@@ -1,5 +1,5 @@
-import { ERROR_TRIGGER_NODE_TYPE } from '@/constants';
-import { INodeUi } from '@/Interface';
+import { ERROR_TRIGGER_NODE_TYPE, TEMPLATES_NODES_FILTER } from '@/constants';
+import { INodeUi, ITemplateNode } from '@/Interface';
 import dateformat from 'dateformat';
 
 const KEYWORDS_TO_FILTER = ['API', 'OAuth1', 'OAuth2'];
@@ -43,4 +43,15 @@ export function getActivatableTriggerNodes(nodes: INodeUi[]) {
 		// Error Trigger does not behave like other triggers and workflows using it can not be activated
 		return !node.disabled && node.type !== ERROR_TRIGGER_NODE_TYPE;
 	});
+}
+
+export function filterTemplateNodes(nodes: ITemplateNode[]) {
+	const notCoreNodes = nodes.filter((node: ITemplateNode) => {
+		return !(node.categories || []).some(
+			(category) => category.name === 'Core Nodes',
+		);
+	});
+
+	const results = notCoreNodes.length > 0 ? notCoreNodes : nodes;
+	return results.filter((elem) => !TEMPLATES_NODES_FILTER.includes(elem.name));
 }

--- a/packages/editor-ui/src/components/helpers.ts
+++ b/packages/editor-ui/src/components/helpers.ts
@@ -1,4 +1,4 @@
-import { ERROR_TRIGGER_NODE_TYPE, TEMPLATES_NODES_FILTER } from '@/constants';
+import { CORE_NODES_CATEGORY, ERROR_TRIGGER_NODE_TYPE, TEMPLATES_NODES_FILTER } from '@/constants';
 import { INodeUi, ITemplateNode } from '@/Interface';
 import dateformat from 'dateformat';
 
@@ -48,7 +48,7 @@ export function getActivatableTriggerNodes(nodes: INodeUi[]) {
 export function filterTemplateNodes(nodes: ITemplateNode[]) {
 	const notCoreNodes = nodes.filter((node: ITemplateNode) => {
 		return !(node.categories || []).some(
-			(category) => category.name === 'Core Nodes',
+			(category) => category.name === CORE_NODES_CATEGORY,
 		);
 	});
 

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -142,3 +142,7 @@ export const MODAL_CONFIRMED = 'confirmed';
 export const VALID_EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export const LOCAL_STORAGE_ACTIVATION_FLAG = 'N8N_HIDE_ACTIVATION_ALERT';
 
+export const TEMPLATES_NODES_FILTER = [
+	'n8n-nodes-base.start',
+	'n8n-nodes-base.respondToWebhook',
+];

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -860,12 +860,11 @@
 		"categoriesHeading": "Categories",
 		"collection": "Collection",
 		"collections": "Collections",
-		"collectionNotFound": "No collections found. Try adjusting your search to see more.",
 		"endResult": "Share your own useful workflows <a href='https://n8n.io/dashboard' target='_blank'>here</a> through your n8n.io account",
 		"heading": "Workflow templates",
 		"newButton": "New blank workflow",
+		"noSearchResults": "Nothing found. Try adjusting your search to see more.",
 		"searchPlaceholder": "Search workflows",
-		"workflowsNotFound": "No workflows found. Try adjusting your search to see more.",
 		"workflow": "Workflow",
 		"workflows": "Workflows"
 	},

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -847,6 +847,7 @@
 		},
 		"details": {
 			"appsInTheWorkflow": "Apps in this workflow",
+			"appsInTheCollection": "This collection features",
 			"by": "by",
 			"categories": "Categories",
 			"created": "Created",
@@ -860,11 +861,12 @@
 		"collection": "Collection",
 		"collections": "Collections",
 		"collectionNotFound": "No collections found. Try adjusting your search to see more.",
-		"endResult": "End of results",
+		"endResult": "Share your own useful workflows <a href='https://n8n.io/dashboard' target='_blank'>here</a> through your n8n.io account",
 		"heading": "Workflow templates",
 		"newButton": "New blank workflow",
 		"searchPlaceholder": "Search workflows",
 		"workflowsNotFound": "No workflows found. Try adjusting your search to see more.",
+		"workflow": "Workflow",
 		"workflows": "Workflows"
 	},
 	"textEdit": {

--- a/packages/editor-ui/src/plugins/icons.ts
+++ b/packages/editor-ui/src/plugins/icons.ts
@@ -10,6 +10,7 @@ import {
 	faArrowRight,
 	faAt,
 	faBook,
+	faBoxOpen,
 	faBug,
 	faCalendar,
 	faCheck,
@@ -102,6 +103,7 @@ addIcon(faArrowLeft);
 addIcon(faArrowRight);
 addIcon(faAt);
 addIcon(faBook);
+addIcon(faBoxOpen);
 addIcon(faBug);
 addIcon(faCalendar);
 addIcon(faCheck);

--- a/packages/editor-ui/src/plugins/icons.ts
+++ b/packages/editor-ui/src/plugins/icons.ts
@@ -68,7 +68,6 @@ import {
 	faRedo,
 	faRss,
 	faSave,
-	faShapes,
 	faSearch,
 	faSearchMinus,
 	faSearchPlus,
@@ -164,7 +163,6 @@ addIcon(faSave);
 addIcon(faSearch);
 addIcon(faSearchMinus);
 addIcon(faSearchPlus);
-addIcon(faShapes);
 addIcon(faServer);
 addIcon(faSignInAlt);
 addIcon(faSlidersH);

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -67,10 +67,6 @@ export default new Router({
 			},
 		},
 		{
-			path: '/',
-			redirect: '/workflow',
-		},
-		{
 			path: '/workflows/templates/:id',
 			name: 'WorkflowTemplate',
 			components: {

--- a/packages/editor-ui/src/views/CollectionView.vue
+++ b/packages/editor-ui/src/views/CollectionView.vue
@@ -6,7 +6,7 @@
 				<div :class="$style.wrapper">
 					<div :class="$style.title">
 						<n8n-heading v-if="!loading" tag="h1" size="2xlarge">{{ collection.name }}</n8n-heading>
-						<n8n-text v-if="!loading" color="text-base" size="small" :bold="true">
+						<n8n-text v-if="!loading" color="text-base" size="small">
 							{{ $locale.baseText('templates.collection') }}
 						</n8n-text>
 						<n8n-loading :animated="true" :loading="loading" :rows="2" variant="h1" />
@@ -31,7 +31,11 @@
 					/>
 				</div>
 				<div :class="$style.details">
-					<TemplateDetails :loading="loading" :template="collection" />
+					<TemplateDetails
+					  :block-title="$locale.baseText('template.details.appsInTheCollection')"
+						:loading="loading"
+						:template="collection"
+					/>
 				</div>
 			</div>
 		</div>

--- a/packages/editor-ui/src/views/CollectionView.vue
+++ b/packages/editor-ui/src/views/CollectionView.vue
@@ -22,7 +22,7 @@
 					/>
 					<TemplateList
 						:abbreviate-number="abbreviateNumber"
-						:infinity-scroll="false"
+						:infinite-scroll-enabled="false"
 						:loading="loading"
 						:navigate-to="navigateTo"
 						:node-icon-size="18"

--- a/packages/editor-ui/src/views/TemplateView.vue
+++ b/packages/editor-ui/src/views/TemplateView.vue
@@ -24,7 +24,7 @@
 			</div>
 			<div>
 				<div :class="$style.image">
-					<workflow-preview
+					<WorkflowPreview
 						v-if="showPreview"
 						:workflow="template.workflow"
 						@close="onHidePreview"

--- a/packages/editor-ui/src/views/TemplateView.vue
+++ b/packages/editor-ui/src/views/TemplateView.vue
@@ -6,6 +6,9 @@
 				<div :class="$style.wrapper">
 					<div :class="$style.title">
 						<n8n-heading v-if="!loading" tag="h1" size="2xlarge">{{ template.name }}</n8n-heading>
+						<n8n-text v-if="!loading" color="text-base" size="small">
+							{{ $locale.baseText('templates.workflow') }}
+						</n8n-text>
 						<n8n-loading :animated="true" :loading="loading" :rows="2" variant="h1" />
 					</div>
 					<div :class="$style.button">
@@ -21,7 +24,12 @@
 			</div>
 			<div>
 				<div :class="$style.image">
-					<workflow-preview v-if="showPreview" :workflow="template.workflow" @close="onHidePreview" :loading="loading"/>
+					<workflow-preview
+						v-if="showPreview"
+						:workflow="template.workflow"
+						@close="onHidePreview"
+						:loading="loading"
+					/>
 				</div>
 				<div :class="$style.content">
 					<div :class="$style.markdown">
@@ -32,7 +40,11 @@
 						/>
 					</div>
 					<div :class="$style.details">
-						<TemplateDetails :loading="loading" :template="template" />
+						<TemplateDetails
+							:block-title="$locale.baseText('template.details.appsInTheWorkflow')"
+							:loading="loading"
+							:template="template"
+						/>
 					</div>
 				</div>
 			</div>
@@ -96,15 +108,13 @@ export default mixins(workflowHelpers).extend({
 			this.showPreview = false;
 		},
 		scrollToTop() {
-			setTimeout(() => {
-				window.scrollTo({
-					top: 0,
-					behavior: 'smooth',
-				});
-			}, 50);
+			window.scrollTo({
+				top: 0,
+			});
 		},
 	},
 	async mounted() {
+		this.scrollToTop();
 		if (!this.isTemplatesEnabled) {
 			this.$router.replace({ name: 'NodeViewNew' });
 		}
@@ -119,7 +129,6 @@ export default mixins(workflowHelpers).extend({
 			});
 		}
 		this.loading = false;
-		this.scrollToTop();
 	},
 });
 </script>

--- a/packages/editor-ui/src/views/TemplateView.vue
+++ b/packages/editor-ui/src/views/TemplateView.vue
@@ -200,7 +200,7 @@ export default mixins(workflowHelpers).extend({
 }
 
 .markdown {
-	width: 100%;
+	width: calc(100% - 180px);
 	padding-right: var(--spacing-2xl);
 }
 

--- a/packages/editor-ui/src/views/TemplatesView.vue
+++ b/packages/editor-ui/src/views/TemplatesView.vue
@@ -11,9 +11,9 @@
 					<div :class="$style.button">
 						<n8n-button
 							size="small"
-							type="outline"
+							type="primary"
 							:label="$locale.baseText('templates.newButton')"
-							:transparentBackground="true"
+							:transparentBackground="false"
 							@click="openNewWorkflow"
 						/>
 					</div>

--- a/packages/editor-ui/src/views/TemplatesView.vue
+++ b/packages/editor-ui/src/views/TemplatesView.vue
@@ -43,7 +43,7 @@
 						<TemplateList
 							:abbreviate-number="abbreviateNumber"
 							:categories="categories"
-							:infinity-scroll="true"
+							:infinite-scroll-enabled="true"
 							:loading="loading"
 							:navigate-to="navigateTo"
 							:search="search"

--- a/packages/editor-ui/src/views/TemplatesView.vue
+++ b/packages/editor-ui/src/views/TemplatesView.vue
@@ -50,6 +50,11 @@
 							:total-workflows="totalWorkflows"
 							:workflows="workflows"
 						/>
+						<div v-if="!workflows.length && !collections.length">
+							<n8n-text color="text-base">{{
+								$locale.baseText('templates.noSearchResults')
+							}}</n8n-text>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
[x] Change menu icon to
[x] Change z-index of traverse carousel actions (left + right chevrons) so they’re above the “fade to background” layer.
[x] Change menu icon to
[x]Offset the position of the traverse carousel actions, so they sit outside the column. Offset them so that the edge of the action touches column 
[x] Replace “end of results” string with Share your own useful workflows[here](https://n8n.io/dashboard)through your n8n.io account
[x] Still showing core nodes next to non-core nodes
[x] Infitiny Scroll - Multiply API Request fix. content flashing on infinite scroll (probably related to duplicate graphql requets)
[x] Change “collection” subtitle on collection page to regular weight; Add same subtitle for workflow individual page: Workflow (same position etc as on collection page)
[x] Change “Apps in this collection” to This collection features
[x] Change height of WF preview iframe to 500px
[x] Scroll to Top Fix. When clicking on a template while scrolled in the main view,
[x] Fix existing iframe rendering issue (start node not zooming etc)
[x] Help menu icons are off (in both expanded and popup)
[x] Bug buttons Carousel: open search page, search for “maxt” and clear the searchbar
[x] Change “new blank workflow” button to primary type, from current secondary
[x] Total count of node icons should exceed 5 icons (5 includes the “+X”; so only 4 actual node icons)
[x] Filter Start Node and Webhook Respond Node 
[x] Created Constants which is included into functions to filter the nodes that we want in the future
[x] If there are no collections found (or no workflows found) hide the section
[x] Categories Sidebar is moving because of the long names of some Categories Names
