### PR TITLE
Support getting Wise statements as JSON, CSV or PDF - N8N-3847

### DIFF
--- a/packages/nodes-base/nodes/Wise/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wise/GenericFunctions.ts
@@ -58,6 +58,10 @@ export async function wiseApiRequest(
 		delete options.qs;
 	}
 
+	if (option.encoding) {
+		delete options.json;
+	}
+
 	if (Object.keys(option)) {
 		Object.assign(options, option);
 	}
@@ -110,26 +114,6 @@ export async function wiseApiRequest(
 	} else {
 		throw new NodeApiError(this.getNode(), { ...response, message: response.statusMessage });
 	}
-}
-
-/**
- * Populate the binary property of node items with binary data for a PDF file.
- */
-export async function handleBinaryData(
-	this: IExecuteFunctions,
-	items: INodeExecutionData[],
-	i: number,
-	endpoint: string,
-) {
-	const data = await wiseApiRequest.call(this, 'GET', endpoint, {}, {}, { encoding: null });
-	const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
-
-	items[i].binary = items[i].binary ?? {};
-	items[i].binary![binaryProperty] = await this.helpers.prepareBinaryData(data);
-	items[i].binary![binaryProperty].fileName = this.getNodeParameter('fileName', i) as string;
-	items[i].binary![binaryProperty].fileExtension = 'pdf';
-
-	return items;
 }
 
 export function getTriggerName(eventName: string) {

--- a/packages/nodes-base/nodes/Wise/Wise.node.ts
+++ b/packages/nodes-base/nodes/Wise/Wise.node.ts
@@ -28,7 +28,6 @@ import {
 import {
 	BorderlessAccount,
 	ExchangeRateAdditionalFields,
-	handleBinaryData,
 	Profile,
 	Recipient,
 	StatementAdditionalFields,
@@ -175,7 +174,7 @@ export class Wise implements INodeType {
 
 		let responseData;
 		const returnData: IDataObject[] = [];
-		let downloadReceipt = false;
+		let binaryOutput = false;
 
 		for (let i = 0; i < items.length; i++) {
 
@@ -221,7 +220,8 @@ export class Wise implements INodeType {
 
 						const profileId = this.getNodeParameter('profileId', i);
 						const borderlessAccountId = this.getNodeParameter('borderlessAccountId', i);
-						const endpoint = `v3/profiles/${profileId}/borderless-accounts/${borderlessAccountId}/statement.json`;
+						const format = this.getNodeParameter('format', i) as 'json' | 'csv' | 'pdf';
+						const endpoint = `v3/profiles/${profileId}/borderless-accounts/${borderlessAccountId}/statement.${format}`;
 
 						const qs = {
 							currency: this.getNodeParameter('currency', i),
@@ -241,8 +241,19 @@ export class Wise implements INodeType {
 							qs.intervalEnd = moment().utc().format();
 						}
 
-						responseData = await wiseApiRequest.call(this, 'GET', endpoint, {}, qs);
+						if (format === 'json') {
+							responseData = await wiseApiRequest.call(this, 'GET', endpoint, {}, qs);
+						}
+						else {
+							const data = await wiseApiRequest.call(this, 'GET', endpoint, {}, qs, {encoding: 'arraybuffer'});
+							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
 
+							items[i].binary = items[i].binary ?? {};
+							items[i].binary![binaryProperty] = await this.helpers.prepareBinaryData(data, this.getNodeParameter('fileName', i) as string);
+
+							responseData = items;
+							binaryOutput = true;
+						}
 					}
 
 				} else if (resource === 'exchangeRate') {
@@ -454,14 +465,20 @@ export class Wise implements INodeType {
 						// ----------------------------------
 
 						const transferId = this.getNodeParameter('transferId', i);
-						downloadReceipt = this.getNodeParameter('downloadReceipt', i) as boolean;
-
+						const downloadReceipt = this.getNodeParameter('downloadReceipt', i) as boolean;
+						
 						if (downloadReceipt) {
 
 							// https://api-docs.transferwise.com/#transfers-get-receipt-pdf
 
-							responseData = await handleBinaryData.call(this, items, i, `v1/transfers/${transferId}/receipt.pdf`);
+							const data = await wiseApiRequest.call(this, 'GET', `v1/transfers/${transferId}/receipt.pdf`, {}, {}, {encoding: 'arraybuffer'});
+							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
 
+							items[i].binary = items[i].binary ?? {};
+							items[i].binary![binaryProperty] = await this.helpers.prepareBinaryData(data, this.getNodeParameter('fileName', i) as string);
+
+							responseData = items;
+							binaryOutput = true;
 						} else {
 
 							// https://api-docs.transferwise.com/#transfers-get-by-id
@@ -518,7 +535,7 @@ export class Wise implements INodeType {
 				: returnData.push(responseData);
 		}
 
-		if (downloadReceipt && responseData !== undefined) {
+		if (binaryOutput && responseData !== undefined) {
 			return this.prepareOutputData(responseData);
 		}
 

--- a/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
@@ -128,6 +128,82 @@ export const accountFields: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Format',
+		name: 'format',
+		type: 'options',
+		default: 'json',
+		description: 'File format to retrieve the statement in',
+		displayOptions: {
+			show: {
+				resource: [
+					'account',
+				],
+				operation: [
+					'getStatement',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'JSON',
+				value: 'json',
+			},
+			{
+				name: 'CSV',
+				value: 'csv',
+			},
+			{
+				name: 'PDF',
+				value: 'pdf',
+			},
+		],
+	},
+	{
+		displayName: 'Binary Property',
+		name: 'binaryProperty',
+		type: 'string',
+		required: true,
+		default: 'data',
+		description: 'Name of the binary property to which to write to',
+		displayOptions: {
+			show: {
+				resource: [
+					'account',
+				],
+				operation: [
+					'getStatement',
+				],
+				format: [
+					'csv',
+					'pdf',
+				],
+			},
+		},
+	},
+	{
+		displayName: 'File Name',
+		name: 'fileName',
+		type: 'string',
+		required: true,
+		default: '',
+		placeholder: 'data.pdf',
+		description: 'Name of the file that will be downloaded',
+		displayOptions: {
+			show: {
+				resource: [
+					'account',
+				],
+				operation: [
+					'getStatement',
+				],
+				format: [
+					'csv',
+					'pdf',
+				],
+			},
+		},
+	},
+	{
 		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',


### PR DESCRIPTION
Wise exports statements in JSON, CSV and PDF formats, but currently, n8n supports only JSON.
This may be more of a feature request, but I thought of opening a PR since I already "fixed" it for internal use.

While modifying `getStatements` I noticed `transfer: get` used a helper function that set `{encoding: null}` while using the new `httpRequest` helper, so I updated it too.

Tested:
- `getStatement` with output types JSON, CSV and PDF
- `transfer: get` with output types JSON and PDF