### PR TITLE
fix(npm): improve .npmignore to reduce the size of the published packages - N8N-4459

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,28 @@
+dist/test
+dist/**/*.{js.map,d.ts}
+
+.DS_Store
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*
+
+.editorconfig
+.eslintrc.js
+tsconfig.json
+tslint.json
+
+.turbo

--- a/packages/design-system/.npmignore
+++ b/packages/design-system/.npmignore
@@ -1,25 +1,15 @@
-.DS_Store
+/src/**/*.{ts,vue,scss,snap}
+/theme/src
+!dist
+
 storybook-static
+.storybook
 
-
-# local env files
-.env.local
-.env.*.local
-
-# Log files
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+.browserslistrc
+babel.config.js
+gulpfile.js
+jest.config.js
+vite.config.ts
 
 *.md
 *.stories.js

--- a/packages/editor-ui/.npmignore
+++ b/packages/editor-ui/.npmignore
@@ -1,33 +1,12 @@
-/tests/
 /src
-
-# local env files
-.env.local
-.env.*.local
-
-# Log files
-yarn-debug.log*
-yarn-error.log*
-
-# Editor directories and files
-.idea
-.vscode
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw*
+/tests
+!dist
 
 .browserslistrc
-.editorconfig
-.eslintrc.js
 babel.config.js
 cypress.json
 jest.config.js
 postcss.config.js
-tsconfig.json
-tslint.json
 vue.config.js
 dist/report.html
-dist/**/*.map
 public/


### PR DESCRIPTION
| package | gzipped (before) | unpacked (before) | gzipped (after) | unpacked (after) |
| --- | --- | --- | --- | --- |
| cli | 367.7 kB | 2.3 MB | 165.5 kB | 1.0 MB |
| core | 65.4 kB | 450.6 kB | 26.5 kB | 164.9 kB |
| design-system | 180.9 kB | 660.2 kB | 117.6 kB | 449.2 kB |
| editor-ui | 3.5 MB | 12.4 MB | 3.5 MB | 12.4 MB |
| node-dev | 13.5 kB | 44.7 kB | 10.6 kB | 35.3 kB |
| nodes-base | 3.0 MB | 24.3 MB | 2.0 MB | 15.2 MB |
| workflow | 101.4 kB | 827.7 kB | 28.8 kB | 165.7 kB |


Ticket: N8N-4459