### PR TITLE
Add permissions details to credentials for User Management

### DIFF
--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -183,6 +183,7 @@ export async function init(
 		}
 	}
 
+	// @ts-ignore
 	collections.Credentials = linkRepository(entities.CredentialsEntity);
 	collections.Execution = linkRepository(entities.ExecutionEntity);
 	collections.Workflow = linkRepository(entities.WorkflowEntity);

--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -183,7 +183,6 @@ export async function init(
 		}
 	}
 
-	// @ts-ignore
 	collections.Credentials = linkRepository(entities.CredentialsEntity);
 	collections.Execution = linkRepository(entities.ExecutionEntity);
 	collections.Workflow = linkRepository(entities.WorkflowEntity);

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -28,16 +28,17 @@ import { Repository } from 'typeorm';
 
 import { ChildProcess } from 'child_process';
 import { Url } from 'url';
-import { Request } from 'express';
-import { WorkflowEntity } from './databases/entities/WorkflowEntity';
-import { TagEntity } from './databases/entities/TagEntity';
-import { Role } from './databases/entities/Role';
-import { User } from './databases/entities/User';
-import { SharedCredentials } from './databases/entities/SharedCredentials';
-import { SharedWorkflow } from './databases/entities/SharedWorkflow';
-import { Settings } from './databases/entities/Settings';
-import { InstalledPackages } from './databases/entities/InstalledPackages';
-import { InstalledNodes } from './databases/entities/InstalledNodes';
+
+import type { Request } from 'express';
+import type { WorkflowEntity } from './databases/entities/WorkflowEntity';
+import type { TagEntity } from './databases/entities/TagEntity';
+import type { Role } from './databases/entities/Role';
+import type { User } from './databases/entities/User';
+import type { SharedCredentials } from './databases/entities/SharedCredentials';
+import type { SharedWorkflow } from './databases/entities/SharedWorkflow';
+import type { Settings } from './databases/entities/Settings';
+import type { InstalledPackages } from './databases/entities/InstalledPackages';
+import type { InstalledNodes } from './databases/entities/InstalledNodes';
 
 export interface IActivationError {
 	time: number;
@@ -168,15 +169,6 @@ export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted 
 	id: number | string;
 	name: string;
 }
