### PR TITLE
ci: Use a fixed version of NPM in the release process (no-changelog)

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -6,7 +6,7 @@ COPY .npmrc /usr/local/etc/npmrc
 
 RUN \
 	apk add --update git graphicsmagick tini tzdata ca-certificates && \
-	npm install -g npm@latest full-icu && \
+	npm install -g npm@8.19.2 full-icu && \
 	rm -rf /var/cache/apk/* /root/.npm /tmp/* && \
 	# Install fonts
 	apk --no-cache add --virtual fonts msttcorefonts-installer fontconfig && \

--- a/docker/images/n8n-debian/Dockerfile
+++ b/docker/images/n8n-debian/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 # Set a custom user to not have n8n run as root
 USER root
 
-RUN npm_config_user=root npm install -g npm@latest full-icu n8n@${N8N_VERSION}
+RUN npm_config_user=root npm install -g npm@8.19.2 full-icu n8n@${N8N_VERSION}
 
 ENV NODE_ICU_DATA /usr/local/lib/node_modules/full-icu
 

--- a/docker/images/n8n-rhel7/Dockerfile
+++ b/docker/images/n8n-rhel7/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 # Set a custom user to not have n8n run as root
 USER root
 
-RUN npm_config_user=root npm install -g npm@latest n8n@${N8N_VERSION}
+RUN npm_config_user=root npm install -g npm@8.19.2 n8n@${N8N_VERSION}
 
 WORKDIR /data
 


### PR DESCRIPTION
since NPM `8.19.3` we are seeing random timeout issues in the release process. 