### PR TITLE
Replacing xc-auth with xc-token

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -45,7 +45,7 @@ export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoa
 
 	const options: OptionsWithUri = {
 		headers: {
-			'xc-auth': credentials.apiToken,
+			'xc-token': credentials.apiToken,
 		},
 		method,
 		body,


### PR DESCRIPTION
The correct header for usage with an API key is xc-token. 
The xc-auth is used only with expiring refresh tokens and it is unsustainable.