### PR TITLE
feat: Airtable - encourage use of new Personal Access Tokens and send auth in header

### DIFF
--- a/packages/nodes-base/credentials/AirtableApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtableApi.credentials.ts
@@ -22,8 +22,8 @@ export class AirtableApi implements ICredentialType {
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
-			qs: {
-				api_key: '={{$credentials.apiKey}}',
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
 			},
 		},
 	};

--- a/packages/nodes-base/credentials/AirtableApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtableApi.credentials.ts
@@ -9,7 +9,9 @@ export class AirtableApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'API Key',
+			displayName: 'Personal Access Token (or User API Key)',
+			description:
+				'Personal Access Tokens start with "pat" and User API keys start with "key". User API keys will stop working in early 2024.',
 			name: 'apiKey',
 			type: 'string',
 			typeOptions: { password: true },

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -39,14 +39,14 @@ export class Airtable implements INodeType {
 					{
 						name: 'Append',
 						value: 'append',
-						description: 'Append the data to a table',
-						action: 'Append data to a table',
+						description: 'Append the data to a table (requires data.records:write scope)',
+						action: 'Append data to a table (requires data.records:write scope)',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Delete data from a table',
-						action: 'Delete data from a table',
+						description: 'Delete data from a table (requires data.records:write scope)',
+						action: 'Delete data from a table (requires data.records:write scope)',
 					},
 					{
 						name: 'List',
@@ -57,14 +57,14 @@ export class Airtable implements INodeType {
 					{
 						name: 'Read',
 						value: 'read',
-						description: 'Read data from a table',
-						action: 'Read data from a table',
+						description: 'Read data from a table (requires data.records:read scope)',
+						action: 'Read data from a table (requires data.records:read scope)',
 					},
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Update data in a table',
-						action: 'Update data in a table',
+						description: 'Update data in a table (requires data.records:write scope)',
+						action: 'Update data in a table (requires data.records:write scope)',
 					},
 				],
 				default: 'read',

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -36,11 +36,6 @@ export async function apiRequest(
 ): Promise<any> {
 	query = query || {};
 
-	// For some reason for some endpoints the bearer auth does not work
-	// and it returns 404 like for the /meta request. So we always send
-	// it as query string.
-	// query.api_key = credentials.apiKey;
-
 	const options: OptionsWithUri = {
 		headers: {},
 		method,


### PR DESCRIPTION
## Background
[In January 2023, Airtable GA'ed improved API authentication options, new APIs, and the deprecation timeline of User API keys](https://airtable.com/developers/web/api/changelog#anchor-2023-01-18). While OAuth is preferred for third-party integration platforms like n8n, it's important to at least support the new personal access tokens (PATs) which **must** be used in an `Authorization` header instead of via query string (`?api_key=keyXXX`). 

ℹ️ There should not be any degradation for user API keys that were previously passed in via query string. They have always been allowed to be passed through headers as well. 

## This PR
- Updates language in the existing API credential provider to mention PATs (patXXX) and that User API Keys (keyXXX) will eventually stop working
- Updates the credential provider to use the `Authorization` header instead of query string

## Todos
- [ ] [Update n8n credential docs](https://docs.n8n.io/integrations/builtin/credentials/airtable/) to mention PATs. The docs should be sure to mention that users will need to select the correct [scopes](https://airtable.com/developers/web/api/scopes) to add to their PATs. User API keys effectively included all access the user account had; PATs need to have specific scopes selected (just like OAuth)

## Future PRs should...
- Implement OAuth 2 w/ PKCE, which n8n does not yet natively support (at the time of this writing)