### PR TITLE
feat(cli): Load all nodes and credentials code in isolation - N8N-4362

### DIFF
--- a/packages/cli/src/CommunityNodes/helpers.ts
+++ b/packages/cli/src/CommunityNodes/helpers.ts
@@ -4,7 +4,7 @@
 import { promisify } from 'util';
 import { exec } from 'child_process';
 import { access as fsAccess, mkdir as fsMkdir } from 'fs/promises';
-
+import { Script } from 'vm';
 import axios from 'axios';
 import { UserSettings } from 'n8n-core';
 import { LoggerProxy, PublicInstalledPackage } from 'n8n-workflow';
@@ -235,3 +235,9 @@ export const isClientError = (error: Error): boolean => {
 export function isNpmError(error: unknown): error is { code: number; stdout: string } {
 	return typeof error === 'object' && error !== null && 'code' in error && 'stdout' in error;
 }
+
+export const loadClassInIsolation = (filePath: string, className: string) => {
+	const script = new Script(`new (require('${filePath}').${className})()`);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return script.runInNewContext({ require });
+};

--- a/packages/cli/src/CommunityNodes/helpers.ts
+++ b/packages/cli/src/CommunityNodes/helpers.ts
@@ -4,7 +4,7 @@
 import { promisify } from 'util';
 import { exec } from 'child_process';
 import { access as fsAccess, mkdir as fsMkdir } from 'fs/promises';
-import { Script } from 'vm';
+import { createContext, Script } from 'vm';
 import axios from 'axios';
 import { UserSettings } from 'n8n-core';
 import { LoggerProxy, PublicInstalledPackage } from 'n8n-workflow';
@@ -236,8 +236,9 @@ export function isNpmError(error: unknown): error is { code: number; stdout: str
 	return typeof error === 'object' && error !== null && 'code' in error && 'stdout' in error;
 }
 
+const context = createContext({ require });
 export const loadClassInIsolation = (filePath: string, className: string) => {
 	const script = new Script(`new (require('${filePath}').${className})()`);
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return script.runInNewContext({ require });
+	return script.runInContext(context);
 };

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -37,13 +37,12 @@ import config from '../config';
 import { NodeTypes } from '.';
 import { InstalledPackages } from './databases/entities/InstalledPackages';
 import { InstalledNodes } from './databases/entities/InstalledNodes';
-import { executeCommand } from './CommunityNodes/helpers';
+import { executeCommand, loadClassInIsolation } from './CommunityNodes/helpers';
 import { RESPONSE_ERROR_MESSAGES } from './constants';
 import {
 	persistInstalledPackageData,
 	removePackageFromDatabase,
 } from './CommunityNodes/packageModel';
-import { loadClassInIsolation } from './PackageHelper';
 
 const CUSTOM_NODES_CATEGORY = 'Custom Nodes';
 
@@ -113,10 +112,8 @@ class LoadNodesAndCredentialsClass {
 				await fsAccess(checkPath);
 				// Folder exists, so use it.
 				return path.dirname(checkPath);
-			} catch (error) {
+			} catch (_) {
 				// Folder does not exist so get next one
-				// eslint-disable-next-line no-continue
-				continue;
 			}
 		}
 		throw new Error('Could not find "node_modules" folder!');
