### PR TITLE
🐞 AWS DynamoDB:  Fix Expression Attribute Names - N8N-4187

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -303,7 +303,7 @@ export class AwsDynamoDB implements INodeType {
 						const select = this.getNodeParameter('select', 0) as string;
 						const returnAll = this.getNodeParameter('returnAll', 0) as boolean;
 						const scan = this.getNodeParameter('scan', 0) as boolean;
-						const eanUi = this.getNodeParameter('additionalFields.eanUi.eanValues', i, []) as IAttributeNameUi[];
+						const eanUi = this.getNodeParameter('options.eanUi.eanValues', i, []) as IAttributeNameUi[];
 
 						const body: IRequestBody = {
 							TableName: this.getNodeParameter('tableName', i) as string,

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -29,12 +29,10 @@ export function adjustExpressionAttributeValues(eavUi: IAttributeValueUi[]) {
 }
 
 export function adjustExpressionAttributeName(eanUi: IAttributeNameUi[]) {
-
-	// tslint:disable-next-line: no-any
-	const ean: { [key: string]: any } = {};
+	const ean: { [key: string]: string } = {};
 
 	eanUi.forEach(({ key, value }) => {
-		ean[addPound(key)] = { value } as IAttributeValueValue;
+		ean[addPound(key)] = value;
 	});
 
 	return ean;


### PR DESCRIPTION
This PR includes fixes for two separate issues I ran into while attempting to use the AWS DynamoDB node:

* Expression Attribute Names option was not working at all with the **Get All** operation of the **Item** resource.
    * The code was attempting to pull from `additionalFields` but on that operation it is defined as `options`. 

* Specifying Expression Attribute Names in the parameters would cause the request to fail with the following error message:
    * > ERROR: AWS error response [400]: 400 - "{\"__type\":\"com.amazon.coral.service#SerializationException\",\"Message\":\"Start of structure or map found where not expected\"}"
    * After reviewing the [AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html), the issue was that the value of an attribute name should be a string, not an object.

From [AWS Docs](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html#API_GetItem_RequestSyntax): 

> **ExpressionAttributeNames** — (`map`<`String`>)
> One or more substitution tokens for attribute names in the `ProjectionExpression` parameter.