### PR TITLE
feat(eslint-config): add custom eslint rule 'no-uncaught-json-parse'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n",
-  "version": "0.195.4",
+  "version": "0.195.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n",
-      "version": "0.195.4",
+      "version": "0.195.5",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*",
@@ -3293,6 +3293,397 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@jest/expect": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
+      "integrity": "sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^28.1.3",
+        "jest-snapshot": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
+      "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^28.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@jest/transform": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
+      "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^28.1.3",
+        "@jridgewell/trace-mapping": "^0.3.13",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@jest/types": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/@types/yargs": {
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/expect": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
+      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-haste-map": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
+      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-message-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^28.1.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-snapshot": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
+      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^28.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-haste-map": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^28.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
+      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-worker": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/@jest/expect/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@jest/expect/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@jest/fake-timers": {
       "version": "27.5.1",
@@ -20109,6 +20500,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-n8n-local-rules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n8n-local-rules/-/eslint-plugin-n8n-local-rules-1.0.0.tgz",
+      "integrity": "sha512-qe6sVFDP1Vj5eXlqZxYZpIjwYvhuqXlI0P8OfPyhiPOhMkFtr0TpFphD8/6WCzkm7LJCvG1eJEzURCtMIsFTAg==",
       "dev": true
     },
     "node_modules/eslint-plugin-n8n-nodes-base": {
@@ -49201,8 +49598,270 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-diff": "^2.0.1",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n8n-local-rules": "^1.0.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-vue": "^9.4.0"
+        "eslint-plugin-vue": "^9.4.0",
+        "jest": "^28.1.3"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/console": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
+      "integrity": "sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/core": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
+      "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.1.3",
+        "@jest/reporters": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^28.1.3",
+        "jest-config": "^28.1.3",
+        "jest-haste-map": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-resolve-dependencies": "^28.1.3",
+        "jest-runner": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "jest-watcher": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.1.3",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/environment": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
+      "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "jest-mock": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/fake-timers": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
+      "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@types/node": "*",
+        "jest-message-util": "^28.1.3",
+        "jest-mock": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/globals": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
+      "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/types": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/reporters": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.1.3.tgz",
+      "integrity": "sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@jridgewell/trace-mapping": "^0.3.13",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/source-map": {
+      "version": "28.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.1.2.tgz",
+      "integrity": "sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.13",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/test-result": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.1.3.tgz",
+      "integrity": "sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/test-sequencer": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz",
+      "integrity": "sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^28.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/transform": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
+      "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^28.1.3",
+        "@jridgewell/trace-mapping": "^0.3.13",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@jest/types": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+      "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/@types/yargs": {
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+      "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "packages/@n8n_io/eslint-config/node_modules/argparse": {
@@ -49210,6 +49869,58 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "packages/@n8n_io/eslint-config/node_modules/babel-jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
+      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^28.1.3",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^28.1.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/babel-plugin-jest-hoist": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
+      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/babel-preset-jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
+      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^28.1.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
     },
     "packages/@n8n_io/eslint-config/node_modules/chalk": {
       "version": "4.1.2",
@@ -49225,6 +49936,38 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/emittery": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+      "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "packages/@n8n_io/eslint-config/node_modules/escape-string-regexp": {
@@ -49329,6 +50072,66 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "packages/@n8n_io/eslint-config/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/expect": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
+      "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/@n8n_io/eslint-config/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -49356,6 +50159,540 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/@n8n_io/eslint-config/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^28.1.3"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-changed-files": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
+      "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-circus": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+      "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/expect": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-cli": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
+      "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "import-local": "^3.0.2",
+        "jest-config": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "prompts": "^2.0.1",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-config": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
+      "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "babel-jest": "^28.1.3",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^28.1.3",
+        "jest-environment-node": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-runner": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-docblock": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
+      "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-each": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
+      "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-environment-node": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
+      "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "jest-mock": "^28.1.3",
+        "jest-util": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-haste-map": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
+      "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^28.0.2",
+        "jest-util": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-leak-detector": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
+      "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-message-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+      "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^28.1.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^28.1.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-regex-util": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-resolve": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
+      "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^28.1.3",
+        "jest-validate": "^28.1.3",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^1.1.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-resolve-dependencies": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
+      "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "^28.0.2",
+        "jest-snapshot": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-runner": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
+      "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^28.1.3",
+        "@jest/environment": "^28.1.3",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^28.1.1",
+        "jest-environment-node": "^28.1.3",
+        "jest-haste-map": "^28.1.3",
+        "jest-leak-detector": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-resolve": "^28.1.3",
+        "jest-runtime": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "jest-watcher": "^28.1.3",
+        "jest-worker": "^28.1.3",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-runtime": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
+      "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^28.1.3",
+        "@jest/fake-timers": "^28.1.3",
+        "@jest/globals": "^28.1.3",
+        "@jest/source-map": "^28.1.2",
+        "@jest/test-result": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "execa": "^5.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-mock": "^28.1.3",
+        "jest-regex-util": "^28.0.2",
+        "jest-resolve": "^28.1.3",
+        "jest-snapshot": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-snapshot": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
+      "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^28.1.3",
+        "@jest/transform": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^28.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "jest-haste-map": "^28.1.3",
+        "jest-matcher-utils": "^28.1.3",
+        "jest-message-util": "^28.1.3",
+        "jest-util": "^28.1.3",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^28.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-util": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
+      "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-validate": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
+      "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^28.1.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^28.0.2",
+        "leven": "^3.1.0",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-watcher": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
+      "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^28.1.3",
+        "@jest/types": "^28.1.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.10.2",
+        "jest-util": "^28.1.3",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-worker": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+      "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "packages/@n8n_io/eslint-config/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -49380,6 +50717,66 @@
         "node": ">=10"
       }
     },
+    "packages/@n8n_io/eslint-config/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "packages/@n8n_io/eslint-config/node_modules/semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -49393,6 +50790,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "packages/@n8n_io/eslint-config/node_modules/supports-color": {
@@ -49419,11 +50826,74 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/@n8n_io/eslint-config/node_modules/v8-to-istanbul": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/@n8n_io/eslint-config/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "packages/@n8n_io/eslint-config/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/@n8n_io/eslint-config/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "packages/cli": {
       "name": "n8n",
@@ -49919,6 +51389,7 @@
         "jsplumb": "2.15.4",
         "lodash.camelcase": "^4.3.0",
         "lodash.debounce": "^4.0.8",
+        "lodash.get": "^4.4.2",
         "lodash.orderby": "^4.6.0",
         "lodash.set": "^4.3.2",
         "luxon": "^2.3.0",
@@ -52641,6 +54112,319 @@
         }
       }
     },
