### PR TITLE
fix(editor): Support tabbing away from inline expression editor

### DIFF
--- a/packages/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/editor-ui/src/components/ExpressionParameterInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<div :class="$style['expression-parameter-input']" v-click-outside="onBlur">
+	<div :class="$style['expression-parameter-input']" v-click-outside="onBlur" @keydown.tab="onBlur">
 		<div :class="[$style['all-sections'], { [$style['focused']]: isFocused }]">
 			<div
 				:class="[
@@ -128,7 +128,7 @@ export default Vue.extend({
 
 			this.$emit('focus');
 		},
-		onBlur(event: FocusEvent) {
+		onBlur(event: FocusEvent | KeyboardEvent) {
 			if (
 				event.target instanceof Element &&
 				Array.from(event.target.classList).some((_class) => _class.includes('resizer'))


### PR DESCRIPTION
Support navigating away from inline expression editor with `tab`, as allowed by other params.