### PR TITLE
fix(docker): revert docker `USER` and `WORKDIR` changes

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -17,10 +17,8 @@ RUN set -eux; \
 	find /usr/local/lib/node_modules/n8n -type f -name "*.ts" -o -name "*.js.map" -o -name "*.vue" | xargs rm && \
 	rm -rf /root/.npm
 
-RUN \
-	mkdir .n8n && \
-	chown node:node .n8n && \
-	ln -s /docker-entrypoint.sh /home/node/docker-entrypoint.sh
-USER node
-COPY docker-entrypoint.sh ./
-ENTRYPOINT ["tini", "--", "./docker-entrypoint.sh"]
+# Set a custom user to not have n8n run as root
+USER root
+WORKDIR /data
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
+
+if [ -d /root/.n8n ] ; then
+  chmod o+rx /root
+  chown -R node /root/.n8n
+  ln -s /root/.n8n /home/node/
+fi
+
+chown -R node /home/node
+
 if [ "$#" -gt 0 ]; then
   # Got started with arguments
-  exec node "$@"
+  exec su-exec node "$@"
 else
   # Got started without arguments
-  exec n8n
+  exec su-exec n8n
 fi


### PR DESCRIPTION
Switching from `root` to another user needs a bit more testing, as we need to figure out how to auto-migrate all existing instances of n8n when people upgrade.

This reverts parts of https://github.com/n8n-io/n8n/pull/3973
