### PR TITLE
fix: Pass in the correct server reference to external hooks (no-changelog)

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -442,7 +442,7 @@ export abstract class AbstractServer {
 			console.log(`Locale: ${defaultLocale}`);
 		}
 
-		await externalHooks.run('n8n.ready', [server, config]);
+		await externalHooks.run('n8n.ready', [this, config]);
 	}
 }
 

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -442,7 +442,7 @@ export abstract class AbstractServer {
 			console.log(`Locale: ${defaultLocale}`);
 		}
 
-		await externalHooks.run('n8n.ready', [app, config]);
+		await externalHooks.run('n8n.ready', [server, config]);
 	}
 }
 


### PR DESCRIPTION
This broke in https://github.com/n8n-io/n8n/pull/5080 as I did not test external hooks extensively enough.