### PR TITLE
Disable basic auth after owner has been set up

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -420,7 +420,7 @@ class App {
 					// Skip basic auth for a few listed endpoints or when instance owner has been setup
 					if (
 						authIgnoreRegex.exec(req.url) ||
-						config.get('userManagement.isInstanceOwnerSetUp') === true
+						config.get('userManagement.isInstanceOwnerSetUp')
 					) {
 						return next();
 					}

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -417,7 +417,11 @@ class App {
 
 			this.app.use(
 				async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-					if (authIgnoreRegex.exec(req.url)) {
+					// Skip basic auth for a few listed endpoints or when instance owner has been setup
+					if (
+						authIgnoreRegex.exec(req.url) ||
+						config.get('userManagement.isInstanceOwnerSetUp') === true
+					) {
 						return next();
 					}
 					const realm = 'n8n - Editor UI';


### PR DESCRIPTION
This fixes the issue reported by Jon about an auth loop problem after setting up the instance owner