### PR TITLE
feat(core): Run Error Workflow also on activation error

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -27,7 +27,6 @@ import {
 	IRun,
 	IRunExecutionData,
 	ITaskData,
-	IWorkflowCredentials,
 	IWorkflowExecuteAdditionalData,
 	IWorkflowExecuteHooks,
 	IWorkflowHooksOptionalParameters,
@@ -57,7 +56,6 @@ import {
 	Push,
 	ResponseHelper,
 	WebhookHelpers,
-	WorkflowCredentials,
 	WorkflowHelpers,
 } from '.';
 import {
@@ -66,7 +64,6 @@ import {
 	getWorkflowOwner,
 } from './UserManagement/UserManagementHelper';
 import { whereClause } from './WorkflowHelpers';
-import { RESPONSE_ERROR_MESSAGES } from './constants';
 
 const ERROR_TRIGGER_TYPE = config.getEnv('nodes.errorTriggerType');
 
@@ -79,7 +76,7 @@ const ERROR_TRIGGER_TYPE = config.getEnv('nodes.errorTriggerType');
  * @param {WorkflowExecuteMode} mode The mode in which the workflow got started in
  * @param {string} [executionId] The id the execution got saved as
  */
-function executeErrorWorkflow(
+export function executeErrorWorkflow(
 	workflowData: IWorkflowBase,
 	fullRunData: IRun,
 	mode: WorkflowExecuteMode,
@@ -1028,7 +1025,7 @@ export function sendMessageToUI(source: string, messages: any[]) {
  * Returns the base additional data without webhooks
  *
  * @export
- * @param {IWorkflowCredentials} credentials
+ * @param {userId} string
  * @param {INodeParameters} currentNodeParameters
  * @returns {Promise<IWorkflowExecuteAdditionalData>}
  */

--- a/packages/core/src/ActiveWorkflows.ts
+++ b/packages/core/src/ActiveWorkflows.ts
@@ -13,6 +13,7 @@ import {
 	LoggerProxy as Logger,
 	Workflow,
 	WorkflowActivateMode,
+	WorkflowActivationError,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
@@ -82,17 +83,26 @@ export class ActiveWorkflows {
 		let triggerResponse: ITriggerResponse | undefined;
 		this.workflowData[id].triggerResponses = [];
 		for (const triggerNode of triggerNodes) {
-			triggerResponse = await workflow.runTrigger(
-				triggerNode,
-				getTriggerFunctions,
-				additionalData,
-				mode,
-				activation,
-			);
-			if (triggerResponse !== undefined) {
-				// If a response was given save it
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				this.workflowData[id].triggerResponses!.push(triggerResponse);
+			try {
+				triggerResponse = await workflow.runTrigger(
+					triggerNode,
+					getTriggerFunctions,
+					additionalData,
+					mode,
+					activation,
+				);
+				if (triggerResponse !== undefined) {
+					// If a response was given save it
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					this.workflowData[id].triggerResponses!.push(triggerResponse);
+				}
+			} catch (error) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				throw new WorkflowActivationError(
+					'There was a problem activating the workflow',
+					error,
+					triggerNode,
+				);
 			}
 		}
 
@@ -100,17 +110,26 @@ export class ActiveWorkflows {
 		if (pollNodes.length) {
 			this.workflowData[id].pollResponses = [];
 			for (const pollNode of pollNodes) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				this.workflowData[id].pollResponses!.push(
-					await this.activatePolling(
+				try {
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					this.workflowData[id].pollResponses!.push(
+						await this.activatePolling(
+							pollNode,
+							workflow,
+							additionalData,
+							getPollFunctions,
+							mode,
+							activation,
+						),
+					);
+				} catch (error) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+					throw new WorkflowActivationError(
+						'There was a problem activating the workflow',
+						error,
 						pollNode,
-						workflow,
-						additionalData,
-						getPollFunctions,
-						mode,
-						activation,
-					),
-				);
+					);
+				}
 			}
 		}
 	}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -9,6 +9,7 @@ import { URLSearchParams } from 'url';
 import { IDeferredPromise } from './DeferredPromise';
 import { Workflow } from './Workflow';
 import { WorkflowHooks } from './WorkflowHooks';
+import { WorkflowActivationError } from './WorkflowActivationError';
 import { WorkflowOperationError } from './WorkflowErrors';
 import { NodeApiError, NodeOperationError } from './NodeErrors';
 
@@ -56,7 +57,11 @@ export interface IConnection {
 	index: number;
 }
 
-export type ExecutionError = WorkflowOperationError | NodeOperationError | NodeApiError;
+export type ExecutionError =
+	| WorkflowActivationError
+	| WorkflowOperationError
+	| NodeOperationError
+	| NodeApiError;
 
 // Get used to gives nodes access to credentials
 export interface IGetCredentials {

--- a/packages/workflow/src/WorkflowActivationError.ts
+++ b/packages/workflow/src/WorkflowActivationError.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-cycle
+import { ExecutionBaseError, INode } from '.';
+
+/**
+ * Class for instantiating an workflow activation error
+ */
+export class WorkflowActivationError extends ExecutionBaseError {
+	node: INode | undefined;
+
+	constructor(message: string, error: Error, node?: INode) {
+		super(error);
+		this.node = node;
+		this.cause = error;
+		this.message = message;
+	}
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -11,6 +11,7 @@ export * from './NodeErrors';
 export * as TelemetryHelpers from './TelemetryHelpers';
 export * from './RoutingNode';
 export * from './Workflow';
+export * from './WorkflowActivationError';
 export * from './WorkflowDataProxy';
 export * from './WorkflowErrors';
 export * from './WorkflowHooks';


### PR DESCRIPTION
Run Error Workflow also when workflow gets deactivated or could not be activated on startup because of error.

That solves the problem that right now often workflows get deactivated on startup or at runtime because of errors. The workflow owners will currently miss that unless they check the instance logs or the active workflows.