### PR TITLE
WIP:✨ Add OAuth2 for Jira

### DIFF
--- a/packages/nodes-base/credentials/JiraSoftwareCloudOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/JiraSoftwareCloudOAuth2Api.credentials.ts
@@ -1,0 +1,78 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+const scopes = [
+	'offline_access',
+	'read:jira-user',
+	'read:jira-work',
+	'write:jira-work',
+	'manage:jira-webhook',
+	'manage:jira-project',
+	'manage:jira-configuration',
+	// 'manage:jira-data-provider',
+	// 'read:servicedesk-request',
+	// 'manage:servicedesk-customer',
+	// 'write:servicedesk-request',
+	// 'read:servicemanagement-insight-objects',
+];
+
+export class JiraSoftwareCloudOAuth2Api implements ICredentialType {
+	name = 'jiraSoftwareCloudOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Jira SW Cloud OAuth2 API';
+
+	documentationUrl = 'jira';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'authorizationCode',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://auth.atlassian.com/authorize',
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://auth.atlassian.com/oauth/token',
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'audience=api.atlassian.com',
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'response_type=code',
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: 'prompt=consent',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'body',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			// type: 'hidden',
+			type: 'string',
+			default: scopes.join(' '),
+		},
+	];
+}

--- a/packages/nodes-base/nodes/Jira/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jira/GenericFunctions.ts
@@ -22,14 +22,17 @@ export async function jiraSoftwareCloudApiRequest(
 	const jiraVersion = this.getNodeParameter('jiraVersion', 0) as string;
 
 	let domain = '';
-	let credentialType: string;
+	let credentialType = 'jiraSoftwareCloudApi';
 
-	if (jiraVersion === 'server') {
-		domain = (await this.getCredentials('jiraSoftwareServerApi')).domain as string;
-		credentialType = 'jiraSoftwareServerApi';
+	if (jiraVersion === 'cloudOAuth2') {
+		const cloudID = this.getNodeParameter('cloudID', 0) as string;
+		credentialType = 'jiraSoftwareCloudOAuth2Api';
+		domain = `https://api.atlassian.com/ex/jira/${cloudID}`;
 	} else {
-		domain = (await this.getCredentials('jiraSoftwareCloudApi')).domain as string;
-		credentialType = 'jiraSoftwareCloudApi';
+		if (jiraVersion === 'server') {
+			credentialType = 'jiraSoftwareServerApi';
+		}
+		domain = (await this.getCredentials(credentialType)).domain as string;
 	}
 
 	const options: OptionsWithUri = {

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -72,6 +72,15 @@ export class Jira implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'jiraSoftwareCloudOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						jiraVersion: ['cloudOAuth2'],
+					},
+				},
+			},
 		],
 		properties: [
 			{
@@ -84,11 +93,32 @@ export class Jira implements INodeType {
 						value: 'cloud',
 					},
 					{
+						name: 'Cloud OAuth2',
+						value: 'cloudOAuth2',
+					},
+					{
 						name: 'Server (Self Hosted)',
 						value: 'server',
 					},
 				],
 				default: 'cloud',
+			},
+			{
+				displayName: 'Jira Instance Name or ID',
+				name: 'cloudID',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+				displayOptions: {
+					show: {
+						jiraVersion: ['cloudOAuth2'],
+					},
+				},
+				typeOptions: {
+					loadOptionsMethod: 'getCloudIDs',
+					loadOptionsDependsOn: ['jiraVersion'],
+				},
+				default: '',
 			},
 			{
 				displayName: 'Resource',
@@ -457,6 +487,31 @@ export class Jira implements INodeType {
 					}
 					return 0;
 				});
+
+				return returnData;
+			},
+
+			async getCloudIDs(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+
+				const instances = await jiraSoftwareCloudApiRequest.call(
+					this,
+					'',
+					'GET',
+					{},
+					{},
+					'https://api.atlassian.com/oauth/token/accessible-resources',
+				);
+
+				for (const instance of instances) {
+					const instanceName = `${instance.name} (${instance.url.replace(/https?:\/\//i, '')})`;
+					const instanceId = instance.id;
+
+					returnData.push({
+						name: instanceName,
+						value: instanceId,
+					});
+				}
 
 				return returnData;
 			},

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -161,6 +161,7 @@
       "dist/credentials/IterableApi.credentials.js",
       "dist/credentials/JenkinsApi.credentials.js",
       "dist/credentials/JiraSoftwareCloudApi.credentials.js",
+      "dist/credentials/JiraSoftwareCloudOAuth2Api.credentials.js",
       "dist/credentials/JiraSoftwareServerApi.credentials.js",
       "dist/credentials/JotFormApi.credentials.js",
       "dist/credentials/Kafka.credentials.js",


### PR DESCRIPTION
Adds OAuth2 to the Jira and Jira Trigger nodes:
<img width="454" alt="SCR-20230202-gjf" src="https://user-images.githubusercontent.com/939704/216204479-c9aebcf0-5b7f-406e-a2e0-408b91537a6b.png">

### Changes
- Adds a new credential type `jiraSoftwareCloudOAuth2Api`
- Adds parameter to select the Jira Instance Name/ID to operate against
- Sets the baseURL to `https://api.atlassian.com/ex/jira/${cloudID}`

### To Test
1. Create an Atlassian `OAuth 2.0 integration` - https://developer.atlassian.com/console/myapps/
2. Add `OAuth 2.0 (3LO)` authorisation type with your callback URL
3. Add Jira scope permissions:
    - offline_access
    - read:jira-user
    - read:jira-work
    - write:jira-work
    - manage:jira-webhook
    - manage:jira-project
    - manage:jira-configuration

### ToDo
Currently having issues with the Jira Trigger node which has changes based on the working Jira node:
1. Finding the credentials:
`2023-02-01T23:50:16.895Z | error    | NodeOperationError: Credentials not found "{ file: 'ErrorReporterProxy.js', function: 'report' }"`
2. Finding/running the loadOptions function:
`2023-02-01T23:50:13.356Z | error    | Error: The node-type "n8n-nodes-base.jiraTrigger" does not have the method "getCloudIDs" defined! "{ file: 'ErrorReporterProxy.js', function: 'report' }"`