### PR TITLE
fix: Make users fakedoor route visible on cloud

### DIFF
--- a/packages/editor-ui/src/components/SettingsSidebar.vue
+++ b/packages/editor-ui/src/components/SettingsSidebar.vue
@@ -142,6 +142,7 @@ export default mixins(
 						this.$router.push({ name: VIEWS.API_SETTINGS });
 					}
 					break;
+				case 'users': // Fakedoor feature added via hooks when user management is disabled on cloud
 				case 'environments':
 				case 'logging':
 					this.$router.push({ name: VIEWS.FAKE_DOOR, params: { featureId: key } }).catch(() => {});


### PR DESCRIPTION
<img width="3200" alt="image" src="https://user-images.githubusercontent.com/6179477/202699342-e8ea8a87-0096-44bc-b8e4-c07f60ac2f13.png">
