### PR TITLE
ci: Make end-to-end testing independent of development environments (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Test E2E
         run: |
           pnpm cypress:install
-          pnpm test:e2e:ci:smoke
+          pnpm test:e2e:all
 
       - name: Lint
         env:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test E2E
         run: |
           pnpm cypress:install
-          pnpm test:e2e:ci:smoke
+          pnpm test:e2e:smoke
 
       - name: Fetch base branch for `git diff`
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}

--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
     "webhook": "./packages/cli/bin/n8n webhook",
     "worker": "./packages/cli/bin/n8n worker",
     "cypress:install": "cypress install",
-    "test:e2e:db:clean": "rimraf ~/.n8n/cypress.sqlite",
     "test:e2e:cypress:run": "cypress run",
-    "test:e2e": "pnpm test:e2e:db:clean && cross-env DB_SQLITE_DATABASE=cypress.sqlite N8N_DIAGNOSTICS_ENABLED=false start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:run",
+    "test:e2e": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:run",
     "test:e2e:cypress:dev": "cypress open",
-    "test:e2e:dev": "pnpm test:e2e:db:clean && cross-env DB_SQLITE_DATABASE=cypress.sqlite N8N_DIAGNOSTICS_ENABLED=false CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico test:e2e:cypress:dev",
+    "test:e2e:dev": "cross-env E2E_TESTS=true CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico test:e2e:cypress:dev",
     "test:e2e:cypress:ci:smoke": "cypress run --headless --spec \"cypress/e2e/0-smoke.cy.ts\"",
