### PR TITLE
fix(API): do not reset the auth cookie on every request to `GET /login`

### DIFF
--- a/packages/cli/src/UserManagement/routes/auth.ts
+++ b/packages/cli/src/UserManagement/routes/auth.ts
@@ -70,11 +70,6 @@ export function authenticationMethods(this: N8nApp): void {
 				// If logged in, return user
 				try {
 					user = await resolveJwt(cookieContents);
-
-					if (!config.get('userManagement.isInstanceOwnerSetUp')) {
-						res.cookie(AUTH_COOKIE_NAME, cookieContents);
-					}
-
 					return sanitizeUser(user);
 				} catch (error) {
 					res.clearCookie(AUTH_COOKIE_NAME);

--- a/packages/cli/test/integration/auth.api.test.ts
+++ b/packages/cli/test/integration/auth.api.test.ts
@@ -103,8 +103,9 @@ test('GET /login should return 401 Unauthorized if no cookie', async () => {
 	expect(authToken).toBeUndefined();
 });
 
-test('GET /login should return cookie if UM is disabled', async () => {
-	const ownerShell = await testDb.createUserShell(globalOwnerRole);
+test('GET /login should return cookie if UM is disabled and no cookie is already set', async () => {
+	const authlessAgent = utils.createAgent(app);
+	await testDb.createUserShell(globalOwnerRole);
 
 	config.set('userManagement.isInstanceOwnerSetUp', false);
 
@@ -113,7 +114,7 @@ test('GET /login should return cookie if UM is disabled', async () => {
 		{ value: JSON.stringify(false) },
 	);
 
-	const response = await authAgent(ownerShell).get('/login');
+	const response = await authlessAgent.get('/login');
 
 	expect(response.statusCode).toBe(200);
 


### PR DESCRIPTION
The cookie and the JWT refresh is already handled in `refreshExpiringCookie` middleware, which only updates the cookie 3 days before the expiration.

The middleware also uses `issueCookie`, which ensures that attributes like `sameSite` and `httpOnly` are correctly set on the cookie.