### PR TITLE
feat: Add dynamic translations. Change how sharing unavailable is handled (no-changelog)

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -1022,6 +1022,10 @@ export interface IModalState {
 	httpNodeParameters?: string;
 }
 
+export interface NestedRecord<T> {
+	[key: string]: T | NestedRecord<T>;
+}
+
 export type IRunDataDisplayMode = 'table' | 'json' | 'binary';
 export type nodePanelType = 'input' | 'output';
 
@@ -1095,6 +1099,7 @@ export interface UIState {
 	currentView: string;
 	mainPanelPosition: number;
 	fakeDoorFeatures: IFakeDoor[];
+	dynamicTranslations: NestedRecord<string>;
 	draggable: {
 		isDragging: boolean;
 		type: string;

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -79,7 +79,7 @@
 						<n8n-tooltip>
 							<n8n-button
 								type="secondary"
-								class="mr-2xs"
+								:class="['mr-2xs', $style.disabledShareButton]"
 							>
 								{{ $locale.baseText('workflowDetails.share') }}
 							</n8n-button>
@@ -572,5 +572,9 @@ $--header-spacing: 20px;
 
 .deleteItem {
 	color: var(--color-danger);
+}
+
+.disabledShareButton {
+	cursor: not-allowed;
 }
 </style>

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -116,7 +116,7 @@ import Vue from "vue";
 import mixins from "vue-typed-mixins";
 import {
 	DUPLICATE_MODAL_KEY,
-	EnterpriseEditionFeature, FAKE_DOOR_FEATURES,
+	EnterpriseEditionFeature,
 	MAX_WORKFLOW_NAME_LENGTH,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	VIEWS, WORKFLOW_MENU_ACTIONS,

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -75,6 +75,25 @@
 					>
 						{{ $locale.baseText('workflowDetails.share') }}
 					</n8n-button>
+					<template #fallback>
+						<n8n-tooltip>
+							<n8n-button
+								type="secondary"
+								class="mr-2xs"
+							>
+								{{ $locale.baseText('workflowDetails.share') }}
+							</n8n-button>
+							<template #content>
+								<i18n :path="dynamicTranslations.workflows.sharing.unavailable.description" tag="span">
+									<template #action>
+										<a :href="dynamicTranslations.workflows.sharing.unavailable.linkURL" target="_blank">
+											{{ $locale.baseText(dynamicTranslations.workflows.sharing.unavailable.action) }}
+										</a>
+									</template>
+								</i18n>
+							</template>
+						</n8n-tooltip>
+					</template>
 				</enterprise-edition>
 				<SaveButton
 					type="secondary"
@@ -97,7 +116,7 @@ import Vue from "vue";
 import mixins from "vue-typed-mixins";
 import {
 	DUPLICATE_MODAL_KEY,
-	EnterpriseEditionFeature,
+	EnterpriseEditionFeature, FAKE_DOOR_FEATURES,
 	MAX_WORKFLOW_NAME_LENGTH,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	VIEWS, WORKFLOW_MENU_ACTIONS,
@@ -114,7 +133,7 @@ import SaveButton from "@/components/SaveButton.vue";
 import TagsDropdown from "@/components/TagsDropdown.vue";
 import InlineTextEdit from "@/components/InlineTextEdit.vue";
 import BreakpointsObserver from "@/components/BreakpointsObserver.vue";
-import {IWorkflowDataUpdate, IWorkflowDb, IWorkflowToShare} from "@/Interface";
+import {IFakeDoor, IWorkflowDataUpdate, IWorkflowDb, IWorkflowToShare, NestedRecord} from "@/Interface";
 
 import { saveAs } from 'file-saver';
 import { titleChange } from "@/mixins/titleChange";
@@ -169,6 +188,9 @@ export default mixins(workflowHelpers, titleChange).extend({
 			useWorkflowsStore,
 			useUsersStore,
 		),
+		dynamicTranslations(): NestedRecord<string> {
+			return this.uiStore.dynamicTranslations;
+		},
 		isWorkflowActive(): boolean {
 			return this.workflowsStore.isWorkflowActive;
 		},
@@ -239,6 +261,9 @@ export default mixins(workflowHelpers, titleChange).extend({
 					},
 				] : []),
 			];
+		},
+		fakeDoor(): IFakeDoor | undefined {
+			return this.uiStore.getFakeDoorById(FAKE_DOOR_FEATURES.WORKFLOWS_SHARING);
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -133,7 +133,7 @@ import SaveButton from "@/components/SaveButton.vue";
 import TagsDropdown from "@/components/TagsDropdown.vue";
 import InlineTextEdit from "@/components/InlineTextEdit.vue";
 import BreakpointsObserver from "@/components/BreakpointsObserver.vue";
-import {IFakeDoor, IWorkflowDataUpdate, IWorkflowDb, IWorkflowToShare, NestedRecord} from "@/Interface";
+import {IWorkflowDataUpdate, IWorkflowDb, IWorkflowToShare, NestedRecord} from "@/Interface";
 
 import { saveAs } from 'file-saver';
 import { titleChange } from "@/mixins/titleChange";
@@ -261,9 +261,6 @@ export default mixins(workflowHelpers, titleChange).extend({
 					},
 				] : []),
 			];
-		},
-		fakeDoor(): IFakeDoor | undefined {
-			return this.uiStore.getFakeDoorById(FAKE_DOOR_FEATURES.WORKFLOWS_SHARING);
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -101,11 +101,10 @@ import Vue from 'vue';
 import Modal from './Modal.vue';
 import {
 	EnterpriseEditionFeature,
-	FAKE_DOOR_FEATURES,
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	WORKFLOW_SHARE_MODAL_KEY,
 } from '../constants';
-import {IFakeDoor, IUser, IWorkflowDb, NestedRecord} from "@/Interface";
+import {IUser, IWorkflowDb, NestedRecord} from "@/Interface";
 import { getWorkflowPermissions, IPermissions } from "@/permissions";
 import mixins from "vue-typed-mixins";
 import {showMessage} from "@/mixins/showMessage";

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -1,7 +1,7 @@
 <template>
 	<Modal
 		width="460px"
-		:title="$locale.baseText(dynamicTranslations.workflows.sharing.unavailable.title, { interpolate: { name: workflow.name } })"
+		:title="$locale.baseText(dynamicTranslations.workflows.shareModal.title, { interpolate: { name: workflow.name } })"
 		:eventBus="modalBus"
 		:name="WORKFLOW_SHARE_MODAL_KEY"
 		:center="true"

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -1,7 +1,7 @@
 <template>
 	<Modal
 		width="460px"
-		:title="$locale.baseText(fakeDoor.actionBoxTitle, { interpolate: { name: workflow.name } })"
+		:title="$locale.baseText(dynamicTranslations.workflows.sharing.unavailable.title, { interpolate: { name: workflow.name } })"
 		:eventBus="modalBus"
 		:name="WORKFLOW_SHARE_MODAL_KEY"
 		:center="true"
@@ -52,7 +52,9 @@
 					</n8n-users-list>
 					<template #fallback>
 						<n8n-text>
-							{{ $locale.baseText(fakeDoor.actionBoxDescription) }}
+							<i18n :path="dynamicTranslations.workflows.sharing.unavailable.description" tag="span">
+								<template #action />
+							</i18n>
 						</n8n-text>
 					</template>
 				</enterprise-edition>
@@ -80,12 +82,12 @@
 				</n8n-button>
 
 				<template #fallback>
-					<n8n-link :to="fakeDoor.linkURL">
+					<n8n-link :to="dynamicTranslations.workflows.sharing.unavailable.linkURL">
 						<n8n-button
 							:loading="loading"
 							size="medium"
 						>
-							{{ $locale.baseText(fakeDoor.actionBoxButtonLabel) }}
+							{{ $locale.baseText(dynamicTranslations.workflows.sharing.unavailable.button) }}
 						</n8n-button>
 					</n8n-link>
 				</template>
@@ -103,7 +105,7 @@ import {
 	PLACEHOLDER_EMPTY_WORKFLOW_ID,
 	WORKFLOW_SHARE_MODAL_KEY,
 } from '../constants';
-import {IFakeDoor, IUser, IWorkflowDb} from "@/Interface";
+import {IFakeDoor, IUser, IWorkflowDb, NestedRecord} from "@/Interface";
 import { getWorkflowPermissions, IPermissions } from "@/permissions";
 import mixins from "vue-typed-mixins";
 import {showMessage} from "@/mixins/showMessage";
@@ -174,8 +176,8 @@ export default mixins(
 		isSharingAvailable(): boolean {
 			return this.settingsStore.isEnterpriseFeatureEnabled(EnterpriseEditionFeature.WorkflowSharing) === true;
 		},
-		fakeDoor(): IFakeDoor | undefined {
-			return this.uiStore.getFakeDoorById(FAKE_DOOR_FEATURES.WORKFLOWS_SHARING);
+		dynamicTranslations(): NestedRecord<string> {
+			return this.uiStore.dynamicTranslations;
 		},
 		isDirty(): boolean {
 			const previousSharedWith = this.workflow.sharedWith || [];

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -489,11 +489,6 @@
 	"fakeDoor.credentialEdit.sharing.actionBox.title.cloud.upgrade": "Upgrade to add users",
 	"fakeDoor.credentialEdit.sharing.actionBox.description.cloud.upgrade": "Power and Pro plan users can create multiple user accounts and share credentials. (Sharing workflows is coming soon)",
 	"fakeDoor.credentialEdit.sharing.actionBox.button.cloud.upgrade": "Upgrade",
-	"fakeDoor.workflowsSharing.title.cloud.upgrade": "Upgrade to add users",
-	"fakeDoor.workflowsSharing.description": "Sharing workflows with others is currently available only on n8n cloud, our hosted offering.",
-	"fakeDoor.workflowsSharing.description.cloud.upgrade": "Power and Pro plan users can create multiple user accounts and share workflows.",
-	"fakeDoor.workflowsSharing.button": "Explore n8n cloud",
-	"fakeDoor.workflowsSharing.button.cloud.upgrade": "Upgrade",
 	"fakeDoor.settings.environments.name": "Environments",
 	"fakeDoor.settings.environments.infoText": "Environments allow you to use different settings and credentials in a workflow when you're building it vs when it's running in production",
 	"fakeDoor.settings.environments.actionBox.title": "We’re working on environments (as a paid feature)",
@@ -1404,5 +1399,14 @@
 	"importParameter.showError.invalidCurlCommand.message": "This command is in an unsupported format",
 	"importParameter.showError.invalidProtocol1.title": "Use the {node} node",
 	"importParameter.showError.invalidProtocol2.title": "Invalid Protocol",
-	"importParameter.showError.invalidProtocol.message": "The HTTP node doesn’t support {protocol} requests"
+	"importParameter.showError.invalidProtocol.message": "The HTTP node doesn’t support {protocol} requests",
+	"dynamic.workflows.shareModal.title": "Share '{name}'",
+	"dynamic.workflows.shareModal.title.cloud.upgrade": "Upgrade to add users",
+	"dynamic.workflows.sharing.unavailable.description": "Sharing workflows with others is currently available only on n8n cloud, our hosted offering. {action}",
+	"dynamic.workflows.sharing.unavailable.description.cloud.upgrade": "Sharing is available for Team and Enterprise plans. {action} to unlock more features.",
+	"dynamic.workflows.sharing.unavailable.action": "Explore n8n cloud",
+	"dynamic.workflows.sharing.unavailable.action.cloud.upgrade": "Upgrade now",
+	"dynamic.workflows.sharing.unavailable.button": "Explore n8n cloud",
+	"dynamic.workflows.sharing.unavailable.button.cloud.upgrade": "Upgrade now",
+	"dynamic.workflows.sharing.unavailable.linkUrl": "https://n8n.cloud"
 }

--- a/packages/editor-ui/src/stores/ui.ts
+++ b/packages/editor-ui/src/stores/ui.ts
@@ -163,9 +163,11 @@ export const useUIStore = defineStore(STORES.UI, {
 		],
 		dynamicTranslations: {
 			workflows: {
+				shareModal: {
+					title: 'dynamic.workflows.shareModal.title',
+				},
 				sharing: {
 					unavailable: {
-						title: 'dynamic.workflows.shareModal.title',
 						description: 'dynamic.workflows.sharing.unavailable.description',
 						action: 'dynamic.workflows.sharing.unavailable.action',
 						button: 'dynamic.workflows.sharing.unavailable.button',

--- a/packages/editor-ui/src/stores/ui.ts
+++ b/packages/editor-ui/src/stores/ui.ts
@@ -161,6 +161,19 @@ export const useUIStore = defineStore(STORES.UI, {
 				uiLocations: ['workflowShareModal'],
 			},
 		],
+		dynamicTranslations: {
+			workflows: {
+				sharing: {
+					unavailable: {
+						title: 'dynamic.workflows.shareModal.title',
+						description: 'dynamic.workflows.sharing.unavailable.description',
+						action: 'dynamic.workflows.sharing.unavailable.action',
+						button: 'dynamic.workflows.sharing.unavailable.button',
+						linkURL: 'https://n8n.cloud',
+					},
+				},
+			},
+		},
 		draggable: {
 			isDragging: false,
 			type: '',

--- a/packages/editor-ui/src/stores/webhooks.ts
+++ b/packages/editor-ui/src/stores/webhooks.ts
@@ -1,5 +1,5 @@
 import { STORES } from "@/constants";
-import { IFakeDoor, INodeUi, IRootState } from "@/Interface";
+import {IFakeDoor, INodeUi, IRootState, NestedRecord} from "@/Interface";
 import { IMenuItem } from "n8n-design-system";
 import { IWorkflowSettings } from "n8n-workflow";
 import { defineStore } from "pinia";
@@ -14,6 +14,9 @@ export const useWebhooksStore = defineStore(STORES.WEBHOOKS, {
 	getters: {
 		globalRoleName(): string {
 			return useUsersStore().globalRoleName;
+		},
+		getDynamicTranslations () {
+			return useUIStore().dynamicTranslations;
 		},
 		getFakeDoorFeatures () {
 			return useUIStore().fakeDoorFeatures;
@@ -60,6 +63,9 @@ export const useWebhooksStore = defineStore(STORES.WEBHOOKS, {
 		},
 		setFakeDoorFeatures(fakeDoors: IFakeDoor[]): void {
 			useUIStore().fakeDoorFeatures = fakeDoors;
+		},
+		setDynamicTranslations(translations: NestedRecord<string>): void {
+			useUIStore().dynamicTranslations = translations;
 		},
 	},
 });


### PR DESCRIPTION
Self-hosted:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/6179477/204524832-120d468b-8d49-4a51-b9a2-ba4b2131141a.png">
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/6179477/204525161-67713393-201f-4679-8c8e-ac46b3247af6.png">

Cloud, no UM:
<img width="334" alt="image" src="https://user-images.githubusercontent.com/6179477/204524998-aaa2371d-dc83-4b97-9775-1c1c9b32fd2d.png">
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/6179477/204525092-272cf5f8-0354-4192-bc4d-e6d6a83eb9e4.png">

Cloud, with sharing:
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/6179477/204525477-6f95b72a-c095-4976-94cf-ed0c588c9662.png">

