### PR TITLE
fix: Issue with versioned nodes not loading properly

### DIFF
--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -103,13 +103,7 @@ export class WorkflowRunnerProcess {
 			const { className, sourcePath } = this.data.nodeTypeData[nodeTypeName];
 
 			try {
-				const nodeObject = loadClassInIsolation(sourcePath, className);
-				if (nodeObject.getNodeType !== undefined) {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-					tempNode = nodeObject.getNodeType();
-				} else {
-					tempNode = nodeObject;
-				}
+				tempNode = loadClassInIsolation(sourcePath, className);
 			} catch (error) {
 				throw new Error(`Error loading node "${nodeTypeName}" from: "${sourcePath}"`);
 			}


### PR DESCRIPTION
The `if` block being removed was unnecessary and it was actually causing versioned nodes to no longer work since n8n would load only the latest version.