### PR TITLE
feat(core): Add Prometheus metrics for n8n events and API invocations (experimental)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -136,6 +136,7 @@
     "dotenv": "^8.0.0",
     "express": "^4.16.4",
     "express-openapi-validator": "^4.13.6",
+    "express-prom-bundle": "^6.6.0",
     "fast-glob": "^3.2.5",
     "flatted": "^3.2.4",
     "google-timezones-json": "^1.0.2",

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -182,6 +182,7 @@ export class InternalHooksClass implements IInternalHooksClass {
 		workflow: IWorkflowBase,
 		nodeName: string,
 	): Promise<void> {
+		const nodeInWorkflow = workflow.nodes.find((node) => node.name === nodeName);
 		void eventBus.sendNodeEvent({
 			eventName: 'n8n.node.started',
 			payload: {
@@ -189,6 +190,7 @@ export class InternalHooksClass implements IInternalHooksClass {
 				nodeName,
 				workflowId: workflow.id?.toString(),
 				workflowName: workflow.name,
+				nodeType: nodeInWorkflow?.type,
 			},
 		});
 	}
@@ -198,6 +200,7 @@ export class InternalHooksClass implements IInternalHooksClass {
 		workflow: IWorkflowBase,
 		nodeName: string,
 	): Promise<void> {
+		const nodeInWorkflow = workflow.nodes.find((node) => node.name === nodeName);
 		void eventBus.sendNodeEvent({
 			eventName: 'n8n.node.finished',
 			payload: {
@@ -205,6 +208,7 @@ export class InternalHooksClass implements IInternalHooksClass {
 				nodeName,
 				workflowId: workflow.id?.toString(),
 				workflowName: workflow.name,
+				nodeType: nodeInWorkflow?.type,
 			},
 		});
 	}

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -322,13 +322,10 @@ class Server extends AbstractServer {
 
 	async configure(): Promise<void> {
 		const enableMetrics = config.getEnv('endpoints.metrics.enable');
-		let register: Registry;
 
 		if (enableMetrics) {
 			const prefix = config.getEnv('endpoints.metrics.prefix');
-			register = new promClient.Registry();
-			register.setDefaultLabels({ prefix });
-			promClient.collectDefaultMetrics({ register });
+			promClient.collectDefaultMetrics({ prefix });
 		}
 
 		this.frontendSettings.isNpmAvailable = await exec('npm --version')
@@ -595,8 +592,8 @@ class Server extends AbstractServer {
 		// ----------------------------------------
 		if (enableMetrics) {
 			this.app.get('/metrics', async (req: express.Request, res: express.Response) => {
-				const response = await register.metrics();
-				res.setHeader('Content-Type', register.contentType);
+				const response = await promClient.register.metrics();
+				res.setHeader('Content-Type', promClient.register.contentType);
 				ResponseHelper.sendSuccessResponse(res, response, true, 200);
 			});
 		}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -581,6 +581,24 @@ export const schema = {
 				env: 'N8N_METRICS_PREFIX',
 				doc: 'An optional prefix for metric names. Default: n8n_',
 			},
+			forEachWorkflowId: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_FOREACH_WORKFLOW_ID',
+				doc: 'Whether to create a separate metric per workflow id. Default: false',
+			},
+			forEachNodeType: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_FOREACH_NODE_TYPE',
+				doc: 'Whether to create a separate metric per node type. Default: false',
+			},
+			forEachCredentialType: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_FOREACH_CREDENTIAL_TYPE',
+				doc: 'Whether to create a separate metric per credential type. Default: false',
+			},
 		},
 		rest: {
 			format: String,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -573,7 +573,7 @@ export const schema = {
 				format: 'Boolean',
 				default: false,
 				env: 'N8N_METRICS',
-				doc: 'Enable metrics endpoint',
+				doc: 'Enable /metrics endpoint. Default: false',
 			},
 			prefix: {
 				format: String,
@@ -581,23 +581,53 @@ export const schema = {
 				env: 'N8N_METRICS_PREFIX',
 				doc: 'An optional prefix for metric names. Default: n8n_',
 			},
-			forEachWorkflowId: {
+			includeDefaultMetrics: {
 				format: Boolean,
-				default: false,
-				env: 'N8N_METRICS_FOREACH_WORKFLOW_ID',
-				doc: 'Whether to create a separate metric per workflow id. Default: false',
+				default: true,
+				env: 'N8N_METRICS_INCLUDE_DEFAULT_METRICS',
+				doc: 'Whether to expose default system and node.js metrics. Default: true',
 			},
-			forEachNodeType: {
+			includeWorkflowIdLabel: {
 				format: Boolean,
 				default: false,
-				env: 'N8N_METRICS_FOREACH_NODE_TYPE',
-				doc: 'Whether to create a separate metric per node type. Default: false',
+				env: 'N8N_METRICS_INCLUDE_WORKFLOW_ID_LABEL',
+				doc: 'Whether to include a label for the workflow ID on workflow metrics. Default: false',
 			},
-			forEachCredentialType: {
+			includeNodeTypeLabel: {
 				format: Boolean,
 				default: false,
-				env: 'N8N_METRICS_FOREACH_CREDENTIAL_TYPE',
-				doc: 'Whether to create a separate metric per credential type. Default: false',
+				env: 'N8N_METRICS_INCLUDE_NODE_TYPE_LABEL',
+				doc: 'Whether to include a label for the node type on node metrics. Default: false',
+			},
+			includeCredentialTypeLabel: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_INCLUDE_CREDENTIAL_TYPE_LABEL',
+				doc: 'Whether to include a label for the credential type on credential metrics. Default: false',
+			},
+			includeApiEndpoints: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_INCLUDE_API_ENDPOINTS',
+				doc: 'Whether to expose metrics for API endpoints. Default: false',
+			},
+			includeApiPathLabel: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_INCLUDE_API_PATH_LABEL',
+				doc: 'Whether to include a label for the path of API invocations. Default: false',
+			},
+			includeApiMethodLabel: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_INCLUDE_API_METHOD_LABEL',
+				doc: 'Whether to include a label for the HTTP method (GET, POST, ...) of API invocations. Default: false',
+			},
+			includeApiStatusCodeLabel: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_METRICS_INCLUDE_API_STATUS_CODE_LABEL',
+				doc: 'Whether to include a label for the HTTP status code (200, 404, ...) of API invocations. Default: false',
 			},
 		},
 		rest: {

--- a/packages/cli/src/eventbus/EventMessageClasses/EventMessageAudit.ts
+++ b/packages/cli/src/eventbus/EventMessageClasses/EventMessageAudit.ts
@@ -35,6 +35,11 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	userEmail?: string;
 	firstName?: string;
 	lastName?: string;
+	credentialName?: string;
+	credentialType?: string;
+	credentialId?: string;
+	workflowId?: string;
+	workflowName?: string;
 }
 
 export interface EventMessageAuditOptions extends AbstractEventMessageOptions {

--- a/packages/cli/src/eventbus/EventMessageClasses/EventMessageNode.ts
+++ b/packages/cli/src/eventbus/EventMessageClasses/EventMessageNode.ts
@@ -11,6 +11,11 @@ export type EventNamesNodeType = typeof eventNamesNode[number];
 // --------------------------------------
 export interface EventPayloadNode extends AbstractEventPayload {
 	msg?: string;
+	executionId: string;
+	nodeName: string;
+	workflowId?: string;
+	workflowName: string;
+	nodeType?: string;
 }
 
 export interface EventMessageNodeOptions extends AbstractEventMessageOptions {

--- a/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
@@ -6,7 +6,10 @@ import { MessageEventBusLogWriter } from '../MessageEventBusWriter/MessageEventB
 import EventEmitter from 'events';
 import config from '@/config';
 import * as Db from '@/Db';
-import { messageEventBusDestinationFromDb } from '../MessageEventBusDestination/Helpers.ee';
+import {
+	messageEventBusDestinationFromDb,
+	sendPrometheusMetric,
+} from '../MessageEventBusDestination/Helpers.ee';
 import uniqby from 'lodash.uniqby';
 import { EventMessageConfirmSource } from '../EventMessageClasses/EventMessageConfirm';
 import {
@@ -205,6 +208,8 @@ class MessageEventBus extends EventEmitter {
 	}
 
 	private async emitMessage(msg: EventMessageTypes) {
+		await sendPrometheusMetric(msg);
+
 		// generic emit for external modules to capture events
 		// this is for internal use ONLY and not for use with custom destinations!
 		this.emit('message', msg);

--- a/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
@@ -8,7 +8,7 @@ import config from '@/config';
 import * as Db from '@/Db';
 import {
 	messageEventBusDestinationFromDb,
-	sendPrometheusMetric,
+	incrementPrometheusMetric,
 } from '../MessageEventBusDestination/Helpers.ee';
 import uniqby from 'lodash.uniqby';
 import { EventMessageConfirmSource } from '../EventMessageClasses/EventMessageConfirm';
@@ -208,7 +208,9 @@ class MessageEventBus extends EventEmitter {
 	}
 
 	private async emitMessage(msg: EventMessageTypes) {
-		await sendPrometheusMetric(msg);
+		if (config.getEnv('endpoints.metrics.enable')) {
+			await incrementPrometheusMetric(msg);
+		}
 
 		// generic emit for external modules to capture events
 		// this is for internal use ONLY and not for use with custom destinations!

--- a/packages/cli/src/eventbus/MessageEventBusDestination/Helpers.ee.ts
+++ b/packages/cli/src/eventbus/MessageEventBusDestination/Helpers.ee.ts
@@ -1,10 +1,17 @@
 /* eslint-disable import/no-cycle */
-import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+import {
+	EventMessageTypeNames,
+	LoggerProxy,
+	MessageEventBusDestinationTypeNames,
+} from 'n8n-workflow';
 import type { EventDestinations } from '@/databases/entities/MessageEventBusDestinationEntity';
 import type { MessageEventBusDestination } from './MessageEventBusDestination.ee';
 import { MessageEventBusDestinationSentry } from './MessageEventBusDestinationSentry.ee';
 import { MessageEventBusDestinationSyslog } from './MessageEventBusDestinationSyslog.ee';
 import { MessageEventBusDestinationWebhook } from './MessageEventBusDestinationWebhook.ee';
+import type { EventMessageTypes } from '../EventMessageClasses';
+import promClient from 'prom-client';
+import config from '../../config';
 
 export function messageEventBusDestinationFromDb(
 	dbData: EventDestinations,
@@ -23,4 +30,65 @@ export function messageEventBusDestinationFromDb(
 		}
 	}
 	return null;
+}
+
+function eventNameToMetricName(eventName: string): string {
+	return eventName.replace('n8n.', 'event_').replace(/\./g, '_');
+}
+
+function nodeTypeToMetricName(nodeType: string): string {
+	return nodeType.replace('n8n-nodes-', '').replace(/\./g, '_');
+}
+
+function credentialTypeToMetricName(nodeType: string): string {
+	return nodeType.replace(/\./g, '_');
+}
+
+export async function sendPrometheusMetric(msg: EventMessageTypes): Promise<boolean> {
+	if (!config.getEnv('endpoints.metrics.enable')) return false;
+	let metricName = eventNameToMetricName(msg.eventName);
+	const prefix = config.getEnv('endpoints.metrics.prefix');
+	switch (msg.__type) {
+		case EventMessageTypeNames.audit:
+			if (
+				config.getEnv('endpoints.metrics.forEachCredentialType') &&
+				msg.eventName.startsWith('n8n.audit.user.credentials') &&
+				msg.payload.credentialType
+			) {
+				metricName = `${prefix}${metricName}_${credentialTypeToMetricName(
+					msg.payload.credentialType,
+				)}`;
+			} else if (
+				config.getEnv('endpoints.metrics.forEachWorkflowId') &&
+				msg.eventName.startsWith('n8n.audit.workflow') &&
+				msg.payload.workflowId
+			) {
+				metricName = `${prefix}${metricName}_${msg.payload.workflowId?.toString() ?? 'unknown'}`;
+			}
+			break;
+		case EventMessageTypeNames.node:
+			if (config.getEnv('endpoints.metrics.forEachNodeType') && msg.payload.nodeType) {
+				metricName = `${prefix}${metricName}_${nodeTypeToMetricName(msg.payload.nodeType)}`;
+			}
+			break;
+		case EventMessageTypeNames.workflow:
+			if (config.getEnv('endpoints.metrics.forEachWorkflowId') && msg.payload.workflowId) {
+				metricName = `${prefix}${metricName}_${msg.payload.workflowId?.toString() ?? 'unknown'}`;
+			}
+			break;
+		case EventMessageTypeNames.generic:
+		default:
+	}
+
+	if (!promClient.validateMetricName(metricName)) {
+		LoggerProxy.debug(`Invalid metric name: ${metricName}`);
+		return false;
+	}
+	let counter = promClient.register.getSingleMetric(metricName) as promClient.Counter<string>;
+	if (!counter) {
+		counter = new promClient.Counter({ name: metricName, help: `n8n event ${msg.eventName}` });
+		promClient.register.registerMetric(counter);
+	}
+	counter.inc();
+	return true;
 }

--- a/packages/cli/src/eventbus/MessageEventBusDestination/Helpers.ee.ts
+++ b/packages/cli/src/eventbus/MessageEventBusDestination/Helpers.ee.ts
@@ -1,17 +1,17 @@
 /* eslint-disable import/no-cycle */
+import type { EventDestinations } from '@/databases/entities/MessageEventBusDestinationEntity';
+import { promClient } from '@/metrics';
 import {
 	EventMessageTypeNames,
 	LoggerProxy,
 	MessageEventBusDestinationTypeNames,
 } from 'n8n-workflow';
-import type { EventDestinations } from '@/databases/entities/MessageEventBusDestinationEntity';
+import config from '../../config';
+import type { EventMessageTypes } from '../EventMessageClasses';
 import type { MessageEventBusDestination } from './MessageEventBusDestination.ee';
 import { MessageEventBusDestinationSentry } from './MessageEventBusDestinationSentry.ee';
 import { MessageEventBusDestinationSyslog } from './MessageEventBusDestinationSyslog.ee';
 import { MessageEventBusDestinationWebhook } from './MessageEventBusDestinationWebhook.ee';
-import type { EventMessageTypes } from '../EventMessageClasses';
-import promClient from 'prom-client';
-import config from '../../config';
 
 export function messageEventBusDestinationFromDb(
 	dbData: EventDestinations,
@@ -32,63 +32,84 @@ export function messageEventBusDestinationFromDb(
 	return null;
 }
 
-function eventNameToMetricName(eventName: string): string {
-	return eventName.replace('n8n.', 'event_').replace(/\./g, '_');
+const prometheusCounters: Record<string, promClient.Counter<string> | null> = {};
+
+function getMetricNameForEvent(event: EventMessageTypes): string {
+	const prefix = config.getEnv('endpoints.metrics.prefix');
+	return prefix + event.eventName.replace('n8n.', '').replace(/\./g, '_') + '_total';
 }
 
-function nodeTypeToMetricName(nodeType: string): string {
+function getLabelValueForNode(nodeType: string): string {
 	return nodeType.replace('n8n-nodes-', '').replace(/\./g, '_');
 }
 
-function credentialTypeToMetricName(nodeType: string): string {
-	return nodeType.replace(/\./g, '_');
+function getLabelValueForCredential(credentialType: string): string {
+	return credentialType.replace(/\./g, '_');
 }
 
-export async function sendPrometheusMetric(msg: EventMessageTypes): Promise<boolean> {
-	if (!config.getEnv('endpoints.metrics.enable')) return false;
-	let metricName = eventNameToMetricName(msg.eventName);
-	const prefix = config.getEnv('endpoints.metrics.prefix');
-	switch (msg.__type) {
+function getLabelsForEvent(event: EventMessageTypes): Record<string, string> {
+	switch (event.__type) {
 		case EventMessageTypeNames.audit:
-			if (
-				config.getEnv('endpoints.metrics.forEachCredentialType') &&
-				msg.eventName.startsWith('n8n.audit.user.credentials') &&
-				msg.payload.credentialType
-			) {
-				metricName = `${prefix}${metricName}_${credentialTypeToMetricName(
-					msg.payload.credentialType,
-				)}`;
-			} else if (
-				config.getEnv('endpoints.metrics.forEachWorkflowId') &&
-				msg.eventName.startsWith('n8n.audit.workflow') &&
-				msg.payload.workflowId
-			) {
-				metricName = `${prefix}${metricName}_${msg.payload.workflowId?.toString() ?? 'unknown'}`;
+			if (event.eventName.startsWith('n8n.audit.user.credentials')) {
+				return config.getEnv('endpoints.metrics.includeCredentialTypeLabel')
+					? {
+							credential_type: getLabelValueForCredential(
+								event.payload.credentialType ?? 'unknown',
+							),
+					  }
+					: {};
+			}
+
+			if (event.eventName.startsWith('n8n.audit.workflow')) {
+				return config.getEnv('endpoints.metrics.includeWorkflowIdLabel')
+					? { workflow_id: event.payload.workflowId?.toString() ?? 'unknown' }
+					: {};
 			}
 			break;
+
 		case EventMessageTypeNames.node:
-			if (config.getEnv('endpoints.metrics.forEachNodeType') && msg.payload.nodeType) {
-				metricName = `${prefix}${metricName}_${nodeTypeToMetricName(msg.payload.nodeType)}`;
-			}
-			break;
+			return config.getEnv('endpoints.metrics.includeNodeTypeLabel')
+				? { node_type: getLabelValueForNode(event.payload.nodeType ?? 'unknown') }
+				: {};
+
 		case EventMessageTypeNames.workflow:
-			if (config.getEnv('endpoints.metrics.forEachWorkflowId') && msg.payload.workflowId) {
-				metricName = `${prefix}${metricName}_${msg.payload.workflowId?.toString() ?? 'unknown'}`;
-			}
-			break;
-		case EventMessageTypeNames.generic:
-		default:
+			return config.getEnv('endpoints.metrics.includeWorkflowIdLabel')
+				? { workflow_id: event.payload.workflowId?.toString() ?? 'unknown' }
+				: {};
 	}
 
-	if (!promClient.validateMetricName(metricName)) {
-		LoggerProxy.debug(`Invalid metric name: ${metricName}`);
-		return false;
-	}
-	let counter = promClient.register.getSingleMetric(metricName) as promClient.Counter<string>;
-	if (!counter) {
-		counter = new promClient.Counter({ name: metricName, help: `n8n event ${msg.eventName}` });
+	return {};
+}
+
+function getCounterSingletonForEvent(event: EventMessageTypes) {
+	if (!prometheusCounters[event.eventName]) {
+		const metricName = getMetricNameForEvent(event);
+
+		if (!promClient.validateMetricName(metricName)) {
+			LoggerProxy.debug(`Invalid metric name: ${metricName}. Ignoring it!`);
+			prometheusCounters[event.eventName] = null;
+			return null;
+		}
+
+		const counter = new promClient.Counter({
+			name: metricName,
+			help: `Total number of ${event.eventName} events.`,
+			labelNames: Object.keys(getLabelsForEvent(event)),
+		});
+
 		promClient.register.registerMetric(counter);
+		prometheusCounters[event.eventName] = counter;
 	}
-	counter.inc();
-	return true;
+
+	return prometheusCounters[event.eventName];
+}
+
+export async function incrementPrometheusMetric(event: EventMessageTypes): Promise<void> {
+	const counter = getCounterSingletonForEvent(event);
+
+	if (!counter) {
+		return;
+	}
+
+	counter.inc(getLabelsForEvent(event));
 }

--- a/packages/cli/src/eventbus/eventBusRoutes.ts
+++ b/packages/cli/src/eventbus/eventBusRoutes.ts
@@ -32,6 +32,7 @@ import {
 } from 'n8n-workflow';
 import { User } from '../databases/entities/User';
 import * as ResponseHelper from '@/ResponseHelper';
+import { EventMessageNode, EventMessageNodeOptions } from './EventMessageClasses/EventMessageNode';
 
 export const eventBusRouter = express.Router();
 
@@ -115,6 +116,9 @@ eventBusRouter.post(
 					break;
 				case EventMessageTypeNames.audit:
 					msg = new EventMessageAudit(req.body as EventMessageAuditOptions);
+					break;
+				case EventMessageTypeNames.node:
+					msg = new EventMessageNode(req.body as EventMessageNodeOptions);
 					break;
 				case EventMessageTypeNames.generic:
 				default:

--- a/packages/cli/src/metrics/index.ts
+++ b/packages/cli/src/metrics/index.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import config from '@/config';
+import { N8N_VERSION } from '@/constants';
+import * as ResponseHelper from '@/ResponseHelper';
+import express from 'express';
+import promBundle from 'express-prom-bundle';
+import promClient from 'prom-client';
+import semverParse from 'semver/functions/parse';
+
+export { promClient };
+
+export function configureMetrics(app: express.Application) {
+	if (!config.getEnv('endpoints.metrics.enable')) {
+		return;
+	}
+
+	setupDefaultMetrics();
+	setupN8nVersionMetric();
+	setupApiMetrics(app);
+	mountMetricsEndpoint(app);
+}
+
+function setupN8nVersionMetric() {
+	const n8nVersion = semverParse(N8N_VERSION || '0.0.0');
+
+	if (n8nVersion) {
+		const versionGauge = new promClient.Gauge({
+			name: config.getEnv('endpoints.metrics.prefix') + 'version_info',
+			help: 'n8n version info.',
+			labelNames: ['version', 'major', 'minor', 'patch'],
+		});
+
+		versionGauge.set(
+			{
+				version: n8nVersion.version,
+				major: n8nVersion.major,
+				minor: n8nVersion.minor,
+				patch: n8nVersion.patch,
+			},
+			1,
+		);
+	}
+}
+
+function setupDefaultMetrics() {
+	if (config.getEnv('endpoints.metrics.includeDefaultMetrics')) {
+		promClient.collectDefaultMetrics();
+	}
+}
+
+function setupApiMetrics(app: express.Application) {
+	if (config.getEnv('endpoints.metrics.includeApiEndpoints')) {
+		const metricsMiddleware = promBundle({
+			autoregister: false,
+			includeUp: false,
+			includePath: config.getEnv('endpoints.metrics.includeApiPathLabel'),
+			includeMethod: config.getEnv('endpoints.metrics.includeApiMethodLabel'),
+			includeStatusCode: config.getEnv('endpoints.metrics.includeApiStatusCodeLabel'),
+		});
+
+		app.use(['/rest/', '/webhook/', 'webhook-test/', '/api/'], metricsMiddleware);
+	}
+}
+
+function mountMetricsEndpoint(app: express.Application) {
+	app.get('/metrics', async (req: express.Request, res: express.Response) => {
+		const response = await promClient.register.metrics();
+		res.setHeader('Content-Type', promClient.register.contentType);
+		ResponseHelper.sendSuccessResponse(res, response, true, 200);
+	});
+}

--- a/packages/cli/src/metrics/index.ts
+++ b/packages/cli/src/metrics/index.ts
@@ -32,7 +32,7 @@ function setupN8nVersionMetric() {
 
 		versionGauge.set(
 			{
-				version: n8nVersion.version,
+				version: 'v' + n8nVersion.version,
 				major: n8nVersion.major,
 				minor: n8nVersion.minor,
 				patch: n8nVersion.patch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,7 @@ importers:
       dotenv: ^8.0.0
       express: ^4.16.4
       express-openapi-validator: ^4.13.6
+      express-prom-bundle: ^6.6.0
       fast-glob: ^3.2.5
       flatted: ^3.2.4
       google-timezones-json: ^1.0.2
@@ -252,6 +253,7 @@ importers:
       dotenv: 8.6.0
       express: 4.18.2
       express-openapi-validator: 4.13.8
+      express-prom-bundle: 6.6.0_prom-client@13.2.0
       fast-glob: 3.2.12
       flatted: 3.2.7
       google-timezones-json: 1.0.2
@@ -11561,6 +11563,17 @@ packages:
       path-to-regexp: 6.2.1
     dev: false
 
+  /express-prom-bundle/6.6.0_prom-client@13.2.0:
+    resolution: {integrity: sha512-tZh2P2p5a8/yxQ5VbRav011Poa4R0mHqdFwn9Swe/obXDe5F0jY9wtRAfNYnqk4LXY7akyvR/nrvAHxQPWUjsQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      prom-client: '>=12.0.0'
+    dependencies:
+      on-finished: 2.4.1
+      prom-client: 13.2.0
+      url-value-parser: 2.2.0
+    dev: false
+
   /express/4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
     engines: {node: '>= 0.10.0'}
@@ -21273,6 +21286,11 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  /url-value-parser/2.2.0:
+    resolution: {integrity: sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A==}
+    engines: {node: '>=6.0.0'}
+    dev: false
 
   /url/0.10.3:
     resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}


### PR DESCRIPTION
This PR adds more configurable metrics in Prometheus exposition format to the `/metrics` endpoint.

Which metric groups and labels to expose can be configured via environment variables (to some extent).

Below example output of the `/metrics` endpoint was generated with the following env vars configured:

## Environment variables:

````
N8N_METRICS=true
N8N_METRICS_PREFIX=n8n_
N8N_METRICS_INCLUDE_DEFAULT_METRICS=true
N8N_METRICS_INCLUDE_WORKFLOW_ID_LABEL=true
N8N_METRICS_INCLUDE_NODE_TYPE_LABEL=true
N8N_METRICS_INCLUDE_CREDENTIAL_TYPE_LABEL=true
N8N_METRICS_INCLUDE_API_ENDPOINTS=true
N8N_METRICS_INCLUDE_API_PATH_LABEL=true
N8N_METRICS_INCLUDE_API_METHOD_LABEL=true
N8N_METRICS_INCLUDE_API_STATUS_CODE_LABEL=true
````

## Example output of `GET /metrics`

```
# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total 1.611351

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total 0.261071

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 1.872422

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1674121593

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 257355776

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds 0.005210362

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds 0.00868352

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds 0.460849151

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds 0.011563190651685392

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds 0.006139661652063662

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds 0.012001279

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds 0.012148735

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds 0.012197887

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="WriteStream"} 2
nodejs_active_handles{type="ReadStream"} 1
nodejs_active_handles{type="Server"} 1
nodejs_active_handles{type="Socket"} 2

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total 6

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes 137408512

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes 129931048

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes 2207464

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only"} 176128
nodejs_heap_space_size_total_bytes{space="old"} 106844160
nodejs_heap_space_size_total_bytes{space="code"} 3776512
nodejs_heap_space_size_total_bytes{space="map"} 4202496
nodejs_heap_space_size_total_bytes{space="large_object"} 20779008
nodejs_heap_space_size_total_bytes{space="code_large_object"} 581632
nodejs_heap_space_size_total_bytes{space="new_large_object"} 0
nodejs_heap_space_size_total_bytes{space="new"} 1048576

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only"} 170944
nodejs_heap_space_size_used_bytes{space="old"} 101076768
nodejs_heap_space_size_used_bytes{space="code"} 3421824
nodejs_heap_space_size_used_bytes{space="map"} 3306456
nodejs_heap_space_size_used_bytes{space="large_object"} 20534376
nodejs_heap_space_size_used_bytes{space="code_large_object"} 542048
nodejs_heap_space_size_used_bytes{space="new_large_object"} 0
nodejs_heap_space_size_used_bytes{space="new"} 887696

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only"} 0
nodejs_heap_space_size_available_bytes{space="old"} 3857736
nodejs_heap_space_size_available_bytes{space="code"} 108928
nodejs_heap_space_size_available_bytes{space="map"} 821552
nodejs_heap_space_size_available_bytes{space="large_object"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object"} 1031072
nodejs_heap_space_size_available_bytes{space="new"} 143376

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v16.15.0",major="16",minor="15",patch="0"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor"} 8
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="1",kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="2",kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="5",kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor"} 10
nodejs_gc_duration_seconds_sum{kind="minor"} 0.011158959000371397
nodejs_gc_duration_seconds_count{kind="minor"} 10
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental"} 5
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental"} 6
nodejs_gc_duration_seconds_sum{kind="incremental"} 0.002568940999917686
nodejs_gc_duration_seconds_count{kind="incremental"} 6
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major"} 1
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major"} 3
nodejs_gc_duration_seconds_bucket{le="1",kind="major"} 3
nodejs_gc_duration_seconds_bucket{le="2",kind="major"} 3
nodejs_gc_duration_seconds_bucket{le="5",kind="major"} 3
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major"} 3
nodejs_gc_duration_seconds_sum{kind="major"} 0.03339293400011956
nodejs_gc_duration_seconds_count{kind="major"} 3
nodejs_gc_duration_seconds_bucket{le="0.001",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="0.01",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="0.1",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="1",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="2",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="5",kind="weakcb"} 4
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="weakcb"} 4
nodejs_gc_duration_seconds_sum{kind="weakcb"} 0.000053920999867841604
nodejs_gc_duration_seconds_count{kind="weakcb"} 4

# HELP n8n_version_info n8n version info.
# TYPE n8n_version_info gauge
n8n_version_info{version="v0.211.1",major="0",minor="211",patch="1"} 1

# HELP http_request_duration_seconds duration histogram of http responses labeled with: status_code, method, path
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{le="0.003",status_code="401",method="POST",path="/api/v1/audit"} 0
http_request_duration_seconds_bucket{le="0.03",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="0.1",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="0.3",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="1.5",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="10",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="+Inf",status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_sum{status_code="401",method="POST",path="/api/v1/audit"} 0.009538856
http_request_duration_seconds_count{status_code="401",method="POST",path="/api/v1/audit"} 1
http_request_duration_seconds_bucket{le="0.003",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="0.03",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="0.1",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="0.3",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="1.5",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="10",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="+Inf",status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_sum{status_code="401",method="POST",path="/api/v1/workflows"} 0.001645051
http_request_duration_seconds_count{status_code="401",method="POST",path="/api/v1/workflows"} 1
http_request_duration_seconds_bucket{le="0.003",status_code="200",method="POST",path="/rest/workflows/run"} 0
http_request_duration_seconds_bucket{le="0.03",status_code="200",method="POST",path="/rest/workflows/run"} 1
http_request_duration_seconds_bucket{le="0.1",status_code="200",method="POST",path="/rest/workflows/run"} 2
http_request_duration_seconds_bucket{le="0.3",status_code="200",method="POST",path="/rest/workflows/run"} 2
http_request_duration_seconds_bucket{le="1.5",status_code="200",method="POST",path="/rest/workflows/run"} 2
http_request_duration_seconds_bucket{le="10",status_code="200",method="POST",path="/rest/workflows/run"} 2
http_request_duration_seconds_bucket{le="+Inf",status_code="200",method="POST",path="/rest/workflows/run"} 2
http_request_duration_seconds_sum{status_code="200",method="POST",path="/rest/workflows/run"} 0.071720752
http_request_duration_seconds_count{status_code="200",method="POST",path="/rest/workflows/run"} 2

# HELP n8n_workflow_started_total Total number of n8n.workflow.started events.
# TYPE n8n_workflow_started_total counter
n8n_workflow_started_total{workflow_id="1"} 2

# HELP n8n_node_started_total Total number of n8n.node.started events.
# TYPE n8n_node_started_total counter
n8n_node_started_total{node_type="base_start"} 2
n8n_node_started_total{node_type="base_set"} 2
n8n_node_started_total{node_type="base_code"} 2

# HELP n8n_node_finished_total Total number of n8n.node.finished events.
# TYPE n8n_node_finished_total counter
n8n_node_finished_total{node_type="base_start"} 2
n8n_node_finished_total{node_type="base_set"} 2
n8n_node_finished_total{node_type="base_code"} 2

# HELP n8n_workflow_success_total Total number of n8n.workflow.success events.
# TYPE n8n_workflow_success_total counter
n8n_workflow_success_total{workflow_id="1"} 2
```