### PR TITLE
fix: Make `nodes.exclude` and `nodes.include` work with lazy-loaded nodes

### DIFF
--- a/packages/cli/src/config/types.d.ts
+++ b/packages/cli/src/config/types.d.ts
@@ -77,7 +77,8 @@ type ToReturnType<T extends ConfigOptionPath> = T extends NumericPath
 type ExceptionPaths = {
 	'queue.bull.redis': object;
 	binaryDataManager: IBinaryDataConfig;
-	'nodes.include': undefined;
+	'nodes.exclude': string[] | undefined;
+	'nodes.include': string[] | undefined;
 	'userManagement.isInstanceOwnerSetUp': boolean;
 	'userManagement.skipInstanceOwnerSetup': boolean;
 };


### PR DESCRIPTION
Ticket: N8N-5840

Community issue: https://community.n8n.io/t/i-followed-a-question-and-tried-to-disable-a-base-node-using-nodes-exclude-but-its-not-getting-hidden/20391/2