### PR TITLE
Pinning and unpinning endpoints

### DIFF
--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -192,6 +192,7 @@ export async function init(
 	collections.SharedCredentials = linkRepository(entities.SharedCredentials);
 	collections.SharedWorkflow = linkRepository(entities.SharedWorkflow);
 	collections.Settings = linkRepository(entities.Settings);
+	collections.PinData = linkRepository(entities.PinData);
 
 	isInitialized = true;
 

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -34,6 +34,7 @@ import { User } from './databases/entities/User';
 import { SharedCredentials } from './databases/entities/SharedCredentials';
 import { SharedWorkflow } from './databases/entities/SharedWorkflow';
 import { Settings } from './databases/entities/Settings';
+import { PinData } from './databases/entities/PinData';
 
 export interface IActivationError {
 	time: number;
@@ -82,6 +83,7 @@ export interface IDatabaseCollections {
 	SharedCredentials: Repository<SharedCredentials>;
 	SharedWorkflow: Repository<SharedWorkflow>;
 	Settings: Repository<Settings>;
+	PinData: Repository<PinData>;
 }
 
 export interface IWebhookDb {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -157,6 +157,7 @@ import { ExecutionEntity } from './databases/entities/ExecutionEntity';
 import { SharedWorkflow } from './databases/entities/SharedWorkflow';
 import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from './constants';
 import { credentialsController } from './api/credentials.api';
+import { pinDataController } from './api/pinData.api';
 import {
 	getInstanceBaseUrl,
 	isEmailSetUp,
@@ -1150,6 +1151,8 @@ class App {
 				return true;
 			}),
 		);
+
+		this.app.use(`/${this.restEndpoint}/workflows/:id`, pinDataController);
 
 		this.app.post(
 			`/${this.restEndpoint}/workflows/run`,

--- a/packages/cli/src/api/pinData.api.ts
+++ b/packages/cli/src/api/pinData.api.ts
@@ -1,0 +1,102 @@
+/* eslint-disable import/no-cycle */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import express from 'express';
+import { LoggerProxy as Logger } from 'n8n-workflow';
+import { Db, ResponseHelper } from '..';
+import { RESPONSE_ERROR_MESSAGES } from '../constants';
+import type { WorkflowRequest } from '../requests';
+
+export const pinDataController = express.Router();
+
+const { NO_NODE_NAME, NO_PIN_DATA, NO_WORKFLOW, NO_PINDATA_ID } = RESPONSE_ERROR_MESSAGES;
+
+/**
+ * POST /workflows/:id/pin-data
+ */
+pinDataController.post(
+	'/pin-data',
+	ResponseHelper.send(async (req: WorkflowRequest.PinData): Promise<{ pinDataId: number }> => {
+		const { nodeName, pinData } = req.body;
+
+		if (!nodeName) {
+			Logger.debug('Request to pin data rejected because of missing `nodeName` in body');
+			throw new ResponseHelper.ResponseError(NO_NODE_NAME, undefined, 400);
+		}
+
+		if (!pinData) {
+			Logger.debug('Request to pin data rejected because of missing `pinData` in body');
+			throw new ResponseHelper.ResponseError(NO_PIN_DATA, undefined, 400);
+		}
+
+		const { id: workflowId } = req.params;
+
+		const workflow = await Db.collections.Workflow.findOne(workflowId);
+
+		if (!workflow) {
+			Logger.debug('Request to pin data rejected because `workflowId` was not found');
+			const message = [NO_WORKFLOW, workflowId].join(' ');
+			throw new ResponseHelper.ResponseError(message, undefined, 404);
+		}
+
+		const { id: pinDataId } = await Db.collections.PinData.save({ data: JSON.stringify(pinData) });
+
+		const nodeIndex = workflow.nodes.findIndex((n) => n.name === nodeName);
+
+		if (nodeIndex === -1) {
+			const message = `Failed to find node named "${nodeName}" in workflow ID ${workflow.id}`;
+			throw new ResponseHelper.ResponseError(message, undefined, 404);
+		}
+
+		workflow.nodes.splice(nodeIndex, 1, { ...workflow.nodes[nodeIndex], pinDataId });
+
+		await Db.collections.Workflow.save(workflow);
+
+		Logger.info('Pinned data successfully', { workflowId, nodeName });
+
+		return { pinDataId };
+	}),
+);
+
+/**
+ * POST /workflows/:id/unpin-data
+ */
+pinDataController.post(
+	'/unpin-data',
+	ResponseHelper.send(async (req: WorkflowRequest.UnpinData): Promise<{ success: true }> => {
+		const incomingPinDataId = req.body.pinDataId;
+
+		if (!incomingPinDataId) {
+			Logger.debug('Request to unpin data rejected because of missing `pinDataId` in body');
+			throw new ResponseHelper.ResponseError(NO_PINDATA_ID, undefined, 400);
+		}
+
+		const { id: workflowId } = req.params;
+
+		const workflow = await Db.collections.Workflow.findOne(workflowId);
+
+		if (!workflow) {
+			Logger.debug('Request to unpin data rejected because `workflowId` was not found');
+			const message = [NO_WORKFLOW, workflowId].join(' ');
+			throw new ResponseHelper.ResponseError(message, undefined, 404);
+		}
+
+		await Db.collections.PinData.delete(incomingPinDataId);
+
+		const nodeIndex = workflow.nodes.findIndex((n) => n.pinDataId === Number(incomingPinDataId));
+
+		if (nodeIndex === -1) {
+			const message = `Failed to find pindata ID "${incomingPinDataId}" in workflow ID ${workflow.id}`;
+			throw new ResponseHelper.ResponseError(message, undefined, 404);
+		}
+
+		const { pinDataId, ...rest } = workflow.nodes[nodeIndex];
+
+		workflow.nodes.splice(nodeIndex, 1, rest);
+
+		await Db.collections.Workflow.save(workflow);
+
+		Logger.info('Unpinned data successfully', { workflowId });
+
+		return { success: true };
+	}),
+);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -7,6 +7,10 @@ import { RESPONSE_ERROR_MESSAGES as CORE_RESPONSE_ERROR_MESSAGES } from 'n8n-cor
 export const RESPONSE_ERROR_MESSAGES = {
 	NO_CREDENTIAL: 'Credential not found',
 	NO_ENCRYPTION_KEY: CORE_RESPONSE_ERROR_MESSAGES.NO_ENCRYPTION_KEY,
+	NO_NODE_NAME: 'Query param "nodeName" missing',
+	NO_PIN_DATA: 'Key "pinData" missing in body',
+	NO_WORKFLOW: 'Failed to find workflow ID',
+	NO_PINDATA_ID: 'Key `pinDataId` missing in body',
 };
 
 export const AUTH_COOKIE_NAME = 'n8n-auth';

--- a/packages/cli/src/databases/entities/PinData.ts
+++ b/packages/cli/src/databases/entities/PinData.ts
@@ -9,5 +9,5 @@ export class PinData {
 	@Column({
 		type: config.getEnv('database.type') === 'sqlite' ? 'text' : 'json',
 	})
-	data: object;
+	data: unknown;
 }

--- a/packages/cli/src/requests.d.ts
+++ b/packages/cli/src/requests.d.ts
@@ -69,6 +69,10 @@ export declare namespace WorkflowRequest {
 			destinationNode?: string;
 		}
 	>;
+
+	type PinData = AuthenticatedRequest<{ id: string }, {}, { nodeName: string; pinData: unknown }>;
+
+	type UnpinData = AuthenticatedRequest<{ id: string }, {}, { pinDataId: number }>;
 }
 
 // ----------------------------------

--- a/packages/cli/test/integration/pinData.api.test.ts
+++ b/packages/cli/test/integration/pinData.api.test.ts
@@ -1,0 +1,188 @@
+import express from 'express';
+import * as utils from './shared/utils';
+import type { Role } from '../../src/databases/entities/Role';
+import * as testDb from './shared/testDb';
+import { Db } from '../../src';
+import { WorkflowEntity } from '../../src/databases/entities/WorkflowEntity';
+
+jest.mock('../../src/telemetry');
+
+let app: express.Application;
+let testDbName = '';
+let globalOwnerRole: Role;
+
+beforeAll(async () => {
+	app = utils.initTestServer({
+		endpointGroups: ['pinData'],
+		applyAuth: true,
+	});
+	const initResult = await testDb.init();
+	testDbName = initResult.testDbName;
+
+	globalOwnerRole = await testDb.getGlobalOwnerRole();
+
+	utils.initTestLogger();
+	utils.initTestTelemetry();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['User', 'Workflow'], testDbName);
+});
+
+afterAll(async () => {
+	await testDb.terminate(testDbName);
+});
+
+test('POST /workflows/:id/pin-data should pin data to node', async () => {
+	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+	const authOwnerAgent = utils.createAgent(app, { auth: true, user: ownerShell });
+
+	await createWorkflow();
+
+	const pinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data').send({
+		nodeName: 'Spotify',
+		pinData: { myKey: 'myValue' },
+	});
+
+	expect(pinDataResponse.statusCode).toBe(200);
+	expect(pinDataResponse.body.data.pinDataId).toBeDefined(); // pinned
+
+	const workflow = await Db.collections.Workflow.findOne(1);
+
+	const node = workflow?.nodes.find((n) => n.name === 'Spotify');
+
+	expect(node?.pinDataId).toBe(1); // pinned
+
+	const pinData = await Db.collections.PinData.findOne(node?.pinDataId);
+
+	const pinDataObject =
+		typeof pinData?.data === 'string' ? JSON.parse(pinData.data) : pinData?.data;
+
+	expect(pinDataObject).toMatchObject({ myKey: 'myValue' }); // saved
+});
+
+test('POST /workflows/:id/pin-data should fail with missing pin data', async () => {
+	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+	const authOwnerAgent = utils.createAgent(app, { auth: true, user: ownerShell });
+
+	await createWorkflow();
+
+	const pinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data').send({
+		nodeName: 'Spotify',
+	});
+
+	expect(pinDataResponse.statusCode).toBe(400);
+
+	const workflow = await Db.collections.Workflow.findOne(1);
+
+	const node = workflow?.nodes.find((n) => n.name === 'Spotify');
+
+	expect(node?.pinDataId).toBeUndefined(); // unaffected
+});
+
+test('POST /workflows/:id/pin-data should fail with missing node name', async () => {
+	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+	const authOwnerAgent = utils.createAgent(app, { auth: true, user: ownerShell });
+
+	await createWorkflow();
+
+	const pinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data').send({
+		pinData: { myKey: 'myValue' },
+	});
+
+	expect(pinDataResponse.statusCode).toBe(400);
+
+	const workflow = await Db.collections.Workflow.findOne('1');
+
+	const node = workflow?.nodes.find((n) => n.name === 'Spotify');
+
+	expect(node?.pinDataId).toBeUndefined(); // unaffected
+});
+
+test('POST /workflows/:id/unpin-data should unpin data from node', async () => {
+	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+	const authOwnerAgent = utils.createAgent(app, { auth: true, user: ownerShell });
+
+	await createWorkflow();
+
+	const pinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data').send({
+		nodeName: 'Spotify',
+		pinData: { myKey: 'myValue' },
+	});
+
+	const { pinDataId: storedPinDataId } = pinDataResponse.body.data;
+
+	const unpinDataResponse = await authOwnerAgent
+		.post('/workflows/1/unpin-data')
+		.send({ pinDataId: storedPinDataId });
+
+	expect(unpinDataResponse.statusCode).toBe(200);
+	expect(unpinDataResponse.body.data.success).toBe(true);
+
+	const workflow = await Db.collections.Workflow.findOne(1);
+
+	const node = workflow?.nodes.find((n) => n.name === 'Spotify');
+
+	expect(node?.pinDataId).toBeUndefined(); // unpinned
+
+	const pinData = await Db.collections.PinData.findOne(storedPinDataId);
+
+	expect(pinData).toBeUndefined(); // deleted
+});
+
+test('POST /workflows/:id/unpin-data should fail with missing node name', async () => {
+	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+	const authOwnerAgent = utils.createAgent(app, { auth: true, user: ownerShell });
+
+	await createWorkflow();
+
+	const pinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data').send({
+		nodeName: 'Spotify',
+		pinData: { myKey: 'myValue' },
+	});
+
+	const { pinDataId: storedPinDataId } = pinDataResponse.body.data;
+
+	const unpinDataResponse = await authOwnerAgent.post('/workflows/1/pin-data');
+
+	expect(unpinDataResponse.statusCode).toBe(400);
+
+	const workflow = await Db.collections.Workflow.findOne(1);
+
+	const node = workflow?.nodes.find((n) => n.name === 'Spotify');
+
+	expect(node?.pinDataId).toBe(storedPinDataId); // unaffected
+
+	const pinData = await Db.collections.PinData.findOne(storedPinDataId);
+
+	const pinDataObject =
+		typeof pinData?.data === 'string' ? JSON.parse(pinData.data) : pinData?.data;
+
+	expect(pinDataObject).toMatchObject({ myKey: 'myValue' }); // unaffected
+});
+
+async function createWorkflow() {
+	const workflow = new WorkflowEntity();
+
+	workflow.name = 'My Workflow';
+	workflow.active = false;
+	workflow.connections = {};
+	workflow.nodes = [
+		{
+			parameters: {},
+			name: 'Start',
+			type: 'n8n-nodes-base.start',
+			typeVersion: 1,
+			position: [250, 300],
+		},
+		{
+			name: 'Spotify',
+			type: 'n8n-nodes-base.spotify',
+			parameters: { resource: 'track', operation: 'get', id: '123' },
+			typeVersion: 1,
+			position: [740, 240],
+		},
+	];
+
+	await Db.collections.Workflow.save(workflow);
+}

