### PR TITLE
fix(firestore): :bug: Fix model type write sequence

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -81,17 +81,17 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 		return { booleanValue: value };
 	} else if (value === null) {
 		return { nullValue: null };
+	} else if (isValidDate(value as string)) {
+		const date = new Date(Date.parse(value as string));
+		return { timestampValue: date.toISOString() };
+	} else if (typeof value === 'string') {
+		return { stringValue: value };
 	} else if (!isNaN(value as number)) {
 		if (value.toString().indexOf('.') !== -1) {
 			return { doubleValue: value };
 		} else {
 			return { integerValue: value };
 		}
-	} else if (isValidDate(value as string)) {
-		const date = new Date(Date.parse(value as string));
-		return { timestampValue: date.toISOString() };
-	} else if (typeof value === 'string') {
-		return { stringValue: value };
 	} else if (value && value.constructor === Array) {
 		return { arrayValue: { values: value.map((v) => jsonToDocument(v)) } };
 	} else if (typeof value === 'object') {


### PR DESCRIPTION
- Fix model type write sequence for string of number Eg. `"phone_number" : "660002021"` is being write as Firestore number due to `(!isNaN(value as number))` is performed first. We should check string type and write as string prior to number casting.