### PR TITLE
feat: Use longer stack-traces when error-reporting is enabled

### DIFF
--- a/packages/cli/src/ErrorReporting.ts
+++ b/packages/cli/src/ErrorReporting.ts
@@ -14,6 +14,9 @@ export const initErrorHandling = () => {
 		return;
 	}
 
+	// Collect longer stacktraces
+	Error.stackTraceLimit = 50;
+
 	const dsn = config.getEnv('diagnostics.config.sentry.dsn');
 	const { N8N_VERSION: release, ENVIRONMENT: environment } = process.env;
 


### PR DESCRIPTION
This is needed to get more useful stack traces on Sentry