### PR TITLE
fix: Fix inferred type of X cannot be named error after pnpm update (no-changelog)

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,6 +4,7 @@
 		"rootDir": ".",
 		"types": ["node", "jest"],
 		"noEmit": true,
+		"preserveSymlinks": true,
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"baseUrl": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
 		"incremental": true,
 		"declaration": true,
 		"sourceMap": true,
-		"preserveSymlinks": true,
 		"skipLibCheck": true
 	},
 	"exclude": ["**/dist/**/*", "**/node_modules/**/*"]


### PR DESCRIPTION
After updating to pnpm, IDEs have started erroring-out with the issue as described here: https://github.com/microsoft/TypeScript/issues/42873

Removing `preserveSymlinks` from our root `tsconfig.json` fixes the issue.