### PR TITLE
:sparkles: Introduce simple node versioning

### DIFF
--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -437,8 +437,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 		// Add special database related data
 		newCredentialsData.updatedAt = new Date();
 
-		// TODO: also add user automatically depending on who is logged in, if anybody is logged in
-
 		// Save the credentials in DB
 		const findQuery = {
 			id: credentials.id,
@@ -563,7 +561,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 			parameters: {},
 			name: 'Temp-Node',
 			type: nodeType.description.name,
-			// TODO: What it should really do is to get the version from UI
 			typeVersion: Array.isArray(nodeType.description.version)
 				? nodeType.description.version.slice(-1)[0]
 				: nodeType.description.version,

--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -342,6 +342,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 			decryptedDataOriginal as INodeParameters,
 			true,
 			false,
+			null,
 		) as ICredentialDataDecryptedObject;
 
 		if (decryptedDataOriginal.oauthTokenData !== undefined) {
@@ -562,7 +563,10 @@ export class CredentialsHelper extends ICredentialsHelper {
 			parameters: {},
 			name: 'Temp-Node',
 			type: nodeType.description.name,
-			typeVersion: nodeType.description.version,
+			// TODO: What it should really do is to get the version from UI
+			typeVersion: Array.isArray(nodeType.description.version)
+				? nodeType.description.version.slice(-1)[0]
+				: nodeType.description.version,
 			position: [0, 0],
 		};
 

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -1298,6 +1298,7 @@ export async function getCredentials(
 			!NodeHelpers.displayParameter(
 				additionalData.currentNodeParameters || node.parameters,
 				nodeCredentialDescription,
+				node,
 				node.parameters,
 			)
 		) {

--- a/packages/core/test/Helpers.ts
+++ b/packages/core/test/Helpers.ts
@@ -517,6 +517,65 @@ class NodeTypesClass implements INodeTypes {
 				},
 			},
 		},
+		'n8n-nodes-base.versionTest': {
+			sourcePath: '',
+			type: {
+				description: {
+					displayName: 'Version Test',
+					name: 'versionTest',
+					group: ['input'],
+					version: 1,
+					description: 'Tests if versioning works',
+					defaults: {
+						name: 'Version Test',
+						color: '#0000FF',
+					},
+					inputs: ['main'],
+					outputs: ['main'],
+					properties: [
+						{
+							displayName: 'Display V1',
+							name: 'versionTest',
+							type: 'number',
+							displayOptions: {
+								show: {
+									'@version': [1],
+								},
+							},
+							default: 1,
+						},
+						{
+							displayName: 'Display V2',
+							name: 'versionTest',
+							type: 'number',
+							displayOptions: {
+								show: {
+									'@version': [2],
+								},
+							},
+							default: 2,
+						},
+					],
+				},
+				execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+					const items = this.getInputData();
+					const returnData: INodeExecutionData[] = [];
+
+					for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+						const newItem: INodeExecutionData = {
+							json: {
+								versionFromParameter: this.getNodeParameter('versionTest', itemIndex),
+								versionFromNode: this.getNode().typeVersion,
+							},
+						};
+
+						returnData.push(newItem);
+					}
+
+					return this.prepareOutputData(returnData);
+				},
+			},
+		},
 		'n8n-nodes-base.set': {
 			sourcePath: '',
 			type: {

--- a/packages/core/test/WorkflowExecute.test.ts
+++ b/packages/core/test/WorkflowExecute.test.ts
@@ -1169,6 +1169,145 @@ describe('WorkflowExecute', () => {
 					},
 				},
 			},
+
+			{
+				description:
+					'should display the correct parameters and so correct data when simplified node-versioning is used',
+				input: {
+					workflowData: {
+						nodes: [
+							{
+								parameters: {},
+								name: 'Start',
+								type: 'n8n-nodes-base.start',
+								typeVersion: 1,
+								position: [240, 300],
+							},
+							{
+								parameters: {},
+								name: 'VersionTest1a',
+								type: 'n8n-nodes-base.versionTest',
+								typeVersion: 1,
+								position: [460, 300],
+							},
+							{
+								parameters: {
+									versionTest: 11,
+								},
+								name: 'VersionTest1b',
+								type: 'n8n-nodes-base.versionTest',
+								typeVersion: 1,
+								position: [680, 300],
+							},
+							{
+								parameters: {},
+								name: 'VersionTest2a',
+								type: 'n8n-nodes-base.versionTest',
+								typeVersion: 2,
+								position: [880, 300],
+							},
+							{
+								parameters: {
+									versionTest: 22,
+								},
+								name: 'VersionTest2b',
+								type: 'n8n-nodes-base.versionTest',
+								typeVersion: 2,
+								position: [1080, 300],
+							},
+						],
+						connections: {
+							Start: {
+								main: [
+									[
+										{
+											node: 'VersionTest1a',
+											type: 'main',
+											index: 0,
+										},
+									],
+								],
+							},
+							VersionTest1a: {
+								main: [
+									[
+										{
+											node: 'VersionTest1b',
+											type: 'main',
+											index: 0,
+										},
+									],
+								],
+							},
+							VersionTest1b: {
+								main: [
+									[
+										{
+											node: 'VersionTest2a',
+											type: 'main',
+											index: 0,
+										},
+									],
+								],
+							},
+							VersionTest2a: {
+								main: [
+									[
+										{
+											node: 'VersionTest2b',
+											type: 'main',
+											index: 0,
+										},
+									],
+								],
+							},
+						},
+					},
+				},
+				output: {
+					nodeExecutionOrder: [
+						'Start',
+						'VersionTest1a',
+						'VersionTest1b',
+						'VersionTest2a',
+						'VersionTest2b',
+					],
+					nodeData: {
+						VersionTest1a: [
+							[
+								{
+									versionFromNode: 1,
+									versionFromParameter: 1,
+								},
+							],
+						],
+						VersionTest1b: [
+							[
+								{
+									versionFromNode: 1,
+									versionFromParameter: 11,
+								},
+							],
+						],
+						VersionTest2a: [
+							[
+								{
+									versionFromNode: 2,
+									versionFromParameter: 2,
+								},
+							],
+						],
+						VersionTest2b: [
+							[
+								{
+									versionFromNode: 2,
+									versionFromParameter: 22,
+								},
+							],
+						],
+					},
+				},
+			},
 		];
 
 		const fakeLogger = {

--- a/packages/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/editor-ui/src/components/CollectionParameter.vue
@@ -32,6 +32,7 @@
 
 <script lang="ts">
 import {
+	INodeUi,
 	IUpdateInformation,
 } from '@/Interface';
 
@@ -87,6 +88,9 @@ export default mixins(
 					return this.displayNodeParameter(option as INodeProperties);
 				});
 			},
