### PR TITLE
fix: revert CI checks to ensure that the package-lock.json file is up to date

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -24,7 +24,7 @@ jobs:
       - name: npm install, build, and test
         run: |
           npm install -g npm@latest
-          npm ci
+          npm install
           npm run build --if-present
           npm test
           npm run lint

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: npm install, build, and test
         run: |
           npm install -g npm@latest
-          npm ci
+          npm install
           npm run build --if-present
           npm test
           npm run lint

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           cd n8n
           npm install -g npm@latest
-          npm ci
+          npm install
           npm run build --if-present
         env:
           CI: true

--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -16,7 +16,7 @@ RUN npm config set legacy-peer-deps true
 USER node
 
 RUN \
-	npm ci && \
+	npm install && \
 	npm run build && \
 	# TODO: removing dev dependecies is deleting `bn.js`, which breaks the Snowflake node
 	npm prune --omit=dev && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n",
-  "version": "0.193.5",
+  "version": "0.194.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n",
-      "version": "0.193.5",
+      "version": "0.194.0",
       "workspaces": [
         "packages/*",
         "packages/@n8n_io/*"
@@ -7142,16 +7142,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "bson": "*"
-      }
-    },
     "node_modules/@types/bull": {
       "version": "3.15.9",
       "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
@@ -7735,16 +7725,6 @@
         "moment-timezone": "*"
       }
     },
-    "node_modules/@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/mqtt": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/mqtt/-/mqtt-2.5.0.tgz",
@@ -8195,6 +8175,11 @@
       "integrity": "sha512-y9Ydpp4K9k+gGKFFmpnYNXJxhaq7smglPMcF2wymMaEbPhMS2gHkkD9OMoaqhktJErI+VeHG1ciy1JNz1nhOTQ==",
       "dev": true
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -8246,6 +8231,15 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/xml2js": {
@@ -15460,47 +15454,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/bl/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/bl/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -15913,7 +15866,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
       "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dev": true,
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -35952,50 +35904,25 @@
         "webpack": "^4.5.0 || 5.x"
       }
     },
