### PR TITLE
Fix notice warning missing background color

### DIFF
--- a/packages/design-system/theme/src/_tokens.scss
+++ b/packages/design-system/theme/src/_tokens.scss
@@ -120,7 +120,7 @@
 		var(--color-warning-tint-1-l)
 	);
 
-	--color-warning-tint-2-h: 34%;
+	--color-warning-tint-2-h: 34;
 	--color-warning-tint-2-s: 80%;
 	--color-warning-tint-2-l: 96%;
 	--color-warning-tint-2: hsl(


### PR DESCRIPTION
<img width="364" alt="image" src="https://user-images.githubusercontent.com/44588767/166457606-4861d0c2-ec36-4701-adab-66b28274d4c1.png">
<img width="384" alt="image" src="https://user-images.githubusercontent.com/44588767/166457755-4107d987-5273-4005-afaa-1b05c8ecbc0d.png">
