### PR TITLE
fix(editor-ui): Fix ParameterInput inputField ref focus

### DIFF
--- a/packages/editor-ui/src/components/CredentialsSelect.vue
+++ b/packages/editor-ui/src/components/CredentialsSelect.vue
@@ -7,6 +7,7 @@
 				:value="displayValue"
 				:placeholder="parameter.placeholder ? getPlaceholder() : $locale.baseText('parameterInput.select')"
 				:title="displayTitle"
+				ref="innerSelect"
 				@change="(value) => $emit('valueChanged', value)"
 				@keydown.stop
 				@focus="$emit('setFocus')"
@@ -82,6 +83,12 @@ export default Vue.extend({
 		},
 	},
 	methods: {
+		focus() {
+			const select = this.$refs.innerSelect as Vue & HTMLElement | undefined;
+			if (select) {
+				select.focus();
+			}
+		},
 		/**
 		 * Check if a credential type belongs to one of the supported sets defined
 		 * in the `credentialTypes` key in a `credentialsSelect` parameter

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -869,7 +869,7 @@ export default mixins(
 					// @ts-ignore
 					if (this.$refs.inputField && this.$refs.inputField.$el) {
 						// @ts-ignore
-						this.$refs.inputField.$el.focus();
+						this.$refs.inputField.focus();
 					}
 				});
 

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -869,7 +869,7 @@ export default mixins(
 					// @ts-ignore
 					if (this.$refs.inputField && this.$refs.inputField.$el) {
 						// @ts-ignore
-						this.$refs.inputField.focus();
+						this.$refs.inputField.$el.focus();
 					}
 				});
 


### PR DESCRIPTION
[N8N-4783](https://linear.app/n8n/issue/N8N-4783)

The `CredentialsSelect` component doesn't implement `focus` method, so we need to add one to trigger select focus.