### PR TITLE
refactor: Remove `executeSingle` (no-changelog)

### DIFF
--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -109,9 +109,8 @@ export abstract class DirectoryLoader {
 			nodeVersion = tempNode.currentVersion;
 
 			if (currentVersionNode.hasOwnProperty('executeSingle')) {
-				Logger.warn(
-					`"executeSingle" will get deprecated soon. Please update the code of node "${this.packageName}.${nodeName}" to use "execute" instead!`,
-					{ filePath },
+				throw new Error(
+					`"executeSingle" has been removed. Please update the code of node "${this.packageName}.${nodeName}" to use "execute" instead!`,
 				);
 			}
 		} else {

--- a/packages/node-dev/README.md
+++ b/packages/node-dev/README.md
@@ -1,6 +1,6 @@
 ![n8n.io - Workflow Automation](https://user-images.githubusercontent.com/65276001/173571060-9f2f6d7b-bac0-43b6-bdb2-001da9694058.png)
 
-# n8n-node-dev
+# n8n-node-dev 
 
 Currently very simple and not very sophisticated CLI which makes it easier
 to create credentials and nodes in TypeScript for n8n.
@@ -129,7 +129,6 @@ following methods defined which contains the actual logic:
 Method get called when the workflow gets executed
 
 - `execute`: Executed once no matter how many items
-- `executeSingle`: Executed once for every item
 
 By default always `execute` should be used especially when creating a
 third-party integration. The reason for that is that it is way more flexible
@@ -158,7 +157,6 @@ Property overview
 
 - **description** [required]: Describes the node like its name, properties, hooks, ... see `Node Type Description` bellow.
 - **execute** [optional]: Method get called when the workflow gets executed (once).
-- **executeSingle** [optional]: Method get called when the workflow gets executed (once for every item).
 - **hooks** [optional]: The hook methods.
 - **methods** [optional]: Additional methods. Currently only "loadOptions" exists which allows loading options for parameters from external services
 - **trigger** [optional]: Method gets called once when the workflow gets activated.

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1228,7 +1228,6 @@ export interface INodeType {
 	execute?(
 		this: IExecuteFunctions,
 	): Promise<INodeExecutionData[][] | NodeExecutionWithMetadata[][] | null>;
-	executeSingle?(this: IExecuteSingleFunctions): Promise<INodeExecutionData>;
 	poll?(this: IPollFunctions): Promise<INodeExecutionData[][] | null>;
 	trigger?(this: ITriggerFunctions): Promise<ITriggerResponse | undefined>;
 	webhook?(this: IWebhookFunctions): Promise<IWebhookResponseData>;

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -1181,17 +1181,13 @@ export class Workflow {
 		}
 
 		let connectionInputData: INodeExecutionData[] = [];
-		if (
-			nodeType.execute ||
-			nodeType.executeSingle ||
-			(!nodeType.poll && !nodeType.trigger && !nodeType.webhook)
-		) {
-			// Only stop if first input is empty for execute & executeSingle runs. For all others run anyways
+		if (nodeType.execute || (!nodeType.poll && !nodeType.trigger && !nodeType.webhook)) {
+			// Only stop if first input is empty for execute runs. For all others run anyways
 			// because then it is a trigger node. As they only pass data through and so the input-data
 			// becomes output-data it has to be possible.
 
 			if (inputData.hasOwnProperty('main') && inputData.main.length > 0) {
-				// We always use the data of main input and the first input for executeSingle
+				// We always use the data of main input and the first input for execute
 				connectionInputData = inputData.main[0] as INodeExecutionData[];
 			}
 
@@ -1226,35 +1222,7 @@ export class Workflow {
 			inputData = newInputData;
 		}
 
-		if (nodeType.executeSingle) {
-			const returnPromises: Array<Promise<INodeExecutionData>> = [];
-
-			for (let itemIndex = 0; itemIndex < connectionInputData.length; itemIndex++) {
-				const thisArgs = nodeExecuteFunctions.getExecuteSingleFunctions(
-					this,
-					runExecutionData,
-					runIndex,
-					connectionInputData,
-					inputData,
-					node,
-					itemIndex,
-					additionalData,
-					executionData,
-					mode,
-				);
-
-				returnPromises.push(nodeType.executeSingle.call(thisArgs));
-			}
-
-			if (returnPromises.length === 0) {
-				return { data: null };
-			}
-
-			const promiseResults = await Promise.all(returnPromises);
-			if (promiseResults) {
-				return { data: [promiseResults] };
-			}
-		} else if (nodeType.execute) {
+		if (nodeType.execute) {
 			const thisArgs = nodeExecuteFunctions.getExecuteFunctions(
 				this,
 				runExecutionData,


### PR DESCRIPTION
[This was deprecated 1.5 years ago](https://github.com/n8n-io/n8n/commit/40614672e67a83b2a410b289915e45495e818216), and we have no nodes with an `executeSingle` method on them.