### PR TITLE
feat(editor): setup dark-mode for the code-editor, with automatic switching

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -314,7 +314,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-	body.dark-mode-beta {
+	body.theme-dark-beta {
 		@include theme;
 	}
 }

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -303,6 +303,21 @@
 	--color-json-line: #bfcbd9;
 	--color-json-highlight: #dcdfea;
 
+	--color-code-background: #222020;
+	--color-code-foreground: #f8f8f2;
+	--color-code-caret: #f8f8f0;
+	--color-code-selection: #312b25;
+	--color-code-gutterBackground: #2d2a26;
+	--color-code-gutterForeground: #818080;
+	--color-code-lineHighlight: #312b25;
+	--color-code-tags-comment: #6272a4;
+	--color-code-tags-string: #f1fa8c;
+	--color-code-tags-primitive: #bd93f9;
+	--color-code-tags-keyword: #ff79c6;
+	--color-code-tags-operator: #ff79c6;
+	--color-code-tags-variable: #ea6465;
+	--color-code-tags-definition: #368da5;
+
   // Generated Color Shades from 50 to 950
   // Not yet used in design system
   @each $color in ('neutral', 'success', 'warning', 'danger') {

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -2,7 +2,7 @@
 
 @mixin theme {
 	--color-primary-h: 7;
-	--color-primary-s: 100%;
+	--color-primary-s: 90%;
 	--color-primary-l: 68%;
 	--color-primary: hsl(
 		var(--color-primary-h),
@@ -177,7 +177,7 @@
 
 	--color-text-xlight-h: 0;
 	--color-text-xlight-s: 0%;
-	--color-text-xlight-l: 100%;
+	--color-text-xlight-l: 10%;
 	--color-text-xlight: hsl(
 		var(--color-text-xlight-h),
 		var(--color-text-xlight-s),
@@ -204,7 +204,7 @@
 
 	--color-foreground-xlight-h: 0;
 	--color-foreground-xlight-s: 0%;
-	--color-foreground-xlight-l: 0%;
+	--color-foreground-xlight-l: 10%;
 	--color-foreground-xlight: hsl(
 		var(--color-foreground-xlight-h),
 		var(--color-foreground-xlight-s),
@@ -230,8 +230,8 @@
 	);
 
 	--color-background-light-h: 220;
-	--color-background-light-s: 27%;
-	--color-background-light-l: 0%;
+	--color-background-light-s: 10%;
+	--color-background-light-l: 15%;
 	--color-background-light: hsl(
 		var(--color-background-light-h),
 		var(--color-background-light-s),
@@ -265,9 +265,9 @@
 		var(--color-canvas-dot-l)
 	);
 
-	--color-canvas-background-h: 90;
+	--color-canvas-background-h: 200;
 	--color-canvas-background-s: 10%;
-	--color-canvas-background-l: 0%;
+	--color-canvas-background-l: 10%;
 	--color-canvas-background: hsl(
 		var(--color-canvas-background-h),
 		var(--color-canvas-background-s),
@@ -313,6 +313,8 @@
 	}
 }
 
-body.theme-dark {
-  @include theme;
+@media (prefers-color-scheme: dark) {
+	body.dark-mode-beta {
+		@include theme;
+	}
 }

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -412,6 +412,21 @@
 		var(--color-sticky-default-border-l)
 	);
 
+	--color-code-background: #ffffff;
+	--color-code-foreground: #4d4d4c;
+	--color-code-caret: #aeafad;
+	--color-code-selection: #d6d6d6;
+	--color-code-gutterBackground: #ffffff;
+	--color-code-gutterForeground: #4d4d4c80;
+	--color-code-lineHighlight: #efefef;
+	--color-code-tags-comment: #8e908c;
+	--color-code-tags-string: #718c00;
+	--color-code-tags-primitive: #f5871f;
+	--color-code-tags-keyword: #8959a8;
+	--color-code-tags-operator: #3e999f;
+	--color-code-tags-variable: #c82829;
+	--color-code-tags-definition: #4271ae;
+
 	// Generated Color Shades from 50 to 950
 	// Not yet used in design system
 	@each $color in ('neutral', 'success', 'warning', 'danger') {

--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -18,8 +18,6 @@ import { codeNodeEditorEventBus } from '@/event-bus/code-node-editor-event-bus';
 import { CODE_NODE_TYPE } from '@/constants';
 import { ALL_ITEMS_PLACEHOLDER, EACH_ITEM_PLACEHOLDER } from './constants';
 
-const darkModeBetaEnabled = () => document.body.classList.contains('dark-mode-beta');
-
 export default mixins(linterExtension, completerExtension, workflowHelpers).extend({
 	name: 'code-node-editor',
 	props: {
@@ -40,7 +38,6 @@ export default mixins(linterExtension, completerExtension, workflowHelpers).exte
 		return {
 			editor: null as EditorView | null,
 			linterCompartment: new Compartment(),
-			themeCompartment: new Compartment(),
 		};
 	},
 	watch: {
@@ -155,17 +152,12 @@ export default mixins(linterExtension, completerExtension, workflowHelpers).exte
 			this.$emit('valueChanged', this.placeholder);
 		}
 
-		const { BASE_THEME, DARK_THEME, LIGHT_THEME } = CODE_NODE_EDITOR_THEME;
-		const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-		const themeExtension = darkModeBetaEnabled() && themeMediaQuery.matches ? DARK_THEME : LIGHT_THEME;
-
 		const state = EditorState.create({
 			doc: this.jsCode === '' ? this.placeholder : this.jsCode,
 			extensions: [
 				...baseExtensions,
 				...stateBasedExtensions,
-				BASE_THEME,
-				this.themeCompartment.of(themeExtension),
+				CODE_NODE_EDITOR_THEME,
 				javascript(),
 				this.autocompletionExtension(),
 			],
@@ -174,13 +166,6 @@ export default mixins(linterExtension, completerExtension, workflowHelpers).exte
 		this.editor = new EditorView({
 			parent: this.$refs.codeNodeEditor as HTMLDivElement,
 			state,
-		});
-
-		themeMediaQuery.addEventListener('change', event => {
-			const themeExtension = darkModeBetaEnabled() && event.matches ? DARK_THEME : LIGHT_THEME;
-			this.editor?.dispatch({
-				effects: this.themeCompartment.reconfigure(themeExtension),
-			});
 		});
 	},
 });

--- a/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -2,21 +2,9 @@ import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 
-/**
- * Based on Tomorrow theme by Chris Kempson
- * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/tomorrow.ts
- */
-
 const BASE_STYLING = {
 	fontSize: '0.8em',
 	fontFamily: "Menlo, Consolas, 'DejaVu Sans Mono', monospace !important",
-	background: '#FFFFFF',
-	foreground: '#4D4D4C',
-	caret: '#AEAFAD',
-	selection: '#D6D6D6',
-	gutterBackground: '#FFFFFF',
-	gutterForeground: '#4D4D4C80',
-	lineHighlight: '#EFEFEF',
 	maxHeight: '400px',
 	tooltip: {
 		maxWidth: '300px',
@@ -31,79 +19,158 @@ const BASE_STYLING = {
 	},
 };
 
-const HIGHLIGHT_STYLING = [
-	{
-		tag: tags.comment,
-		color: '#8E908C',
+/**
+ * Based on Tomorrow theme by Chris Kempson
+ * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/tomorrow.ts
+ */
+const LIGHT_THEME = {
+	type: 'light',
+	colors: {
+		background: '#FFFFFF',
+		foreground: '#4D4D4C',
+		caret: '#AEAFAD',
+		selection: '#D6D6D6',
+		gutterBackground: '#FFFFFF',
+		gutterForeground: '#4D4D4C80',
+		lineHighlight: '#EFEFEF',
 	},
-	{
-		tag: [tags.variableName, tags.self, tags.propertyName, tags.attributeName, tags.regexp],
-		color: '#C82829',
+	highlight_styling: [
+		{
+			tag: tags.comment,
+			color: '#8E908C',
+		},
+		{
+			tag: [tags.variableName, tags.self, tags.propertyName, tags.attributeName, tags.regexp],
+			color: '#C82829',
+		},
+		{
+			tag: [tags.number, tags.bool, tags.null],
+			color: '#F5871F',
+		},
+		{
+			tag: [tags.className, tags.typeName, tags.definition(tags.typeName)],
+			color: '#C99E00',
+		},
+		{
+			tag: [tags.string, tags.special(tags.brace)],
+			color: '#718C00',
+		},
+		{
+			tag: tags.operator,
+			color: '#3E999F',
+		},
+		{
+			tag: [tags.definition(tags.propertyName), tags.function(tags.variableName)],
+			color: '#4271AE',
+		},
+		{
+			tag: tags.keyword,
+			color: '#8959A8',
+		},
+		{
+			tag: tags.derefOperator,
+			color: '#4D4D4C',
+		},
+	],
+} as const;
+
+/**
+ * Based on Dracula theme by Zeno Rocha
+ * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/dracula.ts
+ */
+const DARK_THEME = {
+	type: 'dark',
+	colors: {
+		background: '#222020',
+		foreground: '#f8f8f2',
+		caret: '#f8f8f0',
+		selection: '#312b25',
+		gutterBackground: '#2d2a26',
+		gutterForeground: '#818080',
+		lineHighlight: '#312b25',
 	},
-	{
-		tag: [tags.number, tags.bool, tags.null],
-		color: '#F5871F',
+	highlight_styling: [
+		{
+			tag: tags.comment,
+			color: '#6272a4',
+		},
+		{
+			tag: [tags.string, tags.special(tags.brace)],
+			color: '#f1fa8c',
+		},
+		{
+			tag: [tags.number, tags.self, tags.bool, tags.null],
+			color: '#bd93f9',
+		},
+		{
+			tag: [tags.keyword, tags.operator],
+			color: '#ff79c6',
+		},
+		{
+			tag: [tags.definitionKeyword, tags.typeName],
+			color: '#8be9fd',
+		},
+		{
+			tag: tags.definition(tags.typeName),
+			color: '#f8f8f2',
+		},
+		{
+			tag: [
+				tags.className,
+				tags.definition(tags.propertyName),
+				tags.function(tags.variableName),
+				tags.attributeName,
+			],
+			color: '#50fa7b',
+		},
+	],
+} as const;
+
+type ITheme = typeof LIGHT_THEME | typeof DARK_THEME;
+
+const getThemeExtension = (theme: ITheme) => EditorView.theme({
+	'&': {
+		backgroundColor: theme.colors.background,
+		color: theme.colors.foreground,
 	},
-	{
-		tag: [tags.className, tags.typeName, tags.definition(tags.typeName)],
-		color: '#C99E00',
+	'.cm-content': {
+		caretColor: theme.colors.caret,
 	},
-	{
-		tag: [tags.string, tags.special(tags.brace)],
-		color: '#718C00',
+	'.cm-cursor, .cm-dropCursor': {
+		borderLeftColor: theme.colors.caret,
 	},
-	{
-		tag: tags.operator,
-		color: '#3E999F',
+	'&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection': {
+		backgroundColor: theme.colors.selection,
 	},
-	{
-		tag: [tags.definition(tags.propertyName), tags.function(tags.variableName)],
-		color: '#4271AE',
+	'.cm-activeLine': {
+		backgroundColor: theme.colors.lineHighlight,
 	},
-	{
-		tag: tags.keyword,
-		color: '#8959A8',
+	'.cm-gutters': {
+		backgroundColor: theme.colors.gutterBackground,
+		color: theme.colors.gutterForeground,
 	},
-	{
-		tag: tags.derefOperator,
-		color: '#4D4D4C',
+	'.cm-activeLineGutter': {
+		backgroundColor: theme.colors.lineHighlight,
 	},
-];
+}, { dark: theme.type === 'dark' });
+
+const getSyntaxHighlighting = (theme: ITheme) => syntaxHighlighting(HighlightStyle.define(theme.highlight_styling, { themeType: theme.type }));
 
 const cssStyleDeclaration = getComputedStyle(document.documentElement);
 
-export const CODE_NODE_EDITOR_THEME = [
-	EditorView.theme({
+export const CODE_NODE_EDITOR_THEME = {
+	BASE_THEME: EditorView.baseTheme({
 		'&': {
-			backgroundColor: BASE_STYLING.background,
-			color: BASE_STYLING.foreground,
 			'font-size': BASE_STYLING.fontSize,
 			border: cssStyleDeclaration.getPropertyValue('--border-base'),
 			borderRadius: cssStyleDeclaration.getPropertyValue('--border-radius-base'),
 		},
 		'.cm-content': {
 			fontFamily: BASE_STYLING.fontFamily,
-			caretColor: BASE_STYLING.caret,
-		},
-		'.cm-cursor, .cm-dropCursor': {
-			borderLeftColor: BASE_STYLING.caret,
 		},
 		'.cm-tooltip': {
 			maxWidth: BASE_STYLING.tooltip.maxWidth,
 			lineHeight: BASE_STYLING.tooltip.lineHeight,
-		},
-		'&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection': {
-			backgroundColor: BASE_STYLING.selection,
-		},
-		'.cm-activeLine': {
-			backgroundColor: BASE_STYLING.lineHighlight,
-		},
-		'.cm-gutters': {
-			backgroundColor: BASE_STYLING.gutterBackground,
-			color: BASE_STYLING.gutterForeground,
-		},
-		'.cm-activeLineGutter': {
-			backgroundColor: BASE_STYLING.lineHighlight,
 		},
 		'.cm-scroller': {
 			overflow: 'auto',
@@ -118,5 +185,12 @@ export const CODE_NODE_EDITOR_THEME = [
 			cursor: BASE_STYLING.diagnosticButton.cursor,
 		},
 	}),
-	syntaxHighlighting(HighlightStyle.define(HIGHLIGHT_STYLING)),
-];
+	LIGHT_THEME: [
+		getThemeExtension(LIGHT_THEME),
+		getSyntaxHighlighting(LIGHT_THEME),
+	],
+	DARK_THEME: [
+		getThemeExtension(DARK_THEME),
+		getSyntaxHighlighting(DARK_THEME),
+	],
+};

--- a/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -2,6 +2,14 @@ import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 
+/**
+ * Light theme based on Tomorrow theme by Chris Kempson
+ * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/tomorrow.ts
+ *
+ * Dark theme based on Dracula theme by Zeno Rocha
+ * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/dracula.ts
+ */
+
 const BASE_STYLING = {
 	fontSize: '0.8em',
 	fontFamily: "Menlo, Consolas, 'DejaVu Sans Mono', monospace !important",
@@ -19,154 +27,36 @@ const BASE_STYLING = {
 	},
 };
 
-/**
- * Based on Tomorrow theme by Chris Kempson
- * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/tomorrow.ts
- */
-const LIGHT_THEME = {
-	type: 'light',
-	colors: {
-		background: '#FFFFFF',
-		foreground: '#4D4D4C',
-		caret: '#AEAFAD',
-		selection: '#D6D6D6',
-		gutterBackground: '#FFFFFF',
-		gutterForeground: '#4D4D4C80',
-		lineHighlight: '#EFEFEF',
-	},
-	highlight_styling: [
-		{
-			tag: tags.comment,
-			color: '#8E908C',
-		},
-		{
-			tag: [tags.variableName, tags.self, tags.propertyName, tags.attributeName, tags.regexp],
-			color: '#C82829',
-		},
-		{
-			tag: [tags.number, tags.bool, tags.null],
-			color: '#F5871F',
-		},
-		{
-			tag: [tags.className, tags.typeName, tags.definition(tags.typeName)],
-			color: '#C99E00',
-		},
-		{
-			tag: [tags.string, tags.special(tags.brace)],
-			color: '#718C00',
-		},
-		{
-			tag: tags.operator,
-			color: '#3E999F',
-		},
-		{
-			tag: [tags.definition(tags.propertyName), tags.function(tags.variableName)],
-			color: '#4271AE',
-		},
-		{
-			tag: tags.keyword,
-			color: '#8959A8',
-		},
-		{
-			tag: tags.derefOperator,
-			color: '#4D4D4C',
-		},
-	],
-} as const;
-
-/**
- * Based on Dracula theme by Zeno Rocha
- * https://github.com/vadimdemedes/thememirror/blob/main/source/themes/dracula.ts
- */
-const DARK_THEME = {
-	type: 'dark',
-	colors: {
-		background: '#222020',
-		foreground: '#f8f8f2',
-		caret: '#f8f8f0',
-		selection: '#312b25',
-		gutterBackground: '#2d2a26',
-		gutterForeground: '#818080',
-		lineHighlight: '#312b25',
-	},
-	highlight_styling: [
-		{
-			tag: tags.comment,
-			color: '#6272a4',
-		},
-		{
-			tag: [tags.string, tags.special(tags.brace)],
-			color: '#f1fa8c',
-		},
-		{
-			tag: [tags.number, tags.self, tags.bool, tags.null],
-			color: '#bd93f9',
-		},
-		{
-			tag: [tags.keyword, tags.operator],
-			color: '#ff79c6',
-		},
-		{
-			tag: [tags.definitionKeyword, tags.typeName],
-			color: '#8be9fd',
-		},
-		{
-			tag: tags.definition(tags.typeName),
-			color: '#f8f8f2',
-		},
-		{
-			tag: [
-				tags.className,
-				tags.definition(tags.propertyName),
-				tags.function(tags.variableName),
-				tags.attributeName,
-			],
-			color: '#50fa7b',
-		},
-	],
-} as const;
-
-type ITheme = typeof LIGHT_THEME | typeof DARK_THEME;
-
-const getThemeExtension = (theme: ITheme) => EditorView.theme({
-	'&': {
-		backgroundColor: theme.colors.background,
-		color: theme.colors.foreground,
-	},
-	'.cm-content': {
-		caretColor: theme.colors.caret,
-	},
-	'.cm-cursor, .cm-dropCursor': {
-		borderLeftColor: theme.colors.caret,
-	},
-	'&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection': {
-		backgroundColor: theme.colors.selection,
-	},
-	'.cm-activeLine': {
-		backgroundColor: theme.colors.lineHighlight,
-	},
-	'.cm-gutters': {
-		backgroundColor: theme.colors.gutterBackground,
-		color: theme.colors.gutterForeground,
-	},
-	'.cm-activeLineGutter': {
-		backgroundColor: theme.colors.lineHighlight,
-	},
-}, { dark: theme.type === 'dark' });
-
-const getSyntaxHighlighting = (theme: ITheme) => syntaxHighlighting(HighlightStyle.define(theme.highlight_styling, { themeType: theme.type }));
-
 const cssStyleDeclaration = getComputedStyle(document.documentElement);
 
-export const CODE_NODE_EDITOR_THEME = {
-	BASE_THEME: EditorView.baseTheme({
+export const CODE_NODE_EDITOR_THEME = [
+	EditorView.theme({
 		'&': {
 			'font-size': BASE_STYLING.fontSize,
 			border: cssStyleDeclaration.getPropertyValue('--border-base'),
 			borderRadius: cssStyleDeclaration.getPropertyValue('--border-radius-base'),
+			backgroundColor: 'var(--color-code-background)',
+			color: 'var(--color-code-foreground)',
 		},
 		'.cm-content': {
 			fontFamily: BASE_STYLING.fontFamily,
+			caretColor: 'var(--color-code-caret)',
+		},
+		'.cm-cursor, .cm-dropCursor': {
+			borderLeftColor: 'var(--color-code-caret)',
+		},
+		'&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection': {
+			backgroundColor: 'var(--color-code-selection)',
+		},
+		'.cm-activeLine': {
+			backgroundColor: 'var(--color-code-lineHighlight)',
+		},
+		'.cm-activeLineGutter': {
+			backgroundColor: 'var(--color-code-lineHighlight)',
+		},
+		'.cm-gutters': {
+			backgroundColor: 'var(--color-code-gutterBackground)',
+			color: 'var(--color-code-gutterForeground)',
 		},
 		'.cm-tooltip': {
 			maxWidth: BASE_STYLING.tooltip.maxWidth,
@@ -185,12 +75,34 @@ export const CODE_NODE_EDITOR_THEME = {
 			cursor: BASE_STYLING.diagnosticButton.cursor,
 		},
 	}),
-	LIGHT_THEME: [
-		getThemeExtension(LIGHT_THEME),
-		getSyntaxHighlighting(LIGHT_THEME),
-	],
-	DARK_THEME: [
-		getThemeExtension(DARK_THEME),
-		getSyntaxHighlighting(DARK_THEME),
-	],
-};
+	syntaxHighlighting(HighlightStyle.define([
+		{
+			tag: tags.comment,
+			color: 'var(--color-code-tags-comment)',
+		},
+		{
+			tag: [tags.string, tags.special(tags.brace)],
+			color: 'var(--color-code-tags-string)',
+		},
+		{
+			tag: [tags.number, tags.self, tags.bool, tags.null],
+			color: 'var(--color-code-tags-primitive)',
+		},
+		{
+			tag: tags.keyword,
+			color: 'var(--color-code-tags-keyword)',
+		},
+		{
+			tag: tags.operator,
+			color: 'var(--color-code-tags-operator)',
+		},
+		{
+			tag: [tags.variableName, tags.propertyName, tags.attributeName, tags.regexp, tags.className, tags.typeName],
+			color: 'var(--color-code-tags-variable)',
+		},
+		{
+			tag: [tags.definition(tags.typeName), tags.definition(tags.propertyName), tags.function(tags.variableName)],
+			color: 'var(--color-code-tags-definition)',
+		},
+	])),
+];


### PR DESCRIPTION
Bright screens at night hurt my eyes. So, I'd like to start using the dark-mode.

By default this feature is disabled. The feature can be toggled with `document.body.classList.toggle('theme-dark-beta')`