### PR TITLE
fix(GitLab Node): Update credential test endpoint

### DIFF
--- a/packages/nodes-base/credentials/GitlabApi.credentials.ts
+++ b/packages/nodes-base/credentials/GitlabApi.credentials.ts
@@ -40,7 +40,7 @@ export class GitlabApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{$credentials.server.replace(new RegExp("/$"), "") + "/api/v4" }}',
-			url: '/users',
+			url: '/personal_access_tokens/self',
 		},
 	};
 }


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/no-access-via-accesstoken-to-self-hosted-gitlab-ce-ee/21802

To sum it up:
The credentials check of the GitLab node is doing wrong, because it's checking the `/users` endpoint. But that endpoint is used for listing all users of an instance and requires the `api` scope. So if the token has no scope for `api` the credentials test will fail.

A better approach to checking the credentials, without needing any special scope for it, is the endpoint `/personal_access_tokens/self` (see https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header) which shows everything related to the currently used accessToken (e.g. the scopes and expiration date).