### PR TITLE
fix: include typescript types for all n8n packages published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 dist/test
-dist/**/*.{js.map,d.ts}
+dist/**/*.{js.map}
 
 .DS_Store
 


### PR DESCRIPTION
fixes #4464