### PR TITLE
fix: BinaryDataManager should store metadata when saving from buffer as well

### DIFF
--- a/packages/core/src/BinaryDataManager/index.ts
+++ b/packages/core/src/BinaryDataManager/index.ts
@@ -93,6 +93,12 @@ export class BinaryDataManager {
 
 			// Prevent preserving data in memory if handled by a data manager.
 			binaryData.data = this.binaryDataMode;
+
+			await manager.storeBinaryMetadata(identifier, {
+				fileName: binaryData.fileName,
+				mimeType: binaryData.mimeType,
+				fileSize: binaryBuffer.length,
+			});
 		} else {
 			// Else fallback to storing this data in memory.
 			binaryData.data = binaryBuffer.toString(BINARY_ENCODING);


### PR DESCRIPTION
in https://github.com/n8n-io/n8n/pull/4640 we updated BinaryDataManager to start storing file metadata to the filesystem when streaming binary data directly to a file. But, we forgot to save the metadata when saving the data from a Buffer to a file.