### PR TITLE
fix(editor): Transparentize tertiary button on Usage page

### DIFF
--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.vue
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.vue
@@ -152,6 +152,7 @@ const onDialogOpened = () => {
 
 		<div :class="$style.buttons">
 			<n8n-button
+				:class="$style.buttonTertiary"
 				@click="onAddActivationKey"
 				v-if="usageStore.canUserActivateLicense"
 				type="tertiary"
@@ -278,6 +279,13 @@ const onDialogOpened = () => {
 div[class*='info'] > span > span:last-child {
 	line-height: 1.4;
 	padding: 0 0 0 var(--spacing-4xs);
+}
+
+.buttonTertiary {
+	&,
+	&:hover {
+		background: transparent;
+	}
 }
 </style>
 


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
