### PR TITLE
Restore pindata header colors

### DIFF
--- a/packages/design-system/src/components/N8nPanelCallout/PanelCallout.stories.js
+++ b/packages/design-system/src/components/N8nPanelCallout/PanelCallout.stories.js
@@ -32,7 +32,7 @@ export default {
 	},
 };
 
-const template: StoryFn = (args, { argTypes }) => ({
+const template = (args, { argTypes }) => ({
 	props: Object.keys(argTypes),
 	components: {
 		N8nLink,

--- a/packages/design-system/theme/src/_tokens.scss
+++ b/packages/design-system/theme/src/_tokens.scss
@@ -72,18 +72,20 @@
 		var(--color-secondary-l)
 	);
 
-	--color-secondary-tint-1-s: 45%;
-	--color-secondary-tint-1-l: 70%;
+	--color-secondary-tint-1-h: 247;
+	--color-secondary-tint-1-s: 49%;
+	--color-secondary-tint-1-l: 85%;
 	--color-secondary-tint-1: hsl(
-		var(--color-secondary-h),
+		var(--color-secondary-tint-1-h),
 		var(--color-secondary-tint-1-s),
 		var(--color-secondary-tint-1-l)
 	);
 
-	--color-secondary-tint-2-s: 46.7%;
-	--color-secondary-tint-2-l: 97%;
+	--color-secondary-tint-2-h: 247;
+	--color-secondary-tint-2-s: 49%;
+	--color-secondary-tint-2-l: 92%;
 	--color-secondary-tint-2: hsl(
-		var(--color-secondary-h),
+		var(--color-secondary-tint-2-h),
 		var(--color-secondary-tint-2-s),
 		var(--color-secondary-tint-2-l)
 	);


### PR DESCRIPTION
Restored from [tokens stylesheet](https://github.com/n8n-io/n8n/pull/3512/files#diff-9b08f3267a70b652b4317e01400d9096d3f419524638cd4327d9433129d67a9f) in pindata branch.