### PR TITLE
fix: Add download attachments button to Gmail node

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -219,6 +219,7 @@ export async function parseRawEmail(
 
 	messageData: any,
 	dataPropertyNameDownload: string,
+	downloadAttachments: boolean
 ): Promise<INodeExecutionData> {
 	const messageEncoded = Buffer.from(messageData.raw, 'base64').toString('utf8');
 	const responseData = await simpleParser(messageEncoded);
@@ -230,11 +231,6 @@ export async function parseRawEmail(
 
 	const binaryData: IBinaryKeyData = {};
 	if (responseData.attachments) {
-		const downloadAttachments = this.getNodeParameter(
-			'options.downloadAttachments',
-			0,
-			false,
-		) as boolean;
 		if (downloadAttachments) {
 			for (let i = 0; i < responseData.attachments.length; i++) {
 				const attachment = responseData.attachments[i];

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -187,7 +187,7 @@ export class GmailTrigger implements INodeType {
 						name: 'downloadAttachments',
 						type: 'boolean',
 						default: false,
-						description: "Whether the emaail's attachments will be downloaded",
+						description: "Whether the email's attachments will be downloaded",
 					},
 				],
 			},
@@ -284,11 +284,14 @@ export class GmailTrigger implements INodeType {
 				if (!simple) {
 					const dataPropertyNameDownload =
 						(options.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+					const downloadAttachments =
+						(options.downloadAttachments as boolean) || false;
 
 					responseData[i] = await parseRawEmail.call(
 						this,
 						responseData[i],
 						dataPropertyNameDownload,
+						downloadAttachments,
 					);
 				}
 			}

--- a/packages/nodes-base/nodes/Google/Gmail/v1/GmailV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v1/GmailV1.node.ts
@@ -505,11 +505,14 @@ export class GmailV1 implements INodeType {
 						if (format === 'resolved') {
 							const dataPropertyNameDownload =
 								(additionalFields.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+							const downloadAttachments =
+								(additionalFields.downloadAttachments as boolean) || false;
 
 							nodeExecutionData = await parseRawEmail.call(
 								this,
 								responseData,
 								dataPropertyNameDownload,
+								downloadAttachments,
 							);
 						} else {
 							nodeExecutionData = {
@@ -578,11 +581,14 @@ export class GmailV1 implements INodeType {
 								if (format === 'resolved') {
 									const dataPropertyNameDownload =
 										(additionalFields.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+									const downloadAttachments =
+										(additionalFields.downloadAttachments as boolean) || false;
 
 									responseData[index] = await parseRawEmail.call(
 										this,
 										responseData[index],
 										dataPropertyNameDownload,
+										downloadAttachments,
 									);
 								}
 							}
@@ -725,11 +731,14 @@ export class GmailV1 implements INodeType {
 						if (format === 'resolved') {
 							const dataPropertyNameDownload =
 								(additionalFields.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+							const downloadAttachments =
+								(additionalFields.downloadAttachments as boolean) || false;
 
 							nodeExecutionData = await parseRawEmail.call(
 								this,
 								responseData.message,
 								dataPropertyNameDownload,
+								downloadAttachments,
 							);
 
 							// Add the draft-id
@@ -806,11 +815,14 @@ export class GmailV1 implements INodeType {
 								if (format === 'resolved') {
 									const dataPropertyNameDownload =
 										(additionalFields.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+									const downloadAttachments =
+										(additionalFields.downloadAttachments as boolean) || false;
 									const id = responseData[index].id;
 									responseData[index] = await parseRawEmail.call(
 										this,
 										responseData[index].message,
 										dataPropertyNameDownload,
+										downloadAttachments,
 									);
 
 									// Add the draft-id

--- a/packages/nodes-base/nodes/Google/Gmail/v1/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v1/MessageDescription.ts
@@ -363,6 +363,13 @@ export const messageFields: INodeProperties[] = [
 					'Prefix for name of the binary property to which to write the attachment. An index starting with 0 will be added. So if name is "attachment_" the first attachment is saved to "attachment_0".',
 			},
 			{
+				displayName: 'Download Attachments',
+				name: 'downloadAttachments',
+				type: 'boolean',
+				default: false,
+				description: "Whether the email's attachments will be downloaded",
+			},
+			{
 				displayName: 'Format',
 				name: 'format',
 				type: 'options',

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -365,11 +365,14 @@ export class GmailV2 implements INodeType {
 						if (!simple) {
 							const dataPropertyNameDownload =
 								(options.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+							const downloadAttachments =
+								(options.downloadAttachments as boolean) || false;
 
 							nodeExecutionData = await parseRawEmail.call(
 								this,
 								responseData,
 								dataPropertyNameDownload,
+								downloadAttachments,
 							);
 						} else {
 							const [json, _] = await simplifyOutput.call(this, [responseData]);
@@ -431,11 +434,14 @@ export class GmailV2 implements INodeType {
 							if (!simple) {
 								const dataPropertyNameDownload =
 									(options.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+								const downloadAttachments =
+									(options.downloadAttachments as boolean) || false;
 
 								responseData[index] = await parseRawEmail.call(
 									this,
 									responseData[index],
 									dataPropertyNameDownload,
+									downloadAttachments,
 								);
 							}
 						}
@@ -580,11 +586,14 @@ export class GmailV2 implements INodeType {
 
 						const dataPropertyNameDownload =
 							(options.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+						const downloadAttachments =
+							(options.downloadAttachments as boolean) || false;
 
 						const nodeExecutionData = await parseRawEmail.call(
 							this,
 							responseData.message,
 							dataPropertyNameDownload,
+							downloadAttachments,
 						);
 
 						// Add the draft-id
@@ -646,11 +655,14 @@ export class GmailV2 implements INodeType {
 
 							const dataPropertyNameDownload =
 								(options.dataPropertyAttachmentsPrefixName as string) || 'attachment_';
+							const downloadAttachments =
+								(options.downloadAttachments as boolean) || false;
 							const id = responseData[index].id;
 							responseData[index] = await parseRawEmail.call(
 								this,
 								responseData[index].message,
 								dataPropertyNameDownload,
+								downloadAttachments,
 							);
 
 							// Add the draft-id


### PR DESCRIPTION
Fixes [this](https://community.n8n.io/t/get-gmail-binary-but-no-binary/17486/12) post.

Hi, I was using Gmail Node and found I cannot download attachments. More about the issue: [message](https://community.n8n.io/t/get-gmail-binary-but-no-binary/17486/12?u=mjasion).

This PR fixes this issue by adding UI button to download attachments.

### Description of the issue

<details>

Checking the code I found an `if` statement for checking if the node has to download attachments setting:

https://github.com/n8n-io/n8n/blob/8d9b64e26ee8f890db3e2e9b2fa32072eb5dd7f4/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts#L238

If I understood correctly, the node parameter is looking for `options.downloadAttachments`
https://github.com/n8n-io/n8n/blob/8d9b64e26ee8f890db3e2e9b2fa32072eb5dd7f4/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts#L234

which exists in GmailV2, while in GmailV1 not(I don't understand the differences between GmailV1 & GmailV2.)

### What I did

In both Gmail node implementations, before the `parseRaw` function,  the `downloadAttachments` variable is read and being passed the same as `dataPropertyNameDownload`.


</details>

### Screenshots

<details>

Node, with button:
![image](https://user-images.githubusercontent.com/5058132/216778293-1b16d065-e780-4eae-bc79-6062f1ef96b6.png)

And Gdrive node:
![image](https://user-images.githubusercontent.com/5058132/216778376-8c416da5-1349-40c5-999f-85ce76bb2012.png)

</details>

![image](https://user-images.githubusercontent.com/5058132/216778390-65351d09-7f8b-4511-a0d9-cc86af5566ab.png)


