### PR TITLE
Remove call to load nodes on startup

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2897,9 +2897,6 @@ export default mixins(
 			async loadCredentials (): Promise<void> {
 				await this.$store.dispatch('credentials/fetchAllCredentials');
 			},
-			async loadCommunityNodes (): Promise<void> {
-				await this.$store.dispatch('communityNodes/fetchInstalledPackages');
-			},
 			async loadNodesProperties(nodeInfos: INodeTypeNameVersion[]): Promise<void> {
 				const allNodes:INodeTypeDescription[] = this.$store.getters.allNodeTypes;
 
@@ -3007,7 +3004,6 @@ export default mixins(
 				this.loadCredentials(),
 				this.loadCredentialTypes(),
 				this.loadNodeTypes(),
-				this.loadCommunityNodes(),
 			];
 
 			try {


### PR DESCRIPTION
This fixes an issue with non-owner users being unable to log in to n8n.

Fixes #3752