### PR TITLE
docs: Update README (no-changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ changes [here](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-C
 ## Usage
 
 - :books: Learn
-  [how to **install** and **use** it from the command line](https://github.com/n8n-io/n8n/tree/master/packages/cli/README.md)
+  [how to **use** it from the command line](https://docs.n8n.io/reference/cli-commands/)
 - :whale: Learn
-  [how to run n8n in **Docker**](https://github.com/n8n-io/n8n/tree/master/docker/images/n8n/README.md)
+  [how to run n8n in **Docker**](https://docs.n8n.io/hosting/installation/docker/)
 
 ## Start
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The official n8n documentation can be found under: [https://docs.n8n.io](https:/
 
 Additional information and example workflows on the n8n.io website: [https://n8n.io](https://n8n.io)
 
-The changelog can be found [here](https://docs.n8n.io/reference/changelog.html) and the list of breaking
+The release notes can be found [here](https://docs.n8n.io/reference/release-notes/) and the list of breaking
 changes [here](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-CHANGES.md).
 
 ## Usage


### PR DESCRIPTION
Update a link in the README

Should we consider directing the Docker and installation links to the docs? Or are we confident the READMEs they currently link to will stay up to date?