### PR TITLE
:bug: fix hubspot search operators

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/ContactDescription.ts
@@ -999,11 +999,11 @@ export const contactFields: INodeProperties[] = [
 											},
 											{
 												name: 'Contains Exactly',
-												value: 'CONSTAIN_TOKEN',
+												value: 'CONTAINS_TOKEN',
 											},
 											{
 												name: `Doesn't Contain Exactly`,
-												value: 'NOT_CONSTAIN_TOKEN',
+												value: 'NOT_CONTAINS_TOKEN',
 											},
 										],
 										default: 'EQ',


### PR DESCRIPTION
Hubspot Node Search Operations had a typo in search operator spelling.

Actually a funny typo, but needs to be fixed in order to work properly.