### PR TITLE
fix(Respond to Webhook Node): Fix issue that content-type header gets overwritten

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -249,7 +249,7 @@ export class RespondToWebhook implements INodeType {
 				);
 			}
 
-			if (headers['content-type']) {
+			if (!headers['content-type']) {
 				headers['content-type'] = binaryData.mimeType;
 			}
 			responseBody = binaryDataBuffer;


### PR DESCRIPTION
Instead of setting the content type only if not already set, does it set it exactly then when it is set.

Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/handle-content-type-header-for-binary-data-in-response-to-webhook-node/21260?u=mutedjam