### PR TITLE
Apply `node-class-description-inputs-wrong-trigger-node`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -374,7 +374,8 @@ module.exports = {
 			files: ['./packages/nodes-base/nodes/**/*.ts'],
 			plugins: ['eslint-plugin-n8n-nodes-base'],
 			rules: {
-				"n8n-nodes-base/node-param-default-missing": "error"
+				"n8n-nodes-base/node-param-default-missing": "error",
+				"n8n-nodes-base/node-class-description-inputs-wrong-trigger-node": "error"
 			 }
 		},
 	],


### PR DESCRIPTION
Autofixes applied, no issues found.