### PR TITLE
fix(workflow): expression evaluation should respect `N8N_BLOCK_ENV_ACCESS_IN_NODE`

### DIFF
--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -104,7 +104,7 @@ export class Expression {
 			typeof process !== 'undefined'
 				? {
 						arch: process.arch,
-						env: process.env,
+						env: process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true' ? {} : process.env,
 						platform: process.platform,
 						pid: process.pid,
 						ppid: process.ppid,


### PR DESCRIPTION
this is a follow up to https://github.com/n8n-io/n8n/commit/ddb3baa4eddeb85e2f7abe4465ac4ff4058e1ece