### PR TITLE
feat(ManualTrigger node): Implement ManualTrigger node

### DIFF
--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { WEBHOOK_NODE_TYPE } from '@/constants';
+import { WEBHOOK_NODE_TYPE, MANUAL_TRIGGER_NODE_TYPE } from '@/constants';
 import { INodeUi } from '@/Interface';
 import { INodeTypeDescription } from 'n8n-workflow';
 import mixins from 'vue-typed-mixins';
@@ -73,6 +73,9 @@ export default mixins(
 		},
 		isTriggerNode (): boolean {
 			return !!(this.nodeType && this.nodeType.group.includes('trigger'));
+		},
+		isManualTriggerNode (): boolean {
+			return Boolean(this.nodeType && this.nodeType.name === MANUAL_TRIGGER_NODE_TYPE);
 		},
 		isPollingTypeNode (): boolean {
 			return !!(this.nodeType && this.nodeType.polling);
@@ -138,7 +141,7 @@ export default mixins(
 				return this.$locale.baseText('ndv.execute.fetchEvent');
 			}
 
-			if (this.isTriggerNode && !this.isScheduleTrigger) {
+			if (this.isTriggerNode && !this.isScheduleTrigger && !this.isManualTriggerNode) {
 				return this.$locale.baseText('ndv.execute.listenForEvent');
 			}
 

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -88,6 +88,7 @@ export const ITEM_LISTS_NODE_TYPE = 'n8n-nodes-base.itemLists';
 export const JIRA_NODE_TYPE = 'n8n-nodes-base.jira';
 export const JIRA_TRIGGER_NODE_TYPE = 'n8n-nodes-base.jiraTrigger';
 export const MICROSOFT_EXCEL_NODE_TYPE = 'n8n-nodes-base.microsoftExcel';
+export const MANUAL_TRIGGER_NODE_TYPE = 'n8n-nodes-base.manualTrigger';
 export const MICROSOFT_TEAMS_NODE_TYPE = 'n8n-nodes-base.microsoftTeams';
 export const NO_OP_NODE_TYPE = 'n8n-nodes-base.noOp';
 export const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';

--- a/packages/editor-ui/src/plugins/icons.ts
+++ b/packages/editor-ui/src/plugins/icons.ts
@@ -61,6 +61,7 @@ import {
 	faLink,
 	faLightbulb,
 	faMapSigns,
+	faMousePointer,
 	faNetworkWired,
 	faPause,
 	faPauseCircle,
@@ -172,6 +173,7 @@ addIcon(faKey);
 addIcon(faLink);
 addIcon(faLightbulb);
 addIcon(faMapSigns);
+addIcon(faMousePointer);
 addIcon(faNetworkWired);
 addIcon(faPause);
 addIcon(faPauseCircle);

--- a/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
+++ b/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
@@ -1,0 +1,47 @@
+{
+	"node": "n8n-nodes-base.manualTrigger",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": [
+		"Core Nodes"
+	],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.manualTrigger/"
+			}
+		],
+		"generic": [
+			{
+				"label": "Why business process automation with n8n can change your daily life",
+				"icon": "🧬",
+				"url": "https://n8n.io/blog/why-business-process-automation-with-n8n-can-change-your-daily-life/"
+			},
+			{
+				"label": "Why I chose n8n over Zapier in 2020",
+				"icon": "😍",
+				"url": "https://n8n.io/blog/why-i-chose-n8n-over-zapier-in-2020/"
+			},
+			{
+				"label": "Automatically pulling and visualizing data with n8n",
+				"icon": "📈",
+				"url": "https://n8n.io/blog/automatically-pulling-and-visualizing-data-with-n8n/"
+			},
+			{
+				"label": "How to use the HTTP Request Node - The Swiss Army Knife for Workflow Automation",
+				"icon": "🧰",
+				"url": "https://n8n.io/blog/how-to-use-the-http-request-node-the-swiss-army-knife-for-workflow-automation/"
+			},
+			{
+				"label": "Sending SMS the Low-Code Way with Airtable, Twilio Programmable SMS, and n8n",
+				"icon": "📱",
+				"url": "https://n8n.io/blog/sending-sms-the-low-code-way-with-airtable-twilio-programmable-sms-and-n8n/"
+			},
+			{
+				"label": "Automating Conference Organization Processes with n8n",
+				"icon": "🙋‍♀️",
+				"url": "https://n8n.io/blog/automating-conference-organization-processes-with-n8n/"
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
+++ b/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
@@ -11,37 +11,6 @@
 				"url": "https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.manualTrigger/"
 			}
 		],
-		"generic": [
-			{
-				"label": "Why business process automation with n8n can change your daily life",
-				"icon": "🧬",
-				"url": "https://n8n.io/blog/why-business-process-automation-with-n8n-can-change-your-daily-life/"
-			},
-			{
-				"label": "Why I chose n8n over Zapier in 2020",
-				"icon": "😍",
-				"url": "https://n8n.io/blog/why-i-chose-n8n-over-zapier-in-2020/"
-			},
-			{
-				"label": "Automatically pulling and visualizing data with n8n",
-				"icon": "📈",
-				"url": "https://n8n.io/blog/automatically-pulling-and-visualizing-data-with-n8n/"
-			},
-			{
-				"label": "How to use the HTTP Request Node - The Swiss Army Knife for Workflow Automation",
-				"icon": "🧰",
-				"url": "https://n8n.io/blog/how-to-use-the-http-request-node-the-swiss-army-knife-for-workflow-automation/"
-			},
-			{
-				"label": "Sending SMS the Low-Code Way with Airtable, Twilio Programmable SMS, and n8n",
-				"icon": "📱",
-				"url": "https://n8n.io/blog/sending-sms-the-low-code-way-with-airtable-twilio-programmable-sms-and-n8n/"
-			},
-			{
-				"label": "Automating Conference Organization Processes with n8n",
-				"icon": "🙋‍♀️",
-				"url": "https://n8n.io/blog/automating-conference-organization-processes-with-n8n/"
-			}
-		]
+		"generic": []
 	}
 }

