### PR TITLE
:bug: Fix logger error when logging circular json

### DIFF
--- a/packages/cli/src/Logger.ts
+++ b/packages/cli/src/Logger.ts
@@ -42,7 +42,7 @@ class Logger implements ILogger {
 					}),
 				);
 			} else {
-				format = winston.format.printf(({ message }) => message);
+				format = winston.format.printf(({ message }: { message: string }) => message);
 			}
 
 			this.logger.add(

--- a/packages/cli/src/Logger.ts
+++ b/packages/cli/src/Logger.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { inspect } from 'util';
 import winston from 'winston';
 
 import { IDataObject, ILogger, LogTypes } from 'n8n-workflow';
@@ -36,7 +37,7 @@ class Logger implements ILogger {
 					winston.format.printf(({ level, message, timestamp, metadata }) => {
 						// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 						return `${timestamp} | ${level.padEnd(18)} | ${message}${
-							Object.keys(metadata).length ? ` ${JSON.stringify(metadata)}` : ''
+							Object.keys(metadata).length ? ` ${JSON.stringify(inspect(metadata))}` : ''
 						}`;
 					}),
 				);


### PR DESCRIPTION
Use node.js `util.inspect` to fix circular links in JSON