### PR TITLE
feat: Use generic auth-identities for LDAP

### DIFF
--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -171,6 +171,7 @@ export async function init(
 	collections.Webhook = linkRepository(entities.WebhookEntity);
 	collections.Tag = linkRepository(entities.TagEntity);
 
+	collections.AuthIdentity = linkRepository(entities.AuthIdentity);
 	collections.Role = linkRepository(entities.Role);
 	collections.User = linkRepository(entities.User);
 	collections.SharedCredentials = linkRepository(entities.SharedCredentials);

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -28,12 +28,14 @@ import type { FindOperator, Repository } from 'typeorm';
 
 import type { ChildProcess } from 'child_process';
 import { Url } from 'url';
-import type { FeatureConfig } from './databases/entities/FeatureConfig';
-import { LdapSyncHistory } from './databases/entities/LdapSyncHistory';
 
 import type { Request } from 'express';
+
+import type { AuthIdentity } from '@db/entities/AuthIdentity';
+import type { FeatureConfig } from '@db/entities/FeatureConfig';
 import type { InstalledNodes } from '@db/entities/InstalledNodes';
 import type { InstalledPackages } from '@db/entities/InstalledPackages';
+import type { LdapSyncHistory } from '@db/entities/LdapSyncHistory';
 import type { Role } from '@db/entities/Role';
 import type { Settings } from '@db/entities/Settings';
 import type { SharedCredentials } from '@db/entities/SharedCredentials';
@@ -70,6 +72,7 @@ export interface ICredentialsOverwrite {
 }
 
 export interface IDatabaseCollections {
+	AuthIdentity: Repository<AuthIdentity>;
 	Credentials: Repository<ICredentialsDb>;
 	Execution: Repository<IExecutionFlattedDb>;
 	Workflow: Repository<WorkflowEntity>;

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -17,7 +17,7 @@ import {
 	IExecutionTrackProperties,
 } from '@/Interfaces';
 import { Telemetry } from '@/telemetry';
-import { SignInType } from './Ldap/constants';
+import { AuthProviderType } from '@db/entities/AuthIdentity';
 
 export class InternalHooksClass implements IInternalHooksClass {
 	private versionCli: string;
@@ -398,7 +398,7 @@ export class InternalHooksClass implements IInternalHooksClass {
 
 	async onUserSignup(userSignupData: {
 		user_id: string;
-		user_type: SignInType;
+		user_type: AuthProviderType;
 		was_disabled_ldap_user: boolean;
 	}): Promise<void> {
 		return this.telemetry.track('User signed up', userSignupData);

--- a/packages/cli/src/Ldap/constants.ts
+++ b/packages/cli/src/Ldap/constants.ts
@@ -14,11 +14,6 @@ export const LDAP_LOGIN_ENABLED = 'ldap.loginEnabled';
 
 export const BINARY_AD_ATTRIBUTES = ['objectGUID', 'objectSid'];
 
-export enum SignInType {
-	LDAP = 'ldap',
-	EMAIL = 'email',
-}
-
 export enum ConnectionSecurity {
 	NONE = 'none',
 	TLS = 'tls',

--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -195,6 +195,7 @@ export const updateLdapConfig = async (config: LdapConfig): Promise<void> => {
 	}
 
 	await Db.collections.FeatureConfig.update({ name: LDAP_FEATURE_NAME }, { data: config });
+	LdapManager.updateConfig(config);
 	setGlobalLdapConfigVariables(config);
 };
 /**

--- a/packages/cli/src/Ldap/routes/ldap.controller.ee.ts
+++ b/packages/cli/src/Ldap/routes/ldap.controller.ee.ts
@@ -42,8 +42,6 @@ ldapController.put('/config', async (req: LdapConfiguration.Update, res: express
 
 	const data = await getLdapConfig();
 
-	LdapManager.updateConfig(data);
-
 	void InternalHooksManager.getInstance().onUserUpdatedLdapSettings({
 		user_id: req.user.id,
 		...pick(data, NON_SENSIBLE_LDAP_CONFIG_PROPERTIES),

--- a/packages/cli/src/Ldap/types.d.ts
+++ b/packages/cli/src/Ldap/types.d.ts
@@ -48,10 +48,3 @@ export interface SynchronizationList {
 	startedAt: string;
 	errorMessage: string;
 }
-
-export interface LdapDbColumns {
-	email: string;
-	firstName: string;
-	lastName: string;
-	ldapId: string;
-}

--- a/packages/cli/src/UserManagement/Interfaces.ts
+++ b/packages/cli/src/UserManagement/Interfaces.ts
@@ -1,6 +1,8 @@
-import { Application } from 'express';
+import type { Application } from 'express';
 import type { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import type { IExternalHooksClass, IPersonalizationSurveyAnswers } from '@/Interfaces';
+import type { AuthProviderType } from '@/databases/entities/AuthIdentity';
+import type { Role } from '@/databases/entities/Role';
 
 export interface JwtToken {
 	token: string;
@@ -23,6 +25,9 @@ export interface PublicUser {
 	passwordResetToken?: string;
 	createdAt: Date;
 	isPending: boolean;
+	globalRole?: Role;
+	signInType: AuthProviderType;
+	disabled: boolean;
 }
 
 export interface N8nApp {

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -142,14 +142,22 @@ export function sanitizeUser(user: User, withoutKeys?: string[]): PublicUser {
 		resetPasswordTokenExpiration,
 		updatedAt,
 		apiKey,
-		ldapId,
-		...sanitizedUser
+		authIdentities,
+		...rest
 	} = user;
 	if (withoutKeys) {
 		withoutKeys.forEach((key) => {
 			// @ts-ignore
-			delete sanitizedUser[key];
+			delete rest[key];
 		});
+	}
+	const sanitizedUser: PublicUser = {
+		...rest,
+		signInType: 'email',
+	};
+	const ldapIdentity = authIdentities?.find((i) => i.providerType === 'ldap');
+	if (ldapIdentity) {
+		sanitizedUser.signInType = 'ldap';
 	}
 	return sanitizedUser;
 }

--- a/packages/cli/src/UserManagement/auth/jwt.ts
+++ b/packages/cli/src/UserManagement/auth/jwt.ts
@@ -8,7 +8,7 @@ import { AUTH_COOKIE_NAME } from '@/constants';
 import { JwtPayload, JwtToken } from '../Interfaces';
 import { User } from '@db/entities/User';
 import config from '@/config';
-import { ResponseHelper } from '@/index';
+import * as ResponseHelper from '@/ResponseHelper';
 
 export function issueJWT(user: User): JwtToken {
 	const { id, email, password } = user;

--- a/packages/cli/src/UserManagement/routes/users.ts
+++ b/packages/cli/src/UserManagement/routes/users.ts
@@ -25,7 +25,7 @@ import {
 import config from '@/config';
 import { issueCookie } from '../auth/jwt';
 import { InternalHooksManager } from '@/InternalHooksManager';
-import { SignInType } from '@/Ldap/constants';
+import { AuthIdentity } from '@/databases/entities/AuthIdentity';
 
 export function usersNamespace(this: N8nApp): void {
 	/**
@@ -349,7 +349,7 @@ export function usersNamespace(this: N8nApp): void {
 
 			void InternalHooksManager.getInstance().onUserSignup({
 				user_id: invitee.id,
-				user_type: SignInType.EMAIL,
+				user_type: 'email',
 				was_disabled_ldap_user: false,
 			});
 
@@ -363,7 +363,7 @@ export function usersNamespace(this: N8nApp): void {
 	this.app.get(
 		`/${this.restEndpoint}/users`,
 		ResponseHelper.send(async () => {
-			const users = await Db.collections.User.find({ relations: ['globalRole'] });
+			const users = await Db.collections.User.find({ relations: ['globalRole', 'authIdentities'] });
 
 			return users.map((user): PublicUser => sanitizeUser(user, ['personalizationAnswers']));
 		}),
@@ -419,6 +419,7 @@ export function usersNamespace(this: N8nApp): void {
 						{ user: userToDelete },
 						{ user: transferee },
 					);
+					await transactionManager.delete(AuthIdentity, { userId: userToDelete.id });
 					await transactionManager.delete(User, { id: userToDelete.id });
 				});
 
@@ -450,6 +451,7 @@ export function usersNamespace(this: N8nApp): void {
 				await transactionManager.remove(
 					ownedSharedCredentials.map(({ credentials }) => credentials),
 				);
+				await transactionManager.delete(AuthIdentity, { userId: userToDelete.id });
 				await transactionManager.delete(User, { id: userToDelete.id });
 			});
 

--- a/packages/cli/src/databases/entities/AuthIdentity.ts
+++ b/packages/cli/src/databases/entities/AuthIdentity.ts
@@ -1,0 +1,34 @@
+import { Column, Entity, ManyToOne, PrimaryColumn, Unique } from 'typeorm';
+import { AbstractEntity } from './AbstractEntity';
+import { User } from './User';
+
+export type AuthProviderType = 'ldap' | 'email'; //| 'saml' | 'google';
+
+@Entity()
+@Unique(['providerId', 'providerType'])
+export class AuthIdentity extends AbstractEntity {
+	@Column()
+	userId: string;
+
+	@ManyToOne(() => User, (user) => user.authIdentities)
+	user: User;
+
+	@PrimaryColumn()
+	providerId: string;
+
+	@PrimaryColumn()
+	providerType: AuthProviderType;
+
+	static create(
+		user: User,
+		providerId: string,
+		providerType: AuthProviderType = 'ldap',
+	): AuthIdentity {
+		const identity = new AuthIdentity();
+		identity.user = user;
+		identity.userId = user.id;
+		identity.providerId = providerId;
+		identity.providerType = providerType;
+		return identity;
+	}
+}

--- a/packages/cli/src/databases/entities/User.ts
+++ b/packages/cli/src/databases/entities/User.ts
@@ -19,6 +19,7 @@ import { NoXss } from '../utils/customValidators';
 import { objectRetriever, lowerCaser } from '../utils/transformers';
 import { AbstractEntity, jsonColumnType } from './AbstractEntity';
 import type { IPersonalizationSurveyAnswers, IUserSettings } from '@/Interfaces';
+import { AuthIdentity } from './AuthIdentity';
 
 export const MIN_PASSWORD_LENGTH = 8;
 
@@ -80,11 +81,17 @@ export class User extends AbstractEntity implements IUser {
 	})
 	globalRole: Role;
 
+	@OneToMany(() => AuthIdentity, (authIdentity) => authIdentity.user)
+	authIdentities: AuthIdentity[];
+
 	@OneToMany(() => SharedWorkflow, (sharedWorkflow) => sharedWorkflow.user)
 	sharedWorkflows: SharedWorkflow[];
 
 	@OneToMany(() => SharedCredentials, (sharedCredentials) => sharedCredentials.user)
 	sharedCredentials: SharedCredentials[];
+
+	@Column({ type: Boolean, default: false })
+	disabled: boolean;
 
 	@BeforeInsert()
 	@BeforeUpdate()
@@ -95,16 +102,6 @@ export class User extends AbstractEntity implements IUser {
 	@Column({ type: String, nullable: true })
 	@Index({ unique: true })
 	apiKey?: string | null;
-
-	@Column({ type: String, nullable: false, default: 'email' })
-	signInType: 'ldap' | 'email';
-
-	@Column({ type: String, nullable: true })
-	@Index({ unique: true })
-	ldapId?: string | null;
-
-	@Column({ type: Boolean, default: false })
-	disabled: boolean;
 
 	/**
 	 * Whether the user is pending setup completion.

--- a/packages/cli/src/databases/entities/index.ts
+++ b/packages/cli/src/databases/entities/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import { AuthIdentity } from './AuthIdentity';
 import { CredentialsEntity } from './CredentialsEntity';
 import { ExecutionEntity } from './ExecutionEntity';
 import { WorkflowEntity } from './WorkflowEntity';
@@ -16,6 +17,7 @@ import { FeatureConfig } from './FeatureConfig';
 import { LdapSyncHistory } from './LdapSyncHistory';
 
 export const entities = {
+	AuthIdentity,
 	CredentialsEntity,
 	ExecutionEntity,
 	WorkflowEntity,

--- a/packages/cli/src/databases/migrations/mysqldb/1670333612644-CreateLdapEntities.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1670333612644-CreateLdapEntities.ts
@@ -11,11 +11,18 @@ export class CreateLdapEntities1670333612644 implements MigrationInterface {
 		const tablePrefix = getTablePrefix();
 
 		await queryRunner.query(
-			`ALTER TABLE \`${tablePrefix}user\`
-			ADD COLUMN \`ldapId\` VARCHAR(60) DEFAULT null,
-			ADD UNIQUE (\`ldapId\`),
-			ADD COLUMN \`signInType\` VARCHAR(20) DEFAULT \'email'\,
-			ADD COLUMN \`disabled\` BOOLEAN NOT NULL DEFAULT false;`,
+			`ALTER TABLE ${tablePrefix}user ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT false;`,
+		);
+
+		await queryRunner.query(
+			`CREATE TABLE IF NOT EXISTS ${tablePrefix}auth_identity (
+				\`userId\` VARCHAR(36) REFERENCES ${tablePrefix}user (id),
+				\`providerId\` VARCHAR(60) NOT NULL,
+				\`providerType\` VARCHAR(20) NOT NULL,
+				\`createdAt\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				\`updatedAt\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY(\`providerId\`, \`providerType\`)
+			) ENGINE='InnoDB';`,
 		);
 
 		await queryRunner.query(
@@ -54,12 +61,7 @@ export class CreateLdapEntities1670333612644 implements MigrationInterface {
 		const tablePrefix = getTablePrefix();
 		await queryRunner.query(`DROP TABLE ${tablePrefix}ldap_sync_history`);
 		await queryRunner.query(`DROP TABLE ${tablePrefix}feature_config`);
-
-		await queryRunner.query(
-			`ALTER TABLE \`${tablePrefix}user\`
-			DROP COLUMN \`ldapId\`,
-			DROP COLUMN \`signInType\`,
-			DROP COLUMN \`disabled\`;`,
-		);
+		await queryRunner.query(`DROP TABLE ${tablePrefix}auth_identity`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}user DROP COLUMN disabled`);
 	}
 }

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -23,7 +23,7 @@ import { CreateWorkflowsEditorRole1663755770893 } from './1663755770893-CreateWo
 import { CreateCredentialUsageTable1665484192212 } from './1665484192212-CreateCredentialUsageTable';
 import { RemoveCredentialUsageTable1665754637025 } from './1665754637025-RemoveCredentialUsageTable';
 import { AddWorkflowVersionIdColumn1669739707126 } from './1669739707126-AddWorkflowVersionIdColumn';
-import { CreateLdapEntities1670333612644 } from './1670333612644-CreateLdapEntities'
+import { CreateLdapEntities1670333612644 } from './1670333612644-CreateLdapEntities';
 
 export const postgresMigrations = [
 	InitialMigration1587669153312,

--- a/packages/cli/src/databases/migrations/sqlite/1670333612644-CreateLdapEntities.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1670333612644-CreateLdapEntities.ts
@@ -9,66 +9,20 @@ export class CreateLdapEntities1670333612644 implements MigrationInterface {
 
 		const tablePrefix = getTablePrefix();
 
-		await queryRunner.query('PRAGMA foreign_keys=OFF');
-
 		await queryRunner.query(
-			`CREATE TABLE "temporary_user" (
-				"id" VARCHAR PRIMARY KEY NOT NULL,
-				"email" VARCHAR(255) UNIQUE,
-				"firstName" VARCHAR(32),
-				"lastName" VARCHAR(32),
-				"password" VARCHAR,
-				"resetPasswordToken" VARCHAR,
-				"resetPasswordTokenExpiration" INTEGER DEFAULT NULL,
-				"ldapId" VARCHAR(60) UNIQUE DEFAULT NULL,
-				"signInType" VARCHAR(20) DEFAULT email,
-				"personalizationAnswers" TEXT,
-				"createdAt" DATETIME(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
-				"updatedAt" DATETIME(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
-				"globalRoleId" INTEGER NOT NULL,
-				"settings" TEXT,
-				"apiKey" VARCHAR DEFAULT NULL,
-				"disabled" boolean DEFAULT false,
-				FOREIGN KEY ("globalRoleId") REFERENCES "${tablePrefix}role" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`,
+			`ALTER TABLE ${tablePrefix}user ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT false;`,
 		);
 
 		await queryRunner.query(
-			`INSERT INTO "temporary_user"(
-				"id",
-				"email",
-				"firstName",
-				"lastName",
-				"password",
-				"resetPasswordToken",
-				"resetPasswordTokenExpiration",
-				"personalizationAnswers",
-				"createdAt",
-				"updatedAt",
-				"globalRoleId",
-				"settings",
-				"apiKey"
-				) SELECT
-				"id",
-				"email",
-				"firstName",
-				"lastName",
-				"password",
-				"resetPasswordToken",
-				"resetPasswordTokenExpiration",
-				"personalizationAnswers",
-				"createdAt",
-				"updatedAt",
-				"globalRoleId",
-				"settings",
-				"apiKey"
-				FROM "${tablePrefix}user"`,
+			`CREATE TABLE IF NOT EXISTS "${tablePrefix}auth_identity" (
+				"userId" VARCHAR(36) REFERENCES ${tablePrefix}user (id),
+				"providerId" VARCHAR(60) NOT NULL,
+				"providerType" VARCHAR(20) NOT NULL,
+				"createdAt" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				"updatedAt" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY("providerId", "providerType")
+			);`,
 		);
-
-		await queryRunner.query(`DROP TABLE "${tablePrefix}user"`);
-
-		await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "${tablePrefix}user"`);
-
-		await queryRunner.query('PRAGMA foreign_keys=ON');
 
 		await queryRunner.query(
 			`CREATE TABLE IF NOT EXISTS "${tablePrefix}feature_config" (
@@ -106,63 +60,7 @@ export class CreateLdapEntities1670333612644 implements MigrationInterface {
 		const tablePrefix = getTablePrefix();
 		await queryRunner.query(`DROP TABLE ${tablePrefix}ldap_sync_history`);
 		await queryRunner.query(`DROP TABLE ${tablePrefix}feature_config`);
-
-		await queryRunner.query('PRAGMA foreign_keys=OFF');
-
-		await queryRunner.query(
-			`CREATE TABLE "temporary_user" (
-				"id" VARCHAR PRIMARY KEY NOT NULL,
-				"email" VARCHAR(255) UNIQUE,
-				"firstName" VARCHAR(32),
-				"lastName" VARCHAR(32),
-				"password" VARCHAR,
-				"resetPasswordToken" VARCHAR,
-				"resetPasswordTokenExpiration" INTEGER DEFAULT NULL,
-				"personalizationAnswers" TEXT,
-				"createdAt" DATETIME(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
-				"updatedAt" DATETIME(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
-				"globalRoleId" INTEGER NOT NULL,
-				"settings" TEXT,
-				"apiKey" VARCHAR DEFAULT NULL,
-				FOREIGN KEY ("globalRoleId") REFERENCES "${tablePrefix}role" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`,
-		);
-
-		await queryRunner.query(
-			`INSERT INTO "temporary_user"(
-				"id",
-				"email",
-				"firstName",
-				"lastName",
-				"password",
-				"resetPasswordToken",
-				"resetPasswordTokenExpiration",
-				"personalizationAnswers",
-				"createdAt",
-				"updatedAt",
-				"globalRoleId",
-				"settings",
-				"apiKey"
-				) SELECT
-				"id",
-				"email",
-				"firstName",
-				"lastName",
-				"password",
-				"resetPasswordToken",
-				"resetPasswordTokenExpiration",
-				"personalizationAnswers",
-				"createdAt",
-				"updatedAt",
-				"globalRoleId",
-				"settings",
-				"apiKey"
-				FROM "${tablePrefix}user"`,
-		);
-
-		await queryRunner.query(`DROP TABLE "${tablePrefix}user"`);
-
-		await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "${tablePrefix}user"`);
-
-		await queryRunner.query('PRAGMA foreign_keys=ON');
+		await queryRunner.query(`DROP TABLE ${tablePrefix}auth_identity`);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}user DROP COLUMN disabled`);
 	}
 }

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -9,14 +9,8 @@ import * as testDb from './../shared/testDb';
 import type { AuthAgent } from '../shared/types';
 import * as utils from '../shared/utils';
 
-import {
-	LDAP_DEFAULT_CONFIGURATION,
-	LDAP_ENABLED,
-	RunningMode,
-	SignInType,
-} from '@/Ldap/constants';
+import { LDAP_DEFAULT_CONFIGURATION, LDAP_ENABLED, RunningMode } from '@/Ldap/constants';
 import { LdapManager } from '@/Ldap/LdapManager.ee';
-import { LdapConfig } from '@/Ldap/types';
 import { LdapService } from '@/Ldap/LdapService.ee';
 
 jest.mock('@/telemetry');
@@ -52,6 +46,7 @@ beforeEach(async () => {
 	await testDb.truncate(
 		[
 			'User',
+			'AuthIdentity',
 			'SharedCredentials',
 			'SharedWorkflow',
 			'Workflow',
@@ -236,7 +231,7 @@ test('POST /ldap/sync?type=dry should detect new user but not persist change in 
 test('POST /ldap/sync?type=dry should detect updated user but not persist change in model', async () => {
 	const ldapConfig = await testDb.createLdapDefaultConfig({ ldapIdAttribute: 'uid' });
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
@@ -244,12 +239,13 @@ test('POST /ldap/sync?type=dry should detect updated user but not persist change
 
 	const ldapUserId = uniqueId();
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: ldapUserId,
-		email: ldapUserEmail,
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+			email: ldapUserEmail,
+		},
+		ldapUserId,
+	);
 
 	jest.spyOn(LdapService.prototype, 'searchWithAdminBinding').mockImplementation(() =>
 		Promise.resolve([
@@ -284,7 +280,8 @@ test('POST /ldap/sync?type=dry should detect updated user but not persist change
 	expect(synchronization.updated).toBe(1);
 
 	// Make sure the changes in the "LDAP server" were not persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].id).toBe(member.id);
 	expect(localLdapUsers[0].lastName).toBe(member.lastName);
@@ -293,7 +290,7 @@ test('POST /ldap/sync?type=dry should detect updated user but not persist change
 test('POST /ldap/sync?type=dry should detect disabled user but not persist change in model', async () => {
 	const ldapConfig = await testDb.createLdapDefaultConfig({ ldapIdAttribute: 'uid' });
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
@@ -301,12 +298,13 @@ test('POST /ldap/sync?type=dry should detect disabled user but not persist chang
 
 	const ldapUserId = uniqueId();
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: ldapUserId,
-		email: ldapUserEmail,
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+			email: ldapUserEmail,
+		},
+		ldapUserId,
+	);
 
 	jest
 		.spyOn(LdapService.prototype, 'searchWithAdminBinding')
@@ -333,7 +331,8 @@ test('POST /ldap/sync?type=dry should detect disabled user but not persist chang
 	expect(synchronization.disabled).toBe(1);
 
 	// Make sure the changes in the "LDAP server" were not persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].id).toBe(member.id);
 	expect(localLdapUsers[0].disabled).toBe(false);
@@ -347,7 +346,7 @@ test('POST /ldap/sync?type=live should detect new user and persist change in mod
 		emailAttribute: 'mail',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
@@ -384,12 +383,17 @@ test('POST /ldap/sync?type=live should detect new user and persist change in mod
 	expect(synchronization.created).toBe(1);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
-	expect(localLdapUsers.length).toBe(1);
-	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
-	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
-	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
+	const allUsers = await getAllUsers();
+	expect(allUsers.length).toBe(2);
+	expect(allUsers[0].email).toBe(owner.email);
+	expect(allUsers[1].email).toBe(ldapUser.mail);
+	expect(allUsers[1].lastName).toBe(ldapUser.sn);
+	expect(allUsers[1].firstName).toBe(ldapUser.givenName);
+
+	const authIdentities = await getLdapIdentities();
+	expect(authIdentities.length).toBe(1);
+	expect(authIdentities[0].providerId).toBe(ldapUser.uid);
+	expect(authIdentities[0].providerType).toBe('ldap');
 });
 
 test('POST /ldap/sync?type=live should detect updated user and persist change in model', async () => {
@@ -400,7 +404,7 @@ test('POST /ldap/sync?type=live should detect updated user and persist change in
 		emailAttribute: 'mail',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
@@ -412,14 +416,15 @@ test('POST /ldap/sync?type=live should detect updated user and persist change in
 		uid: uniqueId(),
 	};
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		email: ldapUser.mail,
-		firstName: ldapUser.givenName,
-		lastName: randomName(),
-		ldapId: ldapUser.uid,
-		signInType: SignInType.LDAP,
-	});
+	await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+			email: ldapUser.mail,
+			firstName: ldapUser.givenName,
+			lastName: randomName(),
+		},
+		ldapUser.uid,
+	);
 
 	jest
 		.spyOn(LdapService.prototype, 'searchWithAdminBinding')
@@ -446,13 +451,14 @@ test('POST /ldap/sync?type=live should detect updated user and persist change in
 	expect(synchronization.updated).toBe(1);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
 	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
 	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
+	expect(localLdapIdentities[0].providerId).toBe(ldapUser.uid);
 });
 
 test('POST /ldap/sync?type=live should detect disabled user and persist change in model', async () => {
@@ -463,7 +469,7 @@ test('POST /ldap/sync?type=live should detect disabled user and persist change i
 		emailAttribute: 'mail',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
@@ -475,14 +481,15 @@ test('POST /ldap/sync?type=live should detect disabled user and persist change i
 		uid: uniqueId(),
 	};
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		email: ldapUser.mail,
-		firstName: ldapUser.givenName,
-		lastName: ldapUser.sn,
-		ldapId: ldapUser.uid,
-		signInType: SignInType.LDAP,
-	});
+	await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+			email: ldapUser.mail,
+			firstName: ldapUser.givenName,
+			lastName: ldapUser.sn,
+		},
+		ldapUser.uid,
+	);
 
 	jest
 		.spyOn(LdapService.prototype, 'searchWithAdminBinding')
@@ -509,14 +516,16 @@ test('POST /ldap/sync?type=live should detect disabled user and persist change i
 	expect(synchronization.disabled).toBe(1);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const allUsers = await getAllUsers();
+	expect(allUsers.length).toBe(2);
+	expect(allUsers[0].email).toBe(owner.email);
+	expect(allUsers[1].email).toBe(ldapUser.mail);
+	expect(allUsers[1].lastName).toBe(ldapUser.sn);
+	expect(allUsers[1].firstName).toBe(ldapUser.givenName);
+	expect(allUsers[1].disabled).toBe(true);
 
-	expect(localLdapUsers.length).toBe(1);
-	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
-	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
-	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
-	expect(localLdapUsers[0].disabled).toBe(true);
+	const authIdentities = await getLdapIdentities();
+	expect(authIdentities.length).toBe(0);
 });
 
 test('GET /ldap/sync should return paginated synchronizations', async () => {
@@ -560,10 +569,9 @@ test('POST /login should allow new LDAP user to login and synchronize data', asy
 		bindingAdminDn: 'adminDn',
 		bindingAdminPassword: 'adminPassword',
 	});
+	LdapManager.updateConfig(ldapConfig);
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
-
-	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
+	await testDb.createUser({ globalRole: globalOwnerRole });
 
 	const authlessAgent = utils.createAgent(app);
 
@@ -591,13 +599,14 @@ test('POST /login should allow new LDAP user to login and synchronize data', asy
 	expect(response.statusCode).toBe(200);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
 	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
 	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
+	expect(localLdapIdentities[0].providerId).toBe(ldapUser.uid);
 	expect(localLdapUsers[0].disabled).toBe(false);
 });
 
@@ -615,9 +624,9 @@ test('POST /login should allow existing LDAP user to login and synchronize data'
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
-	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
+	await testDb.createUser({ globalRole: globalOwnerRole });
 
 	const authlessAgent = utils.createAgent(app);
 
@@ -629,14 +638,15 @@ test('POST /login should allow existing LDAP user to login and synchronize data'
 		uid: uniqueId(),
 	};
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		email: ldapUser.mail,
-		firstName: 'firstname',
-		lastName: 'lastname',
-		ldapId: ldapUser.uid,
-		signInType: SignInType.LDAP,
-	});
+	await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+			email: ldapUser.mail,
+			firstName: 'firstname',
+			lastName: 'lastname',
+		},
+		ldapUser.uid,
+	);
 
 	jest
 		.spyOn(LdapService.prototype, 'searchWithAdminBinding')
@@ -654,13 +664,14 @@ test('POST /login should allow existing LDAP user to login and synchronize data'
 	expect(response.statusCode).toBe(200);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
 	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
 	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
+	expect(localLdapIdentities[0].providerId).toBe(ldapUser.uid);
 	expect(localLdapUsers[0].disabled).toBe(false);
 });
 
@@ -678,9 +689,9 @@ test('POST /login should transform email user into LDAP user when match found', 
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
-	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
+	await testDb.createUser({ globalRole: globalOwnerRole });
 
 	const authlessAgent = utils.createAgent(app);
 
@@ -692,12 +703,11 @@ test('POST /login should transform email user into LDAP user when match found', 
 		uid: uniqueId(),
 	};
 
-	const member = await testDb.createUser({
+	await testDb.createUser({
 		globalRole: globalMemberRole,
 		email: ldapUser.mail,
 		firstName: ldapUser.givenName,
 		lastName: 'lastname',
-		signInType: SignInType.EMAIL,
 	});
 
 	jest
@@ -716,17 +726,18 @@ test('POST /login should transform email user into LDAP user when match found', 
 	expect(response.statusCode).toBe(200);
 
 	// Make sure the changes in the "LDAP server" were persisted in the database
-	const localLdapUsers = await Db.collections.User.find({ signInType: SignInType.LDAP });
+	const localLdapIdentities = await getLdapIdentities();
+	const localLdapUsers = localLdapIdentities.map(({ user }) => user);
 
 	expect(localLdapUsers.length).toBe(1);
 	expect(localLdapUsers[0].email).toBe(ldapUser.mail);
 	expect(localLdapUsers[0].lastName).toBe(ldapUser.sn);
 	expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
-	expect(localLdapUsers[0].ldapId).toBe(ldapUser.uid);
+	expect(localLdapIdentities[0].providerId).toBe(ldapUser.uid);
 	expect(localLdapUsers[0].disabled).toBe(false);
 });
 
-test('PUT /ldap/config should apply "Convert all LDAP users to emaiL users" strategy when LDAP login disabled', async () => {
+test('PUT /ldap/config should apply "Convert all LDAP users to email users" strategy when LDAP login disabled', async () => {
 	const ldapConfig = await testDb.createLdapDefaultConfig({
 		loginEnabled: true,
 		loginLabel: '',
@@ -740,17 +751,18 @@ test('PUT /ldap/config should apply "Convert all LDAP users to emaiL users" stra
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: uniqueId(),
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+		},
+		uniqueId(),
+	);
 
-	const configuration = ldapConfig.data as LdapConfig;
+	const configuration = ldapConfig;
 
 	// disable the login, so the strategy is applied
 	await authAgent(owner)
@@ -758,13 +770,12 @@ test('PUT /ldap/config should apply "Convert all LDAP users to emaiL users" stra
 		.send({ ...configuration, loginEnabled: false });
 
 	const emailUser = await Db.collections.User.findOneOrFail(member.id);
+	const localLdapIdentities = await getLdapIdentities();
 
 	expect(emailUser.email).toBe(member.email);
 	expect(emailUser.lastName).toBe(member.lastName);
 	expect(emailUser.firstName).toBe(member.firstName);
-	expect(emailUser.ldapId).toBeDefined();
-	expect(emailUser.disabled).toBe(false);
-	expect(emailUser.signInType).toBe(SignInType.EMAIL);
+	expect(localLdapIdentities.length).toEqual(0);
 });
 
 test('Instance owner should able to delete LDAP users', async () => {
@@ -781,17 +792,18 @@ test('Instance owner should able to delete LDAP users', async () => {
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: uniqueId(),
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+		},
+		uniqueId(),
+	);
 
-	// delete the rember
+	// delete the remember
 	await authAgent(owner).post(`/users/${member.id}`);
 });
 
@@ -809,15 +821,16 @@ test('Instance owner should able to delete LDAP users and transfer workflows and
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: uniqueId(),
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+		},
+		uniqueId(),
+	);
 
 	// delete the LDAP member and transfer its workflows/credentials to instance owner
 	await authAgent(owner).post(`/users/${member.id}?transferId=${owner.id}`);
@@ -837,22 +850,23 @@ test('Sign-type should be returned when listing users', async () => {
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: uniqueId(),
-	});
+	await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+		},
+		uniqueId(),
+	);
 
 	const response = await authAgent(owner).get(`/users`);
 
 	const { data } = response.body;
 
-	expect(data[0].signInType).toBe('email');
-	expect(data[1].signInType).toBe('ldap');
+	expect(data[0].signInType).toStrictEqual('email');
+	expect(data[1].signInType).toStrictEqual('ldap');
 });
 
 test('Once user disabled during synchronization it should lose access to the instance', async () => {
@@ -869,15 +883,16 @@ test('Once user disabled during synchronization it should lose access to the ins
 		bindingAdminPassword: 'adminPassword',
 	});
 
-	LdapManager.updateConfig(ldapConfig.data as LdapConfig);
+	LdapManager.updateConfig(ldapConfig);
 
 	const owner = await testDb.createUser({ globalRole: globalOwnerRole });
 
-	const member = await testDb.createUser({
-		globalRole: globalMemberRole,
-		signInType: SignInType.LDAP,
-		ldapId: uniqueId(),
-	});
+	const member = await testDb.createLdapUser(
+		{
+			globalRole: globalMemberRole,
+		},
+		uniqueId(),
+	);
 
 	jest
 		.spyOn(LdapService.prototype, 'searchWithAdminBinding')
@@ -889,3 +904,11 @@ test('Once user disabled during synchronization it should lose access to the ins
 
 	expect(response.body.code).toBe(401);
 });
+
+const getLdapIdentities = () =>
+	Db.collections.AuthIdentity.find({
+		where: { providerType: 'ldap' },
+		relations: ['user'],
+	});
+
+const getAllUsers = () => Db.collections.User.find({ relations: ['globalRole'] });

--- a/packages/cli/test/integration/shared/testDb.ts
+++ b/packages/cli/test/integration/shared/testDb.ts
@@ -36,9 +36,10 @@ import type {
 	MappingName,
 } from './types';
 
-import { LDAP_DEFAULT_CONFIGURATION, LDAP_FEATURE_NAME, SignInType } from '@/Ldap/constants';
+import { LDAP_DEFAULT_CONFIGURATION, LDAP_FEATURE_NAME } from '@/Ldap/constants';
 import { LdapConfig } from '@/Ldap/types';
 import type { DatabaseType, ICredentialsDb } from '@/Interfaces';
+import { AuthIdentity } from '@/databases/entities/AuthIdentity';
 
 export type TestDBType = 'postgres' | 'mysql';
 
@@ -240,20 +241,22 @@ function toTableName(sourceName: CollectionName | MappingName) {
 	if (isMapping(sourceName)) return MAPPING_TABLES[sourceName];
 
 	return {
+		AuthIdentity: 'auth_identity',
 		Credentials: 'credentials_entity',
-		Workflow: 'workflow_entity',
 		Execution: 'execution_entity',
-		Tag: 'tag_entity',
-		Webhook: 'webhook_entity',
+		FeatureConfig: 'feature_config',
+		InstalledNodes: 'installed_nodes',
+		InstalledPackages: 'installed_packages',
+		LdapSyncHistory: 'ldap_sync_history',
 		Role: 'role',
-		User: 'user',
+		Settings: 'settings',
 		SharedCredentials: 'shared_credentials',
 		SharedWorkflow: 'shared_workflow',
-		Settings: 'settings',
-		InstalledPackages: 'installed_packages',
-		InstalledNodes: 'installed_nodes',
-		FeatureConfig: 'feature_config',
-		LdapSyncHistory: 'ldap_sync_history',
+		Tag: 'tag_entity',
+		User: 'user',
+		Webhook: 'webhook_entity',
+		Workflow: 'workflow_entity',
+		WorkflowStatistics: 'workflow_statistics',
 	}[sourceName];
 }
 
@@ -314,18 +317,26 @@ export function affixRoleToSaveCredential(role: Role) {
  * Store a user in the DB, defaulting to a `member`.
  */
 export async function createUser(attributes: Partial<User> = {}): Promise<User> {
-	const { email, password, firstName, lastName, globalRole, signInType, ...rest } = attributes;
-	const user = {
+	const { email, password, firstName, lastName, globalRole, ...rest } = attributes;
+	const user: Partial<User> = {
 		email: email ?? randomEmail(),
 		password: await hashPassword(password ?? randomValidPassword()),
 		firstName: firstName ?? randomName(),
 		lastName: lastName ?? randomName(),
 		globalRole: globalRole ?? (await getGlobalMemberRole()),
-		signInType: signInType ?? SignInType.EMAIL,
 		...rest,
 	};
 
 	return Db.collections.User.save(user);
+}
+
+export async function createLdapUser(
+	attributes: Partial<User> = {},
+	ldapId: string,
+): Promise<User> {
+	const user = await createUser(attributes);
+	await Db.collections.AuthIdentity.save(AuthIdentity.create(user, ldapId, 'ldap'));
+	return user;
 }
 
 export async function createOwner() {
@@ -722,9 +733,12 @@ async function encryptCredentialData(credential: CredentialsEntity) {
 }
 
 export async function createLdapDefaultConfig(attributes: Partial<LdapConfig> = {}) {
-	const configuration = {
-		...LDAP_DEFAULT_CONFIGURATION,
-		...attributes,
-	}
-	return Db.collections.FeatureConfig.save({ name: LDAP_FEATURE_NAME, data: configuration })
+	const { data: ldapConfig } = await Db.collections.FeatureConfig.save({
+		name: LDAP_FEATURE_NAME,
+		data: {
+			...LDAP_DEFAULT_CONFIGURATION,
+			...attributes,
+		},
+	});
+	return ldapConfig;
 }

--- a/packages/design-system/src/components/N8nUserInfo/UserInfo.vue
+++ b/packages/design-system/src/components/N8nUserInfo/UserInfo.vue
@@ -21,7 +21,7 @@
 			<div>
 				<n8n-text size="small" color="text-light">{{ email }}</n8n-text>
 			</div>
-			<div>
+			<div v-if="!isOwner">
 				<n8n-text v-if="signInType" size="small" color="text-light">
 					Sign-in type: {{ signInType }}
 				</n8n-text>
@@ -55,6 +55,9 @@ export default mixins(Locale).extend({
 		email: {
 			type: String,
 		},
+		isOwner: {
+			type: Boolean,
+		},
 		isPendingUser: {
 			type: Boolean,
 		},
@@ -63,7 +66,6 @@ export default mixins(Locale).extend({
 		},
 		disabled: {
 			type: Boolean,
-			default: false,
 		},
 		signInType: {
 			type: String,

--- a/packages/design-system/src/components/N8nUserSelect/UserSelect.stories.ts
+++ b/packages/design-system/src/components/N8nUserSelect/UserSelect.stories.ts
@@ -40,28 +40,16 @@ UserSelect.args = {
 			firstName: 'Sunny',
 			lastName: 'Side',
 			email: 'sunny@n8n.io',
-			globalRole: {
-				name: 'owner',
-				id: '1',
-			},
 		},
 		{
 			id: '2',
 			firstName: 'Kobi',
 			lastName: 'Dog',
 			email: 'kobi@n8n.io',
-			globalRole: {
-				name: 'member',
-				id: '2',
-			},
 		},
 		{
 			id: '3',
 			email: 'invited@n8n.io',
-			globalRole: {
-				name: 'member',
-				id: '2',
-			},
 		},
 	],
 	placeholder: 'Select user to transfer to',

--- a/packages/design-system/src/components/N8nUsersList/UsersList.stories.ts
+++ b/packages/design-system/src/components/N8nUsersList/UsersList.stories.ts
@@ -37,10 +37,6 @@ UsersList.args = {
 			isDefaultUser: false,
 			isPendingUser: false,
 			isOwner: true,
-			globalRole: {
-				name: 'owner',
-				id: 1,
-			},
 			signInType: 'email',
 			disabled: false,
 		},
@@ -53,10 +49,6 @@ UsersList.args = {
 			isDefaultUser: false,
 			isPendingUser: false,
 			isOwner: false,
-			globalRole: {
-				name: 'member',
-				id: '2',
-			},
 			signInType: 'ldap',
 			disabled: true,
 		},
@@ -66,10 +58,6 @@ UsersList.args = {
 			isDefaultUser: false,
 			isPendingUser: true,
 			isOwner: false,
-			globalRole: {
-				name: 'member',
-				id: '2',
-			},
 		},
 	],
 	currentUserId: '1',

--- a/packages/design-system/src/components/N8nUsersList/UsersList.vue
+++ b/packages/design-system/src/components/N8nUsersList/UsersList.vue
@@ -6,18 +6,20 @@
 			class="ph-no-capture"
 			:class="i === sortedUsers.length - 1 ? $style.itemContainer : $style.itemWithBorder"
 		>
-			<n8n-user-info
-				v-bind="user"
-				:isCurrentUser="currentUserId === user.id"
-				:disabled="showDisabledBadge(user)"
-			/>
+			<n8n-user-info v-bind="user" :isCurrentUser="currentUserId === user.id" />
 			<div :class="$style.badgeContainer">
 				<n8n-badge v-if="user.isOwner" theme="tertiary" bold>
 					{{ t('nds.auth.roles.owner') }}
 				</n8n-badge>
 				<slot v-if="!user.isOwner && !readonly" name="actions" :user="user" />
 				<n8n-action-toggle
-					v-if="!user.isOwner && !readonly && getActions(user).length > 0 && actions.length > 0"
+					v-if="
+						!user.isOwner &&
+						user.signInType !== 'ldap' &&
+						!readonly &&
+						getActions(user).length > 0 &&
+						actions.length > 0
+					"
 					placement="bottom"
 					:actions="getActions(user)"
 					theme="dark"
@@ -150,9 +152,6 @@ export default mixins(Locale).extend({
 			if (action === 'delete' || action === 'reinvite') {
 				this.$emit(action, user.id);
 			}
-		},
-		showDisabledBadge(user: IUser): boolean {
-			return user.signInType === 'ldap' && user.disabled;
 		},
 	},
 });

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -613,7 +613,7 @@ export interface IUserResponse {
 	};
 	personalizationAnswers?: IPersonalizationSurveyVersions | null;
 	isPending: boolean;
-	signInType: SignInType;
+	signInType?: SignInType;
 }
 
 export interface IUser extends IUserResponse {

--- a/packages/editor-ui/src/stores/users.ts
+++ b/packages/editor-ui/src/stores/users.ts
@@ -1,6 +1,6 @@
 import { changePassword, deleteUser, getCurrentUser, getUsers, inviteUsers, login, loginCurrentUser, logout, reinvite, sendForgotPasswordEmail, setupOwner, signup, skipOwnerSetup, submitPersonalizationSurvey, updateCurrentUser, updateCurrentUserPassword, validatePasswordToken, validateSignupToken } from "@/api/users";
 import { PERSONALIZATION_MODAL_KEY, STORES } from "@/constants";
-import { IInviteResponse, IPersonalizationLatestVersion, IUser, IUserResponse, IUsersState } from "@/Interface";
+import { IInviteResponse, IPersonalizationLatestVersion, IRole, IUser, IUserResponse, IUsersState } from "@/Interface";
 import { getPersonalizedNodeTypes, isAuthorized, PERMISSIONS, ROLE } from "@/utils";
 import { defineStore } from "pinia";
 import Vue from "vue";
@@ -8,7 +8,7 @@ import { useRootStore } from "./n8nRootStore";
 import { useSettingsStore } from "./settings";
 import { useUIStore } from "./ui";
 
-const isDefaultUser = (user: IUserResponse | null) => Boolean(user && user.isPending && user.globalRole && user.globalRole.name === ROLE.Owner);
+const isDefaultUser = (user: IUserResponse | null) => Boolean(user && user.isPending && user.globalRole?.name === ROLE.Owner);
 const isPendingUser = (user: IUserResponse | null) => Boolean(user && user.isPending);
 
 export const useUsersStore = defineStore(STORES.USERS, {
@@ -26,8 +26,8 @@ export const useUsersStore = defineStore(STORES.USERS, {
 		getUserById(state) {
 			return (userId: string): IUser | null => state.users[userId];
 		},
-		globalRoleName(): string {
-			return this.currentUser?.globalRole?.name || '';
+		globalRoleName(): IRole {
+			return this.currentUser?.globalRole?.name ?? 'default';
 		},
 		canUserDeleteTags(): boolean {
 			return isAuthorized(PERMISSIONS.TAGS.CAN_DELETE_TAGS, this.currentUser);
@@ -72,7 +72,7 @@ export const useUsersStore = defineStore(STORES.USERS, {
 					fullName: userResponse.firstName? `${updatedUser.firstName} ${updatedUser.lastName || ''}`: undefined,
 					isDefaultUser: isDefaultUser(updatedUser),
 					isPendingUser: isPendingUser(updatedUser),
-					isOwner: Boolean(updatedUser.globalRole && updatedUser.globalRole.name === ROLE.Owner),
+					isOwner: updatedUser.globalRole?.name === ROLE.Owner,
 				};
 				Vue.set(this.users, user.id, user);
 			});

--- a/packages/editor-ui/src/utils/userUtils.ts
+++ b/packages/editor-ui/src/utils/userUtils.ts
@@ -66,7 +66,7 @@ export const isAuthorized = (permissions: IPermissions, currentUser: IUser | nul
 			return false;
 		}
 
-		if (currentUser && currentUser.globalRole) {
+		if (currentUser?.globalRole?.name) {
 			const role = currentUser.isDefaultUser ? ROLE.Default : currentUser.globalRole.name;
 			if (permissions.deny.role && permissions.deny.role.includes(role)) {
 				return false;
@@ -88,7 +88,7 @@ export const isAuthorized = (permissions: IPermissions, currentUser: IUser | nul
 			return true;
 		}
 
-		if (currentUser && currentUser.globalRole) {
+		if (currentUser?.globalRole?.name) {
 			const role = currentUser.isDefaultUser ? ROLE.Default : currentUser.globalRole.name;
 			if (permissions.allow.role && permissions.allow.role.includes(role)) {
 				return true;

--- a/packages/editor-ui/src/views/SettingsLdapView.vue
+++ b/packages/editor-ui/src/views/SettingsLdapView.vue
@@ -64,7 +64,7 @@
 					/>
 				</div>
 			</div>
-			<div v-show="loginEnabled">
+			<div v-if="loginEnabled">
 				<n8n-heading tag="h1" class="mb-xl mt-3xl" size="medium">{{ $locale.baseText('settings.ldap.section.synchronization.title') }}</n8n-heading>
 				<div :class="$style.syncTable">
 					<el-table

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -115,7 +115,7 @@ export default mixins(
 			return this.usersStore.currentUser;
 		},
 		signInWithLdap(): boolean {
-			return this.currentUser?.signInType === SignInType.LDAP;
+			return this.currentUser?.signInType === 'ldap';
 		},
 		isLDAPFeatureEnabled(): boolean {
 			return this.settingsStore.settings.enterprise.ldap === true;


### PR DESCRIPTION
This will help us not only support other auth providers, but also multiple auth providers, which will be relevant soon when we migrate all cloud users to a separate Auth service.