### PR TITLE
Remove test description wrappers for user management backend

### DIFF
--- a/packages/cli/test/integration/auth.endpoints.test.ts
+++ b/packages/cli/test/integration/auth.endpoints.test.ts
@@ -14,129 +14,125 @@ import { getGlobalOwnerRole } from './shared/utils';
 
 let globalOwnerRole: Role;
 
-describe('auth endpoints', () => {
-	describe('Owner requests', () => {
-		let app: express.Application;
+let app: express.Application;
 
-		beforeAll(async () => {
-			app = utils.initTestServer({ namespaces: ['auth'], applyAuth: true });
-			await utils.initTestDb();
-			await utils.truncate(['User']);
+beforeAll(async () => {
+	app = utils.initTestServer({ namespaces: ['auth'], applyAuth: true });
+	await utils.initTestDb();
+	await utils.truncate(['User']);
 
-			globalOwnerRole = await getGlobalOwnerRole();
-			utils.initLogger();
-		});
+	globalOwnerRole = await getGlobalOwnerRole();
+	utils.initLogger();
+});
 
-		beforeEach(async () => {
-			await utils.createUser({
-				id: uuid(),
-				email: TEST_USER.email,
-				firstName: TEST_USER.firstName,
-				lastName: TEST_USER.lastName,
-				password: hashSync(TEST_USER.password, genSaltSync(10)),
-				role: globalOwnerRole,
-			});
-
-			config.set('userManagement.hasOwner', true);
-
-			await Db.collections.Settings!.update(
-				{ key: 'userManagement.hasOwner' },
-				{ value: JSON.stringify(true) },
-			);
-		});
-
-		afterEach(async () => {
-			await utils.truncate(['User']);
-		});
-
-		afterAll(() => {
-			return getConnection().close();
-		});
-
-		test('POST /login should log user in', async () => {
-			const authlessAgent = await utils.createAgent(app);
-
-			const response = await authlessAgent.post('/login').send({
-				email: TEST_USER.email,
-				password: TEST_USER.password,
-			});
-
-			expect(response.statusCode).toBe(200);
-
-			const {
-				id,
-				email,
-				firstName,
-				lastName,
-				password,
-				personalizationAnswers,
-				globalRole,
-				resetPasswordToken,
-			} = response.body.data;
-
-			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBe(TEST_USER.email);
-			expect(firstName).toBe(TEST_USER.firstName);
-			expect(lastName).toBe(TEST_USER.lastName);
-			expect(password).toBeUndefined();
-			expect(personalizationAnswers).toBeNull();
-			expect(password).toBeUndefined();
-			expect(resetPasswordToken).toBeUndefined();
-			expect(globalRole).toBeDefined();
-			expect(globalRole.name).toBe('owner');
-			expect(globalRole.scope).toBe('global');
-
-			const authToken = utils.getAuthToken(response);
-			expect(authToken).toBeDefined();
-		});
-
-		test('GET /login should receive logged in user', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
-
-			const response = await authOwnerAgent.get('/login');
-
-			expect(response.statusCode).toBe(200);
-
-			const {
-				id,
-				email,
-				firstName,
-				lastName,
-				password,
-				personalizationAnswers,
-				globalRole,
-				resetPasswordToken,
-			} = response.body.data;
-
-			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBe(TEST_USER.email);
-			expect(firstName).toBe(TEST_USER.firstName);
-			expect(lastName).toBe(TEST_USER.lastName);
-			expect(password).toBeUndefined();
-			expect(personalizationAnswers).toBeNull();
-			expect(password).toBeUndefined();
-			expect(resetPasswordToken).toBeUndefined();
-			expect(globalRole).toBeDefined();
-			expect(globalRole.name).toBe('owner');
-			expect(globalRole.scope).toBe('global');
-
-			expect(response.headers['set-cookie']).toBeUndefined();
-		});
-
-		test('POST /logout should log user out', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
-
-			const response = await authOwnerAgent.post('/logout');
-
-			expect(response.statusCode).toBe(200);
-			expect(response.body).toEqual(LOGGED_OUT_RESPONSE_BODY);
-
-			const authToken = utils.getAuthToken(response);
-			expect(authToken).toBeUndefined();
-		});
+beforeEach(async () => {
+	await utils.createUser({
+		id: uuid(),
+		email: TEST_USER.email,
+		firstName: TEST_USER.firstName,
+		lastName: TEST_USER.lastName,
+		password: hashSync(TEST_USER.password, genSaltSync(10)),
+		role: globalOwnerRole,
 	});
+
+	config.set('userManagement.hasOwner', true);
+
+	await Db.collections.Settings!.update(
+		{ key: 'userManagement.hasOwner' },
+		{ value: JSON.stringify(true) },
+	);
+});
+
+afterEach(async () => {
+	await utils.truncate(['User']);
+});
+
+afterAll(() => {
+	return getConnection().close();
+});
+
+test('POST /login should log user in', async () => {
+	const authlessAgent = await utils.createAgent(app);
+
+	const response = await authlessAgent.post('/login').send({
+		email: TEST_USER.email,
+		password: TEST_USER.password,
+	});
+
+	expect(response.statusCode).toBe(200);
+
+	const {
+		id,
+		email,
+		firstName,
+		lastName,
+		password,
+		personalizationAnswers,
+		globalRole,
+		resetPasswordToken,
+	} = response.body.data;
+
+	expect(validator.isUUID(id)).toBe(true);
+	expect(email).toBe(TEST_USER.email);
+	expect(firstName).toBe(TEST_USER.firstName);
+	expect(lastName).toBe(TEST_USER.lastName);
+	expect(password).toBeUndefined();
+	expect(personalizationAnswers).toBeNull();
+	expect(password).toBeUndefined();
+	expect(resetPasswordToken).toBeUndefined();
+	expect(globalRole).toBeDefined();
+	expect(globalRole.name).toBe('owner');
+	expect(globalRole.scope).toBe('global');
+
+	const authToken = utils.getAuthToken(response);
+	expect(authToken).toBeDefined();
+});
+
+test('GET /login should receive logged in user', async () => {
+	const owner = await Db.collections.User!.findOneOrFail();
+	const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+
+	const response = await authOwnerAgent.get('/login');
+
+	expect(response.statusCode).toBe(200);
+
+	const {
+		id,
+		email,
+		firstName,
+		lastName,
+		password,
+		personalizationAnswers,
+		globalRole,
+		resetPasswordToken,
+	} = response.body.data;
+
+	expect(validator.isUUID(id)).toBe(true);
+	expect(email).toBe(TEST_USER.email);
+	expect(firstName).toBe(TEST_USER.firstName);
+	expect(lastName).toBe(TEST_USER.lastName);
+	expect(password).toBeUndefined();
+	expect(personalizationAnswers).toBeNull();
+	expect(password).toBeUndefined();
+	expect(resetPasswordToken).toBeUndefined();
+	expect(globalRole).toBeDefined();
+	expect(globalRole.name).toBe('owner');
+	expect(globalRole.scope).toBe('global');
+
+	expect(response.headers['set-cookie']).toBeUndefined();
+});
+
+test('POST /logout should log user out', async () => {
+	const owner = await Db.collections.User!.findOneOrFail();
+	const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+
+	const response = await authOwnerAgent.post('/logout');
+
+	expect(response.statusCode).toBe(200);
+	expect(response.body).toEqual(LOGGED_OUT_RESPONSE_BODY);
+
+	const authToken = utils.getAuthToken(response);
+	expect(authToken).toBeUndefined();
 });
 
 const TEST_USER = {

--- a/packages/cli/test/integration/auth.middleware.test.ts
+++ b/packages/cli/test/integration/auth.middleware.test.ts
@@ -11,22 +11,18 @@ beforeAll(async () => {
 	utils.initLogger();
 });
 
-describe('Unauthorized requests', () => {
-	['GET /me', 'PATCH /me', 'PATCH /me/password', 'POST /me/survey'].forEach((route) => {
-		const [method, endpoint] = route.split(' ').map((i) => i.toLowerCase());
+['GET /me', 'PATCH /me', 'PATCH /me/password', 'POST /me/survey'].forEach((route) => {
+	const [method, endpoint] = route.split(' ').map((i) => i.toLowerCase());
 
-		test(`${route} should return 401 Unauthorized`, async () => {
-			const response = await request(app)[method](endpoint).use(utils.prefix(REST_PATH_SEGMENT));
-
-			expect(response.statusCode).toBe(401);
-		});
-	});
-});
-
-describe('Unauthorized requests', () => {
-	test(`POST /owner should return 401 Unauthorized`, async () => {
-		const response = await request(app).post('/owner').use(utils.prefix(REST_PATH_SEGMENT));
+	test(`${route} should return 401 Unauthorized`, async () => {
+		const response = await request(app)[method](endpoint).use(utils.prefix(REST_PATH_SEGMENT));
 
 		expect(response.statusCode).toBe(401);
 	});
+});
+
+test(`POST /owner should return 401 Unauthorized`, async () => {
+	const response = await request(app).post('/owner').use(utils.prefix(REST_PATH_SEGMENT));
+
+	expect(response.statusCode).toBe(401);
 });

--- a/packages/cli/test/integration/auth.middleware.test.ts
+++ b/packages/cli/test/integration/auth.middleware.test.ts
@@ -4,39 +4,29 @@ import { REST_PATH_SEGMENT } from './shared/constants';
 
 import * as utils from './shared/utils';
 
-describe('/me endpoints', () => {
-	let app: express.Application;
+let app: express.Application;
 
-	beforeAll(async () => {
-		app = utils.initTestServer({ applyAuth: true });
-		utils.initLogger();
-	});
+beforeAll(async () => {
+	app = utils.initTestServer({ applyAuth: true });
+	utils.initLogger();
+});
 
-	describe('Unauthorized requests', () => {
-		['GET /me', 'PATCH /me', 'PATCH /me/password', 'POST /me/survey'].forEach((route) => {
-			const [method, endpoint] = route.split(' ').map((i) => i.toLowerCase());
+describe('Unauthorized requests', () => {
+	['GET /me', 'PATCH /me', 'PATCH /me/password', 'POST /me/survey'].forEach((route) => {
+		const [method, endpoint] = route.split(' ').map((i) => i.toLowerCase());
 
-			test(`${route} should return 401 Unauthorized`, async () => {
-				const response = await request(app)[method](endpoint).use(utils.prefix(REST_PATH_SEGMENT));
+		test(`${route} should return 401 Unauthorized`, async () => {
+			const response = await request(app)[method](endpoint).use(utils.prefix(REST_PATH_SEGMENT));
 
-				expect(response.statusCode).toBe(401);
-			});
+			expect(response.statusCode).toBe(401);
 		});
 	});
 });
 
-describe('/owner endpoint', () => {
-	let app: express.Application;
+describe('Unauthorized requests', () => {
+	test(`POST /owner should return 401 Unauthorized`, async () => {
+		const response = await request(app).post('/owner').use(utils.prefix(REST_PATH_SEGMENT));
 
-	beforeAll(async () => {
-		app = utils.initTestServer({ applyAuth: true });
-	});
-
-	describe('Unauthorized requests', () => {
-		test(`POST /owner should return 401 Unauthorized`, async () => {
-			const response = await request(app).post('/owner').use(utils.prefix(REST_PATH_SEGMENT));
-
-			expect(response.statusCode).toBe(401);
-		});
+		expect(response.statusCode).toBe(401);
 	});
 });

--- a/packages/cli/test/integration/me.endpoints.test.ts
+++ b/packages/cli/test/integration/me.endpoints.test.ts
@@ -19,37 +19,65 @@ import {
 } from './shared/random';
 import { getGlobalOwnerRole } from './shared/utils';
 
+let app: express.Application;
 let globalOwnerRole: Role;
 
-describe('/me endpoints', () => {
-	describe('Owner shell requests', () => {
-		let app: express.Application;
+beforeAll(async () => {
+	app = utils.initTestServer({ namespaces: ['me'], applyAuth: true });
+	await utils.initTestDb();
+	globalOwnerRole = await getGlobalOwnerRole();
+	utils.initLogger();
+});
 
-		beforeAll(async () => {
-			app = utils.initTestServer({ namespaces: ['me'], applyAuth: true });
-			await utils.initTestDb();
+afterAll(() => {
+	return getConnection().close();
+});
 
-			globalOwnerRole = await getGlobalOwnerRole();
-			utils.initLogger();
-		});
+describe('Owner shell', () => {
+	beforeEach(async () => {
+		await utils.createOwnerShell();
+	});
 
-		beforeEach(async () => {
-			await utils.createOwnerShell();
-		});
+	afterEach(async () => {
+		await utils.truncate(['User']);
+	});
 
-		afterEach(async () => {
-			await utils.truncate(['User']);
-		});
+	test('GET /me should return sanitized owner shell', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
 
-		afterAll(() => {
-			return getConnection().close();
-		});
+		const response = await authOwnerShellAgent.get('/me');
 
-		test('GET /me should return sanitized owner shell', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+		expect(response.statusCode).toBe(200);
 
-			const response = await authOwnerShellAgent.get('/me');
+		const {
+			id,
+			email,
+			firstName,
+			lastName,
+			personalizationAnswers,
+			globalRole,
+			password,
+			resetPasswordToken,
+		} = response.body.data;
+
+		expect(validator.isUUID(id)).toBe(true);
+		expect(email).toBeNull();
+		expect(firstName).toBeNull();
+		expect(lastName).toBeNull();
+		expect(personalizationAnswers).toBeNull();
+		expect(password).toBeUndefined();
+		expect(resetPasswordToken).toBeUndefined();
+		expect(globalRole.name).toBe('owner');
+		expect(globalRole.scope).toBe('global');
+	});
+
+	test('PATCH /me should succeed with valid inputs', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+
+		for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
+			const response = await authOwnerShellAgent.patch('/me').send(validPayload);
 
 			expect(response.statusCode).toBe(200);
 
@@ -65,176 +93,164 @@ describe('/me endpoints', () => {
 			} = response.body.data;
 
 			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBeNull();
-			expect(firstName).toBeNull();
-			expect(lastName).toBeNull();
+			expect(email).toBe(validPayload.email);
+			expect(firstName).toBe(validPayload.firstName);
+			expect(lastName).toBe(validPayload.lastName);
 			expect(personalizationAnswers).toBeNull();
 			expect(password).toBeUndefined();
 			expect(resetPasswordToken).toBeUndefined();
 			expect(globalRole.name).toBe('owner');
 			expect(globalRole.scope).toBe('global');
-		});
 
-		test('PATCH /me should succeed with valid inputs', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+			const storedOwnerShell = await Db.collections.User!.findOneOrFail(id);
 
-			for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
-				const response = await authOwnerShellAgent.patch('/me').send(validPayload);
-
-				expect(response.statusCode).toBe(200);
-
-				const {
-					id,
-					email,
-					firstName,
-					lastName,
-					personalizationAnswers,
-					globalRole,
-					password,
-					resetPasswordToken,
-				} = response.body.data;
-
-				expect(validator.isUUID(id)).toBe(true);
-				expect(email).toBe(validPayload.email);
-				expect(firstName).toBe(validPayload.firstName);
-				expect(lastName).toBe(validPayload.lastName);
-				expect(personalizationAnswers).toBeNull();
-				expect(password).toBeUndefined();
-				expect(resetPasswordToken).toBeUndefined();
-				expect(globalRole.name).toBe('owner');
-				expect(globalRole.scope).toBe('global');
-
-				const storedOwnerShell = await Db.collections.User!.findOneOrFail(id);
-
-				expect(storedOwnerShell.email).toBe(validPayload.email);
-				expect(storedOwnerShell.firstName).toBe(validPayload.firstName);
-				expect(storedOwnerShell.lastName).toBe(validPayload.lastName);
-			}
-		});
-
-		test('PATCH /me should fail with invalid inputs', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
-
-			for (const invalidPayload of INVALID_PATCH_ME_PAYLOADS) {
-				const response = await authOwnerShellAgent.patch('/me').send(invalidPayload);
-				expect(response.statusCode).toBe(400);
-
-				const storedOwnerShell = await Db.collections.User!.findOneOrFail();
-				expect(storedOwnerShell.email).toBeNull();
-				expect(storedOwnerShell.firstName).toBeNull();
-				expect(storedOwnerShell.lastName).toBeNull();
-			}
-		});
-
-		test('PATCH /me/password should succeed with valid inputs', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
-
-			const validPayloads = Array.from({ length: 3 }, () => ({
-				password: randomValidPassword(),
-			}));
-
-			for (const validPayload of validPayloads) {
-				const response = await authOwnerShellAgent.patch('/me/password').send(validPayload);
-				expect(response.statusCode).toBe(200);
-				expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
-
-				const storedOwnerShell = await Db.collections.User!.findOneOrFail();
-				expect(storedOwnerShell.password).not.toBe(validPayload.password);
-			}
-		});
-
-		test('PATCH /me/password should fail with invalid inputs', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
-
-			const invalidPayloads: Array<any> = [
-				...Array.from({ length: 3 }, () => ({ password: randomInvalidPassword() })),
-				{},
-				undefined,
-				'',
-			];
-
-			for (const invalidPayload of invalidPayloads) {
-				const response = await authOwnerShellAgent.patch('/me/password').send(invalidPayload);
-				expect(response.statusCode).toBe(400);
-
-				const storedMember = await Db.collections.User!.findOneOrFail();
-
-				if (invalidPayload?.password) {
-					expect(storedMember.password).not.toBe(invalidPayload.password);
-				}
-			}
-		});
-
-		test('POST /me/survey should succeed with valid inputs', async () => {
-			const ownerShell = await Db.collections.User!.findOneOrFail();
-			const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
-
-			const validPayloads = [SURVEY, {}];
-
-			for (const validPayload of validPayloads) {
-				const response = await authOwnerShellAgent.post('/me/survey').send(validPayload);
-				expect(response.statusCode).toBe(200);
-				expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
-
-				const storedOwnerShell = await Db.collections.User!.findOneOrFail();
-				expect(storedOwnerShell.personalizationAnswers).toEqual(validPayload);
-			}
-		});
+			expect(storedOwnerShell.email).toBe(validPayload.email);
+			expect(storedOwnerShell.firstName).toBe(validPayload.firstName);
+			expect(storedOwnerShell.lastName).toBe(validPayload.lastName);
+		}
 	});
 
-	describe('Member requests', () => {
-		let app: express.Application;
+	test('PATCH /me should fail with invalid inputs', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
 
-		beforeAll(async () => {
-			app = utils.initTestServer({ namespaces: ['me'], applyAuth: true });
-			await utils.initTestDb();
-			await utils.truncate(['User']);
+		for (const invalidPayload of INVALID_PATCH_ME_PAYLOADS) {
+			const response = await authOwnerShellAgent.patch('/me').send(invalidPayload);
+			expect(response.statusCode).toBe(400);
+
+			const storedOwnerShell = await Db.collections.User!.findOneOrFail();
+			expect(storedOwnerShell.email).toBeNull();
+			expect(storedOwnerShell.firstName).toBeNull();
+			expect(storedOwnerShell.lastName).toBeNull();
+		}
+	});
+
+	test('PATCH /me/password should succeed with valid inputs', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+
+		const validPayloads = Array.from({ length: 3 }, () => ({
+			password: randomValidPassword(),
+		}));
+
+		for (const validPayload of validPayloads) {
+			const response = await authOwnerShellAgent.patch('/me/password').send(validPayload);
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
+
+			const storedOwnerShell = await Db.collections.User!.findOneOrFail();
+			expect(storedOwnerShell.password).not.toBe(validPayload.password);
+		}
+	});
+
+	test('PATCH /me/password should fail with invalid inputs', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+
+		const invalidPayloads: Array<any> = [
+			...Array.from({ length: 3 }, () => ({ password: randomInvalidPassword() })),
+			{},
+			undefined,
+			'',
+		];
+
+		for (const invalidPayload of invalidPayloads) {
+			const response = await authOwnerShellAgent.patch('/me/password').send(invalidPayload);
+			expect(response.statusCode).toBe(400);
+
+			const storedMember = await Db.collections.User!.findOneOrFail();
+
+			if (invalidPayload?.password) {
+				expect(storedMember.password).not.toBe(invalidPayload.password);
+			}
+		}
+	});
+
+	test('POST /me/survey should succeed with valid inputs', async () => {
+		const ownerShell = await Db.collections.User!.findOneOrFail();
+		const authOwnerShellAgent = await utils.createAgent(app, { auth: true, user: ownerShell });
+
+		const validPayloads = [SURVEY, {}];
+
+		for (const validPayload of validPayloads) {
+			const response = await authOwnerShellAgent.post('/me/survey').send(validPayload);
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
+
+			const storedOwnerShell = await Db.collections.User!.findOneOrFail();
+			expect(storedOwnerShell.personalizationAnswers).toEqual(validPayload);
+		}
+	});
+});
+
+describe('Member', () => {
+	beforeEach(async () => {
+		const globalMemberRole = await Db.collections.Role!.findOneOrFail({
+			name: 'member',
+			scope: 'global',
 		});
 
-		beforeEach(async () => {
-			const globalMemberRole = await Db.collections.Role!.findOneOrFail({
-				name: 'member',
-				scope: 'global',
-			});
+		const newMember = new User();
 
-			const newMember = new User();
-
-			Object.assign(newMember, {
-				id: uuid(),
-				email: TEST_USER.email,
-				firstName: TEST_USER.firstName,
-				lastName: TEST_USER.lastName,
-				password: hashSync(randomValidPassword(), genSaltSync(10)),
-				globalRole: globalMemberRole,
-			});
-
-			await Db.collections.User!.save(newMember);
-
-			config.set('userManagement.hasOwner', true);
-
-			await Db.collections.Settings!.update(
-				{ key: 'userManagement.hasOwner' },
-				{ value: JSON.stringify(true) },
-			);
+		Object.assign(newMember, {
+			id: uuid(),
+			email: TEST_USER.email,
+			firstName: TEST_USER.firstName,
+			lastName: TEST_USER.lastName,
+			password: hashSync(randomValidPassword(), genSaltSync(10)),
+			globalRole: globalMemberRole,
 		});
 
-		afterEach(async () => {
-			await utils.truncate(['User']);
-		});
+		await Db.collections.User!.save(newMember);
 
-		afterAll(() => {
-			return getConnection().close();
-		});
+		config.set('userManagement.hasOwner', true);
 
-		test('GET /me should return sanitized member', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+		await Db.collections.Settings!.update(
+			{ key: 'userManagement.hasOwner' },
+			{ value: JSON.stringify(true) },
+		);
+	});
 
-			const response = await authMemberAgent.get('/me');
+	afterEach(async () => {
+		await utils.truncate(['User']);
+	});
+
+	test('GET /me should return sanitized member', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+
+		const response = await authMemberAgent.get('/me');
+
+		expect(response.statusCode).toBe(200);
+
+		const {
+			id,
+			email,
+			firstName,
+			lastName,
+			personalizationAnswers,
+			globalRole,
+			password,
+			resetPasswordToken,
+		} = response.body.data;
+
+		expect(validator.isUUID(id)).toBe(true);
+		expect(email).toBe(TEST_USER.email);
+		expect(firstName).toBe(TEST_USER.firstName);
+		expect(lastName).toBe(TEST_USER.lastName);
+		expect(personalizationAnswers).toBeNull();
+		expect(password).toBeUndefined();
+		expect(resetPasswordToken).toBeUndefined();
+		expect(globalRole.name).toBe('member');
+		expect(globalRole.scope).toBe('global');
+	});
+
+	test('PATCH /me should succeed with valid inputs', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+
+		for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
+			const response = await authMemberAgent.patch('/me').send(validPayload);
 
 			expect(response.statusCode).toBe(200);
 
@@ -250,162 +266,150 @@ describe('/me endpoints', () => {
 			} = response.body.data;
 
 			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBe(TEST_USER.email);
-			expect(firstName).toBe(TEST_USER.firstName);
-			expect(lastName).toBe(TEST_USER.lastName);
+			expect(email).toBe(validPayload.email);
+			expect(firstName).toBe(validPayload.firstName);
+			expect(lastName).toBe(validPayload.lastName);
 			expect(personalizationAnswers).toBeNull();
 			expect(password).toBeUndefined();
 			expect(resetPasswordToken).toBeUndefined();
 			expect(globalRole.name).toBe('member');
 			expect(globalRole.scope).toBe('global');
-		});
 
-		test('PATCH /me should succeed with valid inputs', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+			const storedMember = await Db.collections.User!.findOneOrFail(id);
 
-			for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
-				const response = await authMemberAgent.patch('/me').send(validPayload);
-
-				expect(response.statusCode).toBe(200);
-
-				const {
-					id,
-					email,
-					firstName,
-					lastName,
-					personalizationAnswers,
-					globalRole,
-					password,
-					resetPasswordToken,
-				} = response.body.data;
-
-				expect(validator.isUUID(id)).toBe(true);
-				expect(email).toBe(validPayload.email);
-				expect(firstName).toBe(validPayload.firstName);
-				expect(lastName).toBe(validPayload.lastName);
-				expect(personalizationAnswers).toBeNull();
-				expect(password).toBeUndefined();
-				expect(resetPasswordToken).toBeUndefined();
-				expect(globalRole.name).toBe('member');
-				expect(globalRole.scope).toBe('global');
-
-				const storedMember = await Db.collections.User!.findOneOrFail(id);
-
-				expect(storedMember.email).toBe(validPayload.email);
-				expect(storedMember.firstName).toBe(validPayload.firstName);
-				expect(storedMember.lastName).toBe(validPayload.lastName);
-			}
-		});
-
-		test('PATCH /me should fail with invalid inputs', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
-
-			for (const invalidPayload of INVALID_PATCH_ME_PAYLOADS) {
-				const response = await authMemberAgent.patch('/me').send(invalidPayload);
-				expect(response.statusCode).toBe(400);
-
-				const storedMember = await Db.collections.User!.findOneOrFail();
-				expect(storedMember.email).toBe(TEST_USER.email);
-				expect(storedMember.firstName).toBe(TEST_USER.firstName);
-				expect(storedMember.lastName).toBe(TEST_USER.lastName);
-			}
-		});
-
-		test('PATCH /me/password should succeed with valid inputs', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
-
-			const validPayloads = Array.from({ length: 3 }, () => ({
-				password: randomValidPassword(),
-			}));
-
-			for (const validPayload of validPayloads) {
-				const response = await authMemberAgent.patch('/me/password').send(validPayload);
-				expect(response.statusCode).toBe(200);
-				expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
-
-				const storedMember = await Db.collections.User!.findOneOrFail();
-				expect(storedMember.password).not.toBe(validPayload.password);
-			}
-		});
-
-		test('PATCH /me/password should fail with invalid inputs', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
-
-			const invalidPayloads: Array<any> = [
-				...Array.from({ length: 3 }, () => ({ password: randomInvalidPassword() })),
-				{},
-				undefined,
-				'',
-			];
-
-			for (const invalidPayload of invalidPayloads) {
-				const response = await authMemberAgent.patch('/me/password').send(invalidPayload);
-				expect(response.statusCode).toBe(400);
-
-				const storedMember = await Db.collections.User!.findOneOrFail();
-
-				if (invalidPayload?.password) {
-					expect(storedMember.password).not.toBe(invalidPayload.password);
-				}
-			}
-		});
-
-		test('POST /me/survey should succeed with valid inputs', async () => {
-			const member = await Db.collections.User!.findOneOrFail();
-			const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
-
-			const validPayloads = [SURVEY, {}];
-
-			for (const validPayload of validPayloads) {
-				const response = await authMemberAgent.post('/me/survey').send(validPayload);
-				expect(response.statusCode).toBe(200);
-				expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
-
-				const storedMember = await Db.collections.User!.findOneOrFail();
-				expect(storedMember.personalizationAnswers).toEqual(validPayload);
-			}
-		});
+			expect(storedMember.email).toBe(validPayload.email);
+			expect(storedMember.firstName).toBe(validPayload.firstName);
+			expect(storedMember.lastName).toBe(validPayload.lastName);
+		}
 	});
 
-	describe('Owner requests', () => {
-		let app: express.Application;
+	test('PATCH /me should fail with invalid inputs', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
 
-		beforeAll(async () => {
-			app = utils.initTestServer({ namespaces: ['me'], applyAuth: true });
-			await utils.initTestDb();
-			await utils.truncate(['User']);
+		for (const invalidPayload of INVALID_PATCH_ME_PAYLOADS) {
+			const response = await authMemberAgent.patch('/me').send(invalidPayload);
+			expect(response.statusCode).toBe(400);
+
+			const storedMember = await Db.collections.User!.findOneOrFail();
+			expect(storedMember.email).toBe(TEST_USER.email);
+			expect(storedMember.firstName).toBe(TEST_USER.firstName);
+			expect(storedMember.lastName).toBe(TEST_USER.lastName);
+		}
+	});
+
+	test('PATCH /me/password should succeed with valid inputs', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+
+		const validPayloads = Array.from({ length: 3 }, () => ({
+			password: randomValidPassword(),
+		}));
+
+		for (const validPayload of validPayloads) {
+			const response = await authMemberAgent.patch('/me/password').send(validPayload);
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
+
+			const storedMember = await Db.collections.User!.findOneOrFail();
+			expect(storedMember.password).not.toBe(validPayload.password);
+		}
+	});
+
+	test('PATCH /me/password should fail with invalid inputs', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+
+		const invalidPayloads: Array<any> = [
+			...Array.from({ length: 3 }, () => ({ password: randomInvalidPassword() })),
+			{},
+			undefined,
+			'',
+		];
+
+		for (const invalidPayload of invalidPayloads) {
+			const response = await authMemberAgent.patch('/me/password').send(invalidPayload);
+			expect(response.statusCode).toBe(400);
+
+			const storedMember = await Db.collections.User!.findOneOrFail();
+
+			if (invalidPayload?.password) {
+				expect(storedMember.password).not.toBe(invalidPayload.password);
+			}
+		}
+	});
+
+	test('POST /me/survey should succeed with valid inputs', async () => {
+		const member = await Db.collections.User!.findOneOrFail();
+		const authMemberAgent = await utils.createAgent(app, { auth: true, user: member });
+
+		const validPayloads = [SURVEY, {}];
+
+		for (const validPayload of validPayloads) {
+			const response = await authMemberAgent.post('/me/survey').send(validPayload);
+			expect(response.statusCode).toBe(200);
+			expect(response.body).toEqual(SUCCESS_RESPONSE_BODY);
+
+			const storedMember = await Db.collections.User!.findOneOrFail();
+			expect(storedMember.personalizationAnswers).toEqual(validPayload);
+		}
+	});
+});
+
+describe('Owner', () => {
+	beforeEach(async () => {
+		await Db.collections.User!.save({
+			id: uuid(),
+			email: TEST_USER.email,
+			firstName: TEST_USER.firstName,
+			lastName: TEST_USER.lastName,
+			password: hashSync(randomValidPassword(), genSaltSync(10)),
+			globalRole: globalOwnerRole,
 		});
 
-		beforeEach(async () => {
-			await Db.collections.User!.save({
-				id: uuid(),
-				email: TEST_USER.email,
-				firstName: TEST_USER.firstName,
-				lastName: TEST_USER.lastName,
-				password: hashSync(randomValidPassword(), genSaltSync(10)),
-				globalRole: globalOwnerRole,
-			});
+		config.set('userManagement.hasOwner', true);
+	});
 
-			config.set('userManagement.hasOwner', true);
-		});
+	afterEach(async () => {
+		await utils.truncate(['User']);
+	});
 
-		afterEach(async () => {
-			await utils.truncate(['User']);
-		});
+	test('GET /me should return sanitized owner', async () => {
+		const owner = await Db.collections.User!.findOneOrFail();
+		const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
 
-		afterAll(() => {
-			return getConnection().close();
-		});
+		const response = await authOwnerAgent.get('/me');
 
-		test('GET /me should return sanitized owner', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+		expect(response.statusCode).toBe(200);
 
-			const response = await authOwnerAgent.get('/me');
+		const {
+			id,
+			email,
+			firstName,
+			lastName,
+			personalizationAnswers,
+			globalRole,
+			password,
+			resetPasswordToken,
+		} = response.body.data;
+
+		expect(validator.isUUID(id)).toBe(true);
+		expect(email).toBe(TEST_USER.email);
+		expect(firstName).toBe(TEST_USER.firstName);
+		expect(lastName).toBe(TEST_USER.lastName);
+		expect(personalizationAnswers).toBeNull();
+		expect(password).toBeUndefined();
+		expect(resetPasswordToken).toBeUndefined();
+		expect(globalRole.name).toBe('owner');
+		expect(globalRole.scope).toBe('global');
+	});
+
+	test('PATCH /me should succeed with valid inputs', async () => {
+		const owner = await Db.collections.User!.findOneOrFail();
+		const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+
+		for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
+			const response = await authOwnerAgent.patch('/me').send(validPayload);
 
 			expect(response.statusCode).toBe(200);
 
@@ -421,53 +425,21 @@ describe('/me endpoints', () => {
 			} = response.body.data;
 
 			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBe(TEST_USER.email);
-			expect(firstName).toBe(TEST_USER.firstName);
-			expect(lastName).toBe(TEST_USER.lastName);
+			expect(email).toBe(validPayload.email);
+			expect(firstName).toBe(validPayload.firstName);
+			expect(lastName).toBe(validPayload.lastName);
 			expect(personalizationAnswers).toBeNull();
 			expect(password).toBeUndefined();
 			expect(resetPasswordToken).toBeUndefined();
 			expect(globalRole.name).toBe('owner');
 			expect(globalRole.scope).toBe('global');
-		});
 
-		test('PATCH /me should succeed with valid inputs', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+			const storedOwner = await Db.collections.User!.findOneOrFail(id);
 
-			for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
-				const response = await authOwnerAgent.patch('/me').send(validPayload);
-
-				expect(response.statusCode).toBe(200);
-
-				const {
-					id,
-					email,
-					firstName,
-					lastName,
-					personalizationAnswers,
-					globalRole,
-					password,
-					resetPasswordToken,
-				} = response.body.data;
-
-				expect(validator.isUUID(id)).toBe(true);
-				expect(email).toBe(validPayload.email);
-				expect(firstName).toBe(validPayload.firstName);
-				expect(lastName).toBe(validPayload.lastName);
-				expect(personalizationAnswers).toBeNull();
-				expect(password).toBeUndefined();
-				expect(resetPasswordToken).toBeUndefined();
-				expect(globalRole.name).toBe('owner');
-				expect(globalRole.scope).toBe('global');
-
-				const storedOwner = await Db.collections.User!.findOneOrFail(id);
-
-				expect(storedOwner.email).toBe(validPayload.email);
-				expect(storedOwner.firstName).toBe(validPayload.firstName);
-				expect(storedOwner.lastName).toBe(validPayload.lastName);
-			}
-		});
+			expect(storedOwner.email).toBe(validPayload.email);
+			expect(storedOwner.firstName).toBe(validPayload.firstName);
+			expect(storedOwner.lastName).toBe(validPayload.lastName);
+		}
 	});
 });
 

--- a/packages/cli/test/integration/owner.endpoints.test.ts
+++ b/packages/cli/test/integration/owner.endpoints.test.ts
@@ -12,81 +12,77 @@ import {
 	randomInvalidPassword,
 } from './shared/random';
 
-describe('/owner endpoints', () => {
-	describe('Shell requests', () => {
-		let app: express.Application;
+let app: express.Application;
 
-		beforeAll(async () => {
-			app = utils.initTestServer({ namespaces: ['owner'], applyAuth: true });
-			await utils.initTestDb();
+beforeAll(async () => {
+	app = utils.initTestServer({ namespaces: ['owner'], applyAuth: true });
+	await utils.initTestDb();
 
-			utils.initLogger();
-		});
+	utils.initLogger();
+});
 
-		beforeEach(async () => {
-			await utils.createOwnerShell();
-		});
+beforeEach(async () => {
+	await utils.createOwnerShell();
+});
 
-		afterEach(async () => {
-			await utils.truncate(['User']);
-		});
+afterEach(async () => {
+	await utils.truncate(['User']);
+});
 
-		afterAll(() => {
-			return getConnection().close();
-		});
+afterAll(() => {
+	return getConnection().close();
+});
 
-		test('POST /owner should create owner and enable hasOwner setting', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+test('POST /owner should create owner and enable hasOwner setting', async () => {
+	const owner = await Db.collections.User!.findOneOrFail();
+	const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
 
-			const response = await authOwnerAgent.post('/owner').send(TEST_USER);
+	const response = await authOwnerAgent.post('/owner').send(TEST_USER);
 
-			expect(response.statusCode).toBe(200);
+	expect(response.statusCode).toBe(200);
 
-			const {
-				id,
-				email,
-				firstName,
-				lastName,
-				personalizationAnswers,
-				globalRole,
-				password,
-				resetPasswordToken,
-			} = response.body.data;
+	const {
+		id,
+		email,
+		firstName,
+		lastName,
+		personalizationAnswers,
+		globalRole,
+		password,
+		resetPasswordToken,
+	} = response.body.data;
 
-			expect(validator.isUUID(id)).toBe(true);
-			expect(email).toBe(TEST_USER.email);
-			expect(firstName).toBe(TEST_USER.firstName);
-			expect(lastName).toBe(TEST_USER.lastName);
-			expect(personalizationAnswers).toBeNull();
-			expect(password).toBeUndefined();
-			expect(resetPasswordToken).toBeUndefined();
-			expect(globalRole.name).toBe('owner');
-			expect(globalRole.scope).toBe('global');
+	expect(validator.isUUID(id)).toBe(true);
+	expect(email).toBe(TEST_USER.email);
+	expect(firstName).toBe(TEST_USER.firstName);
+	expect(lastName).toBe(TEST_USER.lastName);
+	expect(personalizationAnswers).toBeNull();
+	expect(password).toBeUndefined();
+	expect(resetPasswordToken).toBeUndefined();
+	expect(globalRole.name).toBe('owner');
+	expect(globalRole.scope).toBe('global');
 
-			const storedOwner = await Db.collections.User!.findOneOrFail(id);
-			expect(storedOwner.password).not.toBe(TEST_USER.password);
-			expect(storedOwner.email).toBe(TEST_USER.email);
-			expect(storedOwner.firstName).toBe(TEST_USER.firstName);
-			expect(storedOwner.lastName).toBe(TEST_USER.lastName);
+	const storedOwner = await Db.collections.User!.findOneOrFail(id);
+	expect(storedOwner.password).not.toBe(TEST_USER.password);
+	expect(storedOwner.email).toBe(TEST_USER.email);
+	expect(storedOwner.firstName).toBe(TEST_USER.firstName);
+	expect(storedOwner.lastName).toBe(TEST_USER.lastName);
 
-			const hasOwnerConfig = config.get('userManagement.hasOwner');
-			expect(hasOwnerConfig).toBe(true);
+	const hasOwnerConfig = config.get('userManagement.hasOwner');
+	expect(hasOwnerConfig).toBe(true);
 
-			const hasOwnerSetting = await utils.getHasOwnerSetting();
-			expect(hasOwnerSetting).toBe(true);
-		});
+	const hasOwnerSetting = await utils.getHasOwnerSetting();
+	expect(hasOwnerSetting).toBe(true);
+});
 
-		test('POST /owner should fail with invalid inputs', async () => {
-			const owner = await Db.collections.User!.findOneOrFail();
-			const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
+test('POST /owner should fail with invalid inputs', async () => {
+	const owner = await Db.collections.User!.findOneOrFail();
+	const authOwnerAgent = await utils.createAgent(app, { auth: true, user: owner });
 
-			for (const invalidPayload of INVALID_POST_OWNER_PAYLOADS) {
-				const response = await authOwnerAgent.post('/owner').send(invalidPayload);
-				expect(response.statusCode).toBe(400);
-			}
-		});
-	});
+	for (const invalidPayload of INVALID_POST_OWNER_PAYLOADS) {
+		const response = await authOwnerAgent.post('/owner').send(invalidPayload);
+		expect(response.statusCode).toBe(400);
+	}
 });
 
 const TEST_USER = {


### PR DESCRIPTION
Remove wrappers, consolidate duplicate `beforeAll` and `afterAll`.

Otherwise only indentation changes. All tests passing.