### PR TITLE
perf: Prevent oclif from loading ts-node and typescript

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -29,6 +29,9 @@ if (![14, 16, 18].includes(nodeVersionMajor)) {
 	process.exit(1);
 }
 
+// Prevent oclif from loading ts-node and typescript
+process.env.OCLIF_TS_NODE = '0';
+
 require('source-map-support').install();
 
 require('@oclif/command')


### PR DESCRIPTION
This reduces the startup memory spike from 200MB to 170MB