### PR TITLE
fix(cli): use absolute paths for loading custom nodes and credentials

### DIFF
--- a/packages/cli/commands/import/credentials.ts
+++ b/packages/cli/commands/import/credentials.ts
@@ -93,9 +93,10 @@ export class ImportCredentialsCommand extends Command {
 					inputPath = inputPath.replace(/\\/g, '/');
 				}
 
-				inputPath = inputPath.replace(/\/$/g, '');
-
-				const files = await glob('*.json', { cwd: inputPath });
+				const files = await glob('*.json', {
+					cwd: inputPath,
+					absolute: true,
+				});
 
 				totalImported = files.length;
 

--- a/packages/cli/commands/import/workflow.ts
+++ b/packages/cli/commands/import/workflow.ts
@@ -115,9 +115,10 @@ export class ImportWorkflowsCommand extends Command {
 					inputPath = inputPath.replace(/\\/g, '/');
 				}
 
-				inputPath = inputPath.replace(/\/$/g, '');
-
-				const files = await glob('*.json', { cwd: inputPath });
+				const files = await glob('*.json', {
+					cwd: inputPath,
+					absolute: true,
+				});
 
 				totalImported = files.length;
 

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -495,6 +495,7 @@ class LoadNodesAndCredentialsClass {
 	async loadDataFromDirectory(setPackageName: string, directory: string): Promise<void> {
 		const files = await glob('**/*.@(node|credentials).js', {
 			cwd: directory,
+			absolute: true,
 		});
 
 		for (const filePath of files) {


### PR DESCRIPTION
custom-node loading broke because of this change, as we started using relative paths for the files returned by `glob` https://github.com/n8n-io/n8n/pull/4082