### PR TITLE
Fixed Actual n8n setup portion of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,14 +99,14 @@ checked out and set up:
 	git clone https://github.com/<your_github_username>/n8n.git
 	```
 
-1. Add the original n8n repository as `upstream` to your forked repository
-    ```
-	git remote add upstream https://github.com/n8n-io/n8n.git
-	```
-
 1. Go into repository folder
 	```
 	cd n8n
+	```
+
+1. Add the original n8n repository as `upstream` to your forked repository
+    ```
+	git remote add upstream https://github.com/n8n-io/n8n.git
 	```
 
 1. Install all dependencies of all modules and link them together:


### PR DESCRIPTION
I have swapped the below two steps in [Actual n8n setup](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md#actual-n8n-setup) as they were not in order.

3. Add the original n8n repository as `upstream` to your forked repository
    ```
	git remote add upstream https://github.com/n8n-io/n8n.git
	```

4. Go into repository folder
	```
	cd n8n
	```

