### PR TITLE
fix(Edit Image Node): Make node work with binary-data-mode 'filesystem'

### DIFF
--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -1383,7 +1383,10 @@ export class EditImage implements INodeType {
 								return reject(error);
 							}
 
-							newItem.binary![dataPropertyName as string].data = (await this.helpers.prepareBinaryData(Buffer.from(buffer))).data;
+							const binaryData = await this.helpers.prepareBinaryData(Buffer.from(buffer));
+							newItem.binary![dataPropertyName as string] = {
+								...newItem.binary![dataPropertyName as string], ...binaryData
+							}
 
 							return resolve(newItem);
 						});


### PR DESCRIPTION
Fixes the bug that the Edit Image node did not work if `N8N_DEFAULT_BINARY_DATA_MODE=filesystem` is set.

https://community.n8n.io/t/edit-image-node-with-n8n-default-binary-data-mode-filesystem-some-operations-not-working/13828