### PR TITLE
fix(Local File Trigger Node): Fix issue that causes a crash if the ignore field is empty (#4824)

### DIFF
--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -182,7 +182,7 @@ export class LocalFileTrigger implements INodeType {
 		}
 
 		const watcher = watch(path, {
-			ignored: options.ignored,
+			ignored: options.ignored === '' ? undefined : options.ignored,
 			persistent: true,
 			ignoreInitial: true,
 			followSymlinks:


### PR DESCRIPTION
Fixes [#4824](https://github.com/n8n-io/n8n/issues/4824)