### PR TITLE
Add support for HubSpot custom objects WIP

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -44,7 +44,12 @@ export const customObjectOperations: INodeProperties[] = [
 			{
 				name: 'Batched get',
 				value: 'batchGet',
-				description: 'Like get, but this has fewer options and is only one request per 100 objects',
+				description: 'Like get, but this has fewer options and costs only one request per 100 objects. Requires continueOnFail',
+			},
+			{
+				name: 'Batched delete',
+				value: 'batchDelete',
+				description: 'Like delete, but this costs only up to two requests per 100 objects. Requires continueOnFail',
 			},
 		],
 		default: 'create',
@@ -715,7 +720,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['customObject'],
-				operation: ['delete'],
+				operation: ['delete', 'batchDelete'],
 			},
 		},
 		default: '',
@@ -729,7 +734,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['customObject'],
-				operation: ['delete'],
+				operation: ['delete', 'batchDelete'],
 			},
 		},
 		default: '',

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -32,15 +32,15 @@ export const customObjectOperations: INodeProperties[] = [
 				description: 'Get a custom Object',
 			},
 			{
+				name: 'Search',
+				value: 'search',
+				description: 'Search custom Objects',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: '(Partially) Update a custom Object',
 			},
-			// {
-			//     name: 'Search',
-			//     value: 'search',
-			//     description: 'Search custom Objects',
-			// },
 		],
 		default: 'create',
 		description: 'The operation to perform.',
