### PR TITLE
fix(editor): Fix save modal appearing post duplication of a workflow

### DIFF
--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -929,7 +929,6 @@ export const workflowHelpers = mixins(externalHooks, nodeHelpers, restApi, showM
 				const workflowData = await this.restApi().createNewWorkflow(workflowDataRequest);
 
 				this.workflowsStore.addWorkflow(workflowData);
-				this.workflowsStore.setWorkflowVersionId(workflowData.versionId);
 
 				if (
 					this.settingsStore.isEnterpriseFeatureEnabled(EnterpriseEditionFeature.Sharing) &&
@@ -953,6 +952,7 @@ export const workflowHelpers = mixins(externalHooks, nodeHelpers, restApi, showM
 
 				this.workflowsStore.setActive(workflowData.active || false);
 				this.workflowsStore.setWorkflowId(workflowData.id);
+				this.workflowsStore.setWorkflowVersionId(workflowData.versionId);
 				this.workflowsStore.setWorkflowName({ newName: workflowData.name, setStateDirty: false });
 				this.workflowsStore.setWorkflowSettings((workflowData.settings as IWorkflowSettings) || {});
 				this.uiStore.stateIsDirty = false;


### PR DESCRIPTION
The versionId in the store was being updated before any checking of "should this open in a new window" was done. This led to the versionId of the new duplicated workflow being used in the tab of the original workflow, leading to the save modal popping up erroneusly