### PR TITLE
Fix credentials import success message

### DIFF
--- a/packages/cli/commands/import/credentials.ts
+++ b/packages/cli/commands/import/credentials.ts
@@ -146,7 +146,7 @@ export class ImportCredentialsCommand extends Command {
 	}
 
 	private reportSuccess(total: number) {
-		console.info(`Successfully imported ${total} ${total === 1 ? 'workflow.' : 'workflows.'}`);
+		console.info(`Successfully imported ${total} ${total === 1 ? 'credential.' : 'credentials.'}`);
 	}
 
 	private async initOwnerCredentialRole() {


### PR DESCRIPTION
I noticed the success message of `import:credentials` suddenly stated it imported workflows instead of credentials.