### PR TITLE
N8N-2962 prevent expressions XSS

### DIFF
--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -118,6 +118,21 @@ export class Expression {
 
 		// @ts-ignore
 		data.document = {};
+		data.global = {};
+		data.window = {};
+		data.Window = {};
+		data.this = {};
+		data.alert = {};
+
+		// Prevent Remote Code Execution
+		data.eval = {};
+		data.setTimeout = {};
+		data.setInterval = {};
+		data.Function = {};
+
+		// Prevent requests
+		data.fetch = {};
+		data.XMLHttpRequest = {};
 
 		// @ts-ignore
 		data.DateTime = DateTime;
@@ -129,8 +144,18 @@ export class Expression {
 
 		// Execute the expression
 		try {
+			if (
+				parameterValue.includes('window') &&
+				!/([a-zA-Z.]window|window[a-zA-Z]|['"](?!\s*[\\+\-*/|]+\s*)[^'"]*window)/g.test(
+					parameterValue,
+				)
+			) {
+				throw new Error(`window is not allowed`);
+			}
+
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			const returnValue = tmpl.tmpl(parameterValue, data);
+
 			if (typeof returnValue === 'function') {
 				throw new Error('Expression resolved to a function. Please add "()"');
 			} else if (returnValue !== null && typeof returnValue === 'object') {
@@ -368,6 +393,7 @@ export class Expression {
 		if (parameterValue === null || parameterValue === undefined) {
 			return parameterValue;
 		}
+
 		// Data is an object
 		const returnData: INodeParameters = {};
 		// eslint-disable-next-line no-restricted-syntax
@@ -381,6 +407,7 @@ export class Expression {
 		if (returnObjectAsString && typeof returnData === 'object') {
 			return this.convertObjectValueToString(returnData);
 		}
+
 		return returnData;
 	}
 }

--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -122,7 +122,12 @@ export class Expression {
 		data.window = {};
 		data.Window = {};
 		data.this = {};
+		data.self = {};
+
+		// Alerts
 		data.alert = {};
+		data.prompt = {};
+		data.confirm = {};
 
 		// Prevent Remote Code Execution
 		data.eval = {};
@@ -144,12 +149,7 @@ export class Expression {
 
 		// Execute the expression
 		try {
-			if (
-				parameterValue.includes('window') &&
-				!/([a-zA-Z.]window|window[a-zA-Z]|['"](?!\s*[\\+\-*/|]+\s*)[^'"]*window)/g.test(
-					parameterValue,
-				)
-			) {
+			if (/([^a-zA-Z0-9"']window[^a-zA-Z0-9"'])/g.test(parameterValue)) {
 				throw new Error(`window is not allowed`);
 			}
 


### PR DESCRIPTION
- Added data overrides for global accessors
- Added data overrides for native functions that allow Remote Code Execution
- Added check for direct window object access (should pass if inside a string and not being workaround using operations)

The regular expression should basically not allow the use of `window`  except when you use
- `somethingwindow`
- `windowSomething`
- `'window'`
- `"window"`
- `something.window`

But it should not allow
- `'' + window`
- `"" + window`
- `'' || window`
- `'' && window`