### PR TITLE
🐛 Fixing credentials rendering when the node has no parameters

### DIFF
--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -80,6 +80,12 @@
 				/>
 			</div>
 		</div>
+		<div
+			:class="{indent}"
+			v-if="filteredParameters.length === 0"
+		>
+			<slot/>
+		</div>
 	</div>
 </template>
 


### PR DESCRIPTION
Fixes N8N-3870
Node I used to reproduce and fix the bug can be found on t[his branch](https://github.com/n8n-io/n8n/tree/credentials-rendering-test-node) (it's based on this PR branch so fix logic is also there).