### PR TITLE
N8N-3265 When leaving parameter details view via pressing 'esc', value is still updated

### DIFF
--- a/packages/editor-ui/src/components/TextEdit.vue
+++ b/packages/editor-ui/src/components/TextEdit.vue
@@ -4,7 +4,7 @@
 
 			<div class="ignore-key-press">
 				<n8n-input-label :label="$locale.nodeText().inputLabelDisplayName(parameter, path)">
-					<div @keydown.stop @keydown.esc="closeDialog()">
+					<div @keydown.stop @keydown.esc="onKeyDownEsc()">
 						<n8n-input v-model="tempValue" type="textarea" ref="inputField" :value="value" :placeholder="$locale.nodeText().placeholder(parameter, path)" @change="valueChanged" @keydown.stop="noOp" :rows="15" />
 					</div>
 				</n8n-input-label>
@@ -33,6 +33,13 @@ export default Vue.extend({
 	methods: {
 		valueChanged (value: string) {
 			this.$emit('valueChanged', value);
+		},
+
+		onKeyDownEsc () {
+			// Resetting input value when closing the dialog, required when closing it using the `Esc` key
+			this.tempValue = this.value;
+
+			this.closeDialog();
 		},
 
 		closeDialog () {


### PR DESCRIPTION
:bug: Resetting text-edit input value when pressing esc key to have matching input values