### PR TITLE
test(editor): Improve canvas e2e tests reliability

### DIFF
--- a/cypress/e2e/10-undo-redo.cy.ts
+++ b/cypress/e2e/10-undo-redo.cy.ts
@@ -38,17 +38,14 @@ describe('Undo/Redo', () => {
 	it('should undo/redo adding node in the middle', () => {
 		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
-		WorkflowPage.actions.addNodeToCanvas(SET_NODE_NAME);
-		WorkflowPage.getters.nodeConnections().realHover();
-		cy.get('.connection-actions .add').filter(':visible').click();
-		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME, false);
+		WorkflowPage.actions.addNodeBetweenFirstTwoNodes(CODE_NODE_NAME);
 		WorkflowPage.actions.zoomToFit();
 		WorkflowPage.actions.hitUndo();
+		WorkflowPage.getters.canvasNodes().should('have.have.length', 2);
+		WorkflowPage.getters.nodeConnections().should('have.length', 1);
+		WorkflowPage.actions.hitRedo();
 		WorkflowPage.getters.canvasNodes().should('have.have.length', 3);
 		WorkflowPage.getters.nodeConnections().should('have.length', 2);
-		WorkflowPage.actions.hitRedo();
-		WorkflowPage.getters.canvasNodes().should('have.have.length', 4);
-		WorkflowPage.getters.nodeConnections().should('have.length', 3);
 	});
 
 	it('should undo/redo deleting node using delete button', () => {

--- a/cypress/e2e/12-canvas.cy.ts
+++ b/cypress/e2e/12-canvas.cy.ts
@@ -61,9 +61,7 @@ describe('Canvas Actions', () => {
 	it('should add note between two connected nodes', () => {
 		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
-		WorkflowPage.getters.nodeConnections().first().realHover();
-		cy.get('.connection-actions .add').filter(':visible').should('be.visible').click()
-		WorkflowPage.actions.addNodeToCanvas(SET_NODE_NAME, false);
+		WorkflowPage.actions.addNodeBetweenFirstTwoNodes(SET_NODE_NAME);
 		WorkflowPage.getters.canvasNodes().should('have.length', 3);
 		WorkflowPage.getters.nodeConnections().should('have.length', 2);
 		// And last node should be pushed to the right
@@ -218,7 +216,7 @@ describe('Canvas Actions', () => {
 		WorkflowPage.actions.addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
 		WorkflowPage.getters.nodeConnections().first().realHover();
-		cy.get('.connection-actions .delete').filter(':visible').should('be.visible').click();
+		cy.get('.connection-actions .delete').first().click({ force: true });
 		WorkflowPage.getters.nodeConnections().should('have.length', 0);
 	});
 

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -170,5 +170,10 @@ export class WorkflowPage extends BasePage {
 		executeWorkflow: () => {
 			this.getters.executeWorkflowButton().click();
 		},
+		addNodeBetweenFirstTwoNodes: (nodeName: string) => {
+			this.getters.nodeConnections().first().realHover();
+			cy.get('.connection-actions .add').first().click({ force: true });
+			this.actions.addNodeToCanvas(nodeName, false);
+		},
 	};
 }


### PR DESCRIPTION
**Description**: There is a piece of cypress code that adds a new node between two existing ones by hovering on the connection and clicking the + button which has been running unreliably on our CI runs. This PR tries to improve this by forcing clicks on the action button without requiring it to be visible.
I have run it twice ([this](https://github.com/n8n-io/n8n/actions/runs/4103719929) and [this](https://github.com/n8n-io/n8n/actions/runs/4103926063)) before making this PR and both passes went successfully.
