### PR TITLE
fix: Don't throw error on expressions referring to nodes that don't exist in the workflow

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -575,13 +575,14 @@ export class WorkflowDataProxy {
 				get(target, name, receiver) {
 					const nodeName = name.toString();
 
-					if (that.workflow.getNode(nodeName) === null) {
-						throw new ExpressionError(`"${nodeName}" node doesn't exist`, {
-							runIndex: that.runIndex,
-							itemIndex: that.itemIndex,
-							failExecution: true,
-						});
-					}
+					// TODO: re-enable this for v1.0.0 release
+					// if (that.workflow.getNode(nodeName) === null) {
+					// 	throw new ExpressionError(`"${nodeName}" node doesn't exist`, {
+					// 		runIndex: that.runIndex,
+					// 		itemIndex: that.itemIndex,
+					// 		failExecution: true,
+					// 	});
+					// }
 
 					return that.nodeDataGetter(nodeName);
 				},


### PR DESCRIPTION
reverting this bit from https://github.com/n8n-io/n8n/pull/4829 to maintain backward compatibility until 1.0.0