### PR TITLE
fix: Prevent keyboard shortcuts in expression editor modal

### DIFF
--- a/packages/editor-ui/src/components/ExpressionEdit.vue
+++ b/packages/editor-ui/src/components/ExpressionEdit.vue
@@ -47,6 +47,7 @@
 								:value="value"
 								:isReadOnly="isReadOnly"
 								@change="valueChanged"
+								@close="closeDialog"
 								ref="inputFieldExpression"
 								data-test-id="expression-modal-input"
 							/>

--- a/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
+++ b/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="root" class="ph-no-capture" @keydown.stop></div>
+	<div ref="root" class="ph-no-capture" @keydown.stop @keydown.esc="onClose"></div>
 </template>
 
 <script lang="ts">
@@ -82,6 +82,9 @@ export default mixins(expressionManager, workflowHelpers).extend({
 		this.editor?.destroy();
 	},
 	methods: {
+		onClose() {
+			this.$emit('close');
+		},
 		itemSelected({ variable }: IVariableItemSelected) {
 			if (!this.editor || this.isReadOnly) return;
 

--- a/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
+++ b/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<div ref="root" class="ph-no-capture"></div>
+	<div ref="root" class="ph-no-capture" @keydown.stop></div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
