### PR TITLE
fix(Slack Node): Add missing channels:read OAuth2 scope

### DIFF
--- a/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
@@ -2,6 +2,7 @@ import { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 //https://api.slack.com/authentication/oauth-v2
 const userScopes = [
+	'channels:read',
 	'channels:write',
 	'chat:write',
 	'files:read',


### PR DESCRIPTION
The missing scope prevents the default OAuth2 authentication process from requesting the scope required to fetch available channels. This prevents operations such as channel -> getAll from working as expected.

Closes HELP-71.