### PR TITLE
perf(editor): improve array intersection utility function

### DIFF
--- a/packages/editor-ui/src/utils.test.ts
+++ b/packages/editor-ui/src/utils.test.ts
@@ -1,0 +1,41 @@
+import { isEmpty, intersection } from "@/utils";
+
+describe("Utils", () => {
+	describe("isEmpty", () => {
+		it.each([
+			[undefined, true],
+			[null, true],
+			[{}, true],
+			[{ a: {}}, true],
+			[{ a: { b: []}}, true],
+			[{ a: { b: [1]}}, false],
+			[[], true],
+			[[{}, {}, {}], true],
+			[[{}, null, false], true],
+			[[{}, null, false, 1], false],
+			[[[], [], []], true],
+			["", true],
+			["0", false],
+			[0, false],
+			[1, false],
+			[false, true],
+			[true, false],
+		])(`for value %s should return %s`, (value, expected) => {
+			expect(isEmpty(value)).toBe(expected);
+		});
+	});
+
+	describe("intersection", () => {
+		it("should return the intersection of two arrays", () => {
+			expect(intersection([1, 2, 3], [2, 3, 4])).toEqual([2, 3]);
+		});
+
+		it("should return the intersection of two arrays without duplicates", () => {
+			expect(intersection([1, 2, 2, 3], [2, 2, 3, 4])).toEqual([2, 3]);
+		});
+
+		it("should return the intersection of four arrays without duplicates", () => {
+			expect(intersection([1, 2, 2, 3, 4], [2, 3, 3, 4], [2, 1, 5, 4, 4, 1], [2, 4, 5, 5, 6, 7])).toEqual([2, 4]);
+		});
+	});
+});

--- a/packages/editor-ui/src/utils.ts
+++ b/packages/editor-ui/src/utils.ts
@@ -57,4 +57,8 @@ export const isEmpty = (value?: unknown): boolean => {
 	return false;
 };
 
-export const intersection = <T>(a: T[], b:T[]): T[] => a.filter(Set.prototype.has, new Set(b));
+export const intersection = <T>(...arrays: T[][]): T[] => {
+	const [a, b, ...rest] = arrays;
+	const ab = a.filter(v => b.includes(v));
+	return [...new Set(rest.length ? intersection(ab, ...rest) : ab)];
+};


### PR DESCRIPTION
Tested with 3 versions of custom functions + lodash + Ramda
See the test results in the screenshot, it is worth having the one that can accept any number of arrays, it's just slightly slower than the other that can take only 2 args

![image](https://user-images.githubusercontent.com/5410822/199350946-a59fdecf-caf3-4992-973f-123ac18931f9.png)
