### PR TITLE
a bug in getSigningKey stops the server app

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -476,7 +476,9 @@ class App {
 				function getKey(header: any, callback: Function) {
 					jwkClient.getSigningKey(header.kid, (err: Error, key: any) => {
 						// eslint-disable-next-line @typescript-eslint/no-throw-literal
-						if (err) throw ResponseHelper.jwtAuthAuthorizationError(res, err.message);
+						if (err) {
+							return callback(err);
+						}
 
 						const signingKey = key.publicKey || key.rsaPublicKey;
 						callback(null, signingKey);


### PR DESCRIPTION
This line 'if (err) throw ResponseHelper.jwtAuthAuthorizationError(res, err.message);'  stops the application. I think the correct way to return error in jwkClient.getSigningKey is to call the callback function