### PR TITLE
Add SSL config to mysqldb connection

### DIFF
--- a/packages/cli/config/schema.ts
+++ b/packages/cli/config/schema.ts
@@ -38,6 +38,32 @@ export const schema = {
 				env: 'DB_LOGGING_MAX_EXECUTION_TIME',
 			},
 		},
+		ssl: {
+			ca: {
+				doc: 'SSL certificate authority',
+				format: String,
+				default: '',
+				env: 'DB_SSL_CA',
+			},
+			cert: {
+				doc: 'SSL certificate',
+				format: String,
+				default: '',
+				env: 'DB_SSL_CERT',
+			},
+			key: {
+				doc: 'SSL key',
+				format: String,
+				default: '',
+				env: 'DB_SSL_KEY',
+			},
+			rejectUnauthorized: {
+				doc: 'If unauthorized SSL connections should be rejected',
+				format: 'Boolean',
+				default: true,
+				env: 'DB_SSL_REJECT_UNAUTHORIZED',
+			},
+		},
 		postgresdb: {
 			database: {
 				doc: 'PostgresDB Database',


### PR DESCRIPTION
On postgres connection already is possible to configure ssl options
on connection.
with this commit, the intention is do the same to mysql.

To do that, was added 4 new env variables (DB_SSL_CA, DB_SSL_CERT,
DB_SSL_KEY, DB_SSL_REJECT_UNAUTHORIZED). These variables should work
to both database (mysql and postgres).

The postgres SSL variables were keeped as fallback, to not break who
is using the old way. In the future we should remove and just keep
theses variables introduced on this commit.