### PR TITLE
Fix crash caused by test webhooks

### DIFF
--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -159,8 +159,10 @@ export class TestWebhooks {
 			}
 
 			// Remove the webhook
-			clearTimeout(this.testWebhookData[webhookKey].timeout);
-			delete this.testWebhookData[webhookKey];
+			if (this.testWebhookData[webhookKey]) {
+				clearTimeout(this.testWebhookData[webhookKey].timeout);
+				delete this.testWebhookData[webhookKey];
+			}
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			this.activeWebhooks!.removeWorkflow(workflow);
 		});


### PR DESCRIPTION
n8n crashes when a test webhook receives two requests at exactly the same time.

```
/usr/local/lib/node_modules/n8n/dist/src/TestWebhooks.js:62
            clearTimeout(this.testWebhookData[webhookKey].timeout);
                                                          ^

TypeError: Cannot read properties of undefined (reading 'timeout')
    at /usr/local/lib/node_modules/n8n/dist/src/TestWebhooks.js:62:59
```