### PR TITLE
N8N-3748 route permissions rework

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -575,6 +575,7 @@ export interface IPermissionGroup {
 	loginStatus?: ILogInStatus[];
 	role?: IRole[];
 	um?: boolean;
+	custom?: () => boolean;
 }
 
 export interface IPermissions {
@@ -916,6 +917,7 @@ export interface IWorkflowsState {
 }
 
 export interface ICommunityNodesState {
+	featureAvailable: boolean;
 	availablePackageCount: number;
 }
 

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -574,12 +574,19 @@ export interface IUserManagementConfig {
 export interface IPermissionGroup {
 	loginStatus?: ILogInStatus[];
 	role?: IRole[];
-	custom?: () => boolean;
+}
+
+export interface IPermissionAllowGroup extends IPermissionGroup {
+	shouldAllow?: () => boolean;
+}
+
+export interface IPermissionDenyGroup extends IPermissionGroup {
+	shouldDeny?: () => boolean;
 }
 
 export interface IPermissions {
-	allow?: IPermissionGroup;
-	deny?: IPermissionGroup;
+	allow?: IPermissionAllowGroup;
+	deny?: IPermissionDenyGroup;
 }
 
 export interface IUserPermissions {
@@ -879,6 +886,7 @@ export interface ISettingsState {
 	promptsData: IN8nPrompts;
 	userManagement: IUserManagementConfig;
 	templatesEndpointHealthy: boolean;
+	communityNodesFeatureEnabled: boolean;
 }
 
 export interface ITemplateState {
@@ -916,7 +924,6 @@ export interface IWorkflowsState {
 }
 
 export interface ICommunityNodesState {
-	featureAvailable: boolean;
 	availablePackageCount: number;
 }
 

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -574,7 +574,6 @@ export interface IUserManagementConfig {
 export interface IPermissionGroup {
 	loginStatus?: ILogInStatus[];
 	role?: IRole[];
-	um?: boolean;
 	custom?: () => boolean;
 }
 

--- a/packages/editor-ui/src/components/mixins/userHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/userHelpers.ts
@@ -18,9 +18,8 @@ export const userHelpers = Vue.extend({
 		canUserAccessRoute(route: Route): boolean {
 			const permissions: IPermissions = route.meta && route.meta.permissions;
 			const currentUser = this.$store.getters['users/currentUser'];
-			const isUMEnabled = this.$store.getters['settings/isUserManagementEnabled'];
 
-			if (permissions && isAuthorized(permissions, { currentUser, isUMEnabled })) {
+			if (permissions && isAuthorized(permissions, currentUser)) {
 				return true;
 			}
 			return false;

--- a/packages/editor-ui/src/modules/communityNodes.ts
+++ b/packages/editor-ui/src/modules/communityNodes.ts
@@ -6,14 +6,21 @@ import { ActionContext, Module } from 'vuex';
 const module: Module<ICommunityNodesState, IRootState> = {
 	namespaced: true,
 	state: {
+		featureAvailable: true,
 		availablePackageCount: 0,
 	},
 	mutations: {
+		setFeatureAvailable: (state: ICommunityNodesState, isAvailable: boolean) => {
+			state.featureAvailable = isAvailable;
+		},
 		setPackageCount: (state: ICommunityNodesState, count: number) => {
 			state.availablePackageCount = count;
 		},
 	},
 	getters: {
+		isFeatureAvailable(state: ICommunityNodesState): boolean {
+			return state.featureAvailable;
+		},
 		packageCount(state: ICommunityNodesState): number {
 			return state.availablePackageCount;
 		},

--- a/packages/editor-ui/src/modules/communityNodes.ts
+++ b/packages/editor-ui/src/modules/communityNodes.ts
@@ -6,21 +6,14 @@ import { ActionContext, Module } from 'vuex';
 const module: Module<ICommunityNodesState, IRootState> = {
 	namespaced: true,
 	state: {
-		featureAvailable: true,
 		availablePackageCount: 0,
 	},
 	mutations: {
-		setFeatureAvailable: (state: ICommunityNodesState, isAvailable: boolean) => {
-			state.featureAvailable = isAvailable;
-		},
 		setPackageCount: (state: ICommunityNodesState, count: number) => {
 			state.availablePackageCount = count;
 		},
 	},
 	getters: {
-		isFeatureAvailable(state: ICommunityNodesState): boolean {
-			return state.featureAvailable;
-		},
 		packageCount(state: ICommunityNodesState): number {
 			return state.availablePackageCount;
 		},

--- a/packages/editor-ui/src/modules/settings.ts
+++ b/packages/editor-ui/src/modules/settings.ts
@@ -24,6 +24,7 @@ const module: Module<ISettingsState, IRootState> = {
 			smtpSetup: false,
 		},
 		templatesEndpointHealthy: false,
+		communityNodesFeatureEnabled: true,
 	},
 	getters: {
 		versionCli(state: ISettingsState) {
@@ -71,6 +72,9 @@ const module: Module<ISettingsState, IRootState> = {
 		executionMode: (state): string => {
 			return state.settings.executionMode;
 		},
+		isCommunityNodesFeatureEnabled: (state): boolean => {
+			return state.communityNodesFeatureEnabled;
+		},
 	},
 	mutations: {
 		setSettings(state: ISettingsState, settings: IN8nUISettings) {
@@ -87,6 +91,9 @@ const module: Module<ISettingsState, IRootState> = {
 		},
 		setTemplatesEndpointHealthy(state: ISettingsState) {
 			state.templatesEndpointHealthy = true;
+		},
+		setCommunityNodesFeatureEnabled(state: ISettingsState, isEnabled: boolean) {
+			state.communityNodesFeatureEnabled = isEnabled;
 		},
 	},
 	actions: {

--- a/packages/editor-ui/src/modules/userHelpers.ts
+++ b/packages/editor-ui/src/modules/userHelpers.ts
@@ -45,6 +45,10 @@ export const PERMISSIONS: IUserPermissions = {
 export const isAuthorized = (permissions: IPermissions, {currentUser, isUMEnabled}: {currentUser: IUser | null, isUMEnabled: boolean}): boolean => {
 	const loginStatus = currentUser ? LOGIN_STATUS.LoggedIn : LOGIN_STATUS.LoggedOut;
 	if (permissions.deny) {
+		if(permissions.deny.custom) {
+			return !permissions.deny.custom();
+		}
+
 		if (permissions.deny.um === isUMEnabled) {
 			return false;
 		}
@@ -65,6 +69,10 @@ export const isAuthorized = (permissions: IPermissions, {currentUser, isUMEnable
 	}
 
 	if (permissions.allow) {
+		if(permissions.allow.custom) {
+			return permissions.allow.custom();
+		}
+
 		if (permissions.allow.um === isUMEnabled) {
 			return true;
 		}

--- a/packages/editor-ui/src/modules/userHelpers.ts
+++ b/packages/editor-ui/src/modules/userHelpers.ts
@@ -42,11 +42,20 @@ export const PERMISSIONS: IUserPermissions = {
 	},
 };
 
+/**
+ * To be authorized, user must pass all deny rules and pass any of the allow rules.
+ *
+ * @param permissions
+ * @param currentUser
+ * @returns
+ */
 export const isAuthorized = (permissions: IPermissions, currentUser: IUser | null): boolean => {
 	const loginStatus = currentUser ? LOGIN_STATUS.LoggedIn : LOGIN_STATUS.LoggedOut;
+	// big AND block
+	// if any of these are false, block user
 	if (permissions.deny) {
-		if(permissions.deny.custom) {
-			return !permissions.deny.custom();
+		if (permissions.deny.shouldDeny && permissions.deny.shouldDeny()) {
+			return false;
 		}
 
 		if (permissions.deny.loginStatus && permissions.deny.loginStatus.includes(loginStatus)) {
@@ -54,7 +63,7 @@ export const isAuthorized = (permissions: IPermissions, currentUser: IUser | nul
 		}
 
 		if (currentUser && currentUser.globalRole) {
-			const role = currentUser.isDefaultUser ? ROLE.Default: currentUser.globalRole.name;
+			const role = currentUser.isDefaultUser ? ROLE.Default : currentUser.globalRole.name;
 			if (permissions.deny.role && permissions.deny.role.includes(role)) {
 				return false;
 			}
@@ -64,9 +73,11 @@ export const isAuthorized = (permissions: IPermissions, currentUser: IUser | nul
 		}
 	}
 
+	// big OR block
+	// if any of these are true, allow user
 	if (permissions.allow) {
-		if(permissions.allow.custom) {
-			return permissions.allow.custom();
+		if (permissions.allow.shouldAllow && permissions.allow.shouldAllow()) {
+			return true;
 		}
 
 		if (permissions.allow.loginStatus && permissions.allow.loginStatus.includes(loginStatus)) {
@@ -74,7 +85,7 @@ export const isAuthorized = (permissions: IPermissions, currentUser: IUser | nul
 		}
 
 		if (currentUser && currentUser.globalRole) {
-			const role = currentUser.isDefaultUser ? ROLE.Default: currentUser.globalRole.name;
+			const role = currentUser.isDefaultUser ? ROLE.Default : currentUser.globalRole.name;
 			if (permissions.allow.role && permissions.allow.role.includes(role)) {
 				return true;
 			}

--- a/packages/editor-ui/src/modules/userHelpers.ts
+++ b/packages/editor-ui/src/modules/userHelpers.ts
@@ -42,15 +42,11 @@ export const PERMISSIONS: IUserPermissions = {
 	},
 };
 
-export const isAuthorized = (permissions: IPermissions, {currentUser, isUMEnabled}: {currentUser: IUser | null, isUMEnabled: boolean}): boolean => {
+export const isAuthorized = (permissions: IPermissions, currentUser: IUser | null): boolean => {
 	const loginStatus = currentUser ? LOGIN_STATUS.LoggedIn : LOGIN_STATUS.LoggedOut;
 	if (permissions.deny) {
 		if(permissions.deny.custom) {
 			return !permissions.deny.custom();
-		}
-
-		if (permissions.deny.um === isUMEnabled) {
-			return false;
 		}
 
 		if (permissions.deny.loginStatus && permissions.deny.loginStatus.includes(loginStatus)) {
@@ -71,10 +67,6 @@ export const isAuthorized = (permissions: IPermissions, {currentUser, isUMEnable
 	if (permissions.allow) {
 		if(permissions.allow.custom) {
 			return permissions.allow.custom();
-		}
-
-		if (permissions.allow.um === isUMEnabled) {
-			return true;
 		}
 
 		if (permissions.allow.loginStatus && permissions.allow.loginStatus.includes(loginStatus)) {

--- a/packages/editor-ui/src/modules/users.ts
+++ b/packages/editor-ui/src/modules/users.ts
@@ -98,21 +98,18 @@ const module: Module<IUsersState, IRootState> = {
 		},
 		canUserDeleteTags(state: IUsersState, getters: any, rootState: IRootState, rootGetters: any) { // tslint:disable-line:no-any
 			const currentUser = getters.currentUser;
-			const isUMEnabled = rootGetters['settings/isUserManagementEnabled'];
 
-			return isAuthorized(PERMISSIONS.TAGS.CAN_DELETE_TAGS, { currentUser, isUMEnabled });
+			return isAuthorized(PERMISSIONS.TAGS.CAN_DELETE_TAGS, currentUser);
 		},
 		canUserAccessSidebarUserInfo(state: IUsersState, getters: any, rootState: IRootState, rootGetters: any) { // tslint:disable-line:no-any
 			const currentUser = getters.currentUser;
-			const isUMEnabled = rootGetters['settings/isUserManagementEnabled'];
 
-			return isAuthorized(PERMISSIONS.PRIMARY_MENU.CAN_ACCESS_USER_INFO, { currentUser, isUMEnabled });
+			return isAuthorized(PERMISSIONS.PRIMARY_MENU.CAN_ACCESS_USER_INFO, currentUser);
 		},
 		showUMSetupWarning(state: IUsersState, getters: any, rootState: IRootState, rootGetters: any) { // tslint:disable-line:no-any
 			const currentUser = getters.currentUser;
-			const isUMEnabled = rootGetters['settings/isUserManagementEnabled'];
 
-			return isAuthorized(PERMISSIONS.USER_SETTINGS.VIEW_UM_SETUP_WARNING, { currentUser, isUMEnabled });
+			return isAuthorized(PERMISSIONS.USER_SETTINGS.VIEW_UM_SETUP_WARNING, currentUser);
 		},
 		personalizedNodeTypes(state: IUsersState, getters: any): string[] { // tslint:disable-line:no-any
 			const user = getters.currentUser as IUser | null;

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -22,6 +22,7 @@ import { IPermissions, IRootState } from './Interface';
 import { LOGIN_STATUS, ROLE } from './modules/userHelpers';
 import { RouteConfigSingleView } from 'vue-router/types/router';
 import { VIEWS } from './constants';
+import { store } from './store';
 
 Vue.use(Router);
 
@@ -368,6 +369,11 @@ const router = new Router({
 				permissions: {
 					allow: {
 						role: [ROLE.Default, ROLE.Owner],
+					},
+					deny: {
+						custom: () => {
+							return store.getters['communityNodes/isFeatureAvailable'] === false;
+						},
 					},
 				},
 			},

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -273,7 +273,9 @@ const router = new Router({
 						role: [ROLE.Default],
 					},
 					deny: {
-						um: false,
+						custom: () => {
+							return store.getters['settings/isUserManagementEnabled'] === false;
+						},
 					},
 				},
 			},
@@ -331,7 +333,9 @@ const router = new Router({
 						role: [ROLE.Default, ROLE.Owner],
 					},
 					deny: {
-						um: false,
+						custom: () => {
+							return store.getters['settings/isUserManagementEnabled'] === false;
+						},
 					},
 				},
 			},

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -273,7 +273,7 @@ const router = new Router({
 						role: [ROLE.Default],
 					},
 					deny: {
-						custom: () => {
+						shouldDeny: () => {
 							return store.getters['settings/isUserManagementEnabled'] === false;
 						},
 					},
@@ -333,7 +333,7 @@ const router = new Router({
 						role: [ROLE.Default, ROLE.Owner],
 					},
 					deny: {
-						custom: () => {
+						shouldDeny: () => {
 							return store.getters['settings/isUserManagementEnabled'] === false;
 						},
 					},
@@ -375,8 +375,8 @@ const router = new Router({
 						role: [ROLE.Default, ROLE.Owner],
 					},
 					deny: {
-						custom: () => {
-							return store.getters['communityNodes/isFeatureAvailable'] === false;
+						shouldDeny: () => {
+							return store.getters['settings/isCommunityNodesFeatureEnabled'] === false;
 						},
 					},
 				},


### PR DESCRIPTION
Closes N8N-3748

This PR introduces following changes:
1. Added new property, `custom`, to the `IPermissionGroup` which enables us to define a custom permission rules in the form of boolean functions.
2. Removed the `um` property from `IPermissionGroup` and implemented UM rules as custom permissions. Also removed the `um` parameter from the `isAuthenticated` function which cleared it's logic a bit and made it a bit more generic since now it only accepts the permissions and the current user.
3. In order to test this, I added the `featureAvailable` flag to the `communityNodes` module and appropriate getter which are used to define permissions for the `/settings/community-nodes` route. ATM, there is no logic implemented to set this flag value based on the env variable since this is out of this PR's scope.