### PR TITLE
test: Disable resource caching when running e2e tests (no-changelog)

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -57,8 +57,8 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('waitForLoad', () => {
-	cy.getByTestId('node-view-loader').should('not.exist', { timeout: 10000 });
-	cy.get('.el-loading-mask').should('not.exist', { timeout: 10000 });
+	cy.getByTestId('node-view-loader',  { timeout: 10000 }).should('not.exist');
+	cy.get('.el-loading-mask',  { timeout: 10000 }).should('not.exist');
 });
 
 Cypress.Commands.add('signin', ({ email, password }) => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,15 +14,16 @@
 // ***********************************************************
 
 import './commands';
-beforeEach(() => {
-	cy.intercept(
-		'/**/*',
-		{ middleware: true },
-		(req) => {
-			req.on('before:response', (res) => {
-				// force all API responses to not be cached
-				res.headers['cache-control'] = 'no-cache, no-store'
-			})
-		}
-	)
+// Disable browser caching before each test
+before(() => {
+	if (Cypress.browser.family === 'chromium') {
+		Cypress.automation('remote:debugger:protocol', {
+			command: 'Network.enable',
+			params: {}
+		});
+		Cypress.automation('remote:debugger:protocol', {
+			command: 'Network.setCacheDisabled',
+			params: { cacheDisabled: true }
+		});
+	}
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,3 +14,15 @@
 // ***********************************************************
 
 import './commands';
+beforeEach(() => {
+	cy.intercept(
+		'/**/*',
+		{ middleware: true },
+		(req) => {
+			req.on('before:response', (res) => {
+				// force all API responses to not be cached
+				res.headers['cache-control'] = 'no-cache, no-store'
+			})
+		}
+	)
+})


### PR DESCRIPTION
The node-creator spec is failing because the intercept can't hook `types/nodes.json` because it's being cached by the browser. This PR sets `cacheDisabled` to true via Chromium `remote:debugger:protocol` effectively preventing the browser from caching assets. 
I also notice that the timeout for the `waitForLoad` command is passed in the wrong way so I've fixed that, this should generally help with tests flakiness as it often takes more than 4s(default CY timeout) to load page in GH runner.
Github issue / Community forum post (link here to close automatically):
