### PR TITLE
fix(pindata): Fix excess run in partial execution

### DIFF
--- a/packages/cli/src/api/workflows.api.ts
+++ b/packages/cli/src/api/workflows.api.ts
@@ -2,7 +2,7 @@
 /* eslint-disable import/no-cycle */
 
 import express from 'express';
-import { IDataObject, IPinData, LoggerProxy, Workflow } from 'n8n-workflow';
+import { IDataObject, INode, IPinData, LoggerProxy, Workflow } from 'n8n-workflow';
 
 import axios from 'axios';
 import { FindManyOptions, In } from 'typeorm';
@@ -565,7 +565,9 @@ workflowsController.post(
 			userId: req.user.id,
 		};
 
-		if (pinnedTrigger) {
+		const hasRunData = (node: INode) => runData !== undefined && !!runData[node.name];
+
+		if (pinnedTrigger && !hasRunData(pinnedTrigger)) {
 			data.startNodes = [pinnedTrigger.name];
 		}
 

--- a/packages/editor-ui/src/components/mixins/workflowRun.ts
+++ b/packages/editor-ui/src/components/mixins/workflowRun.ts
@@ -142,8 +142,6 @@ export const workflowRun = mixins(
 
 				const startNodes: string[] = [];
 
-				const workflowData = await this.getWorkflowDataToSave();
-
 				if (runData !== null && Object.keys(runData).length !== 0) {
 					newRunData = {};
 
@@ -166,11 +164,7 @@ export const workflowRun = mixins(
 								startNodes.push(parentNode);
 								break;
 							}
-
-							// send `runData` only if node is not pinned
-							if (workflowData.pinData && !workflowData.pinData[parentNode]) {
-								newRunData[parentNode] = runData[parentNode].slice(0, 1);
-							}
+							newRunData[parentNode] = runData[parentNode].slice(0, 1);
 						}
 					}
 
@@ -191,6 +185,7 @@ export const workflowRun = mixins(
 					await this.saveCurrentWorkflow();
 				}
 
+				const workflowData = await this.getWorkflowDataToSave();
 
 				const startRunData: IStartRunData = {
 					workflowData,

--- a/packages/editor-ui/src/components/mixins/workflowRun.ts
+++ b/packages/editor-ui/src/components/mixins/workflowRun.ts
@@ -142,6 +142,8 @@ export const workflowRun = mixins(
 
 				const startNodes: string[] = [];
 
+				const workflowData = await this.getWorkflowDataToSave();
+
 				if (runData !== null && Object.keys(runData).length !== 0) {
 					newRunData = {};
 
@@ -164,7 +166,11 @@ export const workflowRun = mixins(
 								startNodes.push(parentNode);
 								break;
 							}
-							newRunData[parentNode] = runData[parentNode].slice(0, 1);
+
+							// send `runData` only if node is not pinned
+							if (workflowData.pinData && !workflowData.pinData[parentNode]) {
+								newRunData[parentNode] = runData[parentNode].slice(0, 1);
+							}
 						}
 					}
 
@@ -185,7 +191,6 @@ export const workflowRun = mixins(
 					await this.saveCurrentWorkflow();
 				}
 
-				const workflowData = await this.getWorkflowDataToSave();
 
 				const startRunData: IStartRunData = {
 					workflowData,


### PR DESCRIPTION
To reproduce, connect two nodes, pin the first and run the second two times as a partial execution, i.e. from any of the `Execute Node` buttons. First node shows two runs the second time. 

Fixing by sending only `pinData` (instead of `pinData` and `runData`) for a pinned node.