### PR TITLE
fix(core): Fix `$items().length` behavior in `executeOnce` mode

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -1148,6 +1148,10 @@ export class WorkflowDataProxy {
 					executionData = that.getNodeExecutionData(nodeName, false, outputIndex, runIndex);
 				}
 
+				if (that.workflow.getNode(that.activeNodeName)?.executeOnce) {
+					executionData = that.connectionInputData.slice(0, 1);
+				}
+
 				return executionData;
 			},
 			$json: {}, // Placeholder


### PR DESCRIPTION
https://community.n8n.io/t/items-length-needs-the-node-name-to-work-correctly-in-the-exec-once-mode/9618?u=mutedjam