### PR TITLE
Adds SSL/TLS toggle to FTP connection

### DIFF
--- a/packages/nodes-base/credentials/Ftp.credentials.ts
+++ b/packages/nodes-base/credentials/Ftp.credentials.ts
@@ -36,8 +36,36 @@ export class Ftp implements ICredentialType {
 			default: '',
 		},
 		{
-			displayName: 'SSL/TLS',
+			displayName: 'Connect using SSL/TLS',
 			name: 'secure',
+			type: 'options',
+			options: [
+				{
+					name: 'False',
+					value: false,
+					description: 'Disable secure connection',
+				},
+				{
+					name: 'True',
+					value: true,
+					description: 'Enable encryption for control & data connection',
+				},
+				{
+					name: 'Control',
+					value: 'control',
+					description: 'Enable encryption for control connection only',
+				},
+			],
+			default: false,
+		},
+		{
+			displayName: 'Ignore Certificate Validation',
+			name: 'disableCertificateValidation',
+			displayOptions: {
+				hide: {
+					secure: [false],
+				},
+			},
 			type: 'boolean',
 			default: false,
 		},

--- a/packages/nodes-base/credentials/Ftp.credentials.ts
+++ b/packages/nodes-base/credentials/Ftp.credentials.ts
@@ -35,5 +35,11 @@ export class Ftp implements ICredentialType {
 			},
 			default: '',
 		},
+		{
+			displayName: 'SSL/TLS',
+			name: 'secure',
+			type: 'boolean',
+			default: false,
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -15,6 +15,7 @@ import { basename, dirname } from 'path';
 
 import ftpClient from 'promise-ftp';
 import sftpClient from 'ssh2-sftp-client';
+import { ConnectionOptions, TlsOptions } from 'tls';
 
 interface ReturnFtpItem {
 	type: string;
@@ -368,6 +369,7 @@ export class Ftp implements INodeType {
 						port: credentials.port as number,
 						user: credentials.username as string,
 						password: credentials.password as string,
+						secure: true,
 					});
 				} catch (error) {
 					return {
@@ -442,11 +444,19 @@ export class Ftp implements INodeType {
 				});
 			} else {
 				ftp = new ftpClient();
+				// credentials.secure = true;
+				// const _secureOptions: ConnectionOptions = {
+				// 	host: credentials.host as string,
+				// 	port: credentials.port as number,
+				// 	timeout: 10000,
+				// };
 				await ftp.connect({
 					host: credentials.host as string,
 					port: credentials.port as number,
 					user: credentials.username as string,
 					password: credentials.password as string,
+					secure: credentials.secure as boolean,
+					// secureOptions: _secureOptions,
 				});
 			}
 


### PR DESCRIPTION
This adds basic yes/no to the FTP connection enabling basic ftps functionality. An underlying issue is that promise-ftp uses an out of date version of @icetee/ftp which has a bug which causes ftps connect to fail. I have a pull request open here https://github.com/realtymaps/promise-ftp/pull/47 to update that library. Updating manually on the local node_modules works, and all tests still pass. 