### PR TITLE
:lipstick: Add word-break: break-word to fix styling issue

### DIFF
--- a/packages/editor-ui/src/n8n-theme.scss
+++ b/packages/editor-ui/src/n8n-theme.scss
@@ -156,6 +156,7 @@
 
 .el-notification__content {
 	text-align: left;
+	word-break: break-word;
 }
 
 


### PR DESCRIPTION
Fix issue with notification panel, when an error is displayed with a long message the content is cut off.