### PR TITLE
fix(core): fix workflow hasing for MySQL

### DIFF
--- a/packages/cli/src/databases/entities/WorkflowEntity.ts
+++ b/packages/cli/src/databases/entities/WorkflowEntity.ts
@@ -29,6 +29,7 @@ import { SharedWorkflow } from './SharedWorkflow';
 import { objectRetriever, sqlite } from '../utils/transformers';
 import { AbstractEntity, jsonColumnType } from './AbstractEntity';
 import type { IWorkflowDb } from '../../Interfaces';
+import { alphabetizeKeys } from '../../utils';
 
 @Entity()
 export class WorkflowEntity extends AbstractEntity implements IWorkflowDb {
@@ -103,7 +104,7 @@ export class WorkflowEntity extends AbstractEntity implements IWorkflowDb {
 		const state = JSON.stringify({
 			name,
 			active,
-			nodes,
+			nodes: nodes ? nodes.map(alphabetizeKeys) : [],
 			connections,
 			settings,
 			staticData,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -30,7 +30,7 @@ export const findSubworkflowStart = findWorkflowStart('integrated');
 
 export const findCliWorkflowStart = findWorkflowStart('cli');
 
-export const alphabetizeKeys = (obj: INode) => {
+export const alphabetizeKeys = (obj: INode) =>
 	Object.keys(obj)
 		.sort()
 		.reduce<Partial<INode>>(
@@ -41,4 +41,3 @@ export const alphabetizeKeys = (obj: INode) => {
 			}),
 			{},
 		);
-};

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { CliWorkflowOperationError, SubworkflowOperationError } from 'n8n-workflow';
 import type { INode } from 'n8n-workflow';
 
@@ -28,3 +29,16 @@ function findWorkflowStart(executionMode: 'integrated' | 'cli') {
 export const findSubworkflowStart = findWorkflowStart('integrated');
 
 export const findCliWorkflowStart = findWorkflowStart('cli');
+
+export const alphabetizeKeys = (obj: INode) => {
+	Object.keys(obj)
+		.sort()
+		.reduce<Partial<INode>>(
+			(acc, key) => ({
+				...acc,
+				// @ts-expect-error @TECH_DEBT Adding index signature to INode causes type issues downstream
+				[key]: obj[key],
+			}),
+			{},
+		);
+};


### PR DESCRIPTION
MySQL does not respect original order of keys. Enforcing order for all DBs for consistency.

Tested with three DBs + PG alt schema.