### PR TITLE
ci: Add libc6-compat to nightly docker builds (no-changelog)

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -7,6 +7,7 @@ COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml tsconfig.
 COPY scripts ./scripts
 COPY packages ./packages
 
+RUN apk add --update libc6-compat
 RUN corepack enable && corepack prepare --activate
 RUN chown -R node:node .
 USER node


### PR DESCRIPTION
related issues:
https://github.com/n8n-io/n8n/issues/4361
https://github.com/n8n-io/n8n/pull/4362