### PR TITLE
add Hubspot Private App Token Authentication 

### DIFF
--- a/packages/nodes-base/credentials/HubspotAppToken.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotAppToken.credentials.ts
@@ -1,0 +1,18 @@
+import {
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class HubspotAppToken implements ICredentialType {
+	name = 'hubspotAppToken';
+	displayName = 'Hubspot App Token';
+	documentationUrl = 'hubspot';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'App Token',
+			name: 'appToken',
+			type: 'string',
+			default: '',
+		},
+	];
+}

--- a/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
@@ -27,6 +27,7 @@ export async function hubspotApiRequest(this: IHookFunctions | IExecuteFunctions
 	const options: OptionsWithUri = {
 		method,
 		qs: query,
+		headers: {},
 		uri: uri || `https://api.hubapi.com${endpoint}`,
 		body,
 		json: true,
@@ -38,6 +39,11 @@ export async function hubspotApiRequest(this: IHookFunctions | IExecuteFunctions
 			const credentials = await this.getCredentials('hubspotApi');
 
 			options.qs.hapikey = credentials!.apiKey as string;
+			return await this.helpers.request!(options);
+		} else if (authenticationMethod === 'appToken') {
+			const credentials = await this.getCredentials('hubspotAppToken');
+
+			options.headers!['Authorization'] = `Bearer ${credentials!.appToken}`;
 			return await this.helpers.request!(options);
 		} else if (authenticationMethod === 'developerApi') {
 			if (endpoint.includes('webhooks')) {

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -98,6 +98,17 @@ export class Hubspot implements INodeType {
 				},
 			},
 			{
+				name: 'hubspotAppToken',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: [
+							'appToken',
+						],
+					},
+				},
+			},
+			{
 				name: 'hubspotOAuth2Api',
 				required: true,
 				displayOptions: {
@@ -118,6 +129,10 @@ export class Hubspot implements INodeType {
 					{
 						name: 'API Key',
 						value: 'apiKey',
+					},
+					{
+						name: 'App Token',
+						value: 'appToken',
 					},
 					{
 						name: 'OAuth2',

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -143,6 +143,7 @@
       "dist/credentials/HttpHeaderAuth.credentials.js",
       "dist/credentials/HttpQueryAuth.credentials.js",
       "dist/credentials/HubspotApi.credentials.js",
+      "dist/credentials/HubspotAppToken.credentials.js",
       "dist/credentials/HubspotDeveloperApi.credentials.js",
       "dist/credentials/HubspotOAuth2Api.credentials.js",
       "dist/credentials/HumanticAiApi.credentials.js",


### PR DESCRIPTION
Adding Private App Token Authentication Method for Hubspot Node.

See: https://developers.hubspot.com/docs/api/private-apps

