### PR TITLE
fix: Non owner should be permitted to use their own credentials

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -5,7 +5,7 @@ import {
 	Workflow,
 	WorkflowOperationError,
 } from 'n8n-workflow';
-import { FindManyOptions, In, ObjectLiteral } from 'typeorm';
+import { FindConditions, In } from 'typeorm';
 import * as Db from '@/Db';
 import config from '@/config';
 import type { SharedCredentials } from '@db/entities/SharedCredentials';
@@ -47,19 +47,16 @@ export class PermissionChecker {
 			workflowUserIds = workflowSharings.map((s) => s.userId);
 		}
 
-		const credentialsWhereCondition: FindManyOptions<SharedCredentials> & { where: ObjectLiteral } =
-			{
-				where: { user: In(workflowUserIds) },
-			};
+		const credentialsWhere: FindConditions<SharedCredentials> = { userId: In(workflowUserIds) };
 
 		if (!isSharingEnabled()) {
 			// If credential sharing is not enabled, get only credentials owned by this user
-			credentialsWhereCondition.where.role = await getRole('credential', 'owner');
+			credentialsWhere.role = await getRole('credential', 'owner');
 		}
 
-		const credentialSharings = await Db.collections.SharedCredentials.find(
-			credentialsWhereCondition,
-		);
+		const credentialSharings = await Db.collections.SharedCredentials.find({
+			where: credentialsWhere,
+		});
 
 		const accessibleCredIds = credentialSharings.map((s) => s.credentialsId.toString());
 


### PR DESCRIPTION
[PAY-54](https://linear.app/n8n/issue/PAY-54/bug-executions-failing-for-credential-that-i-own)

[Postgres and MySQL tests](https://github.com/n8n-io/n8n/actions/runs/3787764417)

https://community.n8n.io/t/instances-with-multiple-users-set-up-should-not-upgrade-to-0-209-x/21106
https://community.n8n.io/t/0-209-1-error-please-recreate-the-credential-or-ask-its-owner-to-share-with-you/21084/5