### PR TITLE
fix(core): Remove `nodeGetter` checks

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -583,28 +583,6 @@ export class WorkflowDataProxy {
 						});
 					}
 
-					if (
-						nodeName !== that.activeNodeName &&
-						!that.runExecutionData?.resultData.runData?.hasOwnProperty(nodeName)
-					) {
-						throw new ExpressionError(`no data, execute "${nodeName}" node first`, {
-							runIndex: that.runIndex,
-							itemIndex: that.itemIndex,
-							failExecution: true,
-						});
-					}
-
-					if (
-						nodeName !== that.activeNodeName &&
-						!that.workflow.getNodeConnectionIndexes(that.activeNodeName, nodeName, 'main')
-					) {
-						throw new ExpressionError(`connect "${that.activeNodeName}" to "${nodeName}"`, {
-							runIndex: that.runIndex,
-							itemIndex: that.itemIndex,
-							failExecution: true,
-						});
-					}
-
 					return that.nodeDataGetter(nodeName);
 				},
 			},


### PR DESCRIPTION
Removing these checks temporarily. To be reintroduced next week accounting for `.parameter` functionality.