### PR TITLE
fix(core): Fix full manual execution for error trigger as starter of 2+ node workflow

### DIFF
--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -916,6 +916,7 @@ export class Workflow {
 		const startingNodeTypes = [
 			'n8n-nodes-base.manualTrigger',
 			'n8n-nodes-base.executeWorkflowTrigger',
+			'n8n-nodes-base.errorTrigger',
 			'n8n-nodes-base.start',
 		];
 


### PR DESCRIPTION
https://linear.app/n8n/issue/N8N-5936/error-trigger-node-is-not-recognized-as-a-node-to-start-a-workflow