### PR TITLE
fix(Wise Node): Respect time parameter on get: exchangeRate

### DIFF
--- a/packages/nodes-base/nodes/Wise/Wise.node.ts
+++ b/packages/nodes-base/nodes/Wise/Wise.node.ts
@@ -281,7 +281,7 @@ export class Wise implements INodeType {
 						if (range !== undefined && time === undefined) {
 							qs.from = moment.tz(range.rangeProperties.from, timezone).utc().format();
 							qs.to = moment.tz(range.rangeProperties.to, timezone).utc().format();
-						} else {
+						} else if (time === undefined) {
 							qs.from = moment().subtract(1, 'months').utc().format();
 							qs.to = moment().format();
 						}


### PR DESCRIPTION
User Report: [Community](https://community.n8n.io/t/get-current-exchange-rate-with-wise/13592?u=mutedjam).
Notion: https://www.notion.so/n8n/Wise-time-parameter-has-no-effect-on-get-exchangeRate-b54e2d12b7e1433ba7367521d0146bbc

When fetching exchange rates, the wise node currently adds the `from` and `to` query parameters which take precedence over the `time` parameter (meaning `time` is ignored).

This PR sets `from` and `to` only if `time` is not set.