### PR TITLE
fix(Email Trigger (IMAP) Node): backport V2 mark-seen-after-processing to V1

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
@@ -314,13 +314,13 @@ export class EmailReadImapV1 implements INodeType {
 			if (format === 'simple' || format === 'raw') {
 				fetchOptions = {
 					bodies: ['TEXT', 'HEADER'],
-					markSeen: postProcessAction === 'read',
+					markSeen: false,
 					struct: true,
 				};
 			} else if (format === 'resolved') {
 				fetchOptions = {
 					bodies: [''],
-					markSeen: postProcessAction === 'read',
+					markSeen: false,
 					struct: true,
 				};
 			}
@@ -459,6 +459,13 @@ export class EmailReadImapV1 implements INodeType {
 				}
 			}
 
+			// only mark messages as seen once processing has finished
+			if (postProcessAction === 'read') {
+				const uidList = results.map((e) => e.attributes.uid);
+				if (uidList.length > 0) {
+					connection.addFlags(uidList, '\\SEEN');
+				}
+			}
 			return newEmails;
 		};
 


### PR DESCRIPTION
This PR ports the change from V2, where emails are only marked as SEEN after they have been successfully processed, to the V1 version of the node.