### PR TITLE
Use instance URL for OAuth callback

### DIFF
--- a/packages/cli/src/api/oauth2Credential.api.ts
+++ b/packages/cli/src/api/oauth2Credential.api.ts
@@ -18,7 +18,7 @@ import {
 import { resolve as pathResolve } from 'path';
 import querystring from 'querystring';
 
-import { Db, ICredentialsDb, ResponseHelper, WebhookHelpers } from '..';
+import { Db, ICredentialsDb, ResponseHelper } from '..';
 import { RESPONSE_ERROR_MESSAGES } from '../constants';
 import {
 	CredentialsHelper,
@@ -29,6 +29,7 @@ import { getLogger } from '../Logger';
 import { OAuthRequest } from '../requests';
 import { externalHooks } from '../Server';
 import config from '../../config';
+import { getInstanceBaseUrl } from '../UserManagement/UserManagementHelper';
 
 export const oauth2CredentialController = express.Router();
 
@@ -109,7 +110,7 @@ oauth2CredentialController.get(
 			clientSecret: get(oauthCredentials, 'clientSecret', '') as string,
 			accessTokenUri: get(oauthCredentials, 'accessTokenUrl', '') as string,
 			authorizationUri: get(oauthCredentials, 'authUrl', '') as string,
-			redirectUri: `${WebhookHelpers.getWebhookBaseUrl()}${restEndpoint}/oauth2-credential/callback`,
+			redirectUri: `${getInstanceBaseUrl()}${restEndpoint}/oauth2-credential/callback`,
 			scopes: split(get(oauthCredentials, 'scope', 'openid,') as string, ','),
 			state: stateEncodedStr,
 		};
@@ -265,7 +266,7 @@ oauth2CredentialController.get(
 				clientSecret: get(oauthCredentials, 'clientSecret', '') as string | undefined,
 				accessTokenUri: get(oauthCredentials, 'accessTokenUrl', '') as string,
 				authorizationUri: get(oauthCredentials, 'authUrl', '') as string,
-				redirectUri: `${WebhookHelpers.getWebhookBaseUrl()}${restEndpoint}/oauth2-credential/callback`,
+				redirectUri: `${getInstanceBaseUrl()}${restEndpoint}/oauth2-credential/callback`,
 				scopes: split(get(oauthCredentials, 'scope', 'openid,') as string, ','),
 			};
 


### PR DESCRIPTION
Based on https://community.n8n.io/t/set-oauth-redirect-url-to-n8n-editor-base-url/14986

Effectively use the instance URL which will maintain the same behaviour if only `WEBHOOK_URL` is configured. However if `N8N_EDITOR_BASE_URL` is configured it will use that instead. This will only impact creating and reconnecting OAuth credentials.