### PR TITLE
fix: Remove annonymous ID

### DIFF
--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -155,7 +155,6 @@ export class Telemetry {
 				this.rudderStack.identify(
 					{
 						userId: this.instanceId,
-						anonymousId: '000000000000',
 						traits: {
 							...traits,
 							instanceId: this.instanceId,


### PR DESCRIPTION
According to the [RudderStack docs](https://www.rudderstack.com/docs/event-spec/standard-events/identify/), only one of `userId` or `annonymousId` should be used. If `annonymousId` is provided then `userId` is ignored.

![image](https://user-images.githubusercontent.com/219272/210792687-c54743fd-bffa-4487-9ea5-e0bd664f3513.png)

This is causing ingestion issues as reported in [Slack](https://n8nio.slack.com/archives/C037J3XEPLJ/p1672922547933079).

Quoting the report: `Events are getting rate-limited due to the device_id: 000000000000 issue and there are already 200k+ pending events accumulated. Inevitably, event delivery delays will be observed.`.

Suggested action: `Customer Action: Include a proper device_id in events`