### PR TITLE
fix(editor): Hide data pinning discoverability tooltip in execution view

### DIFF
--- a/packages/editor-ui/src/components/OutputPanel.vue
+++ b/packages/editor-ui/src/components/OutputPanel.vue
@@ -9,7 +9,6 @@
 		:isExecuting="isNodeRunning"
 		:executingMessage="$locale.baseText('ndv.output.executing')"
 		:sessionId="sessionId"
-		:isReadOnly="isReadOnly"
 		:blockUI="blockUI"
 		:isProductionExecutionPreview="isProductionExecutionPreview"
 		paneType="output"

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -590,10 +590,7 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 			this.eventBus.$on('data-pinning-error', this.onDataPinningError);
 			this.eventBus.$on('data-unpinning', this.onDataUnpinning);
 
-			const hasSeenPinDataTooltip = localStorage.getItem(LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG);
-			if (!hasSeenPinDataTooltip) {
-				this.showPinDataDiscoveryTooltip(this.jsonData);
-			}
+			this.showPinDataDiscoveryTooltip(this.jsonData);
 		}
 		this.ndvStore.setNDVBranchIndex({
 			pane: this.paneType as 'input' | 'output',
@@ -861,7 +858,12 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 				return;
 			}
 
-			if (value && value.length > 0) {
+			if (
+				value &&
+				value.length > 0 &&
+				!this.isReadOnly &&
+				!localStorage.getItem(LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG)
+			) {
 				this.pinDataDiscoveryComplete();
 
 				setTimeout(() => {
@@ -1290,11 +1292,7 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 		},
 		jsonData(value: IDataObject[]) {
 			this.refreshDataSize();
-
-			const hasSeenPinDataTooltip = localStorage.getItem(LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG);
-			if (!hasSeenPinDataTooltip) {
-				this.showPinDataDiscoveryTooltip(value);
-			}
+			this.showPinDataDiscoveryTooltip(value);
 		},
 		binaryData(newData: IBinaryKeyData[], prevData: IBinaryKeyData[]) {
 			if (newData.length && !prevData.length && this.displayMode !== 'binary') {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
