### PR TITLE
n8n-4159 - NocoDB node auth issue in 0.187.x

### DIFF
--- a/packages/nodes-base/credentials/NocoDb.credentials.ts
+++ b/packages/nodes-base/credentials/NocoDb.credentials.ts
@@ -29,14 +29,8 @@ export class NocoDb implements ICredentialType {
 		type:'generic',
 		properties: {
 			headers:{
-				'xc-auth': '={{credentials.apiToken}}',
+				'xc-auth': '={{$credentials.apiToken}}',
 			},
-		},
-	};
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: '={{$credentials.host}}',
-			url: '/lists',
 		},
 	};
 }

--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -56,7 +56,7 @@ export async function apiRequest(this: IHookFunctions | IExecuteFunctions | ILoa
 	}
 
 	try {
-		return await this.helpers.requestWithAuthentication.call(this, 'nocodbApi', options);
+		return await this.helpers.requestWithAuthentication.call(this, 'nocoDb', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error);
 	}


### PR DESCRIPTION
Fixes [n8n-4159](https://linear.app/n8n/issue/N8N-4159/nocodb-node-broken-in-0187x)