### PR TITLE
feat(MySql.credentials): add multipleStatements

### DIFF
--- a/packages/nodes-base/credentials/MySql.credentials.ts
+++ b/packages/nodes-base/credentials/MySql.credentials.ts
@@ -47,6 +47,14 @@ export class MySql implements ICredentialType {
 				'The milliseconds before a timeout occurs during the initial connection to the MySQL server',
 		},
 		{
+			displayName: 'Multiple Statements',
+			name: 'multipleStatements',
+			type: 'boolean',
+			default: false,
+			description:
+				'Allow multiple mysql statements per query. Be careful with this, it could increase the scope of SQL injection attacks.',
+		},
+		{
 			displayName: 'SSL',
 			name: 'ssl',
 			type: 'boolean',


### PR DESCRIPTION
I used Execute Query to Call store procedure on MySQL node, and I want to get session variable  for my usage. [ask question](https://community.n8n.io/t/select-session-variable-on-mysql-node-because-of-output-parameter-of-store-procedure/16226). So I add multipleStatements config to MySql.credentials for supporting multi line queries. 