### PR TITLE
fix(editor): fix node creator search when there's active subcategory

### DIFF
--- a/packages/editor-ui/src/components/Node/NodeCreator/CategorizedItems.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/CategorizedItems.vue
@@ -78,7 +78,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import camelcase from 'lodash.camelcase';
-import { intersection } from 'lodash';
+import { intersection } from '@/utils';
 import { INodeTypeDescription } from 'n8n-workflow';
 
 import { externalHooks } from '@/components/mixins/externalHooks';

--- a/packages/editor-ui/src/components/Node/NodeCreator/CategorizedItems.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/CategorizedItems.vue
@@ -78,8 +78,6 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import camelcase from 'lodash.camelcase';
-import { intersection } from '@/utils';
-import { INodeTypeDescription } from 'n8n-workflow';
 
 import { externalHooks } from '@/components/mixins/externalHooks';
 import { globalLinkActions } from '@/components/mixins/globalLinkActions';
@@ -88,10 +86,11 @@ import mixins from 'vue-typed-mixins';
 import ItemIterator from './ItemIterator.vue';
 import NoResults from './NoResults.vue';
 import SearchBar from './SearchBar.vue';
-import { INodeCreateElement, INodeItemProps, ISubcategoryItemProps, ICategoriesWithNodes, ICategoryItemProps, INodeFilterType, INodeUi } from '@/Interface';
+import { INodeCreateElement, INodeItemProps, ISubcategoryItemProps, ICategoriesWithNodes, ICategoryItemProps, INodeFilterType } from '@/Interface';
 import { WEBHOOK_NODE_TYPE, HTTP_REQUEST_NODE_TYPE, ALL_NODE_FILTER, TRIGGER_NODE_FILTER, REGULAR_NODE_FILTER, NODE_TYPE_COUNT_MAPPER } from '@/constants';
 import { matchesNodeType, matchesSelectType } from './helpers';
 import { BaseTextKey } from '@/plugins/i18n';
+import { intersection } from '@/utils';
 import { sublimeSearch } from './sortUtils';
 
 export default mixins(externalHooks, globalLinkActions).extend({

--- a/packages/editor-ui/src/components/Node/NodeCreator/TriggerHelperPanel.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/TriggerHelperPanel.vue
@@ -8,7 +8,7 @@
 			:initialActiveIndex="0"
 			:searchItems="searchItems"
 			:firstLevelItems="isRoot ? items : []"
-			:excludedCategories="[CORE_NODES_CATEGORY]"
+			:excludedCategories="isRoot ? [] : [CORE_NODES_CATEGORY]"
 			:initialActiveCategories="[COMMUNICATION_CATEGORY]"
 		>
 			<template #header>
@@ -53,7 +53,7 @@ export default mixins(externalHooks).extend({
 	computed: {
 		items() {
 			return [{
-					key: "core_nodes",
+					key: "*",
 					type: "subcategory",
 					title: this.$locale.baseText('nodeCreator.subcategoryNames.appTriggerNodes'),
 					properties: {

--- a/packages/editor-ui/src/utils.ts
+++ b/packages/editor-ui/src/utils.ts
@@ -56,3 +56,5 @@ export const isEmpty = (value?: unknown): boolean => {
 	}
 	return false;
 };
+
+export const intersection = <T>(a: T[], b:T[]): T[] => a.filter(Set.prototype.has, new Set(b));


### PR DESCRIPTION
When searching inside the subcategory we can't simply use `subcategorizedNodes` because these nodes only contain expanded category nodes. This leads search not correctly working for items which are "hidden" by their category.