### PR TITLE
ci: Make custom images consistent with the release images (no-changelog)

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -22,7 +22,8 @@ RUN rm -rf patches .npmrc *.yaml node_modules/.cache packages/**/node_modules/.c
 
 # 2. Start with a new clean image with just the code that is needed to run n8n
 FROM n8nio/base:${NODE_VERSION}
-COPY --from=builder /home/node ./
+COPY --from=builder /home/node /usr/local/lib/node_modules/n8n
+RUN ln -s /usr/local/lib/node_modules/n8n/packages/cli/bin/n8n /usr/local/bin/n8n
 COPY docker/images/n8n-custom/docker-entrypoint.sh /
 
 RUN \

--- a/docker/images/n8n-custom/docker-entrypoint.sh
+++ b/docker/images/n8n-custom/docker-entrypoint.sh
@@ -1,16 +1,8 @@
 #!/bin/sh
 if [ "$#" -gt 0 ]; then
   # Got started with arguments
-  COMMAND=$1;
-
-  if [[ "$COMMAND" == "n8n" ]]; then
-    shift
-    (cd packages/cli; exec node ./bin/n8n "$@")
-  else
-    exec node "$@"
-  fi
-
+  node "$@"
 else
-# Got started without arguments
-cd packages/cli; exec node ./bin/n8n
+  # Got started without arguments
+  n8n
 fi


### PR DESCRIPTION
This ensures that custom images work with all our docker-compose and Kubernetes examples.