### PR TITLE
feat(core): Export OpenAPI spec for external tools

### DIFF
--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -49,6 +49,10 @@ async function createApiRouter(
 		);
 	}
 
+	apiController.get(`/${publicApiEndpoint}/${version}/openapi.yml`, (req, res) => {
+		res.sendFile(openApiSpecPath);
+	});
+
 	apiController.use(
 		`/${publicApiEndpoint}/${version}`,
 		express.json(),


### PR DESCRIPTION
The generated spec is available at `/api/v1/openapi.yml`