-    "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
-    "node_modules/mongodb/node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=12"
       }
     },
     "node_modules/moo": {
@@ -37678,17 +37605,6 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
       "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
       "engines": {
         "node": ">=4"
       }
@@ -42144,14 +42060,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -46278,7 +46186,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -49929,7 +49836,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -52350,7 +52256,7 @@
     },
     "packages/cli": {
       "name": "n8n",
-      "version": "0.193.5",
+      "version": "0.194.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@oclif/command": "^1.5.18",
@@ -52394,10 +52300,10 @@
         "lodash.split": "^4.4.2",
         "lodash.unset": "^4.5.2",
         "mysql2": "~2.3.0",
-        "n8n-core": "~0.133.3",
-        "n8n-editor-ui": "~0.159.4",
-        "n8n-nodes-base": "~0.191.3",
-        "n8n-workflow": "~0.115.1",
+        "n8n-core": "~0.134.0",
+        "n8n-editor-ui": "~0.160.0",
+        "n8n-nodes-base": "~0.192.0",
+        "n8n-workflow": "~0.116.0",
         "nodemailer": "^6.7.1",
         "oauth-1.0a": "^2.2.6",
         "open": "^7.0.0",
@@ -52476,7 +52382,7 @@
     },
     "packages/core": {
       "name": "n8n-core",
-      "version": "0.133.3",
+      "version": "0.134.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "axios": "^0.21.1",
@@ -52488,7 +52394,7 @@
         "form-data": "^4.0.0",
         "lodash.get": "^4.4.2",
         "mime-types": "^2.1.27",
-        "n8n-workflow": "~0.115.1",
+        "n8n-workflow": "~0.116.0",
         "oauth-1.0a": "^2.2.6",
         "p-cancelable": "^2.0.0",
         "qs": "^6.10.1",
@@ -52575,7 +52481,7 @@
     },
     "packages/design-system": {
       "name": "n8n-design-system",
-      "version": "0.33.1",
+      "version": "0.34.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "element-ui": "~2.15.7",
@@ -52642,14 +52548,14 @@
     },
     "packages/editor-ui": {
       "name": "n8n-editor-ui",
-      "version": "0.159.4",
+      "version": "0.160.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@fontsource/open-sans": "^4.5.0",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
         "luxon": "^2.3.0",
         "monaco-editor": "^0.30.1",
-        "n8n-design-system": "~0.33.1",
+        "n8n-design-system": "~0.34.0",
         "timeago.js": "^4.0.2",
         "v-click-outside": "^3.1.2",
         "vue-fragment": "1.5.1",
@@ -52694,7 +52600,7 @@
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "monaco-editor-webpack-plugin": "^5.0.0",
-        "n8n-workflow": "~0.115.1",
+        "n8n-workflow": "~0.116.0",
         "normalize-wheel": "^1.0.1",
         "prismjs": "^1.17.1",
         "quill": "^2.0.0-dev.3",
@@ -52720,7 +52626,7 @@
     },
     "packages/node-dev": {
       "name": "n8n-node-dev",
-      "version": "0.72.1",
+      "version": "0.73.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@oclif/command": "^1.5.18",
@@ -52728,8 +52634,8 @@
         "change-case": "^4.1.1",
         "copyfiles": "^2.1.1",
         "inquirer": "^7.0.1",
-        "n8n-core": "~0.133.3",
-        "n8n-workflow": "~0.115.0",
+        "n8n-core": "~0.134.0",
+        "n8n-workflow": "~0.116.0",
         "oauth-1.0a": "^2.2.6",
         "replace-in-file": "^6.0.0",
         "request": "^2.88.2",
@@ -52752,7 +52658,7 @@
     },
     "packages/nodes-base": {
       "name": "n8n-nodes-base",
-      "version": "0.191.3",
+      "version": "0.192.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@kafkajs/confluent-schema-registry": "1.0.6",
@@ -52783,11 +52689,11 @@
         "mailparser": "^3.2.0",
         "moment": "~2.29.2",
         "moment-timezone": "^0.5.28",
-        "mongodb": "^3.6.9",
+        "mongodb": "^4.9.1",
         "mqtt": "4.2.6",
         "mssql": "^8.1.2",
         "mysql2": "~2.3.0",
-        "n8n-core": "~0.133.3",
+        "n8n-core": "~0.134.0",
         "node-html-markdown": "^1.1.3",
         "node-ssh": "^12.0.0",
         "nodemailer": "^6.7.1",
@@ -52828,7 +52734,6 @@
         "@types/mailparser": "^2.7.3",
         "@types/mime-types": "^2.1.0",
         "@types/moment-timezone": "^0.5.12",
-        "@types/mongodb": "^3.5.4",
         "@types/mqtt": "^2.5.0",
         "@types/mssql": "^6.0.2",
         "@types/node": "^16.11.22",
@@ -52845,15 +52750,40 @@
         "eslint-plugin-n8n-nodes-base": "^1.9.1",
         "gulp": "^4.0.0",
         "jest": "^27.4.7",
-        "n8n-workflow": "~0.115.1",
+        "n8n-workflow": "~0.116.0",
         "ts-jest": "^27.1.3",
         "tslint": "^6.1.2",
         "typescript": "~4.6.0"
       }
     },
+    "packages/nodes-base/node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "packages/nodes-base/node_modules/mongodb": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
+      "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
+      "dependencies": {
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "socks": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.3"
+      }
+    },
     "packages/workflow": {
       "name": "n8n-workflow",
-      "version": "0.115.1",
+      "version": "0.116.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n_io/riot-tmpl": "^1.0.1",
@@ -58238,15 +58168,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bson": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
-      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
-      "dev": true,
-      "requires": {
-        "bson": "*"
-      }
-    },
     "@types/bull": {
       "version": "3.15.9",
       "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
@@ -58821,16 +58742,6 @@
         "moment-timezone": "*"
       }
     },
-    "@types/mongodb": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
-      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dev": true,
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/mqtt": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/mqtt/-/mqtt-2.5.0.tgz",
@@ -59277,6 +59188,11 @@
       "integrity": "sha512-y9Ydpp4K9k+gGKFFmpnYNXJxhaq7smglPMcF2wymMaEbPhMS2gHkkD9OMoaqhktJErI+VeHG1ciy1JNz1nhOTQ==",
       "dev": true
     },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
     "@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -59327,6 +59243,15 @@
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
           "dev": true
         }
+      }
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "@types/xml2js": {
@@ -65119,49 +65044,6 @@
         }
       }
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -65518,7 +65400,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
       "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dev": true,
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -81437,23 +81318,23 @@
         "loader-utils": "^2.0.0"
       }
     },
-    "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+    "mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       },
       "dependencies": {
-        "bson": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
         }
       }
     },
@@ -81782,10 +81663,10 @@
         "lodash.split": "^4.4.2",
         "lodash.unset": "^4.5.2",
         "mysql2": "~2.3.0",
