### PR TITLE
fix(cli): Account for non-array in pindata migration

### DIFF
--- a/packages/cli/src/databases/migrations/sqlite/1659888469333-AddJsonKeyPinData.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1659888469333-AddJsonKeyPinData.ts
@@ -78,7 +78,11 @@ function makeUpdateParams(fetchedWorkflows: PinData.FetchedWorkflow[]) {
 
 			const newPinDataPerWorkflow = Object.keys(pinDataPerWorkflow).reduce<PinData.New>(
 				(newPinDataPerWorkflow, nodeName) => {
-					const pinDataPerNode = pinDataPerWorkflow[nodeName];
+					let pinDataPerNode = pinDataPerWorkflow[nodeName];
+
+					if (!Array.isArray(pinDataPerNode)) {
+						pinDataPerNode = [pinDataPerNode];
+					}
 
 					if (pinDataPerNode.every((item) => item.json)) return newPinDataPerWorkflow;
 


### PR DESCRIPTION
To trigger: Set non-array as node value in `pinData` column, e.g. `{"Set": 123 }`

Close #3937