### PR TITLE
feat: Airtable - add metadata operations and list records params

### DIFF
--- a/packages/nodes-base/credentials/AirtableApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtableApi.credentials.ts
@@ -22,8 +22,8 @@ export class AirtableApi implements ICredentialType {
 	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
-			qs: {
-				api_key: '={{$credentials.apiKey}}',
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
 			},
 		},
 	};

--- a/packages/nodes-base/credentials/AirtableApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtableApi.credentials.ts
@@ -9,7 +9,9 @@ export class AirtableApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'API Key',
+			displayName: 'Personal Access Token (or User API Key)',
+			description:
+				'Personal Access Tokens start with "pat" and User API keys start with "key". User API keys will stop working in early 2024.',
 			name: 'apiKey',
 			type: 'string',
 			typeOptions: { password: true },

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -71,7 +71,7 @@ export class Airtable implements INodeType {
 			},
 
 			// ----------------------------------
-			//         All
+			//         All record actions
 			// ----------------------------------
 
 			{
@@ -81,6 +81,9 @@ export class Airtable implements INodeType {
 				default: { mode: 'url', value: '' },
 				required: true,
 				description: 'The Airtable Base in which to operate on',
+				displayOptions: {
+					show: { operation: ['append', 'delete', 'list', 'read', 'update'] },
+				},
 				modes: [
 					{
 						displayName: 'By URL',
@@ -125,6 +128,9 @@ export class Airtable implements INodeType {
 				type: 'resourceLocator',
 				default: { mode: 'url', value: '' },
 				required: true,
+				displayOptions: {
+					show: { operation: ['append', 'delete', 'list', 'read', 'update'] },
+				},
 				modes: [
 					{
 						displayName: 'By URL',
@@ -216,7 +222,7 @@ export class Airtable implements INodeType {
 			},
 
 			// ----------------------------------
-			//         list
+			//         list records
 			// ----------------------------------
 			{
 				displayName: 'Return All',
@@ -622,7 +628,7 @@ export class Airtable implements INodeType {
 			}
 		} else if (operation === 'list') {
 			// ----------------------------------
-			//         list
+			//         list records
 			// ----------------------------------
 			try {
 				requestMethod = 'GET';

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -643,7 +643,15 @@ export class Airtable implements INodeType {
 				}
 
 				if (returnAll) {
-					responseData = await apiRequestAllItems.call(this, requestMethod, endpoint, body, qs);
+					qs.pageSize = 100;
+					responseData = await apiRequestAllItems.call(
+						this,
+						requestMethod,
+						endpoint,
+						body,
+						'records',
+						qs,
+					);
 				} else {
 					qs.maxRecords = this.getNodeParameter('limit', 0);
 					responseData = await apiRequest.call(this, requestMethod, endpoint, body, qs);

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -428,7 +428,7 @@ export class Airtable implements INodeType {
 								name: 'Visible Field IDs',
 								value: 'visibleFieldIds',
 								description:
-									'Allows optionally including an array of visibleFieldIds (for views of type grid only)',
+									'Includes a list of the visible (non-hidden) field IDs in the `commentCount` attribute (for grid views only)',
 							},
 						],
 						default: [],

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -405,6 +405,44 @@ export class Airtable implements INodeType {
 						],
 						default: [],
 					},
+					{
+						displayName: 'Cell Format',
+						name: 'cellFormat',
+						description: 'The format that should be used for cell values',
+						type: 'options',
+						options: [
+							{
+								name: 'JSON',
+								value: 'json',
+								description: 'Cells will be formatted as JSON, depending on the field type',
+							},
+							{
+								name: 'String',
+								value: 'string',
+								description:
+									'Cells will be formatted as user-facing strings, regardless of the field type. The timeZone and userLocale parameters are required when using string as the cellFormat. Note: You should not rely on the format of these strings, as it is subject to change.',
+							},
+						],
+						default: 'json',
+					},
+					{
+						displayName: 'Time Zone',
+						name: 'timeZone',
+						type: 'string',
+						default: 'America/Los_Angeles',
+						placeholder: 'America/Los_Angeles',
+						description:
+							'The time zone that should be used to format dates when using string as the cellFormat. This parameter is required when using string as the cellFormat. Visit https://airtable.com/developers/web/api/list-records for details valid values.',
+					},
+					{
+						displayName: 'User Locale',
+						name: 'userLocale',
+						type: 'string',
+						default: 'en',
+						placeholder: 'en',
+						description:
+							'The user locale that should be used to format dates when using string as the cellFormat. This parameter is required when using string as the cellFormat. Visit https://airtable.com/developers/web/api/list-records for details valid values.',
+					},
 				],
 			},
 

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -39,14 +39,14 @@ export class Airtable implements INodeType {
 					{
 						name: 'Append',
 						value: 'append',
-						description: 'Append the data to a table',
-						action: 'Append data to a table',
+						description: 'Append the data to a table (requires data.records:write scope)',
+						action: 'Append data to a table (requires data.records:write scope)',
 					},
 					{
 						name: 'Delete',
 						value: 'delete',
-						description: 'Delete data from a table',
-						action: 'Delete data from a table',
+						description: 'Delete data from a table (requires data.records:write scope)',
+						action: 'Delete data from a table (requires data.records:write scope)',
 					},
 					{
 						name: 'List',
@@ -57,14 +57,14 @@ export class Airtable implements INodeType {
 					{
 						name: 'Read',
 						value: 'read',
-						description: 'Read data from a table',
-						action: 'Read data from a table',
+						description: 'Read data from a table (requires data.records:read scope)',
+						action: 'Read data from a table (requires data.records:read scope)',
 					},
 					{
 						name: 'Update',
 						value: 'update',
-						description: 'Update data in a table',
-						action: 'Update data in a table',
+						description: 'Update data in a table (requires data.records:write scope)',
+						action: 'Update data in a table (requires data.records:write scope)',
 					},
 				],
 				default: 'read',

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -382,6 +382,29 @@ export class Airtable implements INodeType {
 						description:
 							'The name or ID of a view in the Stories table. If set, only the records in that view will be returned. The records will be sorted according to the order of the view.',
 					},
+					{
+						displayName: 'Return Fields by Field ID',
+						name: 'returnFieldsByFieldId',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to return field IDs (fldXXXX) instead of the default human-readable/defined field names',
+					},
+					{
+						displayName: 'Record Metadata',
+						name: 'recordMetadata',
+						description: 'Additional record metadata to include',
+						type: 'multiOptions',
+						options: [
+							{
+								name: 'Record Comment Count',
+								value: 'commentCount',
+								description:
+									'Includes the number of comments on a record in the `commentCount` attribute',
+							},
+						],
+						default: [],
+					},
 				],
 			},
 
@@ -698,6 +721,8 @@ export class Airtable implements INodeType {
 				for (const key of Object.keys(additionalOptions)) {
 					if (key === 'sort' && (additionalOptions.sort as IDataObject).property !== undefined) {
 						qs[key] = (additionalOptions[key] as IDataObject).property;
+					} else if (key === 'returnFieldsByFieldId' && additionalOptions[key] === false) {
+						// do nothing (exclude the query parameter): Airtable will return fields by Field ID if "false" is provided
 					} else {
 						qs[key] = additionalOptions[key];
 					}

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -317,7 +317,7 @@ export class Airtable implements INodeType {
 						default: [],
 						placeholder: 'Name',
 						description:
-							'Only data for fields whose names are in this list will be included in the records',
+							'Only data for fields whose names or IDs are in this list will be included in the records',
 					},
 					{
 						displayName: 'Filter By Formula',

--- a/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
+++ b/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
@@ -231,7 +231,8 @@ export class AirtableTrigger implements INodeType {
 			qs.maxRecords = 1;
 		}
 
-		const { records } = await apiRequestAllItems.call(this, 'GET', endpoint, {}, qs);
+		qs.pageSize = 100;
+		const { records } = await apiRequestAllItems.call(this, 'GET', endpoint, {}, 'records', qs);
 
 		webhookData.lastTimeChecked = endDate;
 

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -36,11 +36,6 @@ export async function apiRequest(
 ): Promise<any> {
 	query = query || {};
 
-	// For some reason for some endpoints the bearer auth does not work
-	// and it returns 404 like for the /meta request. So we always send
-	// it as query string.
-	// query.api_key = credentials.apiKey;
-
 	const options: OptionsWithUri = {
 		headers: {},
 		method,

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -73,12 +73,12 @@ export async function apiRequestAllItems(
 	method: string,
 	endpoint: string,
 	body: IDataObject,
+	responseBodyItemsKey: string,
 	query?: IDataObject,
 ): Promise<any> {
 	if (query === undefined) {
 		query = {};
 	}
-	query.pageSize = 100;
 
 	const returnData: IDataObject[] = [];
 
@@ -86,13 +86,13 @@ export async function apiRequestAllItems(
 
 	do {
 		responseData = await apiRequest.call(this, method, endpoint, body, query);
-		returnData.push.apply(returnData, responseData.records);
+		returnData.push.apply(returnData, responseData[responseBodyItemsKey]);
 
 		query.offset = responseData.offset;
 	} while (responseData.offset !== undefined);
 
 	return {
-		records: returnData,
+		[responseBodyItemsKey]: returnData,
 	};
 }
 

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -37,7 +37,9 @@ export async function apiRequest(
 	query = query || {};
 
 	const options: OptionsWithUri = {
-		headers: {},
+		headers: {
+			'user-agent': 'n8n',
+		},
 		method,
 		body,
 		qs: query,

--- a/packages/nodes-base/test/nodes/Airtable/workflow.json
+++ b/packages/nodes-base/test/nodes/Airtable/workflow.json
@@ -29,7 +29,7 @@
 					"mode": "url",
 					"__regex": "https://airtable.com/[a-zA-Z0-9]{2,}/([a-zA-Z0-9]{2,})"
 				},
-				"additionalOptions": {}
+				"additionalListRecordsOptions": {}
 			},
 			"id": "5654d3b3-fe83-4988-889b-94f107d41807",
 			"name": "Airtable",


### PR DESCRIPTION
- [x] Refactor of generic `apiRequestAllItems` function to work for more than just paginating on record-related endpoints (necessary for list bases return all support)
- Adds 2 :new: operations
  - [x] `listBases` - Airtable's [list bases](https://airtable.com/developers/web/api/list-bases) (that the token has access to) endpoint
  - [x] `readBaseSchema` - Airtable's [get base schema](https://airtable.com/developers/web/api/get-base-schema) (including tables, their fields, and views)
- Updates existing `list` (records) endpoint to include 5 🆕  parameters within `additionalListRecordsOptions` ([full list](https://airtable.com/developers/web/api/list-records#query))
   - [x] `returnFieldsByFieldId`
   - [x] `recordMetadata`
   - [x] `cellFormat`
   - [x] `userLocale`
   - [x] `timeZone` 
- [x] Sets user-agent header to `n8n` like many other built-in nodes do ([ref](https://github.com/search?q=repo%3An8n-io%2Fn8n+%27user-agent%27&type=code))

---

⚠️ The new operations will NOT work for all user API keys (keyXXX) so this PR should only be merged after #5362 which adds support for PATs/header-based auth has been merged

---

I am new to contributing to this project, so if the reviewer could take a look at my commit message in [this commit](https://github.com/n8n-io/n8n/pull/5363/commits/734d689197d114185e7901ad8f196758ce471185), I wonder if there is a need for two different "additional options" param collections or if they can be merged and I just didn't figure out how. Thanks!