### PR TITLE
feat(editor): Add support for notice credentials properties

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
@@ -2,7 +2,12 @@
 	<div @keydown.stop :class="$style.container" v-if="credentialProperties.length">
 		<form v-for="parameter in credentialProperties" :key="parameter.name" autocomplete="off">
 			<!-- Why form? to break up inputs, to prevent Chrome autofill -->
+			<n8n-notice
+				v-if="parameter.type === 'notice'"
+				:content="parameter.displayName"
+			/>
 			<parameter-input-expanded
+				v-else
 				:parameter="parameter"
 				:value="credentialData[parameter.name]"
 				:documentationUrl="documentationUrl"


### PR DESCRIPTION
In order to test this, add a property with `notice` type to credentials definition of any node (for example [here](https://github.com/n8n-io/n8n/blob/f9d9f88f8a9d217101c2f5c67f3d3db6aa6b9b92/packages/nodes-base/credentials/HubspotApi.credentials.ts#L7)).
An example of notice param:
```
{
  displayName:
  'On 30 November, 2022 Hubspot will remove API key support. You will have to connect to HubSpot using other auth method. <a href="https://www.hubspot.com/" target="_blank">More details (HubSpot.com)</a>',
  name: 'notice',
  type: 'notice',
  default: '',
},
```