### PR TITLE
:bug: N8N-2868 Telegram Node: sendPhoto: message fails when "Disable Notification" option is present

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2172,6 +2172,8 @@ export class Telegram implements INodeType {
 					const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
 					const propertyName = getPropertyName(operation);
 
+					body.disable_notification = body.disable_notification?.toString() || 'false';
+
 					const formData = {
 						...body,
 						[propertyName]: {


### PR DESCRIPTION
Fixes sending binary data with the Telegram node when using the Disable Notification option. 