-        "n8n-core": "~0.133.3",
-        "n8n-editor-ui": "~0.159.4",
-        "n8n-nodes-base": "~0.191.3",
-        "n8n-workflow": "~0.115.1",
+        "n8n-core": "~0.134.0",
+        "n8n-editor-ui": "~0.160.0",
+        "n8n-nodes-base": "~0.192.0",
+        "n8n-workflow": "~0.116.0",
         "nodemailer": "^6.7.1",
         "nodemon": "^2.0.2",
         "oauth-1.0a": "^2.2.6",
@@ -81839,7 +81720,7 @@
         "jest": "^27.4.7",
         "lodash.get": "^4.4.2",
         "mime-types": "^2.1.27",
-        "n8n-workflow": "~0.115.1",
+        "n8n-workflow": "~0.116.0",
         "oauth-1.0a": "^2.2.6",
         "p-cancelable": "^2.0.0",
         "qs": "^6.10.1",
@@ -81984,8 +81865,8 @@
         "luxon": "^2.3.0",
         "monaco-editor": "^0.30.1",
         "monaco-editor-webpack-plugin": "^5.0.0",
-        "n8n-design-system": "~0.33.1",
-        "n8n-workflow": "~0.115.1",
+        "n8n-design-system": "~0.34.0",
+        "n8n-workflow": "~0.116.0",
         "normalize-wheel": "^1.0.1",
         "prismjs": "^1.17.1",
         "quill": "^2.0.0-dev.3",
@@ -82032,8 +81913,8 @@
         "change-case": "^4.1.1",
         "copyfiles": "^2.1.1",
         "inquirer": "^7.0.1",
-        "n8n-core": "~0.133.3",
-        "n8n-workflow": "~0.115.0",
+        "n8n-core": "~0.134.0",
+        "n8n-workflow": "~0.116.0",
         "oauth-1.0a": "^2.2.6",
         "replace-in-file": "^6.0.0",
         "request": "^2.88.2",
@@ -82063,7 +81944,6 @@
         "@types/mailparser": "^2.7.3",
         "@types/mime-types": "^2.1.0",
         "@types/moment-timezone": "^0.5.12",
-        "@types/mongodb": "^3.5.4",
         "@types/mqtt": "^2.5.0",
         "@types/mssql": "^6.0.2",
         "@types/node": "^16.11.22",
@@ -82107,12 +81987,12 @@
         "mailparser": "^3.2.0",
         "moment": "~2.29.2",
         "moment-timezone": "^0.5.28",
-        "mongodb": "^3.6.9",
+        "mongodb": "^4.9.1",
         "mqtt": "4.2.6",
         "mssql": "^8.1.2",
         "mysql2": "~2.3.0",
-        "n8n-core": "~0.133.3",
-        "n8n-workflow": "~0.115.1",
+        "n8n-core": "~0.134.0",
+        "n8n-workflow": "~0.116.0",
         "node-html-markdown": "^1.1.3",
         "node-ssh": "^12.0.0",
         "nodemailer": "^6.7.1",
@@ -82136,6 +82016,25 @@
         "vm2": "~3.9.5",
         "xlsx": "^0.17.0",
         "xml2js": "^0.4.23"
+      },
+      "dependencies": {
+        "denque": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
+        },
+        "mongodb": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
+          "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
+          "requires": {
+            "bson": "^4.7.0",
+            "denque": "^2.1.0",
+            "mongodb-connection-string-url": "^2.5.3",
+            "saslprep": "^1.0.3",
+            "socks": "^2.7.0"
+          }
+        }
       }
     },
     "n8n-workflow": {
@@ -83265,14 +83164,6 @@
           "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
           "dev": true
         }
-      }
-    },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "requires": {
-        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -86869,11 +86760,6 @@
         }
       }
     },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -90192,7 +90078,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -92905,8 +92790,7 @@
     "webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
     },
     "webpack": {
       "version": "4.46.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7142,6 +7142,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/bson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
+      "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "bson": "*"
+      }
+    },
     "node_modules/@types/bull": {
       "version": "3.15.9",
       "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
@@ -7725,6 +7735,16 @@
         "moment-timezone": "*"
       }
     },
+    "node_modules/@types/mongodb": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
+      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mqtt": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/mqtt/-/mqtt-2.5.0.tgz",
@@ -8175,11 +8195,6 @@
       "integrity": "sha512-y9Ydpp4K9k+gGKFFmpnYNXJxhaq7smglPMcF2wymMaEbPhMS2gHkkD9OMoaqhktJErI+VeHG1ciy1JNz1nhOTQ==",
       "dev": true
     },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -8231,15 +8246,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/xml2js": {
@@ -15454,6 +15460,47 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/bl/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -15866,6 +15913,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
       "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "dev": true,
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -35904,25 +35952,50 @@
         "webpack": "^4.5.0 || 5.x"
       }
     },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
