### PR TITLE
fix(Google Drive Node): Use the correct mimetype on converted downloads

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/GoogleDrive.node.ts
@@ -2297,7 +2297,7 @@ export class GoogleDrive implements INodeType {
 							);
 						}
 
-						const mimeType = file.mimeType ?? response.headers['content-type'] ?? undefined;
+						const mimeType = response.headers['content-type'] ?? file.mimeType ?? undefined;
 						const fileName = downloadOptions.fileName ?? file.name ?? undefined;
 
 						const newItem: INodeExecutionData = {


### PR DESCRIPTION
When converting files, the converted file's mimetype should override the original mimetype

Fixes https://community.n8n.io/t/bug-with-google-drive-node-upload-function/21910