### PR TITLE
fix: View option for binary-data shouldn't download the file on Chrome/Edge

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1515,7 +1515,9 @@ class App {
 					identifier,
 				);
 				if (mimeType) res.setHeader('Content-Type', mimeType);
-				if (fileName) res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+				if (req.query.mode === 'download' && fileName) {
+					res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+				}
 				res.setHeader('Content-Length', fileSize);
 				res.sendFile(binaryPath);
 			},

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -235,7 +235,7 @@ export interface IRestApi {
 	deleteExecutions(sendData: IExecutionDeleteFilter): Promise<void>;
 	retryExecution(id: string, loadWorkflow?: boolean): Promise<boolean>;
 	getTimezones(): Promise<IDataObject>;
-	getBinaryUrl(dataPath: string): string;
+	getBinaryUrl(dataPath: string, mode: 'view' | 'download'): string;
 }
 
 export interface INodeTranslationHeaders {

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -235,7 +235,6 @@ export interface IRestApi {
 	deleteExecutions(sendData: IExecutionDeleteFilter): Promise<void>;
 	retryExecution(id: string, loadWorkflow?: boolean): Promise<boolean>;
 	getTimezones(): Promise<IDataObject>;
-	getBinaryBufferString(dataPath: string): Promise<string>;
 	getBinaryUrl(dataPath: string): string;
 }
 

--- a/packages/editor-ui/src/components/BinaryDataDisplay.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplay.vue
@@ -111,19 +111,5 @@ export default mixins(nodeHelpers, restApi).extend({
 			height: 100%;
 		}
 	}
-
-	.binary-data {
-		background-color: var(--color-foreground-xlight);
-
-		&.image {
-			max-height: calc(100% - 1em);
-			max-width: calc(100% - 1em);
-		}
-
-		&.other {
-			height: calc(100% - 1em);
-			width: calc(100% - 1em);
-		}
-	}
 }
 </style>

--- a/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -56,7 +56,7 @@ export default mixins(restApi).extend({
 			}
 		} else {
 			try {
-				const binaryUrl = this.restApi().getBinaryUrl(id);
+				const binaryUrl = this.restApi().getBinaryUrl(id, 'view');
 				if (isJSONData) {
 					this.jsonData = await (await fetch(binaryUrl)).json();
 				} else {

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -1202,7 +1202,7 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 			const { id, data, fileName, fileExtension, mimeType } = this.binaryData[index][key];
 
 			if (id) {
-				const url = this.restApi().getBinaryUrl(id);
+				const url = this.restApi().getBinaryUrl(id, 'download');
 				saveAs(url, [fileName, fileExtension].join('.'));
 				return;
 			} else {

--- a/packages/editor-ui/src/mixins/restApi.ts
+++ b/packages/editor-ui/src/mixins/restApi.ts
@@ -201,9 +201,8 @@ export const restApi = Vue.extend({
 				},
 
 				// Binary data
-				getBinaryUrl: (dataPath: string): string => {
-					return self.rootStore.getRestApiContext.baseUrl + `/data/${dataPath}`;
-				},
+				getBinaryUrl: (dataPath, mode): string =>
+					self.rootStore.getRestApiContext.baseUrl + `/data/${dataPath}?mode=${mode}`,
 			};
 		},
 	},

--- a/packages/editor-ui/src/mixins/restApi.ts
+++ b/packages/editor-ui/src/mixins/restApi.ts
@@ -201,10 +201,6 @@ export const restApi = Vue.extend({
 				},
 
 				// Binary data
-				getBinaryBufferString: (dataPath: string): Promise<string> => {
-					return self.restApi().makeRestApiRequest('GET', `/data/${dataPath}`);
-				},
-
 				getBinaryUrl: (dataPath: string): string => {
 					return self.rootStore.getRestApiContext.baseUrl + `/data/${dataPath}`;
 				},


### PR DESCRIPTION
On Firefox `embed` tag ignores the `Content-disposition` header, and always shows the content. But, on blink based browsers, the presence of `Content-Disposition: attachment;` ignores the `embed` tag, and downloads the file instead.
This PR adds an explicit query param to distinguish between binary urls for downloading vs viewing.

Also, deleted some unused and duplicate code.