### PR TITLE
Fix Misspelling of "Credentials" in multiple nodes - N8N-3845

### DIFF
--- a/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
@@ -19,7 +19,7 @@ import {
 	awsApiRequestREST,
 	IExpenseDocument,
 	simplify,
-	validateCrendetials,
+	validateCredentials,
 } from './GenericFunctions';
 
 export class AwsTextract implements INodeType {
@@ -93,7 +93,7 @@ export class AwsTextract implements INodeType {
 		credentialTest: {
 			async awsTextractApiCredentialTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject, 'sts');
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject, 'sts');
 				} catch (error) {
 					return {
 						status: 'Error',

--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -128,7 +128,7 @@ export interface IExpenseDocument {
 		}];
 }
 
-export async function validateCrendetials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject, service: string): Promise<any> { // tslint:disable-line:no-any
+export async function validateCredentials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject, service: string): Promise<any> { // tslint:disable-line:no-any
 	const credentials = decryptedCredentials;
 
 	// Concatenate path and instantiate URL object so it parses correctly query strings

--- a/packages/nodes-base/nodes/Dhl/Dhl.node.ts
+++ b/packages/nodes-base/nodes/Dhl/Dhl.node.ts
@@ -15,7 +15,7 @@ import {
 
 import {
 	dhlApiRequest,
-	validateCrendetials,
+	validateCredentials,
 } from './GenericFunctions';
 
 export class Dhl implements INodeType {
@@ -103,7 +103,7 @@ export class Dhl implements INodeType {
 		credentialTest: {
 			async dhlApiCredentialTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject);
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
 					if (error.statusCode === 401) {
 						return {

--- a/packages/nodes-base/nodes/Dhl/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dhl/GenericFunctions.ts
@@ -42,7 +42,7 @@ export async function dhlApiRequest(this: IHookFunctions | IExecuteFunctions | I
 	}
 }
 
-export async function validateCrendetials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
+export async function validateCredentials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
 	const credentials = decryptedCredentials;
 
 	const { apiKey } = credentials as {

--- a/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
+++ b/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
@@ -16,7 +16,7 @@ import {
 
 import {
 	dropcontactApiRequest,
-	validateCrendetials,
+	validateCredentials,
 } from './GenericFunction';
 
 export class Dropcontact implements INodeType {
@@ -273,7 +273,7 @@ export class Dropcontact implements INodeType {
 		credentialTest: {
 			async dropcontactApiCredentialTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject);
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
 					return {
 						status: 'Error',

--- a/packages/nodes-base/nodes/Dropcontact/GenericFunction.ts
+++ b/packages/nodes-base/nodes/Dropcontact/GenericFunction.ts
@@ -57,7 +57,7 @@ export async function dropcontactApiRequest(
 	}
 }
 
-export async function validateCrendetials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
+export async function validateCredentials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
 	const credentials = decryptedCredentials;
 
 	const { apiKey } = credentials as {

--- a/packages/nodes-base/nodes/HaloPSA/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HaloPSA/GenericFunctions.ts
@@ -227,7 +227,7 @@ export function qsSetStatus(status: string) {
 
 // Validation -----------------------------------------------------------------------
 
-export async function validateCrendetials(
+export async function validateCredentials(
 	this: ICredentialTestFunctions,
 	decryptedCredentials: ICredentialDataDecryptedObject,
 ): Promise<IHaloPSATokens> {

--- a/packages/nodes-base/nodes/HaloPSA/HaloPSA.node.ts
+++ b/packages/nodes-base/nodes/HaloPSA/HaloPSA.node.ts
@@ -31,7 +31,7 @@ import {
 	haloPSAApiRequestAllItems,
 	qsSetStatus,
 	simplifyHaloPSAGetOutput,
-	validateCrendetials,
+	validateCredentials,
 } from './GenericFunctions';
 
 export class HaloPSA implements INodeType {
@@ -201,7 +201,7 @@ export class HaloPSA implements INodeType {
 				credential: ICredentialsDecrypted,
 			): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject);
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
 					return {
 						status: 'Error',

--- a/packages/nodes-base/nodes/Linear/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Linear/GenericFunctions.ts
@@ -69,7 +69,7 @@ export async function linearApiRequestAllItems(this: IHookFunctions | IExecuteFu
 	return returnData;
 }
 
-export async function validateCrendetials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
+export async function validateCredentials(this: ICredentialTestFunctions, decryptedCredentials: ICredentialDataDecryptedObject): Promise<any> { // tslint:disable-line:no-any
 	const credentials = decryptedCredentials;
 
 	const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/Linear/Linear.node.ts
+++ b/packages/nodes-base/nodes/Linear/Linear.node.ts
@@ -20,7 +20,7 @@ import {
 	linearApiRequest,
 	linearApiRequestAllItems,
 	sort,
-	validateCrendetials,
+	validateCredentials,
 } from './GenericFunctions';
 
 import {
@@ -79,7 +79,7 @@ export class Linear implements INodeType {
 		credentialTest: {
 			async linearApiTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject);
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
 					const { error: err } = error as JsonObject;
 					const errors = (err as IDataObject).errors as [{ extensions: { code: string } }];

--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -711,7 +711,7 @@ export function getConditions() {
 	return elements;
 }
 
-export function validateCrendetials(this: ICredentialTestFunctions, credentials: ICredentialDataDecryptedObject) {
+export function validateCredentials(this: ICredentialTestFunctions, credentials: ICredentialDataDecryptedObject) {
 	const options: OptionsWithUri = {
 		headers: {
 			'Authorization': `Bearer ${credentials.apiKey}`,

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -30,7 +30,7 @@ import {
 	notionApiRequest,
 	notionApiRequestAllItems,
 	simplifyObjects,
-	validateCrendetials,
+	validateCredentials,
 	validateJSON,
 } from '../GenericFunctions';
 
@@ -198,7 +198,7 @@ export class NotionV2 implements INodeType {
 		credentialTest: {
 			async notionApiCredentialTest(this: ICredentialTestFunctions, credential: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 				try {
-					await validateCrendetials.call(this, credential.data as ICredentialDataDecryptedObject);
+					await validateCredentials.call(this, credential.data as ICredentialDataDecryptedObject);
 				} catch (error) {
 					return {
 						status: 'Error',


### PR DESCRIPTION
Looks like there may have been a sample node that implemented a `validateCrendetials` function that had its header copied to a few different nodes.

This PR replaces all occurrences of that typo with the correctly spelled `validateCredentials` function name.