### PR TITLE
n8n-4331-aws-ses-sending-emails-including-special-characters-fails

### DIFF
--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -1020,7 +1020,10 @@ export class AwsSes implements INodeType {
 
 						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 
-						const params = [`Message.Subject.Data=${subject}`, `Source=${fromEmail}`];
+						const params = [
+							`Message.Subject.Data=${encodeURIComponent(subject)}`,
+							`Source=${fromEmail}`,
+						];
 
 						if (isBodyHtml) {
 							params.push(`Message.Body.Html.Data=${encodeURIComponent(message)}`);


### PR DESCRIPTION
https://community.n8n.io/t/amazon-ses-error-on-valid-body-subject/11116