--- a/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.ts
+++ b/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.ts
@@ -1,0 +1,36 @@
+import { IExecuteFunctions } from 'n8n-core';
+import { INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
+
+export class ManualTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Manual Trigger',
+		name: 'manualTrigger',
+		icon: 'fa:mouse-pointer',
+		group: ['trigger', 'output'],
+		version: 1,
+		description: 'Starts the workflow execution on clicking a buton in N8N',
+		maxNodes: 1,
+		defaults: {
+			name: 'Manual Trigger',
+			color: '#00e000',
+		},
+		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+		inputs: [],
+		outputs: ['main'],
+		properties: [
+			{
+				displayName:
+					'This node is where a manual workflow execution starts. To make one, go back to the canvas and click ‘execute workflow’',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+		],
+	};
+
+	execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+
+		return this.prepareOutputData(items);
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -527,6 +527,7 @@
       "dist/nodes/Mailjet/Mailjet.node.js",
       "dist/nodes/Mailjet/MailjetTrigger.node.js",
       "dist/nodes/Mandrill/Mandrill.node.js",
+      "dist/nodes/ManualTrigger/ManualTrigger.node.js",
       "dist/nodes/Markdown/Markdown.node.js",
       "dist/nodes/Marketstack/Marketstack.node.js",
       "dist/nodes/Matrix/Matrix.node.js",


### PR DESCRIPTION
https://linear.app/n8n/issue/N8N-4638

This is the second of the new trigger nodes, allowing us to deprecate the start node as part of the new trigger tab redesign.
I had to do a small condition adjustment inside `NodeExecuteButton#144`  to make sure we render the `Execute node` text instead of the `Fetch events` trigger text.