### PR TITLE
fix(editor): Correctly show OAuth reconnect button

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -40,12 +40,12 @@
 			:buttonTitle="$locale.baseText('credentialEdit.credentialConfig.reconnectOAuth2Credential')"
 			@click="$emit('oauth')"
 		>
-			<template #button>
+			<template #button v-if="isGoogleOAuthType">
 				<p
 					v-text="`${$locale.baseText('credentialEdit.credentialConfig.reconnect')}:`"
 					:class="$style.googleReconnectLabel"
 				/>
-				<GoogleAuthButton v-if="isGoogleOAuthType" @click="$emit('oauth')" />
+				<GoogleAuthButton @click="$emit('oauth')" />
 			</template>
 		</banner>
 


### PR DESCRIPTION
Banner component falls-back to `buttonTitle` and `buttonLabel` if `button` slot is not provided. We need to make sure to only populate that slot for `GoogleOAuthType` since that's the only one which is using reconnect and Google Sign In button.

Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/oauth2-access-token-not-refreshing/21984
