### PR TITLE
fix(core): Fix issue with combined expression not resolving if one is invalid

### DIFF
--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -26,7 +26,11 @@ tmpl.brackets.set('{{ }}');
 // Make sure that error get forwarded
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 tmpl.tmpl.errorHandler = (error: Error) => {
-	throw error;
+	if (error instanceof ExpressionError) {
+		if (error.context.failExecution) {
+			throw error;
+		}
+	}
 };
 
 export class Expression {


### PR DESCRIPTION
https://community.n8n.io/t/broken-core-functionality-when-calling-2-variables-when-1-does-not-exist/14746