### PR TITLE
fix: Docker custom image needs the `scripts` folder to build  (no-changelog)

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -4,6 +4,7 @@ ARG NODE_VERSION=16
 FROM n8nio/base:${NODE_VERSION} as builder
 
 COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY scripts ./scripts
 COPY packages ./packages
 COPY patches ./patches
 


### PR DESCRIPTION
CI on `master`: https://github.com/n8n-io/n8n/actions/runs/3515760775

CI on this branch: https://github.com/n8n-io/n8n/actions/runs/3515762444