### PR TITLE
fix: handle exception when copying icons to cache

### DIFF
--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -408,9 +408,13 @@ export class LoadNodesAndCredentialsClass implements INodesAndCredentials {
 				type.iconUrl = iconUrl;
 				const source = path.join(dir, icon);
 				const destination = path.join(GENERATED_STATIC_DIR, iconUrl);
-				return mkdir(path.dirname(destination), { recursive: true }).then(async () =>
-					copyFile(source, destination),
-				);
+				return mkdir(path.dirname(destination), { recursive: true }).then(async () => {
+					try {
+						await copyFile(source, destination);
+					} catch (error) {
+						LoggerProxy.warn(`Failed to copy file: "${source}" -> "${destination}"`);
+					}
+				});
 			}),
 		);
 


### PR DESCRIPTION
Unhandled exception when copying icon files to cache introduced in #4865 causes workflow to not run. This handles the copy-file exception to logger so that workflow can continue uninterrupted.

Github issue / Community forum post (link here to close automatically):
Forum discussion: https://community.n8n.io/t/n8n-webhook-empty/22279

resolves #5274 