### PR TITLE
refactor(core): Introduce overload for string-type node parameter (no-changelog)

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -105,7 +105,7 @@ const items = this.getInputData();
 
 for (const i = 0; i < items.length; i++) {
 	const item = items[i].binary as IBinaryKeyData;
-	const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+	const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 	const binaryData = item[binaryPropertyName] as IBinaryData;
 	// Before 0.135.0:
 	const binaryDataBuffer = Buffer.from(binaryData.data, BINARY_ENCODING);

--- a/packages/nodes-base/nodes/ActionNetwork/ActionNetwork.node.ts
+++ b/packages/nodes-base/nodes/ActionNetwork/ActionNetwork.node.ts
@@ -36,14 +36,7 @@ import {
 	tagOperations,
 } from './descriptions';
 
-import {
-	AllFieldsUi,
-	EmailAddressUi,
-	Operation,
-	PersonResponse,
-	Resource,
-	Response,
-} from './types';
+import { AllFieldsUi, EmailAddressUi, PersonResponse, Response } from './types';
 
 export class ActionNetwork implements INodeType {
 	description: INodeTypeDescription = {
@@ -128,8 +121,8 @@ export class ActionNetwork implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as Resource;
-		const operation = this.getNodeParameter('operation', 0) as Operation;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let response;
 

--- a/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
@@ -12,7 +12,6 @@ import {
 	LinksFieldContainer,
 	PersonResponse,
 	PetitionResponse,
-	Resource,
 	Response,
 } from './types';
 
@@ -258,7 +257,7 @@ export const resourceLoaders = {
 //          response simplifiers
 // ----------------------------------------
 
-export const simplifyResponse = (response: Response, resource: Resource) => {
+export const simplifyResponse = (response: Response, resource: string) => {
 	if (resource === 'person') {
 		return simplifyPersonResponse(response as PersonResponse);
 	} else if (resource === 'petition') {

--- a/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
@@ -327,8 +327,8 @@ export class ActiveCampaign implements INodeType {
 		for (let i = 0; i < items.length; i++) {
 			try {
 				dataKey = undefined;
-				resource = this.getNodeParameter('resource', 0) as string;
-				operation = this.getNodeParameter('operation', 0) as string;
+				resource = this.getNodeParameter('resource', 0);
+				operation = this.getNodeParameter('operation', 0);
 
 				requestMethod = 'GET';
 				endpoint = '';
@@ -739,10 +739,10 @@ export class ActiveCampaign implements INodeType {
 						endpoint = '/api/3/deals';
 
 						body.deal = {
-							title: this.getNodeParameter('title', i) as string,
+							title: this.getNodeParameter('title', i),
 							contact: this.getNodeParameter('contact', i) as string,
 							value: this.getNodeParameter('value', i) as number,
-							currency: this.getNodeParameter('currency', i) as string,
+							currency: this.getNodeParameter('currency', i),
 						} as IDataObject;
 
 						const group = this.getNodeParameter('group', i) as string;
@@ -858,8 +858,8 @@ export class ActiveCampaign implements INodeType {
 							service: this.getNodeParameter('service', i) as string,
 							externalid: this.getNodeParameter('externalid', i) as string,
 							name: this.getNodeParameter('name', i) as string,
-							logoUrl: this.getNodeParameter('logoUrl', i) as string,
-							linkUrl: this.getNodeParameter('linkUrl', i) as string,
+							logoUrl: this.getNodeParameter('logoUrl', i),
+							linkUrl: this.getNodeParameter('linkUrl', i),
 						} as IDataObject;
 					} else if (operation === 'update') {
 						// ----------------------------------
@@ -929,11 +929,11 @@ export class ActiveCampaign implements INodeType {
 						endpoint = '/api/3/ecomOrders';
 
 						body.ecomOrder = {
-							source: this.getNodeParameter('source', i) as string,
+							source: this.getNodeParameter('source', i),
 							email: this.getNodeParameter('email', i) as string,
 							totalPrice: this.getNodeParameter('totalPrice', i) as number,
-							currency: this.getNodeParameter('currency', i)!.toString().toUpperCase() as string,
-							externalCreatedDate: this.getNodeParameter('externalCreatedDate', i) as string,
+							currency: this.getNodeParameter('currency', i).toUpperCase(),
+							externalCreatedDate: this.getNodeParameter('externalCreatedDate', i),
 							connectionid: this.getNodeParameter('connectionid', i) as number,
 							customerid: this.getNodeParameter('customerid', i) as number,
 						} as IDataObject;
@@ -948,7 +948,7 @@ export class ActiveCampaign implements INodeType {
 							addAdditionalFields(body.ecomOrder as IDataObject, { externalcheckoutid });
 						}
 
-						const abandonedDate = this.getNodeParameter('abandonedDate', i) as string;
+						const abandonedDate = this.getNodeParameter('abandonedDate', i);
 						if (abandonedDate !== '') {
 							addAdditionalFields(body.ecomOrder as IDataObject, { abandonedDate });
 						}

--- a/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTrigger.node.ts
+++ b/packages/nodes-base/nodes/AcuityScheduling/AcuitySchedulingTrigger.node.ts
@@ -130,7 +130,7 @@ export class AcuitySchedulingTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const endpoint = '/webhooks';
 				const body: IDataObject = {
 					target: webhookUrl,

--- a/packages/nodes-base/nodes/Affinity/Affinity.node.ts
+++ b/packages/nodes-base/nodes/Affinity/Affinity.node.ts
@@ -150,8 +150,8 @@ export class Affinity implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'list') {
@@ -240,8 +240,8 @@ export class Affinity implements INodeType {
 				if (resource === 'person') {
 					//https://api-docs.affinity.co/#create-a-new-person
 					if (operation === 'create') {
-						const firstName = this.getNodeParameter('firstName', i) as string;
-						const lastName = this.getNodeParameter('lastName', i) as string;
+						const firstName = this.getNodeParameter('firstName', i);
+						const lastName = this.getNodeParameter('lastName', i);
 						const emails = this.getNodeParameter('emails', i) as string[];
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IPerson = {

--- a/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
+++ b/packages/nodes-base/nodes/AgileCrm/AgileCrm.node.ts
@@ -93,8 +93,8 @@ export class AgileCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			if (resource === 'contact' || resource === 'company') {
@@ -546,7 +546,7 @@ export class AgileCrm implements INodeType {
 					} else {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-						body.close_date = new Date(this.getNodeParameter('closeDate', i) as string).getTime();
+						body.close_date = new Date(this.getNodeParameter('closeDate', i)).getTime();
 						body.expected_value = this.getNodeParameter('expectedValue', i) as number;
 						body.milestone = this.getNodeParameter('milestone', i) as string;
 						body.probability = this.getNodeParameter('probability', i) as number;

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -493,7 +493,7 @@ export class Airtable implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		const application = this.getNodeParameter('application', 0, undefined, {
 			extractValue: true,

--- a/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
@@ -346,8 +346,8 @@ export class ApiTemplateIo implements INodeType {
 
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'account') {
 			// *********************************************************************
@@ -436,7 +436,7 @@ export class ApiTemplateIo implements INodeType {
 						responseData = await apiTemplateIoApiRequest.call(this, 'POST', '/create', qs, body);
 
 						if (download === true) {
-							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryProperty = this.getNodeParameter('binaryProperty', i);
 							const data = await downloadImage.call(this, responseData.download_url);
 							const fileName = responseData.download_url.split('/').pop();
 							const binaryData = await this.helpers.prepareBinaryData(
@@ -520,7 +520,7 @@ export class ApiTemplateIo implements INodeType {
 						responseData = await apiTemplateIoApiRequest.call(this, 'POST', '/create', qs, data);
 
 						if (download === true) {
-							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryProperty = this.getNodeParameter('binaryProperty', i);
 							const data = await downloadImage.call(this, responseData.download_url);
 							const fileName = responseData.download_url.split('/').pop();
 							const binaryData = await this.helpers.prepareBinaryData(

--- a/packages/nodes-base/nodes/Asana/Asana.node.ts
+++ b/packages/nodes-base/nodes/Asana/Asana.node.ts
@@ -1911,8 +1911,8 @@ export class Asana implements INodeType {
 		const returnData: IDataObject[] = [];
 		const timezone = this.getTimezone();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let requestMethod: IHttpRequestMethods = 'GET';
@@ -2137,9 +2137,9 @@ export class Asana implements INodeType {
 						const isTextHtml = this.getNodeParameter('isTextHtml', i) as boolean;
 
 						if (!isTextHtml) {
-							body.text = this.getNodeParameter('text', i) as string;
+							body.text = this.getNodeParameter('text', i);
 						} else {
-							body.html_text = this.getNodeParameter('text', i) as string;
+							body.html_text = this.getNodeParameter('text', i);
 						}
 
 						requestMethod = 'POST';

--- a/packages/nodes-base/nodes/Automizy/Automizy.node.ts
+++ b/packages/nodes-base/nodes/Automizy/Automizy.node.ts
@@ -125,8 +125,8 @@ export class Automizy implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'contact') {
 				if (operation === 'create') {

--- a/packages/nodes-base/nodes/Autopilot/Autopilot.node.ts
+++ b/packages/nodes-base/nodes/Autopilot/Autopilot.node.ts
@@ -121,8 +121,8 @@ export class Autopilot implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {

--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -247,7 +247,7 @@ export class AwsSns implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -306,7 +306,7 @@ export class AwsSns implements INodeType {
 					const params = [
 						('TopicArn=' + topic) as string,
 						('Subject=' + this.getNodeParameter('subject', i)) as string,
-						('Message=' + this.getNodeParameter('message', i)) as string,
+						'Message=' + this.getNodeParameter('message', i),
 					];
 
 					const responseData = await awsApiRequestSOAP.call(

--- a/packages/nodes-base/nodes/Aws/CertificateManager/AwsCertificateManager.node.ts
+++ b/packages/nodes-base/nodes/Aws/CertificateManager/AwsCertificateManager.node.ts
@@ -51,8 +51,8 @@ export class AwsCertificateManager implements INodeType {
 		const returnData: IDataObject[] = [];
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'certificate') {

--- a/packages/nodes-base/nodes/Aws/Comprehend/AwsComprehend.node.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/AwsComprehend.node.ts
@@ -191,14 +191,14 @@ export class AwsComprehend implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'text') {
 					//https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectDominantLanguage.html
 					if (operation === 'detectDominantLanguage') {
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const simple = this.getNodeParameter('simple', i) as boolean;
 
 						const body: IDataObject = {
@@ -228,7 +228,7 @@ export class AwsComprehend implements INodeType {
 					//https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectSentiment.html
 					if (operation === 'detectSentiment') {
 						const action = 'Comprehend_20171127.DetectSentiment';
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const languageCode = this.getNodeParameter('languageCode', i) as string;
 						const body: IDataObject = {
 							Text: text,
@@ -247,7 +247,7 @@ export class AwsComprehend implements INodeType {
 					//https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectEntities.html
 					if (operation === 'detectEntities') {
 						const action = 'Comprehend_20171127.DetectEntities';
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const languageCode = this.getNodeParameter('languageCode', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/AwsDynamoDB.node.ts
@@ -120,7 +120,7 @@ export class AwsDynamoDB implements INodeType {
 						) as IAttributeNameUi[];
 
 						const body: IRequestBody = {
-							TableName: this.getNodeParameter('tableName', i) as string,
+							TableName: this.getNodeParameter('tableName', i),
 						};
 
 						const expressionAttributeValues = adjustExpressionAttributeValues(eavUi);
@@ -177,7 +177,7 @@ export class AwsDynamoDB implements INodeType {
 
 						// tslint:disable-next-line: no-any
 						const body: { [key: string]: any } = {
-							TableName: this.getNodeParameter('tableName', i) as string,
+							TableName: this.getNodeParameter('tableName', i),
 							Key: {},
 							ReturnValues: this.getNodeParameter('returnValues', 0) as string,
 						};
@@ -242,7 +242,7 @@ export class AwsDynamoDB implements INodeType {
 
 						// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html
 
-						const tableName = this.getNodeParameter('tableName', 0) as string;
+						const tableName = this.getNodeParameter('tableName', 0);
 						const simple = this.getNodeParameter('simple', 0, false) as boolean;
 						const select = this.getNodeParameter('select', 0) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -316,7 +316,7 @@ export class AwsDynamoDB implements INodeType {
 						) as IAttributeNameUi[];
 
 						const body: IRequestBody = {
-							TableName: this.getNodeParameter('tableName', i) as string,
+							TableName: this.getNodeParameter('tableName', i),
 						};
 
 						if (scan === true) {

--- a/packages/nodes-base/nodes/Aws/ELB/AwsElb.node.ts
+++ b/packages/nodes-base/nodes/Aws/ELB/AwsElb.node.ts
@@ -218,8 +218,8 @@ export class AwsElb implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Aws/Rekognition/AwsRekognition.node.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/AwsRekognition.node.ts
@@ -335,8 +335,8 @@ export class AwsRekognition implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'image') {
@@ -415,7 +415,7 @@ export class AwsRekognition implements INodeType {
 							const binaryData = this.getNodeParameter('binaryData', 0);
 
 							if (binaryData) {
-								const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+								const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 								if (items[i].binary === undefined) {
 									throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {

--- a/packages/nodes-base/nodes/Aws/S3/AwsS3.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/AwsS3.node.ts
@@ -87,8 +87,8 @@ export class AwsS3 implements INodeType {
 		const returnData: IDataObject[] = [];
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			const headers: IDataObject = {};
 			try {
@@ -199,7 +199,7 @@ export class AwsS3 implements INodeType {
 
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'search') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const additionalFields = this.getNodeParameter('additionalFields', 0);
 
@@ -273,8 +273,8 @@ export class AwsS3 implements INodeType {
 				if (resource === 'folder') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'create') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
-						const folderName = this.getNodeParameter('folderName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
+						const folderName = this.getNodeParameter('folderName', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						let path = `/${folderName}/`;
 
@@ -310,7 +310,7 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 					if (operation === 'delete') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const folderKey = this.getNodeParameter('folderKey', i) as string;
 
 						responseData = await awsApiRequestSOAP.call(this, `${bucketName}.s3`, 'GET', '', '', {
@@ -390,7 +390,7 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0) as IDataObject;
 
@@ -453,8 +453,8 @@ export class AwsS3 implements INodeType {
 				if (resource === 'file') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
 					if (operation === 'copy') {
-						const sourcePath = this.getNodeParameter('sourcePath', i) as string;
-						const destinationPath = this.getNodeParameter('destinationPath', i) as string;
+						const sourcePath = this.getNodeParameter('sourcePath', i);
+						const destinationPath = this.getNodeParameter('destinationPath', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						headers['x-amz-copy-source'] = sourcePath;
@@ -558,7 +558,7 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 					if (operation === 'download') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -623,7 +623,7 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
 					if (operation === 'delete') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -655,7 +655,7 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0) as IDataObject;
 
@@ -718,8 +718,8 @@ export class AwsS3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'upload') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
-						const fileName = this.getNodeParameter('fileName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
+						const fileName = this.getNodeParameter('fileName', i);
 						const isBinaryData = this.getNodeParameter('binaryData', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const tagsValues = (this.getNodeParameter('tagsUi', i) as IDataObject)
@@ -806,7 +806,7 @@ export class AwsS3 implements INodeType {
 						const region = responseData.LocationConstraint._;
 
 						if (isBinaryData) {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 							if (items[i].binary === undefined) {
 								throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {

--- a/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
+++ b/packages/nodes-base/nodes/Aws/SES/AwsSes.node.ts
@@ -828,8 +828,8 @@ export class AwsSes implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -849,7 +849,7 @@ export class AwsSes implements INodeType {
 
 						const templateContent = this.getNodeParameter('templateContent', i) as string;
 
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const templateSubject = this.getNodeParameter('templateSubject', i) as string;
 
@@ -875,7 +875,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'delete') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const params = [
 							`Action=DeleteCustomVerificationEmailTemplate`,
@@ -894,7 +894,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'get') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const params = [`TemplateName=${templateName}`];
 
@@ -939,7 +939,7 @@ export class AwsSes implements INodeType {
 					if (operation === 'send') {
 						const email = this.getNodeParameter('email', i) as string[];
 
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
@@ -965,7 +965,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'update') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const updateFields = this.getNodeParameter('updateFields', i);
 
@@ -1092,7 +1092,7 @@ export class AwsSes implements INodeType {
 					if (operation === 'sendTemplate') {
 						const toAddresses = this.getNodeParameter('toAddresses', i) as string[];
 
-						const template = this.getNodeParameter('templateName', i) as string;
+						const template = this.getNodeParameter('templateName', i);
 
 						const fromEmail = this.getNodeParameter('fromEmail', i) as string;
 
@@ -1178,7 +1178,7 @@ export class AwsSes implements INodeType {
 
 				if (resource === 'template') {
 					if (operation === 'create') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const subjectPart = this.getNodeParameter('subjectPart', i) as string;
 
@@ -1207,7 +1207,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'delete') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const params = [`TemplateName=${templateName}`];
 
@@ -1222,7 +1222,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'get') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const params = [`TemplateName=${templateName}`];
 
@@ -1263,7 +1263,7 @@ export class AwsSes implements INodeType {
 					}
 
 					if (operation === 'update') {
-						const templateName = this.getNodeParameter('templateName', i) as string;
+						const templateName = this.getNodeParameter('templateName', i);
 
 						const updateFields = this.getNodeParameter('updateFields', i);
 

--- a/packages/nodes-base/nodes/Aws/SQS/AwsSqs.node.ts
+++ b/packages/nodes-base/nodes/Aws/SQS/AwsSqs.node.ts
@@ -290,7 +290,7 @@ export class AwsSqs implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -304,7 +304,7 @@ export class AwsSqs implements INodeType {
 
 				const message = sendInputData
 					? JSON.stringify(items[i].json)
-					: (this.getNodeParameter('message', i) as string);
+					: this.getNodeParameter('message', i);
 				params.push(`MessageBody=${message}`);
 
 				if (options.delaySeconds) {

--- a/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/AwsTextract.node.ts
@@ -115,12 +115,12 @@ export class AwsTextract implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				//https://docs.aws.amazon.com/textract/latest/dg/API_AnalyzeExpense.html
 				if (operation === 'analyzeExpense') {
-					const binaryProperty = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryProperty = this.getNodeParameter('binaryPropertyName', i);
 					const simple = this.getNodeParameter('simple', i) as boolean;
 
 					if (items[i].binary === undefined) {

--- a/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/AwsTranscribe.node.ts
@@ -355,14 +355,14 @@ export class AwsTranscribe implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'transcriptionJob') {
 					//https://docs.aws.amazon.com/comprehend/latest/dg/API_DetectDominantLanguage.html
 					if (operation === 'create') {
-						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i) as string;
+						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i);
 						const mediaFileUri = this.getNodeParameter('mediaFileUri', i) as string;
 						const detectLang = this.getNodeParameter('detectLanguage', i) as boolean;
 
@@ -435,7 +435,7 @@ export class AwsTranscribe implements INodeType {
 					}
 					//https://docs.aws.amazon.com/transcribe/latest/dg/API_DeleteTranscriptionJob.html
 					if (operation === 'delete') {
-						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i) as string;
+						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i);
 
 						const body: IDataObject = {
 							TranscriptionJobName: transcriptionJobName,
@@ -454,7 +454,7 @@ export class AwsTranscribe implements INodeType {
 					}
 					//https://docs.aws.amazon.com/transcribe/latest/dg/API_GetTranscriptionJob.html
 					if (operation === 'get') {
-						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i) as string;
+						const transcriptionJobName = this.getNodeParameter('transcriptionJobName', i);
 						const resolve = this.getNodeParameter('returnTranscript', 0) as boolean;
 
 						const body: IDataObject = {

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employee/create/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employee/create/execute.ts
@@ -17,8 +17,8 @@ export async function create(
 	const endpoint = 'employees';
 
 	//body parameters
-	body.firstName = this.getNodeParameter('firstName', index) as string;
-	body.lastName = this.getNodeParameter('lastName', index) as string;
+	body.firstName = this.getNodeParameter('firstName', index);
+	body.lastName = this.getNodeParameter('lastName', index);
 
 	const additionalFields = this.getNodeParameter('additionalFields', index);
 	const synced = this.getNodeParameter('synced', index) as boolean;
@@ -36,13 +36,13 @@ export async function create(
 		body.employeeNumber = this.getNodeParameter('employeeNumber', index) as string;
 		body.exempt = this.getNodeParameter('exempt', index) as string;
 		body.gender = this.getNodeParameter('gender', index) as string;
-		body.hireDate = this.getNodeParameter('hireDate', index) as string;
+		body.hireDate = this.getNodeParameter('hireDate', index);
 		body.location = this.getNodeParameter('location', index) as string;
 		body.maritalStatus = this.getNodeParameter('maritalStatus', index) as string;
 		body.mobilePhone = this.getNodeParameter('mobilePhone', index) as string;
 		body.paidPer = this.getNodeParameter('paidPer', index) as string;
 		body.payType = this.getNodeParameter('payType', index) as string;
-		body.preferredName = this.getNodeParameter('preferredName', index) as string;
+		body.preferredName = this.getNodeParameter('preferredName', index);
 		body.ssn = this.getNodeParameter('ssn', index) as string;
 	} else {
 		Object.assign(body, {

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employee/update/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employee/update/execute.ts
@@ -34,21 +34,21 @@ export async function update(
 		Object.assign(body, {
 			payRate: this.getNodeParameter('payRate.value', index, {}) as IDataObject,
 		});
-		body.firstName = this.getNodeParameter('firstName', index) as string;
-		body.lastName = this.getNodeParameter('lastName', index) as string;
+		body.firstName = this.getNodeParameter('firstName', index);
+		body.lastName = this.getNodeParameter('lastName', index);
 		body.department = this.getNodeParameter('department', index) as string;
 		body.dateOfBirth = this.getNodeParameter('dateOfBirth', index) as string;
 		body.division = this.getNodeParameter('division', index) as string;
 		body.employeeNumber = this.getNodeParameter('employeeNumber', index) as string;
 		body.exempt = this.getNodeParameter('exempt', index) as string;
 		body.gender = this.getNodeParameter('gender', index) as string;
-		body.hireDate = this.getNodeParameter('hireDate', index) as string;
+		body.hireDate = this.getNodeParameter('hireDate', index);
 		body.location = this.getNodeParameter('location', index) as string;
 		body.maritalStatus = this.getNodeParameter('maritalStatus', index) as string;
 		body.mobilePhone = this.getNodeParameter('mobilePhone', index) as string;
 		body.paidPer = this.getNodeParameter('paidPer', index) as string;
 		body.payType = this.getNodeParameter('payType', index) as string;
-		body.preferredName = this.getNodeParameter('preferredName', index) as string;
+		body.preferredName = this.getNodeParameter('preferredName', index);
 		body.ssn = this.getNodeParameter('ssn', index) as string;
 	} else {
 		if (!Object.keys(updateFields).length) {

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/upload/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/employeeDocument/upload/execute.ts
@@ -19,7 +19,7 @@ export async function upload(this: IExecuteFunctions, index: number) {
 		});
 	}
 
-	const propertyNameUpload = this.getNodeParameter('binaryPropertyName', index) as string;
+	const propertyNameUpload = this.getNodeParameter('binaryPropertyName', index);
 
 	if (items[index]!.binary![propertyNameUpload] === undefined) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/BambooHr/v1/actions/file/upload/execute.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/actions/file/upload/execute.ts
@@ -19,7 +19,7 @@ export async function upload(this: IExecuteFunctions, index: number) {
 		});
 	}
 
-	const propertyNameUpload = this.getNodeParameter('binaryPropertyName', index) as string;
+	const propertyNameUpload = this.getNodeParameter('binaryPropertyName', index);
 
 	if (items[index]!.binary![propertyNameUpload] === undefined) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Bannerbear/Bannerbear.node.ts
+++ b/packages/nodes-base/nodes/Bannerbear/Bannerbear.node.ts
@@ -109,8 +109,8 @@ export class Bannerbear implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'image') {
 				//https://developers.bannerbear.com/#create-an-image

--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.ts
@@ -296,14 +296,14 @@ export class Beeminder implements INodeType {
 		const length = items.length;
 		const timezone = this.getTimezone();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let results;
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'datapoint') {
-					const goalName = this.getNodeParameter('goalName', i) as string;
+					const goalName = this.getNodeParameter('goalName', i);
 					if (operation === 'create') {
 						const value = this.getNodeParameter('value', i) as number;
 						const options = this.getNodeParameter('additionalFields', i) as INodeParameters;

--- a/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
+++ b/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
@@ -252,7 +252,7 @@ export class BitbucketTrigger implements INodeType {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				let endpoint = '';
-				const resource = this.getNodeParameter('resource', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
 				const workspace = this.getNodeParameter('workspace', 0) as string;
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
@@ -278,7 +278,7 @@ export class BitbucketTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const events = this.getNodeParameter('events') as string[];
-				const resource = this.getNodeParameter('resource', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
 				const workspace = this.getNodeParameter('workspace', 0) as string;
 
 				if (resource === 'workspace') {
@@ -302,7 +302,7 @@ export class BitbucketTrigger implements INodeType {
 				let endpoint = '';
 				const webhookData = this.getWorkflowStaticData('node');
 				const workspace = this.getNodeParameter('workspace', 0) as string;
-				const resource = this.getNodeParameter('resource', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
 				if (resource === 'workspace') {
 					endpoint = `/workspaces/${workspace}/hooks/${webhookData.webhookId}`;
 				}

--- a/packages/nodes-base/nodes/Bitly/Bitly.node.ts
+++ b/packages/nodes-base/nodes/Bitly/Bitly.node.ts
@@ -128,13 +128,13 @@ export class Bitly implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'link') {
 					if (operation === 'create') {
-						const longUrl = this.getNodeParameter('longUrl', i) as string;
+						const longUrl = this.getNodeParameter('longUrl', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
 							long_url: longUrl,

--- a/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
+++ b/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
@@ -112,8 +112,8 @@ export class Bitwarden implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/Box/Box.node.ts
+++ b/packages/nodes-base/nodes/Box/Box.node.ts
@@ -72,8 +72,8 @@ export class Box implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const timezone = this.getTimezone();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'file') {
@@ -171,7 +171,7 @@ export class Box implements INodeType {
 					}
 					// https://developer.box.com/reference/get-search/
 					if (operation === 'search') {
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const timezone = this.getTimezone();
@@ -268,7 +268,7 @@ export class Box implements INodeType {
 					if (operation === 'upload') {
 						const parentId = this.getNodeParameter('parentId', i) as string;
 						const isBinaryData = this.getNodeParameter('binaryData', i);
-						const fileName = this.getNodeParameter('fileName', i) as string;
+						const fileName = this.getNodeParameter('fileName', i);
 
 						const attributes: IDataObject = {};
 
@@ -280,7 +280,7 @@ export class Box implements INodeType {
 						}
 
 						if (isBinaryData) {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 							if (items[i].binary === undefined) {
 								throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {
@@ -405,7 +405,7 @@ export class Box implements INodeType {
 					}
 					// https://developer.box.com/reference/get-search/
 					if (operation === 'search') {
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const timezone = this.getTimezone();

--- a/packages/nodes-base/nodes/Brandfetch/Brandfetch.node.ts
+++ b/packages/nodes-base/nodes/Brandfetch/Brandfetch.node.ts
@@ -145,7 +145,7 @@ export class Brandfetch implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		const responseData: INodeExecutionData[] = [];
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Bubble/Bubble.node.ts
+++ b/packages/nodes-base/nodes/Bubble/Bubble.node.ts
@@ -54,8 +54,8 @@ export class Bubble implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const qs: IDataObject = {};
@@ -74,7 +74,7 @@ export class Bubble implements INodeType {
 					//         object: create
 					// ----------------------------------
 
-					const typeNameInput = this.getNodeParameter('typeName', i) as string;
+					const typeNameInput = this.getNodeParameter('typeName', i);
 					const typeName = typeNameInput.replace(/\s/g, '').toLowerCase();
 
 					const { property } = this.getNodeParameter('properties', i) as {
@@ -91,7 +91,7 @@ export class Bubble implements INodeType {
 					//         object: delete
 					// ----------------------------------
 
-					const typeNameInput = this.getNodeParameter('typeName', i) as string;
+					const typeNameInput = this.getNodeParameter('typeName', i);
 					const typeName = typeNameInput.replace(/\s/g, '').toLowerCase();
 					const objectId = this.getNodeParameter('objectId', i) as string;
 
@@ -103,7 +103,7 @@ export class Bubble implements INodeType {
 					//         object: get
 					// ----------------------------------
 
-					const typeNameInput = this.getNodeParameter('typeName', i) as string;
+					const typeNameInput = this.getNodeParameter('typeName', i);
 					const typeName = typeNameInput.replace(/\s/g, '').toLowerCase();
 					const objectId = this.getNodeParameter('objectId', i) as string;
 
@@ -116,7 +116,7 @@ export class Bubble implements INodeType {
 					// ----------------------------------
 
 					const returnAll = this.getNodeParameter('returnAll', 0);
-					const typeNameInput = this.getNodeParameter('typeName', i) as string;
+					const typeNameInput = this.getNodeParameter('typeName', i);
 					const typeName = typeNameInput.replace(/\s/g, '').toLowerCase();
 
 					const endpoint = `/obj/${typeName}`;
@@ -157,7 +157,7 @@ export class Bubble implements INodeType {
 					//         object: update
 					// ----------------------------------
 
-					const typeNameInput = this.getNodeParameter('typeName', i) as string;
+					const typeNameInput = this.getNodeParameter('typeName', i);
 					const typeName = typeNameInput.replace(/\s/g, '').toLowerCase();
 					const objectId = this.getNodeParameter('objectId', i) as string;
 					const endpoint = `/obj/${typeName}/${objectId}`;

--- a/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
+++ b/packages/nodes-base/nodes/Chargebee/Chargebee.node.ts
@@ -462,8 +462,8 @@ export class Chargebee implements INodeType {
 		for (let i = 0; i < items.length; i++) {
 			try {
 				_item = items[i];
-				const resource = this.getNodeParameter('resource', i) as string;
-				const operation = this.getNodeParameter('operation', i) as string;
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 
 				let requestMethod = 'GET';
 				let endpoint = '';

--- a/packages/nodes-base/nodes/CircleCi/CircleCi.node.ts
+++ b/packages/nodes-base/nodes/CircleCi/CircleCi.node.ts
@@ -52,15 +52,15 @@ export class CircleCi implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'pipeline') {
 					if (operation === 'get') {
 						const vcs = this.getNodeParameter('vcs', i) as string;
-						let slug = this.getNodeParameter('projectSlug', i) as string;
+						let slug = this.getNodeParameter('projectSlug', i);
 						const pipelineNumber = this.getNodeParameter('pipelineNumber', i) as number;
 
 						slug = slug.replace(new RegExp(/\//g), '%2F');
@@ -77,7 +77,7 @@ export class CircleCi implements INodeType {
 						const vcs = this.getNodeParameter('vcs', i) as string;
 						const filters = this.getNodeParameter('filters', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
-						let slug = this.getNodeParameter('projectSlug', i) as string;
+						let slug = this.getNodeParameter('projectSlug', i);
 
 						slug = slug.replace(new RegExp(/\//g), '%2F');
 
@@ -110,7 +110,7 @@ export class CircleCi implements INodeType {
 
 					if (operation === 'trigger') {
 						const vcs = this.getNodeParameter('vcs', i) as string;
-						let slug = this.getNodeParameter('projectSlug', i) as string;
+						let slug = this.getNodeParameter('projectSlug', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Cisco/Webex/CiscoWebex.node.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/CiscoWebex.node.ts
@@ -112,8 +112,8 @@ export class CiscoWebex implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 		const timezone = this.getTimezone();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 
@@ -311,7 +311,7 @@ export class CiscoWebex implements INodeType {
 
 				if (resource === 'meeting') {
 					if (operation === 'create') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const start = this.getNodeParameter('start', i) as string;
 						const end = this.getNodeParameter('end', i) as string;
 						const invitees = this.getNodeParameter(
@@ -514,7 +514,7 @@ export class CiscoWebex implements INodeType {
 		// 	if (operation === 'download') {
 		// 		for (let i = 0; i < items.length; i++) {
 		// 			const transcriptId = this.getNodeParameter('transcriptId', i) as string;
-		// 			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+		// 			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 		// 			const meetingId = this.getNodeParameter('meetingId', i) as string;
 		// 			const options = this.getNodeParameter('options', i);
 

--- a/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
@@ -492,7 +492,7 @@ export class CiscoWebexTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const resource = this.getNodeParameter('resource') as string;
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 
 				// Check all the webhooks which exist already if it is identical to the
 				// one that is supposed to get created.
@@ -513,7 +513,7 @@ export class CiscoWebexTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookData = this.getWorkflowStaticData('node');
 				const webhookUrl = this.getNodeWebhookUrl('default');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const resource = this.getNodeParameter('resource') as string;
 				const filters = this.getNodeParameter('filters', {}) as IDataObject;
 				const credentials = await this.getCredentials('ciscoWebexOAuth2Api');

--- a/packages/nodes-base/nodes/Citrix/ADC/CitrixAdc.node.ts
+++ b/packages/nodes-base/nodes/Citrix/ADC/CitrixAdc.node.ts
@@ -61,8 +61,8 @@ export class CitrixAdc implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let responseData: IDataObject | IDataObject[] = {};
 
 		for (let i = 0; i < items.length; i++) {
@@ -70,7 +70,7 @@ export class CitrixAdc implements INodeType {
 				if (resource === 'file') {
 					if (operation === 'upload') {
 						const fileLocation = this.getNodeParameter('fileLocation', i) as string;
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 						const options = this.getNodeParameter('options', i);
 						const endpoint = `/config/systemfile`;
 
@@ -119,7 +119,7 @@ export class CitrixAdc implements INodeType {
 					if (operation === 'download') {
 						const fileName = this.getNodeParameter('fileName', i) as string;
 						const fileLocation = this.getNodeParameter('fileLocation', i) as string;
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 						const endpoint = `/config/systemfile?args=filename:${fileName},filelocation:${encodeURIComponent(
 							fileLocation,
@@ -145,7 +145,7 @@ export class CitrixAdc implements INodeType {
 
 				if (resource === 'certificate') {
 					if (operation === 'create') {
-						const certificateFileName = this.getNodeParameter('certificateFileName', i) as string;
+						const certificateFileName = this.getNodeParameter('certificateFileName', i);
 						const certificateFormat = this.getNodeParameter('certificateFormat', i) as string;
 						const certificateType = this.getNodeParameter('certificateType', i) as string;
 						const certificateRequestFileName = this.getNodeParameter(
@@ -167,7 +167,7 @@ export class CitrixAdc implements INodeType {
 						};
 
 						if (certificateType === 'ROOT_CERT') {
-							const privateKeyFileName = this.getNodeParameter('privateKeyFileName', i) as string;
+							const privateKeyFileName = this.getNodeParameter('privateKeyFileName', i);
 							body = {
 								...body,
 								keyfile: privateKeyFileName,
@@ -213,8 +213,8 @@ export class CitrixAdc implements INodeType {
 							'certificateKeyPairName',
 							i,
 						) as string;
-						const certificateFileName = this.getNodeParameter('certificateFileName', i) as string;
-						const privateKeyFileName = this.getNodeParameter('privateKeyFileName', i) as string;
+						const certificateFileName = this.getNodeParameter('certificateFileName', i);
+						const privateKeyFileName = this.getNodeParameter('privateKeyFileName', i);
 						const certificateFormat = this.getNodeParameter('certificateFormat', i) as string;
 						const notifyExpiration = this.getNodeParameter('notifyExpiration', i) as boolean;
 						const body: IDataObject = {
@@ -225,7 +225,7 @@ export class CitrixAdc implements INodeType {
 						};
 
 						if (certificateFormat === 'PEM') {
-							const password = this.getNodeParameter('password', i) as string;
+							const password = this.getNodeParameter('password', i);
 							const certificateBundle = this.getNodeParameter('certificateBundle', i) as boolean;
 							Object.assign(body, {
 								passplain: password,

--- a/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
+++ b/packages/nodes-base/nodes/Clearbit/Clearbit.node.ts
@@ -62,8 +62,8 @@ export class Clearbit implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'person') {

--- a/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
+++ b/packages/nodes-base/nodes/ClickUp/ClickUp.node.ts
@@ -428,8 +428,8 @@ export class ClickUp implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -1161,7 +1161,7 @@ export class ClickUp implements INodeType {
 				if (resource === 'taskTag') {
 					if (operation === 'add') {
 						const taskId = this.getNodeParameter('taskId', i) as string;
-						const name = this.getNodeParameter('tagName', i) as string;
+						const name = this.getNodeParameter('tagName', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const qs: IDataObject = {};
 						Object.assign(qs, additionalFields);
@@ -1176,7 +1176,7 @@ export class ClickUp implements INodeType {
 					}
 					if (operation === 'remove') {
 						const taskId = this.getNodeParameter('taskId', i) as string;
-						const name = this.getNodeParameter('tagName', i) as string;
+						const name = this.getNodeParameter('tagName', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const qs: IDataObject = {};
 						Object.assign(qs, additionalFields);
@@ -1444,8 +1444,8 @@ export class ClickUp implements INodeType {
 					if (operation === 'create') {
 						const spaceId = this.getNodeParameter('space', i) as string;
 						const name = this.getNodeParameter('name', i) as string;
-						const foregroundColor = this.getNodeParameter('foregroundColor', i) as string;
-						const backgroundColor = this.getNodeParameter('backgroundColor', i) as string;
+						const foregroundColor = this.getNodeParameter('foregroundColor', i);
+						const backgroundColor = this.getNodeParameter('backgroundColor', i);
 						const body: IDataObject = {
 							tag: {
 								name,
@@ -1484,9 +1484,9 @@ export class ClickUp implements INodeType {
 					if (operation === 'update') {
 						const spaceId = this.getNodeParameter('space', i) as string;
 						const tagName = this.getNodeParameter('name', i) as string;
-						const newTagName = this.getNodeParameter('newName', i) as string;
-						const foregroundColor = this.getNodeParameter('foregroundColor', i) as string;
-						const backgroundColor = this.getNodeParameter('backgroundColor', i) as string;
+						const newTagName = this.getNodeParameter('newName', i);
+						const foregroundColor = this.getNodeParameter('foregroundColor', i);
+						const backgroundColor = this.getNodeParameter('backgroundColor', i);
 						const body: IDataObject = {
 							tag: {
 								name: newTagName,

--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -243,9 +243,9 @@ export class Clockify implements INodeType {
 
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Cloudflare/Cloudflare.node.ts
+++ b/packages/nodes-base/nodes/Cloudflare/Cloudflare.node.ts
@@ -74,8 +74,8 @@ export class Cloudflare implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Cockpit/Cockpit.node.ts
+++ b/packages/nodes-base/nodes/Cockpit/Cockpit.node.ts
@@ -102,8 +102,8 @@ export class Cockpit implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		const length = items.length;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Coda/Coda.node.ts
+++ b/packages/nodes-base/nodes/Coda/Coda.node.ts
@@ -242,9 +242,9 @@ export class Coda implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const items = this.getInputData();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
 		let qs: IDataObject = {};
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'table') {
 			// https://coda.io/developers/apis/v1beta1#operation/upsertRows
@@ -859,7 +859,7 @@ export class Coda implements INodeType {
 						const docId = this.getNodeParameter('docId', i) as string;
 						const viewId = this.getNodeParameter('viewId', i) as string;
 						const rowId = this.getNodeParameter('rowId', i) as string;
-						const keyName = this.getNodeParameter('keyName', i) as string;
+						const keyName = this.getNodeParameter('keyName', i);
 						const options = this.getNodeParameter('options', i);
 						const body: IDataObject = {};
 						const endpoint = `/docs/${docId}/tables/${viewId}/rows/${rowId}`;

--- a/packages/nodes-base/nodes/CoinGecko/CoinGecko.node.ts
+++ b/packages/nodes-base/nodes/CoinGecko/CoinGecko.node.ts
@@ -143,8 +143,8 @@ export class CoinGecko implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'coin') {

--- a/packages/nodes-base/nodes/Compression/Compression.node.ts
+++ b/packages/nodes-base/nodes/Compression/Compression.node.ts
@@ -180,12 +180,12 @@ export class Compression implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 		const returnData: INodeExecutionData[] = [];
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (operation === 'decompress') {
-					const binaryPropertyNames = (this.getNodeParameter('binaryPropertyName', 0) as string)
+					const binaryPropertyNames = this.getNodeParameter('binaryPropertyName', 0)
 						.split(',')
 						.map((key) => key.trim());
 
@@ -256,7 +256,7 @@ export class Compression implements INodeType {
 				}
 
 				if (operation === 'compress') {
-					const binaryPropertyNames = (this.getNodeParameter('binaryPropertyName', 0) as string)
+					const binaryPropertyNames = this.getNodeParameter('binaryPropertyName', 0)
 						.split(',')
 						.map((key) => key.trim());
 
@@ -306,7 +306,7 @@ export class Compression implements INodeType {
 					}
 
 					if (outputFormat === 'zip') {
-						const fileName = this.getNodeParameter('fileName', 0) as string;
+						const fileName = this.getNodeParameter('fileName', 0);
 
 						const binaryPropertyOutput = this.getNodeParameter('binaryPropertyOutput', 0) as string;
 

--- a/packages/nodes-base/nodes/Contentful/Contentful.node.ts
+++ b/packages/nodes-base/nodes/Contentful/Contentful.node.ts
@@ -82,8 +82,8 @@ export class Contentful implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let responseData;
 
 		const items = this.getInputData();

--- a/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Contentful/GenericFunctions.ts
@@ -16,7 +16,7 @@ export async function contentfulApiRequest(
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
 	const credentials = await this.getCredentials('contentfulApi');
-	const source = this.getNodeParameter('source', 0) as string;
+	const source = this.getNodeParameter('source', 0);
 	const isPreview = source === 'previewApi';
 
 	const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/ConvertKit/ConvertKit.node.ts
+++ b/packages/nodes-base/nodes/ConvertKit/ConvertKit.node.ts
@@ -159,8 +159,8 @@ export class ConvertKit implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Copper/Copper.node.ts
+++ b/packages/nodes-base/nodes/Copper/Copper.node.ts
@@ -115,8 +115,8 @@ export class Copper implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Copper/CopperTrigger.node.ts
+++ b/packages/nodes-base/nodes/Copper/CopperTrigger.node.ts
@@ -114,7 +114,7 @@ export class CopperTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const resource = this.getNodeParameter('resource') as string;
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const endpoint = '/webhooks';
 				const body: IDataObject = {
 					target: webhookUrl,

--- a/packages/nodes-base/nodes/Cortex/Cortex.node.ts
+++ b/packages/nodes-base/nodes/Cortex/Cortex.node.ts
@@ -166,8 +166,8 @@ export class Cortex implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -202,7 +202,7 @@ export class Cortex implements INodeType {
 								});
 							}
 
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[binaryPropertyName] === undefined) {
 								throw new NodeOperationError(

--- a/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
+++ b/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
@@ -276,7 +276,7 @@ export class CrateDb implements INodeType {
 		let returnItems: INodeExecutionData[] = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'executeQuery') {
 			// ----------------------------------

--- a/packages/nodes-base/nodes/Crypto/Crypto.node.ts
+++ b/packages/nodes-base/nodes/Crypto/Crypto.node.ts
@@ -437,7 +437,7 @@ export class Crypto implements INodeType {
 		for (let i = 0; i < length; i++) {
 			try {
 				item = items[i];
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', i) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', i);
 				const value = this.getNodeParameter('value', i, '') as string;
 				let newValue;
 

--- a/packages/nodes-base/nodes/CustomerIo/CustomerIo.node.ts
+++ b/packages/nodes-base/nodes/CustomerIo/CustomerIo.node.ts
@@ -76,8 +76,8 @@ export class CustomerIo implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const returnData: IDataObject[] = [];
 		const items = this.getInputData();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const body: IDataObject = {};
 
 		let responseData;
@@ -214,7 +214,7 @@ export class CustomerIo implements INodeType {
 				if (resource === 'event') {
 					if (operation === 'track') {
 						const customerId = this.getNodeParameter('customerId', i) as number;
-						const eventName = this.getNodeParameter('eventName', i) as string;
+						const eventName = this.getNodeParameter('eventName', i);
 						const jsonParameters = this.getNodeParameter('jsonParameters', i);
 
 						body.name = eventName;
@@ -263,7 +263,7 @@ export class CustomerIo implements INodeType {
 					}
 
 					if (operation === 'trackAnonymous') {
-						const eventName = this.getNodeParameter('eventName', i) as string;
+						const eventName = this.getNodeParameter('eventName', i);
 						const jsonParameters = this.getNodeParameter('jsonParameters', i);
 
 						body.name = eventName;

--- a/packages/nodes-base/nodes/DateTime/DateTime.node.ts
+++ b/packages/nodes-base/nodes/DateTime/DateTime.node.ts
@@ -376,7 +376,7 @@ export class DateTime implements INodeType {
 
 				if (action === 'format') {
 					const currentDate = this.getNodeParameter('value', i) as string;
-					const dataPropertyName = this.getNodeParameter('dataPropertyName', i) as string;
+					const dataPropertyName = this.getNodeParameter('dataPropertyName', i);
 					const toFormat = this.getNodeParameter('toFormat', i) as string;
 					const options = this.getNodeParameter('options', i);
 					let newDate;
@@ -457,11 +457,11 @@ export class DateTime implements INodeType {
 
 				if (action === 'calculate') {
 					const dateValue = this.getNodeParameter('value', i) as string;
-					const operation = this.getNodeParameter('operation', i) as 'add' | 'subtract';
+					const operation = this.getNodeParameter('operation', i);
 					const duration = this.getNodeParameter('duration', i) as number;
 					const timeUnit = this.getNodeParameter('timeUnit', i) as moment.DurationInputArg2;
 					const { fromFormat } = this.getNodeParameter('options', i) as { fromFormat?: string };
-					const dataPropertyName = this.getNodeParameter('dataPropertyName', i) as string;
+					const dataPropertyName = this.getNodeParameter('dataPropertyName', i);
 
 					const newDate = fromFormat
 						? parseDateByFormat.call(this, dateValue, fromFormat)

--- a/packages/nodes-base/nodes/DeepL/DeepL.node.ts
+++ b/packages/nodes-base/nodes/DeepL/DeepL.node.ts
@@ -112,13 +112,13 @@ export class DeepL implements INodeType {
 
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', i) as string;
-				const operation = this.getNodeParameter('operation', i) as string;
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 				const additionalFields = this.getNodeParameter('additionalFields', i);
 				if (resource === 'language') {
 					if (operation === 'translate') {
 						let body: IDataObject = {};
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const translateTo = this.getNodeParameter('translateTo', i) as string;
 						body = { target_lang: translateTo, text } as IDataObject;
 

--- a/packages/nodes-base/nodes/Demio/Demio.node.ts
+++ b/packages/nodes-base/nodes/Demio/Demio.node.ts
@@ -109,8 +109,8 @@ export class Demio implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -145,7 +145,7 @@ export class Demio implements INodeType {
 					}
 					if (operation === 'register') {
 						const eventId = this.getNodeParameter('eventId', i) as string;
-						const firstName = this.getNodeParameter('firstName', i) as string;
+						const firstName = this.getNodeParameter('firstName', i);
 						const email = this.getNodeParameter('email', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Dhl/Dhl.node.ts
+++ b/packages/nodes-base/nodes/Dhl/Dhl.node.ts
@@ -124,8 +124,8 @@ export class Dhl implements INodeType {
 		const returnData: IDataObject[] = [];
 		let qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Discord/Discord.node.ts
+++ b/packages/nodes-base/nodes/Discord/Discord.node.ts
@@ -132,7 +132,7 @@ export class Discord implements INodeType {
 			const body: DiscordWebhook = {};
 
 			const webhookUri = this.getNodeParameter('webhookUri', i) as string;
-			body.content = this.getNodeParameter('text', i) as string;
+			body.content = this.getNodeParameter('text', i);
 			const options = this.getNodeParameter('options', i);
 
 			if (!body.content && !options.embeds) {

--- a/packages/nodes-base/nodes/Discourse/Discourse.node.ts
+++ b/packages/nodes-base/nodes/Discourse/Discourse.node.ts
@@ -114,16 +114,16 @@ export class Discourse implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'category') {
 					//https://docs.discourse.org/#tag/Categories/paths/~1categories.json/post
 					if (operation === 'create') {
 						const name = this.getNodeParameter('name', i) as string;
-						const color = this.getNodeParameter('color', i) as string;
-						const textColor = this.getNodeParameter('textColor', i) as string;
+						const color = this.getNodeParameter('color', i);
+						const textColor = this.getNodeParameter('textColor', i);
 
 						const body: IDataObject = {
 							name,
@@ -227,7 +227,7 @@ export class Discourse implements INodeType {
 					//https://docs.discourse.org/#tag/Posts/paths/~1posts.json/post
 					if (operation === 'create') {
 						const content = this.getNodeParameter('content', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						const body: IDataObject = {
@@ -339,7 +339,7 @@ export class Discourse implements INodeType {
 					if (operation === 'create') {
 						const name = this.getNodeParameter('name', i) as string;
 						const email = this.getNodeParameter('email', i) as string;
-						const password = this.getNodeParameter('password', i) as string;
+						const password = this.getNodeParameter('password', i);
 						const username = this.getNodeParameter('username', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Disqus/Disqus.node.ts
+++ b/packages/nodes-base/nodes/Disqus/Disqus.node.ts
@@ -572,8 +572,8 @@ export class Disqus implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let requestMethod = '';

--- a/packages/nodes-base/nodes/Drift/Drift.node.ts
+++ b/packages/nodes-base/nodes/Drift/Drift.node.ts
@@ -79,8 +79,8 @@ export class Drift implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {

--- a/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
+++ b/packages/nodes-base/nodes/Dropbox/Dropbox.node.ts
@@ -695,8 +695,8 @@ export class Dropbox implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let requestMethod = '';
@@ -738,7 +738,7 @@ export class Dropbox implements INodeType {
 						requestMethod = 'POST';
 
 						query.arg = JSON.stringify({
-							path: this.getNodeParameter('path', i) as string,
+							path: this.getNodeParameter('path', i),
 						});
 
 						endpoint = 'https://content.dropboxapi.com/2/files/download';
@@ -752,7 +752,7 @@ export class Dropbox implements INodeType {
 
 						query.arg = JSON.stringify({
 							mode: 'overwrite',
-							path: this.getNodeParameter('path', i) as string,
+							path: this.getNodeParameter('path', i),
 						});
 
 						endpoint = 'https://content.dropboxapi.com/2/files/upload';
@@ -769,7 +769,7 @@ export class Dropbox implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(
@@ -793,7 +793,7 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							path: this.getNodeParameter('path', i) as string,
+							path: this.getNodeParameter('path', i),
 						};
 
 						endpoint = 'https://api.dropboxapi.com/2/files/create_folder_v2';
@@ -810,7 +810,7 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							path: this.getNodeParameter('path', i) as string,
+							path: this.getNodeParameter('path', i),
 							limit: 1000,
 						};
 
@@ -839,7 +839,7 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							query: this.getNodeParameter('query', i) as string,
+							query: this.getNodeParameter('query', i),
 							options: {
 								filename_only: true,
 							},
@@ -867,8 +867,8 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							from_path: this.getNodeParameter('path', i) as string,
-							to_path: this.getNodeParameter('toPath', i) as string,
+							from_path: this.getNodeParameter('path', i),
+							to_path: this.getNodeParameter('toPath', i),
 						};
 
 						endpoint = 'https://api.dropboxapi.com/2/files/copy_v2';
@@ -879,7 +879,7 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							path: this.getNodeParameter('path', i) as string,
+							path: this.getNodeParameter('path', i),
 						};
 
 						endpoint = 'https://api.dropboxapi.com/2/files/delete_v2';
@@ -890,8 +890,8 @@ export class Dropbox implements INodeType {
 
 						requestMethod = 'POST';
 						body = {
-							from_path: this.getNodeParameter('path', i) as string,
-							to_path: this.getNodeParameter('toPath', i) as string,
+							from_path: this.getNodeParameter('path', i),
+							to_path: this.getNodeParameter('toPath', i),
 						};
 
 						endpoint = 'https://api.dropboxapi.com/2/files/move_v2';
@@ -954,9 +954,9 @@ export class Dropbox implements INodeType {
 
 					items[i] = newItem;
 
-					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i) as string;
+					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
 
-					const filePathDownload = this.getNodeParameter('path', i) as string;
+					const filePathDownload = this.getNodeParameter('path', i);
 					items[i].binary![dataPropertyNameDownload] = await this.helpers.prepareBinaryData(
 						Buffer.from(responseData),
 						filePathDownload,

--- a/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
+++ b/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
@@ -241,8 +241,8 @@ export class Dropcontact implements INodeType {
 	};
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const entryData = this.getInputData();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		// tslint:disable-next-line: no-any
 		let responseData: any;
 		const returnData: IDataObject[] = [];

--- a/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
+++ b/packages/nodes-base/nodes/ERPNext/ERPNext.node.ts
@@ -120,8 +120,8 @@ export class ERPNext implements INodeType {
 		const body: IDataObject = {};
 		const qs: IDataObject = {};
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			// https://app.swaggerhub.com/apis-docs/alyf.de/ERPNext/11#/Resources/post_api_resource_Webhook
@@ -140,7 +140,7 @@ export class ERPNext implements INodeType {
 					// https://app.swaggerhub.com/apis-docs/alyf.de/ERPNext/11#/General/get_api_resource__DocType___DocumentName_
 
 					const docType = this.getNodeParameter('docType', i) as string;
-					const documentName = this.getNodeParameter('documentName', i) as string;
+					const documentName = this.getNodeParameter('documentName', i);
 
 					responseData = await erpNextApiRequest.call(
 						this,
@@ -241,7 +241,7 @@ export class ERPNext implements INodeType {
 					// https://app.swaggerhub.com/apis-docs/alyf.de/ERPNext/11#/General/delete_api_resource__DocType___DocumentName_
 
 					const docType = this.getNodeParameter('docType', i) as string;
-					const documentName = this.getNodeParameter('documentName', i) as string;
+					const documentName = this.getNodeParameter('documentName', i);
 
 					responseData = await erpNextApiRequest.call(
 						this,
@@ -270,7 +270,7 @@ export class ERPNext implements INodeType {
 					});
 
 					const docType = this.getNodeParameter('docType', i) as string;
-					const documentName = this.getNodeParameter('documentName', i) as string;
+					const documentName = this.getNodeParameter('documentName', i);
 
 					responseData = await erpNextApiRequest.call(
 						this,

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -991,8 +991,8 @@ export class EditImage implements INodeType {
 			try {
 				item = items[itemIndex];
 
-				const operation = this.getNodeParameter('operation', itemIndex) as string;
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex) as string;
+				const operation = this.getNodeParameter('operation', itemIndex);
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex);
 
 				const options = this.getNodeParameter('options', itemIndex, {}) as IDataObject;
 

--- a/packages/nodes-base/nodes/Egoi/Egoi.node.ts
+++ b/packages/nodes-base/nodes/Egoi/Egoi.node.ts
@@ -541,8 +541,8 @@ export class Egoi implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const items = this.getInputData();
 		const length = items.length;
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {

--- a/packages/nodes-base/nodes/Elastic/ElasticSecurity/ElasticSecurity.node.ts
+++ b/packages/nodes-base/nodes/Elastic/ElasticSecurity/ElasticSecurity.node.ts
@@ -166,8 +166,8 @@ export class ElasticSecurity implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 
@@ -538,7 +538,7 @@ export class ElasticSecurity implements INodeType {
 
 						if (connectorType === '.jira') {
 							body.config = {
-								apiUrl: this.getNodeParameter('apiUrl', i) as string,
+								apiUrl: this.getNodeParameter('apiUrl', i),
 								projectKey: this.getNodeParameter('projectKey', i) as string,
 							};
 							body.secrets = {
@@ -547,7 +547,7 @@ export class ElasticSecurity implements INodeType {
 							};
 						} else if (connectorType === '.resilient') {
 							body.config = {
-								apiUrl: this.getNodeParameter('apiUrl', i) as string,
+								apiUrl: this.getNodeParameter('apiUrl', i),
 								orgId: this.getNodeParameter('orgId', i) as string,
 							};
 							body.secrets = {
@@ -556,11 +556,11 @@ export class ElasticSecurity implements INodeType {
 							};
 						} else if (connectorType === '.servicenow') {
 							body.config = {
-								apiUrl: this.getNodeParameter('apiUrl', i) as string,
+								apiUrl: this.getNodeParameter('apiUrl', i),
 							};
 							body.secrets = {
 								username: this.getNodeParameter('username', i) as string,
-								password: this.getNodeParameter('password', i) as string,
+								password: this.getNodeParameter('password', i),
 							};
 						}
 

--- a/packages/nodes-base/nodes/Elastic/ElasticSecurity/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Elastic/ElasticSecurity/GenericFunctions.ts
@@ -65,7 +65,7 @@ export async function elasticSecurityApiRequestAllItems(
 	const returnData: IDataObject[] = [];
 	let responseData: any; // tslint:disable-line
 
-	const resource = this.getNodeParameter('resource', 0) as 'case' | 'caseComment';
+	const resource = this.getNodeParameter('resource', 0);
 
 	do {
 		responseData = await elasticSecurityApiRequest.call(this, method, endpoint, body, qs);

--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
@@ -66,7 +66,7 @@ export class Elasticsearch implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 
 		const resource = this.getNodeParameter('resource', 0) as 'document' | 'index';
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/EmailSend/EmailSend.node.ts
+++ b/packages/nodes-base/nodes/EmailSend/EmailSend.node.ts
@@ -132,7 +132,7 @@ export class EmailSend implements INodeType {
 				const ccEmail = this.getNodeParameter('ccEmail', itemIndex) as string;
 				const bccEmail = this.getNodeParameter('bccEmail', itemIndex) as string;
 				const subject = this.getNodeParameter('subject', itemIndex) as string;
-				const text = this.getNodeParameter('text', itemIndex) as string;
+				const text = this.getNodeParameter('text', itemIndex);
 				const html = this.getNodeParameter('html', itemIndex) as string;
 				const attachmentPropertyString = this.getNodeParameter('attachments', itemIndex) as string;
 				const options = this.getNodeParameter('options', itemIndex, {}) as IDataObject;

--- a/packages/nodes-base/nodes/Eventbrite/EventbriteTrigger.node.ts
+++ b/packages/nodes-base/nodes/Eventbrite/EventbriteTrigger.node.ts
@@ -259,7 +259,7 @@ export class EventbriteTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const organisation = this.getNodeParameter('organization') as string;
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const actions = this.getNodeParameter('actions') as string[];
 				const endpoint = `/organizations/${organisation}/webhooks/`;
 				const body: IDataObject = {

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -142,7 +142,7 @@ export class ExecuteWorkflow implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		const source = this.getNodeParameter('source', 0) as string;
+		const source = this.getNodeParameter('source', 0);
 
 		const workflowInfo: IExecuteWorkflowInfo = {};
 
@@ -152,7 +152,7 @@ export class ExecuteWorkflow implements INodeType {
 				workflowInfo.id = this.getNodeParameter('workflowId', 0) as string;
 			} else if (source === 'localFile') {
 				// Read workflow from filesystem
-				const workflowPath = this.getNodeParameter('workflowPath', 0) as string;
+				const workflowPath = this.getNodeParameter('workflowPath', 0);
 
 				let workflowJson;
 				try {
@@ -175,7 +175,7 @@ export class ExecuteWorkflow implements INodeType {
 				workflowInfo.code = JSON.parse(workflowJson) as IWorkflowBase;
 			} else if (source === 'url') {
 				// Read workflow from url
-				const workflowUrl = this.getNodeParameter('workflowUrl', 0) as string;
+				const workflowUrl = this.getNodeParameter('workflowUrl', 0);
 
 				const requestOptions = {
 					headers: {

--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -299,7 +299,7 @@ export class FacebookGraphApi implements INodeType {
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const graphApiCredentials = await this.getCredentials('facebookGraphApi');
 
-			const hostUrl = this.getNodeParameter('hostUrl', itemIndex) as string;
+			const hostUrl = this.getNodeParameter('hostUrl', itemIndex);
 			const httpRequestMethod = this.getNodeParameter('httpRequestMethod', itemIndex) as string;
 			let graphApiVersion = this.getNodeParameter('graphApiVersion', itemIndex) as string;
 			const node = this.getNodeParameter('node', itemIndex) as string;

--- a/packages/nodes-base/nodes/Flow/Flow.node.ts
+++ b/packages/nodes-base/nodes/Flow/Flow.node.ts
@@ -60,8 +60,8 @@ export class Flow implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			if (resource === 'task') {

--- a/packages/nodes-base/nodes/Freshdesk/Freshdesk.node.ts
+++ b/packages/nodes-base/nodes/Freshdesk/Freshdesk.node.ts
@@ -1096,8 +1096,8 @@ export class Freshdesk implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'ticket') {
@@ -1107,7 +1107,7 @@ export class Freshdesk implements INodeType {
 						const value = this.getNodeParameter('requesterIdentificationValue', i) as string;
 						const status = this.getNodeParameter('status', i) as string;
 						const priority = this.getNodeParameter('priority', i) as string;
-						const source = this.getNodeParameter('source', i) as string;
+						const source = this.getNodeParameter('source', i);
 						const options = this.getNodeParameter('options', i);
 						//const jsonActive = this.getNodeParameter('jsonParameters') as boolean;
 						const body: ICreateTicketBody = {

--- a/packages/nodes-base/nodes/Freshservice/Freshservice.node.ts
+++ b/packages/nodes-base/nodes/Freshservice/Freshservice.node.ts
@@ -271,8 +271,8 @@ export class Freshservice implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		const defaultTimezone = this.getTimezone();
 

--- a/packages/nodes-base/nodes/FreshworksCrm/FreshworksCrm.node.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/FreshworksCrm.node.ts
@@ -239,8 +239,8 @@ export class FreshworksCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const defaultTimezone = this.getTimezone();
 
 		let responseData;
@@ -353,8 +353,8 @@ export class FreshworksCrm implements INodeType {
 							is_allday: boolean;
 						};
 
-						const startDate = this.getNodeParameter('fromDate', i) as string;
-						const endDate = this.getNodeParameter('endDate', i) as string;
+						const startDate = this.getNodeParameter('fromDate', i);
+						const endDate = this.getNodeParameter('endDate', i);
 						const attendees = this.getNodeParameter('attendees.attendee', i, []) as [
 							{ type: string; contactId: string; userId: string },
 						];
@@ -818,7 +818,7 @@ export class FreshworksCrm implements INodeType {
 
 					if (operation === 'query') {
 						// https://developers.freshworks.com/crm/api/#search
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						let entities = this.getNodeParameter('entities', i);
 						const returnAll = this.getNodeParameter('returnAll', 0, false);
 

--- a/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
@@ -49,7 +49,7 @@ export async function getAllItemsViewId(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	{ fromLoadOptions } = { fromLoadOptions: false },
 ) {
-	let resource = this.getNodeParameter('resource', 0) as string;
+	let resource = this.getNodeParameter('resource', 0);
 	let keyword = 'All';
 
 	if (resource === 'account' || fromLoadOptions) {

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -415,7 +415,7 @@ export class Ftp implements INodeType {
 		// const returnData: IDataObject[] = [];
 		const returnItems: INodeExecutionData[] = [];
 		let responseData;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		let credentials: ICredentialDataDecryptedObject | undefined = undefined;
 		const protocol = this.getNodeParameter('protocol', 0) as string;
@@ -466,7 +466,7 @@ export class Ftp implements INodeType {
 
 				if (protocol === 'sftp') {
 					if (operation === 'list') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 
 						const recursive = this.getNodeParameter('recursive', i) as boolean;
 
@@ -487,7 +487,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'delete') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 						const options = this.getNodeParameter('options', i);
 
 						if (options.folder === true) {
@@ -500,11 +500,11 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'rename') {
-						const oldPath = this.getNodeParameter('oldPath', i) as string;
+						const oldPath = this.getNodeParameter('oldPath', i);
 						const { createDirectories = false } = this.getNodeParameter('options', i) as {
 							createDirectories: boolean;
 						};
-						const newPath = this.getNodeParameter('newPath', i) as string;
+						const newPath = this.getNodeParameter('newPath', i);
 
 						if (createDirectories) {
 							await recursivelyCreateSftpDirs(sftp!, newPath);
@@ -516,7 +516,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'download') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 
 						responseData = await sftp!.get(path);
 
@@ -525,7 +525,7 @@ export class Ftp implements INodeType {
 							i,
 						) as string;
 
-						const filePathDownload = this.getNodeParameter('path', i) as string;
+						const filePathDownload = this.getNodeParameter('path', i);
 						items[i].binary![dataPropertyNameDownload] = await this.helpers.prepareBinaryData(
 							responseData as Buffer,
 							filePathDownload,
@@ -535,7 +535,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'upload') {
-						const remotePath = this.getNodeParameter('path', i) as string;
+						const remotePath = this.getNodeParameter('path', i);
 						await recursivelyCreateSftpDirs(sftp!, remotePath);
 
 						if (this.getNodeParameter('binaryData', i) === true) {
@@ -548,7 +548,7 @@ export class Ftp implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(
@@ -575,7 +575,7 @@ export class Ftp implements INodeType {
 
 				if (protocol === 'ftp') {
 					if (operation === 'list') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 
 						const recursive = this.getNodeParameter('recursive', i) as boolean;
 
@@ -598,7 +598,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'delete') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 						const options = this.getNodeParameter('options', i);
 
 						if (options.folder === true) {
@@ -611,7 +611,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'download') {
-						const path = this.getNodeParameter('path', i) as string;
+						const path = this.getNodeParameter('path', i);
 
 						responseData = await ftp!.get(path);
 
@@ -629,7 +629,7 @@ export class Ftp implements INodeType {
 							i,
 						) as string;
 
-						const filePathDownload = this.getNodeParameter('path', i) as string;
+						const filePathDownload = this.getNodeParameter('path', i);
 						items[i].binary![dataPropertyNameDownload] = await this.helpers.prepareBinaryData(
 							responseData,
 							filePathDownload,
@@ -639,9 +639,9 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'rename') {
-						const oldPath = this.getNodeParameter('oldPath', i) as string;
+						const oldPath = this.getNodeParameter('oldPath', i);
 
-						const newPath = this.getNodeParameter('newPath', i) as string;
+						const newPath = this.getNodeParameter('newPath', i);
 
 						responseData = await ftp!.rename(oldPath, newPath);
 
@@ -649,7 +649,7 @@ export class Ftp implements INodeType {
 					}
 
 					if (operation === 'upload') {
-						const remotePath = this.getNodeParameter('path', i) as string;
+						const remotePath = this.getNodeParameter('path', i);
 						const fileName = basename(remotePath);
 						const dirPath = remotePath.replace(fileName, '');
 
@@ -663,7 +663,7 @@ export class Ftp implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(

--- a/packages/nodes-base/nodes/GetResponse/GetResponse.node.ts
+++ b/packages/nodes-base/nodes/GetResponse/GetResponse.node.ts
@@ -135,8 +135,8 @@ export class GetResponse implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {

--- a/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
@@ -19,7 +19,7 @@ export async function ghostApiRequest(
 	uri?: string,
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const source = this.getNodeParameter('source', 0) as string;
+	const source = this.getNodeParameter('source', 0);
 
 	let credentials;
 	let version;

--- a/packages/nodes-base/nodes/Ghost/Ghost.node.ts
+++ b/packages/nodes-base/nodes/Ghost/Ghost.node.ts
@@ -124,9 +124,9 @@ export class Ghost implements INodeType {
 		const timezone = this.getTimezone();
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const source = this.getNodeParameter('source', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
+		const source = this.getNodeParameter('source', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -181,7 +181,7 @@ export class Ghost implements INodeType {
 				if (source === 'adminApi') {
 					if (resource === 'post') {
 						if (operation === 'create') {
-							const title = this.getNodeParameter('title', i) as string;
+							const title = this.getNodeParameter('title', i);
 
 							const contentFormat = this.getNodeParameter('contentFormat', i) as string;
 

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -211,7 +211,7 @@ export class Git implements INodeType {
 			return repositoryPath;
 		};
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		let _item: INodeExecutionData;
 		const returnItems: INodeExecutionData[] = [];
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -302,7 +302,7 @@ export class Git implements INodeType {
 					//         commit
 					// ----------------------------------
 
-					const message = this.getNodeParameter('message', itemIndex, '') as string;
+					const message = this.getNodeParameter('message', itemIndex, '');
 
 					let pathsToAdd: string[] | undefined = undefined;
 					if (options.files !== undefined) {

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -1658,8 +1658,8 @@ export class Github implements INodeType {
 		let requestMethod: string;
 		let endpoint: string;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 		const fullOperation = `${resource}:${operation}`;
 
 		for (let i = 0; i < items.length; i++) {
@@ -1693,7 +1693,7 @@ export class Github implements INodeType {
 
 						requestMethod = 'PUT';
 
-						const filePath = this.getNodeParameter('filePath', i) as string;
+						const filePath = this.getNodeParameter('filePath', i);
 
 						const additionalParameters = this.getNodeParameter(
 							'additionalParameters',
@@ -1737,7 +1737,7 @@ export class Github implements INodeType {
 								});
 							}
 
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[binaryPropertyName] === undefined) {
 								throw new NodeOperationError(
@@ -1784,7 +1784,7 @@ export class Github implements INodeType {
 							body.branch = (additionalParameters.branch as IDataObject).branch;
 						}
 
-						const filePath = this.getNodeParameter('filePath', i) as string;
+						const filePath = this.getNodeParameter('filePath', i);
 						body.message = this.getNodeParameter('commitMessage', i) as string;
 
 						body.sha = await getFileSha.call(
@@ -1799,7 +1799,7 @@ export class Github implements INodeType {
 					} else if (operation === 'get') {
 						requestMethod = 'GET';
 
-						const filePath = this.getNodeParameter('filePath', i) as string;
+						const filePath = this.getNodeParameter('filePath', i);
 						const additionalParameters = this.getNodeParameter(
 							'additionalParameters',
 							i,
@@ -1812,7 +1812,7 @@ export class Github implements INodeType {
 						endpoint = `/repos/${owner}/${repository}/contents/${encodeURI(filePath)}`;
 					} else if (operation === 'list') {
 						requestMethod = 'GET';
-						const filePath = this.getNodeParameter('filePath', i) as string;
+						const filePath = this.getNodeParameter('filePath', i);
 						endpoint = `/repos/${owner}/${repository}/contents/${encodeURI(filePath)}`;
 					}
 				} else if (resource === 'issue') {
@@ -1823,7 +1823,7 @@ export class Github implements INodeType {
 
 						requestMethod = 'POST';
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 						body.body = this.getNodeParameter('body', i) as string;
 						const labels = this.getNodeParameter('labels', i) as IDataObject[];
 
@@ -2037,7 +2037,7 @@ export class Github implements INodeType {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);
 
-						body.event = snakeCase(this.getNodeParameter('event', i) as string).toUpperCase();
+						body.event = snakeCase(this.getNodeParameter('event', i)).toUpperCase();
 						if (body.event === 'REQUEST_CHANGES' || body.event === 'COMMENT') {
 							body.body = this.getNodeParameter('body', i) as string;
 						}
@@ -2123,7 +2123,7 @@ export class Github implements INodeType {
 							});
 						}
 						// Add the returned data to the item as binary property
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						const newItem: INodeExecutionData = {
 							json: items[i].json,

--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1025,8 +1025,8 @@ export class Gitlab implements INodeType {
 		let endpoint: string;
 		let returnAll = false;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 		const fullOperation = `${resource}:${operation}`;
 
 		for (let i = 0; i < items.length; i++) {
@@ -1058,7 +1058,7 @@ export class Gitlab implements INodeType {
 
 						requestMethod = 'POST';
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 						body.description = this.getNodeParameter('body', i) as string;
 						body.due_date = this.getNodeParameter('due_date', i) as string;
 						const labels = this.getNodeParameter('labels', i) as IDataObject[];

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -24,8 +24,8 @@ export async function goToWebinarApiRequest(
 	body: IDataObject | IDataObject[],
 	option: IDataObject = {},
 ) {
-	const operation = this.getNodeParameter('operation', 0) as string;
-	const resource = this.getNodeParameter('resource', 0) as string;
+	const operation = this.getNodeParameter('operation', 0);
+	const resource = this.getNodeParameter('resource', 0);
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
@@ -150,8 +150,8 @@ export class GoToWebinar implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/Google/Analytics/GoogleAnalytics.node.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/GoogleAnalytics.node.ts
@@ -141,8 +141,8 @@ export class GoogleAnalytics implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let method = '';
 		const qs: IDataObject = {};

--- a/packages/nodes-base/nodes/Google/BigQuery/GoogleBigQuery.node.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/GoogleBigQuery.node.ts
@@ -142,8 +142,8 @@ export class GoogleBigQuery implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'record') {
 			// *********************************************************************

--- a/packages/nodes-base/nodes/Google/Books/GoogleBooks.node.ts
+++ b/packages/nodes-base/nodes/Google/Books/GoogleBooks.node.ts
@@ -345,8 +345,8 @@ export class GoogleBooks implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const qs: IDataObject = {};
 		let responseData;
 

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -129,8 +129,8 @@ export class GoogleCalendar implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const timezone = this.getTimezone();
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
+++ b/packages/nodes-base/nodes/Google/Chat/GoogleChat.node.ts
@@ -199,8 +199,8 @@ export class GoogleChat implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'media') {
@@ -243,7 +243,7 @@ export class GoogleChat implements INodeType {
 
 						items[i] = newItem;
 
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						items[i].binary![binaryPropertyName] = await this.helpers.prepareBinaryData(
 							responseData,
@@ -477,7 +477,7 @@ export class GoogleChat implements INodeType {
 
 						// https://developers.google.com/chat/reference/rest/v1/spaces.messages.attachments/get
 
-						const attachmentName = this.getNodeParameter('attachmentName', i) as string;
+						const attachmentName = this.getNodeParameter('attachmentName', i);
 
 						responseData = await googleApiRequest.call(this, 'GET', `/v1/${attachmentName}`);
 					}
@@ -489,7 +489,7 @@ export class GoogleChat implements INodeType {
 
 						// https://developers.google.com/chat/how-tos/webhooks
 
-						const uri = this.getNodeParameter('incomingWebhookUrl', i) as string;
+						const uri = this.getNodeParameter('incomingWebhookUrl', i);
 
 						// get additional fields for threadKey
 						const additionalFields = this.getNodeParameter('additionalFields', i);

--- a/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
+++ b/packages/nodes-base/nodes/Google/CloudNaturalLanguage/GoogleCloudNaturalLanguage.node.ts
@@ -254,13 +254,13 @@ export class GoogleCloudNaturalLanguage implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const length = items.length;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const responseData = [];
 		for (let i = 0; i < length; i++) {
 			if (resource === 'document') {
 				if (operation === 'analyzeSentiment') {
-					const source = this.getNodeParameter('source', i) as string;
+					const source = this.getNodeParameter('source', i);
 					const options = this.getNodeParameter('options', i);
 					const encodingType = (options.encodingType as string | undefined) || 'UTF16';
 					const documentType = (options.documentType as string | undefined) || 'PLAIN_TEXT';

--- a/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
@@ -121,7 +121,7 @@ export const objectOperations: INodeProperties[] = [
 							// Handle body creation
 							async function (this, requestOptions) {
 								// Populate metadata JSON
-								let metadata: IDataObject = { name: this.getNodeParameter('objectName') as string };
+								let metadata: IDataObject = { name: this.getNodeParameter('objectName') };
 								const bodyData = this.getNodeParameter('createData') as IDataObject;
 								const useBinary = this.getNodeParameter('createFromBinary') as boolean;
 

--- a/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
@@ -91,8 +91,8 @@ export class GoogleContacts implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {
@@ -272,7 +272,7 @@ export class GoogleContacts implements INodeType {
 						const endpoint = useQuery ? ':searchContacts' : '/me/connections';
 
 						if (useQuery) {
-							qs.query = this.getNodeParameter('query', i) as string;
+							qs.query = this.getNodeParameter('query', i);
 						}
 
 						if (options.sortOrder) {

--- a/packages/nodes-base/nodes/Google/Docs/GoogleDocs.node.ts
+++ b/packages/nodes-base/nodes/Google/Docs/GoogleDocs.node.ts
@@ -202,8 +202,8 @@ export class GoogleDocs implements INodeType {
 
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -214,7 +214,7 @@ export class GoogleDocs implements INodeType {
 						const folderId = this.getNodeParameter('folderId', i) as string;
 
 						const body: IDataObject = {
-							name: this.getNodeParameter('title', i) as string,
+							name: this.getNodeParameter('title', i),
 							mimeType: 'application/vnd.google-apps.document',
 							...(folderId && folderId !== 'default' ? { parents: [folderId] } : {}),
 						};

--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -2106,8 +2106,8 @@ export class GoogleDrive implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -2524,7 +2524,7 @@ export class GoogleDrive implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -93,8 +93,8 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'document') {
 			if (operation === 'get') {
@@ -334,7 +334,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 
 				await Promise.all(
 					items.map(async (item: IDataObject, i: number) => {
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						responseData = await googleApiRequest.call(
 							this,
 							'POST',

--- a/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/GoogleFirebaseRealtimeDatabase.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/RealtimeDatabase/GoogleFirebaseRealtimeDatabase.node.ts
@@ -166,7 +166,7 @@ export class GoogleFirebaseRealtimeDatabase implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		//https://firebase.google.com/docs/reference/rest/database
 
 		if (
@@ -212,7 +212,7 @@ export class GoogleFirebaseRealtimeDatabase implements INodeType {
 					this,
 					projectId,
 					method,
-					this.getNodeParameter('path', i) as string,
+					this.getNodeParameter('path', i),
 					document,
 				);
 
@@ -239,7 +239,7 @@ export class GoogleFirebaseRealtimeDatabase implements INodeType {
 
 			if (typeof responseData === 'string' || typeof responseData === 'number') {
 				responseData = {
-					[this.getNodeParameter('path', i) as string]: responseData,
+					[this.getNodeParameter('path', i)]: responseData,
 				};
 			}
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -113,8 +113,8 @@ export class GSuiteAdmin implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'group') {
 				//https://developers.google.com/admin-sdk/directory/v1/reference/groups/insert
@@ -216,7 +216,7 @@ export class GSuiteAdmin implements INodeType {
 
 					const lastName = this.getNodeParameter('lastName', i) as string;
 
-					const password = this.getNodeParameter('password', i) as string;
+					const password = this.getNodeParameter('password', i);
 
 					const username = this.getNodeParameter('username', i) as string;
 

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -123,7 +123,7 @@ export async function googleApiRequest(
 		}
 
 		if (error.httpCode === '409') {
-			const resource = this.getNodeParameter('resource', 0) as string;
+			const resource = this.getNodeParameter('resource', 0);
 			if (resource === 'label') {
 				const options = {
 					message: `Label name exists already`,

--- a/packages/nodes-base/nodes/Google/Gmail/v1/GmailV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v1/GmailV1.node.ts
@@ -175,8 +175,8 @@ export class GmailV1 implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let method = '';
 		let body: IDataObject = {};
@@ -347,7 +347,7 @@ export class GmailV1 implements INodeType {
 							cc: ccStr,
 							bcc: bccStr,
 							subject: this.getNodeParameter('subject', i) as string,
-							body: this.getNodeParameter('message', i) as string,
+							body: this.getNodeParameter('message', i),
 							attachments: attachmentsList,
 						};
 
@@ -461,7 +461,7 @@ export class GmailV1 implements INodeType {
 							cc: ccStr,
 							bcc: bccStr,
 							subject,
-							body: this.getNodeParameter('message', i) as string,
+							body: this.getNodeParameter('message', i),
 							attachments: attachmentsList,
 						};
 
@@ -683,7 +683,7 @@ export class GmailV1 implements INodeType {
 							cc: ccStr,
 							bcc: bccStr,
 							subject: this.getNodeParameter('subject', i) as string,
-							body: this.getNodeParameter('message', i) as string,
+							body: this.getNodeParameter('message', i),
 							attachments: attachmentsList,
 						};
 

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -204,8 +204,8 @@ export class GmailV2 implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Google/Perspective/GooglePerspective.node.ts
+++ b/packages/nodes-base/nodes/Google/Perspective/GooglePerspective.node.ts
@@ -239,7 +239,7 @@ export class GooglePerspective implements INodeType {
 					const body: CommentAnalyzeBody = {
 						comment: {
 							type: 'PLAIN_TEXT',
-							text: this.getNodeParameter('text', i) as string,
+							text: this.getNodeParameter('text', i),
 						},
 						requestedAttributes,
 					};

--- a/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheetsV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheetsV1.node.ts
@@ -102,8 +102,8 @@ export class GoogleSheetsV1 implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 
 		if (resource === 'sheet') {
 			const spreadsheetId = this.getNodeParameter('sheetId', 0) as string;
@@ -112,7 +112,7 @@ export class GoogleSheetsV1 implements INodeType {
 
 			let range = '';
 			if (!['create', 'delete', 'remove'].includes(operation)) {
-				range = this.getNodeParameter('range', 0) as string;
+				range = this.getNodeParameter('range', 0);
 			}
 
 			const options = this.getNodeParameter('options', 0, {}) as IDataObject;
@@ -450,7 +450,7 @@ export class GoogleSheetsV1 implements INodeType {
 
 				for (let i = 0; i < this.getInputData().length; i++) {
 					try {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const sheetsUi = this.getNodeParameter('sheetsUi', i, {}) as IDataObject;
 
 						const body = {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/clear.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/clear.operation.ts
@@ -187,7 +187,7 @@ export async function execute(
 		}
 
 		if (clearType === 'specificRange') {
-			const rangeField = this.getNodeParameter('range', i) as string;
+			const rangeField = this.getNodeParameter('range', i);
 			const region = rangeField.includes('!') ? rangeField.split('!')[1] || '' : rangeField;
 
 			range = `${sheetName}!${region}`;

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/create.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/create.operation.ts
@@ -85,7 +85,7 @@ export async function execute(
 	const existingSheetNames = await getExistingSheetNames(sheet);
 
 	for (let i = 0; i < items.length; i++) {
-		const sheetTitle = this.getNodeParameter('title', i, {}) as string;
+		const sheetTitle = this.getNodeParameter('title', i, {});
 
 		if (existingSheetNames.includes(sheetTitle)) {
 			continue;

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/spreadsheet/create.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/spreadsheet/create.operation.ts
@@ -119,7 +119,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 	const returnData: IDataObject[] = [];
 
 	for (let i = 0; i < items.length; i++) {
-		const title = this.getNodeParameter('title', i) as string;
+		const title = this.getNodeParameter('title', i);
 		const sheetsUi = this.getNodeParameter('sheetsUi', i, {}) as IDataObject;
 
 		const body = {

--- a/packages/nodes-base/nodes/Google/Slides/GoogleSlides.node.ts
+++ b/packages/nodes-base/nodes/Google/Slides/GoogleSlides.node.ts
@@ -387,8 +387,8 @@ export class GoogleSlides implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
@@ -433,7 +433,7 @@ export class GoogleSlides implements INodeType {
 
 						const download = this.getNodeParameter('download', 0);
 						if (download === true) {
-							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 							const data = await this.helpers.request({
 								uri: responseData.contentUrl,
@@ -477,7 +477,7 @@ export class GoogleSlides implements INodeType {
 						// ----------------------------------
 
 						const body = {
-							title: this.getNodeParameter('title', i) as string,
+							title: this.getNodeParameter('title', i),
 						};
 
 						responseData = await googleApiRequest.call(this, 'POST', '/presentations', body);

--- a/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
+++ b/packages/nodes-base/nodes/Google/Task/GoogleTasks.node.ts
@@ -83,8 +83,8 @@ export class GoogleTasks implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let body: IDataObject = {};
 		for (let i = 0; i < length; i++) {
 			try {
@@ -93,7 +93,7 @@ export class GoogleTasks implements INodeType {
 						body = {};
 						//https://developers.google.com/tasks/v1/reference/tasks/insert
 						const taskId = this.getNodeParameter('task', i) as string;
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						if (additionalFields.parent) {

--- a/packages/nodes-base/nodes/Google/Translate/GoogleTranslate.node.ts
+++ b/packages/nodes-base/nodes/Google/Translate/GoogleTranslate.node.ts
@@ -186,13 +186,13 @@ export class GoogleTranslate implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const responseData: INodeExecutionData[] = [];
 		for (let i = 0; i < length; i++) {
 			if (resource === 'language') {
 				if (operation === 'translate') {
-					const text = this.getNodeParameter('text', i) as string;
+					const text = this.getNodeParameter('text', i);
 					const translateTo = this.getNodeParameter('translateTo', i) as string;
 
 					const response = await googleApiRequest.call(this, 'POST', `/language/translate/v2`, {

--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -189,8 +189,8 @@ export class YouTube implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'channel') {
@@ -383,7 +383,7 @@ export class YouTube implements INodeType {
 					//https://developers.google.com/youtube/v3/docs/channelBanners/insert
 					if (operation === 'uploadBanner') {
 						const channelId = this.getNodeParameter('channelId', i) as string;
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 						let mimeType;
 
@@ -518,7 +518,7 @@ export class YouTube implements INodeType {
 					}
 					//https://developers.google.com/youtube/v3/docs/playlists/insert
 					if (operation === 'create') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const options = this.getNodeParameter('options', i);
 
 						qs.part = 'snippet';
@@ -563,7 +563,7 @@ export class YouTube implements INodeType {
 					//https://developers.google.com/youtube/v3/docs/playlists/update
 					if (operation === 'update') {
 						const playlistId = this.getNodeParameter('playlistId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const updateFields = this.getNodeParameter('updateFields', i);
 
 						qs.part = 'snippet, status';
@@ -846,10 +846,10 @@ export class YouTube implements INodeType {
 					}
 					//https://developers.google.com/youtube/v3/guides/uploading_a_video?hl=en
 					if (operation === 'upload') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const categoryId = this.getNodeParameter('categoryId', i) as string;
 						const options = this.getNodeParameter('options', i);
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 						let mimeType;
 
@@ -967,7 +967,7 @@ export class YouTube implements INodeType {
 					//https://developers.google.com/youtube/v3/docs/playlists/update
 					if (operation === 'update') {
 						const id = this.getNodeParameter('videoId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const categoryId = this.getNodeParameter('categoryId', i) as string;
 						const updateFields = this.getNodeParameter('updateFields', i);
 

--- a/packages/nodes-base/nodes/Gotify/Gotify.node.ts
+++ b/packages/nodes-base/nodes/Gotify/Gotify.node.ts
@@ -163,13 +163,13 @@ export class Gotify implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'message') {
 					if (operation === 'create') {
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Grafana/Grafana.node.ts
+++ b/packages/nodes-base/nodes/Grafana/Grafana.node.ts
@@ -123,8 +123,8 @@ export class Grafana implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 
@@ -165,7 +165,7 @@ export class Grafana implements INodeType {
 
 						// https://grafana.com/docs/grafana/latest/http_api/dashboard/#delete-dashboard-by-uid
 
-						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i) as string;
+						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i);
 						const uid = deriveUid.call(this, uidOrUrl);
 						const endpoint = `/dashboards/uid/${uid}`;
 						responseData = await grafanaApiRequest.call(this, 'DELETE', endpoint);
@@ -176,7 +176,7 @@ export class Grafana implements INodeType {
 
 						// https://grafana.com/docs/grafana/latest/http_api/dashboard/#get-dashboard-by-uid
 
-						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i) as string;
+						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i);
 						const uid = deriveUid.call(this, uidOrUrl);
 						const endpoint = `/dashboards/uid/${uid}`;
 						responseData = await grafanaApiRequest.call(this, 'GET', endpoint);
@@ -212,7 +212,7 @@ export class Grafana implements INodeType {
 
 						// https://grafana.com/docs/grafana/latest/http_api/dashboard/#create--update-dashboard
 
-						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i) as string;
+						const uidOrUrl = this.getNodeParameter('dashboardUidOrUrl', i);
 						const uid = deriveUid.call(this, uidOrUrl);
 
 						// ensure dashboard to update exists

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -382,7 +382,7 @@ export class GraphQL implements INodeType {
 					};
 				}
 
-				const gqlQuery = this.getNodeParameter('query', itemIndex, '') as string;
+				const gqlQuery = this.getNodeParameter('query', itemIndex, '');
 				if (requestMethod === 'GET') {
 					if (!requestOptions.qs) {
 						requestOptions.qs = {};
@@ -393,7 +393,7 @@ export class GraphQL implements INodeType {
 						requestOptions.body = {
 							query: gqlQuery,
 							variables: this.getNodeParameter('variables', itemIndex, {}) as object,
-							operationName: this.getNodeParameter('operationName', itemIndex) as string,
+							operationName: this.getNodeParameter('operationName', itemIndex),
 						};
 						if (typeof requestOptions.body.variables === 'string') {
 							try {
@@ -430,7 +430,7 @@ export class GraphQL implements INodeType {
 					response = await this.helpers.request(requestOptions);
 				}
 				if (responseFormat === 'string') {
-					const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+					const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 					returnItems.push({
 						json: {
 							[dataPropertyName]: response,

--- a/packages/nodes-base/nodes/Grist/Grist.node.ts
+++ b/packages/nodes-base/nodes/Grist/Grist.node.ts
@@ -118,7 +118,7 @@ export class Grist implements INodeType {
 		let responseData;
 		const returnData: IDataObject[] = [];
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/HackerNews/HackerNews.node.ts
+++ b/packages/nodes-base/nodes/HackerNews/HackerNews.node.ts
@@ -265,8 +265,8 @@ export class HackerNews implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let returnAll = false;
 
 		for (let i = 0; i < items.length; i++) {

--- a/packages/nodes-base/nodes/HaloPSA/HaloPSA.node.ts
+++ b/packages/nodes-base/nodes/HaloPSA/HaloPSA.node.ts
@@ -222,8 +222,8 @@ export class HaloPSA implements INodeType {
 
 		const tokens = await getAccessTokens.call(this);
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		//====================================================================
 		//                        Main Loop
@@ -236,7 +236,7 @@ export class HaloPSA implements INodeType {
 
 					if (operation === 'create') {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const name = this.getNodeParameter('clientName', i) as string;
+						const name = this.getNodeParameter('clientName', i);
 						const body: IDataObject = {
 							name,
 							...additionalFields,
@@ -347,7 +347,7 @@ export class HaloPSA implements INodeType {
 					];
 
 					if (operation === 'create') {
-						const name = this.getNodeParameter('siteName', i) as string;
+						const name = this.getNodeParameter('siteName', i);
 						const clientId = this.getNodeParameter('clientId', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
@@ -566,7 +566,7 @@ export class HaloPSA implements INodeType {
 					];
 
 					if (operation === 'create') {
-						const name = this.getNodeParameter('userName', i) as string;
+						const name = this.getNodeParameter('userName', i);
 						const siteId = this.getNodeParameter('siteId', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {

--- a/packages/nodes-base/nodes/Harvest/Harvest.node.ts
+++ b/packages/nodes-base/nodes/Harvest/Harvest.node.ts
@@ -204,8 +204,8 @@ export class Harvest implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let requestMethod = '';
@@ -256,7 +256,7 @@ export class Harvest implements INodeType {
 
 						body.project_id = this.getNodeParameter('projectId', i) as string;
 						body.task_id = this.getNodeParameter('taskId', i) as string;
-						body.spent_date = this.getNodeParameter('spentDate', i) as string;
+						body.spent_date = this.getNodeParameter('spentDate', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);
@@ -284,7 +284,7 @@ export class Harvest implements INodeType {
 
 						body.project_id = this.getNodeParameter('projectId', i) as string;
 						body.task_id = this.getNodeParameter('taskId', i) as string;
-						body.spent_date = this.getNodeParameter('spentDate', i) as string;
+						body.spent_date = this.getNodeParameter('spentDate', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);
@@ -683,8 +683,8 @@ export class Harvest implements INodeType {
 						requestMethod = 'POST';
 						endpoint = 'users';
 
-						body.first_name = this.getNodeParameter('firstName', i) as string;
-						body.last_name = this.getNodeParameter('lastName', i) as string;
+						body.first_name = this.getNodeParameter('firstName', i);
+						body.last_name = this.getNodeParameter('lastName', i);
 						body.email = this.getNodeParameter('email', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -795,7 +795,7 @@ export class Harvest implements INodeType {
 						endpoint = 'contacts';
 
 						body.client_id = this.getNodeParameter('clientId', i) as string;
-						body.first_name = this.getNodeParameter('firstName', i) as string;
+						body.first_name = this.getNodeParameter('firstName', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);
@@ -1148,7 +1148,7 @@ export class Harvest implements INodeType {
 
 						body.project_id = this.getNodeParameter('projectId', i) as string;
 						body.expense_category_id = this.getNodeParameter('expenseCategoryId', i) as string;
-						body.spent_date = this.getNodeParameter('spentDate', i) as string;
+						body.spent_date = this.getNodeParameter('spentDate', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						Object.assign(body, additionalFields);

--- a/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
+++ b/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
@@ -151,8 +151,8 @@ export class HelpScout implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'conversation') {
@@ -454,7 +454,7 @@ export class HelpScout implements INodeType {
 					if (operation === 'create') {
 						const conversationId = this.getNodeParameter('conversationId', i) as string;
 						const _type = this.getNodeParameter('type', i) as string;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const attachments = this.getNodeParameter('attachmentsUi', i) as IDataObject;
 						const body: IThread = {

--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -182,8 +182,8 @@ export class HomeAssistant implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		const length = items.length;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const qs: IDataObject = {};
 		let responseData;
 		for (let i = 0; i < length; i++) {

--- a/packages/nodes-base/nodes/HtmlExtract/HtmlExtract.node.ts
+++ b/packages/nodes-base/nodes/HtmlExtract/HtmlExtract.node.ts
@@ -214,7 +214,7 @@ export class HtmlExtract implements INodeType {
 		let item: INodeExecutionData;
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			try {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex);
 				const extractionValues = this.getNodeParameter(
 					'extractionValues',
 					itemIndex,

--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -1019,7 +1019,7 @@ export class HttpRequestV1 implements INodeType {
 			const fullResponse = !!options.fullResponse as boolean;
 
 			if (responseFormat === 'file') {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 
 				const newItem: INodeExecutionData = {
 					json: {},
@@ -1065,7 +1065,7 @@ export class HttpRequestV1 implements INodeType {
 
 				returnItems.push(newItem);
 			} else if (responseFormat === 'string') {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 
 				if (fullResponse === true) {
 					const returnItem: IDataObject = {};

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -1067,7 +1067,7 @@ export class HttpRequestV2 implements INodeType {
 			const fullResponse = !!options.fullResponse as boolean;
 
 			if (responseFormat === 'file') {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 
 				const newItem: INodeExecutionData = {
 					json: {},
@@ -1113,7 +1113,7 @@ export class HttpRequestV2 implements INodeType {
 
 				returnItems.push(newItem);
 			} else if (responseFormat === 'string') {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 
 				if (fullResponse === true) {
 					const returnItem: IDataObject = {};

--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -933,8 +933,8 @@ export class Hubspot implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		//https://legacydocs.hubspot.com/docs/methods/lists/contact-lists-overview
 		if (resource === 'contactList') {

--- a/packages/nodes-base/nodes/HumanticAI/HumanticAi.node.ts
+++ b/packages/nodes-base/nodes/HumanticAI/HumanticAi.node.ts
@@ -61,8 +61,8 @@ export class HumanticAi implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'profile') {
 				if (operation === 'create') {
@@ -71,7 +71,7 @@ export class HumanticAi implements INodeType {
 					qs.userid = userId;
 
 					if (sendResume) {
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						if (items[i].binary === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {
@@ -144,7 +144,7 @@ export class HumanticAi implements INodeType {
 					qs.userid = userId;
 
 					if (sendResume) {
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						if (items[i].binary === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {
@@ -184,7 +184,7 @@ export class HumanticAi implements INodeType {
 						);
 						responseData = responseData.data;
 					} else {
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const body: IDataObject = {
 							text,
 						};

--- a/packages/nodes-base/nodes/Hunter/Hunter.node.ts
+++ b/packages/nodes-base/nodes/Hunter/Hunter.node.ts
@@ -274,7 +274,7 @@ export class Hunter implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const operation = this.getNodeParameter('operation', 0);
 				//https://hunter.io/api-documentation/v2#domain-search
 				if (operation === 'domainSearch') {
 					const returnAll = this.getNodeParameter('returnAll', i);

--- a/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
+++ b/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
@@ -300,15 +300,15 @@ export class ICalendar implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 		const returnData: INodeExecutionData[] = [];
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		if (operation === 'createEventFile') {
 			for (let i = 0; i < length; i++) {
-				const title = this.getNodeParameter('title', i) as string;
+				const title = this.getNodeParameter('title', i);
 				const allDay = this.getNodeParameter('allDay', i) as boolean;
 				const start = this.getNodeParameter('start', i) as string;
 				let end = this.getNodeParameter('end', i) as string;
 				end = allDay ? (moment(end).utc().add(1, 'day').format() as string) : end;
-				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 				const additionalFields = this.getNodeParameter('additionalFields', i);
 				let fileName = 'event.ics';
 

--- a/packages/nodes-base/nodes/Intercom/Intercom.node.ts
+++ b/packages/nodes-base/nodes/Intercom/Intercom.node.ts
@@ -108,8 +108,8 @@ export class Intercom implements INodeType {
 		for (let i = 0; i < length; i++) {
 			try {
 				qs = {};
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 				//https://developers.intercom.com/intercom-api-reference/reference#leads
 				if (resource === 'lead') {
 					if (operation === 'create' || operation === 'update') {

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -267,8 +267,8 @@ export class InvoiceNinja implements INodeType {
 
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const apiVersion = this.getNodeParameter('apiVersion', 0) as string;
 
 		for (let i = 0; i < length; i++) {

--- a/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/ItemLists.node.ts
@@ -736,8 +736,8 @@ return 0;`,
 		const items = this.getInputData();
 		const length = items.length;
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		if (resource === 'itemList') {
 			if (operation === 'splitOutItems') {
 				for (let i = 0; i < length; i++) {
@@ -1001,7 +1001,7 @@ return 0;`,
 					return this.prepareOutputData(returnData);
 				} else {
 					let newItems: IDataObject[] = items.map((item) => item.json);
-					const destinationFieldName = this.getNodeParameter('destinationFieldName', 0) as string;
+					const destinationFieldName = this.getNodeParameter('destinationFieldName', 0);
 					const fieldsToExclude = (
 						this.getNodeParameter('fieldsToExclude.fields', 0, []) as IDataObject[]
 					).map((entry) => entry.fieldName);

--- a/packages/nodes-base/nodes/Iterable/Iterable.node.ts
+++ b/packages/nodes-base/nodes/Iterable/Iterable.node.ts
@@ -97,8 +97,8 @@ export class Iterable implements INodeType {
 		const timezone = this.getTimezone();
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'event') {
 			if (operation === 'track') {

--- a/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
+++ b/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
@@ -486,8 +486,8 @@ export class Jenkins implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -446,8 +446,8 @@ export class Jira implements INodeType {
 		let responseData;
 		const qs: IDataObject = {};
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const jiraVersion = this.getNodeParameter('jiraVersion', 0) as string;
 
 		if (resource === 'issue') {
@@ -976,7 +976,7 @@ export class Jira implements INodeType {
 			//https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post
 			if (operation === 'add') {
 				for (let i = 0; i < length; i++) {
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 					const issueKey = this.getNodeParameter('issueKey', i) as string;
 
 					if (items[i].binary === undefined) {
@@ -1066,7 +1066,7 @@ export class Jira implements INodeType {
 					returnData.push(...executionData);
 				}
 				if (download) {
-					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
 						returnData[index]['binary'] = {};
 
@@ -1120,7 +1120,7 @@ export class Jira implements INodeType {
 					returnData.push(...executionData);
 				}
 				if (download) {
-					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryProperty', 0);
 					for (const [index, attachment] of returnData.entries()) {
 						returnData[index]['binary'] = {};
 						//@ts-ignore

--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -328,13 +328,13 @@ export class Kafka implements INodeType {
 				if (sendInputData === true) {
 					message = JSON.stringify(items[i].json);
 				} else {
-					message = this.getNodeParameter('message', i) as string;
+					message = this.getNodeParameter('message', i);
 				}
 
 				if (useSchemaRegistry) {
 					try {
-						const schemaRegistryUrl = this.getNodeParameter('schemaRegistryUrl', 0) as string;
-						const eventName = this.getNodeParameter('eventName', 0) as string;
+						const schemaRegistryUrl = this.getNodeParameter('schemaRegistryUrl', 0);
+						const eventName = this.getNodeParameter('eventName', 0);
 
 						const registry = new SchemaRegistry({ host: schemaRegistryUrl });
 						const id = await registry.getLatestSchemaId(eventName);

--- a/packages/nodes-base/nodes/Keap/Keap.node.ts
+++ b/packages/nodes-base/nodes/Keap/Keap.node.ts
@@ -249,8 +249,8 @@ export class Keap implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'company') {
 				//https://developer.keap.com/docs/rest/#!/Company/createCompanyUsingPOST
@@ -261,7 +261,7 @@ export class Keap implements INodeType {
 						.faxesValues as IDataObject[];
 					const phones = (this.getNodeParameter('phonesUi', i) as IDataObject)
 						.phonesValues as IDataObject[];
-					const companyName = this.getNodeParameter('companyName', i) as string;
+					const companyName = this.getNodeParameter('companyName', i);
 					const additionalFields = this.getNodeParameter('additionalFields', i);
 					const body: ICompany = {
 						company_name: companyName,
@@ -575,7 +575,7 @@ export class Keap implements INodeType {
 				//https://developer.infusionsoft.com/docs/rest/#!/E-Commerce/createOrderUsingPOST
 				if (operation === 'create') {
 					const contactId = parseInt(this.getNodeParameter('contactId', i) as string, 10);
-					const orderDate = this.getNodeParameter('orderDate', i) as string;
+					const orderDate = this.getNodeParameter('orderDate', i);
 					const orderTitle = this.getNodeParameter('orderTitle', i) as string;
 					const orderType = this.getNodeParameter('orderType', i) as string;
 					const orderItems = (this.getNodeParameter('orderItemsUi', i) as IDataObject)
@@ -638,7 +638,7 @@ export class Keap implements INodeType {
 			if (resource === 'ecommerceProduct') {
 				//https://developer.infusionsoft.com/docs/rest/#!/Product/createProductUsingPOST
 				if (operation === 'create') {
-					const productName = this.getNodeParameter('productName', i) as string;
+					const productName = this.getNodeParameter('productName', i);
 					const additionalFields = this.getNodeParameter('additionalFields', i);
 					const body: IEcommerceProduct = {
 						product_name: productName,
@@ -829,7 +829,7 @@ export class Keap implements INodeType {
 						body.contact_id = contactId;
 					}
 					if (binaryData) {
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						if (items[i].binary === undefined) {
 							throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {

--- a/packages/nodes-base/nodes/Kitemaker/Kitemaker.node.ts
+++ b/packages/nodes-base/nodes/Kitemaker/Kitemaker.node.ts
@@ -239,7 +239,7 @@ export class Kitemaker implements INodeType {
 					// ----------------------------------
 
 					const input = {
-						title: this.getNodeParameter('title', i) as string,
+						title: this.getNodeParameter('title', i),
 						statusId: this.getNodeParameter('statusId', i) as string[],
 					};
 

--- a/packages/nodes-base/nodes/KoBoToolbox/KoBoToolbox.node.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/KoBoToolbox.node.ts
@@ -81,8 +81,8 @@ export class KoBoToolbox implements INodeType {
 		let returnData: any[] = [];
 		const binaryItems: INodeExecutionData[] = [];
 		const items = this.getInputData();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			if (resource === 'form') {

--- a/packages/nodes-base/nodes/Lemlist/Lemlist.node.ts
+++ b/packages/nodes-base/nodes/Lemlist/Lemlist.node.ts
@@ -103,8 +103,8 @@ export class Lemlist implements INodeType {
 	async execute(this: IExecuteFunctions) {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/Line/Line.node.ts
+++ b/packages/nodes-base/nodes/Line/Line.node.ts
@@ -63,14 +63,14 @@ export class Line implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'notification') {
 					//https://notify-bot.line.me/doc/en/
 					if (operation === 'send') {
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Linear/Linear.node.ts
+++ b/packages/nodes-base/nodes/Linear/Linear.node.ts
@@ -159,14 +159,14 @@ export class Linear implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'issue') {
 					if (operation === 'create') {
 						const teamId = this.getNodeParameter('teamId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IGraphqlBody = {
 							query: query.createIssue(),

--- a/packages/nodes-base/nodes/LingvaNex/LingvaNex.node.ts
+++ b/packages/nodes-base/nodes/LingvaNex/LingvaNex.node.ts
@@ -151,11 +151,11 @@ export class LingvaNex implements INodeType {
 		const items = this.getInputData();
 		const length = items.length;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		const responseData = [];
 		for (let i = 0; i < length; i++) {
 			if (operation === 'translate') {
-				const text = this.getNodeParameter('text', i) as string;
+				const text = this.getNodeParameter('text', i);
 				const translateTo = this.getNodeParameter('translateTo', i) as string;
 				const options = this.getNodeParameter('options', i);
 

--- a/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
+++ b/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
@@ -72,8 +72,8 @@ export class LinkedIn implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let body: any = {}; // tslint:disable-line:no-any
 
@@ -81,7 +81,7 @@ export class LinkedIn implements INodeType {
 			try {
 				if (resource === 'post') {
 					if (operation === 'create') {
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const shareMediaCategory = this.getNodeParameter('shareMediaCategory', i) as string;
 						const postAs = this.getNodeParameter('postAs', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -146,7 +146,7 @@ export class LinkedIn implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(

--- a/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
+++ b/packages/nodes-base/nodes/MQTT/Mqtt.node.ts
@@ -247,7 +247,7 @@ export class Mqtt implements INodeType {
 						if (sendInputData === true) {
 							message = JSON.stringify(items[i].json);
 						} else {
-							message = this.getNodeParameter('message', i) as string;
+							message = this.getNodeParameter('message', i);
 						}
 						client.publish(topic, message, options);
 					} catch (e) {

--- a/packages/nodes-base/nodes/Magento/Magento2.node.ts
+++ b/packages/nodes-base/nodes/Magento/Magento2.node.ts
@@ -310,8 +310,8 @@ export class Magento2 implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -462,8 +462,8 @@ export class Magento2 implements INodeType {
 					if (operation === 'update') {
 						//https://magento.redoc.ly/2.3.7-admin/tag/customerscustomerId#operation/customerCustomerRepositoryV1SavePut
 						const customerId = this.getNodeParameter('customerId', i) as string;
-						const firstName = this.getNodeParameter('firstName', i) as string;
-						const lastName = this.getNodeParameter('lastName', i) as string;
+						const firstName = this.getNodeParameter('firstName', i);
+						const lastName = this.getNodeParameter('lastName', i);
 						const email = this.getNodeParameter('email', i) as string;
 
 						const { addresses, customAttributes, password, ...rest } = this.getNodeParameter(

--- a/packages/nodes-base/nodes/Mailcheck/Mailcheck.node.ts
+++ b/packages/nodes-base/nodes/Mailcheck/Mailcheck.node.ts
@@ -80,8 +80,8 @@ export class Mailcheck implements INodeType {
 		const length = items.length;
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'email') {

--- a/packages/nodes-base/nodes/Mailchimp/Mailchimp.node.ts
+++ b/packages/nodes-base/nodes/Mailchimp/Mailchimp.node.ts
@@ -1678,8 +1678,8 @@ export class Mailchimp implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/MailerLite/MailerLite.node.ts
+++ b/packages/nodes-base/nodes/MailerLite/MailerLite.node.ts
@@ -77,8 +77,8 @@ export class MailerLite implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'subscriber') {

--- a/packages/nodes-base/nodes/MailerLite/MailerLiteTrigger.node.ts
+++ b/packages/nodes-base/nodes/MailerLite/MailerLiteTrigger.node.ts
@@ -107,7 +107,7 @@ export class MailerLiteTrigger implements INodeType {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				// Check all the webhooks which exist already if it is identical to the
 				// one that is supposed to get created.
 				const endpoint = '/webhooks';
@@ -124,7 +124,7 @@ export class MailerLiteTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookData = this.getWorkflowStaticData('node');
 				const webhookUrl = this.getNodeWebhookUrl('default');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 
 				const endpoint = '/webhooks';
 

--- a/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
+++ b/packages/nodes-base/nodes/Mailgun/Mailgun.node.ts
@@ -117,7 +117,7 @@ export class Mailgun implements INodeType {
 				const ccEmail = this.getNodeParameter('ccEmail', itemIndex) as string;
 				const bccEmail = this.getNodeParameter('bccEmail', itemIndex) as string;
 				const subject = this.getNodeParameter('subject', itemIndex) as string;
-				const text = this.getNodeParameter('text', itemIndex) as string;
+				const text = this.getNodeParameter('text', itemIndex);
 				const html = this.getNodeParameter('html', itemIndex) as string;
 				const attachmentPropertyString = this.getNodeParameter('attachments', itemIndex) as string;
 

--- a/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
@@ -15,7 +15,7 @@ export async function mailjetApiRequest(
 	option: IDataObject = {},
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const resource = this.getNodeParameter('resource', 0) as string;
+	const resource = this.getNodeParameter('resource', 0);
 
 	let credentialType;
 

--- a/packages/nodes-base/nodes/Mailjet/Mailjet.node.ts
+++ b/packages/nodes-base/nodes/Mailjet/Mailjet.node.ts
@@ -97,8 +97,8 @@ export class Mailjet implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -107,7 +107,7 @@ export class Mailjet implements INodeType {
 					if (operation === 'send') {
 						const fromEmail = this.getNodeParameter('fromEmail', i) as string;
 						const htmlBody = this.getNodeParameter('html', i) as string;
-						const textBody = this.getNodeParameter('text', i) as string;
+						const textBody = this.getNodeParameter('text', i);
 						const subject = this.getNodeParameter('subject', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const toEmail = (this.getNodeParameter('toEmail', i) as string).split(',') as string[];
@@ -291,9 +291,9 @@ export class Mailjet implements INodeType {
 				if (resource === 'sms') {
 					//https://dev.mailjet.com/sms/reference/send-message#v4_post_sms-send
 					if (operation === 'send') {
-						const from = this.getNodeParameter('from', i) as string;
+						const from = this.getNodeParameter('from', i);
 						const to = this.getNodeParameter('to', i) as boolean;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const body: IDataObject = {
 							From: from,
 							To: to,

--- a/packages/nodes-base/nodes/Mailjet/MailjetTrigger.node.ts
+++ b/packages/nodes-base/nodes/Mailjet/MailjetTrigger.node.ts
@@ -76,7 +76,7 @@ export class MailjetTrigger implements INodeType {
 				const endpoint = `/v3/rest/eventcallbackurl`;
 				const responseData = await mailjetApiRequest.call(this, 'GET', endpoint);
 
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const webhookUrl = this.getNodeWebhookUrl('default');
 
 				for (const webhook of responseData.Data) {
@@ -93,7 +93,7 @@ export class MailjetTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const endpoint = '/v3/rest/eventcallbackurl';
 				const body: IDataObject = {
 					Url: webhookUrl,

--- a/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
+++ b/packages/nodes-base/nodes/Mandrill/Mandrill.node.ts
@@ -714,8 +714,8 @@ export class Mandrill implements INodeType {
 		const items = this.getInputData();
 		let responseData;
 		let emailSentResponse;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Marketstack/Marketstack.node.ts
+++ b/packages/nodes-base/nodes/Marketstack/Marketstack.node.ts
@@ -24,7 +24,7 @@ import {
 	validateTimeOptions,
 } from './GenericFunctions';
 
-import { EndOfDayDataFilters, Operation, Resource } from './types';
+import { EndOfDayDataFilters, Resource } from './types';
 
 export class Marketstack implements INodeType {
 	description: INodeTypeDescription = {
@@ -85,7 +85,7 @@ export class Marketstack implements INodeType {
 		const items = this.getInputData();
 
 		const resource = this.getNodeParameter('resource', 0) as Resource;
-		const operation = this.getNodeParameter('operation', 0) as Operation;
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData: any; // tslint:disable-line: no-any
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -107,7 +107,7 @@ export async function handleMatrixCall(
 	} else if (resource === 'message') {
 		if (operation === 'create') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
-			const text = this.getNodeParameter('text', index, '') as string;
+			const text = this.getNodeParameter('text', index, '');
 			const messageType = this.getNodeParameter('messageType', index) as string;
 			const messageFormat = this.getNodeParameter('messageFormat', index) as string;
 			const body: IDataObject = {
@@ -189,7 +189,7 @@ export async function handleMatrixCall(
 		if (operation === 'upload') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const mediaType = this.getNodeParameter('mediaType', index) as string;
-			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', index) as string;
+			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', index);
 
 			let body;
 			const qs: IDataObject = {};

--- a/packages/nodes-base/nodes/Matrix/Matrix.node.ts
+++ b/packages/nodes-base/nodes/Matrix/Matrix.node.ts
@@ -139,8 +139,8 @@ export class Matrix implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData() as IDataObject[];
 		const returnData: IDataObject[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/channel/create/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/channel/create/execute.ts
@@ -16,7 +16,7 @@ export async function create(
 	const type = this.getNodeParameter('type', index) as string;
 
 	body.team_id = this.getNodeParameter('teamId', index) as string;
-	body.display_name = this.getNodeParameter('displayName', index) as string;
+	body.display_name = this.getNodeParameter('displayName', index);
 	body.name = this.getNodeParameter('channel', index) as string;
 	body.type = type === 'public' ? 'O' : 'P';
 

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/message/post/execute.ts
@@ -13,7 +13,7 @@ export async function post(this: IExecuteFunctions, index: number): Promise<INod
 	const endpoint = `posts`;
 
 	body.channel_id = this.getNodeParameter('channelId', index) as string;
-	body.message = this.getNodeParameter('message', index) as string;
+	body.message = this.getNodeParameter('message', index);
 
 	const attachments = this.getNodeParameter('attachments', index, []) as unknown as IAttachment[];
 	// The node does save the fields data differently than the API

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/create/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/create/execute.ts
@@ -14,7 +14,7 @@ export async function create(
 	const body = {
 		user_id: this.getNodeParameter('userId', index),
 		post_id: this.getNodeParameter('postId', index),
-		emoji_name: (this.getNodeParameter('emojiName', index) as string).replace(/:/g, ''),
+		emoji_name: this.getNodeParameter('emojiName', index).replace(/:/g, ''),
 		create_at: Date.now(),
 	} as { user_id: string; post_id: string; emoji_name: string; create_at: number };
 

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/del/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/del/execute.ts
@@ -7,7 +7,7 @@ import { apiRequest } from '../../../transport';
 export async function del(this: IExecuteFunctions, index: number): Promise<INodeExecutionData[]> {
 	const userId = this.getNodeParameter('userId', index) as string;
 	const postId = this.getNodeParameter('postId', index) as string;
-	const emojiName = (this.getNodeParameter('emojiName', index) as string).replace(/:/g, '');
+	const emojiName = this.getNodeParameter('emojiName', index).replace(/:/g, '');
 
 	const qs = {} as IDataObject;
 	const requestMethod = 'DELETE';

--- a/packages/nodes-base/nodes/Mattermost/v1/actions/user/create/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/user/create/execute.ts
@@ -28,7 +28,7 @@ export async function create(
 
 	if (authService === 'email') {
 		body.email = this.getNodeParameter('email', index) as string;
-		body.password = this.getNodeParameter('password', index) as string;
+		body.password = this.getNodeParameter('password', index);
 	} else {
 		body.auth_data = this.getNodeParameter('authData', index) as string;
 	}

--- a/packages/nodes-base/nodes/Mautic/Mautic.node.ts
+++ b/packages/nodes-base/nodes/Mautic/Mautic.node.ts
@@ -319,8 +319,8 @@ export class Mautic implements INodeType {
 		let qs: IDataObject;
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			qs = {};
@@ -605,11 +605,11 @@ export class Mautic implements INodeType {
 						let body: IDataObject = {};
 						if (!jsonActive) {
 							body.email = this.getNodeParameter('email', i) as string;
-							body.firstname = this.getNodeParameter('firstName', i) as string;
-							body.lastname = this.getNodeParameter('lastName', i) as string;
-							body.company = this.getNodeParameter('company', i) as string;
+							body.firstname = this.getNodeParameter('firstName', i);
+							body.lastname = this.getNodeParameter('lastName', i);
+							body.company = this.getNodeParameter('company', i);
 							body.position = this.getNodeParameter('position', i) as string;
-							body.title = this.getNodeParameter('title', i) as string;
+							body.title = this.getNodeParameter('title', i);
 						} else {
 							const json = validateJSON(this.getNodeParameter('bodyJson', i) as string);
 							if (json !== undefined) {

--- a/packages/nodes-base/nodes/Medium/Medium.node.ts
+++ b/packages/nodes-base/nodes/Medium/Medium.node.ts
@@ -400,8 +400,8 @@ export class Medium implements INodeType {
 		for (let i = 0; i < items.length; i++) {
 			qs = {};
 			try {
-				resource = this.getNodeParameter('resource', i) as string;
-				operation = this.getNodeParameter('operation', i) as string;
+				resource = this.getNodeParameter('resource', i);
+				operation = this.getNodeParameter('operation', i);
 
 				if (resource === 'post') {
 					//https://github.com/Medium/medium-api-docs
@@ -410,7 +410,7 @@ export class Medium implements INodeType {
 						//         post:create
 						// ----------------------------------
 
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const contentFormat = this.getNodeParameter('contentFormat', i) as string;
 						const content = this.getNodeParameter('content', i) as string;
 						bodyRequest = {

--- a/packages/nodes-base/nodes/MessageBird/MessageBird.node.ts
+++ b/packages/nodes-base/nodes/MessageBird/MessageBird.node.ts
@@ -297,8 +297,8 @@ export class MessageBird implements INodeType {
 		for (let i = 0; i < items.length; i++) {
 			qs = {};
 			try {
-				resource = this.getNodeParameter('resource', i) as string;
-				operation = this.getNodeParameter('operation', i) as string;
+				resource = this.getNodeParameter('resource', i);
+				operation = this.getNodeParameter('operation', i);
 
 				if (resource === 'sms') {
 					//https://developers.messagebird.com/api/sms-messaging/#sms-api
@@ -310,7 +310,7 @@ export class MessageBird implements INodeType {
 						requestMethod = 'POST';
 						requestPath = '/messages';
 						const originator = this.getNodeParameter('originator', i) as string;
-						const body = this.getNodeParameter('message', i) as string;
+						const body = this.getNodeParameter('message', i);
 
 						bodyRequest = {
 							recipients: [],

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
@@ -150,8 +150,8 @@ export class MicrosoftDynamicsCrm implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
@@ -168,8 +168,8 @@ export class MicrosoftExcel implements INodeType {
 		let qs: IDataObject = {};
 		const result: IDataObject[] = [];
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'table') {
 			//https://docs.microsoft.com/en-us/graph/api/table-post-rows?view=graph-rest-1.0&tabs=http
@@ -611,7 +611,7 @@ export class MicrosoftExcel implements INodeType {
 					if (operation === 'getContent') {
 						const workbookId = this.getNodeParameter('workbook', i) as string;
 						const worksheetId = this.getNodeParameter('worksheet', i) as string;
-						const range = this.getNodeParameter('range', i) as string;
+						const range = this.getNodeParameter('range', i);
 						const rawData = this.getNodeParameter('rawData', i);
 						if (rawData) {
 							const filters = this.getNodeParameter('filters', i);

--- a/packages/nodes-base/nodes/Microsoft/GraphSecurity/MicrosoftGraphSecurity.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/GraphSecurity/MicrosoftGraphSecurity.node.ts
@@ -64,10 +64,8 @@ export class MicrosoftGraphSecurity implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as
-			| 'secureScore'
-			| 'secureScoreControlProfile';
-		const operation = this.getNodeParameter('operation', 0) as 'get' | 'getAll' | 'update';
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -66,8 +66,8 @@ export class MicrosoftOneDrive implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'file') {
@@ -167,7 +167,7 @@ export class MicrosoftOneDrive implements INodeType {
 					}
 					//https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_search?view=odsp-graph-online
 					if (operation === 'search') {
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						responseData = await microsoftApiRequestAllItems.call(
 							this,
 							'value',
@@ -196,10 +196,10 @@ export class MicrosoftOneDrive implements INodeType {
 					if (operation === 'upload') {
 						const parentId = this.getNodeParameter('parentId', i) as string;
 						const isBinaryData = this.getNodeParameter('binaryData', i);
-						const fileName = this.getNodeParameter('fileName', i) as string;
+						const fileName = this.getNodeParameter('fileName', i);
 
 						if (isBinaryData) {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 							if (items[i].binary === undefined) {
 								throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {
@@ -305,7 +305,7 @@ export class MicrosoftOneDrive implements INodeType {
 					}
 					//https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_search?view=odsp-graph-online
 					if (operation === 'search') {
-						const query = this.getNodeParameter('query', i) as string;
+						const query = this.getNodeParameter('query', i);
 						responseData = await microsoftApiRequestAllItems.call(
 							this,
 							'value',
@@ -334,7 +334,7 @@ export class MicrosoftOneDrive implements INodeType {
 				if (resource === 'file' || resource === 'folder') {
 					if (operation === 'rename') {
 						const itemId = this.getNodeParameter('itemId', i) as string;
-						const newName = this.getNodeParameter('newName', i) as string;
+						const newName = this.getNodeParameter('newName', i);
 						const body = { name: newName };
 						responseData = await microsoftApiRequest.call(
 							this,

--- a/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlook.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlook.node.ts
@@ -137,8 +137,8 @@ export class MicrosoftOutlook implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (['draft', 'message'].includes(resource)) {
 			if (operation === 'delete') {
@@ -565,7 +565,7 @@ export class MicrosoftOutlook implements INodeType {
 				for (let i = 0; i < length; i++) {
 					try {
 						const messageId = this.getNodeParameter('messageId', i) as string;
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						if (items[i].binary === undefined) {
@@ -814,7 +814,7 @@ export class MicrosoftOutlook implements INodeType {
 			if (operation === 'create') {
 				for (let i = 0; i < length; i++) {
 					try {
-						const displayName = this.getNodeParameter('displayName', i) as string;
+						const displayName = this.getNodeParameter('displayName', i);
 						const folderType = this.getNodeParameter('folderType', i) as string;
 						const body: IDataObject = {
 							displayName,

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -282,7 +282,7 @@ export class MicrosoftSql implements INodeType {
 		let responseData: IDataObject | IDataObject[] = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		try {
 			if (operation === 'executeQuery') {
@@ -290,7 +290,7 @@ export class MicrosoftSql implements INodeType {
 				//         executeQuery
 				// ----------------------------------
 
-				const rawQuery = this.getNodeParameter('query', 0) as string;
+				const rawQuery = this.getNodeParameter('query', 0);
 
 				const queryResult = await pool.request().query(rawQuery);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeams.node.ts
@@ -140,7 +140,7 @@ export class MicrosoftTeams implements INodeType {
 			async getPlans(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				let groupId = this.getCurrentNodeParameter('groupId') as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const operation = this.getNodeParameter('operation', 0);
 				if (operation === 'update' && (groupId === undefined || groupId === null)) {
 					// groupId not found at base, check updateFields for the groupId
 					groupId = this.getCurrentNodeParameter('updateFields.groupId') as string;
@@ -163,7 +163,7 @@ export class MicrosoftTeams implements INodeType {
 			async getBuckets(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				let planId = this.getCurrentNodeParameter('planId') as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const operation = this.getNodeParameter('operation', 0);
 				if (operation === 'update' && (planId === undefined || planId === null)) {
 					// planId not found at base, check updateFields for the planId
 					planId = this.getCurrentNodeParameter('updateFields.planId') as string;
@@ -186,7 +186,7 @@ export class MicrosoftTeams implements INodeType {
 			async getMembers(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				let groupId = this.getCurrentNodeParameter('groupId') as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const operation = this.getNodeParameter('operation', 0);
 				if (operation === 'update' && (groupId === undefined || groupId === null)) {
 					// groupId not found at base, check updateFields for the groupId
 					groupId = this.getCurrentNodeParameter('updateFields.groupId') as string;
@@ -210,7 +210,7 @@ export class MicrosoftTeams implements INodeType {
 				const returnData: INodePropertyOptions[] = [];
 
 				let planId = this.getCurrentNodeParameter('planId') as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const operation = this.getNodeParameter('operation', 0);
 				if (operation === 'update' && (planId === undefined || planId === null)) {
 					// planId not found at base, check updateFields for the planId
 					planId = this.getCurrentNodeParameter('updateFields.planId') as string;
@@ -263,8 +263,8 @@ export class MicrosoftTeams implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'channel') {
@@ -361,7 +361,7 @@ export class MicrosoftTeams implements INodeType {
 						const teamId = this.getNodeParameter('teamId', i) as string;
 						const channelId = this.getNodeParameter('channelId', i) as string;
 						const messageType = this.getNodeParameter('messageType', i) as string;
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 						const options = this.getNodeParameter('options', i);
 
 						const body: IDataObject = {
@@ -418,7 +418,7 @@ export class MicrosoftTeams implements INodeType {
 					if (operation === 'create') {
 						const chatId = this.getNodeParameter('chatId', i) as string;
 						const messageType = this.getNodeParameter('messageType', i) as string;
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 						const body: IDataObject = {
 							body: {
 								contentType: messageType,
@@ -471,7 +471,7 @@ export class MicrosoftTeams implements INodeType {
 					if (operation === 'create') {
 						const planId = this.getNodeParameter('planId', i) as string;
 						const bucketId = this.getNodeParameter('bucketId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
 							planId,

--- a/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
@@ -96,8 +96,8 @@ export class MicrosoftToDo implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const timezone = this.getTimezone();
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'linkedResource') {
@@ -107,7 +107,7 @@ export class MicrosoftToDo implements INodeType {
 						const taskId = this.getNodeParameter('taskId', i) as string;
 						const body: IDataObject = {
 							applicationName: this.getNodeParameter('applicationName', i) as string,
-							displayName: this.getNodeParameter('displayName', i) as string,
+							displayName: this.getNodeParameter('displayName', i),
 							...this.getNodeParameter('additionalFields', i),
 						};
 
@@ -204,7 +204,7 @@ export class MicrosoftToDo implements INodeType {
 					if (operation === 'create') {
 						const taskListId = this.getNodeParameter('taskListId', i) as string;
 						const body: IDataObject = {
-							title: this.getNodeParameter('title', i) as string,
+							title: this.getNodeParameter('title', i),
 							...this.getNodeParameter('additionalFields', i),
 						};
 
@@ -323,7 +323,7 @@ export class MicrosoftToDo implements INodeType {
 					// https://docs.microsoft.com/en-us/graph/api/todo-post-lists?view=graph-rest-1.0&tabs=http
 					if (operation === 'create') {
 						const body = {
-							displayName: this.getNodeParameter('displayName', i) as string,
+							displayName: this.getNodeParameter('displayName', i),
 						};
 
 						responseData = await microsoftApiRequest.call(this, 'POST', '/todo/lists/', body, qs);
@@ -379,7 +379,7 @@ export class MicrosoftToDo implements INodeType {
 					} else if (operation === 'update') {
 						const listId = this.getNodeParameter('listId', i) as string;
 						const body = {
-							displayName: this.getNodeParameter('displayName', i) as string,
+							displayName: this.getNodeParameter('displayName', i),
 						};
 
 						responseData = await microsoftApiRequest.call(

--- a/packages/nodes-base/nodes/Mindee/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mindee/GenericFunctions.ts
@@ -13,7 +13,7 @@ export async function mindeeApiRequest(
 	option = {},
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const resource = this.getNodeParameter('resource', 0) as string;
+	const resource = this.getNodeParameter('resource', 0);
 
 	let service;
 

--- a/packages/nodes-base/nodes/Mindee/Mindee.node.ts
+++ b/packages/nodes-base/nodes/Mindee/Mindee.node.ts
@@ -154,14 +154,14 @@ export class Mindee implements INodeType {
 		const length = items.length;
 		let responseData;
 		const version = this.getNodeParameter('apiVersion', 0) as number;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let endpoint;
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'receipt') {
 					if (operation === 'predict') {
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						const rawData = this.getNodeParameter('rawData', i);
 
@@ -232,7 +232,7 @@ export class Mindee implements INodeType {
 
 				if (resource === 'invoice') {
 					if (operation === 'predict') {
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						const rawData = this.getNodeParameter('rawData', i);
 

--- a/packages/nodes-base/nodes/Misp/Misp.node.ts
+++ b/packages/nodes-base/nodes/Misp/Misp.node.ts
@@ -171,8 +171,8 @@ export class Misp implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 
@@ -365,7 +365,7 @@ export class Misp implements INodeType {
 						//               feed: create
 						// ----------------------------------------
 
-						const url = this.getNodeParameter('url', i) as string;
+						const url = this.getNodeParameter('url', i);
 
 						throwOnInvalidUrl.call(this, url);
 

--- a/packages/nodes-base/nodes/Mocean/Mocean.node.ts
+++ b/packages/nodes-base/nodes/Mocean/Mocean.node.ts
@@ -235,11 +235,11 @@ export class Mocean implements INodeType {
 			body = {};
 			qs = {};
 			try {
-				resource = this.getNodeParameter('resource', itemIndex, '') as string;
-				operation = this.getNodeParameter('operation', itemIndex, '') as string;
-				text = this.getNodeParameter('message', itemIndex, '') as string;
+				resource = this.getNodeParameter('resource', itemIndex, '');
+				operation = this.getNodeParameter('operation', itemIndex, '');
+				text = this.getNodeParameter('message', itemIndex, '');
 				requestMethod = 'POST';
-				body['mocean-from'] = this.getNodeParameter('from', itemIndex, '') as string;
+				body['mocean-from'] = this.getNodeParameter('from', itemIndex, '');
 				body['mocean-to'] = this.getNodeParameter('to', itemIndex, '') as string;
 
 				if (resource === 'voice') {
@@ -256,7 +256,7 @@ export class Mocean implements INodeType {
 					body['mocean-command'] = JSON.stringify(command);
 					endpoint = '/rest/2/voice/dial';
 				} else if (resource === 'sms') {
-					dlrUrl = this.getNodeParameter('options.dlrUrl', itemIndex, '') as string;
+					dlrUrl = this.getNodeParameter('options.dlrUrl', itemIndex, '');
 					dataKey = 'messages';
 					body['mocean-text'] = text;
 					if (dlrUrl !== '') {

--- a/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts
+++ b/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts
@@ -230,8 +230,8 @@ export class MondayCom implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'board') {
@@ -335,7 +335,7 @@ export class MondayCom implements INodeType {
 				if (resource === 'boardColumn') {
 					if (operation === 'create') {
 						const boardId = parseInt(this.getNodeParameter('boardId', i) as string, 10);
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const columnType = this.getNodeParameter('columnType', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -88,7 +88,7 @@ export class MongoDb implements INodeType {
 		let responseData: IDataObject | IDataObject[] = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'aggregate') {
 			// ----------------------------------
@@ -96,7 +96,7 @@ export class MongoDb implements INodeType {
 			// ----------------------------------
 
 			try {
-				const queryParameter = JSON.parse(this.getNodeParameter('query', 0) as string);
+				const queryParameter = JSON.parse(this.getNodeParameter('query', 0));
 
 				if (queryParameter._id && typeof queryParameter._id === 'string') {
 					queryParameter._id = new ObjectId(queryParameter._id);
@@ -122,7 +122,7 @@ export class MongoDb implements INodeType {
 			try {
 				const { deletedCount } = await mdb
 					.collection(this.getNodeParameter('collection', 0) as string)
-					.deleteMany(JSON.parse(this.getNodeParameter('query', 0) as string));
+					.deleteMany(JSON.parse(this.getNodeParameter('query', 0)));
 
 				responseData = [{ deletedCount }];
 			} catch (error) {
@@ -138,7 +138,7 @@ export class MongoDb implements INodeType {
 			// ----------------------------------
 
 			try {
-				const queryParameter = JSON.parse(this.getNodeParameter('query', 0) as string);
+				const queryParameter = JSON.parse(this.getNodeParameter('query', 0));
 
 				if (queryParameter._id && typeof queryParameter._id === 'string') {
 					queryParameter._id = new ObjectId(queryParameter._id);

--- a/packages/nodes-base/nodes/MonicaCrm/MonicaCrm.node.ts
+++ b/packages/nodes-base/nodes/MonicaCrm/MonicaCrm.node.ts
@@ -211,8 +211,8 @@ export class MonicaCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Msg91/Msg91.node.ts
+++ b/packages/nodes-base/nodes/Msg91/Msg91.node.ts
@@ -131,8 +131,8 @@ export class Msg91 implements INodeType {
 			body = {};
 			qs = {};
 
-			resource = this.getNodeParameter('resource', i) as string;
-			operation = this.getNodeParameter('operation', i) as string;
+			resource = this.getNodeParameter('resource', i);
+			operation = this.getNodeParameter('operation', i);
 
 			if (resource === 'sms') {
 				if (operation === 'send') {
@@ -145,9 +145,9 @@ export class Msg91 implements INodeType {
 
 					qs.route = 4;
 					qs.country = 0;
-					qs.sender = this.getNodeParameter('from', i) as string;
+					qs.sender = this.getNodeParameter('from', i);
 					qs.mobiles = this.getNodeParameter('to', i) as string;
-					qs.message = this.getNodeParameter('message', i) as string;
+					qs.message = this.getNodeParameter('message', i);
 				} else {
 					throw new NodeOperationError(
 						this.getNode(),

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -278,7 +278,7 @@ export class MySql implements INodeType {
 		const credentials = await this.getCredentials('mySql');
 		const connection = await createConnection(credentials);
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		let returnItems: INodeExecutionData[] = [];
 
 		if (operation === 'executeQuery') {
@@ -288,7 +288,7 @@ export class MySql implements INodeType {
 
 			try {
 				const queryQueue = items.map((item, index) => {
-					const rawQuery = this.getNodeParameter('query', index) as string;
+					const rawQuery = this.getNodeParameter('query', index);
 
 					return connection.query(rawQuery);
 				});

--- a/packages/nodes-base/nodes/N8nTrainingCustomerDatastore/N8nTrainingCustomerDatastore.node.ts
+++ b/packages/nodes-base/nodes/N8nTrainingCustomerDatastore/N8nTrainingCustomerDatastore.node.ts
@@ -113,7 +113,7 @@ export class N8nTrainingCustomerDatastore implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 		const length = items.length;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		let responseData;
 
 		for (let i = 0; i < length; i++) {

--- a/packages/nodes-base/nodes/N8nTrainingCustomerMessenger/N8nTrainingCustomerMessenger.node.ts
+++ b/packages/nodes-base/nodes/N8nTrainingCustomerMessenger/N8nTrainingCustomerMessenger.node.ts
@@ -45,7 +45,7 @@ export class N8nTrainingCustomerMessenger implements INodeType {
 		for (let i = 0; i < length; i++) {
 			const customerId = this.getNodeParameter('customerId', i) as string;
 
-			const message = this.getNodeParameter('message', i) as string;
+			const message = this.getNodeParameter('message', i);
 
 			responseData = { output: `Sent message to customer ${customerId}:  ${message}` };
 

--- a/packages/nodes-base/nodes/Nasa/Nasa.node.ts
+++ b/packages/nodes-base/nodes/Nasa/Nasa.node.ts
@@ -850,8 +850,8 @@ export class Nasa implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const qs: IDataObject = {};
@@ -1050,7 +1050,7 @@ export class Nasa implements INodeType {
 				}
 
 				if (resource === 'earthImagery') {
-					const binaryProperty = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryProperty = this.getNodeParameter('binaryPropertyName', i);
 
 					const data = await nasaApiRequest.call(this, 'GET', endpoint, qs, { encoding: null });
 
@@ -1072,7 +1072,7 @@ export class Nasa implements INodeType {
 					download = this.getNodeParameter('download', 0);
 
 					if (download === true) {
-						const binaryProperty = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryPropertyName', i);
 
 						const data = await nasaApiRequest.call(
 							this,

--- a/packages/nodes-base/nodes/Netlify/Netlify.node.ts
+++ b/packages/nodes-base/nodes/Netlify/Netlify.node.ts
@@ -84,8 +84,8 @@ export class Netlify implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const qs: IDataObject = {};
 		const body: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Netlify/NetlifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Netlify/NetlifyTrigger.node.ts
@@ -199,7 +199,7 @@ export class NetlifyTrigger implements INodeType {
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const req = this.getRequestObject();
 		const simple = this.getNodeParameter('simple', false) as boolean;
-		const event = this.getNodeParameter('event') as string;
+		const event = this.getNodeParameter('event');
 		let response = req.body;
 
 		if (simple === true && event === 'submissionCreated') {

--- a/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
+++ b/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
@@ -871,8 +871,8 @@ export class NextCloud implements INodeType {
 			credentials = await this.getCredentials('nextCloudOAuth2Api');
 		}
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let requestMethod = '';
@@ -891,14 +891,14 @@ export class NextCloud implements INodeType {
 						// ----------------------------------
 
 						requestMethod = 'GET';
-						endpoint = this.getNodeParameter('path', i) as string;
+						endpoint = this.getNodeParameter('path', i);
 					} else if (operation === 'upload') {
 						// ----------------------------------
 						//         upload
 						// ----------------------------------
 
 						requestMethod = 'PUT';
-						endpoint = this.getNodeParameter('path', i) as string;
+						endpoint = this.getNodeParameter('path', i);
 
 						if (this.getNodeParameter('binaryDataUpload', i) === true) {
 							// Is binary file to upload
@@ -910,7 +910,7 @@ export class NextCloud implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							if (item.binary[propertyNameUpload] === undefined) {
 								throw new NodeOperationError(
@@ -933,14 +933,14 @@ export class NextCloud implements INodeType {
 						// ----------------------------------
 
 						requestMethod = 'MKCOL';
-						endpoint = this.getNodeParameter('path', i) as string;
+						endpoint = this.getNodeParameter('path', i);
 					} else if (operation === 'list') {
 						// ----------------------------------
 						//         list
 						// ----------------------------------
 
 						requestMethod = 'PROPFIND';
-						endpoint = this.getNodeParameter('path', i) as string;
+						endpoint = this.getNodeParameter('path', i);
 					}
 				}
 
@@ -951,8 +951,8 @@ export class NextCloud implements INodeType {
 						// ----------------------------------
 
 						requestMethod = 'COPY';
-						endpoint = this.getNodeParameter('path', i) as string;
-						const toPath = this.getNodeParameter('toPath', i) as string;
+						endpoint = this.getNodeParameter('path', i);
+						const toPath = this.getNodeParameter('toPath', i);
 						headers.Destination = `${credentials.webDavUrl}/${encodeURI(toPath)}`;
 					} else if (operation === 'delete') {
 						// ----------------------------------
@@ -960,15 +960,15 @@ export class NextCloud implements INodeType {
 						// ----------------------------------
 
 						requestMethod = 'DELETE';
-						endpoint = this.getNodeParameter('path', i) as string;
+						endpoint = this.getNodeParameter('path', i);
 					} else if (operation === 'move') {
 						// ----------------------------------
 						//         move
 						// ----------------------------------
 
 						requestMethod = 'MOVE';
-						endpoint = this.getNodeParameter('path', i) as string;
-						const toPath = this.getNodeParameter('toPath', i) as string;
+						endpoint = this.getNodeParameter('path', i);
+						const toPath = this.getNodeParameter('toPath', i);
 						headers.Destination = `${credentials.webDavUrl}/${encodeURI(toPath)}`;
 					} else if (operation === 'share') {
 						// ----------------------------------
@@ -984,7 +984,7 @@ export class NextCloud implements INodeType {
 
 						const bodyParameters = this.getNodeParameter('options', i);
 
-						bodyParameters.path = this.getNodeParameter('path', i) as string;
+						bodyParameters.path = this.getNodeParameter('path', i);
 						bodyParameters.shareType = this.getNodeParameter('shareType', i) as number;
 
 						if (bodyParameters.shareType === 0) {
@@ -1145,7 +1145,7 @@ export class NextCloud implements INodeType {
 
 					items[i] = newItem;
 
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 					items[i].binary![binaryPropertyName] = await this.helpers.prepareBinaryData(
 						responseData,

--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -209,8 +209,8 @@ export class NocoDB implements INodeType {
 		let responseData;
 
 		const version = this.getNodeParameter('version', 0) as number;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let returnAll = false;
 		let requestMethod = '';

--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -82,7 +82,7 @@ export async function notionApiRequestAllItems(
 	query: IDataObject = {},
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const resource = this.getNodeParameter('resource', 0) as string;
+	const resource = this.getNodeParameter('resource', 0);
 
 	const returnData: IDataObject[] = [];
 

--- a/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
+++ b/packages/nodes-base/nodes/Notion/NotionTrigger.node.ts
@@ -147,7 +147,7 @@ export class NotionTrigger implements INodeType {
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
 		const webhookData = this.getWorkflowStaticData('node');
 		const databaseId = this.getNodeParameter('databaseId', '', { extractValue: true }) as string;
-		const event = this.getNodeParameter('event') as string;
+		const event = this.getNodeParameter('event');
 		const simple = this.getNodeParameter('simple') as boolean;
 
 		const lastTimeChecked = webhookData.lastTimeChecked

--- a/packages/nodes-base/nodes/Notion/v1/NotionV1.node.ts
+++ b/packages/nodes-base/nodes/Notion/v1/NotionV1.node.ts
@@ -232,8 +232,8 @@ export class NotionV1 implements INodeType {
 		const qs: IDataObject = {};
 		const timezone = this.getTimezone();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'block') {
 			if (operation === 'append') {
@@ -521,7 +521,7 @@ export class NotionV1 implements INodeType {
 					body.parent['page_id'] = extractPageId(
 						this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
 					);
-					body.properties = formatTitle(this.getNodeParameter('title', i) as string);
+					body.properties = formatTitle(this.getNodeParameter('title', i));
 					const blockValues = this.getNodeParameter('blockUi.blockValues', i, []) as IDataObject[];
 					extractDatabaseMentionRLC(blockValues);
 					body.children = formatBlocks(blockValues);
@@ -557,7 +557,7 @@ export class NotionV1 implements INodeType {
 
 			if (operation === 'search') {
 				for (let i = 0; i < length; i++) {
-					const text = this.getNodeParameter('text', i) as string;
+					const text = this.getNodeParameter('text', i);
 					const options = this.getNodeParameter('options', i);
 					const returnAll = this.getNodeParameter('returnAll', i);
 					const simple = this.getNodeParameter('simple', i) as boolean;

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -238,8 +238,8 @@ export class NotionV2 implements INodeType {
 		const qs: IDataObject = {};
 		const timezone = this.getTimezone();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let download = false;
 
 		if (resource === 'block') {
@@ -364,7 +364,7 @@ export class NotionV2 implements INodeType {
 
 			if (operation === 'search') {
 				for (let i = 0; i < length; i++) {
-					const text = this.getNodeParameter('text', i) as string;
+					const text = this.getNodeParameter('text', i);
 					const options = this.getNodeParameter('options', i);
 					const returnAll = this.getNodeParameter('returnAll', i);
 					const simple = this.getNodeParameter('simple', i) as boolean;
@@ -428,7 +428,7 @@ export class NotionV2 implements INodeType {
 					}
 				}
 				for (let i = 0; i < length; i++) {
-					const title = this.getNodeParameter('title', i) as string;
+					const title = this.getNodeParameter('title', i);
 					const simple = this.getNodeParameter('simple', i) as boolean;
 					// tslint:disable-next-line: no-any
 					const body: { [key: string]: any } = {
@@ -672,7 +672,7 @@ export class NotionV2 implements INodeType {
 					body.parent['page_id'] = extractPageId(
 						this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
 					);
-					body.properties = formatTitle(this.getNodeParameter('title', i) as string);
+					body.properties = formatTitle(this.getNodeParameter('title', i));
 					const blockValues = this.getNodeParameter('blockUi.blockValues', i, []) as IDataObject[];
 					extractDatabaseMentionRLC(blockValues);
 					body.children = formatBlocks(blockValues);
@@ -691,7 +691,7 @@ export class NotionV2 implements INodeType {
 
 			if (operation === 'search') {
 				for (let i = 0; i < length; i++) {
-					const text = this.getNodeParameter('text', i) as string;
+					const text = this.getNodeParameter('text', i);
 					const options = this.getNodeParameter('options', i);
 					const returnAll = this.getNodeParameter('returnAll', i);
 					const simple = this.getNodeParameter('simple', i) as boolean;

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -301,8 +301,8 @@ export class Odoo implements INodeType {
 		const returnData: IDataObject[] = [];
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		const credentials = await this.getCredentials('odooApi');
 		const url = (credentials.url as string).replace(/\/$/, '');
@@ -332,7 +332,7 @@ export class Odoo implements INodeType {
 							delete additionalFields.address;
 						}
 
-						const name = this.getNodeParameter('contactName', i) as string;
+						const name = this.getNodeParameter('contactName', i);
 						const fields: IDataObject = {
 							name,
 							...additionalFields,
@@ -647,7 +647,7 @@ export class Odoo implements INodeType {
 				if (resource === 'opportunity') {
 					if (operation === 'create') {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const name = this.getNodeParameter('opportunityName', i) as string;
+						const name = this.getNodeParameter('opportunityName', i);
 						const fields: IDataObject = {
 							name,
 							...additionalFields,

--- a/packages/nodes-base/nodes/OneSimpleApi/OneSimpleApi.node.ts
+++ b/packages/nodes-base/nodes/OneSimpleApi/OneSimpleApi.node.ts
@@ -657,8 +657,8 @@ export class OneSimpleApi implements INodeType {
 		let download;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 
 				if (resource === 'website') {
 					if (operation === 'pdf') {
@@ -763,7 +763,7 @@ export class OneSimpleApi implements INodeType {
 
 				if (resource === 'socialProfile') {
 					if (operation === 'instagramProfile') {
-						const profileName = this.getNodeParameter('profileName', i) as string;
+						const profileName = this.getNodeParameter('profileName', i);
 						qs.profile = profileName;
 						responseData = await oneSimpleApiRequest.call(
 							this,
@@ -775,7 +775,7 @@ export class OneSimpleApi implements INodeType {
 					}
 
 					if (operation === 'spotifyArtistProfile') {
-						const artistName = this.getNodeParameter('artistName', i) as string;
+						const artistName = this.getNodeParameter('artistName', i);
 						qs.profile = artistName;
 						responseData = await oneSimpleApiRequest.call(this, 'GET', '/spotify_profile', {}, qs);
 					}
@@ -815,7 +815,7 @@ export class OneSimpleApi implements INodeType {
 					}
 
 					if (operation === 'qrCode') {
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 						const options = this.getNodeParameter('options', i);
 						download = this.getNodeParameter('download', i);
 

--- a/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
+++ b/packages/nodes-base/nodes/Onfleet/Onfleet.node.ts
@@ -175,8 +175,8 @@ export class Onfleet implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const items = this.getInputData();
 
 		const operations: { [key: string]: Function } = {

--- a/packages/nodes-base/nodes/Onfleet/Onfleet.ts
+++ b/packages/nodes-base/nodes/Onfleet/Onfleet.ts
@@ -384,7 +384,7 @@ export class Onfleet {
 			/* -------------------------------------------------------------------------- */
 			/*                        Get fields for create webhook                       */
 			/* -------------------------------------------------------------------------- */
-			const url = this.getNodeParameter('url', item) as string;
+			const url = this.getNodeParameter('url', item);
 			const name = this.getNodeParameter('name', item) as string;
 			const trigger = this.getNodeParameter('trigger', item) as number;
 			const additionalFields = this.getNodeParameter('additionalFields', item) as IDataObject;

--- a/packages/nodes-base/nodes/OpenThesaurus/OpenThesaurus.node.ts
+++ b/packages/nodes-base/nodes/OpenThesaurus/OpenThesaurus.node.ts
@@ -139,12 +139,12 @@ export class OpenThesaurus implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (operation === 'getSynonyms') {
-					const text = this.getNodeParameter('text', i) as string;
+					const text = this.getNodeParameter('text', i);
 					const options = this.getNodeParameter('options', i);
 
 					qs.q = text;

--- a/packages/nodes-base/nodes/OpenWeatherMap/OpenWeatherMap.node.ts
+++ b/packages/nodes-base/nodes/OpenWeatherMap/OpenWeatherMap.node.ts
@@ -199,7 +199,7 @@ export class OpenWeatherMap implements INodeType {
 
 		const credentials = await this.getCredentials('openWeatherMapApi');
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		let endpoint = '';
 		let locationSelection;

--- a/packages/nodes-base/nodes/Orbit/Orbit.node.ts
+++ b/packages/nodes-base/nodes/Orbit/Orbit.node.ts
@@ -115,15 +115,15 @@ export class Orbit implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'activity') {
 					if (operation === 'create') {
 						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
 						const memberId = this.getNodeParameter('memberId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
 							title,
@@ -315,10 +315,10 @@ export class Orbit implements INodeType {
 					}
 					if (operation === 'lookup') {
 						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
-						const source = this.getNodeParameter('source', i) as string;
+						const source = this.getNodeParameter('source', i);
 
 						if (['github', 'twitter', 'discourse'].includes(source)) {
-							qs.source = this.getNodeParameter('source', i) as string;
+							qs.source = this.getNodeParameter('source', i);
 							const searchBy = this.getNodeParameter('searchBy', i) as string;
 							if (searchBy === 'id') {
 								qs.uid = this.getNodeParameter('id', i) as string;
@@ -459,7 +459,7 @@ export class Orbit implements INodeType {
 					if (operation === 'create') {
 						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
 						const memberId = this.getNodeParameter('memberId', i) as string;
-						const url = this.getNodeParameter('url', i) as string;
+						const url = this.getNodeParameter('url', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
 							type: 'post',

--- a/packages/nodes-base/nodes/Oura/Oura.node.ts
+++ b/packages/nodes-base/nodes/Oura/Oura.node.ts
@@ -61,8 +61,8 @@ export class Oura implements INodeType {
 		let responseData;
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			if (resource === 'profile') {

--- a/packages/nodes-base/nodes/Paddle/Paddle.node.ts
+++ b/packages/nodes-base/nodes/Paddle/Paddle.node.ts
@@ -169,8 +169,8 @@ export class Paddle implements INodeType {
 		const length = items.length;
 		let responseData;
 		const body: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'coupon') {
@@ -204,7 +204,7 @@ export class Paddle implements INodeType {
 							}
 
 							if (discountType === 'flat') {
-								body.currency = this.getNodeParameter('currency', i) as string;
+								body.currency = this.getNodeParameter('currency', i);
 							}
 
 							body.coupon_type = couponType;

--- a/packages/nodes-base/nodes/PagerDuty/PagerDuty.node.ts
+++ b/packages/nodes-base/nodes/PagerDuty/PagerDuty.node.ts
@@ -207,14 +207,14 @@ export class PagerDuty implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'incident') {
 					//https://api-reference.pagerduty.com/#!/Incidents/post_incidents
 					if (operation === 'create') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const serviceId = this.getNodeParameter('serviceId', i) as string;
 						const email = this.getNodeParameter('email', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);

--- a/packages/nodes-base/nodes/PayPal/PayPal.node.ts
+++ b/packages/nodes-base/nodes/PayPal/PayPal.node.ts
@@ -135,8 +135,8 @@ export class PayPal implements INodeType {
 		let responseData;
 		const qs: IDataObject = {};
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
+++ b/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
@@ -62,12 +62,12 @@ export class Peekalink implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (operation === 'isAvailable') {
-					const url = this.getNodeParameter('url', i) as string;
+					const url = this.getNodeParameter('url', i);
 					const body: IDataObject = {
 						link: url,
 					};
@@ -75,7 +75,7 @@ export class Peekalink implements INodeType {
 					responseData = await peekalinkApiRequest.call(this, 'POST', `/is-available/`, body);
 				}
 				if (operation === 'preview') {
-					const url = this.getNodeParameter('url', i) as string;
+					const url = this.getNodeParameter('url', i);
 					const body: IDataObject = {
 						link: url,
 					};

--- a/packages/nodes-base/nodes/Phantombuster/Phantombuster.node.ts
+++ b/packages/nodes-base/nodes/Phantombuster/Phantombuster.node.ts
@@ -106,8 +106,8 @@ export class Phantombuster implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'agent') {

--- a/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/PhilipsHue.node.ts
@@ -91,8 +91,8 @@ export class PhilipsHue implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'light') {
 				if (operation === 'update') {

--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -4034,8 +4034,8 @@ export class Pipedrive implements INodeType {
 		let endpoint: string;
 		let returnAll = false;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let customProperties: ICustomProperties | undefined;
 		if (
@@ -4145,7 +4145,7 @@ export class Pipedrive implements INodeType {
 						requestMethod = 'POST';
 						endpoint = '/deals';
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 
 						const associateWith = this.getNodeParameter('associateWith', i) as
 							| 'organization'
@@ -4347,7 +4347,7 @@ export class Pipedrive implements INodeType {
 							});
 						}
 
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 						if (item.binary[binaryPropertyName] === undefined) {
 							throw new NodeOperationError(
@@ -4849,7 +4849,7 @@ export class Pipedrive implements INodeType {
 
 					items[i] = newItem;
 
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 
 					items[i].binary![binaryPropertyName] = await this.helpers.prepareBinaryData(
 						responseData.data,

--- a/packages/nodes-base/nodes/Plivo/Plivo.node.ts
+++ b/packages/nodes-base/nodes/Plivo/Plivo.node.ts
@@ -67,8 +67,8 @@ export class Plivo implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			let responseData;
@@ -84,9 +84,9 @@ export class Plivo implements INodeType {
 					// ----------------------------------
 
 					const body = {
-						src: this.getNodeParameter('from', i) as string,
+						src: this.getNodeParameter('from', i),
 						dst: this.getNodeParameter('to', i) as string,
-						text: this.getNodeParameter('message', i) as string,
+						text: this.getNodeParameter('message', i),
 					} as IDataObject;
 
 					responseData = await plivoApiRequest.call(this, 'POST', '/Message', body);
@@ -104,7 +104,7 @@ export class Plivo implements INodeType {
 					// https://www.plivo.com/docs/voice/api/call#make-a-call
 
 					const body = {
-						from: this.getNodeParameter('from', i) as string,
+						from: this.getNodeParameter('from', i),
 						to: this.getNodeParameter('to', i) as string,
 						answer_url: this.getNodeParameter('answer_url', i) as string,
 						answer_method: this.getNodeParameter('answer_method', i) as string,
@@ -125,9 +125,9 @@ export class Plivo implements INodeType {
 					// https://www.plivo.com/docs/sms/api/message#send-a-message
 
 					const body = {
-						src: this.getNodeParameter('from', i) as string,
+						src: this.getNodeParameter('from', i),
 						dst: this.getNodeParameter('to', i) as string,
-						text: this.getNodeParameter('message', i) as string,
+						text: this.getNodeParameter('message', i),
 						type: 'mms',
 						media_urls: this.getNodeParameter('media_urls', i) as string,
 					} as IDataObject;

--- a/packages/nodes-base/nodes/PostHog/PostHog.node.ts
+++ b/packages/nodes-base/nodes/PostHog/PostHog.node.ts
@@ -76,8 +76,8 @@ export class PostHog implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'alias') {
 			if (operation === 'create') {
@@ -133,7 +133,7 @@ export class PostHog implements INodeType {
 				try {
 					const events: IEvent[] = [];
 					for (let i = 0; i < length; i++) {
-						const eventName = this.getNodeParameter('eventName', i) as string;
+						const eventName = this.getNodeParameter('eventName', i);
 
 						const distinctId = this.getNodeParameter('distinctId', i) as string;
 

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.functions.ts
@@ -174,7 +174,7 @@ export async function pgQueryV2(
 	type QueryWithValues = { query: string; values?: string[] };
 	const allQueries = new Array<QueryWithValues>();
 	for (let i = 0; i < items.length; i++) {
-		const query = this.getNodeParameter('query', i) as string;
+		const query = this.getNodeParameter('query', i);
 		const values = valuesArray[i];
 		const queryFormat = { query, values };
 		allQueries.push(queryFormat);

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -361,7 +361,7 @@ export class Postgres implements INodeType {
 		let returnItems: INodeExecutionData[] = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'executeQuery') {
 			// ----------------------------------

--- a/packages/nodes-base/nodes/ProfitWell/ProfitWell.node.ts
+++ b/packages/nodes-base/nodes/ProfitWell/ProfitWell.node.ts
@@ -88,8 +88,8 @@ export class ProfitWell implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'company') {

--- a/packages/nodes-base/nodes/Pushbullet/Pushbullet.node.ts
+++ b/packages/nodes-base/nodes/Pushbullet/Pushbullet.node.ts
@@ -376,8 +376,8 @@ export class Pushbullet implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'push') {
@@ -399,15 +399,15 @@ export class Pushbullet implements INodeType {
 						}
 
 						if (['note', 'link'].includes(type)) {
-							body.title = this.getNodeParameter('title', i) as string;
+							body.title = this.getNodeParameter('title', i);
 
 							if (type === 'link') {
-								body.url = this.getNodeParameter('url', i) as string;
+								body.url = this.getNodeParameter('url', i);
 							}
 						}
 
 						if (type === 'file') {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 							if (items[i].binary === undefined) {
 								throw new NodeOperationError(this.getNode(), 'No binary data exists on item!');

--- a/packages/nodes-base/nodes/Pushcut/Pushcut.node.ts
+++ b/packages/nodes-base/nodes/Pushcut/Pushcut.node.ts
@@ -169,12 +169,12 @@ export class Pushcut implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'notification') {
 				if (operation === 'send') {
-					const notificationName = this.getNodeParameter('notificationName', i) as string;
+					const notificationName = this.getNodeParameter('notificationName', i);
 
 					const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/Pushover/Pushover.node.ts
+++ b/packages/nodes-base/nodes/Pushover/Pushover.node.ts
@@ -302,15 +302,15 @@ export class Pushover implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'message') {
 					if (operation === 'push') {
 						const userKey = this.getNodeParameter('userKey', i) as string;
 
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 
 						const priority = this.getNodeParameter('priority', i) as number;
 

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -214,7 +214,7 @@ export class QuestDb implements INodeType {
 		let returnItems: INodeExecutionData[] = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'executeQuery') {
 			// ----------------------------------

--- a/packages/nodes-base/nodes/QuickBase/QuickBase.node.ts
+++ b/packages/nodes-base/nodes/QuickBase/QuickBase.node.ts
@@ -121,8 +121,8 @@ export class QuickBase implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'field') {
 			if (operation === 'getAll') {
@@ -207,7 +207,7 @@ export class QuickBase implements INodeType {
 
 					items[i] = newItem;
 
-					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i) as string;
+					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
 
 					responseData = await quickbaseApiRequest.call(
 						this,

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -232,8 +232,8 @@ export async function handleBinaryData(
 	resource: string,
 	resourceId: string,
 ) {
-	const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
-	const fileName = this.getNodeParameter('fileName', i) as string;
+	const binaryProperty = this.getNodeParameter('binaryProperty', i);
+	const fileName = this.getNodeParameter('fileName', i);
 	const endpoint = `/v3/company/${companyId}/${resource}/${resourceId}/pdf`;
 	const data = await quickBooksApiRequest.call(this, 'GET', endpoint, {}, {}, { encoding: null });
 

--- a/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
+++ b/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
@@ -188,8 +188,8 @@ export class QuickBooks implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -348,7 +348,7 @@ export class RabbitMQ implements INodeType {
 					if (sendInputData === true) {
 						message = JSON.stringify(items[i].json);
 					} else {
-						message = this.getNodeParameter('message', i) as string;
+						message = this.getNodeParameter('message', i);
 					}
 
 					let headers: IDataObject = {};
@@ -415,7 +415,7 @@ export class RabbitMQ implements INodeType {
 					if (sendInputData === true) {
 						message = JSON.stringify(items[i].json);
 					} else {
-						message = this.getNodeParameter('message', i) as string;
+						message = this.getNodeParameter('message', i);
 					}
 
 					let headers: IDataObject = {};

--- a/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
+++ b/packages/nodes-base/nodes/Raindrop/Raindrop.node.ts
@@ -97,8 +97,8 @@ export class Raindrop implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: IDataObject[] = [];

--- a/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
@@ -53,8 +53,8 @@ export class ReadBinaryFile implements INodeType {
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
 			try {
 				item = items[itemIndex];
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex) as string;
-				const filePath = this.getNodeParameter('filePath', itemIndex) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex);
+				const filePath = this.getNodeParameter('filePath', itemIndex);
 
 				let data;
 				try {

--- a/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
@@ -41,7 +41,7 @@ export class ReadBinaryFiles implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const fileSelector = this.getNodeParameter('fileSelector', 0) as string;
-		const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+		const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 
 		const files = await glob(fileSelector);
 

--- a/packages/nodes-base/nodes/ReadPdf/ReadPDF.node.ts
+++ b/packages/nodes-base/nodes/ReadPdf/ReadPDF.node.ts
@@ -40,7 +40,7 @@ export class ReadPDF implements INodeType {
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
 			try {
 				item = items[itemIndex];
-				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', itemIndex) as string;
+				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', itemIndex);
 
 				if (item.binary === undefined) {
 					item.binary = {};

--- a/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Reddit/GenericFunctions.ts
@@ -64,8 +64,8 @@ export async function redditApiRequestAllItems(
 	let responseData;
 	const returnData: IDataObject[] = [];
 
-	const resource = this.getNodeParameter('resource', 0) as string;
-	const operation = this.getNodeParameter('operation', 0) as string;
+	const resource = this.getNodeParameter('resource', 0);
+	const operation = this.getNodeParameter('operation', 0);
 	const returnAll = this.getNodeParameter('returnAll', 0, false) as boolean;
 
 	qs.limit = 100;

--- a/packages/nodes-base/nodes/Reddit/Reddit.node.ts
+++ b/packages/nodes-base/nodes/Reddit/Reddit.node.ts
@@ -91,8 +91,8 @@ export class Reddit implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];

--- a/packages/nodes-base/nodes/Redis/Redis.node.ts
+++ b/packages/nodes-base/nodes/Redis/Redis.node.ts
@@ -670,7 +670,7 @@ export class Redis implements INodeType {
 
 			const client = redis.createClient(redisOptions);
 
-			const operation = this.getNodeParameter('operation', 0) as string;
+			const operation = this.getNodeParameter('operation', 0);
 
 			client.on('error', (err: Error) => {
 				client.quit();
@@ -706,7 +706,7 @@ export class Redis implements INodeType {
 								await clientDel(keyDelete);
 								returnItems.push(items[itemIndex]);
 							} else if (operation === 'get') {
-								const propertyName = this.getNodeParameter('propertyName', itemIndex) as string;
+								const propertyName = this.getNodeParameter('propertyName', itemIndex);
 								const keyGet = this.getNodeParameter('key', itemIndex) as string;
 								const keyType = this.getNodeParameter('keyType', itemIndex) as string;
 

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -227,7 +227,7 @@ export class RespondToWebhook implements INodeType {
 			const responseDataSource = this.getNodeParameter('responseDataSource', 0) as string;
 
 			if (responseDataSource === 'set') {
-				responseBinaryPropertyName = this.getNodeParameter('inputFieldName', 0) as string;
+				responseBinaryPropertyName = this.getNodeParameter('inputFieldName', 0);
 			} else {
 				const binaryKeys = Object.keys(item.binary);
 				if (binaryKeys.length === 0) {

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -368,15 +368,15 @@ export class Rocketchat implements INodeType {
 		const length = items.length;
 		let responseData;
 		const returnData: IDataObject[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'chat') {
 					//https://rocket.chat/docs/developer-guides/rest-api/chat/postmessage
 					if (operation === 'postMessage') {
 						const channel = this.getNodeParameter('channel', i) as string;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const options = this.getNodeParameter('options', i);
 						const jsonActive = this.getNodeParameter('jsonParameters', i);
 

--- a/packages/nodes-base/nodes/RssFeedRead/RssFeedRead.node.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/RssFeedRead.node.ts
@@ -38,7 +38,7 @@ export class RssFeedRead implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		try {
-			const url = this.getNodeParameter('url', 0) as string;
+			const url = this.getNodeParameter('url', 0);
 
 			if (!url) {
 				throw new NodeOperationError(this.getNode(), 'The parameter "URL" has to be set!');

--- a/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
+++ b/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
@@ -147,8 +147,8 @@ export class Rundeck implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 		const rundeckApi = new RundeckApi(this);
 		await rundeckApi.init();
 

--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -84,8 +84,8 @@ export class S3 implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				const headers: IDataObject = {};
@@ -191,7 +191,7 @@ export class S3 implements INodeType {
 
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'search') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const additionalFields = this.getNodeParameter('additionalFields', 0);
 
@@ -271,8 +271,8 @@ export class S3 implements INodeType {
 				if (resource === 'folder') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'create') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
-						const folderName = this.getNodeParameter('folderName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
+						const folderName = this.getNodeParameter('folderName', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						let path = `/${folderName}/`;
 
@@ -313,7 +313,7 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 					if (operation === 'delete') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const folderKey = this.getNodeParameter('folderKey', i) as string;
 
 						responseData = await s3ApiRequestSOAP.call(this, bucketName, 'GET', '', '', {
@@ -398,7 +398,7 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0) as IDataObject;
 
@@ -466,8 +466,8 @@ export class S3 implements INodeType {
 				if (resource === 'file') {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
 					if (operation === 'copy') {
-						const sourcePath = this.getNodeParameter('sourcePath', i) as string;
-						const destinationPath = this.getNodeParameter('destinationPath', i) as string;
+						const sourcePath = this.getNodeParameter('sourcePath', i);
+						const destinationPath = this.getNodeParameter('destinationPath', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						headers['x-amz-copy-source'] = sourcePath;
@@ -576,7 +576,7 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 					if (operation === 'download') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -641,7 +641,7 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
 					if (operation === 'delete') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -678,7 +678,7 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0) as IDataObject;
 
@@ -746,8 +746,8 @@ export class S3 implements INodeType {
 					}
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'upload') {
-						const bucketName = this.getNodeParameter('bucketName', i) as string;
-						const fileName = this.getNodeParameter('fileName', i) as string;
+						const bucketName = this.getNodeParameter('bucketName', i);
+						const fileName = this.getNodeParameter('fileName', i);
 						const isBinaryData = this.getNodeParameter('binaryData', i) as boolean;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const tagsValues = (this.getNodeParameter('tagsUi', i) as IDataObject)
@@ -835,7 +835,7 @@ export class S3 implements INodeType {
 						const region = responseData.LocationConstraint._;
 
 						if (isBinaryData) {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 
 							if (items[i].binary === undefined) {
 								throw new NodeOperationError(this.getNode(), 'No binary data exists on item!', {

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -383,7 +383,7 @@ export class Salesforce implements INodeType {
 			// select them easily
 			async getCustomFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const resource = this.getNodeParameter('resource', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
 				// TODO: find a way to filter this object to get just the lead sources instead of the whole object
 				const { fields } = await salesforceApiRequest.call(
 					this,
@@ -407,7 +407,7 @@ export class Salesforce implements INodeType {
 			// select them easily
 			async getRecordTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				let resource = this.getNodeParameter('resource', 0) as string;
+				let resource = this.getNodeParameter('resource', 0);
 				if (resource === 'customObject') {
 					resource = this.getNodeParameter('customObject', 0) as string;
 				}
@@ -1065,8 +1065,8 @@ export class Salesforce implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		Logger.debug(
 			`Running "Salesforce" node named "${this.getNode.name}" resource "${resource}" operation "${operation}"`,
@@ -1077,7 +1077,7 @@ export class Salesforce implements INodeType {
 				if (resource === 'lead') {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Lead/post-lead
 					if (operation === 'create' || operation === 'upsert') {
-						const company = this.getNodeParameter('company', i) as string;
+						const company = this.getNodeParameter('company', i);
 						const lastname = this.getNodeParameter('lastname', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: ILead = {
@@ -1355,7 +1355,7 @@ export class Salesforce implements INodeType {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Note/post-note
 					if (operation === 'addNote') {
 						const leadId = this.getNodeParameter('leadId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const options = this.getNodeParameter('options', i);
 						const body: INote = {
 							Title: title,
@@ -1701,7 +1701,7 @@ export class Salesforce implements INodeType {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Note/post-note
 					if (operation === 'addNote') {
 						const contactId = this.getNodeParameter('contactId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const options = this.getNodeParameter('options', i);
 						const body: INote = {
 							Title: title,
@@ -1835,9 +1835,9 @@ export class Salesforce implements INodeType {
 				if (resource === 'document') {
 					//https://developer.salesforce.com/docs/atlas.en-us.206.0.api_rest.meta/api_rest/dome_sobject_insert_update_blob.htm
 					if (operation === 'upload') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 						let data;
 						const body: { entity_content: { [key: string]: string } } = {
 							entity_content: {
@@ -1895,8 +1895,8 @@ export class Salesforce implements INodeType {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Opportunity/post-opportunity
 					if (operation === 'create' || operation === 'upsert') {
 						const name = this.getNodeParameter('name', i) as string;
-						const closeDate = this.getNodeParameter('closeDate', i) as string;
-						const stageName = this.getNodeParameter('stageName', i) as string;
+						const closeDate = this.getNodeParameter('closeDate', i);
+						const stageName = this.getNodeParameter('stageName', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IOpportunity = {
 							Name: name,
@@ -2083,7 +2083,7 @@ export class Salesforce implements INodeType {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Note/post-note
 					if (operation === 'addNote') {
 						const opportunityId = this.getNodeParameter('opportunityId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const options = this.getNodeParameter('options', i);
 						const body: INote = {
 							Title: title,
@@ -2373,7 +2373,7 @@ export class Salesforce implements INodeType {
 					//https://developer.salesforce.com/docs/api-explorer/sobject/Note/post-note
 					if (operation === 'addNote') {
 						const accountId = this.getNodeParameter('accountId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const options = this.getNodeParameter('options', i);
 						const body: INote = {
 							Title: title,
@@ -2855,7 +2855,7 @@ export class Salesforce implements INodeType {
 						const name = this.getNodeParameter('name', i) as string;
 						const parentId = this.getNodeParameter('parentId', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+						const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 						const body: IAttachment = {
 							Name: name,
 							ParentId: parentId,
@@ -3022,7 +3022,7 @@ export class Salesforce implements INodeType {
 				if (resource === 'flow') {
 					//https://developer.salesforce.com/docs/atlas.en-us.api_action.meta/api_action/actions_obj_flow.htm
 					if (operation === 'invoke') {
-						const apiName = this.getNodeParameter('apiName', i) as string;
+						const apiName = this.getNodeParameter('apiName', i);
 						const jsonParameters = this.getNodeParameter('jsonParameters', i);
 						let variables = {};
 						if (jsonParameters) {
@@ -3062,7 +3062,7 @@ export class Salesforce implements INodeType {
 				if (resource === 'search') {
 					//https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm
 					if (operation === 'query') {
-						qs.q = this.getNodeParameter('query', i) as string;
+						qs.q = this.getNodeParameter('query', i);
 						responseData = await salesforceApiRequestAllItems.call(
 							this,
 							'records',

--- a/packages/nodes-base/nodes/Salesmate/Salesmate.node.ts
+++ b/packages/nodes-base/nodes/Salesmate/Salesmate.node.ts
@@ -137,8 +137,8 @@ export class Salesmate implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'company') {
 				if (operation === 'create') {
@@ -387,7 +387,7 @@ export class Salesmate implements INodeType {
 			if (resource === 'activity') {
 				if (operation === 'create') {
 					const owner = this.getNodeParameter('owner', i) as number;
-					const title = this.getNodeParameter('title', i) as string;
+					const title = this.getNodeParameter('title', i);
 					const type = this.getNodeParameter('type', i) as string;
 					const rawData = this.getNodeParameter('rawData', i);
 					const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -580,13 +580,13 @@ export class Salesmate implements INodeType {
 			}
 			if (resource === 'deal') {
 				if (operation === 'create') {
-					const title = this.getNodeParameter('title', i) as string;
+					const title = this.getNodeParameter('title', i);
 					const owner = this.getNodeParameter('owner', i) as number;
 					const primaryContact = this.getNodeParameter('primaryContact', i) as number;
 					const pipeline = this.getNodeParameter('pipeline', i) as string;
 					const status = this.getNodeParameter('status', i) as string;
 					const stage = this.getNodeParameter('stage', i) as string;
-					const currency = this.getNodeParameter('currency', i) as string;
+					const currency = this.getNodeParameter('currency', i);
 					const rawData = this.getNodeParameter('rawData', i);
 					const additionalFields = this.getNodeParameter('additionalFields', i);
 					const body: IDeal = {

--- a/packages/nodes-base/nodes/SeaTable/SeaTable.node.ts
+++ b/packages/nodes-base/nodes/SeaTable/SeaTable.node.ts
@@ -136,8 +136,8 @@ export class SeaTable implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let responseData;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		const body: IDataObject = {};
 		const qs: IDataObject = {};
@@ -149,7 +149,7 @@ export class SeaTable implements INodeType {
 				//         row:create
 				// ----------------------------------
 
-				const tableName = this.getNodeParameter('tableName', 0) as string;
+				const tableName = this.getNodeParameter('tableName', 0);
 				const tableColumns = await getTableColumns.call(this, tableName);
 
 				body.table_name = tableName;
@@ -281,7 +281,7 @@ export class SeaTable implements INodeType {
 				//         row:getAll
 				// ----------------------------------
 
-				const tableName = this.getNodeParameter('tableName', 0) as string;
+				const tableName = this.getNodeParameter('tableName', 0);
 				const tableColumns = await getTableColumns.call(this, tableName);
 
 				for (let i = 0; i < items.length; i++) {
@@ -341,7 +341,7 @@ export class SeaTable implements INodeType {
 			} else if (operation === 'delete') {
 				for (let i = 0; i < items.length; i++) {
 					try {
-						const tableName = this.getNodeParameter('tableName', 0) as string;
+						const tableName = this.getNodeParameter('tableName', 0);
 						const rowId = this.getNodeParameter('rowId', i) as string;
 						const body: IDataObject = {
 							table_name: tableName,
@@ -379,7 +379,7 @@ export class SeaTable implements INodeType {
 				//         row:update
 				// ----------------------------------
 
-				const tableName = this.getNodeParameter('tableName', 0) as string;
+				const tableName = this.getNodeParameter('tableName', 0);
 				const tableColumns = await getTableColumns.call(this, tableName);
 
 				body.table_name = tableName;

--- a/packages/nodes-base/nodes/SeaTable/SeaTableTrigger.node.ts
+++ b/packages/nodes-base/nodes/SeaTable/SeaTableTrigger.node.ts
@@ -102,9 +102,9 @@ export class SeaTableTrigger implements INodeType {
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
 		const webhookData = this.getWorkflowStaticData('node');
-		const tableName = this.getNodeParameter('tableName') as string;
+		const tableName = this.getNodeParameter('tableName');
 		const simple = this.getNodeParameter('simple') as boolean;
-		const event = this.getNodeParameter('event') as string;
+		const event = this.getNodeParameter('event');
 		const ctx: ICtx = {};
 		const credentials = await this.getCredentials('seaTableApi');
 

--- a/packages/nodes-base/nodes/SecurityScorecard/SecurityScorecard.node.ts
+++ b/packages/nodes-base/nodes/SecurityScorecard/SecurityScorecard.node.ts
@@ -103,8 +103,8 @@ export class SecurityScorecard implements INodeType {
 		let responseData;
 		const length = items.length;
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			if (resource === 'portfolio') {
@@ -216,7 +216,7 @@ export class SecurityScorecard implements INodeType {
 
 			if (resource === 'report') {
 				if (operation === 'download') {
-					const reportUrl = this.getNodeParameter('url', i) as string;
+					const reportUrl = this.getNodeParameter('url', i);
 
 					const response = await scorecardApiRequest.call(this, 'GET', '', {}, {}, reportUrl, {
 						encoding: null,
@@ -242,7 +242,7 @@ export class SecurityScorecard implements INodeType {
 
 					items[i] = newItem;
 
-					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i) as string;
+					const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
 
 					const fileName = reportUrl.split('/').pop();
 

--- a/packages/nodes-base/nodes/Segment/Segment.node.ts
+++ b/packages/nodes-base/nodes/Segment/Segment.node.ts
@@ -75,8 +75,8 @@ export class Segment implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -351,7 +351,7 @@ export class Segment implements INodeType {
 					//https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/#track
 					if (operation === 'event') {
 						const userId = this.getNodeParameter('userId', i) as string;
-						const event = this.getNodeParameter('event', i) as string;
+						const event = this.getNodeParameter('event', i);
 						const context = (this.getNodeParameter('context', i) as IDataObject)
 							.contextUi as IDataObject;
 						const integrations = (this.getNodeParameter('integrations', i) as IDataObject)

--- a/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
+++ b/packages/nodes-base/nodes/SendGrid/SendGrid.node.ts
@@ -138,8 +138,8 @@ export class SendGrid implements INodeType {
 		let responseData;
 		const timezone = this.getTimezone();
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		// https://sendgrid.com/docs/api-reference/
 		if (resource === 'contact') {
 			if (operation === 'getAll') {
@@ -545,7 +545,7 @@ export class SendGrid implements INodeType {
 							],
 							from: {
 								email: (this.getNodeParameter('fromEmail', i) as string).trim(),
-								name: this.getNodeParameter('fromName', i) as string,
+								name: this.getNodeParameter('fromName', i),
 							},
 							mail_settings: {
 								sandbox_mode: {

--- a/packages/nodes-base/nodes/Sendy/Sendy.node.ts
+++ b/packages/nodes-base/nodes/Sendy/Sendy.node.ts
@@ -66,18 +66,18 @@ export class Sendy implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'campaign') {
 				if (operation === 'create') {
-					const fromName = this.getNodeParameter('fromName', i) as string;
+					const fromName = this.getNodeParameter('fromName', i);
 
 					const fromEmail = this.getNodeParameter('fromEmail', i) as string;
 
 					const replyTo = this.getNodeParameter('replyTo', i) as string;
 
-					const title = this.getNodeParameter('title', i) as string;
+					const title = this.getNodeParameter('title', i);
 
 					const subject = this.getNodeParameter('subject', i) as string;
 

--- a/packages/nodes-base/nodes/SentryIo/SentryIo.node.ts
+++ b/packages/nodes-base/nodes/SentryIo/SentryIo.node.ts
@@ -222,7 +222,7 @@ export class SentryIo implements INodeType {
 				const returnData: INodePropertyOptions[] = [];
 				const projects = await sentryApiRequestAllItems.call(this, 'GET', `/api/0/projects/`, {});
 
-				const organizationSlug = this.getNodeParameter('organizationSlug') as string;
+				const organizationSlug = this.getNodeParameter('organizationSlug');
 
 				for (const project of projects) {
 					if (organizationSlug !== project.organization.slug) {
@@ -251,7 +251,7 @@ export class SentryIo implements INodeType {
 			async getTeams(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				const organizationSlug = this.getNodeParameter('organizationSlug') as string;
+				const organizationSlug = this.getNodeParameter('organizationSlug');
 				const teams = await sentryApiRequestAllItems.call(
 					this,
 					'GET',
@@ -287,15 +287,15 @@ export class SentryIo implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'event') {
 					if (operation === 'getAll') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const full = this.getNodeParameter('full', i) as boolean;
 						const returnAll = this.getNodeParameter('returnAll', i);
 
@@ -316,8 +316,8 @@ export class SentryIo implements INodeType {
 						}
 					}
 					if (operation === 'get') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const eventId = this.getNodeParameter('eventId', i) as string;
 
 						const endpoint = `/api/0/projects/${organizationSlug}/${projectSlug}/events/${eventId}/`;
@@ -327,8 +327,8 @@ export class SentryIo implements INodeType {
 				}
 				if (resource === 'issue') {
 					if (operation === 'getAll') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
 
 						const endpoint = `/api/0/projects/${organizationSlug}/${projectSlug}/issues/`;
@@ -400,7 +400,7 @@ export class SentryIo implements INodeType {
 				}
 				if (resource === 'organization') {
 					if (operation === 'get') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const endpoint = `/api/0/organizations/${organizationSlug}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'GET', endpoint, qs);
@@ -459,8 +459,8 @@ export class SentryIo implements INodeType {
 				}
 				if (resource === 'project') {
 					if (operation === 'create') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const teamSlug = this.getNodeParameter('teamSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const teamSlug = this.getNodeParameter('teamSlug', i);
 						const name = this.getNodeParameter('name', i) as string;
 
 						const endpoint = `/api/0/teams/${organizationSlug}/${teamSlug}/projects/`;
@@ -473,8 +473,8 @@ export class SentryIo implements INodeType {
 						responseData = await sentryIoApiRequest.call(this, 'POST', endpoint, body, qs);
 					}
 					if (operation === 'get') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const endpoint = `/api/0/projects/${organizationSlug}/${projectSlug}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'GET', endpoint, qs);
@@ -496,16 +496,16 @@ export class SentryIo implements INodeType {
 						}
 					}
 					if (operation === 'update') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const endpoint = `/api/0/projects/${organizationSlug}/${projectSlug}/`;
 						const body = this.getNodeParameter('updateFields', i);
 
 						responseData = await sentryIoApiRequest.call(this, 'PUT', endpoint, body, qs);
 					}
 					if (operation === 'delete') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const projectSlug = this.getNodeParameter('projectSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const projectSlug = this.getNodeParameter('projectSlug', i);
 						const endpoint = `/api/0/projects/${organizationSlug}/${projectSlug}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'DELETE', endpoint, qs);
@@ -514,14 +514,14 @@ export class SentryIo implements INodeType {
 				}
 				if (resource === 'release') {
 					if (operation === 'get') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const version = this.getNodeParameter('version', i) as string;
 						const endpoint = `/api/0/organizations/${organizationSlug}/releases/${version}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'GET', endpoint, qs);
 					}
 					if (operation === 'getAll') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const endpoint = `/api/0/organizations/${organizationSlug}/releases/`;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
@@ -543,17 +543,17 @@ export class SentryIo implements INodeType {
 						}
 					}
 					if (operation === 'delete') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const version = this.getNodeParameter('version', i) as string;
 						const endpoint = `/api/0/organizations/${organizationSlug}/releases/${version}/`;
 						responseData = await sentryIoApiRequest.call(this, 'DELETE', endpoint, qs);
 						responseData = { success: true };
 					}
 					if (operation === 'create') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const endpoint = `/api/0/organizations/${organizationSlug}/releases/`;
 						const version = this.getNodeParameter('version', i) as string;
-						const url = this.getNodeParameter('url', i) as string;
+						const url = this.getNodeParameter('url', i);
 						const projects = this.getNodeParameter('projects', i) as string[];
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -612,7 +612,7 @@ export class SentryIo implements INodeType {
 						responseData = await sentryIoApiRequest.call(this, 'POST', endpoint, qs);
 					}
 					if (operation === 'update') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const version = this.getNodeParameter('version', i) as string;
 						const endpoint = `/api/0/organizations/${organizationSlug}/releases/${version}/`;
 
@@ -668,14 +668,14 @@ export class SentryIo implements INodeType {
 				}
 				if (resource === 'team') {
 					if (operation === 'get') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const teamSlug = this.getNodeParameter('teamSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const teamSlug = this.getNodeParameter('teamSlug', i);
 						const endpoint = `/api/0/teams/${organizationSlug}/${teamSlug}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'GET', endpoint, qs);
 					}
 					if (operation === 'getAll') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const endpoint = `/api/0/organizations/${organizationSlug}/teams/`;
 						const returnAll = this.getNodeParameter('returnAll', i);
 
@@ -693,7 +693,7 @@ export class SentryIo implements INodeType {
 					}
 
 					if (operation === 'create') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
 						const name = this.getNodeParameter('name', i) as string;
 						const endpoint = `/api/0/organizations/${organizationSlug}/teams/`;
 
@@ -708,8 +708,8 @@ export class SentryIo implements INodeType {
 						responseData = await sentryIoApiRequest.call(this, 'POST', endpoint, qs);
 					}
 					if (operation === 'update') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const teamSlug = this.getNodeParameter('teamSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const teamSlug = this.getNodeParameter('teamSlug', i);
 						const endpoint = `/api/0/teams/${organizationSlug}/${teamSlug}/`;
 
 						const body = this.getNodeParameter('updateFields', i);
@@ -717,8 +717,8 @@ export class SentryIo implements INodeType {
 						responseData = await sentryIoApiRequest.call(this, 'PUT', endpoint, body, qs);
 					}
 					if (operation === 'delete') {
-						const organizationSlug = this.getNodeParameter('organizationSlug', i) as string;
-						const teamSlug = this.getNodeParameter('teamSlug', i) as string;
+						const organizationSlug = this.getNodeParameter('organizationSlug', i);
+						const teamSlug = this.getNodeParameter('teamSlug', i);
 						const endpoint = `/api/0/teams/${organizationSlug}/${teamSlug}/`;
 
 						responseData = await sentryIoApiRequest.call(this, 'DELETE', endpoint, qs);

--- a/packages/nodes-base/nodes/ServiceNow/ServiceNow.node.ts
+++ b/packages/nodes-base/nodes/ServiceNow/ServiceNow.node.ts
@@ -251,8 +251,8 @@ export class ServiceNow implements INodeType {
 			},
 			async getUsers(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 
 				const qs = {
 					sysparm_fields: 'sys_id,user_name',
@@ -509,8 +509,8 @@ export class ServiceNow implements INodeType {
 		const length = items.length;
 		let responseData = {};
 		let qs: IDataObject;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -544,7 +544,7 @@ export class ServiceNow implements INodeType {
 						}
 					} else if (operation === 'getAll') {
 						const download = this.getNodeParameter('download', i);
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
 						const options = this.getNodeParameter('options', i);
 
@@ -600,9 +600,9 @@ export class ServiceNow implements INodeType {
 							responseData = (responseData as IDataObject[]).map((data) => ({ json: data }));
 						}
 					} else if (operation === 'upload') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const recordId = this.getNodeParameter('id', i) as string;
-						const inputDataFieldName = this.getNodeParameter('inputDataFieldName', i) as string;
+						const inputDataFieldName = this.getNodeParameter('inputDataFieldName', i);
 						const options = this.getNodeParameter('options', i);
 
 						let binaryData: IBinaryData;
@@ -855,7 +855,7 @@ export class ServiceNow implements INodeType {
 					}
 				} else if (resource === 'tableRecord') {
 					if (operation === 'create') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const dataToSend = this.getNodeParameter('dataToSend', i) as string;
 						let body = {};
 
@@ -884,7 +884,7 @@ export class ServiceNow implements INodeType {
 						);
 						responseData = response.result;
 					} else if (operation === 'delete') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const id = this.getNodeParameter('id', i) as string;
 						responseData = await serviceNowApiRequest.call(
 							this,
@@ -893,7 +893,7 @@ export class ServiceNow implements INodeType {
 						);
 						responseData = { success: true };
 					} else if (operation === 'get') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const id = this.getNodeParameter('id', i) as string;
 						qs = this.getNodeParameter('options', i);
 
@@ -910,7 +910,7 @@ export class ServiceNow implements INodeType {
 						);
 						responseData = response.result;
 					} else if (operation === 'getAll') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const returnAll = this.getNodeParameter('returnAll', i);
 						qs = this.getNodeParameter('options', i);
 
@@ -939,7 +939,7 @@ export class ServiceNow implements INodeType {
 							);
 						}
 					} else if (operation === 'update') {
-						const tableName = this.getNodeParameter('tableName', i) as string;
+						const tableName = this.getNodeParameter('tableName', i);
 						const id = this.getNodeParameter('id', i) as string;
 						const dataToSend = this.getNodeParameter('dataToSend', i) as string;
 						let body = {};

--- a/packages/nodes-base/nodes/Shopify/Shopify.node.ts
+++ b/packages/nodes-base/nodes/Shopify/Shopify.node.ts
@@ -165,8 +165,8 @@ export class Shopify implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'order') {
@@ -357,7 +357,7 @@ export class Shopify implements INodeType {
 					let body: IProduct = {};
 					//https://shopify.dev/docs/admin-api/rest/reference/products/product#create-2020-04
 					if (operation === 'create') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 
 						const additionalFields = this.getNodeParameter(
 							'additionalFields',

--- a/packages/nodes-base/nodes/Signl4/Signl4.node.ts
+++ b/packages/nodes-base/nodes/Signl4/Signl4.node.ts
@@ -234,15 +234,15 @@ export class Signl4 implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'alert') {
 					//https://connect.signl4.com/webhook/docs/index.html
 					// Send alert
 					if (operation === 'send') {
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						const data: IDataObject = {

--- a/packages/nodes-base/nodes/Slack/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/GenericFunctions.ts
@@ -57,9 +57,10 @@ export async function slackApiRequest(
 			if (response.error === 'paid_teams_only') {
 				throw new NodeOperationError(
 					this.getNode(),
-					`Your current Slack plan does not include the resource '${
-						this.getNodeParameter('resource', 0) as string
-					}'`,
+					`Your current Slack plan does not include the resource '${this.getNodeParameter(
+						'resource',
+						0,
+					)}'`,
 					{
 						description: `Hint: Upgrate to the Slack plan that includes the funcionality you want to use.`,
 					},

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -266,8 +266,8 @@ export class Slack implements INodeType {
 		let qs: IDataObject;
 		let responseData;
 		const authentication = this.getNodeParameter('authentication', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -626,7 +626,7 @@ export class Slack implements INodeType {
 					if (['post', 'postEphemeral'].includes(operation)) {
 						const channel = this.getNodeParameter('channel', i) as string;
 						const { sendAsUser } = this.getNodeParameter('otherOptions', i) as IDataObject;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const body: IDataObject = {
 							channel,
 							text,
@@ -900,7 +900,7 @@ export class Slack implements INodeType {
 					//https://api.slack.com/methods/chat.update
 					if (operation === 'update') {
 						const channel = this.getNodeParameter('channelId', i) as string;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const ts = this.getNodeParameter('ts', i) as string;
 						const attachments = this.getNodeParameter(
 							'attachments',
@@ -1091,7 +1091,7 @@ export class Slack implements INodeType {
 							body.title = options.title as string;
 						}
 						if (binaryData) {
-							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 							if (
 								items[i].binary === undefined ||
 								//@ts-ignore

--- a/packages/nodes-base/nodes/Sms77/Sms77.node.ts
+++ b/packages/nodes-base/nodes/Sms77/Sms77.node.ts
@@ -263,9 +263,9 @@ export class Sms77 implements INodeType {
 			try {
 				if (resource === 'sms') {
 					if (operation === 'send') {
-						const from = this.getNodeParameter('from', i) as string;
+						const from = this.getNodeParameter('from', i);
 						const to = this.getNodeParameter('to', i) as string;
-						const text = this.getNodeParameter('message', i) as string;
+						const text = this.getNodeParameter('message', i);
 						const options = this.getNodeParameter('options', i);
 						const body = {
 							from,
@@ -280,7 +280,7 @@ export class Sms77 implements INodeType {
 				if (resource === 'voice') {
 					if (operation === 'send') {
 						const to = this.getNodeParameter('to', i) as string;
-						const text = this.getNodeParameter('message', i) as string;
+						const text = this.getNodeParameter('message', i);
 						const options = this.getNodeParameter('options', i);
 						const body = {
 							to,

--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -166,7 +166,7 @@ export class Snowflake implements INodeType {
 		await connect(connection);
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'executeQuery') {
 			// ----------------------------------
@@ -174,7 +174,7 @@ export class Snowflake implements INodeType {
 			// ----------------------------------
 
 			for (let i = 0; i < items.length; i++) {
-				const query = this.getNodeParameter('query', i) as string;
+				const query = this.getNodeParameter('query', i);
 				responseData = await execute(connection, query, []);
 				returnData.push.apply(returnData, responseData as IDataObject[]);
 			}

--- a/packages/nodes-base/nodes/Splunk/Splunk.node.ts
+++ b/packages/nodes-base/nodes/Splunk/Splunk.node.ts
@@ -159,8 +159,8 @@ export class Splunk implements INodeType {
 		const items = this.getInputData();
 		const returnData: IDataObject[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Spontit/Spontit.node.ts
+++ b/packages/nodes-base/nodes/Spontit/Spontit.node.ts
@@ -52,8 +52,8 @@ export class Spontit implements INodeType {
 		const returnData: IDataObject[] = [];
 		const timezone = this.getTimezone();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < items.length; i++) {
 			try {
 				if (resource === 'push') {

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -791,8 +791,8 @@ export class Spotify implements INodeType {
 		let propertyName = '';
 		let responseData;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 
 		// Set initial values
 		requestMethod = 'GET';
@@ -974,7 +974,7 @@ export class Spotify implements INodeType {
 						propertyName = 'albums.items';
 
 						returnAll = this.getNodeParameter('returnAll', i);
-						const q = this.getNodeParameter('query', i) as string;
+						const q = this.getNodeParameter('query', i);
 						const filters = this.getNodeParameter('filters', i);
 
 						qs = {
@@ -1049,7 +1049,7 @@ export class Spotify implements INodeType {
 						propertyName = 'artists.items';
 
 						returnAll = this.getNodeParameter('returnAll', i);
-						const q = this.getNodeParameter('query', i) as string;
+						const q = this.getNodeParameter('query', i);
 						const filters = this.getNodeParameter('filters', i);
 
 						qs = {
@@ -1181,7 +1181,7 @@ export class Spotify implements INodeType {
 						propertyName = 'playlists.items';
 
 						returnAll = this.getNodeParameter('returnAll', i);
-						const q = this.getNodeParameter('query', i) as string;
+						const q = this.getNodeParameter('query', i);
 						const filters = this.getNodeParameter('filters', i);
 
 						qs = {
@@ -1223,7 +1223,7 @@ export class Spotify implements INodeType {
 						propertyName = 'tracks.items';
 
 						returnAll = this.getNodeParameter('returnAll', i);
-						const q = this.getNodeParameter('query', i) as string;
+						const q = this.getNodeParameter('query', i);
 						const filters = this.getNodeParameter('filters', i);
 
 						qs = {

--- a/packages/nodes-base/nodes/SpreadsheetFile/SpreadsheetFile.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/SpreadsheetFile.node.ts
@@ -296,7 +296,7 @@ export class SpreadsheetFile implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		const newItems: INodeExecutionData[] = [];
 
@@ -308,7 +308,7 @@ export class SpreadsheetFile implements INodeType {
 				try {
 					item = items[i];
 
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 					const options = this.getNodeParameter('options', i, {}) as IDataObject;
 
 					if (item.binary === undefined || item.binary[binaryPropertyName] === undefined) {
@@ -413,7 +413,7 @@ export class SpreadsheetFile implements INodeType {
 		} else if (operation === 'toFile') {
 			try {
 				// Write the workflow data to spreadsheet file
-				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+				const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 				const fileFormat = this.getNodeParameter('fileFormat', 0) as string;
 				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 				const sheetToJsonOptions: JSON2SheetOpts = {};

--- a/packages/nodes-base/nodes/Ssh/Ssh.node.ts
+++ b/packages/nodes-base/nodes/Ssh/Ssh.node.ts
@@ -247,8 +247,8 @@ export class Ssh implements INodeType {
 
 		const returnItems: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		const authentication = this.getNodeParameter('authentication', 0) as string;
 
 		const temporaryFiles: string[] = [];
@@ -307,7 +307,7 @@ export class Ssh implements INodeType {
 								'binaryPropertyName',
 								i,
 							) as string;
-							const parameterPath = this.getNodeParameter('path', i) as string;
+							const parameterPath = this.getNodeParameter('path', i);
 
 							const { path } = await file({ prefix: 'n8n-ssh-' });
 							temporaryFiles.push(path);
@@ -340,8 +340,8 @@ export class Ssh implements INodeType {
 						}
 
 						if (operation === 'upload') {
-							const parameterPath = this.getNodeParameter('path', i) as string;
-							const fileName = this.getNodeParameter('options.fileName', i, '') as string;
+							const parameterPath = this.getNodeParameter('path', i);
+							const fileName = this.getNodeParameter('options.fileName', i, '');
 
 							const item = items[i];
 
@@ -351,7 +351,7 @@ export class Ssh implements INodeType {
 								});
 							}
 
-							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i) as string;
+							const propertyNameUpload = this.getNodeParameter('binaryPropertyName', i);
 
 							const binaryData = item.binary[propertyNameUpload] as IBinaryData;
 

--- a/packages/nodes-base/nodes/Stackby/Stackby.node.ts
+++ b/packages/nodes-base/nodes/Stackby/Stackby.node.ts
@@ -177,7 +177,7 @@ export class Stackby implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 		if (operation === 'read') {
 			for (let i = 0; i < length; i++) {
 				try {

--- a/packages/nodes-base/nodes/Storyblok/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Storyblok/GenericFunctions.ts
@@ -19,7 +19,7 @@ export async function storyblokApiRequest(
 	option: IDataObject = {},
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const authenticationMethod = this.getNodeParameter('source', 0) as string;
+	const authenticationMethod = this.getNodeParameter('source', 0);
 
 	let options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Storyblok/Storyblok.node.ts
+++ b/packages/nodes-base/nodes/Storyblok/Storyblok.node.ts
@@ -152,9 +152,9 @@ export class Storyblok implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const source = this.getNodeParameter('source', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const source = this.getNodeParameter('source', 0);
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (source === 'contentApi') {

--- a/packages/nodes-base/nodes/Strapi/Strapi.node.ts
+++ b/packages/nodes-base/nodes/Strapi/Strapi.node.ts
@@ -109,8 +109,8 @@ export class Strapi implements INodeType {
 		const qs: IDataObject = {};
 		const headers: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		const { apiVersion } = await this.getCredentials('strapiApi');
 		const { jwt } = await getToken.call(this);

--- a/packages/nodes-base/nodes/Strava/Strava.node.ts
+++ b/packages/nodes-base/nodes/Strava/Strava.node.ts
@@ -53,8 +53,8 @@ export class Strava implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'activity') {
@@ -64,7 +64,7 @@ export class Strava implements INodeType {
 
 						const type = this.getNodeParameter('type', i) as string;
 
-						const startDate = this.getNodeParameter('startDate', i) as string;
+						const startDate = this.getNodeParameter('startDate', i);
 
 						const elapsedTime = this.getNodeParameter('elapsedTime', i) as number;
 

--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -133,8 +133,8 @@ export class Stripe implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
@@ -207,7 +207,7 @@ export class Stripe implements INodeType {
 
 						const body = {
 							customer: this.getNodeParameter('customerId', i),
-							currency: (this.getNodeParameter('currency', i) as string).toLowerCase(),
+							currency: this.getNodeParameter('currency', i).toLowerCase(),
 							amount: this.getNodeParameter('amount', i),
 							source: this.getNodeParameter('source', i),
 						} as IDataObject;

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -124,8 +124,8 @@ export class Supabase implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (resource === 'row') {
 			if (operation === 'create') {

--- a/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
+++ b/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
@@ -362,7 +362,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 		default: {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				const objectType = this.getNodeParameter('objectType') as string;
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				// Check all the webhooks which exist already if it is identical to the
 				// one that is supposed to get created.
 				const endpoint = '/webhooks';
@@ -410,7 +410,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const objectType = this.getNodeParameter('objectType') as string;
 				const endpoint = '/webhooks';
 				const ids: string[] = [];
@@ -472,7 +472,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 	};
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
-		const event = this.getNodeParameter('event') as string;
+		const event = this.getNodeParameter('event');
 		const objectType = this.getNodeParameter('objectType') as string;
 		const authenticationMethod = this.getNodeParameter('authentication') as string;
 		let credentials: IDataObject;

--- a/packages/nodes-base/nodes/Tapfiliate/Tapfiliate.node.ts
+++ b/packages/nodes-base/nodes/Tapfiliate/Tapfiliate.node.ts
@@ -96,8 +96,8 @@ export class Tapfiliate implements INodeType {
 		const qs: IDataObject = {};
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'affiliate') {

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1683,8 +1683,8 @@ export class Telegram implements INodeType {
 		let requestMethod: string;
 		let endpoint: string;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 		const binaryData = this.getNodeParameter('binaryData', 0, false);
 
 		for (let i = 0; i < items.length; i++) {
@@ -1773,7 +1773,7 @@ export class Telegram implements INodeType {
 						endpoint = 'setChatTitle';
 
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 					}
 					// } else if (resource === 'bot') {
 					// 	if (operation === 'info') {
@@ -1806,7 +1806,7 @@ export class Telegram implements INodeType {
 							body.message_id = this.getNodeParameter('messageId', i) as string;
 						}
 
-						body.text = this.getNodeParameter('text', i) as string;
+						body.text = this.getNodeParameter('text', i);
 
 						// Add additional fields and replyMarkup
 						addAdditionalFields.call(this, body, i);
@@ -1911,7 +1911,7 @@ export class Telegram implements INodeType {
 						endpoint = 'sendMessage';
 
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
-						body.text = this.getNodeParameter('text', i) as string;
+						body.text = this.getNodeParameter('text', i);
 
 						// Add additional fields and replyMarkup
 						addAdditionalFields.call(this, body, i);
@@ -1982,11 +1982,11 @@ export class Telegram implements INodeType {
 				let responseData;
 
 				if (binaryData === true) {
-					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0) as string;
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 					const binaryData = items[i].binary![binaryPropertyName] as IBinaryData;
 					const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
 					const propertyName = getPropertyName(operation);
-					const fileName = this.getNodeParameter('additionalFields.fileName', 0, '') as string;
+					const fileName = this.getNodeParameter('additionalFields.fileName', 0, '');
 
 					const filename = fileName || binaryData.fileName?.toString();
 

--- a/packages/nodes-base/nodes/TheHive/TheHive.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHive.node.ts
@@ -315,8 +315,8 @@ export class TheHive implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
@@ -894,8 +894,8 @@ export class TheHive implements INodeType {
 
 						let body: IDataObject = {
 							dataType: this.getNodeParameter('dataType', i) as string,
-							message: this.getNodeParameter('message', i) as string,
-							startDate: Date.parse(this.getNodeParameter('startDate', i) as string),
+							message: this.getNodeParameter('message', i),
+							startDate: Date.parse(this.getNodeParameter('startDate', i)),
 							tlp: this.getNodeParameter('tlp', i) as number,
 							ioc: this.getNodeParameter('ioc', i) as boolean,
 							sighted: this.getNodeParameter('sighted', i) as boolean,
@@ -914,7 +914,7 @@ export class TheHive implements INodeType {
 								});
 							}
 
-							const binaryPropertyName = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryPropertyName = this.getNodeParameter('binaryProperty', i);
 
 							if (item.binary[binaryPropertyName] === undefined) {
 								throw new NodeOperationError(
@@ -1282,7 +1282,7 @@ export class TheHive implements INodeType {
 							title: this.getNodeParameter('title', i),
 							description: this.getNodeParameter('description', i),
 							severity: this.getNodeParameter('severity', i),
-							startDate: Date.parse(this.getNodeParameter('startDate', i) as string),
+							startDate: Date.parse(this.getNodeParameter('startDate', i)),
 							owner: this.getNodeParameter('owner', i),
 							flag: this.getNodeParameter('flag', i),
 							tlp: this.getNodeParameter('tlp', i),
@@ -1496,7 +1496,7 @@ export class TheHive implements INodeType {
 						const caseId = this.getNodeParameter('caseId', i) as string;
 
 						const body: IDataObject = {
-							title: this.getNodeParameter('title', i) as string,
+							title: this.getNodeParameter('title', i),
 							status: this.getNodeParameter('status', i) as string,
 							flag: this.getNodeParameter('flag', i),
 							...prepareOptional(this.getNodeParameter('options', i, {}) as INodeParameters),
@@ -1768,7 +1768,7 @@ export class TheHive implements INodeType {
 
 						let body: IDataObject = {
 							message: this.getNodeParameter('message', i),
-							startDate: Date.parse(this.getNodeParameter('startDate', i) as string),
+							startDate: Date.parse(this.getNodeParameter('startDate', i)),
 							status: this.getNodeParameter('status', i),
 						};
 						const optionals = this.getNodeParameter('options', i);

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -272,7 +272,7 @@ export class TimescaleDb implements INodeType {
 		let returnItems = [];
 
 		const items = this.getInputData();
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === 'executeQuery') {
 			// ----------------------------------

--- a/packages/nodes-base/nodes/Todoist/v1/TodoistV1.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v1/TodoistV1.node.ts
@@ -702,8 +702,8 @@ export class TodoistV1 implements INodeType {
 		const length = items.length;
 		const service = new TodoistService();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'task') {

--- a/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
@@ -701,8 +701,8 @@ export class TodoistV2 implements INodeType {
 		const length = items.length;
 		const service = new TodoistService();
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'task') {

--- a/packages/nodes-base/nodes/Toggl/TogglTrigger.node.ts
+++ b/packages/nodes-base/nodes/Toggl/TogglTrigger.node.ts
@@ -51,7 +51,7 @@ export class TogglTrigger implements INodeType {
 
 	async poll(this: IPollFunctions): Promise<INodeExecutionData[][] | null> {
 		const webhookData = this.getWorkflowStaticData('node');
-		const event = this.getNodeParameter('event') as string;
+		const event = this.getNodeParameter('event');
 		let endpoint: string;
 
 		if (event === 'newTimeEntry') {

--- a/packages/nodes-base/nodes/TravisCi/TravisCi.node.ts
+++ b/packages/nodes-base/nodes/TravisCi/TravisCi.node.ts
@@ -52,8 +52,8 @@ export class TravisCi implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {

--- a/packages/nodes-base/nodes/Trello/Trello.node.ts
+++ b/packages/nodes-base/nodes/Trello/Trello.node.ts
@@ -194,8 +194,8 @@ export class Trello implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 
 		// For Post
 		let body: IDataObject;
@@ -409,7 +409,7 @@ export class Trello implements INodeType {
 							extractValue: true,
 						}) as string;
 
-						qs.text = this.getNodeParameter('text', i) as string;
+						qs.text = this.getNodeParameter('text', i);
 
 						requestMethod = 'POST';
 
@@ -441,7 +441,7 @@ export class Trello implements INodeType {
 
 						const commentId = this.getNodeParameter('commentId', i) as string;
 
-						qs.text = this.getNodeParameter('text', i) as string;
+						qs.text = this.getNodeParameter('text', i);
 
 						endpoint = `cards/${cardId}/actions/${commentId}/comments`;
 					} else {
@@ -560,7 +560,7 @@ export class Trello implements INodeType {
 							extractValue: true,
 						}) as string;
 
-						const url = this.getNodeParameter('url', i) as string;
+						const url = this.getNodeParameter('url', i);
 
 						Object.assign(qs, {
 							url,
@@ -782,7 +782,7 @@ export class Trello implements INodeType {
 						}) as string;
 
 						const name = this.getNodeParameter('name', i) as string;
-						const color = this.getNodeParameter('color', i) as string;
+						const color = this.getNodeParameter('color', i);
 
 						Object.assign(qs, {
 							idBoard,

--- a/packages/nodes-base/nodes/Twake/Twake.node.ts
+++ b/packages/nodes-base/nodes/Twake/Twake.node.ts
@@ -186,8 +186,8 @@ export class Twake implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			if (resource === 'message') {
 				if (operation === 'send') {

--- a/packages/nodes-base/nodes/Twilio/Twilio.node.ts
+++ b/packages/nodes-base/nodes/Twilio/Twilio.node.ts
@@ -222,8 +222,8 @@ export class Twilio implements INodeType {
 				body = {};
 				qs = {};
 
-				resource = this.getNodeParameter('resource', i) as string;
-				operation = this.getNodeParameter('operation', i) as string;
+				resource = this.getNodeParameter('resource', i);
+				operation = this.getNodeParameter('operation', i);
 
 				if (resource === 'sms') {
 					if (operation === 'send') {
@@ -234,9 +234,9 @@ export class Twilio implements INodeType {
 						requestMethod = 'POST';
 						endpoint = '/Messages.json';
 
-						body.From = this.getNodeParameter('from', i) as string;
+						body.From = this.getNodeParameter('from', i);
 						body.To = this.getNodeParameter('to', i) as string;
-						body.Body = this.getNodeParameter('message', i) as string;
+						body.Body = this.getNodeParameter('message', i);
 						body.StatusCallback = this.getNodeParameter('options.statusCallback', i, '') as string;
 
 						const toWhatsapp = this.getNodeParameter('toWhatsapp', i) as boolean;
@@ -261,9 +261,9 @@ export class Twilio implements INodeType {
 						requestMethod = 'POST';
 						endpoint = '/Calls.json';
 
-						const message = this.getNodeParameter('message', i) as string;
+						const message = this.getNodeParameter('message', i);
 						const useTwiml = this.getNodeParameter('twiml', i) as boolean;
-						body.From = this.getNodeParameter('from', i) as string;
+						body.From = this.getNodeParameter('from', i);
 						body.To = this.getNodeParameter('to', i) as string;
 
 						if (useTwiml) {

--- a/packages/nodes-base/nodes/Twist/Twist.node.ts
+++ b/packages/nodes-base/nodes/Twist/Twist.node.ts
@@ -159,8 +159,8 @@ export class Twist implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'channel') {
@@ -627,7 +627,7 @@ export class Twist implements INodeType {
 					//https://developer.twist.com/v3/#add-thread
 					if (operation === 'create') {
 						const channelId = this.getNodeParameter('channelId', i) as string;
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const content = this.getNodeParameter('content', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {

--- a/packages/nodes-base/nodes/Twitter/Twitter.node.ts
+++ b/packages/nodes-base/nodes/Twitter/Twitter.node.ts
@@ -95,15 +95,15 @@ export class Twitter implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'directMessage') {
 					//https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/new-event
 					if (operation === 'create') {
 						const userId = this.getNodeParameter('userId', i) as string;
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IDataObject = {
 							type: 'message_create',
@@ -150,7 +150,7 @@ export class Twitter implements INodeType {
 				if (resource === 'tweet') {
 					// https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update
 					if (operation === 'create') {
-						const text = this.getNodeParameter('text', i) as string;
+						const text = this.getNodeParameter('text', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: ITweet = {
 							status: text,

--- a/packages/nodes-base/nodes/UnleashedSoftware/UnleashedSoftware.node.ts
+++ b/packages/nodes-base/nodes/UnleashedSoftware/UnleashedSoftware.node.ts
@@ -69,8 +69,8 @@ export class UnleashedSoftware implements INodeType {
 		let responseData;
 
 		for (let i = 0; i < length; i++) {
-			const resource = this.getNodeParameter('resource', 0) as string;
-			const operation = this.getNodeParameter('operation', 0) as string;
+			const resource = this.getNodeParameter('resource', 0);
+			const operation = this.getNodeParameter('operation', 0);
 
 			//https://apidocs.unleashedsoftware.com/SalesOrders
 			if (resource === 'salesOrder') {

--- a/packages/nodes-base/nodes/Uplead/Uplead.node.ts
+++ b/packages/nodes-base/nodes/Uplead/Uplead.node.ts
@@ -60,8 +60,8 @@ export class Uplead implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'person') {
@@ -88,7 +88,7 @@ export class Uplead implements INodeType {
 				if (resource === 'company') {
 					if (operation === 'enrich') {
 						const domain = this.getNodeParameter('domain', i) as string;
-						const company = this.getNodeParameter('company', i) as string;
+						const company = this.getNodeParameter('company', i);
 						if (domain) {
 							qs.domain = domain;
 						}

--- a/packages/nodes-base/nodes/UptimeRobot/UptimeRobot.node.ts
+++ b/packages/nodes-base/nodes/UptimeRobot/UptimeRobot.node.ts
@@ -121,8 +121,8 @@ export class UptimeRobot implements INodeType {
 		const timezone = this.getTimezone();
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 				let body: IDataObject = {};
 				//https://uptimerobot.com/#methods
 				if (resource === 'account') {
@@ -135,8 +135,8 @@ export class UptimeRobot implements INodeType {
 				if (resource === 'monitor') {
 					if (operation === 'create') {
 						body = {
-							friendly_name: this.getNodeParameter('friendlyName', i) as string,
-							url: this.getNodeParameter('url', i) as string,
+							friendly_name: this.getNodeParameter('friendlyName', i),
+							url: this.getNodeParameter('url', i),
 							type: this.getNodeParameter('type', i) as number,
 						};
 
@@ -220,7 +220,7 @@ export class UptimeRobot implements INodeType {
 				if (resource === 'alertContact') {
 					if (operation === 'create') {
 						body = {
-							friendly_name: this.getNodeParameter('friendlyName', i) as string,
+							friendly_name: this.getNodeParameter('friendlyName', i),
 							value: this.getNodeParameter('value', i) as string,
 							type: this.getNodeParameter('type', i) as number,
 						};
@@ -295,7 +295,7 @@ export class UptimeRobot implements INodeType {
 
 						body = {
 							duration: this.getNodeParameter('duration', i) as number,
-							friendly_name: this.getNodeParameter('friendlyName', i) as string,
+							friendly_name: this.getNodeParameter('friendlyName', i),
 							start_time: parsedStartTime,
 							type,
 						};
@@ -368,7 +368,7 @@ export class UptimeRobot implements INodeType {
 				if (resource === 'publicStatusPage') {
 					if (operation === 'create') {
 						body = {
-							friendly_name: this.getNodeParameter('friendlyName', i) as string,
+							friendly_name: this.getNodeParameter('friendlyName', i),
 							monitors: this.getNodeParameter('monitors', i) as string,
 							...(this.getNodeParameter('additionalFields', i) as IDataObject),
 						};

--- a/packages/nodes-base/nodes/UrlScanIo/UrlScanIo.node.ts
+++ b/packages/nodes-base/nodes/UrlScanIo/UrlScanIo.node.ts
@@ -57,7 +57,7 @@ export class UrlScanIo implements INodeType {
 		const returnData: IDataObject[] = [];
 
 		const resource = this.getNodeParameter('resource', 0) as 'scan';
-		const operation = this.getNodeParameter('operation', 0) as 'perform' | 'get' | 'getAll';
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 
@@ -108,7 +108,7 @@ export class UrlScanIo implements INodeType {
 						};
 
 						const body: IDataObject = {
-							url: this.getNodeParameter('url', i) as string,
+							url: this.getNodeParameter('url', i),
 							...rest,
 						};
 

--- a/packages/nodes-base/nodes/Venafi/Datacenter/VenafiTlsProtectDatacenter.node.ts
+++ b/packages/nodes-base/nodes/Venafi/Datacenter/VenafiTlsProtectDatacenter.node.ts
@@ -59,8 +59,8 @@ export class VenafiTlsProtectDatacenter implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'certificate') {
@@ -108,7 +108,7 @@ export class VenafiTlsProtectDatacenter implements INodeType {
 					if (operation === 'download') {
 						const certificateDn = this.getNodeParameter('certificateDn', i) as string;
 						const includePrivateKey = this.getNodeParameter('includePrivateKey', i) as boolean;
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						const body: IDataObject = {
@@ -118,7 +118,7 @@ export class VenafiTlsProtectDatacenter implements INodeType {
 						};
 
 						if (includePrivateKey) {
-							const password = this.getNodeParameter('password', i) as string;
+							const password = this.getNodeParameter('password', i);
 							(body.IncludePrivateKey = true), (body.Password = password);
 						}
 

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
@@ -18,7 +18,7 @@ export async function venafiApiRequest(
 	option: IDataObject = {},
 	// tslint:disable-next-line:no-any
 ): Promise<any> {
-	const operation = this.getNodeParameter('operation', 0) as string;
+	const operation = this.getNodeParameter('operation', 0);
 
 	const options: OptionsWithUri = {
 		headers: {

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
@@ -137,8 +137,8 @@ export class VenafiTlsProtectCloud implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'certificateRequest') {
@@ -162,7 +162,7 @@ export class VenafiTlsProtectCloud implements INodeType {
 								'applicationServerTypeId',
 								i,
 							) as string;
-							const commonName = this.getNodeParameter('commonName', i) as string;
+							const commonName = this.getNodeParameter('commonName', i);
 							const additionalFields = this.getNodeParameter('additionalFields', i);
 
 							const keyTypeDetails: IKeyTypeParameters = {};
@@ -311,7 +311,7 @@ export class VenafiTlsProtectCloud implements INodeType {
 					//https://api.venafi.cloud/webjars/swagger-ui/index.html?configUrl=%2Fv3%2Fapi-docs%2Fswagger-config&urls.primaryName=outagedetection-service#/
 					if (operation === 'download') {
 						const certificateId = this.getNodeParameter('certificateId', i) as string;
-						const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+						const binaryProperty = this.getNodeParameter('binaryProperty', i);
 						const downloadItem = this.getNodeParameter('downloadItem', i) as string;
 						const options = this.getNodeParameter('options', i);
 

--- a/packages/nodes-base/nodes/Vero/Vero.node.ts
+++ b/packages/nodes-base/nodes/Vero/Vero.node.ts
@@ -64,8 +64,8 @@ export class Vero implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 				//https://developers.getvero.com/?bash#users
 				if (resource === 'user') {
 					//https://developers.getvero.com/?bash#users-identify
@@ -169,7 +169,7 @@ export class Vero implements INodeType {
 					if (operation === 'track') {
 						const id = this.getNodeParameter('id', i) as string;
 						const email = this.getNodeParameter('email', i) as string;
-						const eventName = this.getNodeParameter('eventName', i) as string;
+						const eventName = this.getNodeParameter('eventName', i);
 						const jsonActive = this.getNodeParameter('jsonParameters', i);
 						const body = {
 							identity: { id, email },

--- a/packages/nodes-base/nodes/Vonage/Vonage.node.ts
+++ b/packages/nodes-base/nodes/Vonage/Vonage.node.ts
@@ -399,13 +399,13 @@ export class Vonage implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'sms') {
 					if (operation === 'send') {
-						const from = this.getNodeParameter('from', i) as string;
+						const from = this.getNodeParameter('from', i);
 
 						const to = this.getNodeParameter('to', i) as string;
 
@@ -418,7 +418,7 @@ export class Vonage implements INodeType {
 						};
 
 						if (type === 'text' || type === 'unicode') {
-							const message = this.getNodeParameter('message', i) as string;
+							const message = this.getNodeParameter('message', i);
 
 							body.text = message;
 						}
@@ -434,9 +434,9 @@ export class Vonage implements INodeType {
 						}
 
 						if (type === 'wappush') {
-							const title = this.getNodeParameter('title', i) as string;
+							const title = this.getNodeParameter('title', i);
 
-							const url = this.getNodeParameter('url', i) as string;
+							const url = this.getNodeParameter('url', i);
 
 							const validity = this.getNodeParameter('validity', i) as number;
 

--- a/packages/nodes-base/nodes/Webflow/Webflow.node.ts
+++ b/packages/nodes-base/nodes/Webflow/Webflow.node.ts
@@ -133,8 +133,8 @@ export class Webflow implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
 

--- a/packages/nodes-base/nodes/Webflow/WebflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/Webflow/WebflowTrigger.node.ts
@@ -203,7 +203,7 @@ export class WebflowTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const siteId = this.getNodeParameter('site') as string;
 
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const registeredWebhooks = (await webflowApiRequest.call(
 					this,
 					'GET',
@@ -224,7 +224,7 @@ export class WebflowTrigger implements INodeType {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
 				const siteId = this.getNodeParameter('site') as string;
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const endpoint = `/sites/${siteId}/webhooks`;
 				const body: IDataObject = {
 					site_id: siteId,

--- a/packages/nodes-base/nodes/Wekan/Wekan.node.ts
+++ b/packages/nodes-base/nodes/Wekan/Wekan.node.ts
@@ -239,8 +239,8 @@ export class Wekan implements INodeType {
 		let returnAll;
 		let limit;
 
-		const operation = this.getNodeParameter('operation', 0) as string;
-		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
+		const resource = this.getNodeParameter('resource', 0);
 
 		// For Post
 		let body: IDataObject;
@@ -266,7 +266,7 @@ export class Wekan implements INodeType {
 						requestMethod = 'POST';
 						endpoint = 'boards';
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 						body.owner = this.getNodeParameter('owner', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -323,7 +323,7 @@ export class Wekan implements INodeType {
 
 						endpoint = `boards/${boardId}/lists/${listId}/cards`;
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 						body.swimlaneId = this.getNodeParameter('swimlaneId', i) as string;
 						body.authorId = this.getNodeParameter('authorId', i) as string;
 
@@ -466,7 +466,7 @@ export class Wekan implements INodeType {
 
 						endpoint = `boards/${boardId}/lists`;
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 					} else if (operation === 'delete') {
 						// ----------------------------------
 						//         delete
@@ -520,7 +520,7 @@ export class Wekan implements INodeType {
 
 						endpoint = `boards/${boardId}/cards/${cardId}/checklists`;
 
-						body.title = this.getNodeParameter('title', i) as string;
+						body.title = this.getNodeParameter('title', i);
 
 						body.items = this.getNodeParameter('items', i) as string[];
 					} else if (operation === 'delete') {

--- a/packages/nodes-base/nodes/Wise/Wise.node.ts
+++ b/packages/nodes-base/nodes/Wise/Wise.node.ts
@@ -167,8 +167,8 @@ export class Wise implements INodeType {
 	async execute(this: IExecuteFunctions) {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		const timezone = this.getTimezone();
 
@@ -252,12 +252,12 @@ export class Wise implements INodeType {
 							const data = await wiseApiRequest.call(this, 'GET', endpoint, {}, qs, {
 								encoding: 'arraybuffer',
 							});
-							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 							items[i].binary = items[i].binary ?? {};
 							items[i].binary![binaryProperty] = await this.helpers.prepareBinaryData(
 								data,
-								this.getNodeParameter('fileName', i) as string,
+								this.getNodeParameter('fileName', i),
 							);
 
 							responseData = items;
@@ -476,12 +476,12 @@ export class Wise implements INodeType {
 								{},
 								{ encoding: 'arraybuffer' },
 							);
-							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const binaryProperty = this.getNodeParameter('binaryProperty', i);
 
 							items[i].binary = items[i].binary ?? {};
 							items[i].binary![binaryProperty] = await this.helpers.prepareBinaryData(
 								data,
-								this.getNodeParameter('fileName', i) as string,
+								this.getNodeParameter('fileName', i),
 							);
 
 							responseData = items;

--- a/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
@@ -126,8 +126,8 @@ export class WooCommerce implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			if (resource === 'customer') {

--- a/packages/nodes-base/nodes/WooCommerce/WooCommerceTrigger.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerceTrigger.node.ts
@@ -101,7 +101,7 @@ export class WooCommerceTrigger implements INodeType {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const currentEvent = this.getNodeParameter('event') as string;
+				const currentEvent = this.getNodeParameter('event');
 				const endpoint = `/webhooks`;
 
 				const webhooks = await woocommerceApiRequest.call(
@@ -128,7 +128,7 @@ export class WooCommerceTrigger implements INodeType {
 				const credentials = await this.getCredentials('wooCommerceApi');
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const event = this.getNodeParameter('event') as string;
+				const event = this.getNodeParameter('event');
 				const secret = getAutomaticSecret(credentials);
 				const endpoint = '/webhooks';
 				const body: IDataObject = {

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -123,15 +123,15 @@ export class Wordpress implements INodeType {
 		const length = items.length;
 		let responseData;
 		const qs: IDataObject = {};
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'post') {
 					//https://developer.wordpress.org/rest-api/reference/posts/#create-a-post
 					if (operation === 'create') {
-						const title = this.getNodeParameter('title', i) as string;
+						const title = this.getNodeParameter('title', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IPost = {
 							title,
@@ -310,10 +310,10 @@ export class Wordpress implements INodeType {
 					if (operation === 'create') {
 						const name = this.getNodeParameter('name', i) as string;
 						const username = this.getNodeParameter('username', i) as string;
-						const firstName = this.getNodeParameter('firstName', i) as string;
-						const lastName = this.getNodeParameter('lastName', i) as string;
+						const firstName = this.getNodeParameter('firstName', i);
+						const lastName = this.getNodeParameter('lastName', i);
 						const email = this.getNodeParameter('email', i) as string;
-						const password = this.getNodeParameter('password', i) as string;
+						const password = this.getNodeParameter('password', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const body: IUser = {
 							name,

--- a/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
@@ -70,9 +70,9 @@ export class WriteBinaryFile implements INodeType {
 
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
 			try {
-				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex) as string;
+				const dataPropertyName = this.getNodeParameter('dataPropertyName', itemIndex);
 
-				const fileName = this.getNodeParameter('fileName', itemIndex) as string;
+				const fileName = this.getNodeParameter('fileName', itemIndex);
 				const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 
 				const flag = options.append ? 'a' : 'w';

--- a/packages/nodes-base/nodes/Xero/Xero.node.ts
+++ b/packages/nodes-base/nodes/Xero/Xero.node.ts
@@ -216,8 +216,8 @@ export class Xero implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 				//https://developer.xero.com/documentation/api/invoices
 				if (resource === 'invoice') {
 					if (operation === 'create') {

--- a/packages/nodes-base/nodes/Xml/Xml.node.ts
+++ b/packages/nodes-base/nodes/Xml/Xml.node.ts
@@ -221,7 +221,7 @@ export class Xml implements INodeType {
 		const items = this.getInputData();
 
 		const mode = this.getNodeParameter('mode', 0) as string;
-		const dataPropertyName = this.getNodeParameter('dataPropertyName', 0) as string;
+		const dataPropertyName = this.getNodeParameter('dataPropertyName', 0);
 		const options = this.getNodeParameter('options', 0, {}) as IDataObject;
 
 		let item: INodeExecutionData;

--- a/packages/nodes-base/nodes/Yourls/Yourls.node.ts
+++ b/packages/nodes-base/nodes/Yourls/Yourls.node.ts
@@ -52,13 +52,13 @@ export class Yourls implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'url') {
 					if (operation === 'shorten') {
-						const url = this.getNodeParameter('url', i) as string;
+						const url = this.getNodeParameter('url', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						qs.url = url;
 						qs.action = 'shorturl';
@@ -67,14 +67,14 @@ export class Yourls implements INodeType {
 					}
 
 					if (operation === 'expand') {
-						const shortUrl = this.getNodeParameter('shortUrl', i) as string;
+						const shortUrl = this.getNodeParameter('shortUrl', i);
 						qs.shorturl = shortUrl;
 						qs.action = 'expand';
 						responseData = await yourlsApiRequest.call(this, 'GET', {}, qs);
 					}
 
 					if (operation === 'stats') {
-						const shortUrl = this.getNodeParameter('shortUrl', i) as string;
+						const shortUrl = this.getNodeParameter('shortUrl', i);
 						qs.shorturl = shortUrl;
 						qs.action = 'url-stats';
 						responseData = await yourlsApiRequest.call(this, 'GET', {}, qs);

--- a/packages/nodes-base/nodes/Zammad/Zammad.node.ts
+++ b/packages/nodes-base/nodes/Zammad/Zammad.node.ts
@@ -319,8 +319,8 @@ export class Zammad implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 
-		const resource = this.getNodeParameter('resource', 0) as ZammadTypes.Resource;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 		const returnData: INodeExecutionData[] = [];
@@ -666,7 +666,7 @@ export class Zammad implements INodeType {
 
 						const body = {
 							article: {},
-							title: this.getNodeParameter('title', i) as string,
+							title: this.getNodeParameter('title', i),
 							group: this.getNodeParameter('group', i) as string,
 							customer: this.getNodeParameter('customer', i) as string,
 						};

--- a/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
+++ b/packages/nodes-base/nodes/Zendesk/Zendesk.node.ts
@@ -270,8 +270,8 @@ export class Zendesk implements INodeType {
 		let responseData;
 		for (let i = 0; i < length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', 0) as string;
-				const operation = this.getNodeParameter('operation', 0) as string;
+				const resource = this.getNodeParameter('resource', 0);
+				const operation = this.getNodeParameter('operation', 0);
 				//https://developer.zendesk.com/api-reference/ticketing/introduction/
 				if (resource === 'ticket') {
 					//https://developer.zendesk.com/rest_api/docs/support/tickets

--- a/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
+++ b/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
@@ -33,7 +33,6 @@ import {
 } from './GenericFunctions';
 
 import {
-	CamelCaseResource,
 	GetAllFilterOptions,
 	LoadedAccounts,
 	LoadedContacts,
@@ -332,8 +331,8 @@ export class ZohoCrm implements INodeType {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
-		const resource = this.getNodeParameter('resource', 0) as CamelCaseResource;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		let responseData;
 

--- a/packages/nodes-base/nodes/Zoom/Zoom.node.ts
+++ b/packages/nodes-base/nodes/Zoom/Zoom.node.ts
@@ -156,8 +156,8 @@ export class Zoom implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		let qs: IDataObject = {};
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -429,7 +429,7 @@ export class Zoom implements INodeType {
 				// 		const meetingId = this.getNodeParameter('meetingId', i) as string;
 				// 		const emailId = this.getNodeParameter('email', i) as string;
 				// 		body.email = emailId;
-				// 		const firstName = this.getNodeParameter('firstName', i) as string;
+				// 		const firstName = this.getNodeParameter('firstName', i);
 				// 		body.first_name = firstName;
 				// 		const additionalFields = this.getNodeParameter(
 				// 			'additionalFields',

--- a/packages/nodes-base/nodes/Zulip/Zulip.node.ts
+++ b/packages/nodes-base/nodes/Zulip/Zulip.node.ts
@@ -130,8 +130,8 @@ export class Zulip implements INodeType {
 		const returnData: IDataObject[] = [];
 		const length = items.length;
 		let responseData;
-		const resource = this.getNodeParameter('resource', 0) as string;
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'message') {
@@ -429,9 +429,9 @@ export class Zulip implements INodeType {
 
 					if (operation === 'create') {
 						body.email = this.getNodeParameter('email', i) as string;
-						body.password = this.getNodeParameter('password', i) as string;
-						body.full_name = this.getNodeParameter('fullName', i) as string;
-						body.short_name = this.getNodeParameter('shortName', i) as string;
+						body.password = this.getNodeParameter('password', i);
+						body.full_name = this.getNodeParameter('fullName', i);
+						body.short_name = this.getNodeParameter('shortName', i);
 
 						responseData = await zulipApiRequest.call(this, 'POST', `/users`, body);
 					}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -561,6 +561,30 @@ namespace ExecuteFunctions {
 			| 'resolveData';
 	}
 
+	namespace StringReturning {
+		export type NodeParameter =
+			| 'binaryProperty'
+			| 'color'
+			| 'company'
+			| 'currency'
+			| 'event'
+			| 'from'
+			| 'message'
+			| 'operation'
+			| 'password'
+			| 'path'
+			| 'query'
+			| 'range'
+			| 'resource'
+			| 'source'
+			| 'text'
+			| 'title'
+			| 'url'
+			| `${string}${StringSuffix}`;
+
+		type StringSuffix = 'Color' | 'Date' | 'Name' | 'Path' | 'Slug' | 'Url';
+	}
+
 	namespace RecordReturning {
 		export type NodeParameter = 'additionalFields' | 'filters' | 'options' | 'updateFields';
 	}
@@ -572,6 +596,12 @@ namespace ExecuteFunctions {
 			itemIndex?: number,
 		): T['resource'];
 
+		getNodeParameter(
+			parameterName: StringReturning.NodeParameter,
+			itemIndex: number,
+			fallbackValue?: string,
+			options?: IGetNodeParameterOptions,
+		): string;
 		getNodeParameter(
 			parameterName: RecordReturning.NodeParameter,
 			itemIndex: number,


### PR DESCRIPTION
- This PR covers many cases but is not meant to be exhaustive, e.g. some params are string in most but not all cases, some params are inferrable but the overload would need to be added to another function group, etc. This PR is large enough, so we can tackle those separately later.
- In a small handful of cases, `resource` and `operation` were string union, but we do not gain much if anything from string union vs. string for resource and operation, so defaulting them back to string.
- To reveal all collapsed files: `document.querySelectorAll('.js-button-text').forEach(i => i.click())`
- Related: 
  - #4644
  - #4647
  - #4648