### PR TITLE
fix(core & function nodes): Update function nodes to work with binary-data-mode 'filesystem'.

### DIFF
--- a/packages/core/src/BinaryDataManager/index.ts
+++ b/packages/core/src/BinaryDataManager/index.ts
@@ -55,7 +55,13 @@ export class BinaryDataManager {
 			return this.managers[this.binaryDataMode]
 				.storeBinaryData(binaryBuffer, executionId)
 				.then((filename) => {
+					// Add data manager reference id.
 					retBinaryData.id = this.generateBinaryId(filename);
+
+					// Prevent preserving data in memory if handled by a data manager.
+					retBinaryData.data = this.binaryDataMode;
+
+					// Short-circuit return to prevent further actions.
 					return retBinaryData;
 				});
 		}

--- a/packages/core/src/BinaryDataManager/index.ts
+++ b/packages/core/src/BinaryDataManager/index.ts
@@ -50,14 +50,17 @@ export class BinaryDataManager {
 	): Promise<IBinaryData> {
 		const retBinaryData = binaryData;
 
+		// If a manager handles this binary, return the binary data with it's reference id.
 		if (this.managers[this.binaryDataMode]) {
-			await this.managers[this.binaryDataMode]
+			return this.managers[this.binaryDataMode]
 				.storeBinaryData(binaryBuffer, executionId)
 				.then((filename) => {
 					retBinaryData.id = this.generateBinaryId(filename);
+					return retBinaryData;
 				});
 		}
 
+		// Else fallback to storing this data in memory.
 		retBinaryData.data = binaryBuffer.toString(BINARY_ENCODING);
 		return binaryData;
 	}

