### PR TITLE
Added public url variable for emails

### DIFF
--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -411,11 +411,11 @@ const config = convict({
 		env: 'N8N_SSL_CERT',
 		doc: 'SSL Cert for HTTPS Protocol',
 	},
-	editorUrl: {
+	editorBaseUrl: {
 		format: String,
 		default: '',
-		env: 'N8N_EDITOR_URL',
-		doc: 'Public URL where the editor is accessible. Also used for emails sent from n8n.',
+		env: 'N8N_EDITOR_BASE_URL',
+		doc: 'Public URL where the editor is accessible; path will be concatenated to this base. Also used for emails sent from n8n.',
 	},
 
 	security: {

--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -411,10 +411,10 @@ const config = convict({
 		env: 'N8N_SSL_CERT',
 		doc: 'SSL Cert for HTTPS Protocol',
 	},
-	externalUrl: {
+	editorUrl: {
 		format: String,
 		default: '',
-		env: 'N8N_EXTERNAL_URL',
+		env: 'N8N_EDITOR_URL',
 		doc: 'Public URL where your instance can be reached. Used by emails sent from n8n.',
 	},
 

--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -411,6 +411,12 @@ const config = convict({
 		env: 'N8N_SSL_CERT',
 		doc: 'SSL Cert for HTTPS Protocol',
 	},
+	externalUrl: {
+		format: String,
+		default: '',
+		env: 'N8N_EXTERNAL_URL',
+		doc: 'Public URL where your instance can be reached. Used by emails sent from n8n.',
+	},
 
 	security: {
 		excludeEndpoints: {

--- a/packages/cli/config/index.ts
+++ b/packages/cli/config/index.ts
@@ -415,7 +415,7 @@ const config = convict({
 		format: String,
 		default: '',
 		env: 'N8N_EDITOR_URL',
-		doc: 'Public URL where your instance can be reached. Used by emails sent from n8n.',
+		doc: 'Public URL where the editor is accessible. Also used for emails sent from n8n.',
 	},
 
 	security: {

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -446,6 +446,7 @@ export interface IN8nUISettings {
 	};
 	timezone: string;
 	urlBaseWebhook: string;
+	urlBaseEditor: string;
 	versionCli: string;
 	n8nMetadata?: {
 		[key: string]: string | number | undefined;

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -171,7 +171,7 @@ import { ExecutionEntity } from './databases/entities/ExecutionEntity';
 import { SharedWorkflow } from './databases/entities/SharedWorkflow';
 import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from './constants';
 import { credentialsController } from './api/credentials.api';
-import { isEmailSetUp } from './UserManagement/UserManagementHelper';
+import { getInstanceBaseUrl, isEmailSetUp } from './UserManagement/UserManagementHelper';
 
 require('body-parser-xml')(bodyParser);
 
@@ -296,6 +296,7 @@ class App {
 			maxExecutionTimeout: this.maxExecutionTimeout,
 			timezone: this.timezone,
 			urlBaseWebhook,
+			urlBaseEditor: getInstanceBaseUrl(),
 			versionCli: '',
 			oauthCallbackUrls: {
 				oauth1: `${urlBaseWebhook}${this.restEndpoint}/oauth1-credential/callback`,

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -56,7 +56,8 @@ export async function getInstanceOwner(): Promise<User> {
  */
 export function getInstanceBaseUrl(): string {
 	const editorBaseUrl = config.get('editorBaseUrl');
-	return editorBaseUrl ? editorBaseUrl + config.get('path') : GenericHelpers.getBaseUrl();
+	const baseUrl = editorBaseUrl ? editorBaseUrl + config.get('path') : GenericHelpers.getBaseUrl();
+	return baseUrl.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl;
 }
 
 export async function isInstanceOwnerSetup(): Promise<boolean> {

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -55,7 +55,8 @@ export async function getInstanceOwner(): Promise<User> {
  * Return the n8n instance base URL without trailing slash.
  */
 export function getInstanceBaseUrl(): string {
-	const baseUrl = GenericHelpers.getBaseUrl();
+	const externalUrl = config.get('externalUrl');
+	const baseUrl = externalUrl || GenericHelpers.getBaseUrl();
 	return baseUrl.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl;
 }
 

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -55,8 +55,8 @@ export async function getInstanceOwner(): Promise<User> {
  * Return the n8n instance base URL without trailing slash.
  */
 export function getInstanceBaseUrl(): string {
-	const externalUrl = config.get('externalUrl');
-	const baseUrl = externalUrl || GenericHelpers.getBaseUrl();
+	const editorUrl = config.get('editorUrl');
+	const baseUrl = editorUrl || GenericHelpers.getBaseUrl();
 	return baseUrl.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl;
 }
 

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -55,9 +55,8 @@ export async function getInstanceOwner(): Promise<User> {
  * Return the n8n instance base URL without trailing slash.
  */
 export function getInstanceBaseUrl(): string {
-	const editorUrl = config.get('editorUrl');
-	const baseUrl = editorUrl || GenericHelpers.getBaseUrl();
-	return baseUrl.endsWith('/') ? baseUrl.slice(0, baseUrl.length - 1) : baseUrl;
+	const editorBaseUrl = config.get('editorBaseUrl');
+	return editorBaseUrl ? editorBaseUrl + config.get('path') : GenericHelpers.getBaseUrl();
 }
 
 export async function isInstanceOwnerSetup(): Promise<boolean> {

--- a/packages/cli/src/UserManagement/routes/passwordReset.ts
+++ b/packages/cli/src/UserManagement/routes/passwordReset.ts
@@ -11,11 +11,10 @@ import { LoggerProxy as Logger } from 'n8n-workflow';
 
 import { Db, InternalHooksManager, ResponseHelper } from '../..';
 import { N8nApp } from '../Interfaces';
-import { validatePassword } from '../UserManagementHelper';
+import { getInstanceBaseUrl, validatePassword } from '../UserManagementHelper';
 import * as UserManagementMailer from '../email';
 import type { PasswordResetRequest } from '../../requests';
 import { issueCookie } from '../auth/jwt';
-import { getBaseUrl } from '../../GenericHelpers';
 import config = require('../../../config');
 
 export function passwordResetNamespace(this: N8nApp): void {
@@ -73,7 +72,7 @@ export function passwordResetNamespace(this: N8nApp): void {
 
 			await Db.collections.User!.update(id, { resetPasswordToken, resetPasswordTokenExpiration });
 
-			const baseUrl = getBaseUrl();
+			const baseUrl = getInstanceBaseUrl();
 			const url = new URL('/change-password', baseUrl);
 			url.searchParams.append('userId', id);
 			url.searchParams.append('token', resetPasswordToken);

--- a/packages/cli/src/UserManagement/routes/passwordReset.ts
+++ b/packages/cli/src/UserManagement/routes/passwordReset.ts
@@ -73,7 +73,7 @@ export function passwordResetNamespace(this: N8nApp): void {
 			await Db.collections.User!.update(id, { resetPasswordToken, resetPasswordTokenExpiration });
 
 			const baseUrl = getInstanceBaseUrl();
-			const url = new URL(`${baseUrl}change-password`);
+			const url = new URL(`${baseUrl}/change-password`);
 			url.searchParams.append('userId', id);
 			url.searchParams.append('token', resetPasswordToken);
 

--- a/packages/cli/src/UserManagement/routes/passwordReset.ts
+++ b/packages/cli/src/UserManagement/routes/passwordReset.ts
@@ -73,7 +73,7 @@ export function passwordResetNamespace(this: N8nApp): void {
 			await Db.collections.User!.update(id, { resetPasswordToken, resetPasswordTokenExpiration });
 
 			const baseUrl = getInstanceBaseUrl();
-			const url = new URL(`${baseUrl}/change-password`);
+			const url = new URL(`${baseUrl}change-password`);
 			url.searchParams.append('userId', id);
 			url.searchParams.append('token', resetPasswordToken);
 

--- a/packages/cli/src/UserManagement/routes/passwordReset.ts
+++ b/packages/cli/src/UserManagement/routes/passwordReset.ts
@@ -73,7 +73,7 @@ export function passwordResetNamespace(this: N8nApp): void {
 			await Db.collections.User!.update(id, { resetPasswordToken, resetPasswordTokenExpiration });
 
 			const baseUrl = getInstanceBaseUrl();
-			const url = new URL('/change-password', baseUrl);
+			const url = new URL(`${baseUrl}/change-password`);
 			url.searchParams.append('userId', id);
 			url.searchParams.append('token', resetPasswordToken);
 

--- a/packages/cli/src/UserManagement/routes/users.ts
+++ b/packages/cli/src/UserManagement/routes/users.ts
@@ -176,7 +176,7 @@ export function usersNamespace(this: N8nApp): void {
 			const emailingResults = await Promise.all(
 				usersPendingSetup.map(async ([email, id]) => {
 					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-					const inviteAcceptUrl = `${baseUrl}/signup?inviterId=${req.user.id}&inviteeId=${id}`;
+					const inviteAcceptUrl = `${baseUrl}signup?inviterId=${req.user.id}&inviteeId=${id}`;
 					const result = await mailer?.invite({
 						email,
 						inviteAcceptUrl,
@@ -512,7 +512,7 @@ export function usersNamespace(this: N8nApp): void {
 			}
 
 			const baseUrl = getInstanceBaseUrl();
-			const inviteAcceptUrl = `${baseUrl}/signup?inviterId=${req.user.id}&inviteeId=${reinvitee.id}`;
+			const inviteAcceptUrl = `${baseUrl}signup?inviterId=${req.user.id}&inviteeId=${reinvitee.id}`;
 
 			let mailer: UserManagementMailer.UserManagementMailer | undefined;
 			try {

--- a/packages/cli/src/UserManagement/routes/users.ts
+++ b/packages/cli/src/UserManagement/routes/users.ts
@@ -176,7 +176,7 @@ export function usersNamespace(this: N8nApp): void {
 			const emailingResults = await Promise.all(
 				usersPendingSetup.map(async ([email, id]) => {
 					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-					const inviteAcceptUrl = `${baseUrl}signup?inviterId=${req.user.id}&inviteeId=${id}`;
+					const inviteAcceptUrl = `${baseUrl}/signup?inviterId=${req.user.id}&inviteeId=${id}`;
 					const result = await mailer?.invite({
 						email,
 						inviteAcceptUrl,
@@ -512,7 +512,7 @@ export function usersNamespace(this: N8nApp): void {
 			}
 
 			const baseUrl = getInstanceBaseUrl();
-			const inviteAcceptUrl = `${baseUrl}signup?inviterId=${req.user.id}&inviteeId=${reinvitee.id}`;
+			const inviteAcceptUrl = `${baseUrl}/signup?inviterId=${req.user.id}&inviteeId=${reinvitee.id}`;
 
 			let mailer: UserManagementMailer.UserManagementMailer | undefined;
 			try {


### PR DESCRIPTION
This allows users that run n8n behind a reverse proxy to set the URL where n8n is accessible.

PS: the change to the password reset was necessary because the previous implementation was overriding the previous path if it exists, replacing it with `/change-password` turning the URLs invalid.