### PR TITLE
N8N-3267 Drop-downs break after removing expressions

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -391,6 +391,10 @@ export default mixins(
 					}
 				}
 
+				if (this.parameter.type === 'multiOptions' && typeof returnValue === 'string' && !this.isValueExpression) {
+					returnValue = (returnValue || '').split(',');
+				}
+
 				return returnValue;
 			},
 			expressionDisplayValue (): string {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -771,7 +771,8 @@ export default mixins(
 					let value = this.expressionValueComputed;
 
 					if (this.parameter.type === 'multiOptions' && typeof value === 'string') {
-						value = (value || '').split(',');
+						value = (value || '').split(',')
+							.filter((value) => (this.parameterOptions || []).find((option) => option.value === value));
 					}
 
 					this.valueChanged(typeof value !== 'undefined' ? value : null);

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -391,10 +391,6 @@ export default mixins(
 					}
 				}
 
-				if (this.parameter.type === 'multiOptions' && typeof returnValue === 'string' && !this.isValueExpression) {
-					returnValue = (returnValue || '').split(',');
-				}
-
 				return returnValue;
 			},
 			expressionDisplayValue (): string {
@@ -425,7 +421,7 @@ export default mixins(
 
 				return false;
 			},
-			expressionValueComputed (): NodeParameterValue | null {
+			expressionValueComputed (): NodeParameterValue | string[] | null {
 				if (this.areExpressionsDisabled) {
 					return this.value;
 				}
@@ -737,7 +733,7 @@ export default mixins(
 
 				this.$emit('textInput', parameterData);
 			},
-			valueChanged (value: string | number | boolean | Date | null) {
+			valueChanged (value: string[] | string | number | boolean | Date | null) {
 				if (value instanceof Date) {
 					value = value.toISOString();
 				}
@@ -772,7 +768,13 @@ export default mixins(
 					this.expressionEditDialogVisible = true;
 					this.trackExpressionEditOpen();
 				} else if (command === 'removeExpression') {
-					this.valueChanged(this.expressionValueComputed !== undefined ? this.expressionValueComputed : null);
+					let value = this.expressionValueComputed;
+
+					if (this.parameter.type === 'multiOptions' && typeof value === 'string') {
+						value = (value || '').split(',');
+					}
+
+					this.valueChanged(typeof value !== 'undefined' ? value : null);
 				} else if (command === 'refreshOptions') {
 					this.loadRemoteParameterOptions();
 				}


### PR DESCRIPTION
**Description**:
When clicking **Add Expression** the value gets transformed into a string, while the `multiOption` input expects a string array. Splitting by `,` will ensure that when clicking **Remove Expression**, the value gets transformed back into a string array.