### PR TITLE
fix: Do not attempt to save statistics data for unsaved workflows

### DIFF
--- a/packages/cli/src/events/WorkflowStatistics.ts
+++ b/packages/cli/src/events/WorkflowStatistics.ts
@@ -24,7 +24,7 @@ export async function workflowExecutionCompleted(
 
 	// Get the workflow id
 	const workflowId = workflowData.id;
-	if (workflowId === undefined) return;
+	if (!workflowId) return;
 
 	// Try insertion and if it fails due to key conflicts then update the existing entry instead
 	try {
@@ -59,7 +59,8 @@ export async function workflowExecutionCompleted(
 	}
 }
 
-export async function nodeFetchedData(workflowId: string, node: INode): Promise<void> {
+export async function nodeFetchedData(workflowId: string | undefined, node: INode): Promise<void> {
+	if (!workflowId) return;
 	// Try to insert the data loaded statistic
 	try {
 		await Db.collections.WorkflowStatistics.insert({

--- a/packages/cli/src/events/WorkflowStatistics.ts
+++ b/packages/cli/src/events/WorkflowStatistics.ts
@@ -59,7 +59,10 @@ export async function workflowExecutionCompleted(
 	}
 }
 
-export async function nodeFetchedData(workflowId: string | undefined, node: INode): Promise<void> {
+export async function nodeFetchedData(
+	workflowId: string | undefined | null,
+	node: INode,
+): Promise<void> {
 	if (!workflowId) return;
 	// Try to insert the data loaded statistic
 	try {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

Reason: workflowId can also be `null` what causes it to fail eventually.