### PR TITLE
fix: Disable some error tracking 

### DIFF
--- a/packages/cli/src/CrashJournal.ts
+++ b/packages/cli/src/CrashJournal.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { mkdir, utimes, open, rm } from 'fs/promises';
 import { join, dirname } from 'path';
 import { UserSettings } from 'n8n-core';
-import { ErrorReporterProxy as ErrorReporter, LoggerProxy, sleep } from 'n8n-workflow';
+import { LoggerProxy, sleep } from 'n8n-workflow';
 
 export const touchFile = async (filePath: string): Promise<void> => {
 	await mkdir(dirname(filePath), { recursive: true });
@@ -20,7 +20,6 @@ const journalFile = join(UserSettings.getUserN8nFolderPath(), 'crash.journal');
 export const init = async () => {
 	if (existsSync(journalFile)) {
 		// Crash detected
-		ErrorReporter.warn('Last session crashed');
 		LoggerProxy.error('Last session crashed');
 		// add a 10 seconds pause to slow down crash-looping
 		await sleep(10_000);

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,5 +1,3 @@
-import * as ErrorReporter from './ErrorReporterProxy';
-
 export type Primitives = string | number | boolean | bigint | symbol | null | undefined;
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
@@ -19,9 +17,6 @@ export const deepCopy = <T extends ((object | Date) & { toJSON?: () => string })
 		return source.toJSON() as T;
 	}
 	if (hash.has(source)) {
-		ErrorReporter.warn('Circular reference detected', {
-			extra: { source, path },
-		});
 		return hash.get(source);
 	}
 	// Array


### PR DESCRIPTION
we are running out of quota on Sentry, and need to disable these two events from being tracked.