--- a/packages/cli/test/integration/shared/testDb.ts
+++ b/packages/cli/test/integration/shared/testDb.ts
@@ -109,7 +109,13 @@ export async function truncate(collections: CollectionName[], testDbName: string
 
 	if (dbType === 'sqlite') {
 		await testDb.query('PRAGMA foreign_keys=OFF');
-		await Promise.all(collections.map((collection) => Db.collections[collection].clear()));
+		await Promise.all(
+			collections.map((collection) => {
+				const tableName = toTableName(collection);
+				Db.collections[collection].clear();
+				testDb.query(`DELETE FROM sqlite_sequence WHERE name = '${tableName}';`); // reset autoincrement
+			}),
+		);
 		return testDb.query('PRAGMA foreign_keys=ON');
 	}
 
@@ -150,6 +156,7 @@ function toTableName(collectionName: CollectionName) {
 		SharedCredentials: 'shared_credentials',
 		SharedWorkflow: 'shared_workflow',
 		Settings: 'settings',
+		PinData: 'pin_data',
 	}[collectionName];
 }
 

--- a/packages/cli/test/integration/shared/types.d.ts
+++ b/packages/cli/test/integration/shared/types.d.ts
@@ -15,7 +15,7 @@ export type SmtpTestAccount = {
 	};
 };
 
