### PR TITLE
fix(core): Fix issue that worker and webhook service close directly

### DIFF
--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -80,6 +80,9 @@ export class Webhook extends BaseCommand {
 	async run() {
 		await new WebhookServer().start();
 		this.logger.info('Webhook listener waiting for requests.');
+
+		// Make sure that the process does not close
+		await new Promise(() => {});
 	}
 
 	async catch(error: Error) {

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -353,6 +353,9 @@ export class Worker extends BaseCommand {
 				}
 			});
 		}
+
+		// Make sure that the process does not close
+		await new Promise(() => {});
 	}
 
 	async catch(error: Error) {


### PR DESCRIPTION
Fixes issure reported in #5460

Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/i-have-a-crash-with-n8n-worker-at-newest-version/22921/3