### PR TITLE
fix(editor): Display default missing value in table view as `undefined`

### DIFF
--- a/packages/editor-ui/src/components/RunDataTable.vue
+++ b/packages/editor-ui/src/components/RunDataTable.vue
@@ -482,8 +482,8 @@ export default mixins(externalHooks).extend({
 							(typeof entry[key] === 'object' && Object.keys(entry[key] || {}).length > 0) ||
 							false;
 					} else {
-						// Entry does not have key so add null
-						entryRows.push(null);
+						// Entry does not have key so add undefined
+						entryRows.push(undefined);
 					}
 				});
 


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-43/table-view-does-not-reliably-display-null-or-undefined-values