### PR TITLE
fix: remove --forceExit flag from cli tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "start:default": "cd bin && ./n8n",
     "start:windows": "cd bin && n8n",
     "test": "npm run test:sqlite",
-    "test:sqlite": "N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest --forceExit",
+    "test:sqlite": "N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest",
     "test:postgres": "N8N_LOG_LEVEL=silent DB_TYPE=postgresdb jest",
     "test:postgres:alt-schema": "DB_POSTGRESDB_SCHEMA=alt_schema npm run test:postgres",
     "test:mysql": "N8N_LOG_LEVEL=silent DB_TYPE=mysqldb jest",


### PR DESCRIPTION
I'm unsure what changed but it seems to just work now. Worth keeping an eye on though.