### PR TITLE
feat(editor): Improve license activation error messages (no-changelog)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -103,7 +103,7 @@
     "tsconfig-paths": "^3.14.1"
   },
   "dependencies": {
-    "@n8n_io/license-sdk": "^1.6.1",
+    "@n8n_io/license-sdk": "^1.7.0",
     "@oclif/command": "^1.8.16",
     "@oclif/core": "^1.16.4",
     "@oclif/errors": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
   packages/cli:
     specifiers:
       '@apidevtools/swagger-cli': 4.0.0
-      '@n8n_io/license-sdk': ^1.6.1
+      '@n8n_io/license-sdk': ^1.7.0
       '@oclif/command': ^1.8.16
       '@oclif/core': ^1.16.4
       '@oclif/dev-cli': ^1.22.2
@@ -208,7 +208,7 @@ importers:
       winston: ^3.3.3
       yamljs: ^0.3.0
     dependencies:
-      '@n8n_io/license-sdk': 1.6.1
+      '@n8n_io/license-sdk': 1.7.0
       '@oclif/command': 1.8.18_@oclif+config@1.18.5
       '@oclif/core': 1.16.6
       '@oclif/errors': 1.3.6
@@ -3321,8 +3321,8 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: true
 
-  /@n8n_io/license-sdk/1.6.1:
-    resolution: {integrity: sha512-cVFs67ydYScRyuxaPTXEyrIz8JcpwyE9vYWWtkbNNsW9OOjYAqd5wg3hcurctrtg3Tn7gsu+9E3P5LQBH2F7lg==}
+  /@n8n_io/license-sdk/1.7.0:
+    resolution: {integrity: sha512-5Hs+G8xKQXyvODL08NUN4IV0qnJdAWgZo1jRqf8yBhXpFCKFerh5HKZdLdpzpatk5rrRps6pFmcnVwOCcFBrPA==}
     engines: {node: '>=14.0.0', npm: '>=7.10.0'}
     dependencies:
       axios: 1.1.3


### PR DESCRIPTION
This PR addresses the [PM feedback](https://www.notion.so/n8n/n8n-pro-MVP-review-fdd4f45bb18e41278e3159098bb2b10f#bcb3c7796c2f4580a7e55cc475833ccb) on error messages during license activation.

The desired wording of error messages is accomplished by overriding the `error.message` property depending on the `errorId` constant returned by the License SDK. Errors not explicitly overridden will be kept in their original form.

Note that changing below toast title from "Error" to "Activation failed" is not done yet as I could not figure out where to do it.

<img width="338" alt="image" src="https://user-images.githubusercontent.com/10939809/208292459-a94279c2-eacc-4624-95e3-73925ab8bdc6.png">
