### PR TITLE
fix(core): Allow "window" again in expressions

### DIFF
--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -156,10 +156,6 @@ export class Expression {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let returnValue;
 		try {
-			if (/([^a-zA-Z0-9"']window[^a-zA-Z0-9"'])/g.test(parameterValue)) {
-				throw new Error(`window is not allowed`);
-			}
-
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 			returnValue = tmpl.tmpl(parameterValue, data);
 		} catch (error) {


### PR DESCRIPTION
Temp fix:
https://community.n8n.io/t/there-is-an-error-with-ssh-node-in-newest-version/14543/2
https://community.n8n.io/t/recent-update-has-broken-set-and-creating-puppeteer-scripts/14493

A proper one will be released with the next version.

Linking #3366 for discoverability.