### PR TITLE
ci: Fix CI timeout issues (no-changelog)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ const config = {
 	testEnvironment: 'node',
 	testRegex: '\\.(test|spec)\\.(js|ts)$',
 	testPathIgnorePatterns: ['/dist/', '/node_modules/'],
+	testTimeout: 10_000,
 	transform: {
 		'^.+\\.ts$': ['ts-jest', tsJestOptions],
 	},

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,6 @@ const config = {
 	testEnvironment: 'node',
 	testRegex: '\\.(test|spec)\\.(js|ts)$',
 	testPathIgnorePatterns: ['/dist/', '/node_modules/'],
-	testTimeout: 10_000,
 	transform: {
 		'^.+\\.ts$': ['ts-jest', tsJestOptions],
 	},

--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -3,6 +3,9 @@ import express, { Router } from 'express';
 import fs from 'fs/promises';
 import path from 'path';
 
+import validator from 'validator';
+import { middleware as openapiValidatorMiddleware } from 'express-openapi-validator';
+import YAML from 'yamljs';
 import type { HttpError } from 'express-openapi-validator/dist/framework/types';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { JsonObject } from 'swagger-ui-express';
@@ -19,7 +22,6 @@ async function createApiRouter(
 	publicApiEndpoint: string,
 ): Promise<Router> {
 	const n8nPath = config.getEnv('path');
-	const YAML = await import('yamljs');
 	const swaggerDocument = YAML.load(openApiSpecPath) as JsonObject;
 	// add the server depending on the config so the user can interact with the API
 	// from the Swagger UI
@@ -46,12 +48,10 @@ async function createApiRouter(
 		);
 	}
 
-	const { default: validator } = await import('validator');
-	const { middleware } = await import('express-openapi-validator');
 	apiController.use(
 		`/${publicApiEndpoint}/${version}`,
 		express.json(),
-		middleware({
+		openapiValidatorMiddleware({
 			apiSpec: openApiSpecPath,
 			operationHandlers: handlersDirectory,
 			validateRequests: true,

--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -16,7 +16,6 @@ async function createApiRouter(
 	version: string,
 	openApiSpecPath: string,
 	handlersDirectory: string,
-	swaggerThemeCss: string,
 	publicApiEndpoint: string,
 ): Promise<Router> {
 	const n8nPath = config.getEnv('path');
@@ -33,6 +32,8 @@ async function createApiRouter(
 
 	if (!config.getEnv('publicApi.swaggerUi.disabled')) {
 		const { serveFiles, setup } = await import('swagger-ui-express');
+		const swaggerThemePath = path.join(__dirname, 'swaggerTheme.css');
+		const swaggerThemeCss = await fs.readFile(swaggerThemePath, { encoding: 'utf-8' });
 
 		apiController.use(
 			`/${publicApiEndpoint}/${version}/docs`,
@@ -129,15 +130,13 @@ async function createApiRouter(
 export const loadPublicApiVersions = async (
 	publicApiEndpoint: string,
 ): Promise<{ apiRouters: express.Router[]; apiLatestVersion: number }> => {
-	const swaggerThemePath = path.join(__dirname, 'swaggerTheme.css');
 	const folders = await fs.readdir(__dirname);
-	const css = (await fs.readFile(swaggerThemePath)).toString();
 	const versions = folders.filter((folderName) => folderName.startsWith('v'));
 
 	const apiRouters = await Promise.all(
 		versions.map(async (version) => {
 			const openApiPath = path.join(__dirname, version, 'openapi.yml');
-			return createApiRouter(version, openApiPath, __dirname, css, publicApiEndpoint);
+			return createApiRouter(version, openApiPath, __dirname, publicApiEndpoint);
 		}),
 	);
 

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -22,6 +22,7 @@ if (inE2ETests) {
 }
 if (inTest) {
 	process.env.N8N_PUBLIC_API_DISABLED = 'true';
+	process.env.N8N_PUBLIC_API_SWAGGERUI_DISABLED = 'true';
 } else {
 	dotenv.config();
 }

--- a/packages/cli/test/integration/publicApi/credentials.test.ts
+++ b/packages/cli/test/integration/publicApi/credentials.test.ts
@@ -18,7 +18,11 @@ let credentialOwnerRole: Role;
 let saveCredential: SaveCredentialFunction;
 
 beforeAll(async () => {
-	app = await utils.initTestServer({ endpointGroups: ['publicApi'], applyAuth: false });
+	app = await utils.initTestServer({
+		endpointGroups: ['publicApi'],
+		applyAuth: false,
+		enablePublicAPI: true,
+	});
 	await testDb.init();
 
 	utils.initConfigFile();

--- a/packages/cli/test/integration/publicApi/executions.test.ts
+++ b/packages/cli/test/integration/publicApi/executions.test.ts
@@ -13,7 +13,11 @@ let globalOwnerRole: Role;
 let workflowRunner: ActiveWorkflowRunner;
 
 beforeAll(async () => {
-	app = await utils.initTestServer({ endpointGroups: ['publicApi'], applyAuth: false });
+	app = await utils.initTestServer({
+		endpointGroups: ['publicApi'],
+		applyAuth: false,
+		enablePublicAPI: true,
+	});
 	await testDb.init();
 
 	globalOwnerRole = await testDb.getGlobalOwnerRole();
@@ -43,7 +47,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	await workflowRunner.removeAll();
+	await workflowRunner?.removeAll();
 });
 
 afterAll(async () => {

--- a/packages/cli/test/integration/publicApi/workflows.test.ts
+++ b/packages/cli/test/integration/publicApi/workflows.test.ts
@@ -17,7 +17,11 @@ let workflowOwnerRole: Role;
 let workflowRunner: ActiveWorkflowRunner;
 
 beforeAll(async () => {
-	app = await utils.initTestServer({ endpointGroups: ['publicApi'], applyAuth: false });
+	app = await utils.initTestServer({
+		endpointGroups: ['publicApi'],
+		applyAuth: false,
+		enablePublicAPI: true,
+	});
 	await testDb.init();
 
 	const [fetchedGlobalOwnerRole, fetchedGlobalMemberRole, fetchedWorkflowOwnerRole] =
@@ -49,7 +53,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	await workflowRunner.removeAll();
+	await workflowRunner?.removeAll();
 });
 
 afterAll(async () => {

--- a/packages/cli/test/integration/shared/testDb.ts
+++ b/packages/cli/test/integration/shared/testDb.ts
@@ -95,7 +95,8 @@ export async function init() {
  * Drop test DB, closing bootstrap connection if existing.
  */
 export async function terminate() {
-	await Db.getConnection().destroy();
+	const connection = Db.getConnection();
+	if (connection.isInitialized) await connection.destroy();
 }
 
 /**


### PR DESCRIPTION
1. load public api versions only when needed
2. do not load swagger-ui in tests
3. revert lazy-loading of openapi dependencies