### PR TITLE
fix(SendInBlue Trigger Node): fix typo in credential name

### DIFF
--- a/packages/nodes-base/nodes/SendInBlue/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendInBlue/GenericFunctions.ts
@@ -308,7 +308,7 @@ export namespace SendInBlueWebhookApi {
 		webhooks: WebhookDetails[];
 	}
 
-	const credentialsName = 'sendinblueApi';
+	const credentialsName = 'sendInBlueApi';
 	const baseURL = 'https://api.sendinblue.com/v3';
 	export const supportedAuthMap = new Map<string, (ref: IWebhookFunctions) => Promise<string>>([
 		[


### PR DESCRIPTION
Credential's property name should be "sendInBlueApi".
[Issue ](https://github.com/n8n-io/n8n/issues/4356)