### PR TITLE
Nextcloud Node: Include optional fields in Folder:List

### DIFF
--- a/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
+++ b/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
@@ -642,6 +642,91 @@ export class NextCloud implements INodeType {
 				placeholder: '/invoices/2019/',
 				description: 'The path of which to list the content. The path should start with "/".',
 			},
+			{
+				displayName: 'List Folder Options',
+				name: 'folderListOptions',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						operation: ['list'],
+						resource: ['folder'],
+					},
+				},
+				description: 'Additional options for the Folder > List operation',
+				options: [
+					{
+						displayName: 'Include Fields',
+						name: 'folderListIncludeFields',
+						type: 'multiOptions',
+						options: [
+							{
+								name: 'Comments Unread',
+								value: 'oc:comments-unread',
+							},
+							{
+								name: 'Contained File Count',
+								value: 'nc:contained-file-count',
+							},
+							{
+								name: 'Contained Folder Count',
+								value: 'nc:contained-folder-count',
+							},
+							{
+								name: 'Content Type',
+								value: 'd:getcontenttype',
+							},
+							{
+								name: 'eTag',
+								value: 'd:getetag',
+							},
+							{
+								name: 'Favorite',
+								value: 'oc:favorite',
+							},
+							{
+								name: 'File ID',
+								value: 'oc:fileid',
+							},
+							{
+								name: 'File Path',
+								value: 'd:getcontentlength',
+							},
+							{
+								name: 'Has Preview',
+								value: 'nc:has-preview',
+							},
+							{
+								name: 'Last Modified',
+								value: 'd:getlastmodified',
+							},
+							{
+								name: 'Owner Display Name',
+								value: 'oc:owner-display-name',
+							},
+							{
+								name: 'Permissions',
+								value: 'oc:permissions',
+							},
+							{
+								name: 'Resource Type',
+								value: 'd:resourcetype',
+							},
+							{
+								name: 'Share Types',
+								value: 'oc:share-types',
+							},
+							{
+								name: 'Size',
+								value: 'oc:size',
+							},
+						],
+						default: [],
+						description: 'Include only selected fields',
+					},
+				],
+			},
 
 			// ----------------------------------
 			//         user
@@ -881,7 +966,7 @@ export class NextCloud implements INodeType {
 
 		let body: string | Buffer | IDataObject = '';
 		const headers: IDataObject = {};
-		let qs;
+		let qs: any;
 
 		for (let i = 0; i < items.length; i++) {
 			try {
@@ -942,6 +1027,25 @@ export class NextCloud implements INodeType {
 
 						requestMethod = 'PROPFIND';
 						endpoint = this.getNodeParameter('path', i) as string;
+
+						const folderListOptions: any = this.getNodeParameter('folderListOptions', i);
+						const customFields = folderListOptions.folderListIncludeFields as string[];
+
+						if (customFields.length > 0) {
+							// https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html
+							let propXML = '';
+
+							for (const field of customFields) {
+								propXML += `<${field} />`;
+							}
+
+							const propFindBody = `<?xml version="1.0"?>
+								<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+									<d:prop>${propXML}</d:prop>
+								</d:propfind>`;
+
+							body = propFindBody;
+						}
 					}
 				}
 
@@ -983,7 +1087,11 @@ export class NextCloud implements INodeType {
 						headers['OCS-APIRequest'] = true;
 						headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
-						const bodyParameters = this.getNodeParameter('options', i);
+						const bodyParameters: any = this.getNodeParameter('options', i);
+
+						if (bodyParameters == null) {
+							throw new NodeOperationError(this.getNode(), 'Body parameters are missing');
+						}
 
 						bodyParameters.path = this.getNodeParameter('path', i) as string;
 						bodyParameters.shareType = this.getNodeParameter('shareType', i) as number;
@@ -1232,6 +1340,21 @@ export class NextCloud implements INodeType {
 						'd:getlastmodified': 'lastModified',
 						'd:getcontentlength': 'contentLength',
 						'd:getcontenttype': 'contentType',
+
+						// handled below
+						// 'd:getetag': 'getetag',
+						// 'd:resourcetype': 'resourcetype',
+
+						'oc:fileid': 'fileId',
+						'oc:permissions': 'permissions',
+						'oc:size': 'size',
+						'nc:has-preview': 'hasPreview',
+						'oc:favorite': 'favorite',
+						'oc:comments-unread': 'commentsUnread',
+						'oc:owner-display-name': 'ownerDisplayName',
+						'oc:share-types': 'shareTypes',
+						'nc:contained-folder-count': 'containedFolderCount',
+						'nc:contained-file-count': 'containedFileCount',
 					};
 
 					if (
@@ -1272,8 +1395,11 @@ export class NextCloud implements INodeType {
 								} else {
 									newItem.type = 'folder';
 								}
-								// @ts-ignore
-								newItem.eTag = props['d:getetag'].slice(1, -1);
+
+								if (props['d:getetag'] != null) {
+									// @ts-ignore
+									newItem.eTag = props['d:getetag'].slice(1, -1);
+								}
 
 								returnData.push(newItem);
 							}


### PR DESCRIPTION
This PR adds the ability to get additional fields for the Folder:List operation to the NextCloud Node.

Before this change the user is able to get from NextCloud Folder:List only default file or folder properties.

After this change the user is able to get any file or folder property for Folder:List operation by specifying fields to include in the "Additional Options" field for Folder:List operation. Those fields are:

1. Comments Unread
2. Contained File Count
3. Contained Folder Count
4. Content Type
5. eTag
6. Favorite
7. File ID
8. File Path
9. Has Preview
10. Last Modified
11. Owner Display Name
12. Permissions
13. Resource Type
14. Share Types
15. Size

Here is how they look:
![Image](https://user-images.githubusercontent.com/11395921/210939007-35149aef-3cb5-4a70-816f-4f95f3bc3925.png)
