### PR TITLE
Fix disabled parent output in partial execution

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -192,6 +192,9 @@ export class WorkflowExecute {
 				for (const connections of incomingNodeConnections.main) {
 					for (let inputIndex = 0; inputIndex < connections.length; inputIndex++) {
 						connection = connections[inputIndex];
+
+						if (workflow.getNode(connection.node)?.disabled) continue;
+
 						incomingData.push(
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 							runData[connection.node][runIndex].data![connection.type][connection.index]!,
@@ -257,7 +260,10 @@ export class WorkflowExecute {
 		// Only run the parent nodes and no others
 		let runNodeFilter: string[] | undefined;
 		// eslint-disable-next-line prefer-const
-		runNodeFilter = workflow.getParentNodes(destinationNode);
+		runNodeFilter = workflow
+			.getParentNodes(destinationNode)
+			.filter((parentNodeName) => !workflow.getNode(parentNodeName)?.disabled);
+
 		runNodeFilter.push(destinationNode);
 
 		this.runExecutionData = {

--- a/packages/editor-ui/src/components/mixins/workflowRun.ts
+++ b/packages/editor-ui/src/components/mixins/workflowRun.ts
@@ -151,7 +151,9 @@ export const workflowRun = mixins(
 						// node for each of the branches
 						const parentNodes = workflow.getParentNodes(directParentNode, 'main');
 
-						// Add also the direct parent to be checked
+						// Add also the enabled direct parent to be checked
+						if (workflow.nodes[directParentNode].disabled) continue;
+
 						parentNodes.push(directParentNode);
 
 						for (const parentNode of parentNodes) {


### PR DESCRIPTION
Running twice a node whose parent is disabled causes the disabled parent to produce output. Reproducible at least since 0.180.

In a partial execution:
- skip disabled node when marking start nodes
- skip disabled node when collecting incoming data
- skip disabled node when filtering for nodes to run

To test, run Destination twice - both times the disabled parent should output nothing.

```json
{
  "nodes": [
    {
      "parameters": {
        "path": "1a7141ce-8a2b-4e72-aba4-1a31db380607",
        "options": {}
      },
      "id": "f476600c-1fd6-4b1b-bb69-a8726543f7f9",
      "name": "Webhook",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        980,
        360
      ],
      "webhookId": "1a7141ce-8a2b-4e72-aba4-1a31db380607",
      "disabled": true
    },
    {
      "parameters": {
        "functionCode": "return [\n  {\n    source: true, \n  }\n]"
      },
      "id": "486726c1-f561-4ec1-89e4-1de679c8ca90",
      "name": "Source",
      "type": "n8n-nodes-base.function",
      "typeVersion": 1,
      "position": [
        980,
        540
      ]
    },
    {
      "parameters": {
        "functionCode": "return items;"
      },
      "id": "dad217d1-3316-412a-9ef7-672836d74f18",
      "name": "Destination",
      "type": "n8n-nodes-base.function",
      "typeVersion": 1,
      "position": [
        1240,
        360
      ]
    }
  ],
  "connections": {
    "Webhook": {
      "main": [
        [
          {
            "node": "Destination",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Source": {
      "main": [
        [
          {
            "node": "Destination",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
```