### PR TITLE
fix(core): Fix the issue with test webhooks getting removed incorrectly (no-changelog)

### DIFF
--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -141,13 +141,13 @@ class TestWebhooks {
 				if (sessionId !== undefined) {
 					push.send('testWebhookReceived', { workflowId, executionId }, sessionId);
 				}
-			} finally {
-				// Delete webhook also if an error is thrown
-				if (timeout) clearTimeout(timeout);
-				delete testWebhookData[webhookKey];
+			} catch {}
 
-				await activeWebhooks.removeWorkflow(workflow);
-			}
+			// Delete webhook also if an error is thrown
+			if (timeout) clearTimeout(timeout);
+			delete testWebhookData[webhookKey];
+
+			await activeWebhooks.removeWorkflow(workflow);
 		});
 	}
 


### PR DESCRIPTION
This broke because of the change [here](https://github.com/n8n-io/n8n/pull/5443/files#diff-b386248ff00977749c873ed85821c241b773e9740d7e7adf94e05b73b350ed74L152). 
`finally` block is called even if there is a `return` in the `try` block, and this is causing the test webhook to be removed, even when it shouldn't be removed.

Fixes #5465
