### PR TITLE
docs(Manual Trigger Node): correct documentation link (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
+++ b/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
@@ -8,7 +8,7 @@
 	"resources": {
 		"primaryDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.manualTrigger/"
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.manualWorkflowTrigger/"
 			}
 		],
 		"generic": []

--- a/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
+++ b/packages/nodes-base/nodes/ManualTrigger/ManualTrigger.node.json
@@ -8,7 +8,7 @@
 	"resources": {
 		"primaryDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.manualWorkflowTrigger/"
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger/"
 			}
 		],
 		"generic": []


### PR DESCRIPTION
Current URL 404s. Revised URL based on this unmerged PR: 

https://github.com/n8n-io/n8n-docs/pull/984