### PR TITLE
fix(editor): Allow special chars in node selector completion

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/itemIndex.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/itemIndex.completions.ts
@@ -65,7 +65,7 @@ export const itemIndexCompletions = (Vue as CodeNodeEditorMixin).extend({
 		selectorCompletions(context: CompletionContext, matcher: string | null = null) {
 			const pattern =
 				matcher === null
-					? /\$\((?<quotedNodeName>['"][\w\s]+['"])\)\..*/ // $('nodeName').
+					? /\$\((?<quotedNodeName>['"][\S\s]+['"])\)\..*/ // $('nodeName').
 					: new RegExp(`${matcher}\..*`);
 
 			const preCursor = context.matchBefore(pattern);


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-222/bug-code-node-autocomplete-breaks-when-in-node-name