+    "@jest/expect": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
+      "integrity": "sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==",
+      "dev": true,
+      "requires": {
+        "expect": "^28.1.3",
+        "jest-snapshot": "^28.1.3"
+      },
+      "dependencies": {
+        "@jest/transform": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
+          "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^28.1.3",
+            "@jridgewell/trace-mapping": "^0.3.13",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.1.3",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+          "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.1.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+          "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+          "dev": true
+        },
+        "expect": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
+          "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3"
+          }
+        },
+        "jest-diff": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+          "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^28.1.1",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
+          "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.1.3",
+            "jest-worker": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.8"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+          "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-message-util": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+          "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^28.1.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.1.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-regex-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "dev": true
+        },
+        "jest-snapshot": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
+          "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/traverse": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/babel__traverse": "^7.0.6",
+            "@types/prettier": "^2.1.5",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^28.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "jest-haste-map": "^28.1.3",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^28.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "jest-util": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
+          "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-worker": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+          "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+          "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.1.3",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+          "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
+      "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^28.0.2"
+      },
+      "dependencies": {
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        }
+      }
+    },
     "@jest/fake-timers": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
@@ -53450,15 +55234,265 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-diff": "^2.0.1",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n8n-local-rules": "^1.0.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-vue": "^9.4.0"
+        "eslint-plugin-vue": "^9.4.0",
+        "jest": "^28.1.3"
       },
       "dependencies": {
+        "@jest/console": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.1.3.tgz",
+          "integrity": "sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-28.1.3.tgz",
+          "integrity": "sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.1.3",
+            "@jest/reporters": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "jest-changed-files": "^28.1.3",
+            "jest-config": "^28.1.3",
+            "jest-haste-map": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.1.3",
+            "jest-resolve-dependencies": "^28.1.3",
+            "jest-runner": "^28.1.3",
+            "jest-runtime": "^28.1.3",
+            "jest-snapshot": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "jest-validate": "^28.1.3",
+            "jest-watcher": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.1.3",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-28.1.3.tgz",
+          "integrity": "sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "jest-mock": "^28.1.3"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.1.3.tgz",
+          "integrity": "sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@sinonjs/fake-timers": "^9.1.2",
+            "@types/node": "*",
+            "jest-message-util": "^28.1.3",
+            "jest-mock": "^28.1.3",
+            "jest-util": "^28.1.3"
+          }
+        },
+        "@jest/globals": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-28.1.3.tgz",
+          "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.3",
+            "@jest/expect": "^28.1.3",
+            "@jest/types": "^28.1.3"
+          }
+        },
+        "@jest/reporters": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-28.1.3.tgz",
+          "integrity": "sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@jridgewell/trace-mapping": "^0.3.13",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^5.1.0",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "jest-worker": "^28.1.3",
+            "slash": "^3.0.0",
+            "string-length": "^4.0.1",
+            "strip-ansi": "^6.0.0",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^9.0.1"
+          }
+        },
+        "@jest/source-map": {
+          "version": "28.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-28.1.2.tgz",
+          "integrity": "sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.13",
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.9"
+          }
+        },
+        "@jest/test-result": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.1.3.tgz",
+          "integrity": "sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz",
+          "integrity": "sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^28.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.1.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
+          "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^28.1.3",
+            "@jridgewell/trace-mapping": "^0.3.13",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.1.3",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
+          "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.1.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "9.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+          "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+          "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
+        },
+        "babel-jest": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
+          "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^28.1.3",
+            "@types/babel__core": "^7.1.14",
+            "babel-plugin-istanbul": "^6.1.1",
+            "babel-preset-jest": "^28.1.3",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
+          "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.1.14",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
+          "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^28.1.3",
+            "babel-preset-current-node-syntax": "^1.0.0"
+          }
         },
         "chalk": {
           "version": "4.1.2",
@@ -53469,6 +55503,29 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+          "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+          "dev": true
+        },
+        "emittery": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+          "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -53548,6 +55605,48 @@
             "estraverse": "^5.2.0"
           }
         },
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "expect": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
+          "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -53564,6 +55663,419 @@
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
+          }
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        },
+        "jest": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
+          "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "import-local": "^3.0.2",
+            "jest-cli": "^28.1.3"
+          }
+        },
+        "jest-changed-files": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.1.3.tgz",
+          "integrity": "sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==",
+          "dev": true,
+          "requires": {
+            "execa": "^5.0.0",
+            "p-limit": "^3.1.0"
+          }
+        },
+        "jest-circus": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-28.1.3.tgz",
+          "integrity": "sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.3",
+            "@jest/expect": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^0.7.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^28.1.3",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-runtime": "^28.1.3",
+            "jest-snapshot": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "p-limit": "^3.1.0",
+            "pretty-format": "^28.1.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-cli": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-28.1.3.tgz",
+          "integrity": "sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "import-local": "^3.0.2",
+            "jest-config": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "jest-validate": "^28.1.3",
+            "prompts": "^2.0.1",
+            "yargs": "^17.3.1"
+          }
+        },
+        "jest-config": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-28.1.3.tgz",
+          "integrity": "sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/test-sequencer": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "babel-jest": "^28.1.3",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^28.1.3",
+            "jest-environment-node": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.1.3",
+            "jest-runner": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "jest-validate": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^28.1.3",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "jest-diff": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+          "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^28.1.1",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-docblock": {
+          "version": "28.1.1",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.1.1.tgz",
+          "integrity": "sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-28.1.3.tgz",
+          "integrity": "sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^28.0.2",
+            "jest-util": "^28.1.3",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-environment-node": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.1.3.tgz",
+          "integrity": "sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.3",
+            "@jest/fake-timers": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "jest-mock": "^28.1.3",
+            "jest-util": "^28.1.3"
+          }
+        },
+        "jest-get-type": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
+          "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^28.0.2",
+            "jest-util": "^28.1.3",
+            "jest-worker": "^28.1.3",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.8"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
+          "integrity": "sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+          "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-message-util": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
+          "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^28.1.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^28.1.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-regex-util": {
+          "version": "28.0.2",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.3.tgz",
+          "integrity": "sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.1.3",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^28.1.3",
+            "jest-validate": "^28.1.3",
+            "resolve": "^1.20.0",
+            "resolve.exports": "^1.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz",
+          "integrity": "sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==",
+          "dev": true,
+          "requires": {
+            "jest-regex-util": "^28.0.2",
+            "jest-snapshot": "^28.1.3"
+          }
+        },
+        "jest-runner": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-28.1.3.tgz",
+          "integrity": "sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^28.1.3",
+            "@jest/environment": "^28.1.3",
+            "@jest/test-result": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "graceful-fs": "^4.2.9",
+            "jest-docblock": "^28.1.1",
+            "jest-environment-node": "^28.1.3",
+            "jest-haste-map": "^28.1.3",
+            "jest-leak-detector": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-resolve": "^28.1.3",
+            "jest-runtime": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "jest-watcher": "^28.1.3",
+            "jest-worker": "^28.1.3",
+            "p-limit": "^3.1.0",
+            "source-map-support": "0.5.13"
+          }
+        },
+        "jest-runtime": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.1.3.tgz",
+          "integrity": "sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^28.1.3",
+            "@jest/fake-timers": "^28.1.3",
+            "@jest/globals": "^28.1.3",
+            "@jest/source-map": "^28.1.2",
+            "@jest/test-result": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "chalk": "^4.0.0",
+            "cjs-module-lexer": "^1.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "execa": "^5.0.0",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-mock": "^28.1.3",
+            "jest-regex-util": "^28.0.2",
+            "jest-resolve": "^28.1.3",
+            "jest-snapshot": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.1.3.tgz",
+          "integrity": "sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/traverse": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^28.1.3",
+            "@jest/transform": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/babel__traverse": "^7.0.6",
+            "@types/prettier": "^2.1.5",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^28.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^28.1.3",
+            "jest-get-type": "^28.0.2",
+            "jest-haste-map": "^28.1.3",
+            "jest-matcher-utils": "^28.1.3",
+            "jest-message-util": "^28.1.3",
+            "jest-util": "^28.1.3",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^28.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "jest-util": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
+          "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-validate": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
+          "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^28.1.3",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^28.0.2",
+            "leven": "^3.1.0",
+            "pretty-format": "^28.1.3"
+          }
+        },
+        "jest-watcher": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.1.3.tgz",
+          "integrity": "sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^28.1.3",
+            "@jest/types": "^28.1.3",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "jest-util": "^28.1.3",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
+          "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
           }
         },
         "js-yaml": {
@@ -53584,6 +56096,50 @@
             "yallist": "^4.0.0"
           }
         },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "pretty-format": {
+          "version": "28.1.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+          "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^28.1.3",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -53591,6 +56147,16 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
         },
         "supports-color": {
@@ -53608,10 +56174,58 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         },
+        "v8-to-istanbul": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
+          "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.12",
+            "@types/istanbul-lib-coverage": "^2.0.1",
+            "convert-source-map": "^1.6.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+          "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }
@@ -66271,6 +68885,12 @@
         }
       }
     },
