### PR TITLE
[Feature] - Add TLS unauthorized support to Redis bull connections

### DIFF
--- a/packages/cli/commands/start.ts
+++ b/packages/cli/commands/start.ts
@@ -224,6 +224,7 @@ export class Start extends Command {
 
 				if (config.getEnv('executions.mode') === 'queue') {
 					const redisHost = config.getEnv('queue.bull.redis.host');
+					const redisTLSRejectUnauthorized = config.getEnv('queue.bull.redis.tls.rejectUnauthorized');
 					const redisPassword = config.getEnv('queue.bull.redis.password');
 					const redisPort = config.getEnv('queue.bull.redis.port');
 					const redisDB = config.getEnv('queue.bull.redis.db');
@@ -265,6 +266,17 @@ export class Start extends Command {
 					}
 					if (redisDB) {
 						settings.db = redisDB;
+					}
+					if (redisTLSRejectUnauthorized) {
+						if (redisTLSRejectUnauthorized === 'true') {
+							settings.tls = {
+								rejectUnauthorized: true
+							};
+						} else if (redisTLSRejectUnauthorized === 'false') {
+							settings.tls = {
+								rejectUnauthorized: false
+							};
+						}
 					}
 
 					// This connection is going to be our heartbeat

--- a/packages/cli/commands/start.ts
+++ b/packages/cli/commands/start.ts
@@ -268,11 +268,12 @@ export class Start extends Command {
 						settings.db = redisDB;
 					}
 					if (redisTLSRejectUnauthorized) {
-						if (redisTLSRejectUnauthorized === 'true') {
+						const _redisTLSRejectUnauthorized = redisTLSRejectUnauthorized.toLowerCase();
+						if (_redisTLSRejectUnauthorized === 'true') {
 							settings.tls = {
 								rejectUnauthorized: true
 							};
-						} else if (redisTLSRejectUnauthorized === 'false') {
+						} else if (_redisTLSRejectUnauthorized === 'false') {
 							settings.tls = {
 								rejectUnauthorized: false
 							};

--- a/packages/cli/commands/webhook.ts
+++ b/packages/cli/commands/webhook.ts
@@ -201,11 +201,12 @@ export class Webhook extends Command {
 						settings.db = redisDB;
 					}
 					if (redisTLSRejectUnauthorized) {
-						if (redisTLSRejectUnauthorized === 'true') {
+						const _redisTLSRejectUnauthorized = redisTLSRejectUnauthorized.toLowerCase();
+						if (_redisTLSRejectUnauthorized === 'true') {
 							settings.tls = {
 								rejectUnauthorized: true
 							};
-						} else if (redisTLSRejectUnauthorized === 'false') {
+						} else if (_redisTLSRejectUnauthorized === 'false') {
 							settings.tls = {
 								rejectUnauthorized: false
 							};

--- a/packages/cli/commands/webhook.ts
+++ b/packages/cli/commands/webhook.ts
@@ -157,6 +157,7 @@ export class Webhook extends Command {
 
 				if (config.getEnv('executions.mode') === 'queue') {
 					const redisHost = config.getEnv('queue.bull.redis.host');
+					const redisTLSRejectUnauthorized = config.getEnv('queue.bull.redis.tls.rejectUnauthorized');
 					const redisPassword = config.getEnv('queue.bull.redis.password');
 					const redisPort = config.getEnv('queue.bull.redis.port');
 					const redisDB = config.getEnv('queue.bull.redis.db');
@@ -198,6 +199,17 @@ export class Webhook extends Command {
 					}
 					if (redisDB) {
 						settings.db = redisDB;
+					}
+					if (redisTLSRejectUnauthorized) {
+						if (redisTLSRejectUnauthorized === 'true') {
+							settings.tls = {
+								rejectUnauthorized: true
+							};
+						} else if (redisTLSRejectUnauthorized === 'false') {
+							settings.tls = {
+								rejectUnauthorized: false
+							};
+						}
 					}
 
 					// This connection is going to be our heartbeat

--- a/packages/cli/config/schema.ts
+++ b/packages/cli/config/schema.ts
@@ -338,6 +338,14 @@ export const schema = {
 					default: 10000,
 					env: 'QUEUE_BULL_REDIS_TIMEOUT_THRESHOLD',
 				},
+				tls: {
+					rejectUnauthorized: {
+						doc: 'Redis TLS reject unauthorized',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_REJECT_UNAUTHORIZED',
+					},
+				},
 			},
 			queueRecoveryInterval: {
 				doc: 'If > 0 enables an active polling to the queue that can recover for Redis crashes. Given in seconds; 0 is disabled. May increase Redis traffic significantly.',

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -28,6 +28,8 @@ export class Queue {
 			} else {
 				delete redisOptions.tls
 			}
+		} else {
+			if (redisOptions?.tls) delete redisOptions.tls
 		}
 
 		// Disabling ready check is necessary as it allows worker to

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -17,7 +17,19 @@ export class Queue {
 		this.activeExecutions = ActiveExecutions.getInstance();
 
 		const prefix = config.getEnv('queue.bull.prefix');
-		const redisOptions = config.getEnv('queue.bull.redis');
+		const redisOptions:any = config.getEnv('queue.bull.redis');
+		
+		if (redisOptions?.tls?.rejectUnauthorized) {
+			const _redisTLSRejectUnauthorized: string = redisOptions.tls.rejectUnauthorized.toLowerCase();
+			if (_redisTLSRejectUnauthorized === 'true') {
+				redisOptions.tls.rejectUnauthorized = true;
+			} else if (_redisTLSRejectUnauthorized === 'false') {
+				redisOptions.tls.rejectUnauthorized = false;
+			} else {
+				delete redisOptions.tls
+			}
+		}
+
 		// Disabling ready check is necessary as it allows worker to
 		// quickly reconnect to Redis if Redis crashes or is unreachable
 		// for some time. With it enabled, worker might take minutes to realize


### PR DESCRIPTION
As Redis5 is at end of life and Redis6 introduced TLS: Today there is no support for utilizing the Redis bull connections when scaling n8n to utilize a TLS connection. Hosting Providers like Heroku have Redis5 at end of life, and are enforcing TLS with Redis6. 

This code commit is specific to add a new environment variable to utilize the rejectUnauthorized key inside the RedisOptions of TLS. I wasn't sure how/what the standard maybe to pass certificates themselves, so I did not make that code change. 

This for now should allow those using n8n on Heroku to utilize redis6 once they remove support for Redis5 at the end of the month.  

To the maintainers -- The same changes should probably be made to any n8n flow utilized by redis to also have such an option; additionally, what would be the best way to test this? The contributing markdown file doesn't address these type of core change requests. 
