### PR TITLE
docs: Update documentation url for n8n credentials (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/N8nApi.credentials.ts
+++ b/packages/nodes-base/credentials/N8nApi.credentials.ts
@@ -10,7 +10,7 @@ export class N8nApi implements ICredentialType {
 
 	displayName = 'n8n API';
 
-	documentationUrl = 'n8nApi';
+	documentationUrl = 'https://docs.n8n.io/api/authentication/';
 
 	properties: INodeProperties[] = [
 		{


### PR DESCRIPTION
Fix documentionUrl to point to the right location.

Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/out-of-date-links-in-the-ui-for-n8n-node/21046