### PR TITLE
Assign parent workflow ID to subworkflows from generic JSON

### DIFF
--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -247,6 +247,7 @@ export class WorkflowRunner {
 			active: data.workflowData.active,
 			nodeTypes,
 			staticData: data.workflowData.staticData,
+			settings: data.workflowData.settings,
 		});
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
 			data.userId,

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2199,7 +2199,11 @@ export function getExecuteFunctions(
 				inputData?: INodeExecutionData[],
 			): Promise<any> {
 				return additionalData
-					.executeWorkflow(workflowInfo, additionalData, inputData)
+					.executeWorkflow(workflowInfo, additionalData, {
+						parentWorkflowId: workflow.id?.toString(),
+						inputData,
+						parentWorkflowSettings: workflow.settings,
+					})
 					.then(async (result) =>
 						BinaryDataManager.getInstance().duplicateBinaryData(
 							result,

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1437,10 +1437,14 @@ export interface IWorkflowExecuteAdditionalData {
 	executeWorkflow: (
 		workflowInfo: IExecuteWorkflowInfo,
 		additionalData: IWorkflowExecuteAdditionalData,
-		inputData?: INodeExecutionData[],
-		parentExecutionId?: string,
-		loadedWorkflowData?: IWorkflowBase,
-		loadedRunData?: any,
+		options?: {
+			parentWorkflowId?: string;
+			inputData?: INodeExecutionData[];
+			parentExecutionId?: string;
+			loadedWorkflowData?: IWorkflowBase;
+			loadedRunData?: any;
+			parentWorkflowSettings?: IWorkflowSettings;
+		},
 	) => Promise<any>;
 	// hooks?: IWorkflowExecuteHooks;
 	executionId?: string;

--- a/packages/workflow/test/Helpers.ts
+++ b/packages/workflow/test/Helpers.ts
@@ -217,7 +217,7 @@ export function getExecuteFunctions(
 				workflowInfo: IExecuteWorkflowInfo,
 				inputData?: INodeExecutionData[],
 			): Promise<any> {
-				return additionalData.executeWorkflow(workflowInfo, additionalData, inputData);
+				return additionalData.executeWorkflow(workflowInfo, additionalData, { inputData });
 			},
 			getContext(type: string): IContextObject {
 				return NodeHelpers.getContext(runExecutionData, type, node);


### PR DESCRIPTION
This PR changes some important behaviors when running sub-workflows via `Execute Workflow` node with arbitrary JSON.

- Assign parent workflow ID to sub-workflow so it is displayed under the Executions list
- Use the same settings as the parent so persistence configurations are followed
- (Code refactor: ) changed the `executeWorkflow` function's optional arguments to an object