### PR TITLE
ci: Send Slack notifications when important builds fail (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -44,3 +44,11 @@ jobs:
         env:
           CI_LINT_MASTER: true
         run: pnpm lint
+
+      - name: Notify Slack on failure
+        uses: act10ns/slack@v2.0.0
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          channel: '#updates-build-alerts'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -47,3 +47,11 @@ jobs:
       - name: Test Postgres (alternate schema)
         working-directory: packages/cli
         run: pnpm test:postgres:alt-schema
+
+      - name: Notify Slack on failure
+        uses: act10ns/slack@v2.0.0
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          channel: '#updates-build-alerts'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -93,3 +93,11 @@ jobs:
       #     git config --global user.email 'n8n-test-bot@users.noreply.github.com'
       #     git commit -am "Automated credential update"
       #     git push --force --quiet "https://janober:${{ secrets.TOKEN }}@github.com/n8n-io/test-workflows.git" main:main
+
+      - name: Notify Slack on failure
+        uses: act10ns/slack@v2.0.0
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          channel: '#updates-build-alerts'
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The messages send to Slack could be improved, but that can be done later.  
This is what the notifications looks like right now.

![image](https://user-images.githubusercontent.com/196144/202489683-e4ca047f-0c2c-458a-97f3-75c4268d0571.png)

N8N-5255
N8N-5328
