### PR TITLE
fix(core): Disable transactions on sqlite migrations that use `PRAGMA foreign_keys`

### DIFF
--- a/packages/cli/src/databases/migrations/sqlite/1652367743993-AddUserSettings.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1652367743993-AddUserSettings.ts
@@ -5,6 +5,8 @@ import { logMigrationEnd, logMigrationStart } from '@db/utils/migrationHelpers';
 export class AddUserSettings1652367743993 implements MigrationInterface {
 	name = 'AddUserSettings1652367743993';
 
+	transaction = false;
+
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		logMigrationStart(this.name);
 

--- a/packages/cli/src/databases/migrations/sqlite/1652905585850-AddAPIKeyColumn.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1652905585850-AddAPIKeyColumn.ts
@@ -1,8 +1,11 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import config from '@/config';
 import { logMigrationEnd, logMigrationStart } from '@db/utils/migrationHelpers';
+
 export class AddAPIKeyColumn1652905585850 implements MigrationInterface {
 	name = 'AddAPIKeyColumn1652905585850';
+
+	transaction = false;
 
 	async up(queryRunner: QueryRunner): Promise<void> {
 		logMigrationStart(this.name);

--- a/packages/cli/src/databases/migrations/sqlite/1673268682475-DeleteExecutionsWithWorkflows.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1673268682475-DeleteExecutionsWithWorkflows.ts
@@ -3,6 +3,9 @@ import { getTablePrefix, logMigrationEnd, logMigrationStart } from '@db/utils/mi
 
 export class DeleteExecutionsWithWorkflows1673268682475 implements MigrationInterface {
 	name = 'DeleteExecutionsWithWorkflows1673268682475';
+
+	transaction = false;
+
 	public async up(queryRunner: QueryRunner): Promise<void> {
 		logMigrationStart(this.name);
 		const tablePrefix = getTablePrefix();


### PR DESCRIPTION
`PRAGMA foreign_keys` is [a no-op within a sqlite transaction](https://www.sqlite.org/pragma.html#pragma_foreign_keys). This causes cascade deletes to happen when we create a new user table, and drop the old user table.

This issue was introduced in `0.211.0` via https://github.com/n8n-io/n8n/pull/5129.

https://community.n8n.io/t/workflows-gone-after-setting-up-user-management/22717
https://community.n8n.io/t/nothing-works-since-the-update/22738/

Fixes https://n8nio.sentry.io/issues/3919885885