### PR TITLE
fix(editor): use correct attribute on button to make it full width

### DIFF
--- a/packages/editor-ui/src/components/MultipleParameter.vue
+++ b/packages/editor-ui/src/components/MultipleParameter.vue
@@ -27,7 +27,7 @@
 			<div v-if="values && Object.keys(values).length === 0 || isReadOnly" class="no-items-exist">
 				<n8n-text size="small">{{ $locale.baseText('multipleParameter.currentlyNoItemsExist') }}</n8n-text>
 			</div>
-			<n8n-button v-if="!isReadOnly" type="tertiary" fullWidth @click="addItem()" :label="addButtonText" />
+			<n8n-button v-if="!isReadOnly" type="tertiary" block @click="addItem()" :label="addButtonText" />
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5410822/188791587-fab443ae-b6f7-42d7-8c47-87e0d2f15d50.png)

Add attachment button should fill the full width of its container