### PR TITLE
refactor: remove console.warn from `deepCopy`

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -8,7 +8,6 @@ export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
 		return source;
 	}
 	if (hash.has(source)) {
-		console.warn(`Circular reference detected at "source${path}"`);
 		return hash.get(source);
 	}
 	// Date


### PR DESCRIPTION
Jan realized that this was logging way too much (as in, we have way too many circular references).

I've changed this to be reported to Sentry, which should hopefully get merged next week.