### PR TITLE
:recycle: Add fileExtension from FileTypeResult to buffer data

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -809,6 +809,7 @@ export async function prepareBinaryData(
 	filePath?: string,
 	mimeType?: string,
 ): Promise<IBinaryData> {
+	let fileExtension = '';
 	if (!mimeType) {
 		// If no mime type is given figure it out
 
@@ -825,6 +826,7 @@ export async function prepareBinaryData(
 			const fileTypeData = await fromBuffer(binaryData);
 			if (fileTypeData) {
 				mimeType = fileTypeData.mime;
+				fileExtension = fileTypeData.ext;
 			}
 		}
 
@@ -836,6 +838,7 @@ export async function prepareBinaryData(
 
 	const returnData: IBinaryData = {
 		mimeType,
+		fileExtension,
 		data: '',
 	};
 

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -809,7 +809,7 @@ export async function prepareBinaryData(
 	filePath?: string,
 	mimeType?: string,
 ): Promise<IBinaryData> {
-	let fileExtension = '';
+	let fileExtension: string | undefined;
 	if (!mimeType) {
 		// If no mime type is given figure it out
 


### PR DESCRIPTION
Add fileExtension information from FileTypeResult

If there is no mime type we should get the fileExtension from the 'file-type' package's fromBuffer method