### PR TITLE
fix(editor): Add 'Stop execution' button to execution preview

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
@@ -18,7 +18,8 @@
 					<n8n-spinner v-if="executionUIDetails.name === 'running'" size="small" :class="[$style.spinner, 'mr-4xs']"/>
 					<n8n-text :class="$style.statusLabel" size="small">{{ executionUIDetails.label }}</n8n-text>
 					<n8n-text v-if="executionUIDetails.name === 'running'" :color="isActive? 'text-dark' : 'text-base'" size="small">
-						{{ $locale.baseText('executionDetails.runningTimeRunning', { interpolate: { time: executionUIDetails.runningTime } }) }}
+						{{ $locale.baseText('executionDetails.runningTimeRunning') }}
+						<execution-time :start-time="execution.startedAt"/>
 					</n8n-text>
 					<n8n-text v-else-if="executionUIDetails.name !== 'waiting' && executionUIDetails.name !== 'unknown'" :color="isActive? 'text-dark' : 'text-base'" size="small">
 						{{ $locale.baseText('executionDetails.runningTimeFinished', { interpolate: { time: executionUIDetails.runningTime } }) }}
@@ -56,6 +57,7 @@ import { executionHelpers, IExecutionUIData } from '../mixins/executionsHelpers'
 import { VIEWS } from '../../constants';
 import { showMessage } from '../mixins/showMessage';
 import { restApi } from '../mixins/restApi';
