### PR TITLE
fix: Fix default owner e2e tests intermittently failing with detached DOM element

### DIFF
--- a/cypress/pages/sidebar/main-sidebar.ts
+++ b/cypress/pages/sidebar/main-sidebar.ts
@@ -10,6 +10,12 @@ export class MainSidebar extends BasePage {
 	};
 	actions = {
 		goToSettings: () => this.getters.settings().click(),
-		goToCredentials: () => this.getters.credentials().click(),
+		goToCredentials: () =>
+			this.getters
+				.credentials()
+				.should(($el) => {
+					expect(Cypress.dom.isDetached($el)).to.eq(false);
+				})
+				.click(),
 	};
 }


### PR DESCRIPTION
For context: https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/