### PR TITLE
ci: revert stricter PR title checks (no-changelog)

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,4 +1,4 @@
-name: Check PR title
+name: Test Pull Request Semantics
 
 on:
   pull_request:
@@ -10,30 +10,23 @@ on:
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    permissions:
+      checks: write
+      pull-requests: read
+      contents: read
     steps:
-      - name: Validate PR title
-        id: validate_pr_title
-        uses: ivov/validate-n8n-pull-request-title@v1
+      - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Post validation issue comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: always()
         with:
-          header: pr_title_failed_validation
-          message: |
-            Thank you for your contribution!
-            PR titles in this repo follow our version of the Conventional Commits spec.
-            This allows us to automatically generate the changelog for the next release.
-            Therefore, we ask you to adjust your PR title to solve the issue(s) below:
-
-            ${{ steps.validate_pr_title.outputs.validation_issues }}
-
-      - name: Remove validation issue comment
-        if: ${{ steps.validate_pr_title.outputs.validation_issues == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr_title_failed_validation
-          delete: true
+          # https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8
+          types: |
+            feat
+            fix
+            perf
+            test
+            docs
+            refactor
+            build
+            ci
+          requireScope: false


### PR DESCRIPTION
This reverts commit 6d62471a11f7407a43afab3e7db827bec50d315e.

Reason: Not working on forks for lack of permissions.