### PR TITLE
fix(editor): Wrong popup title when "Click To Copy" on OAuth2 Redirect Url credentials

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -53,8 +53,7 @@
 			:value="oAuthCallbackUrl"
 			:copyButtonText="$locale.baseText('credentialEdit.credentialConfig.clickToCopy')"
 			:hint="$locale.baseText('credentialEdit.credentialConfig.subtitle', { interpolate: { appName } })"
-			:toastTitle="$locale.baseText('credentialEdit.credentialEdit.showMessage.title')"
-			:toastMessage="$locale.baseText('credentialEdit.credentialConfig.redirectUrlCopiedToClipboard')"
+			:toastTitle="$locale.baseText('credentialEdit.credentialConfig.redirectUrlCopiedToClipboard')"
 		/>
 
 		<CredentialInputs


### PR DESCRIPTION
<img width="1805" alt="image (3)" src="https://user-images.githubusercontent.com/5410822/188728880-74a8e0e6-84a4-41e1-ba5d-ea3dcbe96620.png">
