### PR TITLE
use `state` instead of `cid` for oauth1 callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "n8n",
-	"version": "0.176.0",
+	"version": "0.177.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "n8n",
-			"version": "0.176.0",
+			"version": "0.177.0",
 			"dependencies": {
 				"@babel/core": "^7.14.6",
 				"@fontsource/open-sans": "^4.5.0",

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1746,7 +1746,7 @@ class App {
 				const oauthRequestData = {
 					oauth_callback: `${WebhookHelpers.getWebhookBaseUrl()}${
 						this.restEndpoint
-					}/oauth1-credential/callback?cid=${credentialId}`,
+					}/oauth1-credential/callback?state=${credentialId}`,
 				};
 
 				await this.externalHooks.run('oauth1.authenticate', [oAuthOptions, oauthRequestData]);
@@ -1805,7 +1805,7 @@ class App {
 			`/${this.restEndpoint}/oauth1-credential/callback`,
 			async (req: OAuthRequest.OAuth1Credential.Callback, res: express.Response) => {
 				try {
-					const { oauth_verifier, oauth_token, cid: credentialId } = req.query;
+					const { oauth_verifier, oauth_token, state: credentialId } = req.query;
 
 					if (!oauth_verifier || !oauth_token) {
 						const errorResponse = new ResponseHelper.ResponseError(
@@ -1916,7 +1916,7 @@ class App {
 				} catch (error) {
 					LoggerProxy.error('OAuth1 callback failed because of insufficient user permissions', {
 						userId: req.user?.id,
-						credentialId: req.query.cid,
+						credentialId: req.query.state,
 					});
 					// Error response
 					return ResponseHelper.sendErrorResponse(res, error);

--- a/packages/cli/src/requests.d.ts
+++ b/packages/cli/src/requests.d.ts
@@ -236,7 +236,7 @@ export declare namespace OAuthRequest {
 			{},
 			{},
 			{},
-			{ oauth_verifier: string; oauth_token: string; cid: string }
+			{ oauth_verifier: string; oauth_token: string; state: string }
 		> & {
 			user?: User;
 		};


### PR DESCRIPTION
Currently twitter oauth1.0a could not be authenticated, the error is:

    OAuth1 callback failed because of insufficient user permissions

By investigating the code, I found that when /oauth1-credential/callback
is called, `const credential = await getCredentialWithoutUser(credentialId)`
failed because `creadentialId` from `req.query.cid` is nil.

This is because twitter api only allowes `state` parameter to be passed
round-trip, others like `cid` is ignored, which we passed eariler in
/oauth1-credential/auth handler. (Google does the same, AFAIK)

> If you wish to include request-specific data in the callback URL, you can use the state parameter to store data that will be included after the user is redirected. It can either encode the data in the state parameter itself or use the parameter as a session ID to store the state on the server.
>
> https://developer.twitter.com/en/docs/apps/callback-urls

In this PR, I simply changed the parameter name from `cid` to `state`
and tested that it can fix this issue.

Though `state` could be a JSON string to hold more data, it's currently
OK to just be the value of `credentialId`, if we need to add more
values, we can change `state` to JSON like what has been implemented in
/oauth2-credential.