### PR TITLE
Fix bugs in dynamodb connector - Fixes #4956 #4957

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
@@ -66,7 +66,8 @@ export async function awsApiRequestAllItems(
 	let responseData;
 
 	do {
-		responseData = await awsApiRequest.call(this, service, method, path, body, headers);
+		const originalHeaders = Object.assign({}, headers); //The awsapirequest function adds the hmac signature to the headers, if we pass the modified headers back in on the next call it will fail with invalid signature
+		responseData = await awsApiRequest.call(this, service, method, path, body, originalHeaders);
 		if (responseData.LastEvaluatedKey) {
 			body!.ExclusiveStartKey = responseData.LastEvaluatedKey;
 		}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -81,6 +81,8 @@ function decodeAttribute(type: AttributeValueType, attribute: string) {
 		case 'SS':
 		case 'NS':
 			return attribute;
+		case 'M':
+			return simplify(attribute);
 		default:
 			return null;
 	}


### PR DESCRIPTION
Bug 1) Map types were not being returned when using the "simplify" option. The map type (M) was missing from the decode attributes function. The map type is an object, so it recurively simplifies the object and returns that.
Bug 2) Return all did not work if there was more than one page of data (which is the entire point of return all). Headers from the previous iteration were being passed causing an invalid signature error.

Fixes #4956 Fixes #4957

https://community.n8n.io/t/bug-with-dynamodb-connector-using-simplify-setting/20790/5