### PR TITLE
fix: Upgrade amqplib to address CVE-2022-0686

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -2,12 +2,6 @@ import { IDataObject, IExecuteFunctions, ITriggerFunctions, sleep } from 'n8n-wo
 
 import * as amqplib from 'amqplib';
 
-declare module 'amqplib' {
-	interface Channel {
-		connection: amqplib.Connection;
-	}
-}
-
 export async function rabbitmqConnect(
 	this: IExecuteFunctions | ITriggerFunctions,
 	options: IDataObject,

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -725,7 +725,7 @@
     ]
   },
   "devDependencies": {
-    "@types/amqplib": "^0.8.2",
+    "@types/amqplib": "^0.10.1",
     "@types/aws4": "^1.5.1",
     "@types/basic-auth": "^1.1.2",
     "@types/cheerio": "^0.22.15",
@@ -758,7 +758,7 @@
   "dependencies": {
     "@kafkajs/confluent-schema-registry": "1.0.6",
     "@types/js-nacl": "^1.3.0",
-    "amqplib": "^0.8.0",
+    "amqplib": "^0.10.3",
     "aws4": "^1.8.0",
     "basic-auth": "^2.0.1",
     "change-case": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,7 +669,7 @@ importers:
   packages/nodes-base:
     specifiers:
       '@kafkajs/confluent-schema-registry': 1.0.6
-      '@types/amqplib': ^0.8.2
+      '@types/amqplib': ^0.10.1
       '@types/aws4': ^1.5.1
       '@types/basic-auth': ^1.1.2
       '@types/cheerio': ^0.22.15
@@ -696,7 +696,7 @@ importers:
       '@types/tmp': ^0.2.0
       '@types/uuid': ^8.3.2
       '@types/xml2js': ^0.4.3
-      amqplib: ^0.8.0
+      amqplib: ^0.10.3
       aws4: ^1.8.0
       basic-auth: ^2.0.1
       change-case: ^4.1.1
@@ -758,7 +758,7 @@ importers:
     dependencies:
       '@kafkajs/confluent-schema-registry': 1.0.6
       '@types/js-nacl': 1.3.0
-      amqplib: 0.8.0
+      amqplib: 0.10.3
       aws4: 1.11.0
       basic-auth: 2.0.1
       change-case: 4.1.2
@@ -815,7 +815,7 @@ importers:
       xlsx: 0.17.5
       xml2js: 0.4.23
     devDependencies:
-      '@types/amqplib': 0.8.2
+      '@types/amqplib': 0.10.1
       '@types/aws4': 1.11.2
       '@types/basic-auth': 1.1.3
       '@types/cheerio': 0.22.31
@@ -883,6 +883,17 @@ importers:
       '@types/xml2js': 0.4.11
 
 packages:
+
+  /@acuminous/bitsyntax/0.1.2:
+    resolution: {integrity: sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      buffer-more-ints: 1.0.0
+      debug: 4.3.4
+      safe-buffer: 5.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@adobe/css-tools/4.0.1:
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
@@ -5393,10 +5404,9 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  /@types/amqplib/0.8.2:
-    resolution: {integrity: sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==}
+  /@types/amqplib/0.10.1:
+    resolution: {integrity: sha512-j6ANKT79ncUDnAs/+9r9eDujxbeJoTjoVu33gHHcaPfmLQaMhvfbH2GqSe8KUM444epAp1Vl3peVOQfZk3UIqA==}
     dependencies:
-      '@types/bluebird': 3.5.37
       '@types/node': 16.11.65
     dev: true
 
@@ -7021,15 +7031,13 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  /amqplib/0.8.0:
-    resolution: {integrity: sha512-icU+a4kkq4Y1PS4NNi+YPDMwdlbFcZ1EZTQT2nigW3fvOb6AOgUQ9+Mk4ue0Zu5cBg/XpDzB40oH10ysrk2dmA==}
+  /amqplib/0.10.3:
+    resolution: {integrity: sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==}
     engines: {node: '>=10'}
     dependencies:
-      bitsyntax: 0.1.0
-      bluebird: 3.7.2
+      '@acuminous/bitsyntax': 0.1.2
       buffer-more-ints: 1.0.0
       readable-stream: 1.1.14
-      safe-buffer: 5.2.1
       url-parse: 1.5.10
     transitivePeerDependencies:
       - supports-color
@@ -7908,17 +7916,6 @@ packages:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
     dev: false
 
-  /bitsyntax/0.1.0:
-    resolution: {integrity: sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      buffer-more-ints: 1.0.0
-      debug: 2.6.9
-      safe-buffer: 5.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -7944,6 +7941,7 @@ packages:
 
   /bluebird/3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+    dev: true
 
   /bn.js/4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}


### PR DESCRIPTION
n8n is not actually vulnerable to CVE-2022-0686, but some security scanners are looking at the older version of `amqplib` and assuming that we are also pulling in an older version of `url-parse`. But, due to how out pnpm packages are setup, we are already using `url-parse` > `1.5.8`.