### PR TITLE
feat(WebhookHelpers.ts, Webhook.node.ts): no body response for webhook

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -204,7 +204,14 @@ export async function executeWebhook(
 		200,
 	) as number;
 
-	if (!['onReceived', 'lastNode', 'responseNode'].includes(responseMode as string)) {
+	if (
+		![
+			'onReceived',
+			'lastNode',
+			'responseNode',
+			'noBodyResponse'
+		].includes(responseMode as string)
+	) {
 		// If the mode is not known we error. Is probably best like that instead of using
 		// the default that people know as early as possible (probably already testing phase)
 		// that something does not resolve properly.
@@ -345,6 +352,17 @@ export async function executeWebhook(
 					responseCode,
 				});
 			}
+
+			didSendResponse = true;
+		}
+
+		// Some systems require that a webhook doesn't respond with any data
+		// if responseMode is set to noBodyResponse we will see this fire
+		if (responseMode === 'noBodyResponse' && !didSendResponse) {
+			// Return response without data
+			responseCallback(null, {
+				responseCode,
+			});
 
 			didSendResponse = true;
 		}

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -165,6 +165,11 @@ export class Webhook implements INodeType {
 						value: 'responseNode',
 						description: 'Response defined in that node',
 					},
+					{
+						name: 'No Body Response',
+						value: 'noBodyResponse',
+						description: 'Returns data without a body',
+					},
 				],
 				default: 'onReceived',
 				description: 'When and how to respond to the webhook.',


### PR DESCRIPTION
No body for webhook response. This may be helpful if certain services that require a response to not have a body. For example Xero webhooks require that the response doesn't have a body. So to be able to use the webhook node we need to be able to send a response without a body payload.