### PR TITLE
WIP: ✨ Add cred dropdown for custom OAuth scope levels

### DIFF
--- a/packages/nodes-base/credentials/GoogleAnalyticsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleAnalyticsOAuth2Api.credentials.ts
@@ -1,10 +1,13 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/analytics',
-	'https://www.googleapis.com/auth/analytics.readonly',
-];
-
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/analytics',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/analytics.readonly',
+	],
+};
 export class GoogleAnalyticsOAuth2Api implements ICredentialType {
 	name = 'googleAnalyticsOAuth2';
 	extends = ['googleOAuth2Api'];
@@ -14,8 +17,9 @@ export class GoogleAnalyticsOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleCalendarOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleCalendarOAuth2Api.credentials.ts
@@ -1,9 +1,15 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/calendar',
-	'https://www.googleapis.com/auth/calendar.events',
-];
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/calendar',
+		'https://www.googleapis.com/auth/calendar.events',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/calendar.readonly',
+		'https://www.googleapis.com/auth/calendar.events.readonly',
+	],
+};
 
 export class GoogleCalendarOAuth2Api implements ICredentialType {
 	name = 'googleCalendarOAuth2Api';
@@ -14,8 +20,9 @@ export class GoogleCalendarOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleContactsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleContactsOAuth2Api.credentials.ts
@@ -1,7 +1,15 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = ['https://www.googleapis.com/auth/contacts'];
-
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/contacts',
+		'https://www.googleapis.com/auth/directory.readonly',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/contacts.readonly',
+		'https://www.googleapis.com/auth/directory.readonly',
+	],
+};
 export class GoogleContactsOAuth2Api implements ICredentialType {
 	name = 'googleContactsOAuth2Api';
 	extends = ['googleOAuth2Api'];
@@ -11,8 +19,9 @@ export class GoogleContactsOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleDocsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleDocsOAuth2Api.credentials.ts
@@ -1,10 +1,16 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/documents',
-	'https://www.googleapis.com/auth/drive',
-	'https://www.googleapis.com/auth/drive.file',
-];
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/documents',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/documents.readonly',
+	],
+	"n8n Sheets Only": [
+		'https://www.googleapis.com/auth/drive.file',
+	],
+};
 
 export class GoogleDocsOAuth2Api implements ICredentialType {
 	name = 'googleDocsOAuth2Api';
@@ -15,8 +21,9 @@ export class GoogleDocsOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleDriveOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleDriveOAuth2Api.credentials.ts
@@ -1,10 +1,21 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/drive',
-	'https://www.googleapis.com/auth/drive.appdata',
-	'https://www.googleapis.com/auth/drive.photos.readonly',
-];
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/drive',
+		'https://www.googleapis.com/auth/drive.appdata',
+		'https://www.googleapis.com/auth/drive.photos.readonly',
+		'https://www.googleapis.com/auth/drive.activity',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/drive.readonly',
+		'https://www.googleapis.com/auth/drive.photos.readonly',
+		'https://www.googleapis.com/auth/drive.activity.readonly',
+	],
+	"n8n Files Only": [
+		'https://www.googleapis.com/auth/drive.file',
+	],
+};
 
 export class GoogleDriveOAuth2Api implements ICredentialType {
 	name = 'googleDriveOAuth2Api';
@@ -15,8 +26,9 @@ export class GoogleDriveOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleSheetsOAuth2Api.credentials.ts
@@ -1,9 +1,16 @@
-import { ICredentialType, INodeProperties } from 'n8n-workflow';
+import { ICredentialType, IDataObject, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/drive.file',
-	'https://www.googleapis.com/auth/spreadsheets',
-];
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/spreadsheets',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/spreadsheets.readonly',
+	],
+	"n8n Sheets Only": [
+		'https://www.googleapis.com/auth/drive.file',
+	],
+};
 
 export class GoogleSheetsOAuth2Api implements ICredentialType {
 	name = 'googleSheetsOAuth2Api';
@@ -14,8 +21,9 @@ export class GoogleSheetsOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleSlidesOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleSlidesOAuth2Api.credentials.ts
@@ -1,9 +1,16 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = [
-	'https://www.googleapis.com/auth/drive.file',
-	'https://www.googleapis.com/auth/presentations',
-];
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/presentations',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/presentations.readonly',
+	],
+	"n8n Slides Only": [
+		'https://www.googleapis.com/auth/drive.file',
+	],
+};
 
 export class GoogleSlidesOAuth2Api implements ICredentialType {
 	name = 'googleSlidesOAuth2Api';
@@ -14,8 +21,9 @@ export class GoogleSlidesOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GoogleTasksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleTasksOAuth2Api.credentials.ts
@@ -1,7 +1,13 @@
 import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = ['https://www.googleapis.com/auth/tasks'];
-
+const scopes: { [key: string]: string[] } = {
+	"Read & Write": [
+		'https://www.googleapis.com/auth/tasks',
+	],
+	"Read Only": [
+		'https://www.googleapis.com/auth/tasks.readonly',
+	],
+};
 export class GoogleTasksOAuth2Api implements ICredentialType {
 	name = 'googleTasksOAuth2Api';
 	extends = ['googleOAuth2Api'];
@@ -11,8 +17,9 @@ export class GoogleTasksOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: scopes.join(' '),
+			type: 'options',
+			options: Object.entries(scopes).map(x => ({name: x[0], value: x[1].join(' ')})),
+			default: 'Read & Write',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/MicrosoftGraphSecurityOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftGraphSecurityOAuth2Api.credentials.ts
@@ -9,8 +9,18 @@ export class MicrosoftGraphSecurityOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
-			default: 'SecurityEvents.ReadWrite.All',
+			type: 'options',
+			options: [
+				{
+					name: 'Read & Write',
+					value: 'SecurityEvents.ReadWrite.All',
+				},
+				{
+					name: 'Read Only',
+					value: 'SecurityEvents.Read.All',
+				},
+			],
+			default: 'Read & Write',
 		},
 	];
 }


### PR DESCRIPTION
Briefly discussed in discord - https://discord.com/channels/832547762716278804/832547763191152642/1026463938692517888

Add OAuth2 scope options so users can limit their exposure. Generally useful to limit the blast radius of n8n creds, and especially important when credential sharing becomes a thing.

In this example with Google Drive a user can choose:
1. `Read & Write`: same as the original default. Access to create, read, modify, and delete all files
2. `Read Only`: ability to read and list all available files
3. `n8n Files Only`: create, read, modify, and delete all files created by n8n **only**

![SCR-20221003-i4x](https://user-images.githubusercontent.com/939704/193573404-dfe1cdf6-bc5e-4f80-b7f3-b3bc54c6a00a.png)
