### PR TITLE
fix(editor): Prevent refresh on submit in credential edit modal

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
@@ -5,6 +5,7 @@
 			:key="parameter.name"
 			autocomplete="off"
 			data-test-id="credential-connection-parameter"
+			@submit.prevent
 		>
 			<!-- Why form? to break up inputs, to prevent Chrome autofill -->
 			<n8n-notice v-if="parameter.type === 'notice'" :content="parameter.displayName" />


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-156/bug-pressing-enter-in-credentials-modal-input-refreshes-page