### PR TITLE
ci: adapt workflow tests to work with updated github actions

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: 'n8n/package-lock.json'
 
       - name: Install dependencies
         run: |
@@ -41,8 +42,8 @@ jobs:
         shell: bash
 
       - name: npm install and build
+        working-directory: n8n
         run: |
-          cd n8n
           npm install -g npm@latest
           npm install
           npm run build --if-present


### PR DESCRIPTION
broke in https://github.com/n8n-io/n8n/pull/4153

[Test run](https://github.com/n8n-io/n8n/actions/runs/3111087967/jobs/5042980710)