### PR TITLE
fix(editor): fix an issue with not being able to save some of the forms

### DIFF
--- a/packages/design-system/src/components/N8nFormInput/FormInput.vue
+++ b/packages/design-system/src/components/N8nFormInput/FormInput.vue
@@ -196,6 +196,8 @@ const showErrors = computed(() => (
 ));
 
 onMounted(() => {
+	emit('validate', !validationError.value);
+
 	if (props.focusInitially && inputRef.value) inputRef.value.focus();
 });
 


### PR DESCRIPTION
During the [composition-api refactoring, ](https://github.com/n8n-io/n8n/commit/8a4b9722c57ba98101e7bb09a5367467472efdbf)I forgot to add `validate` emit on FormInput mount. This leads to FormInputs component not setting `isReadyToSubmit` correctly, which prevents the submission of some forms.