### PR TITLE
feat(node-email): Change EmailReadImap display name and name

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
@@ -30,7 +30,7 @@ import _ from 'lodash';
 
 export class EmailReadImap implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'EmailReadImap',
+		displayName: 'Email Trigger (IMAP)',
 		name: 'emailReadImap',
 		icon: 'fa:inbox',
 		group: ['trigger'],
@@ -38,7 +38,7 @@ export class EmailReadImap implements INodeType {
 		description: 'Triggers the workflow when a new email is received',
 		eventTriggerDescription: 'Waiting for you to receive an email',
 		defaults: {
-			name: 'IMAP Email',
+			name: 'Email Trigger',
 			color: '#44AA22',
 		},
 		inputs: [],


### PR DESCRIPTION
- [x] Should be located both within the “On App Event” and within the “Other ways…” category of triggers
- [x] Rename to Email Trigger (IMAP) in the node list and Email Trigger on canvas
