### PR TITLE
feat(nodes-base): pre-generate the package cache at build time

### DIFF
--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -16,7 +16,8 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "dev": "npm run watch",
-    "build": "tsc && gulp build:icons && gulp build:translations",
+    "build": "tsc && gulp build:icons && npm run build:translations && npm run build:cache",
+    "build:cache": "node scripts/generate-cache.js",
     "build:translations": "gulp build:translations",
     "format": "cd ../.. && node_modules/prettier/bin-prettier.js --write \"packages/nodes-base/**/*.{ts,json}\"",
     "lint": "tslint -p tsconfig.json -c tslint.json && eslint nodes credentials src",

--- a/packages/nodes-base/scripts/generate-cache.js
+++ b/packages/nodes-base/scripts/generate-cache.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const { fileURLToPath } = require('url');
+const { PackageDirectoryLoader } = require('n8n-core');
+const { LoggerProxy } = require('n8n-workflow');
+
+LoggerProxy.init({
+	log: console.log.bind(console, '->'),
+});
+
+const packagePath = path.resolve(__dirname, '..');
+const loader = new PackageDirectoryLoader(packagePath);
+loader.init({ cachingEnabled: true });


### PR DESCRIPTION
this adds cache generation in the build process. which ensures that docker images come with a per-generated cache and can benefit from cache at the first run itself.