--- a/packages/core/src/BinaryDataManager/index.ts
+++ b/packages/core/src/BinaryDataManager/index.ts
@@ -51,11 +51,10 @@ export class BinaryDataManager {
 		const retBinaryData = binaryData;
 
 		if (this.managers[this.binaryDataMode]) {
-			return this.managers[this.binaryDataMode]
+			await this.managers[this.binaryDataMode]
 				.storeBinaryData(binaryBuffer, executionId)
 				.then((filename) => {
 					retBinaryData.id = this.generateBinaryId(filename);
-					return retBinaryData;
 				});
 		}
 

--- a/packages/core/src/Interfaces.ts
+++ b/packages/core/src/Interfaces.ts
@@ -43,6 +43,7 @@ export interface IExecuteFunctions extends IExecuteFunctionsBase {
 			mimeType?: string,
 		): Promise<IBinaryData>;
 		getBinaryDataBuffer(itemIndex: number, propertyName: string): Promise<Buffer>;
+		setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData>;
 		request: (uriOrObject: string | IDataObject | any, options?: IDataObject) => Promise<any>; // tslint:disable-line:no-any
 		requestWithAuthentication(
 			this: IAllExecuteFunctions,
@@ -74,6 +75,7 @@ export interface IExecuteFunctions extends IExecuteFunctionsBase {
 export interface IExecuteSingleFunctions extends IExecuteSingleFunctionsBase {
 	helpers: {
 		getBinaryDataBuffer(propertyName: string, inputIndex?: number): Promise<Buffer>;
+		setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData>;
 		httpRequest(requestOptions: IHttpRequestOptions): Promise<any>; // tslint:disable-line:no-any
 		prepareBinaryData(
 			binaryData: Buffer,

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -805,7 +805,6 @@ export async function getBinaryDataBuffer(
 	return BinaryDataManager.getInstance().retrieveBinaryData(binaryData);
 }
 
-
 /**
  * Store an incoming IBinaryData & related buffer using the configured binary data manager.
  *
@@ -817,7 +816,7 @@ export async function getBinaryDataBuffer(
 export async function setBinaryDataBuffer(
 	data: IBinaryData,
 	binaryData: Buffer,
-	executionId: string
+	executionId: string,
 ): Promise<IBinaryData> {
 	return BinaryDataManager.getInstance().storeBinaryData(data, binaryData, executionId);
 }
@@ -1937,16 +1936,8 @@ export function getExecutePollFunctions(
 			},
 			helpers: {
 				httpRequest,
-				async setBinaryDataBuffer(
-					data: IBinaryData,
-					binaryData: Buffer	
-				): Promise<IBinaryData> {
-					return setBinaryDataBuffer.call(
-						this,
-						data,
-						binaryData,
-						additionalData.executionId!
-					);
+				async setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData> {
+					return setBinaryDataBuffer.call(this, data, binaryData, additionalData.executionId!);
 				},
 				async prepareBinaryData(
 					binaryData: Buffer,
@@ -2119,16 +2110,8 @@ export function getExecuteTriggerFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async setBinaryDataBuffer(
-					data: IBinaryData,
-					binaryData: Buffer	
-				): Promise<IBinaryData> {
-					return setBinaryDataBuffer.call(
-						this,
-						data,
-						binaryData,
-						additionalData.executionId!
-					);
+				async setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData> {
+					return setBinaryDataBuffer.call(this, data, binaryData, additionalData.executionId!);
 				},
 				async prepareBinaryData(
 					binaryData: Buffer,
@@ -2386,16 +2369,8 @@ export function getExecuteFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async setBinaryDataBuffer(
-					data: IBinaryData,
-					binaryData: Buffer	
-				): Promise<IBinaryData> {
-					return setBinaryDataBuffer.call(
-						this,
-						data,
-						binaryData,
-						additionalData.executionId!
-					);
+				async setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData> {
+					return setBinaryDataBuffer.call(this, data, binaryData, additionalData.executionId!);
 				},
 				async prepareBinaryData(
 					binaryData: Buffer,
@@ -2639,16 +2614,8 @@ export function getExecuteSingleFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async setBinaryDataBuffer(
-					data: IBinaryData,
-					binaryData: Buffer	
-				): Promise<IBinaryData> {
-					return setBinaryDataBuffer.call(
-						this,
-						data,
-						binaryData,
-						additionalData.executionId!
-					);
+				async setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData> {
+					return setBinaryDataBuffer.call(this, data, binaryData, additionalData.executionId!);
 				},
 				async prepareBinaryData(
 					binaryData: Buffer,
@@ -3147,16 +3114,8 @@ export function getExecuteWebhookFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async setBinaryDataBuffer(
-					data: IBinaryData,
-					binaryData: Buffer	
-				): Promise<IBinaryData> {
-					return setBinaryDataBuffer.call(
-						this,
-						data,
-						binaryData,
-						additionalData.executionId!
-					);
+				async setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData> {
+					return setBinaryDataBuffer.call(this, data, binaryData, additionalData.executionId!);
 				},
 				async prepareBinaryData(
 					binaryData: Buffer,

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -809,8 +809,8 @@ export async function getBinaryDataBuffer(
  * Store an incoming IBinaryData & related buffer using the configured binary data manager.
  *
  * @export
- * @param {Buffer} binaryData
  * @param {IBinaryData} data
+ * @param {Buffer} binaryData
  * @returns {Promise<IBinaryData>}
  */
 export async function setBinaryDataBuffer(

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -814,10 +814,10 @@ export async function getBinaryDataBuffer(
  * @param {IBinaryData} data
  * @returns {Promise<IBinaryData>}
  */
-export async function storeBinaryDataBuffer(
+export async function setBinaryDataBuffer(
+	data: IBinaryData,
 	binaryData: Buffer,
-	executionId: string,
-	data: IBinaryData
+	executionId: string
 ): Promise<IBinaryData> {
 	return BinaryDataManager.getInstance().storeBinaryData(data, binaryData, executionId);
 }
@@ -891,7 +891,7 @@ export async function prepareBinaryData(
 		}
 	}
 
-	return storeBinaryDataBuffer(binaryData, executionId, returnData);
+	return setBinaryDataBuffer(returnData, binaryData, executionId);
 }
 
 /**
@@ -1937,15 +1937,15 @@ export function getExecutePollFunctions(
 			},
 			helpers: {
 				httpRequest,
-				async storeBinaryDataBuffer(
-					binaryData: Buffer,
+				async setBinaryDataBuffer(
 					data: IBinaryData,
+					binaryData: Buffer	
 				): Promise<IBinaryData> {
-					return storeBinaryDataBuffer.call(
+					return setBinaryDataBuffer.call(
 						this,
+						data,
 						binaryData,
-						additionalData.executionId!,
-						data
+						additionalData.executionId!
 					);
 				},
 				async prepareBinaryData(
@@ -2119,15 +2119,15 @@ export function getExecuteTriggerFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async storeBinaryDataBuffer(
-					binaryData: Buffer,
+				async setBinaryDataBuffer(
 					data: IBinaryData,
+					binaryData: Buffer	
 				): Promise<IBinaryData> {
-					return storeBinaryDataBuffer.call(
+					return setBinaryDataBuffer.call(
 						this,
+						data,
 						binaryData,
-						additionalData.executionId!,
-						data
+						additionalData.executionId!
 					);
 				},
 				async prepareBinaryData(
@@ -2386,15 +2386,15 @@ export function getExecuteFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async storeBinaryDataBuffer(
-					binaryData: Buffer,
+				async setBinaryDataBuffer(
 					data: IBinaryData,
+					binaryData: Buffer	
 				): Promise<IBinaryData> {
-					return storeBinaryDataBuffer.call(
+					return setBinaryDataBuffer.call(
 						this,
+						data,
 						binaryData,
-						additionalData.executionId!,
-						data
+						additionalData.executionId!
 					);
 				},
 				async prepareBinaryData(
@@ -2639,15 +2639,15 @@ export function getExecuteSingleFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async storeBinaryDataBuffer(
-					binaryData: Buffer,
+				async setBinaryDataBuffer(
 					data: IBinaryData,
+					binaryData: Buffer	
 				): Promise<IBinaryData> {
-					return storeBinaryDataBuffer.call(
+					return setBinaryDataBuffer.call(
 						this,
+						data,
 						binaryData,
-						additionalData.executionId!,
-						data
+						additionalData.executionId!
 					);
 				},
 				async prepareBinaryData(
@@ -3147,15 +3147,15 @@ export function getExecuteWebhookFunctions(
 						additionalCredentialOptions,
 					);
 				},
-				async storeBinaryDataBuffer(
-					binaryData: Buffer,
+				async setBinaryDataBuffer(
 					data: IBinaryData,
+					binaryData: Buffer	
 				): Promise<IBinaryData> {
-					return storeBinaryDataBuffer.call(
+					return setBinaryDataBuffer.call(
 						this,
+						data,
 						binaryData,
-						additionalData.executionId!,
-						data
+						additionalData.executionId!
 					);
 				},
 				async prepareBinaryData(

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -805,6 +805,23 @@ export async function getBinaryDataBuffer(
 	return BinaryDataManager.getInstance().retrieveBinaryData(binaryData);
 }
 
+
+/**
+ * Store an incoming IBinaryData & related buffer using the configured binary data manager.
+ *
+ * @export
+ * @param {Buffer} binaryData
+ * @param {IBinaryData} data
+ * @returns {Promise<IBinaryData>}
+ */
+export async function storeBinaryDataBuffer(
+	binaryData: Buffer,
+	executionId: string,
+	data: IBinaryData
+): Promise<IBinaryData> {
+	return BinaryDataManager.getInstance().storeBinaryData(data, binaryData, executionId);
+}
+
 /**
  * Takes a buffer and converts it into the format n8n uses. It encodes the binary data as
  * base64 and adds metadata.
@@ -874,7 +891,7 @@ export async function prepareBinaryData(
 		}
 	}
 
-	return BinaryDataManager.getInstance().storeBinaryData(returnData, binaryData, executionId);
+	return storeBinaryDataBuffer(binaryData, executionId, returnData);
 }
 
 /**
@@ -1920,6 +1937,17 @@ export function getExecutePollFunctions(
 			},
 			helpers: {
 				httpRequest,
+				async storeBinaryDataBuffer(
+					binaryData: Buffer,
+					data: IBinaryData,
+				): Promise<IBinaryData> {
+					return storeBinaryDataBuffer.call(
+						this,
+						binaryData,
+						additionalData.executionId!,
+						data
+					);
+				},
 				async prepareBinaryData(
 					binaryData: Buffer,
 					filePath?: string,
@@ -2089,6 +2117,17 @@ export function getExecuteTriggerFunctions(
 						node,
 						additionalData,
 						additionalCredentialOptions,
+					);
+				},
+				async storeBinaryDataBuffer(
+					binaryData: Buffer,
+					data: IBinaryData,
+				): Promise<IBinaryData> {
+					return storeBinaryDataBuffer.call(
+						this,
+						binaryData,
+						additionalData.executionId!,
+						data
 					);
 				},
 				async prepareBinaryData(
@@ -2347,6 +2386,17 @@ export function getExecuteFunctions(
 						additionalCredentialOptions,
 					);
 				},
+				async storeBinaryDataBuffer(
+					binaryData: Buffer,
+					data: IBinaryData,
+				): Promise<IBinaryData> {
+					return storeBinaryDataBuffer.call(
+						this,
+						binaryData,
+						additionalData.executionId!,
+						data
+					);
+				},
 				async prepareBinaryData(
 					binaryData: Buffer,
 					filePath?: string,
@@ -2587,6 +2637,17 @@ export function getExecuteSingleFunctions(
 						node,
 						additionalData,
 						additionalCredentialOptions,
+					);
+				},
+				async storeBinaryDataBuffer(
+					binaryData: Buffer,
+					data: IBinaryData,
+				): Promise<IBinaryData> {
+					return storeBinaryDataBuffer.call(
+						this,
+						binaryData,
+						additionalData.executionId!,
+						data
 					);
 				},
 				async prepareBinaryData(
@@ -3084,6 +3145,17 @@ export function getExecuteWebhookFunctions(
 						node,
 						additionalData,
 						additionalCredentialOptions,
+					);
+				},
+				async storeBinaryDataBuffer(
+					binaryData: Buffer,
+					data: IBinaryData,
+				): Promise<IBinaryData> {
+					return storeBinaryDataBuffer.call(
+						this,
+						binaryData,
+						additionalData.executionId!,
+						data
 					);
 				},
 				async prepareBinaryData(

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -17,7 +17,7 @@ describe('NodeExecuteFunctions', () => {
 		});
 
 		test(`test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'default' mode`, async () => {
-			// Setup a 'filesystem' binary data manager instance
+			// Setup a 'default' binary data manager instance
 			await BinaryDataManager.init({
 				mode: 'default',
 				availableModes: 'default',

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -30,7 +30,7 @@ describe('NodeExecuteFunctions', () => {
 			let setBinaryDataBufferResponse: IBinaryData = await NodeExecuteFunctions.setBinaryDataBuffer(
 				{
 					mimeType: 'txt',
-					data: 'This should be overwritten in the response',
+					data: 'This should be overwritten by the actual payload in the response',
 				},
 				inputData,
 				'executionId',
@@ -77,19 +77,18 @@ describe('NodeExecuteFunctions', () => {
 			});
 
 			// Set our binary data buffer
-			let originalData: string = 'This should remain in the response';
 			let inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
 			let setBinaryDataBufferResponse: IBinaryData = await NodeExecuteFunctions.setBinaryDataBuffer(
 				{
 					mimeType: 'txt',
-					data: originalData,
+					data: 'This should be overwritten with the name of the configured data manager',
 				},
 				inputData,
 				'executionId',
 			);
 
-			// Expect our return object contains the existing input data, as our file manager should have taken over.
-			expect(setBinaryDataBufferResponse.data).toEqual(originalData);
+			// Expect our return object to contain the name of the configured data manager.
+			expect(setBinaryDataBufferResponse.data).toEqual('filesystem');
 
 			// Ensure that the input data was successfully persisted to disk.
 			expect(

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -9,7 +9,6 @@ const temporaryDir = mkdtempSync(join(tmpdir(), 'n8n'));
 
 describe('NodeExecuteFunctions', () => {
 	describe(`test binary data helper methods`, () => {
-
 		// Reset BinaryDataManager for each run. This is a dirty operation, as individual managers are not cleaned.
 		beforeEach(() => {
 			//@ts-ignore
@@ -37,7 +36,7 @@ describe('NodeExecuteFunctions', () => {
 				'executionId',
 			);
 
-			// Expect our return object to contain the base64 encoding of the input data.
+			// Expect our return object to contain the base64 encoding of the input data, as it should be stored in memory.
 			expect(setBinaryDataBufferResponse.data).toEqual(inputData.toString('base64'));
 
 			// Now, re-fetch our data.
@@ -78,25 +77,26 @@ describe('NodeExecuteFunctions', () => {
 			});
 
 			// Set our binary data buffer
+			let originalData: string = 'This should remain in the response';
 			let inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
 			let setBinaryDataBufferResponse: IBinaryData = await NodeExecuteFunctions.setBinaryDataBuffer(
 				{
 					mimeType: 'txt',
-					data: 'This should be overwritten in the response',
+					data: originalData,
 				},
 				inputData,
 				'executionId',
 			);
 
-			// Expect our return object to contain the base64 encoding of the input data.
-			expect(setBinaryDataBufferResponse.data).toEqual(inputData.toString('base64'));
+			// Expect our return object contains the existing input data, as our file manager should have taken over.
+			expect(setBinaryDataBufferResponse.data).toEqual(originalData);
 
 			// Ensure that the input data was successfully persisted to disk.
-			expect(setBinaryDataBufferResponse.data).toEqual(
+			expect(
 				readFileSync(
 					`${temporaryDir}/${setBinaryDataBufferResponse.id?.replace('filesystem:', '')}`,
-				).toString('base64'),
-			);
+				),
+			).toEqual(inputData);
 
 			// Now, re-fetch our data.
 			// An ITaskDataConnections object is used to share data between nodes. The top level property, 'main', represents the successful output object from a previous node.

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -1,0 +1,128 @@
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readFileSync, mkdtempSync } from 'fs';
+
+import { BinaryDataManager, NodeExecuteFunctions } from '../src';
+import { IBinaryData, ITaskDataConnections } from 'n8n-workflow';
+
+const temporaryDir = mkdtempSync(join(tmpdir(), 'n8n'));
+
+describe('NodeExecuteFunctions', () => {
+	describe(`test binary data helper methods`, () => {
+
+		// Reset BinaryDataManager for each run. This is a dirty operation, as individual managers are not cleaned.
+		beforeEach(() => {
+			//@ts-ignore
+			BinaryDataManager.instance = undefined;
+		});
+
+		test(`test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'default' mode`, async () => {
+			// Setup a 'filesystem' binary data manager instance
+			await BinaryDataManager.init({
+				mode: 'default',
+				availableModes: 'default',
+				localStoragePath: temporaryDir,
+				binaryDataTTL: 1,
+				persistedBinaryDataTTL: 1,
+			});
+
+			// Set our binary data buffer
+			let inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
+			let setBinaryDataBufferResponse: IBinaryData = await NodeExecuteFunctions.setBinaryDataBuffer(
+				{
+					mimeType: 'txt',
+					data: 'This should be overwritten in the response',
+				},
+				inputData,
+				'executionId',
+			);
+
+			// Expect our return object to contain the base64 encoding of the input data.
+			expect(setBinaryDataBufferResponse.data).toEqual(inputData.toString('base64'));
+
+			// Now, re-fetch our data.
+			// An ITaskDataConnections object is used to share data between nodes. The top level property, 'main', represents the successful output object from a previous node.
+			let taskDataConnectionsInput: ITaskDataConnections = {
+				main: [],
+			};
+
+			// We add an input set, with one item at index 0, to this input. It contains an empty json payload and our binary data.
+			taskDataConnectionsInput.main.push([
+				{
+					json: {},
+					binary: {
+						data: setBinaryDataBufferResponse,
+					},
+				},
+			]);
+
+			// Now, lets fetch our data! The item will be item index 0.
+			let getBinaryDataBufferResponse: Buffer = await NodeExecuteFunctions.getBinaryDataBuffer(
+				taskDataConnectionsInput,
+				0,
+				'data',
+				0,
+			);
+
+			expect(getBinaryDataBufferResponse).toEqual(inputData);
+		});
+
+		test(`test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'filesystem' mode`, async () => {
+			// Setup a 'filesystem' binary data manager instance
+			await BinaryDataManager.init({
+				mode: 'filesystem',
+				availableModes: 'filesystem',
+				localStoragePath: temporaryDir,
+				binaryDataTTL: 1,
+				persistedBinaryDataTTL: 1,
+			});
+
+			// Set our binary data buffer
+			let inputData: Buffer = Buffer.from('This is some binary data', 'utf8');
+			let setBinaryDataBufferResponse: IBinaryData = await NodeExecuteFunctions.setBinaryDataBuffer(
+				{
+					mimeType: 'txt',
+					data: 'This should be overwritten in the response',
+				},
+				inputData,
+				'executionId',
+			);
+
+			// Expect our return object to contain the base64 encoding of the input data.
+			expect(setBinaryDataBufferResponse.data).toEqual(inputData.toString('base64'));
+
+			// Ensure that the input data was successfully persisted to disk.
+			expect(setBinaryDataBufferResponse.data).toEqual(
+				readFileSync(
+					`${temporaryDir}/${setBinaryDataBufferResponse.id?.replace('filesystem:', '')}`,
+				).toString('base64'),
+			);
+
+			// Now, re-fetch our data.
+			// An ITaskDataConnections object is used to share data between nodes. The top level property, 'main', represents the successful output object from a previous node.
+			let taskDataConnectionsInput: ITaskDataConnections = {
+				main: [],
+			};
+
+			// We add an input set, with one item at index 0, to this input. It contains an empty json payload and our binary data.
+			taskDataConnectionsInput.main.push([
+				{
+					json: {},
+					binary: {
+						data: setBinaryDataBufferResponse,
+					},
+				},
+			]);
+
+			// Now, lets fetch our data! The item will be item index 0.
+			let getBinaryDataBufferResponse: Buffer = await NodeExecuteFunctions.getBinaryDataBuffer(
+				taskDataConnectionsInput,
+				0,
+				'data',
+				0,
+			);
+
+			expect(getBinaryDataBufferResponse).toEqual(inputData);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -5,6 +5,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
+	IBinaryKeyData,
 } from 'n8n-workflow';
 
 const { NodeVM } = require('vm2');
@@ -61,6 +62,11 @@ return items;`,
 		// Copy the items as they may get changed in the functions
 		items = JSON.parse(JSON.stringify(items));
 
+		// Assign item indexes
+		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+			items[itemIndex].index = itemIndex;
+		}
+
 		const cleanupData = (inputData: IDataObject): IDataObject => {
 			Object.keys(inputData).map((key) => {
 				if (inputData[key] !== null && typeof inputData[key] === 'object') {
@@ -84,6 +90,48 @@ return items;`,
 			items,
 			// To be able to access data of other items
 			$item: (index: number) => this.getWorkflowDataProxy(index),
+			getBinaryDataAsync: async (item: INodeExecutionData): Promise<IBinaryKeyData | undefined> => {
+				// Fetch Binary Data, if available.
+				if (item?.binary && item?.index != undefined && item?.index != null) {
+					for (const binaryPropertyName of Object.keys(item.binary)) {
+						item.binary[binaryPropertyName].data = (
+							await this.helpers.getBinaryDataBuffer(item.index, binaryPropertyName)
+						)?.toString('base64');
+					}
+				}
+
+				// Return Data
+				return item.binary;
+			},
+			setBinaryDataAsync: async (item: INodeExecutionData, data: IBinaryKeyData) => {
+				// Ensure item is provided, else return a friendly error.
+				if (!item) {
+					throw new NodeOperationError(
+						this.getNode(),
+						'No item was provided to setBinaryDataAsync (item: INodeExecutionData, data: IBinaryKeyData).',
+					);
+				}
+
+				// Ensure data is provided, else return a friendly error.
+				if (!data) {
+					throw new NodeOperationError(
+						this.getNode(),
+						'No data was provided to setBinaryDataAsync (item: INodeExecutionData, data: IBinaryKeyData).',
+					);
+				}
+
+				// Set Binary Data
+				for (const binaryPropertyName of Object.keys(data)) {
+					const binaryItem = data[binaryPropertyName];
+					data[binaryPropertyName] = await this.helpers.setBinaryDataBuffer(
+						binaryItem,
+						Buffer.from(binaryItem.data, 'base64'),
+					);
+				}
+
+				// Return Data
+				item.binary = data;
+			},
 		};
 
 		// Make it possible to access data via $node, $parameter, ...

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -1,11 +1,11 @@
 import { IExecuteFunctions } from 'n8n-core';
 import {
+	IBinaryKeyData,
 	IDataObject,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
-	IBinaryKeyData,
 } from 'n8n-workflow';
 
 const { NodeVM } = require('vm2');
@@ -92,7 +92,7 @@ return items;`,
 			$item: (index: number) => this.getWorkflowDataProxy(index),
 			getBinaryDataAsync: async (item: INodeExecutionData): Promise<IBinaryKeyData | undefined> => {
 				// Fetch Binary Data, if available.
-				if (item?.binary && item?.index != undefined && item?.index != null) {
+				if (item?.binary && item?.index !== undefined && item?.index !== null) {
 					for (const binaryPropertyName of Object.keys(item.binary)) {
 						item.binary[binaryPropertyName].data = (
 							await this.helpers.getBinaryDataBuffer(item.index, binaryPropertyName)
@@ -129,7 +129,7 @@ return items;`,
 					);
 				}
 
-				// Return Data
+				// Set Item Reference
 				item.binary = data;
 			},
 		};

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -91,7 +91,7 @@ return items;`,
 			// To be able to access data of other items
 			$item: (index: number) => this.getWorkflowDataProxy(index),
 			getBinaryDataAsync: async (item: INodeExecutionData): Promise<IBinaryKeyData | undefined> => {
-				// Fetch Binary Data, if available.
+				// Fetch Binary Data, if available. Cannot check item with `if (item?.index)`, as index may be 0.
 				if (item?.binary && item?.index !== undefined && item?.index !== null) {
 					for (const binaryPropertyName of Object.keys(item.binary)) {
 						item.binary[binaryPropertyName].data = (

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -88,18 +88,20 @@ return item;`,
 				const sandbox = {
 					/** @deprecated for removal */
 					getBinaryData: (): IBinaryKeyData | undefined => {
-						if (mode === 'manual')
+						if (mode === 'manual') {
 							this.sendMessageToUI(
 								'getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.',
 							);
+						}
 						return item.binary;
 					},
 					/** @deprecated for removal */
 					setBinaryData: async (data: IBinaryKeyData) => {
-						if (mode === 'manual')
+						if (mode === 'manual') {
 							this.sendMessageToUI(
 								'setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.',
 							);
+						}
 						item.binary = data;
 					},
 					getNodeParameter: this.getNodeParameter,
@@ -108,7 +110,7 @@ return item;`,
 					item: item.json,
 					getBinaryDataAsync: async (): Promise<IBinaryKeyData | undefined> => {
 						// Fetch Binary Data, if available.
-						if (item?.binary && item?.index != undefined && item?.index != null) {
+						if (item?.binary && item?.index !== undefined && item?.index !== null) {
 							for (const binaryPropertyName of Object.keys(item.binary)) {
 								item.binary[binaryPropertyName].data = (
 									await this.helpers.getBinaryDataBuffer(item.index, binaryPropertyName)
@@ -136,7 +138,7 @@ return item;`,
 							);
 						}
 
-						// Return Data
+						// Set Item Reference
 						item.binary = data;
 					},
 				};

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -86,7 +86,7 @@ return item;`,
 
 				// Define the global objects for the custom function
 				const sandbox = {
-					/** @deprecated for removal */
+					/** @deprecated for removal - replaced by getBinaryDataAsync() */
 					getBinaryData: (): IBinaryKeyData | undefined => {
 						if (mode === 'manual') {
 							this.sendMessageToUI(
@@ -95,7 +95,7 @@ return item;`,
 						}
 						return item.binary;
 					},
-					/** @deprecated for removal */
+					/** @deprecated for removal - replaced by setBinaryDataAsync() */
 					setBinaryData: async (data: IBinaryKeyData) => {
 						if (mode === 'manual') {
 							this.sendMessageToUI(
@@ -109,7 +109,7 @@ return item;`,
 					helpers: this.helpers,
 					item: item.json,
 					getBinaryDataAsync: async (): Promise<IBinaryKeyData | undefined> => {
-						// Fetch Binary Data, if available.
+						// Fetch Binary Data, if available. Cannot check item with `if (item?.index)`, as index may be 0.
 						if (item?.binary && item?.index !== undefined && item?.index !== null) {
 							for (const binaryPropertyName of Object.keys(item.binary)) {
 								item.binary[binaryPropertyName].data = (

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -87,12 +87,12 @@ return item;`,
 				const sandbox = {
 					/** @deprecated for removal */
 					getBinaryData: (): IBinaryKeyData | undefined => {
-						if (mode === 'manual') this.sendMessageToUI("getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.")
+						if (mode === 'manual') this.sendMessageToUI("getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.");
 						return item.binary;
 					},
 					/** @deprecated for removal */
 					setBinaryData: async (data: IBinaryKeyData) => {
-						if (mode === 'manual') this.sendMessageToUI("setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.")
+						if (mode === 'manual') this.sendMessageToUI("setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.");
 						item.binary = data;
 					},
 					getNodeParameter: this.getNodeParameter,
@@ -101,17 +101,17 @@ return item;`,
 					item: item.json,
 					getBinaryDataAsync: async (): Promise<IBinaryKeyData | undefined> => {
 						if (item?.binary) {
-							for (let binaryPropertyName of Object.keys(item.binary)) {
-								item.binary[binaryPropertyName].data = (await this.helpers.getBinaryDataBuffer(itemIndex, binaryPropertyName))?.toString('base64')
+							for (const binaryPropertyName of Object.keys(item.binary)) {
+								item.binary[binaryPropertyName].data = (await this.helpers.getBinaryDataBuffer(itemIndex, binaryPropertyName))?.toString('base64');
 							}
 						}
 						return item.binary;
 					},
 					setBinaryDataAsync: async (data: IBinaryKeyData) => {
 						if (data) {
-							for (let binaryPropertyName of Object.keys(data)) {
-								let binaryItem = data[binaryPropertyName];
-								data[binaryPropertyName] = (await this.helpers.setBinaryDataBuffer(binaryItem, Buffer.from(binaryItem.data, 'base64')))
+							for (const binaryPropertyName of Object.keys(data)) {
+								const binaryItem = data[binaryPropertyName];
+								data[binaryPropertyName] = (await this.helpers.setBinaryDataBuffer(binaryItem, Buffer.from(binaryItem.data, 'base64')));
 							}
 						}
 						item.binary = data;

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -83,14 +83,36 @@ return item;`,
 
 				// Define the global objects for the custom function
 				const sandbox = {
+					/** @deprecated for removal */
 					getBinaryData: (): IBinaryKeyData | undefined => {
+						this.sendMessageToUI("getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.")
 						return item.binary;
+					},
+					/** @deprecated for removal */
+					setBinaryData: async (data: IBinaryKeyData) => {
+						this.sendMessageToUI("setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.")
+						item.binary = data;
 					},
 					getNodeParameter: this.getNodeParameter,
 					getWorkflowStaticData: this.getWorkflowStaticData,
 					helpers: this.helpers,
 					item: item.json,
-					setBinaryData: (data: IBinaryKeyData) => {
+					getBinaryDataAsync: async (): Promise<IBinaryKeyData | undefined> => {
+						if (item?.binary) {
+							for (let binaryPropertyName of Object.keys(item.binary)) {
+								item.binary[binaryPropertyName].data = (await this.helpers.getBinaryDataBuffer(itemIndex, binaryPropertyName))?.toString('base64')
+							}
+						}
+						return item.binary;
+					},
+					setBinaryDataAsync: async (data: IBinaryKeyData) => {
+						if (data) {
+							for (let binaryPropertyName of Object.keys(data)) {
+								let binaryItem = data[binaryPropertyName];
+								data[binaryPropertyName] = (await this.helpers.storeBinaryDataBuffer(Buffer.from(binaryItem.data, 'base64'), binaryItem))
+								data[binaryPropertyName].data = "";
+							}
+						}
 						item.binary = data;
 					},
 				};

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -75,6 +75,8 @@ return item;`,
 		};
 
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
+			const mode = this.getMode();
+
 			try {
 				item = items[itemIndex];
 
@@ -85,12 +87,12 @@ return item;`,
 				const sandbox = {
 					/** @deprecated for removal */
 					getBinaryData: (): IBinaryKeyData | undefined => {
-						this.sendMessageToUI("getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.")
+						if (mode === 'manual') this.sendMessageToUI("getBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to getBinaryDataAsync(...) instead.")
 						return item.binary;
 					},
 					/** @deprecated for removal */
 					setBinaryData: async (data: IBinaryKeyData) => {
-						this.sendMessageToUI("setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.")
+						if (mode === 'manual') this.sendMessageToUI("setBinaryData(...) is deprecated and will be removed in a future version. Please consider switching to setBinaryDataAsync(...) instead.")
 						item.binary = data;
 					},
 					getNodeParameter: this.getNodeParameter,
@@ -109,8 +111,7 @@ return item;`,
 						if (data) {
 							for (let binaryPropertyName of Object.keys(data)) {
 								let binaryItem = data[binaryPropertyName];
-								data[binaryPropertyName] = (await this.helpers.storeBinaryDataBuffer(Buffer.from(binaryItem.data, 'base64'), binaryItem))
-								data[binaryPropertyName].data = "";
+								data[binaryPropertyName] = (await this.helpers.setBinaryDataBuffer(binaryItem, Buffer.from(binaryItem.data, 'base64')))
 							}
 						}
 						item.binary = data;
@@ -120,8 +121,6 @@ return item;`,
 				// Make it possible to access data via $node, $parameter, ...
 				const dataProxy = this.getWorkflowDataProxy(itemIndex);
 				Object.assign(sandbox, dataProxy);
-
-				const mode = this.getMode();
 
 				const options = {
 					console: mode === 'manual' ? 'redirect' : 'inherit',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -878,6 +878,7 @@ export interface INodeExecutionData {
 	binary?: IBinaryKeyData;
 	error?: NodeApiError | NodeOperationError;
 	pairedItem?: IPairedItemData | IPairedItemData[] | number;
+	index?: number;
 }
 
 export interface INodeExecuteFunctions {


### PR DESCRIPTION
Hello! 👋 

This is a PR addressing issue #3618.

> **Describe the bug**
> FunctionItem `getBinaryData()` returns empty `data` payloads when default binary data mode set to `filesystem`, though data is visible in the node input. 
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 1. Set `N8N_DEFAULT_BINARY_DATA_MODE` to `filesystem`
> 2. Tie together a stream that includes a node that outputs binary data, as well as a FunctionItem node that accepts this binary data.
> 3. Call `getBinaryData()` in your function. The data element is empty and the binary data is inaccessible.
> 
> **Expected behavior**
> If `N8N_DEFAULT_BINARY_DATA_MODE` is left to memory, the `getBinaryData()` helper method correctly returns binary data. 

**Added** ✨
- Added an additional helper method to `NodeExecuteFunctions.ts`, `setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData>`, which allows a node to store binary data when the `IBinaryData` object already exists. Previously, one had to recreate this object using `prepareBinaryData`.
- `FunctionItem` & `Function` nodes: `getBinaryDataAsync(...)` helper method has been added. This uses the configured BinaryDataManager to retrieve binary data.
- `FunctionItem` & `Function` nodes: `setBinaryDataAsync(...)` helper method has been added. This uses the configured BinaryDataManager to store binary data.

**Deprecated** 🙅
- `FunctionItem` node: `getBinaryData(...)` has been deprecated. Users should migrate to `getBinaryDataAsync(...)` instead.
- `FunctionItem` node: `setBinaryData(...)` has been deprecated. Users should migrate to `setBinaryDataAsync(...)` instead.