### PR TITLE
feat: Draft implementation of generic declarative pagination

### DIFF
--- a/packages/nodes-base/nodes/N8n/ExecutionDescription.ts
+++ b/packages/nodes-base/nodes/N8n/ExecutionDescription.ts
@@ -40,7 +40,20 @@ export const executionOperations: INodeProperties[] = [
 						paginate: true,
 					},
 					operations: {
-						pagination: getCursorPaginator(),
+						pagination: {
+							type: 'generic',
+							properties: {
+								request: {
+									qs: {
+										cursor: '={{ $response.nextCursor }}',
+										// limit: 10, // Can be set to have more control over the page size
+									},
+								},
+								rootProperty: 'data',
+								// Here '$response.nextCursor' might be undefined or null based on the API response
+								continue: '={{ $parameter.returnAll && !!$response.nextCursor }}',
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
(A rebased version of an earlier PR https://github.com/n8n-io/n8n/pull/4160, which was based on a work-in-progress n8n node.)

This draft PR proposes a declarative syntax for a generic pagination type. This should remove for many cases the need to manually implement a custom "pagination" function. It is mostly functional but requires some more finalization effort, see e.g. https://github.com/n8n-io/n8n/pull/4160#discussion_r981431259.

To test this, you need to create an n8n API key, and a credential that makes use of it. Then you can create an "n8n" node and try the "Execution/getAll" operation, which invokes the pagination.
