### PR TITLE
fix(editor): Fix workflow back button navigation 

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -34,7 +34,6 @@ import { HIRING_BANNER, LOCAL_STORAGE_THEME, VIEWS } from './constants';
 
 import mixins from 'vue-typed-mixins';
 import { showMessage } from './components/mixins/showMessage';
-import { IUser } from './Interface';
 import { userHelpers } from './components/mixins/userHelpers';
 import { loadLanguage } from './plugins/i18n';
 import { restApi } from '@/components/mixins/restApi';

--- a/packages/editor-ui/src/components/SettingsSidebar.vue
+++ b/packages/editor-ui/src/components/SettingsSidebar.vue
@@ -22,7 +22,6 @@
 
 <script lang="ts">
 import mixins from 'vue-typed-mixins';
-import { mapGetters } from 'vuex';
 import { ABOUT_MODAL_KEY, VERSIONS_MODAL_KEY, VIEWS } from '@/constants';
 import { userHelpers } from './mixins/userHelpers';
 import { pushConnection } from "@/components/mixins/pushConnection";
@@ -122,11 +121,6 @@ export default mixins(
 		},
 		onVersionClick() {
 			this.uiStore.openModal(ABOUT_MODAL_KEY);
-		},
-		onReturn() {
-			// const history = this.$router.options.routes;
-			console.log("🚀 ~ file: SettingsSidebar.vue ~ line 128 ~ onReturn ~ history", this.previousRoute);
-			// this.$router.back();
 		},
 		openUpdatesPanel() {
 			this.uiStore.openModal(VERSIONS_MODAL_KEY);

--- a/packages/editor-ui/src/components/SettingsSidebar.vue
+++ b/packages/editor-ui/src/components/SettingsSidebar.vue
@@ -2,7 +2,7 @@
 	<div :class="$style.container">
 		<n8n-menu :items="sidebarMenuItems" @select="handleSelect">
 			<template #header>
-				<div :class="$style.returnButton" @click="onReturn">
+				<div :class="$style.returnButton" @click="$emit('return')">
 					<i class="mr-xs">
 						<font-awesome-icon icon="arrow-left" />
 					</i>
@@ -124,7 +124,9 @@ export default mixins(
 			this.uiStore.openModal(ABOUT_MODAL_KEY);
 		},
 		onReturn() {
-			this.$router.push({name: VIEWS.HOMEPAGE});
+			// const history = this.$router.options.routes;
+			console.log("🚀 ~ file: SettingsSidebar.vue ~ line 128 ~ onReturn ~ history", this.previousRoute);
+			// this.$router.back();
 		},
 		openUpdatesPanel() {
 			this.uiStore.openModal(VERSIONS_MODAL_KEY);

--- a/packages/editor-ui/src/components/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/components/mixins/workflowHelpers.ts
@@ -831,7 +831,7 @@ export const workflowHelpers = mixins(
 					}
 
 					if (redirect) {
-						this.$router.push({
+						this.$router.replace({
 							name: VIEWS.WORKFLOW,
 							params: { name: workflowData.id as string, action: 'workflowSave' },
 						});

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -426,6 +426,7 @@ const router = new Router({
 		{
 			path: '/settings',
 			component: SettingsView,
+			props: true,
 			children: [
 				{
 					path: 'personal',
@@ -534,10 +535,9 @@ const router = new Router({
 				{
 					path: 'coming-soon/:featureId',
 					name: VIEWS.FAKE_DOOR,
-					component: {
+					components: {
 						settingsView: SettingsFakeDoorView,
 					},
-					props: true,
 					meta: {
 						telemetry: {
 							pageCategory: 'settings',

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -9,6 +9,7 @@ import NodeView from '@/views/NodeView.vue';
 import ExecutionsView from '@/components/ExecutionsView/ExecutionsView.vue';
 import ExecutionsLandingPage from '@/components/ExecutionsView/ExecutionsLandingPage.vue';
 import ExecutionPreview from '@/components/ExecutionsView/ExecutionPreview.vue';
+import SettingsView from './views/SettingsView.vue';
 import SettingsPersonalView from './views/SettingsPersonalView.vue';
 import SettingsUsersView from './views/SettingsUsersView.vue';
 import SettingsCommunityNodesView from './views/SettingsCommunityNodesView.vue';
@@ -424,132 +425,136 @@ const router = new Router({
 		},
 		{
 			path: '/settings',
-			redirect: '/settings/personal',
-		},
-		{
-			path: '/settings/users',
-			name: VIEWS.USERS_SETTINGS,
-			components: {
-				default: SettingsUsersView,
-			},
-			meta: {
-				telemetry: {
-					pageCategory: 'settings',
-					getProperties(route: Route) {
-						return {
-							feature: 'users',
-						};
+			component: SettingsView,
+			children: [
+				{
+					path: 'personal',
+					name: VIEWS.PERSONAL_SETTINGS,
+					components: {
+						settingsView: SettingsPersonalView,
 					},
-				},
-				permissions: {
-					allow: {
-						role: [ROLE.Default, ROLE.Owner],
-					},
-					deny: {
-						shouldDeny: () => {
-							const settingsStore = useSettingsStore();
-							return settingsStore.isUserManagementEnabled === false;
+					meta: {
+						telemetry: {
+							pageCategory: 'settings',
+							getProperties(route: Route) {
+								return {
+									feature: 'personal',
+								};
+							},
+						},
+						permissions: {
+							allow: {
+								loginStatus: [LOGIN_STATUS.LoggedIn],
+							},
+							deny: {
+								role: [ROLE.Default],
+							},
 						},
 					},
 				},
-			},
-		},
-		{
-			path: '/settings/personal',
-			name: VIEWS.PERSONAL_SETTINGS,
-			components: {
-				default: SettingsPersonalView,
-			},
-			meta: {
-				telemetry: {
-					pageCategory: 'settings',
-					getProperties(route: Route) {
-						return {
-							feature: 'personal',
-						};
+				{
+					path: 'users',
+					name: VIEWS.USERS_SETTINGS,
+					components: {
+						settingsView: SettingsUsersView,
 					},
-				},
-				permissions: {
-					allow: {
-						loginStatus: [LOGIN_STATUS.LoggedIn],
-					},
-					deny: {
-						role: [ROLE.Default],
-					},
-				},
-			},
-		},
-		{
-			path: '/settings/api',
-			name: VIEWS.API_SETTINGS,
-			components: {
-				default: SettingsApiView,
-			},
-			meta: {
-				telemetry: {
-					pageCategory: 'settings',
-					getProperties(route: Route) {
-						return {
-							feature: 'api',
-						};
-					},
-				},
-				permissions: {
-					allow: {
-						loginStatus: [LOGIN_STATUS.LoggedIn],
-					},
-					deny: {
-						shouldDeny: () => {
-							const settingsStore =  useSettingsStore();
-							return settingsStore.isPublicApiEnabled === false;
+					meta: {
+						telemetry: {
+							pageCategory: 'settings',
+							getProperties(route: Route) {
+								return {
+									feature: 'users',
+								};
+							},
+						},
+						permissions: {
+							allow: {
+								role: [ROLE.Default, ROLE.Owner],
+							},
+							deny: {
+								shouldDeny: () => {
+									const settingsStore = useSettingsStore();
+									return settingsStore.isUserManagementEnabled === false;
+								},
+							},
 						},
 					},
 				},
-			},
-		},
-		{
-			path: '/settings/community-nodes',
-			name: VIEWS.COMMUNITY_NODES,
-			components: {
-				default: SettingsCommunityNodesView,
-			},
-			meta: {
-				telemetry: {
-					pageCategory: 'settings',
-				},
-				permissions: {
-					allow: {
-						role: [ROLE.Default, ROLE.Owner],
+				{
+					path: 'api',
+					name: VIEWS.API_SETTINGS,
+					components: {
+						settingsView: SettingsApiView,
 					},
-					deny: {
-						shouldDeny: () => {
-							const settingsStore = useSettingsStore();
-							return settingsStore.isCommunityNodesFeatureEnabled === false;
+					meta: {
+						telemetry: {
+							pageCategory: 'settings',
+							getProperties(route: Route) {
+								return {
+									feature: 'api',
+								};
+							},
+						},
+						permissions: {
+							allow: {
+								loginStatus: [LOGIN_STATUS.LoggedIn],
+							},
+							deny: {
+								shouldDeny: () => {
+									const settingsStore =  useSettingsStore();
+									return settingsStore.isPublicApiEnabled === false;
+								},
+							},
 						},
 					},
 				},
-			},
-		},
-		{
-			path: '/settings/coming-soon/:featureId',
-			name: VIEWS.FAKE_DOOR,
-			component: SettingsFakeDoorView,
-			props: true,
-			meta: {
-				telemetry: {
-					pageCategory: 'settings',
-					getProperties(route: Route) {
-						return {
-							feature: route.params['featureId'],
-						};
+				{
+					path: 'community-nodes',
+					name: VIEWS.COMMUNITY_NODES,
+					components: {
+						settingsView: SettingsCommunityNodesView,
+					},
+					meta: {
+						telemetry: {
+							pageCategory: 'settings',
+						},
+						permissions: {
+							allow: {
+								role: [ROLE.Default, ROLE.Owner],
+							},
+							deny: {
+								shouldDeny: () => {
+									const settingsStore = useSettingsStore();
+									return settingsStore.isCommunityNodesFeatureEnabled === false;
+								},
+							},
+						},
 					},
 				},
-				permissions: {
-					allow: {
-						loginStatus: [LOGIN_STATUS.LoggedIn],
+				{
+					path: 'coming-soon/:featureId',
+					name: VIEWS.FAKE_DOOR,
+					component: {
+						settingsView: SettingsFakeDoorView,
+					},
+					props: true,
+					meta: {
+						telemetry: {
+							pageCategory: 'settings',
+							getProperties(route: Route) {
+								return {
+									feature: route.params['featureId'],
+								};
+							},
+						},
+						permissions: {
+							allow: {
+								loginStatus: [LOGIN_STATUS.LoggedIn],
+							},
+						},
 					},
 				},
-			},
+			],
 		},
 		{
 			path: '*',

--- a/packages/editor-ui/src/stores/canvas.ts
+++ b/packages/editor-ui/src/stores/canvas.ts
@@ -17,6 +17,7 @@ export const useCanvasStore = defineStore('canvas', () => {
 	const nodeTypesStore = useNodeTypesStore();
 	const uiStore = useUIStore();
 	const jsPlumbInstance = jsPlumb.getInstance();
+	console.log("🚀 ~ file: canvas.ts ~ line 20 ~ useCanvasStore ~ jsPlumbInstance", jsPlumbInstance);
 
 	const nodes = computed<INodeUi[]>(() => workflowStore.allNodes);
 	const triggerNodes = computed<INodeUi[]>(

--- a/packages/editor-ui/src/stores/canvas.ts
+++ b/packages/editor-ui/src/stores/canvas.ts
@@ -17,7 +17,6 @@ export const useCanvasStore = defineStore('canvas', () => {
 	const nodeTypesStore = useNodeTypesStore();
 	const uiStore = useUIStore();
 	const jsPlumbInstance = jsPlumb.getInstance();
-	console.log("🚀 ~ file: canvas.ts ~ line 20 ~ useCanvasStore ~ jsPlumbInstance", jsPlumbInstance);
 
 	const nodes = computed<INodeUi[]>(() => workflowStore.allNodes);
 	const triggerNodes = computed<INodeUi[]>(

--- a/packages/editor-ui/src/views/SettingsApiView.vue
+++ b/packages/editor-ui/src/views/SettingsApiView.vue
@@ -1,69 +1,67 @@
 <template>
-	<SettingsView>
-		<div :class="$style.container">
-			<div :class="$style.header">
-				<n8n-heading size="2xlarge">
-					{{ $locale.baseText('settings.api') }}
-					<span :style="{ fontSize: 'var(--font-size-s)', color: 'var(--color-text-light)', }">
-						({{ $locale.baseText('beta') }})
-					</span>
-				</n8n-heading>
-			</div>
-
-			<div v-if="apiKey">
-				<p class="mb-s">
-					<n8n-info-tip :bold="false">
-						<i18n path="settings.api.view.info" tag="span">
-							<template #apiAction>
-								<a
-									href="https://docs.n8n.io/api"
-									target="_blank"
-									v-text="$locale.baseText('settings.api.view.info.api')"
-								/>
-							</template>
-							<template #webhookAction>
-								<a
-									href="https://docs.n8n.io/integrations/core-nodes/n8n-nodes-base.webhook/"
-									target="_blank"
-									v-text="$locale.baseText('settings.api.view.info.webhook')"
-								/>
-							</template>
-						</i18n>
-					</n8n-info-tip>
-				</p>
-				<n8n-card class="mb-4xs" :class="$style.card">
-					<span :class="$style.delete">
-						<n8n-link @click="showDeleteModal" :bold="true">
-							{{ $locale.baseText('generic.delete') }}
-						</n8n-link>
-					</span>
-					<div class="ph-no-capture">
-						<CopyInput
-							:label="$locale.baseText('settings.api.view.myKey')"
-							:value="apiKey"
-							:copy-button-text="$locale.baseText('generic.clickToCopy')"
-							:toast-title="$locale.baseText('settings.api.view.copy.toast')"
-							@copy="onCopy"
-						/>
-					</div>
-				</n8n-card>
-				<div :class="$style.hint">
-					<n8n-text size="small">
-						{{ $locale.baseText('settings.api.view.tryapi') }}
-					</n8n-text>
-					<n8n-link :to="apiPlaygroundPath" :newWindow="true" size="small">
-						{{ $locale.baseText('settings.api.view.apiPlayground') }}
-					</n8n-link>
-				</div>
-			</div>
-			<n8n-action-box
-				v-else-if="mounted"
-				:buttonText="$locale.baseText(loading ? 'settings.api.create.button.loading' : 'settings.api.create.button')"
-				:description="$locale.baseText('settings.api.create.description')"
-				@click="createApiKey"
-			/>
+	<div :class="$style.container">
+		<div :class="$style.header">
+			<n8n-heading size="2xlarge">
+				{{ $locale.baseText('settings.api') }}
+				<span :style="{ fontSize: 'var(--font-size-s)', color: 'var(--color-text-light)', }">
+					({{ $locale.baseText('beta') }})
+				</span>
+			</n8n-heading>
 		</div>
-	</SettingsView>
+
+		<div v-if="apiKey">
+			<p class="mb-s">
+				<n8n-info-tip :bold="false">
+					<i18n path="settings.api.view.info" tag="span">
+						<template #apiAction>
+							<a
+								href="https://docs.n8n.io/api"
+								target="_blank"
+								v-text="$locale.baseText('settings.api.view.info.api')"
+							/>
+						</template>
+						<template #webhookAction>
+							<a
+								href="https://docs.n8n.io/integrations/core-nodes/n8n-nodes-base.webhook/"
+								target="_blank"
+								v-text="$locale.baseText('settings.api.view.info.webhook')"
+							/>
+						</template>
+					</i18n>
+				</n8n-info-tip>
+			</p>
+			<n8n-card class="mb-4xs" :class="$style.card">
+				<span :class="$style.delete">
+					<n8n-link @click="showDeleteModal" :bold="true">
+						{{ $locale.baseText('generic.delete') }}
+					</n8n-link>
+				</span>
+				<div class="ph-no-capture">
+					<CopyInput
+						:label="$locale.baseText('settings.api.view.myKey')"
+						:value="apiKey"
+						:copy-button-text="$locale.baseText('generic.clickToCopy')"
+						:toast-title="$locale.baseText('settings.api.view.copy.toast')"
+						@copy="onCopy"
+					/>
+				</div>
+			</n8n-card>
+			<div :class="$style.hint">
+				<n8n-text size="small">
+					{{ $locale.baseText('settings.api.view.tryapi') }}
+				</n8n-text>
+				<n8n-link :to="apiPlaygroundPath" :newWindow="true" size="small">
+					{{ $locale.baseText('settings.api.view.apiPlayground') }}
+				</n8n-link>
+			</div>
+		</div>
+		<n8n-action-box
+			v-else-if="mounted"
+			:buttonText="$locale.baseText(loading ? 'settings.api.create.button.loading' : 'settings.api.create.button')"
+			:description="$locale.baseText('settings.api.create.description')"
+			@click="createApiKey"
+		/>
+	</div>
 </template>
 
 <script lang="ts">
@@ -71,8 +69,7 @@ import { showMessage } from '@/components/mixins/showMessage';
 import { IUser } from '@/Interface';
 import mixins from 'vue-typed-mixins';
 
-import SettingsView from './SettingsView.vue';
-import CopyInput from '../components/CopyInput.vue';
+import CopyInput from '@/components/CopyInput.vue';
 import { mapStores } from 'pinia';
 import { useSettingsStore } from '@/stores/settings';
 import { useRootStore } from '@/stores/n8nRootStore';
@@ -83,7 +80,6 @@ export default mixins(
 ).extend({
 	name: 'SettingsPersonalView',
 	components: {
-		SettingsView,
 		CopyInput,
 	},
 	data() {

--- a/packages/editor-ui/src/views/SettingsCommunityNodesView.vue
+++ b/packages/editor-ui/src/views/SettingsCommunityNodesView.vue
@@ -1,62 +1,60 @@
 <template>
-	<SettingsView>
-		<div :class="$style.container">
-			<div :class="$style.headingContainer">
-				<n8n-heading size="2xlarge">{{ $locale.baseText('settings.communityNodes') }}</n8n-heading>
-				<n8n-button
-					v-if="!settingsStore.isQueueModeEnabled && communityNodesStore.getInstalledPackages.length > 0 && !loading"
-					:label="$locale.baseText('settings.communityNodes.installModal.installButton.label')"
-					size="large"
-					@click="openInstallModal"
-				/>
-			</div>
-			<div v-if="settingsStore.isQueueModeEnabled" :class="$style.actionBoxContainer">
-				<n8n-action-box
-					:heading="$locale.baseText('settings.communityNodes.empty.title')"
-					:description="getEmptyStateDescription"
-					:calloutText="actionBoxConfig.calloutText"
-					:calloutTheme="actionBoxConfig.calloutTheme"
-				/>
-			</div>
-			<div
-				:class="$style.cardsContainer"
-				v-else-if="loading"
-			>
-				<community-package-card
-					v-for="n in 2"
-					:key="'index-' + n"
-					:loading="true"
-				></community-package-card>
-			</div>
-			<div
-				v-else-if="communityNodesStore.getInstalledPackages.length === 0"
-				:class="$style.actionBoxContainer"
-			>
-				<n8n-action-box
-					:heading="$locale.baseText('settings.communityNodes.empty.title')"
-					:description="getEmptyStateDescription"
-					:buttonText="
-						shouldShowInstallButton
-							? $locale.baseText('settings.communityNodes.empty.installPackageLabel')
-							: ''
-					"
-					:calloutText="actionBoxConfig.calloutText"
-					:calloutTheme="actionBoxConfig.calloutTheme"
-					@click="openInstallModal"
-				/>
-			</div>
-			<div
-				:class="$style.cardsContainer"
-				v-else
-			>
-				<community-package-card
-					v-for="communityPackage in communityNodesStore.getInstalledPackages"
-					:key="communityPackage.packageName"
-					:communityPackage="communityPackage"
-				></community-package-card>
-			</div>
+	<div :class="$style.container">
+		<div :class="$style.headingContainer">
+			<n8n-heading size="2xlarge">{{ $locale.baseText('settings.communityNodes') }}</n8n-heading>
+			<n8n-button
+				v-if="!settingsStore.isQueueModeEnabled && communityNodesStore.getInstalledPackages.length > 0 && !loading"
+				:label="$locale.baseText('settings.communityNodes.installModal.installButton.label')"
+				size="large"
+				@click="openInstallModal"
+			/>
 		</div>
-	</SettingsView>
+		<div v-if="settingsStore.isQueueModeEnabled" :class="$style.actionBoxContainer">
+			<n8n-action-box
+				:heading="$locale.baseText('settings.communityNodes.empty.title')"
+				:description="getEmptyStateDescription"
+				:calloutText="actionBoxConfig.calloutText"
+				:calloutTheme="actionBoxConfig.calloutTheme"
+			/>
+		</div>
+		<div
+			:class="$style.cardsContainer"
+			v-else-if="loading"
+		>
+			<community-package-card
+				v-for="n in 2"
+				:key="'index-' + n"
+				:loading="true"
+			></community-package-card>
+		</div>
+		<div
+			v-else-if="communityNodesStore.getInstalledPackages.length === 0"
+			:class="$style.actionBoxContainer"
+		>
+			<n8n-action-box
+				:heading="$locale.baseText('settings.communityNodes.empty.title')"
+				:description="getEmptyStateDescription"
+				:buttonText="
+					shouldShowInstallButton
+						? $locale.baseText('settings.communityNodes.empty.installPackageLabel')
+						: ''
+				"
+				:calloutText="actionBoxConfig.calloutText"
+				:calloutTheme="actionBoxConfig.calloutTheme"
+				@click="openInstallModal"
+			/>
+		</div>
+		<div
+			:class="$style.cardsContainer"
+			v-else
+		>
+			<community-package-card
+				v-for="communityPackage in communityNodesStore.getInstalledPackages"
+				:key="communityPackage.packageName"
+				:communityPackage="communityPackage"
+			></community-package-card>
+		</div>
+	</div>
 </template>
 
 <script lang="ts">
@@ -64,10 +62,8 @@ import {
 	COMMUNITY_PACKAGE_INSTALL_MODAL_KEY,
 	COMMUNITY_NODES_INSTALLATION_DOCS_URL,
 	COMMUNITY_NODES_NPM_INSTALLATION_URL,
-} from '../constants';
-import { mapGetters } from 'vuex';
-import SettingsView from './SettingsView.vue';
-import CommunityPackageCard from '../components/CommunityPackageCard.vue';
+} from '@/constants';
+import CommunityPackageCard from '@/components/CommunityPackageCard.vue';
 import { showMessage } from '@/components/mixins/showMessage';
 import mixins from 'vue-typed-mixins';
 import { PublicInstalledPackage } from 'n8n-workflow';
@@ -84,7 +80,6 @@ export default mixins(
 ).extend({
 	name: 'SettingsCommunityNodesView',
 	components: {
-		SettingsView,
 		CommunityPackageCard,
 	},
 	data () {

--- a/packages/editor-ui/src/views/SettingsFakeDoorView.vue
+++ b/packages/editor-ui/src/views/SettingsFakeDoorView.vue
@@ -1,5 +1,5 @@
 <template>
-	<FeatureComingSoon :featureId="featureId" showTitle />
+	<feature-coming-soon :featureId="featureId" showTitle />
 </template>
 
 <script lang="ts">

--- a/packages/editor-ui/src/views/SettingsFakeDoorView.vue
+++ b/packages/editor-ui/src/views/SettingsFakeDoorView.vue
@@ -1,21 +1,17 @@
 <template>
-	<SettingsView>
-		<FeatureComingSoon :featureId="featureId" showTitle />
-	</SettingsView>
+	<FeatureComingSoon :featureId="featureId" showTitle />
 </template>
 
 <script lang="ts">
 import { IFakeDoor } from '@/Interface';
 import Vue from 'vue';
-import SettingsView from './SettingsView.vue';
-import FeatureComingSoon from '../components/FeatureComingSoon.vue';
+import FeatureComingSoon from '@/components/FeatureComingSoon.vue';
 import { mapStores } from 'pinia';
 import { useUIStore } from '@/stores/ui';
 
 export default Vue.extend({
 	name: 'SettingsFakeDoorView',
 	components: {
-		SettingsView,
 		FeatureComingSoon,
 	},
 	props: {

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -55,12 +55,6 @@ export default mixins(
 	showMessage,
 ).extend({
 	name: 'SettingsPersonalView',
-	// beforeRouteEnter(to, from, next) {
-	// 	console.log("🚀 ~ file: SettingsSidebar.vue ~ line 44 ~ beforeRouteEnter ~ from", from);
-	// 	// next(vm => {
-	// 	// 	vm.previousRoute = from;
-	// 	// });
-	// },
 	data() {
 		return {
 			hasAnyChanges: false,

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -1,45 +1,44 @@
 <template>
-	<SettingsView>
-		<div :class="$style.container">
-			<div :class="$style.header">
-				<n8n-heading size="2xlarge">{{ $locale.baseText('settings.personal.personalSettings') }}</n8n-heading>
-				<div class="ph-no-capture" :class="$style.user">
-					<span :class="$style.username">
-						<n8n-text  color="text-light">{{currentUser.fullName}}</n8n-text>
-					</span>
-					<n8n-avatar :firstName="currentUser.firstName" :lastName="currentUser.lastName" size="large" />
-				</div>
-			</div>
-			<div>
-				<div :class="$style.sectionHeader">
-					<n8n-heading size="large">{{ $locale.baseText('settings.personal.basicInformation') }}</n8n-heading>
-				</div>
-				<div>
-					<n8n-form-inputs
-						v-if="formInputs"
-						:inputs="formInputs"
-						:eventBus="formBus"
-						@input="onInput"
-						@ready="onReadyToSubmit"
-						@submit="onSubmit"
-					/>
-				</div>
-			</div>
-			<div>
-				<div :class="$style.sectionHeader">
-					<n8n-heading size="large">{{ $locale.baseText('settings.personal.security') }}</n8n-heading>
-				</div>
-				<div>
-					<n8n-input-label :label="$locale.baseText('auth.password')">
-						<n8n-link @click="openPasswordModal">{{ $locale.baseText('auth.changePassword') }}</n8n-link>
-					</n8n-input-label>
-				</div>
-			</div>
-			<div>
-				<n8n-button float="right" :label="$locale.baseText('settings.personal.save')" size="large" :disabled="!hasAnyChanges || !readyToSubmit" @click="onSaveClick" />
+	<div :class="$style.container">
+		<div :class="$style.header">
+			<n8n-heading size="2xlarge">{{ $locale.baseText('settings.personal.personalSettings') }}</n8n-heading>
+			<div class="ph-no-capture" :class="$style.user">
+				<span :class="$style.username">
+					<n8n-text  color="text-light">{{currentUser.fullName}}</n8n-text>
+				</span>
+				<n8n-avatar :firstName="currentUser.firstName" :lastName="currentUser.lastName" size="large" />
 			</div>
 		</div>
-	</SettingsView>
+		<div>
+			<div :class="$style.sectionHeader">
+				<n8n-heading size="large">{{ $locale.baseText('settings.personal.basicInformation') }}</n8n-heading>
+			</div>
+			<div>
+				<n8n-form-inputs
+					v-if="formInputs"
+					:inputs="formInputs"
+					:eventBus="formBus"
+					@input="onInput"
+					@ready="onReadyToSubmit"
+					@submit="onSubmit"
+				/>
+			</div>
+		</div>
+		<div>
+			<div :class="$style.sectionHeader">
+				<n8n-heading size="large">{{ $locale.baseText('settings.personal.security') }}</n8n-heading>
+			</div>
+			<div>
+				<n8n-input-label :label="$locale.baseText('auth.password')">
+					<n8n-link @click="openPasswordModal">{{ $locale.baseText('auth.changePassword') }}</n8n-link>
+				</n8n-input-label>
+			</div>
+		</div>
+		<div>
+			<n8n-button float="right" :label="$locale.baseText('settings.personal.save')" size="large" :disabled="!hasAnyChanges || !readyToSubmit" @click="onSaveClick" />
+		</div>
+	</div>
+
 </template>
 
 <script lang="ts">
@@ -52,15 +51,16 @@ import { mapStores } from 'pinia';
 import Vue from 'vue';
 import mixins from 'vue-typed-mixins';
 
-import SettingsView from './SettingsView.vue';
-
 export default mixins(
 	showMessage,
 ).extend({
 	name: 'SettingsPersonalView',
-	components: {
-		SettingsView,
-	},
+	// beforeRouteEnter(to, from, next) {
+	// 	console.log("🚀 ~ file: SettingsSidebar.vue ~ line 44 ~ beforeRouteEnter ~ from", from);
+	// 	// next(vm => {
+	// 	// 	vm.previousRoute = from;
+	// 	// });
+	// },
 	data() {
 		return {
 			hasAnyChanges: false,

--- a/packages/editor-ui/src/views/SettingsUsersView.vue
+++ b/packages/editor-ui/src/views/SettingsUsersView.vue
@@ -1,49 +1,46 @@
 <template>
-	<SettingsView>
-		<div :class="$style.container">
-			<div>
-				<n8n-heading size="2xlarge">{{ $locale.baseText('settings.users') }}</n8n-heading>
-				<div :class="$style.buttonContainer" v-if="!usersStore.showUMSetupWarning">
-						<n8n-tooltip :disabled="settingsStore.isSmtpSetup" placement="bottom">
-							<i18n slot="content" path="settings.users.setupSMTPToInviteUsers" tag="span">
-								<template #action>
-									<a
-										href="https://docs.n8n.io/reference/user-management.html#step-one-smtp"
-										target="_blank"
-										v-text="$locale.baseText('settings.users.setupSMTPToInviteUsers.instructions')"
-									/>
-								</template>
-							</i18n>
-							<div>
-								<n8n-button :label="$locale.baseText('settings.users.invite')" @click="onInvite" size="large" :disabled="!settingsStore.isSmtpSetup" />
-							</div>
-						</n8n-tooltip>
-				</div>
-			</div>
-			<div v-if="usersStore.showUMSetupWarning" :class="$style.setupInfoContainer">
-				<n8n-action-box
-					:heading="$locale.baseText('settings.users.setupToInviteUsers')"
-					:buttonText="$locale.baseText('settings.users.setupMyAccount')"
-					:description="$locale.baseText('settings.users.setupToInviteUsersInfo')"
-					@click="redirectToSetup"
-				/>
-			</div>
-			<div :class="$style.usersContainer" v-else>
-				<PageAlert
-					v-if="!settingsStore.isSmtpSetup"
-					:message="$locale.baseText('settings.users.smtpToAddUsersWarning')"
-					:popupClass="$style.alert"
-				/>
-				<n8n-users-list :users="usersStore.allUsers" :currentUserId="usersStore.currentUserId" @delete="onDelete" @reinvite="onReinvite" />
+	<div :class="$style.container">
+		<div>
+			<n8n-heading size="2xlarge">{{ $locale.baseText('settings.users') }}</n8n-heading>
+			<div :class="$style.buttonContainer" v-if="!usersStore.showUMSetupWarning">
+					<n8n-tooltip :disabled="settingsStore.isSmtpSetup" placement="bottom">
+						<i18n slot="content" path="settings.users.setupSMTPToInviteUsers" tag="span">
+							<template #action>
+								<a
+									href="https://docs.n8n.io/reference/user-management.html#step-one-smtp"
+									target="_blank"
+									v-text="$locale.baseText('settings.users.setupSMTPToInviteUsers.instructions')"
+								/>
+							</template>
+						</i18n>
+						<div>
+							<n8n-button :label="$locale.baseText('settings.users.invite')" @click="onInvite" size="large" :disabled="!settingsStore.isSmtpSetup" />
+						</div>
+					</n8n-tooltip>
 			</div>
 		</div>
-	</SettingsView>
+		<div v-if="usersStore.showUMSetupWarning" :class="$style.setupInfoContainer">
+			<n8n-action-box
+				:heading="$locale.baseText('settings.users.setupToInviteUsers')"
+				:buttonText="$locale.baseText('settings.users.setupMyAccount')"
+				:description="$locale.baseText('settings.users.setupToInviteUsersInfo')"
+				@click="redirectToSetup"
+			/>
+		</div>
+		<div :class="$style.usersContainer" v-else>
+			<PageAlert
+				v-if="!settingsStore.isSmtpSetup"
+				:message="$locale.baseText('settings.users.smtpToAddUsersWarning')"
+				:popupClass="$style.alert"
+			/>
+			<n8n-users-list :users="usersStore.allUsers" :currentUserId="usersStore.currentUserId" @delete="onDelete" @reinvite="onReinvite" />
+		</div>
+	</div>
 </template>
 
 <script lang="ts">
 import { INVITE_USER_MODAL_KEY, VIEWS } from '@/constants';
 
-import SettingsView from './SettingsView.vue';
 import PageAlert from '../components/PageAlert.vue';
 import { IUser } from '@/Interface';
 import mixins from 'vue-typed-mixins';
@@ -56,7 +53,6 @@ import { useUsersStore } from '@/stores/users';
 export default mixins(showMessage).extend({
 	name: 'SettingsUsersView',
 	components: {
-		SettingsView,
 		PageAlert,
 	},
 	async mounted() {

--- a/packages/editor-ui/src/views/SettingsView.vue
+++ b/packages/editor-ui/src/views/SettingsView.vue
@@ -3,9 +3,7 @@
 		<SettingsSidebar @return="onReturn" />
 		<div :class="$style.contentContainer">
 			<div :class="$style.content">
-				<keep-alive include="NodeView" :max="1">
 					<router-view name="settingsView" />
-				</keep-alive>
 			</div>
 		</div>
 	</div>

--- a/packages/editor-ui/src/views/SettingsView.vue
+++ b/packages/editor-ui/src/views/SettingsView.vue
@@ -1,26 +1,46 @@
 <template>
 	<div :class="$style.container">
-		<SettingsSidebar />
+		<SettingsSidebar @return="onReturn" />
 		<div :class="$style.contentContainer">
 			<div :class="$style.content">
-				<slot>
-				</slot>
+				<keep-alive include="NodeView" :max="1">
+					<router-view name="settingsView" />
+				</keep-alive>
 			</div>
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
+import { Route } from 'vue-router';
 
-import SettingsSidebar from '../components/SettingsSidebar.vue';
+import { VIEWS } from '@/constants';
+import SettingsSidebar from '@/components/SettingsSidebar.vue';
 
-export default Vue.extend({
+const SettingsView = defineComponent({
 	name: 'SettingsView',
 	components: {
 		SettingsSidebar,
 	},
+	beforeRouteEnter(to, from, next) {
+		next(vm => {
+			(vm as unknown as InstanceType<typeof SettingsView>).previousRoute = from;
+		});
+	},
+	data() {
+		return {
+			previousRoute: null as Route | null,
+		};
+	},
+	methods: {
+		onReturn() {
+			this.$router.push(this.previousRoute ? this.previousRoute.path : { name: VIEWS.HOMEPAGE });
+		},
+	},
 });
+
+export default SettingsView;
 </script>
 
 <style lang="scss" module>

--- a/packages/editor-ui/src/views/SettingsView.vue
+++ b/packages/editor-ui/src/views/SettingsView.vue
@@ -3,7 +3,11 @@
 		<SettingsSidebar @return="onReturn" />
 		<div :class="$style.contentContainer">
 			<div :class="$style.content">
-					<router-view name="settingsView" />
+				<!--
+					Because we're using nested routes the props are going to be bind to the top level route
+					so we need to pass them down to the child component
+				-->
+				<router-view name="settingsView" v-bind="$attrs" />
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
When saving and navigating away from a newly created workflow, we need to replace the `/workflow/new` route with the `/workflow/$id` so that when a user comes back, they land on the workflow itself. In order to do this, we have to `replace` the routes instead of pushing them. 
Also, when a user lands on the settings page, the sidebar button should take them to either the previous location, if there's one, or go to the workflows view. In order to do this, we need to store the `from` route when accessing the Settings. For this, I had to refactor settings routing to use children routes and nested `<router-view />`. Doing this, we also have to move `props: true` from the FAKE_DOOR route to the SettingsView route and pass it as props in the component.


https://user-images.githubusercontent.com/12657221/200580180-b92f7353-cfa1-48bb-9d8e-fed461db977e.mp4


