### PR TITLE
fix(cli): use a non-env config flag to detect if enterprise features are enabled

### DIFF
--- a/packages/cli/config/schema.ts
+++ b/packages/cli/config/schema.ts
@@ -875,6 +875,15 @@ export const schema = {
 		},
 	},
 
+	enterprise: {
+		features: {
+			sharing: {
+				format: Boolean,
+				default: false,
+			},
+		},
+	},
+
 	hiringBanner: {
 		enabled: {
 			doc: 'Whether hiring banner in browser console is enabled.',

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -312,7 +312,7 @@ class App {
 			},
 			isNpmAvailable: false,
 			enterprise: {
-				sharing: isCredentialsSharingEnabled(),
+				sharing: false,
 			},
 		};
 	}
@@ -342,7 +342,7 @@ class App {
 
 		// refresh enterprise status
 		Object.assign(this.frontendSettings.enterprise, {
-			credentialsSharing: isCredentialsSharingEnabled(),
+			sharing: isCredentialsSharingEnabled(),
 		});
 
 		if (config.get('nodes.packagesMissing').length > 0) {

--- a/packages/cli/src/credentials/helpers.ts
+++ b/packages/cli/src/credentials/helpers.ts
@@ -1,15 +1,9 @@
 /* eslint-disable import/no-cycle */
-import {
-	getInstanceBaseUrl,
-	isUserManagementEnabled,
-} from '../UserManagement/UserManagementHelper';
+import config from '../../config';
+import { isUserManagementEnabled } from '../UserManagement/UserManagementHelper';
 
 export function isCredentialsSharingEnabled(): boolean {
-	return (
-		isUserManagementEnabled() &&
-		(getInstanceBaseUrl().endsWith('n8n.cloud') ||
-			String(process.env.N8N_CREDENTIALS_SHARING_ENABLED) === 'true')
-	);
+	return isUserManagementEnabled() && config.getEnv('enterprise.features.sharing');
 }
 
 // return the difference between two arrays


### PR DESCRIPTION
Fixes: N8N-4472

Now the flag is only settable via code-change, or with external hooks.