### PR TITLE
fix(editor): Omit `pairedItem` from proxy completions

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/proxyMocks.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/proxyMocks.ts
@@ -21,7 +21,7 @@ export const nodeSelectorProxy = new Proxy(
 	{},
 	{
 		ownKeys() {
-			return ['all', 'context', 'first', 'item', 'last', 'params', 'pairedItem', 'itemMatching'];
+			return ['all', 'context', 'first', 'item', 'last', 'params', 'itemMatching'];
 		},
 		get(_, property) {
 			if (property === 'all') return [];
@@ -30,7 +30,6 @@ export const nodeSelectorProxy = new Proxy(
 			if (property === 'item') return {};
 			if (property === 'last') return {};
 			if (property === 'params') return {};
-			if (property === 'pairedItem') return {};
 			if (property === 'itemMatching') return {};
 
 			return undefined;
@@ -39,7 +38,7 @@ export const nodeSelectorProxy = new Proxy(
 );
 
 export const itemProxy = new Proxy(
-	{ json: {}, pairedItem: {} },
+	{ json: {} },
 	{
 		get(_, property) {
 			if (property === 'json') return {};

--- a/packages/editor-ui/src/plugins/codemirror/completions/proxy.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/proxy.completions.ts
@@ -56,7 +56,7 @@ export function proxyCompletions(context: CompletionContext): CompletionResult |
 }
 
 function generateOptions(toResolve: string, proxy: IDataObject, word: Word): Completion[] {
-	const SKIP_SET = new Set(['__ob__']);
+	const SKIP_SET = new Set(['__ob__', 'pairedItem']);
 
 	if (word.text.includes('json[')) {
 		return Object.keys(proxy.json as object)


### PR DESCRIPTION
Requested [here](https://n8nio.slack.com/archives/C0430ND6D5E/p1672998271463669?thread_ts=1672996114.257269&cid=C0430ND6D5E)