### PR TITLE
:sparkles: Add Get Telegram Chat Administrators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "n8n",
-	"version": "0.168.2",
+	"version": "0.174.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "n8n",
-			"version": "0.168.2",
+			"version": "0.174.0",
 			"dependencies": {
 				"@babel/core": "^7.14.6",
 				"@fontsource/open-sans": "^4.5.0",

--- a/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftDynamicsOAuth2Api.credentials.ts
@@ -11,7 +11,7 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 	displayName = 'Microsoft Dynamics OAuth2 API';
 	documentationUrl = 'microsoft';
 	properties: INodeProperties[] = [
-		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
+		//	https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
 		{
 			displayName: 'Subdomain',
 			name: 'subdomain',
@@ -20,11 +20,93 @@ export class MicrosoftDynamicsOAuth2Api implements ICredentialType {
 			placeholder: 'organization',
 			default: '',
 		},
+		//	https://docs.microsoft.com/en-us/power-platform/admin/new-datacenter-regions
+		//	https://arunpotti.com/2021/03/15/dynamics-365-crm-online-regions-list/
+		{
+			displayName: 'Region',
+			name: 'region',
+			type: 'options',
+			default: 'crm.dynamics.com',
+			options: [
+				{
+					name: 'Asia Pacific (APAC/ APJ)',
+					value: 'crm5.dynamics.com',
+				},
+				{
+					name: 'Australia (OCE)',
+					value: 'crm6.dynamics.com',
+				},
+				{
+					name: 'Canada (CAN)',
+					value: 'crm3.dynamics.com',
+				},
+				{
+					name: 'China (CHN)',
+					value: 'crm.dynamics.cn',
+				},
+				{
+					name: 'Europe, Middle East, Africa (EMEA/ EUR)',
+					value: 'crm4.dynamics.com',
+				},
+				{
+					name: 'France (FRA)',
+					value: 'crm12.dynamics.com',
+				},
+				{
+					name: 'Germany (GER)',
+					value: 'crm16.dynamics.com',
+				},
+				{
+					name: 'India (IND)',
+					value: 'crm8.dynamics.com',
+				},
+				{
+					name: 'Japan (JPN)',
+					value: 'crm7.dynamics.com',
+				},
+				{
+					name: 'Microsoft Cloud Germany (DEU)',
+					value: 'crm.microsoftdynamics.de',
+				},
+				{
+					name: 'North America (NAM)',
+					value: 'crm.dynamics.com',
+				},
+				{
+					name: 'North America 2 (US Gov GCC)',
+					value: 'crm9.dynamics.com',
+				},
+				{
+					name: 'South Africa (ZAF)',
+					value: 'crm14.dynamics.com',
+				},
+				{
+					name: 'South America (LATAM/ SAM)',
+					value: 'crm2.dynamics.com',
+				},
+				{
+					name: 'Switzerland (CHE)',
+					value: 'crm17.dynamics.com',
+				},
+				{
+					name: 'United Arab Emirates (UAE)',
+					value: 'crm15.dynamics.com',
+				},
+				{
+					name: 'United Kingdom  (UK/ GBR)',
+					value: 'crm11.dynamics.com',
+				},
+				{
+					name: 'United States Government Community Cloud (GCC High)',
+					value: 'crm.microsoftdynamics.us',
+				},
+			],
+		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '=openid offline_access https://{{$self.subdomain}}.crm.dynamics.com/.default',
+			default: '=openid offline_access https://{{$self.subdomain}}.{{$self.region}}/.default',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -16,7 +16,7 @@ import {
 } from 'n8n-workflow';
 
 export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions, method: string, resource: string, body: any = {}, qs: IDataObject = {}, uri?: string, option: IDataObject = {}): Promise<any> { // tslint:disable-line:no-any
-	const credenitals = await this.getCredentials('microsoftDynamicsOAuth2Api') as { subdomain: string };
+	const credentials = await this.getCredentials('microsoftDynamicsOAuth2Api') as { subdomain: string, region: string };
 
 	let options: OptionsWithUri = {
 		headers: {
@@ -27,7 +27,7 @@ export async function microsoftApiRequest(this: IExecuteFunctions | IExecuteSing
 		method,
 		body,
 		qs,
-		uri: uri || `https://${credenitals.subdomain}.crm.dynamics.com/api/data/v9.2${resource}`,
+		uri: uri || `https://${credentials.subdomain}.${credentials.region}/api/data/v9.2${resource}`,
 		json: true,
 	};
 

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -126,14 +126,14 @@ export class Telegram implements INodeType {
 						description: 'Get the Administrators of a chat.',
 					},
 					{
+						name: 'Get Member',
+						value: 'member',
+						description: 'Get the member of a chat.',
+					},
+					{
 						name: 'Leave',
 						value: 'leave',
 						description: 'Leave a group, supergroup or channel.',
-					},
-					{
-						name: 'Member',
-						value: 'member',
-						description: 'Get the member of a chat.',
 					},
 					{
 						name: 'Set Description',
@@ -2222,6 +2222,9 @@ export class Telegram implements INodeType {
 						});
 						continue;
 					}
+				} else if (resource === 'chat' && operation === 'administrators') {
+					returnData.push(...this.helpers.returnJsonArray(responseData.result));
+					continue;
 				}
 
 				// if (resource === 'bot' && operation === 'info') {

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -121,6 +121,11 @@ export class Telegram implements INodeType {
 						description: 'Get up to date information about a chat.',
 					},
 					{
+						name: 'Get Administrators',
+						value: 'administrators',
+						description: 'Get the Administrators of a chat.',
+					},
+					{
 						name: 'Leave',
 						value: 'leave',
 						description: 'Leave a group, supergroup or channel.',
@@ -293,6 +298,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						operation: [
+							'administrators',
 							'deleteMessage',
 							'get',
 							'leave',
@@ -1906,6 +1912,15 @@ export class Telegram implements INodeType {
 						// ----------------------------------
 
 						endpoint = 'getChat';
+
+						body.chat_id = this.getNodeParameter('chatId', i) as string;
+
+					} else if (operation === 'administrators') {
+						// ----------------------------------
+						//         chat:administrators
+						// ----------------------------------
+
+						endpoint = 'getChatAdministrators';
 
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
 


### PR DESCRIPTION
### Why this PR?
This feature allows us to get the list of Administrators in the Chat

As Requested in: https://community.n8n.io/t/is-it-possible-to-scrape-telegram-group-admins-with-the-telegram-node/13090/3

### Expected Output:
Returns list of administrators in the chat

![getadmins](https://user-images.githubusercontent.com/8493007/166101721-e11d82b5-7c5e-4191-8ccc-bcfb35b9aafb.png)