@@ -153,8 +150,7 @@ class LoadNodesAndCredentialsClass {
 		if (process.env[CUSTOM_EXTENSION_ENV] !== undefined) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const customExtensionFolders = process.env[CUSTOM_EXTENSION_ENV]!.split(';');
-			// eslint-disable-next-line prefer-spread
-			customDirectories.push.apply(customDirectories, customExtensionFolders);
+			customDirectories.push(...customExtensionFolders);
 		}
 
 		for (const directory of customDirectories) {
@@ -201,9 +197,7 @@ class LoadNodesAndCredentialsClass {
 	 * @param {string} filePath The file to read credentials from
 	 * @returns {Promise<void>}
 	 */
-	async loadCredentialsFromFile(credentialName: string, filePath: string): Promise<void> {
-		// eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
-
+	loadCredentialsFromFile(credentialName: string, filePath: string): void {
 		let tempCredential: ICredentialType;
 		try {
 			tempCredential = loadClassInIsolation(filePath, credentialName);
@@ -354,13 +348,12 @@ class LoadNodesAndCredentialsClass {
 	 * @param {string} filePath The file to read node from
 	 * @returns {Promise<void>}
 	 */
-	async loadNodeFromFile(
+	loadNodeFromFile(
 		packageName: string,
 		nodeName: string,
 		filePath: string,
-	): Promise<INodeTypeNameVersion | undefined> {
+	): INodeTypeNameVersion | undefined {
 		let tempNode: INodeType | INodeVersionedType;
-		let fullNodeName: string;
 		let nodeVersion = 1;
 
 		try {
@@ -372,8 +365,7 @@ class LoadNodesAndCredentialsClass {
 			throw error;
 		}
 
-		// eslint-disable-next-line prefer-const
-		fullNodeName = `${packageName}.${tempNode.description.name}`;
+		const fullNodeName = `${packageName}.${tempNode.description.name}`;
 		tempNode.description.name = fullNodeName;
 
 		if (tempNode.description.icon !== undefined && tempNode.description.icon.startsWith('file:')) {
@@ -483,8 +475,7 @@ class LoadNodesAndCredentialsClass {
 
 			node.description.codex = codex;
 		} catch (_) {
-			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-			this.logger.debug(`No codex available for: ${filePath.split('/').pop()}`);
+			this.logger.debug(`No codex available for: ${filePath.split('/').pop() ?? ''}`);
 
 			if (isCustom) {
 				node.description.codex = {
@@ -504,19 +495,15 @@ class LoadNodesAndCredentialsClass {
 	async loadDataFromDirectory(setPackageName: string, directory: string): Promise<void> {
 		const files = await glob(path.join(directory, '**/*.@(node|credentials).js'));
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const loadPromises: any[] = [];
 		for (const filePath of files) {
 			const [fileName, type] = path.parse(filePath).name.split('.');
 
 			if (type === 'node') {
-				loadPromises.push(this.loadNodeFromFile(setPackageName, fileName, filePath));
+				this.loadNodeFromFile(setPackageName, fileName, filePath);
 			} else if (type === 'credentials') {
-				loadPromises.push(this.loadCredentialsFromFile(fileName, filePath));
+				this.loadCredentialsFromFile(fileName, filePath);
 			}
 		}
-
-		await Promise.all(loadPromises);
 	}
 
 	async readPackageJson(packagePath: string): Promise<IN8nNodePackageJson> {
@@ -534,7 +521,6 @@ class LoadNodesAndCredentialsClass {
 	async loadDataFromPackage(packagePath: string): Promise<INodeTypeNameVersion[]> {
 		// Get the absolute path of the package
 		const packageFile = await this.readPackageJson(packagePath);
-		// if (!packageFile.hasOwnProperty('n8n')) {
 		if (!packageFile.n8n) {
 			return [];
 		}
@@ -548,7 +534,7 @@ class LoadNodesAndCredentialsClass {
 			for (const filePath of nodes) {
 				const tempPath = path.join(packagePath, filePath);
 				const [fileName] = path.parse(filePath).name.split('.');
-				const loadData = await this.loadNodeFromFile(packageName, fileName, tempPath);
+				const loadData = this.loadNodeFromFile(packageName, fileName, tempPath);
 				if (loadData) {
 					returnData.push(loadData);
 				}
@@ -559,9 +545,7 @@ class LoadNodesAndCredentialsClass {
 		if (Array.isArray(credentials)) {
 			for (const filePath of credentials) {
 				const tempPath = path.join(packagePath, filePath);
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				const [fileName] = path.parse(filePath).name.split('.');
-				// eslint-disable-next-line @typescript-eslint/no-floating-promises
 				this.loadCredentialsFromFile(fileName, tempPath);
 			}
 		}

--- a/packages/cli/src/PackageHelper.ts
+++ b/packages/cli/src/PackageHelper.ts
@@ -1,7 +1,0 @@
-import { Script } from 'vm';
-
-export const loadClassInIsolation = (filePath: string, className: string) => {
-	const script = new Script(`new (require('${filePath}').${className})()`);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return script.runInNewContext({ require });
-};

--- a/packages/cli/src/PackageHelper.ts
+++ b/packages/cli/src/PackageHelper.ts
@@ -1,0 +1,7 @@
+import { Script } from 'vm';
+
+export const loadClassInIsolation = (filePath: string, className: string) => {
+	const script = new Script(`new (require('${filePath}').${className})()`);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return script.runInNewContext({ require });
+};

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -49,6 +49,7 @@ import { getLogger } from './Logger';
 import config from '../config';
 import { InternalHooksManager } from './InternalHooksManager';
 import { checkPermissionsForExecution } from './UserManagement/UserManagementHelper';
+import { loadClassInIsolation } from './PackageHelper';
 
 export class WorkflowRunnerProcess {
 	data: IWorkflowExecutionDataProcessWithExecution | undefined;
@@ -92,41 +93,30 @@ export class WorkflowRunnerProcess {
 			workflowId: this.data.workflowData.id,
 		});
 
-		let className: string;
-		let tempNode: INodeType;
-		let tempCredential: ICredentialType;
-		let filePath: string;
-
 		this.startedAt = new Date();
 
 		// Load the required nodes
 		const nodeTypesData: INodeTypeData = {};
 		// eslint-disable-next-line no-restricted-syntax
 		for (const nodeTypeName of Object.keys(this.data.nodeTypeData)) {
-			className = this.data.nodeTypeData[nodeTypeName].className;
-
-			filePath = this.data.nodeTypeData[nodeTypeName].sourcePath;
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
-			const tempModule = require(filePath);
+			let tempNode: INodeType;
+			const { className, sourcePath } = this.data.nodeTypeData[nodeTypeName];
 
 			try {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-				const nodeObject = new tempModule[className]();
+				const nodeObject = loadClassInIsolation(sourcePath, className);
 				if (nodeObject.getNodeType !== undefined) {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 					tempNode = nodeObject.getNodeType();
 				} else {
 					tempNode = nodeObject;
 				}
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-				tempNode = new tempModule[className]() as INodeType;
 			} catch (error) {
-				throw new Error(`Error loading node "${nodeTypeName}" from: "${filePath}"`);
+				throw new Error(`Error loading node "${nodeTypeName}" from: "${sourcePath}"`);
 			}
 
 			nodeTypesData[nodeTypeName] = {
 				type: tempNode,
-				sourcePath: filePath,
+				sourcePath,
 			};
 		}
 
@@ -137,22 +127,18 @@ export class WorkflowRunnerProcess {
 		const credentialsTypeData: ICredentialTypeData = {};
 		// eslint-disable-next-line no-restricted-syntax
 		for (const credentialTypeName of Object.keys(this.data.credentialsTypeData)) {
-			className = this.data.credentialsTypeData[credentialTypeName].className;
-
-			filePath = this.data.credentialsTypeData[credentialTypeName].sourcePath;
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
-			const tempModule = require(filePath);
+			let tempCredential: ICredentialType;
+			const { className, sourcePath } = this.data.credentialsTypeData[credentialTypeName];
 
 			try {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-				tempCredential = new tempModule[className]() as ICredentialType;
+				tempCredential = loadClassInIsolation(sourcePath, className);
 			} catch (error) {
-				throw new Error(`Error loading credential "${credentialTypeName}" from: "${filePath}"`);
+				throw new Error(`Error loading credential "${credentialTypeName}" from: "${sourcePath}"`);
 			}
 
 			credentialsTypeData[credentialTypeName] = {
 				type: tempCredential,
-				sourcePath: filePath,
+				sourcePath,
 			};
 		}
 

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -49,7 +49,7 @@ import { getLogger } from './Logger';
 import config from '../config';
 import { InternalHooksManager } from './InternalHooksManager';
 import { checkPermissionsForExecution } from './UserManagement/UserManagementHelper';
-import { loadClassInIsolation } from './PackageHelper';
+import { loadClassInIsolation } from './CommunityNodes/helpers';
 
 export class WorkflowRunnerProcess {
 	data: IWorkflowExecutionDataProcessWithExecution | undefined;


### PR DESCRIPTION
Currently all nodes and credentials are loaded in the same global context as the rest of the app. This becomes a security nightmare as we have more and more community nodes.

We can fix this by loading all nodes and credentials code in isolated contexts, which in turn also reduces any possibilities of external side-effects creating trouble for any inividial node or credential.

PS: This breaks the functionality in the `Function` node where one can refer to env variables with expression like `$ENV_VAR`. 