### PR TITLE
fix(firestore): :bug: Fix Firestore create document failed for number == 0

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -148,7 +148,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 						const document = { fields: {} };
 						columnList.map((column) => {
 							// @ts-ignore
-							if (item['json'][column]) {
+							if (item['json'][column] != null) {
 								// @ts-ignore
 								document.fields[column] = jsonToDocument(item['json'][column]);
 							} else {


### PR DESCRIPTION
- Fix Firestore create document failed for `item['json'][column]` value is `0` would write `null` instead of `0` to Firestore document