-      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+    "node_modules/mongodb": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=4"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/moo": {
@@ -37605,6 +37678,17 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
       "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dependencies": {
+        "require-at": "^1.0.6"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -42060,6 +42144,14 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -46186,6 +46278,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.1"
       },
@@ -49836,6 +49929,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -52689,7 +52783,7 @@
         "mailparser": "^3.2.0",
         "moment": "~2.29.2",
         "moment-timezone": "^0.5.28",
-        "mongodb": "^4.9.1",
+        "mongodb": "^3.6.9",
         "mqtt": "4.2.6",
         "mssql": "^8.1.2",
         "mysql2": "~2.3.0",
@@ -52734,6 +52828,7 @@
         "@types/mailparser": "^2.7.3",
         "@types/mime-types": "^2.1.0",
         "@types/moment-timezone": "^0.5.12",
+        "@types/mongodb": "^3.5.4",
         "@types/mqtt": "^2.5.0",
         "@types/mssql": "^6.0.2",
         "@types/node": "^16.11.22",
@@ -52754,31 +52849,6 @@
         "ts-jest": "^27.1.3",
         "tslint": "^6.1.2",
         "typescript": "~4.6.0"
-      }
-    },
-    "packages/nodes-base/node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "packages/nodes-base/node_modules/mongodb": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
-      "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
-      "dependencies": {
-        "bson": "^4.7.0",
-        "denque": "^2.1.0",
-        "mongodb-connection-string-url": "^2.5.3",
-        "socks": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
       }
     },
     "packages/workflow": {
@@ -58168,6 +58238,15 @@
         "@types/node": "*"
       }
     },
+    "@types/bson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
+      "dev": true,
+      "requires": {
+        "bson": "*"
+      }
+    },
     "@types/bull": {
       "version": "3.15.9",
       "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
@@ -58742,6 +58821,16 @@
         "moment-timezone": "*"
       }
     },
+    "@types/mongodb": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
+      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/mqtt": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/mqtt/-/mqtt-2.5.0.tgz",
@@ -59188,11 +59277,6 @@
       "integrity": "sha512-y9Ydpp4K9k+gGKFFmpnYNXJxhaq7smglPMcF2wymMaEbPhMS2gHkkD9OMoaqhktJErI+VeHG1ciy1JNz1nhOTQ==",
       "dev": true
     },
-    "@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
     "@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -59243,15 +59327,6 @@
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
           "dev": true
         }
-      }
-    },
-    "@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
       }
     },
     "@types/xml2js": {
@@ -65044,6 +65119,49 @@
         }
       }
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -65400,6 +65518,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
       "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "dev": true,
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -81318,23 +81437,23 @@
         "loader-utils": "^2.0.0"
       }
     },
-    "mongodb-connection-string-url": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
-      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+    "mongodb": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       },
       "dependencies": {
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
-          }
+        "bson": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
         }
       }
     },
@@ -81944,6 +82063,7 @@
         "@types/mailparser": "^2.7.3",
         "@types/mime-types": "^2.1.0",
         "@types/moment-timezone": "^0.5.12",
+        "@types/mongodb": "^3.5.4",
         "@types/mqtt": "^2.5.0",
         "@types/mssql": "^6.0.2",
         "@types/node": "^16.11.22",
@@ -81987,7 +82107,7 @@
         "mailparser": "^3.2.0",
         "moment": "~2.29.2",
         "moment-timezone": "^0.5.28",
-        "mongodb": "^4.9.1",
+        "mongodb": "^3.6.9",
         "mqtt": "4.2.6",
         "mssql": "^8.1.2",
         "mysql2": "~2.3.0",
@@ -82016,25 +82136,6 @@
         "vm2": "~3.9.5",
         "xlsx": "^0.17.0",
         "xml2js": "^0.4.23"
-      },
-      "dependencies": {
-        "denque": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-        },
-        "mongodb": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
-          "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
-          "requires": {
-            "bson": "^4.7.0",
-            "denque": "^2.1.0",
-            "mongodb-connection-string-url": "^2.5.3",
-            "saslprep": "^1.0.3",
-            "socks": "^2.7.0"
-          }
-        }
       }
     },
     "n8n-workflow": {
@@ -83164,6 +83265,14 @@
           "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
           "dev": true
         }
+      }
+    },
+    "optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "requires": {
+        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -86760,6 +86869,11 @@
         }
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -90078,6 +90192,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
       "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -92790,7 +92905,8 @@
     "webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true
     },
     "webpack": {
       "version": "4.46.0",


### PR DESCRIPTION
We'll bring this back after the release process is fully automated, and we can update and commit the lockfile in the version bump commit.