### PR TITLE
fix(ActiveCampaign Node): Fix additional fields not being sent when updating account contacts

### DIFF
--- a/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
@@ -509,7 +509,7 @@ export class ActiveCampaign implements INodeType {
 				} else if (resource === 'accountContact') {
 					if (operation === 'create') {
 						// ----------------------------------
-						//         account:create
+						//         accountContact:create
 						// ----------------------------------
 
 						requestMethod = 'POST';
@@ -524,7 +524,7 @@ export class ActiveCampaign implements INodeType {
 						} as IDataObject;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						addAdditionalFields(body.account as IDataObject, additionalFields);
+						addAdditionalFields(body.accountContact as IDataObject, additionalFields);
 					} else if (operation === 'update') {
 						// ----------------------------------
 						//         accountContact:update


### PR DESCRIPTION
For now, trying to set an additional field throws an error. This is because a non-existent object is passed as a `addAdditionalFields` function argument

```
ERROR: Cannot set properties of undefined (setting 'jobTitle')

TypeError: Cannot set properties of undefined (setting 'jobTitle')
    at addAdditionalFields (/app/node_modules/n8n-nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts:78:13)
    at Object.execute (/app/node_modules/n8n-nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts:527:7)
    at Workflow.runNode (/app/node_modules/n8n-workflow/src/Workflow.ts:1270:42)
    at /app/node_modules/n8n/node_modules/n8n-core/src/WorkflowExecute.ts:939:44
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

