### PR TITLE
fix: Database config should resolve entities and migrations folder relative to it's path (no-changelog)

### DIFF
--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -12,11 +12,11 @@ import type { DatabaseType } from '../Interfaces';
 import config from '../../config';
 import { getConfigValue } from '../GenericHelpers';
 
-const entitiesDir = path.resolve('src', 'databases', 'entities');
+const entitiesDir = path.resolve(__dirname, 'entities');
 
 const getDBConnectionOptions = (dbType: DatabaseType) => {
 	const entityPrefix = config.getEnv('database.tablePrefix');
-	const migrationsDir = path.resolve('src', 'databases', 'migrations', dbType);
+	const migrationsDir = path.resolve(__dirname, 'migrations', dbType);
 	const configDBType = dbType === 'mariadb' ? 'mysqldb' : dbType;
 	const connectionDetails =
 		configDBType === 'sqlite'


### PR DESCRIPTION
missed this in https://github.com/n8n-io/n8n/pull/4522.
it's not causing any issues in test and build because the `src` folder is still there. but it breaks the migrations inside a docker image.