### PR TITLE
Add debug configuration file with instructions

### DIFF
--- a/.vscode/DEBUGGER.md
+++ b/.vscode/DEBUGGER.md
@@ -42,3 +42,7 @@ With the debugger you can actually debug any Javascript (derived from Typescript
 - core
 - workflow
 - nodes-base
+
+## Further reading
+
+Please check [VSCode's docs about debugging](https://code.visualstudio.com/docs/editor/debugging) for more information.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Attach to running n8n",
+			"processId": "${command:PickProcess}",
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "node"
+		},
+		{
+			"name": "Launch n8n with debug",
+			"program": "${workspaceFolder}/packages/cli/bin/n8n",
+			"request": "launch",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "node",
+			"env": {
+				// "N8N_PORT": "5679",
+			}
+		}
+	]
+
+	/**
+		How this works:
+
+		This file gives VS Code the ability to start and debug n8n.
+		The editor is not debuggable from here.
+
+		The "Run and Debug" tab of your editor should display the "Launch n8n with debug" option.
+		This should start n8n and open a debug console. You can add breakpoints to
+		Parts of the code residing inside `cli`, `core`, `workflow` and `nodes-base` packages
+
+		You can also choose to "Attach to running n8n". This is useful if you
+		have n8n running in another terminal window and want to debug it.
+		Once you click to Debug, VS Code will prompt you to select a process to attach to.
+	*/
+}

--- a/DEBUGGER.md
+++ b/DEBUGGER.md
@@ -1,0 +1,44 @@
+# How to debug n8n
+
+When developing nodes or making changes to the core, debugging is an important tool.
+
+The process outlined below does not cover front end debugging; right now only back end is covered.
+
+We are based on the premise that you're using VSCode since the configurations provided are tailored for this IDE.
+
+## What is debugging
+
+Debugging is the act of inspecting the code. It can be used to find bugs and, hopefully, fix them.
+
+The act of debugging consists in executing the code while adding "Breakpoints". As the name implies, Breakpoints are points of the code that you want to inspect, by checking variable values and inspecting behavior.
+
+Adding breakpoints is as easy as clicking the row number inside VSCode on the file you wish to debug.
+
+Breakpoints are noted with a red dot in front of the line, meaning that whenever your code reaches that point, the code will stop executing and your IDE will focus the line where the breakpoint was placed, allowing you to inspect variable values, proceed the code or even stop the execution entirely.
+
+## What if I change the code?
+
+You might need to restart the debugger if you make changes to your code, since the running process will be executing an oudated version of the code.
+
+In order to make this process easier you can simply run `npm run watch` in another terminal window, so you don't have to fully build the project. Please note that restarting n8n is still required, but this is much faster.
+
+## Debugging options
+
+Docker debugging is currently not functional. We offer 2 other methods:
+
+1) Launch n8n from inside VSCode:
+   From the "Run and Debug" section in VSCode you can choose the option named "Launch n8n with debug".
+	 This will start n8n to run as normal, but with debugger attached.
+2) Another possibility is if n8n is already running, say, in your terminal.
+   You can attach the debugger to it.
+   This is done by choosing the option "Attach to running n8n".
+	 VSCode will present you with a prompt to select the n8n process. It usually is displayed with `node ./n8n`
+
+## What can be debugged?
+
+With the debugger you can actually debug any Javascript (derived from Typescript) files in the following packages:
+
+- cli
+- core
+- workflow
+- nodes-base


### PR DESCRIPTION
This file allows developers to debug n8n using VSCode's builtin debugging tools.