### PR TITLE
fix(core): make `deepCopy` backward compatible

### DIFF
--- a/packages/nodes-base/nodes/Code/utils.ts
+++ b/packages/nodes-base/nodes/Code/utils.ts
@@ -21,7 +21,7 @@ export function isObject(maybe: unknown): maybe is { [key: string]: unknown } {
 }
 
 function isTraversable(maybe: unknown): maybe is IDataObject {
-	return isObject(maybe) && Object.keys(maybe).length > 0;
+	return isObject(maybe) && typeof maybe.toJSON !== 'function' && Object.keys(maybe).length > 0;
 }
 
 export type CodeNodeMode = 'runOnceForAllItems' | 'runOnceForEachItem';

--- a/packages/workflow/src/NodeErrors.ts
+++ b/packages/workflow/src/NodeErrors.ts
@@ -176,8 +176,12 @@ abstract class NodeError extends ExecutionBaseError {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	protected isTraversableObject(value: any): value is JsonObject {
 		return (
+			value &&
+			typeof value === 'object' &&
+			!Array.isArray(value) &&
+			typeof value.toJSON !== 'function' &&
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			value && typeof value === 'object' && !Array.isArray(value) && !!Object.keys(value).length
+			!!Object.keys(value).length
 		);
 	}
 

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -9,6 +9,13 @@ export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
 	if (typeof source !== 'object' || source === null || source instanceof Function) {
 		return source;
 	}
+	// Date and other Serializable objects
+	const toJSON = (source as Serializable).toJSON;
+	if (typeof toJSON === 'function') {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		return toJSON.call(source) as T;
+	}
+	// Break any cyclic dependencies
 	if (hash.has(source)) {
 		return hash.get(source);
 	}
@@ -21,13 +28,6 @@ export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
 		}
 		return clone;
 	}
-	// Date and other Serializable objects
-	const toJSON = (source as Serializable).toJSON;
-	if (typeof toJSON === 'function') {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-		return toJSON.call(source) as T;
-	}
-
 	// Object
 	clone = {};
 	hash.set(source, clone);

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -12,16 +12,13 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 	if (typeof source !== 'object' || source === null || typeof source === 'function') {
 		return source;
 	}
-	// TODO: remove this when other code parts not expecting objects with `.toJSON` method called
+	// Date and other objects with toJSON method
+	// TODO: remove this when other code parts not expecting objects with `.toJSON` method called and add back checking for Date and cloning it properly
 	if (typeof source.toJSON === 'function') {
 		return source.toJSON() as T;
 	}
 	if (hash.has(source)) {
 		return hash.get(source);
-	}
-	// Date
-	if (source instanceof Date) {
-		return new Date(source.getTime()) as T;
 	}
 	// Array
 	if (Array.isArray(source)) {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -28,7 +28,7 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 		return clone as T;
 	}
 	// Object
