### PR TITLE
fix(editor): Fix merge node connectors

### DIFF
--- a/packages/editor-ui/src/stores/workflows.ts
+++ b/packages/editor-ui/src/stores/workflows.ts
@@ -532,11 +532,15 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			dataPinningEventBus.$emit('unpin-data', { [payload.node.name]: undefined });
 		},
 
-		addConnection(data: { connection: IConnection[] }): void {
+		addConnection(data: { connection: IConnection[]; setStateDirty: boolean }): void {
 			if (data.connection.length !== 2) {
 				// All connections need two entries
 				// TODO: Check if there is an error or whatever that is supposed to be returned
 				return;
+			}
+			const uiStore = useUIStore();
+			if (data.setStateDirty === true) {
+				uiStore.stateIsDirty = true;
 			}
 
 			const sourceData: IConnection = data.connection[0];

--- a/packages/editor-ui/src/stores/workflows.ts
+++ b/packages/editor-ui/src/stores/workflows.ts
@@ -532,17 +532,12 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			dataPinningEventBus.$emit('unpin-data', { [payload.node.name]: undefined });
 		},
 
-		addConnection(data: { connection: IConnection[]; setStateDirty: boolean }): void {
+		addConnection(data: { connection: IConnection[] }): void {
 			if (data.connection.length !== 2) {
 				// All connections need two entries
 				// TODO: Check if there is an error or whatever that is supposed to be returned
 				return;
 			}
-			const uiStore = useUIStore();
-			if (data.setStateDirty === true) {
-				uiStore.stateIsDirty = true;
-			}
-
 			const sourceData: IConnection = data.connection[0];
 			const destinationData: IConnection = data.connection[1];
 

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2088,6 +2088,7 @@ export default mixins(
 
 							this.connectTwoNodes(sourceNodeName, outputIndex, this.pullConnActiveNodeName, 0);
 							this.pullConnActiveNodeName = null;
+							this.dropPrevented = true;
 						}
 						return;
 					}
@@ -2159,11 +2160,9 @@ export default mixins(
 						},
 					];
 
-					this.workflowsStore.addConnection({
-						connection: connectionData,
-						setStateDirty: true,
-					});
 					this.dropPrevented = true;
+					this.workflowsStore.addConnection({ connection: connectionData });
+					this.uiStore.stateIsDirty = true;
 					if (!this.suspendRecordingDetachedConnections) {
 						this.historyStore.pushCommandToUndo(new AddConnectionCommand(connectionData));
 					}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2159,6 +2159,10 @@ export default mixins(
 						},
 					];
 
+					this.workflowsStore.addConnection({
+						connection: connectionData,
+						setStateDirty: true,
+					});
 					this.dropPrevented = true;
 					if (!this.suspendRecordingDetachedConnections) {
 						this.historyStore.pushCommandToUndo(new AddConnectionCommand(connectionData));


### PR DESCRIPTION
In #5259, we've removed `workflowsStore.addConnection` call after `EVENT_CONNECTION`. This resulted in merge node connections not being stored. This PR reverts those changes. 
Github issue / Community forum post (link here to close automatically): #5359