+    "eslint-plugin-n8n-local-rules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n8n-local-rules/-/eslint-plugin-n8n-local-rules-1.0.0.tgz",
+      "integrity": "sha512-qe6sVFDP1Vj5eXlqZxYZpIjwYvhuqXlI0P8OfPyhiPOhMkFtr0TpFphD8/6WCzkm7LJCvG1eJEzURCtMIsFTAg==",
+      "dev": true
+    },
     "eslint-plugin-n8n-nodes-base": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.9.3.tgz",
@@ -77367,6 +79987,7 @@
         "jsplumb": "2.15.4",
         "lodash.camelcase": "^4.3.0",
         "lodash.debounce": "^4.0.8",
+        "lodash.get": "^4.4.2",
         "lodash.orderby": "^4.6.0",
         "lodash.set": "^4.3.2",
         "luxon": "^2.3.0",

--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -40,6 +40,12 @@ module.exports = {
 		 * https://github.com/paleite/eslint-plugin-diff#plugindiffdiff-recommended
 		 */
 		'eslint-plugin-diff',
+
+		/*
+		 * Plugin to allow specifying local ESLint rules.
+		 * https://github.com/ivov/eslint-plugin-n8n-local-rules
+		 */
+		'eslint-plugin-n8n-local-rules',
 	],
 
 	extends: [
@@ -323,6 +329,13 @@ module.exports = {
 		 * https://github.com/import-js/eslint-plugin-import/blob/master/docs/rules/order.md
 		 */
 		'import/order': 'error',
+
+		// ----------------------------------
+		//   eslint-plugin-n8n-local-rules
+		// ----------------------------------
+
+		// TODO: set to `error` and fix offenses
+		'n8n-local-rules/no-uncaught-json-parse': 'warn',
 
 		// ******************************************************************
 		//                    overrides to base ruleset

--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * This file contains any locally defined ESLint rules. They are picked up by
+ * eslint-plugin-n8n-local-rules and exposed as 'n8n-local-rules/<rule-name>'.
+ */
+module.exports = {
+	/**
+	 * A rule to detect calls to JSON.parse() that are not wrapped inside try/catch blocks.
+	 *
+	 * Valid:
+	 * ```js
+	 * try { JSON.parse(foo) } catch(err) { baz() }
+	 * ```
+	 *
+	 * Invalid:
+	 * ```js
+	 * JSON.parse(foo)
+	 * ```
+	 *
+	 * The pattern where an object is cloned with JSON.parse(JSON.stringify()) is allowed
+	 * (abundant in the n8n codebase):
+	 *
+	 * Valid:
+	 * ```js
+	 * JSON.parse(JSON.stringify(foo))
+	 * ```
+	 */
+	'no-uncaught-json-parse': {
+		meta: {
+			type: 'problem',
+			docs: {
+				description: 'Calls to JSON.parse() must be surrounded with a try/catch block.',
+				recommended: 'error',
+			},
+			schema: [],
+			messages: {
+				noUncaughtJsonParse: 'Surround the JSON.parse() call with a try/catch block.',
+			},
+		},
+		defaultOptions: [],
+		create(context) {
+			return {
+				CallExpression(node) {
+					if (!isJsonParseCall(node)) {
+						return;
+					}
+
+					if (isDeepCloneOperation(node)) {
+						return;
+					}
+
+					if (context.getAncestors().find((node) => node.type === 'TryStatement') !== undefined) {
+						return;
+					}
+
+					// Found a JSON.parse() call not wrapped into a try/catch, so report it
+					context.report({
+						messageId: 'noUncaughtJsonParse',
+						node,
+					});
+				},
+			};
+		},
+	},
+};
+
+const isJsonParseCall = (node) =>
+	node.callee.type === 'MemberExpression' &&
+	node.callee.object.type === 'Identifier' &&
+	node.callee.object.name === 'JSON' &&
+	node.callee.property.type === 'Identifier' &&
+	node.callee.property.name === 'parse';
+
+const isDeepCloneOperation = (node) => {
+	const parseArg = node.arguments?.[0];
+	return (
+		parseArg !== undefined &&
+		parseArg.type === 'CallExpression' &&
+		parseArg.callee.type === 'MemberExpression' &&
+		parseArg.callee.object.type === 'Identifier' &&
+		parseArg.callee.object.name === 'JSON' &&
+		parseArg.callee.property.type === 'Identifier' &&
+		parseArg.callee.property.name === 'stringify'
+	);
+};

--- a/packages/@n8n_io/eslint-config/local-rules.test.js
+++ b/packages/@n8n_io/eslint-config/local-rules.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const rules = require('./local-rules'),
+	RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-uncaught-json-parse', rules['no-uncaught-json-parse'], {
+	valid: [
+		{
+			code: 'try { JSON.parse(foo) } catch (e) {}',
+		},
+		{
+			code: 'JSON.parse(JSON.stringify(foo))',
+		},
+	],
+	invalid: [
+		{
+			code: 'JSON.parse(foo)',
+			errors: [{ messageId: 'noUncaughtJsonParse' }],
+		},
+	],
+});

