### PR TITLE
fix(core): updating deepCopy to avoid max callstack with circular deps

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-export const deepCopy = <T>(source: T, hash = new WeakMap()): T => {
+export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
 	let clone: any;
 	let i: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
@@ -8,6 +8,7 @@ export const deepCopy = <T>(source: T, hash = new WeakMap()): T => {
 		return source;
 	}
 	if (hash.has(source)) {
+		console.warn(`Circular reference detected at "source${path}"`);
 		return hash.get(source);
 	}
 	// Date
@@ -19,7 +20,7 @@ export const deepCopy = <T>(source: T, hash = new WeakMap()): T => {
 		clone = [];
 		const len = source.length;
 		for (i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i], hash);
+			clone[i] = deepCopy(source[i], hash, path + `[${i as string}]`);
 		}
 		return clone;
 	}
@@ -28,7 +29,7 @@ export const deepCopy = <T>(source: T, hash = new WeakMap()): T => {
 	hash.set(source, clone);
 	for (i in source) {
 		if (hasOwnProp(i)) {
-			clone[i] = deepCopy((source as any)[i], hash);
+			clone[i] = deepCopy((source as any)[i], hash, path + `.${i as string}`);
 		}
 	}
 	return clone;

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-export const deepCopy = <T>(source: T): T => {
+export const deepCopy = <T>(source: T, hash = new WeakMap()): T => {
 	let clone: any;
 	let i: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
-	// Primitives & Null
-	if (typeof source !== 'object' || source === null) {
+	// Primitives & Null & Function
+	if (typeof source !== 'object' || source === null || source instanceof Function) {
 		return source;
+	}
+	if (hash.has(source)) {
+		return hash.get(source);
 	}
 	// Date
 	if (source instanceof Date) {
@@ -16,15 +19,16 @@ export const deepCopy = <T>(source: T): T => {
 		clone = [];
 		const len = source.length;
 		for (i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i]);
+			clone[i] = deepCopy(source[i], hash);
 		}
 		return clone;
 	}
 	// Object
 	clone = {};
+	hash.set(source, clone);
 	for (i in source) {
 		if (hasOwnProp(i)) {
-			clone[i] = deepCopy((source as any)[i]);
+			clone[i] = deepCopy((source as any)[i], hash);
 		}
 	}
 	return clone;

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -48,4 +48,38 @@ describe('deepCopy', () => {
 		expect(copy.deep.props).toEqual(object.deep.props);
 		expect(copy.deep.props).not.toBe(object.deep.props);
 	});
+
+	it('should avoid max call stack in case of circular deps', () => {
+		const object: Record<string, any> = {
+			deep: {
+				props: {
+					list: [{ a: 1 }, { b: 2 }, { c: 3 }],
+				},
+				arr: [1, 2, 3],
+			},
+			arr: [
+				{
+					prop: {
+						list: ['a', 'b', 'c'],
+					},
+				},
+			],
+			func: () => {},
+			date: new Date(),
+			undef: undefined,
+			nil: null,
+			bool: true,
+			num: 1,
+		};
+
+		object.circular = object;
+
+		const copy = deepCopy(object);
+		expect(copy).toEqual(object);
+		expect(copy).not.toBe(object);
+		expect(copy.arr).toEqual(object.arr);
+		expect(copy.arr).not.toBe(object.arr);
+		expect(copy.deep.props).toEqual(object.deep.props);
+		expect(copy.deep.props).not.toBe(object.deep.props);
+	});
 });

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -73,6 +73,8 @@ describe('deepCopy', () => {
 		};
 
 		object.circular = object;
+		object.deep.props.circular = object;
+		object.deep.arr.push(object)
 
 		const copy = deepCopy(object);
 		expect(copy).toEqual(object);


### PR DESCRIPTION
https://community.n8n.io/t/rangeerror-maximum-call-stack-size-exceeded-in-function-node-n8n-v0-199-0/19137