### PR TITLE
fix(public-api):  Fix error updating workflow with property not defined in the schema

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/workflow.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/workflow.yml
@@ -1,4 +1,5 @@
 type: object
+additionalProperties: false
 required:
   - name
   - nodes

--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -198,7 +198,13 @@ export = {
 				await workflowRunner.remove(id.toString());
 			}
 
-			await updateWorkflow(sharedWorkflow.workflowId, updateData);
+			try {
+				await updateWorkflow(sharedWorkflow.workflowId, updateData);
+			} catch (error) {
+				if (error instanceof Error) {
+					return res.status(400).json({ message: error.message });
+				}
+			}
 
 			if (sharedWorkflow.workflow.active) {
 				try {


### PR DESCRIPTION
As an interim fix before we have schema validation in place, this should fix any unexpected API crashes trying to update a workflow with malformed contents, and return a HTTP 400 instead. Workflow creation isn't affected.

More details on the Linear issue.