### PR TITLE
test(editor): Set e2e test retries

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,10 @@ const { defineConfig } = require('cypress');
 const BASE_URL = 'http://localhost:5678';
 
 module.exports = defineConfig({
+	retries: {
+		openMode: 1,
+		runMode: 3
+	},
 	e2e: {
 		baseUrl: BASE_URL,
 		video: false,


### PR DESCRIPTION
Our e2e specs sometimes fail due to elements being detached, animations, or network flukes(runner BE taking longer to respond than the current 5s timeout). We can experiment with setting 3 retries in the CI(run) mode. This was if spec fails, it has 3 more chances to turn green 😄 