@@ -366,6 +366,264 @@ export const customObjectFields: INodeProperties[] = [
 				type: 'boolean',
 				default: false,
 				description: `Whether to return only results that have been archived.`,
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                            customObject:search                             */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: [
+					'customObject',
+				],
+				operation: [
+					'search',
+				],
+			},
+		},
+		default: false,
+		description: 'If all results should be returned or only up to a given limit.',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: [
+					'customObject',
+				],
+				operation: [
+					'search',
+				],
+				returnAll: [
+					false,
+				],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 250,
+		},
+		default: 100,
+		description: 'How many results to return.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['search'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'properties',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `A list of the properties to be returned in the response. `,
+			},
+			{
+				displayName: 'Filter Groups',
+				name: 'filterGroups',
+				type: 'fixedCollection',
+				default: '',
+				placeholder: 'Add Filter Group',
+				typeOptions: {
+					multipleValues: true,
+				},
+				required: false,
+				options: [
+					{
+						name: 'filterGroupsValues',
+						displayName: 'Filter Group',
+						values: [
+							{
+								displayName: 'Filters',
+								name: 'filtersUi',
+								type: 'fixedCollection',
+								default: '',
+								placeholder: 'Add Filter',
+								typeOptions: {
+									multipleValues: true,
+								},
+								required: false,
+								options: [
+									{
+										name: 'filterValues',
+										displayName: 'Filter',
+										values: [
+											{
+												displayName: 'Property Name',
+												name: 'propertyName',
+												type: 'options',
+												typeOptions: {
+													loadOptionsMethod: 'getCustomObjectProperties',
+												},
+												default: '',
+											},
+											{
+												displayName: 'Operator',
+												name: 'operator',
+												type: 'options',
+												options: [
+													{
+														name: 'Equal',
+														value: 'EQ',
+													},
+													{
+														name: 'Not Equal',
+														value: 'NEQ',
+													},
+													{
+														name: 'Less Than',
+														value: 'LT',
+													},
+													{
+														name: 'Less Than Or Equal',
+														value: 'LTE',
+													},
+													{
+														name: 'Greater Than',
+														value: 'GT',
+													},
+													{
+														name: 'Greater Than Or Equal',
+														value: 'GTE',
+													},
+													{
+														name: 'Between',
+														value: 'BETWEEN',
+													},
+													{
+														name: 'In a set',
+														value: 'IN',
+													},
+													{
+														name: `Not in a set`,
+														value: 'NOT_IN',
+													},
+													{
+														name: 'Is Known',
+														value: 'HAS_PROPERTY',
+													},
+													{
+														name: 'Is Unknown',
+														value: 'NOT_HAS_PROPERTY',
+													},
+													{
+														name: 'Contains Exactly',
+														value: 'CONSTAIN_TOKEN',
+													},
+													{
+														name: `Doesn't Contain Exactly`,
+														value: 'NOT_CONSTAIN_TOKEN',
+													},
+
+												],
+												default: 'EQ',
+											},
+											{
+												displayName: 'Value',
+												name: 'value',
+												displayOptions: {
+													hide: {
+														operator: [
+															'HAS_PROPERTY',
+															'NOT_HAS_PROPERTY',
+															'BETWEEN',
+															'IN',
+															'NOT_IN',
+														],
+													},
+												},
+												type: 'string',
+												default: '',
+											},
+											{
+												displayName: 'Low value',
+												name: 'value',
+												displayOptions: {
+													show: {
+														operator: [
+															'BETWEEN',
+														],
+													},
+												},
+												type: 'string',
+												default: '',
+												description: 'The lower bound for a between filter',
+											},
+											{
+												displayName: 'High value',
+												name: 'highValue',
+												displayOptions: {
+													show: {
+														operator: [
+															'BETWEEN',
+														],
+													},
+												},
+												type: 'string',
+												default: '',
+												description: 'The upper bound for a between filter',
+											},
+											{
+												displayName: 'Values',
+												name: 'values',
+												displayOptions: {
+													show: {
+														operator: [
+															'IN',
+															'NOT_IN',
+														],
+													},
+												},
+												type: 'string',
+												typeOptions: {
+													multipleValues: true,
+												},
+												default: [],
+											},
+										],
+									},
+								],
+								description: 'Use filters to limit the results to only CRM objects with matching property values. More info <a href="https://developers.hubspot.com/docs/api/crm/search">here</a>',
+							},
+						],
+					},
+				],
+				description: `When multiple filters are provided within a filterGroup, they will be combined using a logical AND operator. When multiple filterGroups are provided, they will be combined using a logical OR operator. The system supports a maximum of three filterGroups with up to three filters each. More info <a href="https://developers.hubspot.com/docs/api/crm/search">here</a>`,
+			},
+			{
+				displayName: 'Sort',
+				name: 'sortBy',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `Sort the results ascending by this property`,
+			},
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				description: `Search all searchable properties for this string`,
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -1,0 +1,444 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const customObjectOperations: INodeProperties[] = [
+	{
+		displayName: 'Custom Object Type',
+		name: 'customObjectType',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+			},
+		},
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectTypes',
+		},
+		default: '',
+	},
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a custom Object',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a custom Object',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a custom Object',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: '(Partially) Update a custom Object',
+			},
+			// {
+			//     name: 'Get All',
+			//     value: 'getAll',
+			//     description: 'Get all custom Objects',
+			// },
+			// {
+			//     name: 'Search',
+			//     value: 'search',
+			//     description: 'Search custom Objects',
+			// },
+		],
+		default: 'create',
+		description: 'The operation to perform.',
+	},
+];
+
+export const customObjectFields: INodeProperties[] = [
+	/* -------------------------------------------------------------------------- */
+	/*                              customObject:create                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'customPropertiesUi',
+				placeholder: 'Add Custom Property',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				options: [
+					{
+						name: 'customPropertiesValues',
+						displayName: 'Custom Property',
+						values: [
+							{
+								displayName: 'Property',
+								name: 'property',
+								type: 'options',
+								typeOptions: {
+									loadOptionsMethod: 'getCustomObjectProperties',
+								},
+								default: '',
+								description: 'Name of the property.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'Value of the property',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                              customObject:update                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'ID property',
+		name: 'idProperty',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectIdProperties',
+		},
+		required: false,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The property that will be used as the ID. The property has to have "hasUniqueValue" set to true.',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The value of the idProperty of the object. If idProperty is not set, this defaults to the hubspot object id.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'customPropertiesUi',
+				placeholder: 'Update these properties',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				options: [
+					{
+						name: 'customPropertiesValues',
+						displayName: 'Custom Property',
+						values: [
+							{
+								displayName: 'Property',
+								name: 'property',
+								type: 'options',
+								typeOptions: {
+									loadOptionsMethod: 'getCustomObjectProperties',
+								},
+								default: '',
+								description: 'Name of the property.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'Value of the property',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                             customObject:get                               */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'ID property',
+		name: 'idProperty',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectIdProperties',
+		},
+		required: false,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The property that will be used as the ID. The property has to have "hasUniqueValue" set to true.',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The value of the idProperty of the object. If idProperty is not set, this defaults to the hubspot object id.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['get'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'properties',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `A list of the properties to be returned in the response. `,
+			},
+			{
+				displayName: 'Properties with history',
+				name: 'propertiesWithHistory',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `A list of the properties to be returned along with their history of previous values.`,
+			},
+			// {
+			//     displayName: 'Associations',
+			//     name: 'associations',
+			//     type: 'multiOptions',
+			//     typeOptions: {
+			//         loadOptionsMethod: 'getCustomObjectAssociations',
+			//     },
+			//     default: '',
+			//     description: `A list of object types to retrieve associated IDs for.`,
+			// },
+			{
+				displayName: 'Archived',
+				name: 'archived',
+				type: 'boolean',
+				default: false,
+				description: `Whether to return only results that have been archived.`,
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                              customObject:getAll                           */
+	/* -------------------------------------------------------------------------- */
+	// {
+	//     displayName: 'Get All',
+	//     name: 'returnAll',
+	//     type: 'boolean',
+	//     displayOptions: {
+	//         show: {
+	//             resource: ['customObject'],
+	//             operation: ['getAll'],
+	//         },
+	//     },
+	//     default: false,
+	//     description: 'If all results should be returned or only up to a given limit.',
+	// },
+	// {
+	//     displayName: 'Limit',
+	//     name: 'limit',
+	//     type: 'number',
+	//     displayOptions: {
+	//         show: {
+	//             resource: ['customObject'],
+	//             operation: ['getAll'],
+	//             returnAll: [false],
+	//         },
+	//     },
+	//     typeOptions: {
+	//         minValue: 1,
+	//         maxValue: 250,
+	//     },
+	//     default: 100,
+	//     description: 'How many results to return.',
+	// },
+	// {
+	//     displayName: 'Additional Fields',
+	//     name: 'additionalFields',
+	//     type: 'collection',
+	//     placeholder: 'Add Field',
+	//     default: {},
+	//     displayOptions: {
+	//         show: {
+	//             resource: ['contact'],
+	//             operation: ['getAll'],
+	//         },
+	//     },
+	//     options: [
+	//         {
+	//             displayName: 'Properties',
+	//             name: 'properties',
+	//             type: 'multiOptions',
+	//             typeOptions: {
+	//                 loadOptionsMethod: 'getContactProperties',
+	//             },
+	//             default: '',
+	//             description: `A list of the properties to be returned in the response. `,
+	//         },
+	//         {
+	//             displayName: 'Properties with history',
+	//             name: 'propertiesWithHistory',
+	//             type: 'multiOptions',
+	//             typeOptions: {
+	//                 loadOptionsMethod: 'getContactProperties',
+	//             },
+	//             default: '',
+	//             description: `A list of the properties to be returned along with their history of previous values.`,
+	//         },
+	//         {
+	//             displayName: 'Associations',
+	//             name: 'associations',
+	//             type: 'multiOptions',
+	//             typeOptions: {
+	//                 loadOptionsMethod: 'getContactAssociations',
+	//             },
+	//             default: '',
+	//             description: `A list of object types to retrieve associated IDs for.`,
+	//         },
+	//         {
+	//             displayName: 'Archived',
+	//             name: 'archived',
+	//             type: 'boolean',
+	//             default: false,
+	//             description: `Whether to return only results that have been archived.`,
+	//         },
+	//     ],
+	// },
+
+	/* -------------------------------------------------------------------------- */
+	/*                              customObject:delete                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'ID property',
+		name: 'idProperty',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectIdProperties',
+		},
+		required: false,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['delete'],
+			},
+		},
+		default: '',
+		description: 'The property that will be used as the ID. The property has to have "hasUniqueValue" set to true.',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['delete'],
+			},
+		},
+		default: '',
+		description: 'The value of the idProperty of the object. If idProperty is not set, this defaults to the hubspot object id.',
+	},
+	//*-------------------------------------------------------------------------- */
+	/*                               customObject:search                          */
+	/* -------------------------------------------------------------------------- */
+	// {
+	//     displayName: 'Get All',
+	//     name: 'returnAll',
+	//     type: 'boolean',
+	//     displayOptions: {
+	//         show: {
+	//             resource: ['customObject'],
+	//             operation: ['search'],
+	//         },
+	//     },
+	//     default: false,
+	//     description: 'If all results should be returned or only up to a given limit.',
+	// },
+	// {
+	//     displayName: 'Limit',
+	//     name: 'limit',
+	//     type: 'number',
+	//     displayOptions: {
+	//         show: {
+	//             resource: ['customObject'],
+	//             operation: ['search'],
+	//             returnAll: [false],
+	//         },
+	//     },
+	//     typeOptions: {
+	//         minValue: 1,
+	//         maxValue: 250,
+	//     },
+	//     default: 100,
+	//     description: 'How many results to return.',
+	// },
+];

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -222,6 +222,7 @@ export const customObjectFields: INodeProperties[] = [
 		name: 'idProperty',
 		type: 'options',
 		typeOptions: {
+			loadOptionsDependsOn: ['customObjectType'],
 			loadOptionsMethod: 'getCustomObjectIdProperties',
 		},
 		required: false,

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -14,7 +14,7 @@ export const customObjectOperations: INodeProperties[] = [
 			{
 				name: 'Create/Update',
 				value: 'upsert',
-				description: 'Get all custom Objects',
+				description: 'Update an object or create it if it does not exist',
 			},
 			{
 				name: 'Create',
@@ -50,6 +50,11 @@ export const customObjectOperations: INodeProperties[] = [
 				name: 'Batched delete',
 				value: 'batchDelete',
 				description: 'Like delete, but this costs only up to two requests per 100 objects. Requires continueOnFail',
+			},
+			{
+				name: 'Batched Create/Update',
+				value: 'batchUpsert',
+				description: 'Like upsert, but this costs only up to three requests per 100 objects. Requires continueOnFail',
 			},
 		],
 		default: 'create',
@@ -223,7 +228,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['customObject'],
-				operation: ['upsert'],
+				operation: ['upsert', 'batchUpsert'],
 			},
 		},
 		default: '',
