### PR TITLE
Added option to connect to self-hosted Grist instance.

### DIFF
--- a/packages/nodes-base/credentials/GristApi.credentials.ts
+++ b/packages/nodes-base/credentials/GristApi.credentials.ts
@@ -29,6 +29,10 @@ export class GristApi implements ICredentialType {
 					name: 'Paid',
 					value: 'paid',
 				},
+				{
+					name: 'Self-hosted',
+					value: 'selfhosted',
+				},				
 			],
 		},
 		{
@@ -42,6 +46,21 @@ export class GristApi implements ICredentialType {
 				show: {
 					planType: [
 						'paid',
+					],
+				},
+			},
+		},
+		{
+			displayName: 'Self-hosted URL',
+			name: 'selfHostedUrl',
+			type: 'string',
+			default: '',
+			required: true,
+			description: 'URL of your Grist instance (include http/https without /api and no trailing slash)',
+			displayOptions: {
+				show: {
+					planType: [
+						'selfhosted',
 					],
 				},
 			},

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -31,16 +31,19 @@ export async function gristApiRequest(
 		apiKey,
 		planType,
 		customSubdomain,
+		selfHostedUrl,
 	} = await this.getCredentials('gristApi') as GristCredentials;
 
-	const subdomain = planType === 'free' ? 'docs' : customSubdomain;
+	const gristapiurl = (planType === 'free') ? `https://docs.getgrist.com/api${endpoint}` :
+	(planType === 'paid') ? `https://${customSubdomain}.getgrist.com/api${endpoint}` :
+  	`${selfHostedUrl}/api${endpoint}`;
 
 	const options: OptionsWithUri = {
 		headers: {
 			Authorization: `Bearer ${apiKey}`,
 		},
 		method,
-		uri: `https://${subdomain}.getgrist.com/api${endpoint}`,
+		uri: gristapiurl,
 		qs,
 		body,
 		json: true,

--- a/packages/nodes-base/nodes/Grist/Grist.node.ts
+++ b/packages/nodes-base/nodes/Grist/Grist.node.ts
@@ -85,18 +85,21 @@ export class Grist implements INodeType {
 					apiKey,
 					planType,
 					customSubdomain,
+					selfHostedUrl,
 				} = credential.data as GristCredentials;
 
-				const subdomain = planType === 'free' ? 'docs' : customSubdomain;
-
 				const endpoint = '/orgs';
+
+				const gristapiurl = (planType === 'free') ? `https://docs.getgrist.com/api${endpoint}` :
+				(planType === 'paid') ? `https://${customSubdomain}.getgrist.com/api${endpoint}` :
+  				`${selfHostedUrl}/api${endpoint}`;
 
 				const options: OptionsWithUri = {
 					headers: {
 						Authorization: `Bearer ${apiKey}`,
 					},
 					method: 'GET',
-					uri: `https://${subdomain}.getgrist.com/api${endpoint}`,
+					uri: gristapiurl,
 					qs: { limit: 1 },
 					json: true,
 				};

--- a/packages/nodes-base/nodes/Grist/types.d.ts
+++ b/packages/nodes-base/nodes/Grist/types.d.ts
@@ -1,7 +1,8 @@
 export type GristCredentials = {
 	apiKey: string;
-	planType: 'free' | 'paid';
+	planType: 'free' | 'paid' | 'selfhosted';
 	customSubdomain?: string;
+	selfHostedUrl?: string;
 }
 
 export type GristColumns = {


### PR DESCRIPTION
Hi n8n team,

This pull request adds the option to connect the Grist node to a self-hosted Grist instance like the one available on Docker Hub: https://hub.docker.com/r/gristlabs/grist

No existing functionality is impacted. It just adds an option to the credential node and changes the way the API endpoint is generated.

Happy to update the documentation for the node as well. I assume that should happen after the pull request is accepted?

Cheers,
Thorsten