### PR TITLE
ci: Fix linting on master (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Lint
         env:
           CI_LINT_MASTER: true
-        run: pnpm lint
+        run: pnpm lint --quiet
 
       - name: Notify Slack on failure
         uses: act10ns/slack@v2.0.0

--- a/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSnsTrigger.node.ts
@@ -177,7 +177,7 @@ export class AwsSnsTrigger implements INodeType {
 					data,
 					'ListSubscriptionsByTopicResponse.ListSubscriptionsByTopicResult.Subscriptions',
 				);
-				if (!subscriptions || !subscriptions.member) {
+				if (!subscriptions?.member) {
 					return false;
 				}
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -124,7 +124,7 @@ export class GoogleSheet {
 		const foundItem = response.sheets.find(
 			(item: { properties: { sheetId: number } }) => item.properties.sheetId === +sheetId,
 		);
-		if (!foundItem || !foundItem.properties || !foundItem.properties.title) {
+		if (!foundItem?.properties?.title) {
 			throw new Error(`Sheet with id ${sheetId} not found`);
 		}
 		return foundItem.properties.title;


### PR DESCRIPTION
This broke because we have stricter linting on master now, and the branch that changed that did not have the latest master merged in.