### PR TITLE
refactor: Lint for no interpolation in regular string

### DIFF
--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -341,6 +341,8 @@ const config = (module.exports = {
 
 		'n8n-local-rules/no-unneeded-backticks': 'error',
 
+		'n8n-local-rules/no-interpolation-in-regular-string': 'error',
+
 		// ******************************************************************
 		//                    overrides to base ruleset
 		// ******************************************************************

--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -158,7 +158,7 @@ module.exports = {
 				Literal(node) {
 					if (typeof node.value !== 'string') return;
 
-					if (/\$\{[a-zA-Z0-9_$]*\}/.test(node.value)) {
+					if (/\$\{/.test(node.value)) {
 						context.report({
 							messageId: 'useBackticks',
 							node,

--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -139,6 +139,36 @@ module.exports = {
 			};
 		},
 	},
+
+	'no-interpolation-in-regular-string': {
+		meta: {
+			type: 'problem',
+			docs: {
+				description:
+					'String interpolation `${...}` requires backticks, not single or double quotes.',
+				recommended: 'error',
+			},
+			messages: {
+				useBackticks: 'Use backticks to interpolate',
+			},
+			fixable: 'code',
+		},
+		create(context) {
+			return {
+				Literal(node) {
+					if (typeof node.value !== 'string') return;
+
+					if (/\$\{[a-zA-Z0-9_$]*\}/.test(node.value)) {
+						context.report({
+							messageId: 'useBackticks',
+							node,
+							fix: (fixer) => fixer.replaceText(node, `\`${node.value}\``),
+						});
+					}
+				},
+			};
+		},
+	},
 };
 
 const isJsonParseCall = (node) =>

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/js.snippets.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/js.snippets.ts
@@ -6,6 +6,7 @@ import { completeFromList, snippetCompletion } from '@codemirror/autocomplete';
  */
 export const jsSnippets = completeFromList([
 	...snippets.filter((snippet) => snippet.label !== 'class'),
+	// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 	snippetCompletion('console.log(${arg})', { label: 'console.log()' }),
 	snippetCompletion('DateTime', { label: 'DateTime' }),
 	snippetCompletion('Interval', { label: 'Interval' }),


### PR DESCRIPTION
Request: https://github.com/n8n-io/n8n/pull/5057#pullrequestreview-1232368843

Again, wrote tests but RuleTester is unable to parse backticks:

```js
ruleTester.run('no-interpolation-in-regular-string', rules['no-interpolation-in-regular-string'], {
	valid: [
		{
			code: "var str = 'This is a test';",
		},
		{
			code: 'var str = "This is a test";',
		},
		{
			code: 'var str = `This is a ${test}`;',
		},
	],
	invalid: [
		{
			code: "var str = 'This is a ${test}'",
			errors: [{ messageId: 'useBackticks' }],
			output: 'var str = `This is a ${test}`',
		},
	],
});
```
