### PR TITLE
[Bitwarden] Add support for choosing Personal or Org API Oauth Scopes

### DIFF
--- a/packages/nodes-base/credentials/BitwardenApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitwardenApi.credentials.ts
@@ -36,6 +36,22 @@ export class BitwardenApi implements ICredentialType {
 			],
 		},
 		{
+			displayName: 'Oauth Scope',
+			name: 'oauthScope',
+			type: 'options',
+			default: 'organization',
+			options: [
+				{
+					name: 'Organization',
+					value: 'organization',
+				},
+				{
+					name: 'Personal',
+					value: 'personal',
+				},
+			],
+		},
+		{
 			displayName: 'Self-Hosted Domain',
 			name: 'domain',
 			type: 'string',

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -72,7 +72,7 @@ export async function getAccessToken(
 			client_id: credentials.clientId,
 			client_secret: credentials.clientSecret,
 			grant_type: 'client_credentials',
-			scope: 'api.organization',
+			scope: await getOauthScope.call(this),
 			deviceName: 'n8n',
 			deviceType: 2, // https://github.com/bitwarden/server/blob/master/src/Core/Enums/DeviceType.cs
 			deviceIdentifier: 'n8n',
@@ -110,6 +110,18 @@ export async function handleGetAll(
 		const limit = this.getNodeParameter('limit', i) as number;
 		return responseData.data.slice(0, limit);
 	}
+}
+
+/**
+ * Return the oauth scope based on the user's environment.
+ */
+ async function getOauthScope(this: IExecuteFunctions | ILoadOptionsFunctions) {
+	const { oauthScope } = await this.getCredentials('bitwardenApi');
+
+	return oauthScope === 'organization'
+		? 'api.organization'
+		: 'api';
+
 }
 
 /**


### PR DESCRIPTION
[Bitwarden] This adds a drop down to select Organization or Personal Oauth scope. This way it can support vault warden and personal scopes