### PR TITLE
fix(Edit Image Node): Fix font selection

### DIFF
--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -22,7 +22,7 @@ import {
 } from 'fs';
 import { promisify } from 'util';
 const fsWriteFileAsync = promisify(fsWriteFile);
-import getSystemFonts from 'get-system-fonts'
+import getSystemFonts from 'get-system-fonts';
 
 
 const nodeOperations: INodePropertyOptions[] = [

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -22,7 +22,7 @@ import {
 } from 'fs';
 import { promisify } from 'util';
 const fsWriteFileAsync = promisify(fsWriteFile);
-import * as getSystemFonts from 'get-system-fonts';
+import getSystemFonts from 'get-system-fonts'
 
 
 const nodeOperations: INodePropertyOptions[] = [


### PR DESCRIPTION
Community issue:
https://community.n8n.io/t/font-error-getsystemfonts-in-the-edit-image-node/13923