### PR TITLE
🐛 CLI: Add windows support to import:credentials --separate

### DIFF
--- a/packages/cli/commands/import/credentials.ts
+++ b/packages/cli/commands/import/credentials.ts
@@ -14,7 +14,6 @@ import { LoggerProxy } from 'n8n-workflow';
 
 import fs from 'fs';
 import glob from 'fast-glob';
-import path from 'path';
 import { EntityManager, getConnection } from 'typeorm';
 import { getLogger } from '../../src/Logger';
 import { Db } from '../../src';
@@ -88,9 +87,15 @@ export class ImportCredentialsCommand extends Command {
 			const encryptionKey = await UserSettings.getEncryptionKey();
 
 			if (flags.separate) {
-				const files = await glob(
-					`${flags.input.endsWith(path.sep) ? flags.input : flags.input + path.sep}*.json`,
-				);
+				let { input: inputPath } = flags;
+
+				if (process.platform === 'win32') {
+					inputPath = inputPath.replace(/\\/g, '/');
+				}
+
+				inputPath = inputPath.replace(/\/$/g, '');
+
+				const files = await glob(`${inputPath}/*.json`);
 
 				totalImported = files.length;
 


### PR DESCRIPTION
This is a direct port of the fix in https://github.com/n8n-io/n8n/pull/2441