### PR TITLE
fix(editor): Clear node creator and scrim on workspace reset

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3503,6 +3503,9 @@ export default mixins(
 		resetWorkspace() {
 			this.workflowsStore.resetWorkflow();
 
+			this.onToggleNodeCreator({ createNodeActive: false });
+			this.nodeCreatorStore.setShowScrim(false);
+
 			// Reset nodes
 			this.deleteEveryEndpoint();
 


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-7/wf-canvas-state-needs-to-be-reset-when-adding-wf-template