### PR TITLE
fix(cli): Cache generated assets in user writable directory instead

### DIFF
--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -6,9 +6,7 @@ if [ -d /root/.n8n ] ; then
   ln -s /root/.n8n /home/node/
 fi
 
-# node user needs to be able to write in this folder to be able to customize static assets
-mkdir -p /usr/local/lib/node_modules/n8n/dist/public
-chown -R node /home/node /usr/local/lib/node_modules/n8n/dist/public
+chown -R node /home/node
 
 if [ "$#" -gt 0 ]; then
   # Got started with arguments

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -38,12 +38,10 @@ import { createHmac } from 'crypto';
 import { promisify } from 'util';
 import cookieParser from 'cookie-parser';
 import express from 'express';
-import send from 'send';
 import { FindManyOptions, getConnectionManager, In } from 'typeorm';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import axios, { AxiosRequestConfig } from 'axios';
 import clientOAuth1, { RequestOptions } from 'oauth-1.0a';
-import curlconverter from 'curlconverter';
 // IMPORTANT! Do not switch to anther bcrypt library unless really necessary and
 // tested with all possible systems like Windows, Alpine on ARM, FreeBSD, ...
 import { compare } from 'bcryptjs';
@@ -1787,7 +1785,7 @@ class App {
 			}
 
 			const editorUiDistDir = pathJoin(pathDirname(require.resolve('n8n-editor-ui')), 'dist');
-			const generatedStaticDir = pathJoin(__dirname, '../public');
+			const generatedStaticDir = pathJoin(UserSettings.getUserHome(), '.cache/n8n/public');
 
 			const closingTitleTag = '</title>';
 			const compileFile = async (fileName: string) => {


### PR DESCRIPTION
this is an alternative to https://github.com/n8n-io/n8n/pull/4245, that change caused issue for cloud users and the debian-image users.