### PR TITLE
fix: Invalid credentials should throw 401 and not 500 (no-changelog)

### DIFF
--- a/packages/cli/src/UserManagement/routes/auth.ts
+++ b/packages/cli/src/UserManagement/routes/auth.ts
@@ -43,11 +43,7 @@ export function authenticationMethods(this: N8nApp): void {
 			}
 
 			if (!user?.password || !(await compareHash(req.body.password, user.password))) {
-				// password is empty until user signs up
-				const error = new Error('Wrong username or password. Do you have caps lock on?');
-				// @ts-ignore
-				error.httpStatusCode = 401;
-				throw error;
+				throw new ResponseHelper.AuthError('Wrong username or password. Do you have caps lock on?');
 			}
 
 			await issueCookie(res, user);


### PR DESCRIPTION
I missed to add these in https://github.com/n8n-io/n8n/pull/4691

I've checked not that there are no other cases of http errors that aren't using error classes. This was the last one.