### PR TITLE
Create .dockerignore

### DIFF
--- a/docker/images/n8n-custom/.dockerignore
+++ b/docker/images/n8n-custom/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+packages/node-dev


### PR DESCRIPTION
Adding .dockerignore file, for preventing the copy of the unnecessary files in the build image.
this PR is include with previous (PR #3807)[https://github.com/n8n-io/n8n/pull/3807#discussion_r934234990]