### PR TITLE
fix(api): Add missing node settings parameters - N8N-4140

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/node.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/node.yml
@@ -18,6 +18,22 @@ properties:
   typeVersion:
     type: number
     example: 1
+  executeOnce:
+    type: boolean
+    example: false
+  alwaysOutputData:
+    type: boolean
+    example: false
+  retryOnFail:
+    type: boolean
+    example: false
+  maxTries:
+    type: number
+  waitBetweenTries:
+    type: number
+  continueOnFail:
+    type: boolean
+    example: false
   position:
     type: array
     items:


### PR DESCRIPTION
https://community.n8n.io/t/n8n-api-create-workflow-does-not-accept-workflow-with-always-return-data-property/15892