### PR TITLE
(fix): Added missing full stop to license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/cli/LICENSE.md
+++ b/packages/cli/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/core/LICENSE.md
+++ b/packages/core/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/design-system/LICENSE.md
+++ b/packages/design-system/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/editor-ui/LICENSE.md
+++ b/packages/editor-ui/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/node-dev/LICENSE.md
+++ b/packages/node-dev/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 

--- a/packages/nodes-base/LICENSE.md
+++ b/packages/nodes-base/LICENSE.md
@@ -12,7 +12,7 @@ The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensa
 
 ## Limitations
 
-You may use or modify the software only for your own internal business purposes or for non-commercial or personal use
+You may use or modify the software only for your own internal business purposes or for non-commercial or personal use.
 You may distribute the software or provide it to others only if you do so free of charge for non-commercial purposes.
 You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
 


### PR DESCRIPTION
GitHub does not render the single line breaks in the *Limitations* section. The added full stop makes it easier to read our license.