-	const clone = Object.create(Object.getPrototypeOf(source));
+	const clone = Object.create(Object.getPrototypeOf({}));
 	hash.set(source, clone);
 	for (const i in source) {
 		if (hasOwnProp(i)) {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,37 +1,41 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
-
-type Serializable = { toJSON?: () => string };
-
-export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+type Primitives = string | number | boolean | bigint | symbol | null | undefined;
+export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string }) | Primitives>(
+	source: T,
+	hash = new WeakMap(),
+	path = '',
+): T => {
 	let clone: any;
+	let i: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
 	// Primitives & Null & Function
-	if (typeof source !== 'object' || source === null || source instanceof Function) {
+	if (typeof source !== 'object' || source === null || typeof source === 'function') {
 		return source;
 	}
-	// Date and other Serializable objects
-	const toJSON = (source as Serializable).toJSON;
-	if (typeof toJSON === 'function') {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-		return toJSON.call(source) as T;
+	// TODO: remove this when other code parts not expecting objects with `.toJSON` method called
+	if (typeof source.toJSON === 'function') {
+		return source.toJSON() as T;
 	}
-	// Break any cyclic dependencies
 	if (hash.has(source)) {
 		return hash.get(source);
+	}
+	// Date
+	if (source instanceof Date) {
+		return new Date(source.getTime()) as T;
 	}
 	// Array
 	if (Array.isArray(source)) {
 		clone = [];
 		const len = source.length;
-		for (let i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i], hash, path + `[${i}]`);
+		for (i = 0; i < len; i++) {
+			clone[i] = deepCopy(source[i], hash, path + `[${i as string}]`);
 		}
 		return clone;
 	}
 	// Object
 	clone = {};
 	hash.set(source, clone);
-	for (const i in source) {
+	for (i in source) {
 		if (hasOwnProp(i)) {
 			clone[i] = deepCopy((source as any)[i], hash, path + `.${i as string}`);
 		}

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,12 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 
-type Serializable = any & { toJSON?: (key?: any) => string };
+type Serializable = { toJSON?: () => string };
 
-export const deepCopy = <T extends any | Serializable>(
-	source: T,
-	hash = new WeakMap(),
-	path = '',
-): T => {
+export const deepCopy = <T>(source: T, hash = new WeakMap(), path = ''): T => {
 	let clone: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
 	// Primitives & Null & Function

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-type Primitives = string | number | boolean | bigint | symbol;
+type Primitives = string | number | boolean | bigint | symbol | null | undefined;
 export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string }) | Primitives>(
 	source: T,
 	hash = new WeakMap(),
@@ -28,7 +28,7 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 		return clone as T;
 	}
 	// Object
-	const clone = {} as T;
+	const clone = Object.create(Object.getPrototypeOf(source));
 	hash.set(source, clone);
 	for (const i in source) {
 		if (hasOwnProp(i)) {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-type Primitives = string | number | boolean | bigint | symbol | null | undefined;
-export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string }) | Primitives>(
+type Primitives = string | number | boolean | bigint | symbol;
+type WithToJSON = (object | Date) & { toJSON?: () => string };
+export const deepCopy = <T extends WithToJSON | Primitives>(
 	source: T,
 	hash = new WeakMap(),
 	path = '',
 ): T => {
 	let clone: any;
-	let i: any;
+	let i: string | number;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
 	// Primitives & Null & Function
 	if (typeof source !== 'object' || source === null || typeof source === 'function') {
@@ -28,7 +29,7 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 		clone = [];
 		const len = source.length;
 		for (i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i], hash, path + `[${i as string}]`);
+			clone[i] = deepCopy(source[i], hash, path + `[${i}]`);
 		}
 		return clone;
 	}
@@ -37,7 +38,7 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 	hash.set(source, clone);
 	for (i in source) {
 		if (hasOwnProp(i)) {
-			clone[i] = deepCopy((source as any)[i], hash, path + `.${i as string}`);
+			clone[i] = deepCopy((source as any)[i], hash, path + `.${i}`);
 		}
 	}
 	return clone;

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-type Primitives = string | number | boolean | bigint | symbol;
-type WithToJSON = (object | Date) & { toJSON?: () => string };
-export const deepCopy = <T extends WithToJSON | Primitives>(
+type Primitives = string | number | boolean | bigint | symbol | null | undefined;
+export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string }) | Primitives>(
 	source: T,
 	hash = new WeakMap(),
 	path = '',
 ): T => {
 	let clone: any;
-	let i: string | number;
+	let i: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
 	// Primitives & Null & Function
 	if (typeof source !== 'object' || source === null || typeof source === 'function') {
@@ -29,7 +28,7 @@ export const deepCopy = <T extends WithToJSON | Primitives>(
 		clone = [];
 		const len = source.length;
 		for (i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i], hash, path + `[${i}]`);
+			clone[i] = deepCopy(source[i], hash, path + `[${i as string}]`);
 		}
 		return clone;
 	}
@@ -38,7 +37,7 @@ export const deepCopy = <T extends WithToJSON | Primitives>(
 	hash.set(source, clone);
 	for (i in source) {
 		if (hasOwnProp(i)) {
-			clone[i] = deepCopy((source as any)[i], hash, path + `.${i}`);
+			clone[i] = deepCopy((source as any)[i], hash, path + `.${i as string}`);
 		}
 	}
 	return clone;

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,12 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
-type Primitives = string | number | boolean | bigint | symbol | null | undefined;
+type Primitives = string | number | boolean | bigint | symbol;
 export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string }) | Primitives>(
 	source: T,
 	hash = new WeakMap(),
 	path = '',
 ): T => {
-	let clone: any;
-	let i: any;
 	const hasOwnProp = Object.prototype.hasOwnProperty.bind(source);
 	// Primitives & Null & Function
 	if (typeof source !== 'object' || source === null || typeof source === 'function') {
@@ -22,19 +20,19 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 	}
 	// Array
 	if (Array.isArray(source)) {
-		clone = [];
+		const clone = [];
 		const len = source.length;
-		for (i = 0; i < len; i++) {
-			clone[i] = deepCopy(source[i], hash, path + `[${i as string}]`);
+		for (let i = 0; i < len; i++) {
+			clone[i] = deepCopy(source[i], hash, path + `[${i}]`);
 		}
-		return clone;
+		return clone as T;
 	}
 	// Object
-	clone = {};
+	const clone = {} as T;
 	hash.set(source, clone);
-	for (i in source) {
+	for (const i in source) {
 		if (hasOwnProp(i)) {
-			clone[i] = deepCopy((source as any)[i], hash, path + `.${i as string}`);
+			clone[i] = deepCopy((source as any)[i], hash, path + `.${i}`);
 		}
 	}
 	return clone;

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -19,6 +19,11 @@ describe('jsonParse', () => {
 
 describe('deepCopy', () => {
 	it('should deep copy an object', () => {
+		const serializable = {
+			x: 1,
+			y: 2,
+			toJSON: () => 'x:1,y:2',
+		};
 		const object = {
 			deep: {
 				props: {
@@ -26,6 +31,7 @@ describe('deepCopy', () => {
 				},
 				arr: [1, 2, 3],
 			},
+			serializable,
 			arr: [
 				{
 					prop: {
@@ -34,17 +40,18 @@ describe('deepCopy', () => {
 				},
 			],
 			func: () => {},
-			date: new Date(),
+			date: new Date(1667389172201),
 			undef: undefined,
 			nil: null,
 			bool: true,
 			num: 1,
 		};
 		const copy = deepCopy(object);
-		expect(copy).toEqual(object);
 		expect(copy).not.toBe(object);
 		expect(copy.arr).toEqual(object.arr);
 		expect(copy.arr).not.toBe(object.arr);
+		expect(copy.date).toBe('2022-11-02T11:39:32.201Z');
+		expect(copy.serializable).toBe(serializable.toJSON());
 		expect(copy.deep.props).toEqual(object.deep.props);
 		expect(copy.deep.props).not.toBe(object.deep.props);
 	});
@@ -65,7 +72,7 @@ describe('deepCopy', () => {
 				},
 			],
 			func: () => {},
-			date: new Date(),
+			date: new Date(1667389172201),
 			undef: undefined,
 			nil: null,
 			bool: true,
@@ -74,14 +81,16 @@ describe('deepCopy', () => {
 
 		object.circular = object;
 		object.deep.props.circular = object;
-		object.deep.arr.push(object)
+		object.deep.arr.push(object);
 
 		const copy = deepCopy(object);
-		expect(copy).toEqual(object);
 		expect(copy).not.toBe(object);
 		expect(copy.arr).toEqual(object.arr);
 		expect(copy.arr).not.toBe(object.arr);
-		expect(copy.deep.props).toEqual(object.deep.props);
-		expect(copy.deep.props).not.toBe(object.deep.props);
+		expect(copy.date).toBe('2022-11-02T11:39:32.201Z');
+		expect(copy.deep.props.circular).toBe(copy);
+		expect(copy.deep.props.circular).not.toBe(object);
+		expect(copy.deep.arr.slice(-1)[0]).toBe(copy);
+		expect(copy.deep.arr.slice(-1)[0]).not.toBe(object);
 	});
 });


### PR DESCRIPTION
`JSON.parse(JSON.stringify())`  uses `.toJSON` when available. so should `deepCopy`