### PR TITLE
fix(editor): Allow mapping onto expression editor with selection range

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -39,10 +39,6 @@ export default mixins(expressionManager, workflowHelpers).extend({
 	},
 	watch: {
 		value(newValue) {
-			const range = this.editor?.state.selection.ranges[0];
-
-			if (range !== undefined && range.from !== range.to) return;
-
 			try {
 				this.editor?.dispatch({
 					changes: {


### PR DESCRIPTION
Guard was to prevent cursor position from resetting when autoinserting braces when selection range exists. No longer needed since I had to later refactor the double brace handler for [this](https://www.notion.so/n8n/P1-Reviews-Expression-editor-e049831cb7b34f3d8c54bc6cddb522e8#8a47b86653284196aa00665193d29807).