### PR TITLE
update docs urls to reflect content split

### DIFF
--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -179,7 +179,7 @@
 				<div :class="$style['edit-mode-footer']">
 					<n8n-info-tip :bold="false" :class="$style['edit-mode-footer-infotip']">
 						{{ $locale.baseText('runData.editor.copyDataInfo') }}
-						<n8n-link :to="dataPinningDocsUrl" size="small">
+						<n8n-link :to="dataEditingDocsUrl" size="small">
 							{{ $locale.baseText('generic.learnMore') }}
 						</n8n-link>
 					</n8n-info-tip>
@@ -356,6 +356,7 @@ import {
 
 import {
 	DATA_PINNING_DOCS_URL,
+	DATA_EDITING_DOCS_URL,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_CANVAS_FLAG,
 	MAX_DISPLAY_DATA_SIZE,
@@ -498,6 +499,9 @@ export default mixins(
 			},
 			dataPinningDocsUrl(): string {
 				return DATA_PINNING_DOCS_URL;
+			},
+			dataEditingDocsUrl(): string{
+				return DATA_EDITING_DOCS_URL;
 			},
 			displayMode(): IRunDataDisplayMode {
 				return this.$store.getters['ui/getPanelDisplayMode'](this.paneType);

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -58,6 +58,7 @@ export const BREAKPOINT_XL = 1920;
 
 export const N8N_IO_BASE_URL = `https://api.n8n.io/api/`;
 export const DATA_PINNING_DOCS_URL = 'https://docs.n8n.io/data/data-pinning/';
+export const DATA_EDITING_DOCS_URL = 'https://docs.n8n.io/data/data-editing/';
 export const NPM_COMMUNITY_NODE_SEARCH_API_URL = `https://api.npms.io/v2/`;
 export const NPM_PACKAGE_DOCS_BASE_URL = `https://www.npmjs.com/package/`;
 export const NPM_KEYWORD_SEARCH_URL = `https://www.npmjs.com/search?q=keywords%3An8n-community-node-package`;


### PR DESCRIPTION
I've updated the docs to split the data pinning and data editing content into two pages. So this PR (hopefully!) updates one of the URLs to point to the new data editing doc.

