### PR TITLE
fix: Show trigger actions again in nodes panel

### DIFF
--- a/packages/editor-ui/src/stores/nodeCreator.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.ts
@@ -305,40 +305,31 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, {
 			return nodesWithActions;
 		},
 		mergedAppNodes(): INodeTypeDescription[] {
-			const mergedNodes = [...this.visibleNodesWithActions]
-				// Sort triggers so they are always on top and when later get merged
-				// they won't be disacrded if they have the same name as a core node which doesn't contain actions
-				.sort((a, b) => {
-					if (a.group.includes('trigger')) return -1;
-					if (b.group.includes('trigger')) return 1;
+			const mergedNodes = this.visibleNodesWithActions.reduce(
+				(acc: Record<string, INodeTypeDescription>, node: INodeTypeDescription) => {
+					const clonedNode = deepCopy(node);
+					const isCoreNode = node.codex?.categories?.includes(CORE_NODES_CATEGORY);
+					const actions = node.actions || [];
+					// Do not merge core nodes
+					const normalizedName = isCoreNode
+						? node.name
+						: node.name.toLowerCase().replace('trigger', '');
+					const existingNode = acc[normalizedName];
 
-					return 0;
-				})
-				.reduce(
-					(acc: Record<string, INodeTypeDescription>, node: INodeTypeDescription) => {
-						const clonedNode = deepCopy(node);
-						const isCoreNode = node.codex?.categories?.includes(CORE_NODES_CATEGORY);
-						const actions = node.actions || [];
-						// Do not merge core nodes
-						const normalizedName = isCoreNode
-							? node.name
-							: node.name.toLowerCase().replace('trigger', '');
-						const existingNode = acc[normalizedName];
+					if (existingNode) existingNode.actions?.push(...actions);
+					else acc[normalizedName] = clonedNode;
 
-						if (existingNode) existingNode.actions?.push(...actions);
-						else acc[normalizedName] = clonedNode;
+					if (!isCoreNode) {
+						acc[normalizedName].displayName = node.displayName.replace('Trigger', '');
+					}
 
-						if (!isCoreNode) {
-							acc[normalizedName].displayName = node.displayName.replace('Trigger', '');
-						}
-
-						acc[normalizedName].actions = filterSinglePlaceholderAction(
-							acc[normalizedName].actions || [],
-						);
-						return acc;
-					},
-					{},
-				);
+					acc[normalizedName].actions = filterSinglePlaceholderAction(
+						acc[normalizedName].actions || [],
+					);
+					return acc;
+				},
+				{},
+			);
 			return Object.values(mergedNodes);
 		},
 		getNodeTypesWithManualTrigger:


### PR DESCRIPTION
Revert "fix(editor): Correctly display trigger nodes without actions … #4976 
…and with related regular node in the "On App Events" category (#4976)"

445463a605f5f327f897b23a9b4504939358d0df

Github issue / Community forum post (link here to close automatically):
