### PR TITLE
fix: Stop using prefixed core modules from nodejs (no-changelog)

### DIFF
--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -1,5 +1,5 @@
-import * as path from 'node:path';
-import { readFile } from 'node:fs/promises';
+import * as path from 'path';
+import { readFile } from 'fs/promises';
 import glob from 'fast-glob';
 import { jsonParse, KnownNodesAndCredentials, LoggerProxy as Logger } from 'n8n-workflow';
 import type {


### PR DESCRIPTION
Starting node 18, there are some core modules that only work with the `node:` prefix, like `node:test`. It's very likely that nodejs will switch to prefix-only core modules in the next versions as un-prefixed core modules are susceptible to supply-chain attacks.
So, after we drop node 14, we should update all core modules to use the prefix.