### PR TITLE
fix(Google Drive Node): fix drive hint typo in resource locator

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -1478,7 +1478,7 @@ export class GoogleDrive implements INodeType {
 				type: 'resourceLocator',
 				default: { mode: 'list', value: '' },
 				required: true,
-				hint: 'The Google Drive drive to operator on',
+				hint: 'The Google Drive drive to operate on',
 				modes: [
 					{
 						displayName: 'Drive',


### PR DESCRIPTION
 "The Google Drive drive to operator on" should be "The Google Drive drive to operate on".