### PR TITLE
:books: Contribution guide steps change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The most important directories:
  - [/packages/cli](/packages/cli) - CLI code to run front- & backend
  - [/packages/core](/packages/core) - Core code which handles workflow
                                       execution, active webhooks and
-                                      workflows. **Contact n8n before 
+                                      workflows. **Contact n8n before
 									  starting on any changes here**
  - [/packages/design-system](/packages/design-system) - Vue frontend components
  - [/packages/editor-ui](/packages/editor-ui) - Vue frontend workflow editor
@@ -99,14 +99,14 @@ checked out and set up:
 	git clone https://github.com/<your_github_username>/n8n.git
 	```
 
-1. Add the original n8n repository as `upstream` to your forked repository
-    ```
-	git remote add upstream https://github.com/n8n-io/n8n.git
-	```
-
 1. Go into repository folder
 	```
 	cd n8n
+	```
+
+1. Add the original n8n repository as `upstream` to your forked repository
+    ```
+	git remote add upstream https://github.com/n8n-io/n8n.git
 	```
 
 1. Install all dependencies of all modules and link them together:


### PR DESCRIPTION
Reason for this Pull Request:
- We can't set Remote Upstream from outside of the forked repository folder.
- So the steps have to be changed.