### PR TITLE
refactor(workflow): pass args to custom node invocation

### DIFF
--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1164,9 +1164,10 @@ export interface INodeType {
 	description: INodeTypeDescription;
 	execute?(
 		this: IExecuteFunctions,
+		...args: any[]
 	): Promise<INodeExecutionData[][] | NodeExecutionWithMetadata[][] | null>;
-	executeSingle?(this: IExecuteSingleFunctions): Promise<INodeExecutionData>;
-	poll?(this: IPollFunctions): Promise<INodeExecutionData[][] | null>;
+	executeSingle?(this: IExecuteSingleFunctions, ...args: any[]): Promise<INodeExecutionData>;
+	poll?(this: IPollFunctions, ...args: any[]): Promise<INodeExecutionData[][] | null>;
 	trigger?(this: ITriggerFunctions): Promise<ITriggerResponse | undefined>;
 	webhook?(this: IWebhookFunctions): Promise<IWebhookResponseData>;
 	hooks?: {

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -1238,7 +1238,7 @@ export class Workflow {
 					mode,
 				);
 
-				returnPromises.push(nodeType.executeSingle.call(thisArgs));
+				returnPromises.push(nodeType.executeSingle.call(thisArgs, thisArgs));
 			}
 
 			if (returnPromises.length === 0) {
@@ -1267,7 +1267,7 @@ export class Workflow {
 				executionData,
 				mode,
 			);
-			return { data: await nodeType.execute.call(thisArgs) };
+			return { data: await nodeType.execute.call(thisArgs, thisArgs) };
 		} else if (nodeType.poll) {
 			if (mode === 'manual') {
 				// In manual mode run the poll function
@@ -1278,7 +1278,7 @@ export class Workflow {
 					mode,
 					'manual',
 				);
-				return { data: await nodeType.poll.call(thisArgs) };
+				return { data: await nodeType.poll.call(thisArgs, thisArgs) };
 			}
 			// In any other mode pass data through as it already contains the result of the poll
 			return { data: inputData.main as INodeExecutionData[][] };


### PR DESCRIPTION
# Context

Pass `IExecuteFunctions` as param to execute functions to provide an option of not overriding `this` inside execute method.

# Description

Developing custom nodes with more complex use-cases using inheritance and other OOP best practices is hard to implement because the way that execute method is invoked overrides `this` inside execute function, which limit the usage of `this` to only the object passed as argument.

To allow custom nodes to choose wether keep the current behavior or use its own instance `this` we can pass `thisArgs` as args as well, so custom nodes can write an arrow function that receives `IExecuteFunctions` as param and yet use `this` to reference other class instance members.

# Use case

The reason I'm suggesting this change is because I want to implement an abstract class that handles common code for custom nodes and just delegates the real execution code, eg:

```typescript
export abstract class AbstractNode<TParams> {
  abstract description: INodeTypeDescription
  abstract run(t: TParams): Promise<IDataObject>

  execute = (executeFunctions: IExecuteFunctions): void => {
    console.log('AbstractNode.execute()', executeFunctions)
  }
}

type CodexParams = { prompts: string[] }

export class Codex extends AbstractNode<CodexParams> {
  description: INodeTypeDescription = {}

  run({ prompts }: CodexParams): Promise<IDataObject> {
    return Promise.resolve({ answer: 'Sample answer from codex-ff' })
  }
}
```

Currently this implementation doesn't work because if I write execute as an arrow function to keep class' `this` I can't get `executeFunctions` reference

Forum: https://community.n8n.io/t/custom-node-method-invocation/22728