### PR TITLE
Fixed issue with comparison to display current executions

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -2660,7 +2660,7 @@ class App {
 					for (const data of executingWorkflows) {
 						if (
 							(filter.workflowId !== undefined && filter.workflowId !== data.workflowId) ||
-							!sharedWorkflowIds.includes(data.workflowId)
+							!sharedWorkflowIds.includes(data.workflowId.toString())
 						) {
 							continue;
 						}


### PR DESCRIPTION
Executions that are currently running have their ids returned as integers and not strings, causing the comparison to break. This PR fixes the issue.