### PR TITLE
BUGFIX: Correctly validate string vs number - N8N-3416

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -70,7 +70,7 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 		return { 'booleanValue': value };
 	} else if (value === null) {
 		return { 'nullValue': null };
-	} else if (!isNaN(value as number)) {
+	} else if (/^-?\d+[\.\d]*$/.test(value)) {
 		if (value.toString().indexOf('.') !== -1) {
 			return { 'doubleValue': value };
 		} else {


### PR DESCRIPTION
let value = "343E343"
// value = "23432"
// value = "23432.515"
console.log(/^-?\d+[\.\d]*$/.test(value))
console.log(Number(value))
console.log(parseInt(value))
console.log(+value)
console.log(typeof value === "number")
console.log(!isNaN(value))

Based on the test findings, the value is obviously type text, not number!
However, `!isNaN(value)` returns true, which is incorrect.

The additional tests I included for completeness all produce wrong results in various contexts.
Even though it isn't the most elegant, regular expression tests are the only ones that work.

The current n8n problem that prompted this PR.
```
{"message":"400 - {\"error\":{\"code\":400,\"message\":\"Invalid value at 'writes[3].update.fields[0].value.integer_value' (TYPE_INT64), \\\"396E18\\\"\",\"status\":\"INVALID_ARGUMENT\",\"details\":[{\"@type\":\"type.googleapis.com/google.rpc.BadRequest\",\"fieldViolations\":[{\"field\":\"writes[3].update.fields[0].value.integer_value\",\"description\":\"Invalid value at 'writes[3].update.fields[0].value.integer_value' (TYPE_INT64), \\\"396E18\\\"\"}]}]}}","name":"Error","stack":"Error: Request failed with status code 400\n    at createError (/usr/local/lib/node_modules/n8n/node_modules/axios/lib/core/createError.js:16:15)\n    at settle (/usr/local/lib/node_modules/n8n/node_modules/axios/lib/core/settle.js:17:12)\n    at IncomingMessage.handleStreamEnd (/usr/local/lib/node_modules/n8n/node_modules/axios/lib/adapters/http.js:269:11)\n    at IncomingMessage.emit (node:events:538:35)\n    at endReadableNT (node:internal/streams/readable:1345:12)\n    at processTicksAndRejections (node:internal/process/task_queues:83:21)"}
```