### PR TITLE
feat(ExecuteWorkflowTrigger node): Implement ExecuteWorkflowTrigger node

### DIFF
--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -60,7 +60,7 @@
 				<div v-touch:tap="disableNode" class="option" :title="$locale.baseText('node.activateDeactivateNode')">
 					<font-awesome-icon :icon="nodeDisabledIcon" />
 				</div>
-				<div v-touch:tap="duplicateNode" class="option" :title="$locale.baseText('node.duplicateNode')">
+				<div v-touch:tap="duplicateNode" class="option" :title="$locale.baseText('node.duplicateNode')" v-if="isDuplicatable">
 					<font-awesome-icon icon="clone" />
 				</div>
 				<div v-touch:tap="setNodeActive" class="option touch" :title="$locale.baseText('node.editNode')" v-if="!isReadOnly">
@@ -126,6 +126,10 @@ export default mixins(
 		NodeIcon,
 	},
 	computed: {
+		isDuplicatable(): boolean {
+			if(!this.nodeType) return true;
+			return this.nodeType.maxNodes === undefined || this.sameTypeNodes.length < this.nodeType.maxNodes;
+		},
 		nodeRunData(): ITaskData[] {
 			return this.$store.getters.getWorkflowResultDataByNodeName(this.data.name);
 		},
@@ -194,6 +198,9 @@ export default mixins(
 		},
 		node (): INodeUi | undefined { // same as this.data but reactive..
 			return this.$store.getters.nodesByName[this.name] as INodeUi | undefined;
+		},
+		sameTypeNodes (): INodeUi[] {
+			return this.$store.getters.allNodes.filter((node: INodeUi) => node.type === this.data.type);
 		},
 		nodeClass (): object {
 			return {

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.json
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.json
@@ -1,0 +1,21 @@
+{
+	"node": "n8n-nodes-base.executeWorkflowTrigger",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": [
+		"Core Nodes"
+	],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.n8n-nodes-base.executeWorkflowTrigger/"
+			}
+		],
+		"generic": []
+	},
+	"subcategories": {
+		"Core Nodes": [
+			"Helpers"
+		]
+	}
+}

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -1,0 +1,36 @@
+import { IExecuteFunctions } from 'n8n-core';
+import { INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+export class ExecuteWorkflowTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Execute Workflow Trigger',
+		name: 'executeWorkflowTrigger',
+		icon: 'fa:network-wired',
+		group: ['trigger'],
+		version: 1,
+		description: 'Runs the flow when called by the Execute Workflow node from a different workflow',
+		maxNodes: 1,
+		defaults: {
+			name: 'Execute Workflow Trigger',
+			color: '#ff6d5a',
+		},
+		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+		inputs: [],
+		outputs: ['main'],
+		properties: [
+			{
+				displayName:
+					'This node is where the flow execution starts once this workflow is called by another workflow.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+		],
+	};
+
+	execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+
+		return this.prepareOutputData(items);
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -425,6 +425,7 @@
       "dist/nodes/Eventbrite/EventbriteTrigger.node.js",
       "dist/nodes/ExecuteCommand/ExecuteCommand.node.js",
       "dist/nodes/ExecuteWorkflow/ExecuteWorkflow.node.js",
+      "dist/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.js",
       "dist/nodes/Facebook/FacebookGraphApi.node.js",
       "dist/nodes/Facebook/FacebookTrigger.node.js",
       "dist/nodes/Figma/FigmaTrigger.node.js",


### PR DESCRIPTION
https://linear.app/n8n/issue/N8N-4637

This is PR a prerequisite for the upcoming trigger panel redesign. It implements ExecuteWorkflowTrigger which is one of the two new nodes. This node will be used as a trigger if called by a parent workflow.

As per AC for this node, I've also implemented hiding the duplicate button if the maximum amount of nodes is reached as per `nodeType.maxNodes` or it's undefined.