### PR TITLE
fix(editor): Fix mapping to empty expression input

### DIFF
--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -256,7 +256,7 @@ export default mixins(showMessage).extend({
 					) {
 						updatedValue = `${prevValue} ${data}`;
 					} else if (prevValue && ['string', 'json'].includes(this.parameter.type)) {
-						updatedValue = `=${prevValue} ${data}`;
+						updatedValue = prevValue === '=' ? `=${data}` : `=${prevValue} ${data}`;
 					} else {
 						updatedValue = `=${data}`;
 					}


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-296/bug-when-mapping-value-adds-=-to-expression-if-expression-is-empty