-
-/**
- * Credential with permissions details
- * injected by `CredentialsService`.
- */
-export type CredentialWithPermissions = ICredentialsDb & {
-	ownedBy?: Partial<User>;
-	sharedWith?: Array<Partial<User>>;
-};
 
 export interface ICredentialsResponse extends ICredentialsDb {
 	id: string;

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -168,6 +168,7 @@ export interface ICredentialsBase {
 export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted {
 	id: number | string;
 	name: string;
+	shared?: SharedCredentials[];
 }
 
 export interface ICredentialsResponse extends ICredentialsDb {

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -167,9 +167,16 @@ export interface ICredentialsBase {
 export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted {
 	id: number | string;
 	name: string;
-	ownedBy?: Partial<User>; // injected by service
-	sharedWith?: Array<Partial<User>>; // injected by service
 }
+
+/**
+ * Credential with permissions details
+ * injected by `CredentialsService`.
+ */
+export type CredentialWithPermissions = ICredentialsDb & {
+	ownedBy?: Partial<User>;
+	sharedWith?: Array<Partial<User>>;
+};
 
 export interface ICredentialsResponse extends ICredentialsDb {
 	id: string;

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -167,7 +167,7 @@ export interface ICredentialsBase {
 export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted {
 	id: number | string;
 	name: string;
-	ownedBy?: User; // injected by service
+	ownedBy?: Partial<User>; // injected by service
 	sharedWith?: Array<Partial<User>>; // injected by service
 }
 

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -167,6 +167,8 @@ export interface ICredentialsBase {
 export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted {
 	id: number | string;
 	name: string;
+	ownedBy?: User; // injected by service
+	sharedWith?: Array<Partial<User>>; // injected by service
 }
 
 export interface ICredentialsResponse extends ICredentialsDb {

--- a/packages/cli/src/UserManagement/controllers/AuthController.ts
+++ b/packages/cli/src/UserManagement/controllers/AuthController.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable import/no-cycle */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import type { Request, Response } from 'express';
 import { In } from 'typeorm';
 import validator from 'validator';
@@ -46,6 +45,7 @@ export class AuthController {
 			throw new Error('Unable to access database.');
 		}
 
+		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 		if (!user || !user.password || !(await compareHash(password, user.password))) {
 			// password is empty until user signs up
 			const error = new Error('Wrong username or password. Do you have caps lock on?');
@@ -160,6 +160,7 @@ export class AuthController {
 
 		const inviter = users.find((user) => user.id === inviterId);
 
+		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 		if (!inviter || !inviter.email || !inviter.firstName) {
 			Logger.error(
 				'Request to resolve signup token failed because inviter does not exist or is not set up',

--- a/packages/cli/src/UserManagement/controllers/AuthController.ts
+++ b/packages/cli/src/UserManagement/controllers/AuthController.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable import/no-cycle */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import type { Request, Response } from 'express';
 import { In } from 'typeorm';
 import validator from 'validator';

--- a/packages/cli/src/UserManagement/controllers/PasswordResetController.ts
+++ b/packages/cli/src/UserManagement/controllers/PasswordResetController.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-cycle */
-/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import type { Response } from 'express';
 import { IsNull, MoreThanOrEqual, Not } from 'typeorm';
 import { v4 as uuid } from 'uuid';
@@ -52,6 +51,7 @@ export class PasswordResetController {
 		// User should just be able to reset password if one is already present
 		const user = await Db.collections.User.findOne({ email, password: Not(IsNull()) });
 
+		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
 		if (!user || !user.password) {
 			Logger.debug(
 				'Request to send password reset email failed because no user was found for the provided email',

--- a/packages/cli/src/UserManagement/controllers/PasswordResetController.ts
+++ b/packages/cli/src/UserManagement/controllers/PasswordResetController.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-cycle */
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import type { Response } from 'express';
 import { IsNull, MoreThanOrEqual, Not } from 'typeorm';
 import { v4 as uuid } from 'uuid';

--- a/packages/cli/src/UserManagement/routes/index.ts
+++ b/packages/cli/src/UserManagement/routes/index.ts
@@ -79,7 +79,7 @@ export function addRoutes(this: N8nApp, ignoredEndpoints: string[], restEndpoint
 		}
 		// Not owner and user exists. We now protect restricted urls.
 		const postRestrictedUrls = [`/${this.restEndpoint}/users`, `/${this.restEndpoint}/owner`];
-		const getRestrictedUrls = [`/${this.restEndpoint}/users`];
+		const getRestrictedUrls: string[] = [];
 		const trimmedUrl = req.url.endsWith('/') ? req.url.slice(0, -1) : req.url;
 		if (
 			(req.method === 'POST' && postRestrictedUrls.includes(trimmedUrl)) ||

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -199,7 +199,10 @@ credentialsController.get(
 		const { id: credentialId } = req.params;
 		const includeDecryptedData = req.query.includeData === 'true';
 
-		const sharing = await CredentialsService.getSharing(req.user, credentialId);
+		const sharing = await CredentialsService.getSharing(req.user, credentialId, [
+			'credentials',
+			'role',
+		]);
 
 		if (!sharing) {
 			throw new ResponseHelper.ResponseError(

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -37,7 +37,7 @@ credentialsController.get(
 		let credentials: ICredentialsDb[] | undefined;
 
 		try {
-			credentials = await CredentialsService.getMany(req.user);
+			credentials = await CredentialsService.getManyWithPermissions(req.user);
 		} catch (error) {
 			LoggerProxy.error('Request to list credentials failed', error as Error);
 			throw error;

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -214,12 +214,12 @@ credentialsController.get(
 
 		const { credentials: credential } = sharing;
 
-		const userIsEditor =
-			sharing.credentialId.toString() === credentialId && sharing.role.name === 'editor';
+		const userIsNotOwner =
+			sharing.credentialId.toString() === credentialId && sharing.role.name !== 'owner';
 
 		// @TODO_TECH_DEBT: Stringify `id` with entity field transformer
 
-		if (!includeDecryptedData || userIsEditor) {
+		if (!includeDecryptedData || userIsNotOwner) {
 			const { id, data: _, ...rest } = credential;
 
 			return { id: id.toString(), ...rest };

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -47,7 +47,7 @@ credentialsController.get(
 
 		return credentials.map((credential) => {
 			// eslint-disable-next-line no-param-reassign
-			credential.id = credential.id.toString(); // @TODO: Tech debt - stringify ID in entity
+			credential.id = credential.id.toString(); // @TODO_TECH_DEBT: Stringify ID with entity transformer
 			return credential as ICredentialsResponse;
 		});
 	}),

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -218,9 +218,14 @@ credentialsController.get(
 		const [firstSharing] = sharings;
 		const { credentials: credential } = firstSharing;
 
+		const userIsEditor =
+			sharings.find(
+				(s) => s.credentialId.toString() === credentialId && s.role.name === 'editor',
+			) !== undefined;
+
 		// @TODO_TECH_DEBT: Stringify `id` with entity field transformer
 
-		if (!includeDecryptedData) {
+		if (!includeDecryptedData || userIsEditor) {
 			const { id, data: _, ...rest } = addPermissions(credential);
 
 			return { id: id.toString(), ...rest };

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -236,14 +236,10 @@ credentialsController.get(
 
 		const { credentials: credential } = sharing;
 
-		const userIsNotOwner =
-			sharing.credentialId.toString() === credentialId && sharing.role.name !== 'owner';
-
-		// @TODO_TECH_DEBT: Stringify `id` with entity field transformer
-
-		if (!includeDecryptedData || userIsNotOwner) {
+		if (!includeDecryptedData || sharing.role.name !== 'owner') {
 			const { id, data: _, ...rest } = credential;
 
+			// @TODO_TECH_DEBT: Stringify `id` with entity field transformer
 			return { id: id.toString(), ...rest };
 		}
 
@@ -252,6 +248,7 @@ credentialsController.get(
 		const key = await CredentialsService.getEncryptionKey();
 		const decryptedData = await CredentialsService.decrypt(key, credential);
 
+		// @TODO_TECH_DEBT: Stringify `id` with entity field transformer
 		return { id: id.toString(), data: decryptedData, ...rest };
 	}),
 );

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -11,7 +11,7 @@ export class EECredentialsService extends CredentialsService {
 		user: User,
 		credentialId: string,
 	): Promise<{ ownsCredential: boolean; credential?: CredentialsEntity }> {
-		const sharing = await this.getShared(user, credentialId, ['credentials'], {
+		const sharing = await this.getSharings(user, credentialId, ['credentials'], {
 			allowGlobalOwner: false,
 		});
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -16,13 +16,11 @@ export class EECredentialsService extends CredentialsService {
 			allowGlobalOwner: false,
 		});
 
-		if (sharing) {
-			const { credentials: credential } = sharing;
+		if (!sharing) return { ownsCredential: false };
 
-			return { ownsCredential: true, credential };
-		}
+		const { credentials: credential } = sharing;
 
-		return { ownsCredential: false };
+		return { ownsCredential: true, credential };
 	}
 
 	static async share(credential: CredentialsEntity, sharee: User): Promise<SharedCredentials> {

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -1,23 +1,23 @@
 /* eslint-disable import/no-cycle */
 import { Db } from '..';
-import { CredentialsEntity } from '../databases/entities/CredentialsEntity';
-import { SharedCredentials } from '../databases/entities/SharedCredentials';
-import { User } from '../databases/entities/User';
 import { CredentialsService } from './credentials.service';
 import { RoleService } from '../role/role.service';
+
+import type { CredentialsEntity } from '../databases/entities/CredentialsEntity';
+import type { SharedCredentials } from '../databases/entities/SharedCredentials';
+import type { User } from '../databases/entities/User';
 
 export class EECredentialsService extends CredentialsService {
 	static async isOwned(
 		user: User,
 		credentialId: string,
 	): Promise<{ ownsCredential: boolean; credential?: CredentialsEntity }> {
-		const sharings = await this.getSharings(user, credentialId, ['credentials'], {
+		const sharing = await this.getSharing(user, credentialId, ['credentials'], {
 			allowGlobalOwner: false,
 		});
 
-		if (sharings.length > 0) {
-			const [firstSharing] = sharings;
-			const { credentials: credential } = firstSharing;
+		if (sharing) {
+			const { credentials: credential } = sharing;
 
 			return { ownsCredential: true, credential };
 		}

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-cycle */
 import { Db } from '..';
-import { CredentialsService } from './credentials.service';
 import { CredentialsEntity } from '../databases/entities/CredentialsEntity';
 import { SharedCredentials } from '../databases/entities/SharedCredentials';
 import { User } from '../databases/entities/User';
+import { CredentialsService } from './credentials.service';
 import { RoleService } from '../role/role.service';
 
 export class EECredentialsService extends CredentialsService {
@@ -11,20 +11,25 @@ export class EECredentialsService extends CredentialsService {
 		user: User,
 		credentialId: string,
 	): Promise<{ ownsCredential: boolean; credential?: CredentialsEntity }> {
-		const sharing = await this.getSharings(user, credentialId, ['credentials'], {
+		const sharings = await this.getSharings(user, credentialId, ['credentials'], {
 			allowGlobalOwner: false,
 		});
 
-		return sharing
-			? { ownsCredential: true, credential: sharing.credentials }
-			: { ownsCredential: false };
+		if (sharings.length > 0) {
+			const [firstSharing] = sharings;
+			const { credentials: credential } = firstSharing;
+
+			return { ownsCredential: true, credential };
+		}
+
+		return { ownsCredential: false };
 	}
 
-	static async share(credentials: CredentialsEntity, sharee: User): Promise<SharedCredentials> {
+	static async share(credential: CredentialsEntity, sharee: User): Promise<SharedCredentials> {
 		const role = await RoleService.get({ scope: 'credential', name: 'editor' });
 
 		return Db.collections.SharedCredentials.save({
-			credentials,
+			credentials: credential,
 			user: sharee,
 			role,
 		});

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -34,7 +34,7 @@ export class CredentialsService {
 	static async getSharing(
 		user: User,
 		credentialId: number | string,
-		relations: string[] | undefined = ['credentials', 'role', 'user'],
+		relations: string[] | undefined = ['credentials', 'role'],
 		{ allowGlobalOwner } = { allowGlobalOwner: true },
 	): Promise<SharedCredentials | undefined> {
 		const options: FindOneOptions = {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -26,6 +26,8 @@ import { validateEntity } from '../GenericHelpers';
 import { CredentialRequest } from '../requests';
 import { externalHooks } from '../Server';
 
+import type { Permissions } from './credentials.types';
+
 export class CredentialsService {
 	/**
 	 * Retrieve all the sharings matching a user (in any role) and a credential.
@@ -313,7 +315,3 @@ export class CredentialsService {
 		return helper.testCredentials(user, credentials.type, credentials, nodeToTestWith);
 	}
 }
-
-type Permissions = {
-	[credentialId: string]: { ownedBy?: User; sharedWith?: Array<Partial<User>> };
-};

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -8,7 +8,7 @@ import {
 	INodeCredentialTestResult,
 	LoggerProxy,
 } from 'n8n-workflow';
-import { FindOneOptions, In } from 'typeorm';
+import { FindManyOptions, In } from 'typeorm';
 
 import {
 	createCredentialsFromCredentialsEntity,
@@ -27,13 +27,16 @@ import { CredentialRequest } from '../requests';
 import { externalHooks } from '../Server';
 
 export class CredentialsService {
+	/**
+	 * Retrieve all the sharings matching a user (in any role) and a credential.
+	 */
 	static async getSharings(
 		user: User,
 		credentialId: number | string,
 		relations: string[] | undefined = ['credentials', 'role', 'user'],
-		{ allowGlobalOwner }: { allowGlobalOwner: boolean } = { allowGlobalOwner: true },
-	): Promise<SharedCredentials | undefined> {
-		const options: FindOneOptions = {
+		{ allowGlobalOwner } = { allowGlobalOwner: true },
+	): Promise<SharedCredentials[]> {
+		const options: FindManyOptions = {
 			where: {
 				credentials: { id: credentialId },
 			},
@@ -51,7 +54,7 @@ export class CredentialsService {
 			options.relations = relations;
 		}
 
-		return Db.collections.SharedCredentials.findOne(options);
+		return Db.collections.SharedCredentials.find(options);
 	}
 
 	static async getMany(user: User): Promise<ICredentialsDb[]> {
@@ -72,7 +75,7 @@ export class CredentialsService {
 			}),
 		});
 
-		if (!sharings.length) return [];
+		if (sharings.length === 0) return [];
 
 		const addPermissions = CredentialsService.createAddPermissions(sharings);
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -34,7 +34,7 @@ export class CredentialsService {
 	static async getSharing(
 		user: User,
 		credentialId: number | string,
-		relations: string[] | undefined = ['credentials', 'role'],
+		relations: string[] | undefined = ['credentials'],
 		{ allowGlobalOwner } = { allowGlobalOwner: true },
 	): Promise<SharedCredentials | undefined> {
 		const options: FindOneOptions = {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -129,11 +129,10 @@ export class CredentialsService {
 	private static addPermissions(permissions: Permissions) {
 		return (credential: ICredentialsDb) => {
 			if (permissions[credential.id].ownedBy) {
-				// @ts-ignore @TODO: Type properly
 				credential.ownedBy = permissions[credential.id].ownedBy;
 			}
+
 			if (permissions[credential.id].sharedWith) {
-				// @ts-ignore @TODO: Type properly
 				credential.sharedWith = permissions[credential.id].sharedWith;
 			}
 

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -14,7 +14,6 @@ import {
 	CredentialsHelper,
 	Db,
 	ICredentialsDb,
-	CredentialWithPermissions,
 	ResponseHelper,
 } from '..';
 import { RESPONSE_ERROR_MESSAGES } from '../constants';
@@ -25,7 +24,7 @@ import { externalHooks } from '../Server';
 
 import type { User } from '../databases/entities/User';
 import type { CredentialRequest } from '../requests';
-import type { Permissions } from './credentials.types';
+import type { CredentialWithPermissions, Permissions } from './credentials.types';
 
 export class CredentialsService {
 	/**

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable import/no-cycle */
 import { Credentials, UserSettings } from 'n8n-core';

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -86,7 +86,7 @@ export class CredentialsService {
 		}
 
 		/**
-		 * If member request, return all credentials if owned by or shared with member.
+		 * If member request, return credentials owned by or shared with member.
 		 */
 		const memberCreds = await Db.collections.Credentials.find({
 			select: SELECT_FIELDS,

--- a/packages/cli/src/credentials/credentials.types.ts
+++ b/packages/cli/src/credentials/credentials.types.ts
@@ -1,5 +1,5 @@
 import type { User } from '../databases/entities/User';
 
 export type Permissions = {
-	[credentialId: string]: { ownedBy?: User; sharedWith?: Array<Partial<User>> };
+	[credentialId: string]: { ownedBy?: Partial<User>; sharedWith?: Array<Partial<User>> };
 };

--- a/packages/cli/src/credentials/credentials.types.ts
+++ b/packages/cli/src/credentials/credentials.types.ts
@@ -1,5 +1,8 @@
 import type { User } from '../databases/entities/User';
+import type { ICredentialsDb } from '../Interfaces';
 
 export type Permissions = {
 	[credentialId: string]: { ownedBy?: Partial<User>; sharedWith?: Array<Partial<User>> };
 };
+
+export type CredentialWithPermissions = ICredentialsDb & Permissions[string];

--- a/packages/cli/src/credentials/credentials.types.ts
+++ b/packages/cli/src/credentials/credentials.types.ts
@@ -2,7 +2,10 @@ import type { User } from '../databases/entities/User';
 import type { ICredentialsDb } from '../Interfaces';
 
 export type Permissions = {
-	[credentialId: string]: { ownedBy?: Partial<User>; sharedWith?: Array<Partial<User>> };
+	[credentialId: string]: {
+		ownedBy?: Partial<User>;
+		sharedWith?: Array<Partial<User>>;
+	};
 };
 
 export type CredentialWithPermissions = ICredentialsDb & Permissions[string];

--- a/packages/cli/src/credentials/credentials.types.ts
+++ b/packages/cli/src/credentials/credentials.types.ts
@@ -1,0 +1,5 @@
+import type { User } from '../databases/entities/User';
+
+export type Permissions = {
+	[credentialId: string]: { ownedBy?: User; sharedWith?: Array<Partial<User>> };
+};

--- a/packages/cli/src/credentials/credentials.types.ts
+++ b/packages/cli/src/credentials/credentials.types.ts
@@ -1,11 +1,8 @@
-import type { User } from '../databases/entities/User';
 import type { ICredentialsDb } from '../Interfaces';
 
-export type Permissions = {
-	[credentialId: string]: {
-		ownedBy?: Partial<User>;
-		sharedWith?: Array<Partial<User>>;
-	};
-};
+export interface CredentialWithSharings extends ICredentialsDb {
+	ownedBy?: UserSharingsDetails | null;
+	sharedWith?: UserSharingsDetails[];
+}
 
-export type CredentialWithPermissions = ICredentialsDb & Permissions[string];
+type UserSharingsDetails = { id: string; email: string; firstName: string; lastName: string };

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -403,7 +403,17 @@ test('GET /credentials should retrieve all creds for owner', async () => {
 			expect(typeof type).toBe('string');
 			expect(typeof nodesAccess[0].nodeType).toBe('string');
 			expect(encryptedData).toBeUndefined();
-			expect(ownedBy).not.toBeUndefined();
+
+			expect(typeof ownedBy.id).toBe('string');
+
+			if (ownedBy.email === null) {
+				expect(ownedBy.firstName).toBe(null);
+				expect(ownedBy.lastName).toBe(null);
+			} else {
+				expect(typeof ownedBy.email).toBe('string');
+				expect(typeof ownedBy.firstName).toBe('string');
+				expect(typeof ownedBy.lastName).toBe('string');
+			}
 		}),
 	);
 });
@@ -428,7 +438,17 @@ test('GET /credentials should retrieve owned creds for member', async () => {
 			expect(typeof type).toBe('string');
 			expect(typeof nodesAccess[0].nodeType).toBe('string');
 			expect(encryptedData).toBeUndefined();
-			expect(ownedBy).not.toBeUndefined();
+
+			expect(typeof ownedBy.id).toBe('string');
+
+			if (ownedBy.email === null) {
+				expect(ownedBy.firstName).toBe(null);
+				expect(ownedBy.lastName).toBe(null);
+			} else {
+				expect(typeof ownedBy.email).toBe('string');
+				expect(typeof ownedBy.firstName).toBe('string');
+				expect(typeof ownedBy.lastName).toBe('string');
+			}
 		}),
 	);
 });

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -1,12 +1,13 @@
 import express from 'express';
 import { UserSettings } from 'n8n-core';
+
 import { Db } from '../../src';
 import { RESPONSE_ERROR_MESSAGES } from '../../src/constants';
 import { randomCredentialPayload, randomName, randomString } from './shared/random';
 import * as testDb from './shared/testDb';
-import type { AuthAgent, PermissionedCredential, SaveCredentialFunction } from './shared/types';
 import * as utils from './shared/utils';
 
+import type { AuthAgent, SaveCredentialFunction } from './shared/types';
 import type { Role } from '../../src/databases/entities/Role';
 
 jest.mock('../../src/telemetry');

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -394,7 +394,7 @@ test('GET /credentials should retrieve all creds for owner', async () => {
 	const response = await authAgent(owner).get('/credentials');
 
 	expect(response.statusCode).toBe(200);
-	expect(response.body.data.length).toBe(2); // owner retrieved owner's and member's creds
+	expect(response.body.data.length).toBe(2); // owner retrieved owner cred and member cred
 
 	const [ownerCredential, memberCredential] = response.body.data;
 

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -450,7 +450,7 @@ test('GET /credentials should retrieve member creds for member', async () => {
 	const response = await authAgent(member).get('/credentials');
 
 	expect(response.statusCode).toBe(200);
-	expect(response.body.data.length).toBe(3); // member retrieved only member's creds
+	expect(response.body.data.length).toBe(3); // member retrieved only member creds
 
 	for (const memberCredential of response.body.data) {
 		expect(typeof memberCredential.name).toBe('string');

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -380,7 +380,7 @@ test('PATCH /credentials/:id should fail with missing encryption key', async () 
 	mock.mockRestore();
 });
 
-test('GET /credentials should retrieve all creds for owner', async () => {
+test.skip('GET /credentials should retrieve all creds for owner', async () => {
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 	const firstMember = await testDb.createUser({ globalRole: globalMemberRole });
 	const secondMember = await testDb.createUser({ globalRole: globalMemberRole });
@@ -437,7 +437,9 @@ test('GET /credentials should retrieve all creds for owner', async () => {
 	expect(memberCredential.sharedWith).toBeUndefined();
 });
 
-test('GET /credentials should retrieve member creds for member', async () => {
+// @TODO: Test for member request
+
+test.skip('GET /credentials should retrieve member creds for member', async () => {
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 	const member = await testDb.createUser({ globalRole: globalMemberRole });
 

--- a/packages/cli/test/integration/shared/constants.ts
+++ b/packages/cli/test/integration/shared/constants.ts
@@ -41,7 +41,6 @@ export const ROUTES_REQUIRING_AUTHENTICATION: Readonly<string[]> = [
  */
 export const ROUTES_REQUIRING_AUTHORIZATION: Readonly<string[]> = [
 	'POST /users',
-	'GET /users',
 	'DELETE /users/123',
 	'POST /users/123/reinvite',
 	'POST /owner',

--- a/packages/cli/test/integration/shared/types.d.ts
+++ b/packages/cli/test/integration/shared/types.d.ts
@@ -52,12 +52,16 @@ export interface TriggerTime {
 export type InstalledPackagePayload = {
 	packageName: string;
 	installedVersion: string;
-}
+};
 
 export type InstalledNodePayload = {
 	name: string;
 	type: string;
 	latestVersion: string;
 	package: string;
-}
+};
 
+export type PermissionedCredential = CredentialsEntity & {
+	ownedBy: Partial<User>;
+	sharedWith?: Array<Partial<User>>;
+};

--- a/packages/cli/test/integration/shared/types.d.ts
+++ b/packages/cli/test/integration/shared/types.d.ts
@@ -60,8 +60,3 @@ export type InstalledNodePayload = {
 	latestVersion: string;
 	package: string;
 };
-
-export type PermissionedCredential = CredentialsEntity & {
-	ownedBy: Partial<User>;
-	sharedWith?: Array<Partial<User>>;
-};

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -14,6 +14,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable no-param-reassign */
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
 import {
 	GenericValue,
 	IAdditionalCredentialOptions,


### PR DESCRIPTION
- Add permissions details `ownedBy` and `sharedWith` to `GET /credentials`
- Remove filtering in `GET /credentials`
- Open `GET /users` to all authenticated requests, not only owner