+import ExecutionTime from '@/components/ExecutionTime.vue';
 
 export default mixins(
 	executionHelpers,
@@ -63,6 +65,9 @@ export default mixins(
 	restApi,
 ).extend({
 	name: 'execution-card',
+	components: {
+		ExecutionTime,
+	},
 	data() {
 		return {
 			VIEWS,

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
@@ -6,7 +6,7 @@
 		<n8n-text :class="$style.runningMessage">
 			{{ $locale.baseText('executionDetails.runningMessage') }}
 		</n8n-text>
-		<n8n-button class="mt-l" type="tertiary" size="large" icon="stop" @click="handleStopClick">
+		<n8n-button class="mt-l" type="tertiary" size="medium" icon="stop" @click="handleStopClick">
 			{{ $locale.baseText('executionsList.stopExecution') }}
 		</n8n-button>
 	</div>

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
@@ -1,12 +1,12 @@
 <template>
 	<div v-if="executionUIDetails && executionUIDetails.name === 'running'" :class="$style.runningInfo">
 		<div :class="$style.spinner">
-			<font-awesome-icon icon="spinner" spin />
+			<n8n-spinner type="ring" />
 		</div>
-		<n8n-text :class="$style.runningMessage">
+		<n8n-text :class="$style.runningMessage" color="text-light">
 			{{ $locale.baseText('executionDetails.runningMessage') }}
 		</n8n-text>
-		<n8n-button class="mt-l" type="tertiary" size="medium" icon="stop" @click="handleStopClick">
+		<n8n-button class="mt-l" type="tertiary" size="medium" @click="handleStopClick">
 			{{ $locale.baseText('executionsList.stopExecution') }}
 		</n8n-button>
 	</div>
@@ -152,6 +152,14 @@ export default mixins(restApi, showMessage, executionHelpers).extend({
 	}
 }
 
+.spinner {
+	div div {
+		width: 30px;
+		height: 30px;
+		border-width: 2px;
+	}
+}
+
 .running, .spinner { color: var(--color-warning); }
 .waiting { color: var(--color-secondary); }
 .success { color: var(--color-success); }
@@ -162,11 +170,6 @@ export default mixins(restApi, showMessage, executionHelpers).extend({
 	flex-direction: column;
 	align-items: center;
 	margin-top: var(--spacing-4xl);
-}
-
-.spinner {
-	font-size: var(--font-size-2xl);
-	color: var(--color-primary);
 }
 
 .runningMessage {

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
@@ -6,6 +6,9 @@
 		<n8n-text :class="$style.runningMessage">
 			{{ $locale.baseText('executionDetails.runningMessage') }}
 		</n8n-text>
+		<n8n-button class="mt-l" type="tertiary" size="large" icon="stop" @click="handleStopClick">
+			{{ $locale.baseText('executionsList.stopExecution') }}
+		</n8n-button>
 	</div>
 	<div v-else :class="$style.previewContainer">
 		<div :class="{[$style.executionDetails]: true, [$style.sidebarCollapsed]: sidebarCollapsed }" v-if="activeExecution">
@@ -110,6 +113,9 @@ export default mixins(restApi, showMessage, executionHelpers).extend({
 		},
 		handleRetryClick(command: string): void {
 			this.$emit('retryExecution', { execution: this.activeExecution, command });
+		},
+		handleStopClick(): void {
+			this.$emit('stopExecution');
 		},
 		onRetryButtonBlur(event: FocusEvent): void {
 			// Hide dropdown when clicking outside of current document

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionsView.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionsView.vue
@@ -332,9 +332,12 @@ export default mixins(restApi, showMessage, executionHelpers, debounceHelper, wo
 				const activeNotInTheList = existingExecutions.find(ex => ex.id === this.activeExecution.id) === undefined;
 				if (activeNotInTheList && this.executions.length > 0) {
 					this.$router.push({
-					name: VIEWS.EXECUTION_PREVIEW,
-					params: { name: this.currentWorkflow, executionId: this.executions[0].id },
-				}).catch(()=>{});;
+						name: VIEWS.EXECUTION_PREVIEW,
+						params: { name: this.currentWorkflow, executionId: this.executions[0].id },
+					}).catch(()=>{});
+				} else if (this.executions.length === 0) {
+					this.$router.push({ name: VIEWS.EXECUTION_HOME }).catch(()=>{});
+					this.workflowsStore.activeWorkflowExecution = null;
 				}
 			}
 		},

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionsView.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionsView.vue
@@ -12,7 +12,12 @@
 			@refresh="loadAutoRefresh"
 		/>
 		<div :class="$style.content" v-if="!hidePreview">
-			<router-view name="executionPreview" @deleteCurrentExecution="onDeleteCurrentExecution" @retryExecution="onRetryExecution"/>
+			<router-view
+				name="executionPreview"
+				@deleteCurrentExecution="onDeleteCurrentExecution"
+				@retryExecution="onRetryExecution"
+				@stopExecution="onStopExecution"
+			/>
 		</div>
 		<div v-if="executions.length === 0 && filterApplied" :class="$style.noResultsContainer">
 			<n8n-text color="text-base" size="medium" align="center">
@@ -239,6 +244,29 @@ export default mixins(restApi, showMessage, executionHelpers, debounceHelper, wo
 				title: this.$locale.baseText('executionsList.showMessage.handleDeleteSelected.title'),
 				type: 'success',
 			});
+		},
+		async onStopExecution(): Promise<void> {
+			const activeExecutionId = this.$route.params.executionId;
+
+			try {
+				await this.restApi().stopCurrentExecution(activeExecutionId);
+
+				this.$showMessage({
+					title: this.$locale.baseText('executionsList.showMessage.stopExecution.title'),
+					message: this.$locale.baseText(
+						'executionsList.showMessage.stopExecution.message',
+						{ interpolate: { activeExecutionId } },
+					),
+					type: 'success',
+				});
+
+				this.loadAutoRefresh();
+			} catch (error) {
+				this.$showError(
+					error,
+					this.$locale.baseText('executionsList.showError.stopExecution.title'),
+				);
+			}
 		},
 		onFilterUpdated(newFilter: { finished: boolean, status: string }): void {
 			this.filter = newFilter;

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -395,7 +395,7 @@
 	"executionDetails.readOnly.youreViewingTheLogOf": "You're viewing the log of a previous execution. You cannot<br />\n\t\tmake changes since this execution already occurred. Make changes<br />\n\t\tto this workflow by clicking on its name on the left.",
 	"executionDetails.retry": "Retry of execution",
 	"executionDetails.runningTimeFinished": "in {time}",
-	"executionDetails.runningTimeRunning": "for {time}",
+	"executionDetails.runningTimeRunning": "for",
 	"executionDetails.runningMessage": "Execution is running. It will show here once finished.",
 	"executionDetails.workflow": "workflow",
 	"executionsLandingPage.emptyState.noTrigger.heading": "Set up the first step. Then execute your workflow",

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -725,21 +725,11 @@ export default mixins(
 						}
 					}
 
-					if (!nodeErrorFound) {
-						const resultError = data.data.resultData.error;
-						const errorMessage = this.$getExecutionError(data.data);
-						const shouldTrack = resultError && 'node' in resultError && resultError.node!.type.startsWith('n8n-nodes-base');
-						this.$showMessage({
-							title: 'Failed execution',
-							message: errorMessage,
-							type: 'error',
-						}, shouldTrack);
-						if (data.data.resultData.error.stack) {
-							// Display some more information for now in console to make debugging easier
-							// TODO: Improve this in the future by displaying in UI
-							console.error(`Execution ${executionId} error:`); // eslint-disable-line no-console
-							console.error(data.data.resultData.error.stack); // eslint-disable-line no-console
-						}
+					if (!nodeErrorFound && data.data.resultData.error.stack) {
+						// Display some more information for now in console to make debugging easier
+						// TODO: Improve this in the future by displaying in UI
+						console.error(`Execution ${executionId} error:`); // eslint-disable-line no-console
+						console.error(data.data.resultData.error.stack); // eslint-disable-line no-console
 					}
 				}
 				if ((data as IExecutionsSummary).waitTill) {


### PR DESCRIPTION
This PR introduces a few visual changes to the preview for running executions:
1. `Stop execution` button
2. Execution timer in the executions sidebar (shows live timer for running executions),
3. New spinner icon

![SCR-20221117-f07](https://user-images.githubusercontent.com/2598782/202415016-2d3268c5-0ea7-444f-8824-69c395e94d7f.png)
