### PR TITLE
support for customer.io tracking api endpoint region selection

### DIFF
--- a/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
+++ b/packages/nodes-base/credentials/CustomerIoApi.credentials.ts
@@ -18,6 +18,24 @@ export class CustomerIoApi implements ICredentialType {
 			required: true,
 		},
 		{
+			displayName: 'Tracking API endpoint',
+			name: 'trackingEndpoint',
+			type: 'options',
+			options: [
+				{
+					name: 'EU region',
+					value: 'track-eu.customer.io',
+				},
+				{
+					name: 'Global region',
+					value: 'track.customer.io',
+				},
+			],
+			default: 'track.customer.io',
+			description: 'Should be set based on your account region',
+			required: true,
+		},
+		{
 			displayName: 'Tracking Site ID',
 			name: 'trackingSiteId',
 			type: 'string',

--- a/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
@@ -32,7 +32,7 @@ export async function customerIoApiRequest(this: IHookFunctions | IExecuteFuncti
 	};
 
 	if (baseApi === 'tracking') {
-		options.uri = `https://track.customer.io/api/v1${endpoint}`;
+		options.uri = `https://${credentials.trackingEndpoint}/api/v1${endpoint}`;
 		const basicAuthKey = Buffer.from(`${credentials.trackingSiteId}:${credentials.trackingApiKey}`).toString('base64');
 		Object.assign(options.headers, { 'Authorization': `Basic ${basicAuthKey}` });
 	} else if (baseApi === 'api') {


### PR DESCRIPTION
If your account is based in our EU region use the EU endpoints (track-eu.customer.io) for US (other than EU) tracking endpoints (track.customer.io).