### PR TITLE
✨ Add Redis Sentinel support

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -194,7 +194,20 @@ export abstract class AbstractServer {
 		const { host, port, username, password, db }: RedisOptions = config.getEnv('queue.bull.redis');
 		const redisConnectionTimeoutLimit = config.getEnv('queue.bull.redis.timeoutThreshold');
 
+		let sentinelConfig = {};
+		const sentinelEnabled = config.getEnv('queue.bull.sentinel.enabled');
+		if (sentinelEnabled) {
+			const sentinelHosts: string = config.getEnv('queue.bull.sentinel.sentinels');
+			const { name, sentinelPassword }: RedisOptions = config.getEnv('queue.bull.sentinel');
+			const sentinels = sentinelHosts.split(',').map((x) => ({
+				host: x.split(':')[0],
+				port: x.split(':')[1],
+			}));
+			sentinelConfig = { name, sentinels, sentinelPassword };
+		}
+
 		const redis = new Redis({
+			...sentinelConfig,
 			host,
 			port,
 			db,

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -29,7 +29,21 @@ export class Queue {
 
 	async init() {
 		const prefix = config.getEnv('queue.bull.prefix');
-		const redisOptions: RedisOptions = config.getEnv('queue.bull.redis');
+		let redisOptions: RedisOptions = config.getEnv('queue.bull.redis');
+
+		const sentinelEnabled = config.getEnv('queue.bull.sentinel.enabled');
+		let sentinelConfig = {};
+		if (sentinelEnabled) {
+			const sentinelHosts: string = config.getEnv('queue.bull.sentinel.sentinels');
+			const { name, sentinelPassword }: RedisOptions = config.getEnv('queue.bull.sentinel');
+			const sentinels = sentinelHosts.split(',').map((x) => ({
+				host: x.split(':')[0],
+				port: x.split(':')[1],
+			}));
+			sentinelConfig = { name, sentinels, sentinelPassword };
+		}
+
+		redisOptions = { ...redisOptions, ...sentinelConfig };
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		const { default: Bull } = await import('bull');

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -387,6 +387,32 @@ export const schema = {
 					env: 'QUEUE_BULL_REDIS_USERNAME',
 				},
 			},
+			sentinel: {
+				enabled: {
+					doc: 'Enable Redis Sentinel',
+					format: Boolean,
+					default: false,
+					env: 'QUEUE_BULL_SENTINEL_ENABLED',
+				},
+				name: {
+					doc: 'Master group name of the Sentinel',
+					format: String,
+					default: 'mymaster',
+					env: 'QUEUE_BULL_SENTINEL_NAME',
+				},
+				sentinels: {
+					doc: 'Contains a comma separated list of Redis Sentinel hosts in <host>:<port> format.',
+					format: String,
+					default: 'localhost:26379',
+					env: 'QUEUE_BULL_SENTINEL_SENTINELS',
+				},
+				sentinelPassword: {
+					doc: 'Contains a comma separated list of Redis Sentinel hosts in <host>:<port> format.',
+					format: String,
+					default: '',
+					env: 'QUEUE_BULL_SENTINEL_PASSWORD',
+				},
+			},
 			queueRecoveryInterval: {
 				doc: 'If > 0 enables an active polling to the queue that can recover for Redis crashes. Given in seconds; 0 is disabled. May increase Redis traffic significantly.',
 				format: Number,

--- a/packages/cli/src/config/types.d.ts
+++ b/packages/cli/src/config/types.d.ts
@@ -76,6 +76,7 @@ type ToReturnType<T extends ConfigOptionPath> = T extends NumericPath
 
 type ExceptionPaths = {
 	'queue.bull.redis': object;
+	'queue.bull.sentinel': object;
 	binaryDataManager: IBinaryDataConfig;
 	'nodes.exclude': string[] | undefined;
 	'nodes.include': string[] | undefined;


### PR DESCRIPTION
This PR adds Redis Sentinel support for HA using the underlying functionality of the ioredis library. It will connect to one of the supplied sentinels and get the current master. You can provide sentinels in a comma separated list in `<host>:<port>` format.

1. Connecting to a Sentinel
2. Getting the list of other Sentinels for redundancy
3. Connecting to the current master node
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/939704/216609592-e8bf07a0-4f25-41f8-881c-2b3c9cf99008.png">


Example config:
```bash
DEBUG=ioredis:* \
N8N_LOG_LEVEL=debug \
N8N_DIAGNOSTICS_ENABLED=false \
EXECUTIONS_MODE=queue \
QUEUE_BULL_REDIS_PASSWORD=passw0rd \
QUEUE_BULL_SENTINEL_ENABLED=true \
QUEUE_BULL_SENTINEL_SENTINELS="redis-sentinel-1:26379,redis-sentinel-2:26379,redis-sentinel-3:26379" \
./packages/cli/bin/n8n
```

You can also use a Sentinel password with `QUEUE_BULL_SENTINEL_PASSWORD`.

This is a first cut, I'm hoping to do more failure testing next week.