-type EndpointGroup = 'me' | 'users' | 'auth' | 'owner' | 'passwordReset' | 'credentials';
+type EndpointGroup = 'me' | 'users' | 'auth' | 'owner' | 'passwordReset' | 'credentials' | 'pinData';
 
 export type CredentialPayload = {
 	name: string;

--- a/packages/cli/test/integration/shared/utils.ts
+++ b/packages/cli/test/integration/shared/utils.ts
@@ -27,6 +27,7 @@ import type { User } from '../../../src/databases/entities/User';
 import type { EndpointGroup, SmtpTestAccount } from './types';
 import type { N8nApp } from '../../../src/UserManagement/Interfaces';
 import * as UserManagementMailer from '../../../src/UserManagement/email/UserManagementMailer';
+import { pinDataController } from '../../../src/api/pinData.api';
 
 /**
  * Initialize a test server.
@@ -44,7 +45,7 @@ export function initTestServer({
 	const testServer = {
 		app: express(),
 		restEndpoint: REST_PATH_SEGMENT,
-		...(endpointGroups?.includes('credentials') ? { externalHooks: ExternalHooks() } : {}),
+		...(endpointGroups?.includes('credentials') ? { externalHooks: ExternalHooks() } : {}), // TODO: Improve
 	};
 
 	testServer.app.use(bodyParser.json());
@@ -62,12 +63,13 @@ export function initTestServer({
 	const [routerEndpoints, functionEndpoints] = classifyEndpointGroups(endpointGroups);
 
 	if (routerEndpoints.length) {
-		const map: Record<string, express.Router> = {
-			credentials: credentialsController,
+		const map: Record<string, { controller: express.Router; path: string }> = {
+			credentials: { controller: credentialsController, path: 'credentials' },
+			pinData: { controller: pinDataController, path: 'workflows/:id' },
 		};
 
 		for (const group of routerEndpoints) {
-			testServer.app.use(`/${testServer.restEndpoint}/${group}`, map[group]);
+			testServer.app.use(`/${testServer.restEndpoint}/${map[group].path}`, map[group].controller);
 		}
 	}
 
@@ -105,8 +107,10 @@ const classifyEndpointGroups = (endpointGroups: string[]) => {
 	const routerEndpoints: string[] = [];
 	const functionEndpoints: string[] = [];
 
+	const ROUTER_GROUP = ['credentials', 'pinData'];
+
 	endpointGroups.forEach((group) =>
-		(group === 'credentials' ? routerEndpoints : functionEndpoints).push(group),
+		(ROUTER_GROUP.includes(group) ? routerEndpoints : functionEndpoints).push(group),
 	);
 
 	return [routerEndpoints, functionEndpoints];

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -781,6 +781,7 @@ export interface INode {
 	parameters: INodeParameters;
 	credentials?: INodeCredentials;
 	webhookId?: string;
+	pinDataId?: number;
 }
 
 export interface INodes {


### PR DESCRIPTION
```
> n8n@0.178.2 test:postgres
> export N8N_LOG_LEVEL='silent'; export DB_TYPE=postgresdb && jest "pindata"

 PASS  test/integration/pinData.api.test.ts
  ✓ POST /workflows/:id/pin-data should pin data to node (101 ms)
  ✓ POST /workflows/:id/pin-data should fail with missing pin data (55 ms)
  ✓ POST /workflows/:id/pin-data should fail with missing node name (37 ms)
  ✓ POST /workflows/:id/unpin-data should unpin data from node (64 ms)
  ✓ POST /workflows/:id/unpin-data should fail with missing node name (56 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.287 s, estimated 4 s
Ran all test suites matching /pindata/i.
```