-    "test:e2e:ci:smoke": "pnpm test:e2e:db:clean && cross-env DB_SQLITE_DATABASE=cypress.sqlite N8N_DIAGNOSTICS_ENABLED=false start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:ci:smoke"
+    "test:e2e:ci:smoke": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:ci:smoke"
   },
   "dependencies": {
     "n8n": "*"

--- a/package.json
+++ b/package.json
@@ -27,12 +27,9 @@
     "webhook": "./packages/cli/bin/n8n webhook",
     "worker": "./packages/cli/bin/n8n worker",
     "cypress:install": "cypress install",
-    "test:e2e:cypress:run": "cypress run",
-    "test:e2e": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:run",
-    "test:e2e:cypress:dev": "cypress open",
-    "test:e2e:dev": "cross-env E2E_TESTS=true CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico test:e2e:cypress:dev",
-    "test:e2e:cypress:ci:smoke": "cypress run --headless --spec \"cypress/e2e/0-smoke.cy.ts\"",
-    "test:e2e:ci:smoke": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico test:e2e:cypress:ci:smoke"
+    "test:e2e:dev": "cross-env E2E_TESTS=true CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico 'cypress open'",
+    "test:e2e:smoke": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico 'cypress run --headless --spec \"cypress/e2e/0-smoke.cy.ts\"'",
+    "test:e2e:all": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico 'cypress run'"
   },
   "dependencies": {
     "n8n": "*"

--- a/packages/cli/src/UserManagement/email/NodeMailer.ts
+++ b/packages/cli/src/UserManagement/email/NodeMailer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { createTransport, Transporter } from 'nodemailer';
 import { ErrorReporterProxy as ErrorReporter, LoggerProxy as Logger } from 'n8n-workflow';
-import * as config from '@/config';
+import config from '@/config';
 import { MailData, SendEmailResult, UserManagementMailerImplementation } from './Interfaces';
 
 export class NodeMailer implements UserManagementMailerImplementation {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,28 +1,55 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable no-console */
 import convict from 'convict';
 import dotenv from 'dotenv';
+import { tmpdir } from 'os';
+import { mkdtempSync } from 'fs';
+import { join } from 'path';
 import { schema } from './schema';
 
-dotenv.config();
+const inE2ETests = process.env.E2E_TESTS === 'true';
+
+if (inE2ETests) {
+	// Skip loading config from env variables in end-to-end tests
+	process.env = {
+		N8N_USER_FOLDER: mkdtempSync(join(tmpdir(), 'n8n-e2e-')),
+		N8N_DIAGNOSTICS_ENABLED: 'false',
+		N8N_PUBLIC_API_DISABLED: 'true',
+		EXTERNAL_FRONTEND_HOOKS_URLS: '',
+		N8N_PERSONALIZATION_ENABLED: 'false',
+	};
+} else {
+	dotenv.config();
+}
 
 const config = convict(schema);
 
+if (inE2ETests) {
+	config.set('enterprise.features.sharing', true);
+	config.set('enterprise.workflowSharingEnabled', true);
+}
+
 config.getEnv = config.get;
 
-// Overwrite default configuration with settings which got defined in
-// optional configuration files
-if (process.env.N8N_CONFIG_FILES !== undefined) {
-	const configFiles = process.env.N8N_CONFIG_FILES.split(',');
-	if (process.env.NODE_ENV !== 'test') {
-		console.log(`\nLoading configuration overwrites from:\n - ${configFiles.join('\n - ')}\n`);
-	}
+if (!inE2ETests) {
+	// Overwrite default configuration with settings which got defined in
+	// optional configuration files
+	const { N8N_CONFIG_FILES, NODE_ENV } = process.env;
+	if (N8N_CONFIG_FILES !== undefined) {
+		const configFiles = N8N_CONFIG_FILES.split(',');
+		if (NODE_ENV !== 'test') {
+			console.log(`\nLoading configuration overwrites from:\n - ${configFiles.join('\n - ')}\n`);
+		}
 
-	config.loadFile(configFiles);
+		config.loadFile(configFiles);
+	}
 }
 
 config.validate({
 	allowed: 'strict',
 });
 
-export = config;
+// eslint-disable-next-line import/no-default-export
+export default config;
+export type Config = typeof config;

--- a/packages/core/src/UserSettings.ts
+++ b/packages/core/src/UserSettings.ts
@@ -229,14 +229,7 @@ export function getUserSettingsPath(): string {
  *
  */
 export function getUserN8nFolderPath(): string {
-	let userFolder;
-	if (process.env[USER_FOLDER_ENV_OVERWRITE] !== undefined) {
-		userFolder = process.env[USER_FOLDER_ENV_OVERWRITE];
-	} else {
-		userFolder = getUserHome();
-	}
-
-	return path.join(userFolder, USER_SETTINGS_SUBFOLDER);
+	return path.join(getUserHome(), USER_SETTINGS_SUBFOLDER);
 }
 
 /**
@@ -264,16 +257,19 @@ export function getUserN8nFolderDownloadedNodesPath(): string {
  *
  */
 export function getUserHome(): string {
-	let variableName = 'HOME';
-	if (process.platform === 'win32') {
-		variableName = 'USERPROFILE';
-	}
+	if (process.env[USER_FOLDER_ENV_OVERWRITE] !== undefined) {
+		return process.env[USER_FOLDER_ENV_OVERWRITE];
+	} else {
+		let variableName = 'HOME';
+		if (process.platform === 'win32') {
+			variableName = 'USERPROFILE';
+		}
 
-	if (process.env[variableName] === undefined) {
-		// If for some reason the variable does not exist
-		// fall back to current folder
-		return process.cwd();
+		if (process.env[variableName] === undefined) {
+			// If for some reason the variable does not exist
+			// fall back to current folder
+			return process.cwd();
+		}
+		return process.env[variableName] as string;
 	}
-
-	return process.env[variableName] as string;
 }


### PR DESCRIPTION
This change 
* creates a temporary "home" folder for each e2e run, giving tests a clean-slate every time. 
* stops loading config from `process.env` and from additional config files defined in `N8N_CONFIG_FILES`
* enables enterprise features explicitly to be able to test them

I explicitly chose not to delete the temporary folder, as it can be helpful for debugging when tests and fail, and since it's all in the OS's temp directory, these folders will get auto-deleted anyways at every restart.