### PR TITLE
N8N-4467 HTTP Request node: DigestAuth failed when using query Parameters

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -351,8 +351,8 @@ async function parseRequestObject(requestObject: IDataObject) {
 			axiosConfig.headers === undefined
 				? false
 				: Object.keys(axiosConfig.headers)
-						.map((headerKey) => headerKey.toLowerCase())
-						.includes('accept');
+					.map((headerKey) => headerKey.toLowerCase())
+					.includes('accept');
 		if (!acceptHeaderExists) {
 			axiosConfig.headers = Object.assign(axiosConfig.headers || {}, {
 				Accept: 'application/json',
@@ -512,7 +512,8 @@ function digestAuthAxiosConfig(
 			.createHash('md5')
 			.update(`${auth?.username as string}:${realm}:${auth?.password as string}`)
 			.digest('hex');
-		const path = new url.URL(axiosConfig.url!).pathname;
+		const urlURL = new url.URL(axios.getUri(axiosConfig));
+		const path = urlURL.pathname + urlURL.search;
 		const ha2 = crypto
 			.createHash('md5')
 			.update(`${axiosConfig.method ?? 'GET'}:${path}`)

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -351,8 +351,8 @@ async function parseRequestObject(requestObject: IDataObject) {
 			axiosConfig.headers === undefined
 				? false
 				: Object.keys(axiosConfig.headers)
-					.map((headerKey) => headerKey.toLowerCase())
-					.includes('accept');
+						.map((headerKey) => headerKey.toLowerCase())
+						.includes('accept');
 		if (!acceptHeaderExists) {
 			axiosConfig.headers = Object.assign(axiosConfig.headers || {}, {
 				Accept: 'application/json',


### PR DESCRIPTION
Github Issue: [https://github.com/n8n-io/n8n/issues/3817](https://github.com/n8n-io/n8n/issues/3817)
Community Issue: [https://community.n8n.io/t/digestauth-failed-when-using-query-parameters/16495](https://community.n8n.io/t/digestauth-failed-when-using-query-parameters/16495)