### PR TITLE
refactor: Reduce custom docker image size by about 30%

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -7,7 +7,7 @@ COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml tsconfig.
 COPY scripts ./scripts
 COPY packages ./packages
 
-RUN apk add --update libc6-compat
+RUN apk add --update libc6-compat jq
 RUN corepack enable && corepack prepare --activate
 RUN chown -R node:node .
 USER node
@@ -15,8 +15,11 @@ USER node
 RUN pnpm install --frozen-lockfile
 RUN pnpm build
 RUN rm -rf node_modules
+RUN jq '{name: .name, version: .version}' packages/editor-ui/package.json > editor-ui.tmp; mv editor-ui.tmp packages/editor-ui/package.json
+RUN jq '{name: .name, version: .version}' packages/design-system/package.json > design-system.tmp; mv design-system.tmp packages/design-system/package.json
 RUN NODE_ENV=production pnpm install --prod --no-optional
 RUN find . -type f -name "*.ts" -o -name "*.js.map" -o -name "*.vue" -o -name "tsconfig.json" -o -name "*.tsbuildinfo" | xargs rm -rf
+RUN rm -rf packages/@n8n_io/eslint-config packages/editor-ui/src packages/editor-ui/node_modules packages/design-system
 RUN rm -rf patches .npmrc *.yaml node_modules/.cache packages/**/node_modules/.cache packages/**/.turbo .config .cache .local .node /tmp/*
 
 


### PR DESCRIPTION
Frontend dependencies are not needed after the image has been built.

Removing these shrinks the uncompressed image size from 610MB to 430MB, and the compressed image size from 160MB to 125MB.

Test image available: `n8nio/n8n:slimmer-custom-image`