@@ -237,7 +242,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['customObject'],
-				operation: ['upsert'],
+				operation: ['upsert', 'batchUpsert'],
 			},
 		},
 		default: '',
@@ -252,7 +257,7 @@ export const customObjectFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['customObject'],
-				operation: ['upsert'],
+				operation: ['upsert', 'batchUpsert'],
 			},
 		},
 		options: [

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -2,20 +2,6 @@ import { INodeProperties } from 'n8n-workflow';
 
 export const customObjectOperations: INodeProperties[] = [
 	{
-		displayName: 'Custom Object Type',
-		name: 'customObjectType',
-		type: 'options',
-		displayOptions: {
-			show: {
-				resource: ['customObject'],
-			},
-		},
-		typeOptions: {
-			loadOptionsMethod: 'getCustomObjectTypes',
-		},
-		default: '',
-	},
-	{
 		displayName: 'Operation',
 		name: 'operation',
 		type: 'options',
@@ -25,6 +11,11 @@ export const customObjectOperations: INodeProperties[] = [
 			},
 		},
 		options: [
+			// {
+			// 	name: 'Create/Update',
+			// 	value: 'upsert',
+			// 	description: 'Get all custom Objects',
+			// },
 			{
 				name: 'Create',
 				value: 'create',
@@ -33,7 +24,7 @@ export const customObjectOperations: INodeProperties[] = [
 			{
 				name: 'Delete',
 				value: 'delete',
-				description: 'Delete a custom Object',
+				description: 'Archive a custom Object',
 			},
 			{
 				name: 'Get',
@@ -46,11 +37,6 @@ export const customObjectOperations: INodeProperties[] = [
 				description: '(Partially) Update a custom Object',
 			},
 			// {
-			//     name: 'Get All',
-			//     value: 'getAll',
-			//     description: 'Get all custom Objects',
-			// },
-			// {
 			//     name: 'Search',
 			//     value: 'search',
 			//     description: 'Search custom Objects',
@@ -58,6 +44,20 @@ export const customObjectOperations: INodeProperties[] = [
 		],
 		default: 'create',
 		description: 'The operation to perform.',
+	},
+	{
+		displayName: 'Custom Object Type',
+		name: 'customObjectType',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+			},
+		},
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectTypes',
+		},
+		default: '',
 	},
 ];
 
@@ -81,7 +81,7 @@ export const customObjectFields: INodeProperties[] = [
 			{
 				displayName: 'Properties',
 				name: 'customPropertiesUi',
-				placeholder: 'Add Custom Property',
+				placeholder: 'Add Property',
 				type: 'fixedCollection',
 				typeOptions: {
 					multipleValues: true,
@@ -165,7 +165,7 @@ export const customObjectFields: INodeProperties[] = [
 			{
 				displayName: 'Properties',
 				name: 'customPropertiesUi',
-				placeholder: 'Update these properties',
+				placeholder: 'Add Property',
 				type: 'fixedCollection',
 				typeOptions: {
 					multipleValues: true,
@@ -285,94 +285,6 @@ export const customObjectFields: INodeProperties[] = [
 			},
 		],
 	},
-
-	/* -------------------------------------------------------------------------- */
-	/*                              customObject:getAll                           */
-	/* -------------------------------------------------------------------------- */
-	// {
-	//     displayName: 'Get All',
-	//     name: 'returnAll',
-	//     type: 'boolean',
-	//     displayOptions: {
-	//         show: {
-	//             resource: ['customObject'],
-	//             operation: ['getAll'],
-	//         },
-	//     },
-	//     default: false,
-	//     description: 'If all results should be returned or only up to a given limit.',
-	// },
-	// {
-	//     displayName: 'Limit',
-	//     name: 'limit',
-	//     type: 'number',
-	//     displayOptions: {
-	//         show: {
-	//             resource: ['customObject'],
-	//             operation: ['getAll'],
-	//             returnAll: [false],
-	//         },
-	//     },
-	//     typeOptions: {
-	//         minValue: 1,
-	//         maxValue: 250,
-	//     },
-	//     default: 100,
-	//     description: 'How many results to return.',
-	// },
-	// {
-	//     displayName: 'Additional Fields',
-	//     name: 'additionalFields',
-	//     type: 'collection',
-	//     placeholder: 'Add Field',
-	//     default: {},
-	//     displayOptions: {
-	//         show: {
-	//             resource: ['contact'],
-	//             operation: ['getAll'],
-	//         },
-	//     },
-	//     options: [
-	//         {
-	//             displayName: 'Properties',
-	//             name: 'properties',
-	//             type: 'multiOptions',
-	//             typeOptions: {
-	//                 loadOptionsMethod: 'getContactProperties',
-	//             },
-	//             default: '',
-	//             description: `A list of the properties to be returned in the response. `,
-	//         },
-	//         {
-	//             displayName: 'Properties with history',
-	//             name: 'propertiesWithHistory',
-	//             type: 'multiOptions',
-	//             typeOptions: {
-	//                 loadOptionsMethod: 'getContactProperties',
-	//             },
-	//             default: '',
-	//             description: `A list of the properties to be returned along with their history of previous values.`,
-	//         },
-	//         {
-	//             displayName: 'Associations',
-	//             name: 'associations',
-	//             type: 'multiOptions',
-	//             typeOptions: {
-	//                 loadOptionsMethod: 'getContactAssociations',
-	//             },
-	//             default: '',
-	//             description: `A list of object types to retrieve associated IDs for.`,
-	//         },
-	//         {
-	//             displayName: 'Archived',
-	//             name: 'archived',
-	//             type: 'boolean',
-	//             default: false,
-	//             description: `Whether to return only results that have been archived.`,
-	//         },
-	//     ],
-	// },
-
 	/* -------------------------------------------------------------------------- */
 	/*                              customObject:delete                           */
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -11,11 +11,11 @@ export const customObjectOperations: INodeProperties[] = [
 			},
 		},
 		options: [
-			// {
-			// 	name: 'Create/Update',
-			// 	value: 'upsert',
-			// 	description: 'Get all custom Objects',
-			// },
+			{
+				name: 'Create/Update',
+				value: 'upsert',
+				description: 'Get all custom Objects',
+			},
 			{
 				name: 'Create',
 				value: 'create',
@@ -159,6 +159,90 @@ export const customObjectFields: INodeProperties[] = [
 			show: {
 				resource: ['customObject'],
 				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'customPropertiesUi',
+				placeholder: 'Add Property',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				options: [
+					{
+						name: 'customPropertiesValues',
+						displayName: 'Custom Property',
+						values: [
+							{
+								displayName: 'Property',
+								name: 'property',
+								type: 'options',
+								typeOptions: {
+									loadOptionsMethod: 'getCustomObjectProperties',
+								},
+								default: '',
+								description: 'Name of the property.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'Value of the property',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                              customObject:upsert                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'ID property',
+		name: 'idProperty',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectIdProperties',
+		},
+		required: false,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['upsert'],
+			},
+		},
+		default: '',
+		description: 'The property that will be used as the ID. The property has to have "hasUniqueValue" set to true.',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['upsert'],
+			},
+		},
+		default: '',
+		description: 'The value of the idProperty of the object. If idProperty is not set, this defaults to the hubspot object id.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['upsert'],
 			},
 		},
 		options: [

--- a/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/CustomObjectDescription.ts
@@ -41,6 +41,11 @@ export const customObjectOperations: INodeProperties[] = [
 				value: 'update',
 				description: '(Partially) Update a custom Object',
 			},
+			{
+				name: 'Batched get',
+				value: 'batchGet',
+				description: 'Like get, but this has fewer options and is only one request per 100 objects',
+			},
 		],
 		default: 'create',
 		description: 'The operation to perform.',
@@ -366,6 +371,75 @@ export const customObjectFields: INodeProperties[] = [
 				type: 'boolean',
 				default: false,
 				description: `Whether to return only results that have been archived.`,
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                          customObject:batchGet                             */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'ID property',
+		name: 'idProperty',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getCustomObjectIdProperties',
+		},
+		required: false,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['batchGet'],
+			},
+		},
+		default: '',
+		description: 'The property that will be used as the ID. The property has to have "hasUniqueValue" set to true.',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['batchGet'],
+			},
+		},
+		default: '',
+		description: 'The value of the idProperty of the object. If idProperty is not set, this defaults to the hubspot object id.',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['customObject'],
+				operation: ['batchGet'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Properties',
+				name: 'properties',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `A list of the properties to be returned in the response. `,
+			},
+			{
+				displayName: 'Properties with history',
+				name: 'propertiesWithHistory',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getCustomObjectProperties',
+				},
+				default: '',
+				description: `A list of the properties to be returned along with their history of previous values.`,
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -1128,7 +1128,7 @@ export class Hubspot implements INodeType {
 							inputs: [...new Array(batchSize)].map((_, index) =>
 							({
 								id: idMap[this.getNodeParameter('objectId', index + batchStart) as string],
-								properties: getProperties(index),
+								properties: getProperties(index + batchStart),
 							}),
 							).filter(element => element.id !== undefined),
 						};
@@ -1137,7 +1137,7 @@ export class Hubspot implements INodeType {
 							inputs: [...new Array(batchSize)].map((_, index) =>
 							({
 								id: idMap[this.getNodeParameter('objectId', index + batchStart) as string],
-								properties: getProperties(index),
+								properties: getProperties(index + batchStart),
 							}),
 							)
 								.filter(element => element.id === undefined)

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -2802,6 +2802,14 @@ export class Hubspot implements INodeType {
 								message: (error as JsonObject).message,
 							};
 
+							try {
+								errorDetails.objectId = this.getNodeParameter('objectId', i) as string;
+							} catch (e) { }
+
+							try {
+								errorDetails.idProperty = this.getNodeParameter('idProperty', i) as string;
+							} catch (e) { }
+
 							const cause = (error as NodeApiError).cause as Error;
 							errorDetails.response = cause.message;
 

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -982,12 +982,12 @@ export class Hubspot implements INodeType {
 				const endpoint = `/crm/v3/schemas/${customObjectType}`;
 				const result = await hubspotApiRequest.call(this, 'GET', endpoint, {});
 				const properties = result.properties;
-				const idProperties = properties.filter((property: { hasUniqueValue?: boolean }) => property.hasUniqueValue === true)
+				const idProperties = properties.filter((property: { hasUniqueValue?: boolean }) => property.hasUniqueValue === true);
 
 				returnData.push({
 					name: 'Hubspot object ID',
 					value: '',
-				})
+				});
 				for (const property of idProperties) {
 					const propertyLabel = property.label;
 					const propertyValue = property.name;
@@ -1011,7 +1011,7 @@ export class Hubspot implements INodeType {
 		const resource = this.getNodeParameter('resource', 0) as string;
 		const operation = this.getNodeParameter('operation', 0) as string;
 
-		const customObjectType = resource === 'customObject' ? this.getNodeParameter('customObjectType', 0) as string : undefined
+		const customObjectType = resource === 'customObject' ? this.getNodeParameter('customObjectType', 0) as string : undefined;
 		// const customObjectSchema = customObjectType && await hubspotApiRequest.call(this, 'GET', `/crm/v3/schemas/${customObjectType}`, {});
 
 		//https://legacydocs.hubspot.com/docs/methods/lists/contact-lists-overview


### PR DESCRIPTION
In 2020 HubSpot added support for creating custom object types. This PR aims to add support for most operations on custom objects to the HubSpot Node. Associations between custom objects are not in scope.

Features:
- [x] Create custom objects
- [x] Read custom objects
- [x] Update custom objects
- [x] Delete custom objects
- [x] Search custom objects
- [ ] Review and simplify description
- [ ] Add documentation

Optional:
- [x] Use batch operations to save api calls
- [x] Create a synthetic upsert operation for convenience
- [x] ~Look into adding custom objects to the trigger node~ HubSpot does not support webhooks for custom objects
- [x] List custom objects
