### PR TITLE
 🐛 Fixing conflicting hover states between sticky button and node view.

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -408,7 +408,6 @@ export default mixins(
 				const buttonsWrapper = mouseinEvent.target as Element;
 
 				// Once the popup menu is hovered, it's pointer events are disabled so it's not interfering with element underneath it.
-				// This listener is then used to detect when the cursor leaves so it can be hidden and mouse events re-enabled.
 				this.showStickyButton = true;
 				const moveCallback = (mousemoveEvent: MouseEvent) => {
 					if(buttonsWrapper) {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -60,12 +60,20 @@
 		</div>
 		<NodeDetailsView :renaming="renamingActive" @valueChanged="valueChanged"/>
 		<div
-			class="node-buttons-wrapper"
+			:class="['node-buttons-wrapper', showCreateMenu ? 'no-events' : '']"
 			v-if="!createNodeActive && !isReadOnly"
+			@mouseenter="onCreateMenuHoverIn"
 		>
-			<div class="node-creator-button">
-				<n8n-icon-button size="xlarge" icon="plus" @click="() => openNodeCreator('add_node_button')" :title="$locale.baseText('nodeView.addNode')"/>
-				<div class="add-sticky-button" @click="nodeTypeSelected(STICKY_NODE_TYPE)">
+			<div class="node-creator-button visible-button">
+				<n8n-icon-button
+					size="xlarge"
+					icon="plus"
+					@click="() => openNodeCreator('add_node_button')" :title="$locale.baseText('nodeView.addNode')"
+				/>
+				<div
+					:class="['add-sticky-button', showCreateMenu ? 'visible-button' : '']"
+					@click="nodeTypeSelected(STICKY_NODE_TYPE)"
+				>
 					<n8n-icon-button size="large" :icon="['far', 'note-sticky']" type="outline" :title="$locale.baseText('nodeView.addSticky')"/>
 				</div>
 			</div>
@@ -385,6 +393,7 @@ export default mixins(
 				pullConnActive: false,
 				dropPrevented: false,
 				renamingActive: false,
+				showCreateMenu: false,
 			};
 		},
 		beforeDestroy () {
@@ -395,6 +404,32 @@ export default mixins(
 			document.removeEventListener('keyup', this.keyUp);
 		},
 		methods: {
+			onCreateMenuHoverIn() {
+				const vm = this;
+				// When `Create` menu hover area is hovered, show the menu
+				// and start listening for mousemove to know when mouse leaves it.
+				// This listener is necessary since pointer events are disabled on the
+				// hover area while menu is shown so it's not interrupting mouse events in the node view.
+				vm.showCreateMenu = true;
+				const moveCallback = (event: MouseEvent) => {
+					const buttonsWrapper = document.querySelector('.node-buttons-wrapper');
+					if(buttonsWrapper) {
+						const elementH = buttonsWrapper.getBoundingClientRect().height;
+						const elementW = buttonsWrapper.getBoundingClientRect().width;
+						const elementLeftNear = buttonsWrapper.getBoundingClientRect().left;
+						const elementLeftFar = elementLeftNear + elementW;
+						const elementTopNear = buttonsWrapper.getBoundingClientRect().top;
+						const elementTopFar = elementTopNear + elementH;
+						const inside = ((event.pageX > elementLeftNear && event.pageX < elementLeftFar) && (event.pageY > elementTopNear && event.pageY < elementTopFar));
+						if(!inside) {
+							// Once the mouse leaves hover area, hide menu and remove listener
+							vm.showCreateMenu = false;
+							document.removeEventListener('mousemove', moveCallback, false);
+						}
+					}
+				};
+				document.addEventListener('mousemove', moveCallback, false);
+			},
 			clearExecutionData () {
 				this.$store.commit('setWorkflowExecutionData', null);
 				this.updateNodesExecutionIssues();
@@ -2937,6 +2972,10 @@ export default mixins(
 	bottom: 10px;
 }
 
+.no-events {
+	pointer-events: none;
+}
+
 .node-buttons-wrapper {
 	position: fixed;
 	width: 150px;
@@ -2952,10 +2991,9 @@ export default mixins(
 		transition-timing-function: linear;
 	}
 
-	&:hover {
-		.add-sticky-button {
-			opacity: 1;
-		}
+	.visible-button {
+		opacity: 1;
+		pointer-events: all;
 	}
 }
 


### PR DESCRIPTION
This is the new version of #3292 

The fix is implemented in the following way:

1. When mouse enters the hover area of the Add Sticky Note button, pointer events are disabled for the hover area so it's not conflicting with node view,
2. At the same time, mousemove listener is attached to the document which checks when mouse leaves the hover area when pointer events are turned on again and button is hidden which starts the process over.

It's pretty rough but I want to get an initial feedback.
