### PR TITLE
Enable node-class-description-empty-string

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -441,6 +441,7 @@ module.exports = {
 				'n8n-nodes-base/node-param-description-line-break-html-tag': 'error',
 				'n8n-nodes-base/filesystem-wrong-cred-filename': 'error',
 				'n8n-nodes-base/node-param-placeholder-missing-email': 'error',
+				'n8n-nodes-base/node-class-description-empty-string': 'error',
 			},
 		},
 	],


### PR DESCRIPTION
This one yielded nothing when running either `lintfix` (shouldn't since it's not auto fixable) and no errors reported by regular `npm run lint`