### PR TITLE
fix(cli): include "auth-excluded" endpoints on the history middleware as well

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -665,8 +665,16 @@ class App {
 				rewrites: [
 					{
 						from: new RegExp(
-							// eslint-disable-next-line no-useless-escape
-							`^\/(${this.restEndpoint}|healthz|metrics|css|js|${this.endpointWebhook}|${this.endpointWebhookTest})\/?.*$`,
+							`^/(${[
+								'healthz',
+								'metrics',
+								'css',
+								'js',
+								this.restEndpoint,
+								this.endpointWebhook,
+								this.endpointWebhookTest,
+								...excludeEndpoints.split(':'),
+							].join('|')})/?.*$`,
 						),
 						to: (context) => {
 							return context.parsedUrl.pathname!.toString();


### PR DESCRIPTION
right now endpoints defined in `N8N_AUTH_EXCLUDE_ENDPOINTS` are skipping the JWT auth, and the history middleware is returning 404 on these urls. This change ensures that these endpoints skip all auth-related middlewares.

This is needed for N8N-4495