### PR TITLE
fix(cli): when no excludeEndpoints are defined, use the correct regexp for the history middleware

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -673,7 +673,7 @@ class App {
 								this.restEndpoint,
 								this.endpointWebhook,
 								this.endpointWebhookTest,
-								...excludeEndpoints.split(':'),
+								...(excludeEndpoints.length ? excludeEndpoints.split(':') : []),
 							].join('|')})/?.*$`,
 						),
 						to: (context) => {


### PR DESCRIPTION
this bug was introduced here https://github.com/n8n-io/n8n/pull/4028