### PR TITLE
ci(core): fix node-dev Build.ts linting

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -6,6 +6,7 @@ import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { join, dirname, resolve as resolvePath } from 'path';
 import { file as tmpFile } from 'tmp-promise';
 
+import { jsonParse, IDataObject } from 'n8n-workflow';
 import { UserSettings } from 'n8n-core';
 import { IBuildOptions } from '.';
 
@@ -21,13 +22,13 @@ export async function createCustomTsconfig() {
 
 	// Read the tsconfig file
 	const tsConfigString = await readFile(tsconfigPath, { encoding: 'utf8' });
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, n8n-local-rules/no-uncaught-json-parse
-	const tsConfig = JSON.parse(tsConfigString);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const tsConfig = jsonParse<IDataObject>(tsConfigString);
 
 	// Set absolute include paths
 	const newIncludeFiles = [];
 	// eslint-disable-next-line no-restricted-syntax
-	for (const includeFile of tsConfig.include) {
+	for (const includeFile of tsConfig.include as string[]) {
 		newIncludeFiles.push(join(process.cwd(), includeFile));
 	}
 	tsConfig.include = newIncludeFiles;

--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -6,7 +6,7 @@ import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { join, dirname, resolve as resolvePath } from 'path';
 import { file as tmpFile } from 'tmp-promise';
 
-import { jsonParse, IDataObject } from 'n8n-workflow';
+import { jsonParse } from 'n8n-workflow';
 import { UserSettings } from 'n8n-core';
 import { IBuildOptions } from '.';
 
@@ -23,12 +23,12 @@ export async function createCustomTsconfig() {
 	// Read the tsconfig file
 	const tsConfigString = await readFile(tsconfigPath, { encoding: 'utf8' });
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const tsConfig = jsonParse<IDataObject>(tsConfigString);
+	const tsConfig = jsonParse<{ include: string[] }>(tsConfigString);
 
 	// Set absolute include paths
 	const newIncludeFiles = [];
 	// eslint-disable-next-line no-restricted-syntax
-	for (const includeFile of tsConfig.include as string[]) {
+	for (const includeFile of tsConfig.include) {
 		newIncludeFiles.push(join(process.cwd(), includeFile));
 	}
 	tsConfig.include = newIncludeFiles;

--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -21,7 +21,7 @@ export async function createCustomTsconfig() {
 
 	// Read the tsconfig file
 	const tsConfigString = await readFile(tsconfigPath, { encoding: 'utf8' });
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, n8n-local-rules/no-uncaught-json-parse
 	const tsConfig = JSON.parse(tsConfigString);
 
 	// Set absolute include paths


### PR DESCRIPTION
Use the new parseJson helper for parsing of `tsconfig-build.json` inside `node-dev/src/Build.ts`