### PR TITLE
fix: MySQL migration parses database contents if necessary (fix for MariaDB)

### DIFF
--- a/packages/cli/src/databases/migrations/mysqldb/1675940580449-PurgeInvalidWorkflowConnections.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1675940580449-PurgeInvalidWorkflowConnections.ts
@@ -12,8 +12,11 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements MigrationIn
 
 		const tablePrefix = getTablePrefix();
 
-		const workflows: Array<{ id: number; nodes: INode[]; connections: IConnections }> =
-			await queryRunner.query(`
+		const workflows: Array<{
+			id: number;
+			nodes: INode[] | string;
+			connections: IConnections | string;
+		}> = await queryRunner.query(`
 			SELECT id, nodes, connections
 			FROM \`${tablePrefix}workflow_entity\`
 		`);
@@ -21,8 +24,12 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements MigrationIn
 		const nodeTypes = NodeTypes();
 
 		workflows.forEach(async (workflow) => {
-			let connections: IConnections = workflow.connections;
-			const nodes: INode[] = workflow.nodes;
+			let connections: IConnections =
+				typeof workflow.connections === 'string'
+					? JSON.parse(workflow.connections)
+					: workflow.connections;
+			const nodes: INode[] =
+				typeof workflow.nodes === 'string' ? JSON.parse(workflow.nodes) : workflow.nodes;
 
 			const nodesThatCannotReceiveInput: string[] = nodes.reduce((acc, node) => {
 				try {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
