### PR TITLE
Fix issue with n8n not authenticating oauth requests

### DIFF
--- a/packages/cli/src/UserManagement/routes/index.ts
+++ b/packages/cli/src/UserManagement/routes/index.ts
@@ -59,8 +59,8 @@ export function addRoutes(this: N8nApp, ignoredEndpoints: string[], restEndpoint
 			req.url.startsWith('/fonts/') ||
 			req.url.includes('.svg') ||
 			req.url.startsWith(`/${restEndpoint}/settings`) ||
-			req.url.includes('login') ||
-			req.url.includes('logout') ||
+			req.url.startsWith(`/${restEndpoint}/login`) ||
+			req.url.startsWith(`/${restEndpoint}/logout`) ||
 			req.url.startsWith(`/${restEndpoint}/resolve-signup-token`) ||
 			isPostUsersId(req, restEndpoint) ||
 			req.url.startsWith(`/${restEndpoint}/forgot-password`) ||


### PR DESCRIPTION
Changed the pattern recognition so n8n does not bypass authenticating any url that contains `login` or `logout`.