+			node (): INodeUi {
+				return this.$store.getters.activeNode;
+			},
 			// Returns all the options which did not get added already
 			parameterOptions (): Array<INodePropertyOptions | INodeProperties> {
 				return (this.filteredOptions as Array<INodePropertyOptions | INodeProperties>).filter((option) => {
@@ -127,7 +131,7 @@ export default mixins(
 					// If it is not defined no need to do a proper check
 					return true;
 				}
-				return this.displayParameter(this.nodeValues, parameter, this.path);
+				return this.displayParameter(this.nodeValues, parameter, this.path, this.node);
 			},
 			optionSelected (optionName: string) {
 				const options = this.getOptionProperties(optionName);

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -395,6 +395,7 @@ export default mixins(showMessage, nodeHelpers).extend({
 				this.credentialData as INodeParameters,
 				parameter,
 				'',
+				null,
 			);
 		},
 		getCredentialProperties(name: string): INodeProperties[] {
@@ -598,6 +599,7 @@ export default mixins(showMessage, nodeHelpers).extend({
 				this.credentialData as INodeParameters,
 				false,
 				false,
+				null,
 			);
 
 			const credentialDetails: ICredentialsDecrypted = {

--- a/packages/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/editor-ui/src/components/NodeCredentials.vue
@@ -251,7 +251,7 @@ export default mixins(
 				// If it is not defined no need to do a proper check
 				return true;
 			}
-			return this.displayParameter(this.node.parameters, credentialTypeDescription, '');
+			return this.displayParameter(this.node.parameters, credentialTypeDescription, '', this.node);
 		},
 
 		getIssues (credentialTypeName: string): string[] {

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -379,7 +379,7 @@ export default mixins(
 					}
 
 					// Get only the parameters which are different to the defaults
-					let nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false, node.typeVersion);
+					let nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false, node);
 					const oldNodeParameters = Object.assign({}, nodeParameters);
 
 					// Copy the data because it is the data of vuex so make sure that

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -415,7 +415,7 @@ export default mixins(
 
 					// Get the parameters with the now new defaults according to the
 					// from the user actually defined parameters
-					nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, nodeParameters as INodeParameters, true, false, node.typeVersion);
+					nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, nodeParameters as INodeParameters, true, false, node);
 
 					for (const key of Object.keys(nodeParameters as object)) {
 						if (nodeParameters && nodeParameters[key] !== null && nodeParameters[key] !== undefined) {

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -379,7 +379,7 @@ export default mixins(
 					}
 
 					// Get only the parameters which are different to the defaults
-					let nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false);
+					let nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false, node.typeVersion);
 					const oldNodeParameters = Object.assign({}, nodeParameters);
 
 					// Copy the data because it is the data of vuex so make sure that
@@ -415,7 +415,7 @@ export default mixins(
 
 					// Get the parameters with the now new defaults according to the
 					// from the user actually defined parameters
-					nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, nodeParameters as INodeParameters, true, false);
+					nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, nodeParameters as INodeParameters, true, false, node.typeVersion);
 
 					for (const key of Object.keys(nodeParameters as object)) {
 						if (nodeParameters && nodeParameters[key] !== null && nodeParameters[key] !== undefined) {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -468,7 +468,7 @@ export default mixins(
 				const newPath = this.shortPath.split('.');
 				newPath.pop();
 
-				const issues = NodeHelpers.getParameterIssues(this.parameter, this.node.parameters, newPath.join('.'));
+				const issues = NodeHelpers.getParameterIssues(this.parameter, this.node.parameters, newPath.join('.'), this.node);
 
 				if (['options', 'multiOptions'].includes(this.parameter.type) && this.remoteParameterOptionsLoading === false && this.remoteParameterOptionsLoadingIssues === null) {
 					// Check if the value resolves to a valid option

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -89,7 +89,7 @@ import {
 	NodeParameterValue,
 } from 'n8n-workflow';
 
-import { IUpdateInformation } from '@/Interface';
+import { INodeUi, IUpdateInformation } from '@/Interface';
 
 import MultipleParameter from '@/components/MultipleParameter.vue';
 import { genericHelpers } from '@/components/mixins/genericHelpers';
@@ -123,6 +123,9 @@ export default mixins(
 			},
 			filteredParameterNames (): string[] {
 				return this.filteredParameters.map(parameter => parameter.name);
+			},
+			node (): INodeUi {
+				return this.$store.getters.activeNode;
 			},
 		},
 		methods: {
@@ -213,13 +216,13 @@ export default mixins(
 					if (this.path) {
 						rawValues = JSON.parse(JSON.stringify(this.nodeValues));
 						set(rawValues, this.path, nodeValues);
-						return this.displayParameter(rawValues, parameter, this.path);
+						return this.displayParameter(rawValues, parameter, this.path, this.node);
 					} else {
-						return this.displayParameter(nodeValues, parameter, '');
+						return this.displayParameter(nodeValues, parameter, '', this.node);
 					}
 				}
 
-				return this.displayParameter(this.nodeValues, parameter, this.path);
+				return this.displayParameter(this.nodeValues, parameter, this.path, this.node);
 			},
 			valueChanged (parameterData: IUpdateInformation): void {
 				this.$emit('valueChanged', parameterData);

--- a/packages/editor-ui/src/components/mixins/nodeHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/nodeHelpers.ts
@@ -48,8 +48,8 @@ export const nodeHelpers = mixins(
 			},
 
 			// Returns if the given parameter should be displayed or not
-			displayParameter (nodeValues: INodeParameters, parameter: INodeProperties | INodeCredentialDescription, path: string) {
-				return NodeHelpers.displayParameterPath(nodeValues, parameter, path);
+			displayParameter (nodeValues: INodeParameters, parameter: INodeProperties | INodeCredentialDescription, path: string, node: INodeUi | null) {
+				return NodeHelpers.displayParameterPath(nodeValues, parameter, path, node);
 			},
 
 			// Returns all the issues of the node
@@ -200,7 +200,7 @@ export const nodeHelpers = mixins(
 				let selectedCredentials: INodeCredentialsDetails;
 				for (const credentialTypeDescription of nodeType!.credentials!) {
 					// Check if credentials should be displayed else ignore
-					if (this.displayParameter(node.parameters, credentialTypeDescription, '') !== true) {
+					if (this.displayParameter(node.parameters, credentialTypeDescription, '', node) !== true) {
 						continue;
 					}
 

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -323,7 +323,7 @@ export const workflowHelpers = mixins(
 				if (nodeType !== null) {
 					// Node-Type is known so we can save the parameters correctly
 
-					const nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false);
+					const nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, false, false, node);
 					nodeData.parameters = nodeParameters !== null ? nodeParameters : {};
 
 					// Add the node credentials if there are some set and if they should be displayed
@@ -338,7 +338,7 @@ export const workflowHelpers = mixins(
 								continue;
 							}
 
-							if (this.displayParameter(node.parameters, credentialTypeDescription, '') === false) {
+							if (this.displayParameter(node.parameters, credentialTypeDescription, '', node) === false) {
 								// Credential should not be displayed so do also not save
 								continue;
 							}

--- a/packages/editor-ui/src/store.ts
+++ b/packages/editor-ui/src/store.ts
@@ -645,7 +645,7 @@ export const store = new Vuex.Store({
 		},
 
 		updateNodeTypes (state, nodeTypes: INodeTypeDescription[]) {
-			const oldNodesToKeep = state.nodeTypes.filter(node => !nodeTypes.find(n => n.name === node.name && n.version === node.version));
+			const oldNodesToKeep = state.nodeTypes.filter(node => !nodeTypes.find(n => n.name === node.name && n.version.toString() === node.version.toString()));
 			const newNodesState = [...oldNodesToKeep, ...nodeTypes];
 			Vue.set(state, 'nodeTypes', newNodesState);
 			state.nodeTypes = newNodesState;
@@ -852,7 +852,11 @@ export const store = new Vuex.Store({
 
 		nodeType: (state, getters) => (nodeType: string, typeVersion?: number): INodeTypeDescription | null => {
 			const foundType = state.nodeTypes.find(typeData => {
-				return typeData.name === nodeType && typeData.version === (typeVersion || typeData.defaultVersion || DEFAULT_NODETYPE_VERSION);
+				const typeVersion = Array.isArray(typeData.version)
+					? typeData.version
+					: [typeData.version];
+
+				return typeData.name === nodeType && typeVersion.some(versions => [typeVersion, typeData.defaultVersion, DEFAULT_NODETYPE_VERSION].includes(versions));
 			});
 
 			if (foundType === undefined) {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1356,7 +1356,9 @@ export default mixins(
 				const newNodeData: INodeUi = {
 					name: nodeTypeData.defaults.name as string,
 					type: nodeTypeData.name,
-					typeVersion: nodeTypeData.version,
+					typeVersion: Array.isArray(nodeTypeData.version)
+						? nodeTypeData.version.slice(-1)[0]
+						: nodeTypeData.version,
 					position: [0, 0],
 					parameters: {},
 				};
@@ -2445,7 +2447,7 @@ export default mixins(
 					if (nodeType !== null) {
 						let nodeParameters = null;
 						try {
-							nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, true, false);
+							nodeParameters = NodeHelpers.getNodeParameters(nodeType.properties, node.parameters, true, false, node);
 						} catch (e) {
 							console.error(this.$locale.baseText('nodeView.thereWasAProblemLoadingTheNodeParametersOfNode') + `: "${node.name}"`); // eslint-disable-line no-console
 							console.error(e); // eslint-disable-line no-console
@@ -2753,10 +2755,13 @@ export default mixins(
 
 				const nodesToBeFetched:INodeTypeNameVersion[] = [];
 				allNodes.forEach(node => {
-					if(!!nodeInfos.find(n => n.name === node.name && n.version === node.version) && !node.hasOwnProperty('properties')) {
+					const nodeVersions = Array.isArray(node.version) ? node.version : [node.version];
+					if(!!nodeInfos.find(n => n.name === node.name && nodeVersions.includes(n.version)) && !node.hasOwnProperty('properties')) {
 						nodesToBeFetched.push({
 							name: node.name,
-							version: node.version,
+							version: Array.isArray(node.version)
+								? node.version.slice(-1)[0]
+								: node.version,
 						});
 					}
 				});

--- a/packages/nodes-base/nodes/Set/Set.node.ts
+++ b/packages/nodes-base/nodes/Set/Set.node.ts
@@ -15,7 +15,7 @@ export class Set implements INodeType {
 		name: 'set',
 		icon: 'fa:pen',
 		group: ['input'],
-		version: [1, 2],
+		version: 1,
 		description: 'Sets values on items and optionally remove other values',
 		defaults: {
 			name: 'Set',
@@ -24,32 +24,6 @@ export class Set implements INodeType {
 		inputs: ['main'],
 		outputs: ['main'],
 		properties: [
-			{
-				displayName: 'Display V1',
-				name: 'versionTest',
-				type: 'number',
-				displayOptions: {
-					show: {
-						'@version': [
-							1,
-						],
-					},
-				},
-				default: 1,
-			},
-			{
-				displayName: 'Display V2',
-				name: 'versionTest',
-				type: 'number',
-				displayOptions: {
-					show: {
-						'@version': [
-							2,
-						],
-					},
-				},
-				default: 2,
-			},
 			{
 				displayName: 'Keep Only Set',
 				name: 'keepOnlySet',
@@ -212,10 +186,6 @@ export class Set implements INodeType {
 					set(newItem.json, setItem.name as string, setItem.value);
 				}
 			});
-
-
-			newItem.json.versionFromParameter = this.getNodeParameter('versionTest', itemIndex);
-			newItem.json.versionFromNode = this.getNode().typeVersion;
 
 			returnData.push(newItem);
 		}

--- a/packages/nodes-base/nodes/Set/Set.node.ts
+++ b/packages/nodes-base/nodes/Set/Set.node.ts
@@ -213,7 +213,9 @@ export class Set implements INodeType {
 				}
 			});
 
-			newItem.json.versionTest = this.getNodeParameter('versionTest', itemIndex);
+
+			newItem.json.versionFromParameter = this.getNodeParameter('versionTest', itemIndex);
+			newItem.json.versionFromNode = this.getNode().typeVersion;
 
 			returnData.push(newItem);
 		}

--- a/packages/nodes-base/nodes/Set/Set.node.ts
+++ b/packages/nodes-base/nodes/Set/Set.node.ts
@@ -15,7 +15,7 @@ export class Set implements INodeType {
 		name: 'set',
 		icon: 'fa:pen',
 		group: ['input'],
-		version: 1,
+		version: [1, 2],
 		description: 'Sets values on items and optionally remove other values',
 		defaults: {
 			name: 'Set',
@@ -24,6 +24,32 @@ export class Set implements INodeType {
 		inputs: ['main'],
 		outputs: ['main'],
 		properties: [
+			{
+				displayName: 'Display V1',
+				name: 'versionTest',
+				type: 'number',
+				displayOptions: {
+					show: {
+						'@version': [
+							1,
+						],
+					},
+				},
+				default: 1,
+			},
+			{
+				displayName: 'Display V2',
+				name: 'versionTest',
+				type: 'number',
+				displayOptions: {
+					show: {
+						'@version': [
+							2,
+						],
+					},
+				},
+				default: 2,
+			},
 			{
 				displayName: 'Keep Only Set',
 				name: 'keepOnlySet',
@@ -186,6 +212,8 @@ export class Set implements INodeType {
 					set(newItem.json, setItem.name as string, setItem.value);
 				}
 			});
+
+			newItem.json.versionTest = this.getNodeParameter('versionTest', itemIndex);
 
 			returnData.push(newItem);
 		}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1113,7 +1113,7 @@ export interface IRequestOptionsFromParameters {
 }
 
 export interface INodeTypeDescription extends INodeTypeBaseDescription {
-	version: number;
+	version: number | number[];
 	defaults: INodeParameters;
 	eventTriggerDescription?: string;
 	activationMessage?: string;

--- a/packages/workflow/src/RoutingNode.ts
+++ b/packages/workflow/src/RoutingNode.ts
@@ -586,7 +586,14 @@ export class RoutingNode {
 		};
 		let basePath = path ? `${path}.` : '';
 
-		if (!NodeHelpers.displayParameter(this.node.parameters, nodeProperties, this.node.parameters)) {
+		if (
+			!NodeHelpers.displayParameter(
+				this.node.parameters,
+				nodeProperties,
+				this.node,
+				this.node.parameters,
+			)
+		) {
 			return undefined;
 		}
 		if (nodeProperties.routing) {

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -110,6 +110,7 @@ export class Workflow {
 				node.parameters,
 				true,
 				false,
+				node,
 			);
 			node.parameters = nodeParameters !== null ? nodeParameters : {};
 		}

--- a/packages/workflow/test/NodeHelpers.test.ts
+++ b/packages/workflow/test/NodeHelpers.test.ts
@@ -3018,6 +3018,7 @@ describe('Workflow', () => {
 					testData.input.nodeValues,
 					false,
 					false,
+					null,
 				);
 				expect(result).toEqual(testData.output.noneDisplayedFalse.defaultsFalse);
 
@@ -3027,6 +3028,7 @@ describe('Workflow', () => {
 					testData.input.nodeValues,
 					true,
 					false,
+					null,
 				);
 				expect(result).toEqual(testData.output.noneDisplayedFalse.defaultsTrue);
 
@@ -3036,6 +3038,7 @@ describe('Workflow', () => {
 					testData.input.nodeValues,
 					false,
 					true,
+					null,
 				);
 				expect(result).toEqual(testData.output.noneDisplayedTrue.defaultsFalse);
 
@@ -3045,6 +3048,7 @@ describe('Workflow', () => {
 					testData.input.nodeValues,
 					true,
 					true,
+					null,
 				);
 				expect(result).toEqual(testData.output.noneDisplayedTrue.defaultsTrue);
 			});


### PR DESCRIPTION
Allow multiple node-versions in one node to allow small versions simply without much work and code-duplication. 