### PR TITLE
fix parameter name in disqus node

### DIFF
--- a/packages/nodes-base/nodes/Disqus/Disqus.node.ts
+++ b/packages/nodes-base/nodes/Disqus/Disqus.node.ts
@@ -557,7 +557,7 @@ export class Disqus implements INodeType {
 					},
 					{
 						displayName: 'Thread',
-						name: 'threadId',
+						name: 'thread',
 						type: 'string',
 						default: '',
 						description:


### PR DESCRIPTION
Hi,

According to [api docs](https://disqus.com/api/docs/threads/list/) parameter with a thread id should be named thread instead of threadId. When I made request with the current node version, i got such error

```
400 - {"code":2,"response":"Invalid argument, 'threadId'"}
```