### PR TITLE
Fix executions list filtering by waiting status

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -2269,7 +2269,7 @@ class App {
 						let filterToAdd = {};
 
 						if (key === 'waitTill') {
-							filterToAdd = { waitTill: !IsNull() };
+							filterToAdd = { waitTill: Not(IsNull()) };
 						} else if (key === 'finished' && value === false) {
 							filterToAdd = { finished: false, waitTill: IsNull() };
 						} else {


### PR DESCRIPTION
Community issues:
https://community.n8n.io/t/workflow-executions-filtering-by-waiting-status-displays-empty-results/13136
https://community.n8n.io/t/bug-report-filter-for-waiting-in-executions-not-working/12210?u=mutedjam