### PR TITLE
fix: Improve VSCode debugging setup (no-changelog)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,7 @@
 			"env": {
 				// "N8N_PORT": "5679",
 			},
+			"outputCapture": "std",
 			"killBehavior": "polite"
 		},
 		{

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
 			"type": "node",
 			"env": {
 				// "N8N_PORT": "5679",
-			}
+			},
+			"killBehavior": "polite"
 		},
 		{
 			"name": "Debug CLI tests",


### PR DESCRIPTION
1. Shutdown and restart n8n process gracefully
2. Stream stdout/stderr to the debug console, instead of just the output of `console.log`.