### PR TITLE
fix: Credential overwrites should take precedence over credential default values

### DIFF
--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -358,9 +358,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 
 	/**
 	 * Applies credential default data and overwrites
-	 *
-	 * @param {ICredentialDataDecryptedObject} decryptedDataOriginal The credential data to overwrite data on
-	 * @param {string} type  Type of the credentials to overwrite data of
 	 */
 	applyDefaultsAndOverwrites(
 		decryptedDataOriginal: ICredentialDataDecryptedObject,
@@ -371,10 +368,13 @@ export class CredentialsHelper extends ICredentialsHelper {
 	): ICredentialDataDecryptedObject {
 		const credentialsProperties = this.getCredentialsProperties(type);
 
+		// Load and apply the credentials overwrites if any exist
+		const dataWithOverwrites = CredentialsOverwrites().applyOverwrite(type, decryptedDataOriginal);
+
 		// Add the default credential values
 		let decryptedData = NodeHelpers.getNodeParameters(
 			credentialsProperties,
-			decryptedDataOriginal as INodeParameters,
+			dataWithOverwrites as INodeParameters,
 			true,
 			false,
 			null,
@@ -431,10 +431,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 			) as ICredentialDataDecryptedObject;
 		}
 
-		// Load and apply the credentials overwrites if any exist
-		const credentialsOverwrites = CredentialsOverwrites();
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return credentialsOverwrites.applyOverwrite(type, decryptedData);
+		return decryptedData;
 	}
 
 	/**

--- a/packages/cli/src/CredentialsOverwrites.ts
+++ b/packages/cli/src/CredentialsOverwrites.ts
@@ -51,7 +51,6 @@ class CredentialsOverwritesClass {
 			}
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 		return returnData;
 	}
 
@@ -74,7 +73,6 @@ class CredentialsOverwritesClass {
 		}
 
 		const overwrites: ICredentialDataDecryptedObject = {};
-		// eslint-disable-next-line no-restricted-syntax
 		for (const credentialsTypeName of credentialTypeData.extends) {
 			Object.assign(overwrites, this.getOverwrites(credentialsTypeName));
 		}


### PR DESCRIPTION
currently if we have a non-falsey value in a credential defaults, overwrites don't apply for that field. So the overwrites are working only for null, undefined, and ''. 

fixes  #4781 