### PR TITLE
🐛 [Orbit] Use correct workspace identifier for API requests [N8N-3007]

### DIFF
--- a/packages/nodes-base/nodes/Orbit/Orbit.node.ts
+++ b/packages/nodes-base/nodes/Orbit/Orbit.node.ts
@@ -114,7 +114,7 @@ export class Orbit implements INodeType {
 				for (const workspace of workspaces.data) {
 					returnData.push({
 						name: workspace.attributes.name,
-						value: workspace.id,
+						value: workspace.attributes.slug,
 					});
 				}
 				return returnData;


### PR DESCRIPTION
n8n currently uses invalid Orbit API endpoints based on the workspace ID, leading to 404 errors as reported [here on the forum](https://community.n8n.io/t/orbit-node-is-not-working/11590). As per the [Orbit API docs](https://docs.orbit.love/reference/get_-workspace-slug-members-member-slug), a slug is used to identify the workspace rather than an ID.

Community Request:
https://community.n8n.io/t/orbit-node-is-not-working/11590/2