### PR TITLE
fix(editor): Fix displaying of some trigger nodes in the creator panel

### DIFF
--- a/packages/editor-ui/src/stores/nodeCreator.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.ts
@@ -306,8 +306,16 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, {
 			return nodesWithActions;
 		},
 		mergedAppNodes(): INodeTypeDescription[] {
-			const mergedNodes = this.visibleNodesWithActions.reduce(
-				(acc: Record<string, INodeTypeDescription>, node: INodeTypeDescription) => {
+			const mergedNodes = [...this.visibleNodesWithActions]
+				// Sort triggers so they are always on top and when later get merged
+				// they won't be discarded if they have the same name as a core node which doesn't contain actions
+				.sort((a, b) => {
+					if (a.group.includes('trigger')) return -1;
+					if (b.group.includes('trigger')) return 1;
+
+					return 0;
+				})
+				.reduce((acc: Record<string, INodeTypeDescription>, node: INodeTypeDescription) => {
 					const clonedNode = deepCopy(node);
 					const isCoreNode = node.codex?.categories?.includes(CORE_NODES_CATEGORY);
 					const actions = node.actions || [];
@@ -324,14 +332,15 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, {
 						acc[normalizedName].displayName = node.displayName.replace('Trigger', '');
 					}
 
-					acc[normalizedName].actions = filterSinglePlaceholderAction(
-						acc[normalizedName].actions || [],
-					);
 					return acc;
-				},
-				{},
-			);
-			return Object.values(mergedNodes);
+				}, {});
+
+			const filteredNodes = Object.values(mergedNodes).map((node) => ({
+				...node,
+				actions: filterSinglePlaceholderAction(node.actions || []),
+			}));
+
+			return filteredNodes;
 		},
 		getNodeTypesWithManualTrigger:
 			() =>


### PR DESCRIPTION
This PR fixes the bug caused by #4976 where trigger actions wouldn't display if they contained only single placeholder action. 

Github issue / Community forum post (link here to close automatically): #4952 
