### PR TITLE
ci: check commit message format

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -3,19 +3,27 @@ name: Test Pull Requests
 on: [pull_request]
 
 jobs:
-  check-commit-messages:
+  check-pr-title:
     runs-on: ubuntu-latest
     permissions:
       checks: write
       contents: read
     steps:
-      # https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8
-      - uses: gsactions/commit-message-checker@v1
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          pattern: '^(feat|fix|perf|test|docs|refactor|build|ci)'
-          checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
-          error: 'One of the commit titles in the PR should be reworded, see release process docs'
+          # https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8
+          types: |
+            feat
+            fix
+            perf
+            test
+            docs
+            refactor
+            build
+            ci
+          requireScope: false
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -3,6 +3,20 @@ name: Test Pull Requests
 on: [pull_request]
 
 jobs:
+  check-commit-messages:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      # https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8
+      - uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(feat|fix|perf|test|docs|refactor|build|ci)'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+          error: 'One of the commit titles in the PR should be reworded, see release process docs'
+
   build:
     runs-on: ubuntu-latest
 
@@ -27,3 +41,4 @@ jobs:
           npm run lint
         env:
           CI: true
+

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -1,6 +1,9 @@
 name: Test Pull Requests
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   check-pr-title:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _START_PACKAGE
 nodelinter.config.json
 packages/*/package-lock.json
 packages/*/.turbo
+*.swp


### PR DESCRIPTION
This adds a Github Actions PR title linting check to ensure the merge commit message ends up in the [company standard format](https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8) which then ensures correct changelog generation.

It will generate a failing check when there is a problem, which we can use to block a merge with branch protection settings when desired.

A previous approach that checked individual commit messages is discarded, due to the Github UI squash and merge workflow that is commonly used instead of manual git rebase.

Some examples:
![Screenshot from 2022-09-05 14-55-11](https://user-images.githubusercontent.com/3884999/188467412-7bd712b1-8be7-4e4b-a28d-5d4e30a29a7e.png)

![Screenshot from 2022-09-05 14-54-41](https://user-images.githubusercontent.com/3884999/188467431-56c8131e-e46f-43da-bd45-2bee40605fa7.png)