--- a/packages/@n8n_io/eslint-config/package.json
+++ b/packages/@n8n_io/eslint-config/package.json
@@ -11,7 +11,12 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-diff": "^2.0.1",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n8n-local-rules": "^1.0.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-vue": "^9.4.0"
+    "eslint-plugin-vue": "^9.4.0",
+    "jest": "^28.1.3"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }


### PR DESCRIPTION
This PR adds a custom eslint rule `no-uncaught-json-parse` to require any calls to `JSON.parse()` be wrapped inside try/catch blocks:

✅ Valid:
```js
try { JSON.parse(foo) } catch(err) { baz }
```

✅ Valid:
```js
JSON.parse(JSON.stringify(foo))
```

🛑 Invalid:
```js
JSON.parse(foo)
```

It uses the handy [eslint-plugin-n8n-local-rules](https://github.com/ivov/eslint-plugin-n8n-local-rules) by @ivov, which allows us to add simple JS-based rules locally. If we get more of these, we might eventually want to spin them off to their own repo, written in TS and with proper tests and bundling (sidestepped a bit, and have a workable sample implementation of this one ready in the drawer).

The rule is currently disabled, with the intent being to enabling it and fixing the offenses in another issue. By setting the rule to `error` and running `npx turbo run lint --no-cache --continue` currently gives a total of 50 errors, of which 36 are in `n8n-nodes-base`. 

