### PR TITLE
refactor: rename NodeVersionedType to VersionedNodeType and move it to the workflow package

### DIFF
--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -9,7 +9,6 @@
 import { Credentials, NodeExecuteFunctions } from 'n8n-core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { get } from 'lodash';
-import { NodeVersionedType } from 'n8n-nodes-base';
 
 import {
 	ICredentialDataDecryptedObject,
@@ -28,7 +27,8 @@ import {
 	INodeType,
 	INodeTypeData,
 	INodeTypes,
-	INodeVersionedType,
+	IVersionedNodeType,
+	VersionedNodeType,
 	IRequestOptionsSimplified,
 	IRunExecutionData,
 	IWorkflowDataProxyAdditionalKeys,
@@ -60,7 +60,7 @@ const mockNodeTypes: INodeTypes = {
 	nodeTypes: {} as INodeTypeData,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	init: async (nodeTypes?: INodeTypeData): Promise<void> => {},
-	getAll(): Array<INodeType | INodeVersionedType> {
+	getAll(): Array<INodeType | IVersionedNodeType> {
 		// @ts-ignore
 		return Object.values(this.nodeTypes).map((data) => data.type);
 	},
@@ -484,9 +484,9 @@ export class CredentialsHelper extends ICredentialsHelper {
 			// Always set to an array even if node is not versioned to not having
 			// to duplicate the logic
 			const allNodeTypes: INodeType[] = [];
-			if (node instanceof NodeVersionedType) {
+			if (node instanceof VersionedNodeType) {
 				// Node is versioned
-				allNodeTypes.push(...Object.values((node as INodeVersionedType).nodeVersions));
+				allNodeTypes.push(...Object.values((node as IVersionedNodeType).nodeVersions));
 			} else {
 				// Node is not versioned
 				allNodeTypes.push(node as INodeType);
@@ -501,11 +501,11 @@ export class CredentialsHelper extends ICredentialsHelper {
 							if (Object.prototype.hasOwnProperty.call(node, 'nodeVersions')) {
 								// The node is versioned. So check all versions for test function
 								// starting with the latest
-								const versions = Object.keys((node as INodeVersionedType).nodeVersions)
+								const versions = Object.keys((node as IVersionedNodeType).nodeVersions)
 									.sort()
 									.reverse();
 								for (const version of versions) {
-									const versionedNode = (node as INodeVersionedType).nodeVersions[
+									const versionedNode = (node as IVersionedNodeType).nodeVersions[
 										parseInt(version, 10)
 									];
 									if (

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -19,7 +19,7 @@ import {
 	INodeType,
 	INodeTypeData,
 	INodeTypeNameVersion,
-	INodeVersionedType,
+	IVersionedNodeType,
 	LoggerProxy,
 	jsonParse,
 } from 'n8n-workflow';
@@ -351,7 +351,7 @@ class LoadNodesAndCredentialsClass {
 		nodeName: string,
 		filePath: string,
 	): INodeTypeNameVersion | undefined {
-		let tempNode: INodeType | INodeVersionedType;
+		let tempNode: INodeType | IVersionedNodeType;
 		let nodeVersion = 1;
 
 		try {
@@ -375,9 +375,9 @@ class LoadNodesAndCredentialsClass {
 		}
 
 		if (tempNode.hasOwnProperty('nodeVersions')) {
-			const versionedNodeType = (tempNode as INodeVersionedType).getNodeType();
+			const versionedNodeType = (tempNode as IVersionedNodeType).getNodeType();
 			this.addCodex({ node: versionedNodeType, filePath, isCustom: packageName === 'CUSTOM' });
-			nodeVersion = (tempNode as INodeVersionedType).currentVersion;
+			nodeVersion = (tempNode as IVersionedNodeType).currentVersion;
 
 			if (
 				versionedNodeType.description.icon !== undefined &&
@@ -459,7 +459,7 @@ class LoadNodesAndCredentialsClass {
 		filePath,
 		isCustom,
 	}: {
-		node: INodeType | INodeVersionedType;
+		node: INodeType | IVersionedNodeType;
 		filePath: string;
 		isCustom: boolean;
 	}) {

--- a/packages/cli/src/NodeTypes.ts
+++ b/packages/cli/src/NodeTypes.ts
@@ -7,7 +7,7 @@ import {
 	INodeTypeData,
 	INodeTypeDescription,
 	INodeTypes,
-	INodeVersionedType,
+	IVersionedNodeType,
 	NodeHelpers,
 } from 'n8n-workflow';
 
@@ -29,7 +29,7 @@ class NodeTypesClass implements INodeTypes {
 		this.nodeTypes = nodeTypes;
 	}
 
-	getAll(): Array<INodeType | INodeVersionedType> {
+	getAll(): Array<INodeType | IVersionedNodeType> {
 		return Object.values(this.nodeTypes).map((data) => data.type);
 	}
 
@@ -60,7 +60,7 @@ class NodeTypesClass implements INodeTypes {
 
 	attachNodeType(
 		nodeTypeName: string,
-		nodeType: INodeType | INodeVersionedType,
+		nodeType: INodeType | IVersionedNodeType,
 		sourcePath: string,
 	): void {
 		this.nodeTypes[nodeTypeName] = {

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -20,7 +20,7 @@ import {
 	INodeTypes,
 	INodeTypeData,
 	INodeTypeDescription,
-	INodeVersionedType,
+	IVersionedNodeType,
 	IPinData,
 	IRunData,
 	IRunExecutionData,
@@ -313,7 +313,7 @@ export const workflowHelpers = mixins(
 				const nodeTypes: INodeTypes = {
 					nodeTypes: {},
 					init: async (nodeTypes?: INodeTypeData): Promise<void> => { },
-					getAll: (): Array<INodeType | INodeVersionedType> => {
+					getAll: (): Array<INodeType | IVersionedNodeType> => {
 						// Does not get used in Workflow so no need to return it
 						return [];
 					},

--- a/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
@@ -1,9 +1,9 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
-import { NodeVersionedType } from '../../src/NodeVersionedType';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
+
 import { EmailReadImapV1 } from './v1/EmailReadImapV1.node';
 import { EmailReadImapV2 } from './v2/EmailReadImapV2.node';
 
-export class EmailReadImap extends NodeVersionedType {
+export class EmailReadImap extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'Email Trigger (IMAP)',
@@ -14,7 +14,7 @@ export class EmailReadImap extends NodeVersionedType {
 			defaultVersion: 2,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new EmailReadImapV1(baseDescription),
 			2: new EmailReadImapV2(baseDescription),
 		};

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
@@ -1,12 +1,9 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
-
-import { NodeVersionedType } from '../../../src/NodeVersionedType';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { GmailV1 } from './v1/GmailV1.node';
-
 import { GmailV2 } from './v2/GmailV2.node';
 
-export class Gmail extends NodeVersionedType {
+export class Gmail extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'Gmail',
@@ -18,7 +15,7 @@ export class Gmail extends NodeVersionedType {
 			defaultVersion: 2,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new GmailV1(baseDescription),
 			2: new GmailV2(baseDescription),
 		};

--- a/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/HttpRequest.node.ts
@@ -1,14 +1,10 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { HttpRequestV1 } from './V1/HttpRequestV1.node';
-
 import { HttpRequestV2 } from './V2/HttpRequestV2.node';
-
 import { HttpRequestV3 } from './V3/HttpRequestV3.node';
 
-import { NodeVersionedType } from '../../src/NodeVersionedType';
-
-export class HttpRequest extends NodeVersionedType {
+export class HttpRequest extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'HTTP Request',
@@ -20,7 +16,7 @@ export class HttpRequest extends NodeVersionedType {
 			defaultVersion: 3,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new HttpRequestV1(baseDescription),
 			2: new HttpRequestV2(baseDescription),
 			3: new HttpRequestV3(baseDescription),

--- a/packages/nodes-base/nodes/Mattermost/Mattermost.node.ts
+++ b/packages/nodes-base/nodes/Mattermost/Mattermost.node.ts
@@ -1,9 +1,8 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { MattermostV1 } from './v1/MattermostV1.node';
-import { NodeVersionedType } from '../../src/NodeVersionedType';
 
-export class Mattermost extends NodeVersionedType {
+export class Mattermost extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'Mattermost',
@@ -15,7 +14,7 @@ export class Mattermost extends NodeVersionedType {
 			defaultVersion: 1,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new MattermostV1(baseDescription),
 		};
 

--- a/packages/nodes-base/nodes/Merge/Merge.node.ts
+++ b/packages/nodes-base/nodes/Merge/Merge.node.ts
@@ -1,12 +1,9 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
-
-import { NodeVersionedType } from '../../src/NodeVersionedType';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { MergeV1 } from './v1/MergeV1.node';
-
 import { MergeV2 } from './v2/MergeV2.node';
 
-export class Merge extends NodeVersionedType {
+export class Merge extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'Merge',
@@ -18,7 +15,7 @@ export class Merge extends NodeVersionedType {
 			defaultVersion: 2,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new MergeV1(baseDescription),
 			2: new MergeV2(baseDescription),
 		};

--- a/packages/nodes-base/nodes/Notion/Notion.node.ts
+++ b/packages/nodes-base/nodes/Notion/Notion.node.ts
@@ -1,12 +1,9 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { NotionV1 } from './v1/NotionV1.node';
-
 import { NotionV2 } from './v2/NotionV2.node';
 
-import { NodeVersionedType } from '../../src/NodeVersionedType';
-
-export class Notion extends NodeVersionedType {
+export class Notion extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'Notion (Beta)',
@@ -18,7 +15,7 @@ export class Notion extends NodeVersionedType {
 			defaultVersion: 2,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new NotionV1(baseDescription),
 			2: new NotionV2(baseDescription),
 		};

--- a/packages/nodes-base/nodes/SyncroMSP/SyncroMsp.node.ts
+++ b/packages/nodes-base/nodes/SyncroMSP/SyncroMsp.node.ts
@@ -1,10 +1,8 @@
-import { INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
-
-import { NodeVersionedType } from '../../src/NodeVersionedType';
+import { INodeTypeBaseDescription, IVersionedNodeType, VersionedNodeType } from 'n8n-workflow';
 
 import { SyncroMspV1 } from './v1/SyncroMspV1.node';
 
-export class SyncroMsp extends NodeVersionedType {
+export class SyncroMsp extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
 			displayName: 'SyncroMSP',
@@ -17,7 +15,7 @@ export class SyncroMsp extends NodeVersionedType {
 			defaultVersion: 1,
 		};
 
-		const nodeVersions: INodeVersionedType['nodeVersions'] = {
+		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new SyncroMspV1(baseDescription),
 		};
 

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -12,15 +12,13 @@
     "type": "git",
     "url": "git+https://github.com/n8n-io/n8n.git"
   },
-  "main": "dist/src/index",
-  "types": "dist/src/index.d.ts",
   "scripts": {
     "dev": "npm run watch",
     "build": "tsc && gulp build:icons && gulp build:translations",
     "build:translations": "gulp build:translations",
     "format": "cd ../.. && node_modules/prettier/bin-prettier.js --write \"packages/nodes-base/**/*.{ts,json}\"",
-    "lint": "tslint -p tsconfig.json -c tslint.json && eslint nodes credentials src",
-    "lintfix": "tslint --fix -p tsconfig.json -c tslint.json && eslint nodes credentials src --fix",
+    "lint": "tslint -p tsconfig.json -c tslint.json && eslint nodes credentials",
+    "lintfix": "tslint --fix -p tsconfig.json -c tslint.json && eslint nodes credentials --fix",
     "watch": "tsc --watch",
     "test": "jest"
   },

--- a/packages/nodes-base/src/index.ts
+++ b/packages/nodes-base/src/index.ts
@@ -1,3 +1,0 @@
-import { NodeVersionedType } from './NodeVersionedType';
-
-export { NodeVersionedType };

--- a/packages/nodes-base/tsconfig.json
+++ b/packages/nodes-base/tsconfig.json
@@ -11,7 +11,6 @@
 	},
 	"include": [
 		"credentials/**/*.ts",
-		"src/**/*.ts",
 		"nodes/**/*.ts",
 		"nodes/**/*.json",
 		"credentials/translations/**/*.json"

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1144,7 +1144,7 @@ export interface INodeType {
 	};
 }
 
-export interface INodeVersionedType {
+export interface IVersionedNodeType {
 	nodeVersions: {
 		[key: number]: INodeType;
 	};
@@ -1423,7 +1423,7 @@ export type WebhookResponseMode = 'onReceived' | 'lastNode';
 export interface INodeTypes {
 	nodeTypes: INodeTypeData;
 	init(nodeTypes?: INodeTypeData): Promise<void>;
-	getAll(): Array<INodeType | INodeVersionedType>;
+	getAll(): Array<INodeType | IVersionedNodeType>;
 	getByNameAndVersion(nodeType: string, version?: number): INodeType | undefined;
 }
 
@@ -1436,7 +1436,7 @@ export interface ICredentialTypeData {
 
 export interface INodeTypeData {
 	[key: string]: {
-		type: INodeType | INodeVersionedType;
+		type: INodeType | IVersionedNodeType;
 		sourcePath: string;
 	};
 }

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -30,7 +30,7 @@ import {
 	INodePropertyModeValidation,
 	INodePropertyRegexValidation,
 	INodeType,
-	INodeVersionedType,
+	IVersionedNodeType,
 	IParameterDependencies,
 	IRunExecutionData,
 	IWebhookData,
@@ -1379,18 +1379,18 @@ export function mergeNodeProperties(
 }
 
 export function getVersionedNodeType(
-	object: INodeVersionedType | INodeType,
+	object: IVersionedNodeType | INodeType,
 	version?: number,
 ): INodeType {
 	if (isNodeTypeVersioned(object)) {
-		return (object as INodeVersionedType).getNodeType(version);
+		return (object as IVersionedNodeType).getNodeType(version);
 	}
 	return object as INodeType;
 }
 
-export function getVersionedNodeTypeAll(object: INodeVersionedType | INodeType): INodeType[] {
+export function getVersionedNodeTypeAll(object: IVersionedNodeType | INodeType): INodeType[] {
 	if (isNodeTypeVersioned(object)) {
-		return Object.values((object as INodeVersionedType).nodeVersions).map((element) => {
+		return Object.values((object as IVersionedNodeType).nodeVersions).map((element) => {
 			element.description.name = object.description.name;
 			return element;
 		});
@@ -1398,6 +1398,6 @@ export function getVersionedNodeTypeAll(object: INodeVersionedType | INodeType):
 	return [object as INodeType];
 }
 
-export function isNodeTypeVersioned(object: INodeVersionedType | INodeType): boolean {
+export function isNodeTypeVersioned(object: IVersionedNodeType | INodeType): boolean {
 	return !!('getNodeType' in object);
 }

--- a/packages/workflow/src/VersionedNodeType.ts
+++ b/packages/workflow/src/VersionedNodeType.ts
@@ -1,12 +1,14 @@
-import { INodeType, INodeTypeBaseDescription, INodeVersionedType } from 'n8n-workflow';
+import type { INodeTypeBaseDescription, IVersionedNodeType, INodeType } from './Interfaces';
 
-export class NodeVersionedType implements INodeVersionedType {
+export class VersionedNodeType implements IVersionedNodeType {
 	currentVersion: number;
-	nodeVersions: INodeVersionedType['nodeVersions'];
+
+	nodeVersions: IVersionedNodeType['nodeVersions'];
+
 	description: INodeTypeBaseDescription;
 
 	constructor(
-		nodeVersions: INodeVersionedType['nodeVersions'],
+		nodeVersions: IVersionedNodeType['nodeVersions'],
 		description: INodeTypeBaseDescription,
 	) {
 		this.nodeVersions = nodeVersions;

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -15,6 +15,7 @@ export * from './WorkflowActivationError';
 export * from './WorkflowDataProxy';
 export * from './WorkflowErrors';
 export * from './WorkflowHooks';
+export * from './VersionedNodeType';
 export { LoggerProxy, NodeHelpers, ObservableObject, TelemetryHelpers };
 export { deepCopy, jsonParse } from './utils';
 export {

--- a/packages/workflow/test/Helpers.ts
+++ b/packages/workflow/test/Helpers.ts
@@ -25,7 +25,7 @@ import {
 	INodeType,
 	INodeTypeData,
 	INodeTypes,
-	INodeVersionedType,
+	IVersionedNodeType,
 	IRunExecutionData,
 	ITaskDataConnections,
 	IWorkflowBase,
@@ -680,7 +680,7 @@ class NodeTypesClass implements INodeTypes {
 		return Object.values(this.nodeTypes).map((data) => NodeHelpers.getVersionedNodeType(data.type));
 	}
 
-	getByName(nodeType: string): INodeType | INodeVersionedType | undefined {
+	getByName(nodeType: string): INodeType | IVersionedNodeType | undefined {
 		return this.getByNameAndVersion(nodeType);
 	}
 


### PR DESCRIPTION
1. `VersionedNodeType` is semantically more correct than `NodeVersionedType`. Extracted from https://github.com/n8n-io/n8n/pull/4161

2. By moving `VersionedNodeType` to the `workflow` package, we remove the only compile-time dependency of `cli` on `nodes-base`, making it possible to build and test `cli` without having to rebuild `nodes-base` first. This is needed to be able to not have to build `nodes-base` in nightly DB tests https://github.com/n8n-io/n8n/pull/4441

