### PR TITLE
ci: Enable ARM64 builds for custom images (no-changelog)

### DIFF
--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           context: .
           file: ./docker/images/n8n-custom/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ github.event.inputs.tag || 'nightly' }}
           no-cache: true


### PR DESCRIPTION
[Publishing a `nightly` image from this branch](https://github.com/n8n-io/n8n/actions/runs/4084854298).