### PR TITLE
Updated Microsoft Dynamics CRM node

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -813,6 +813,21 @@ export function getLeadFields(): INodeProperties[] {
 				'Last name of the primary contact for the lead to make sure the prospect is addressed correctly in sales calls, email, and marketing campaigns',
 		},
 		{
+			displayName: 'Middle Name',
+			name: 'middlename',
+			type: 'string',
+			default: '',
+			description:
+				'The middle name or initial of the primary contact for the lead to make sure the prospect is addressed correctly.',
+		},
+		{
+			displayName: 'Mobile Phone',
+			name: 'mobilephone',
+			type: 'string',
+			default: '',
+			description: 'Mobile phone number for the primary contact for the lead.',
+		},
+		{
 			displayName: 'Number Of Employees',
 			name: 'numberofemployees',
 			type: 'number',

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -7,6 +7,41 @@ import { NodeApiError } from 'n8n-workflow';
 
 const addressFields: INodeProperties[] = [
 	{
+		displayName: 'City',
+		name: 'city',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Country',
+		name: 'country',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'County',
+		name: 'county',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Fax',
+		name: 'fax',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Latitude',
+		name: 'latitude',
+		type: 'number',
+		typeOptions: {
+			maxValue: 90,
+			minValue: -90,
+			numberPrecision: 6,
+		},
+		default: '',
+	},
+	{
 		displayName: 'Line1',
 		name: 'line1',
 		type: 'string',
@@ -25,27 +60,14 @@ const addressFields: INodeProperties[] = [
 		default: '',
 	},
 	{
-		displayName: 'City',
-		name: 'city',
-		type: 'string',
-		default: '',
-	},
-	{
-		displayName: 'State or Province',
-		name: 'stateorprovince',
-		type: 'string',
-		default: '',
-	},
-	{
-		displayName: 'Country',
-		name: 'country',
-		type: 'string',
-		default: '',
-	},
-	{
-		displayName: 'County',
-		name: 'county',
-		type: 'string',
+		displayName: 'Longitude',
+		name: 'longitude',
+		type: 'number',
+		typeOptions: {
+			maxValue: 180,
+			minValue: -180,
+			numberPrecision: 6,
+		},
 		default: '',
 	},
 	{
@@ -53,6 +75,7 @@ const addressFields: INodeProperties[] = [
 		name: 'name',
 		type: 'string',
 		default: '',
+		description: 'Descriptive name for the address, such as Corporate Headquarters.',
 	},
 	{
 		displayName: 'Postal Code',
@@ -67,8 +90,8 @@ const addressFields: INodeProperties[] = [
 		default: '',
 	},
 	{
-		displayName: 'Primary Contact Name',
-		name: 'primarycontactname',
+		displayName: 'State or Province',
+		name: 'stateorprovince',
 		type: 'string',
 		default: '',
 	},
@@ -91,32 +114,24 @@ const addressFields: INodeProperties[] = [
 		default: '',
 	},
 	{
-		displayName: 'Fax',
-		name: 'fax',
+		displayName: 'UPS Zone',
+		name: 'upszone',
 		type: 'string',
 		default: '',
+		description:
+			'The UPS zone of the address to make sure shipping charges are calculated correctly and deliveries are made promptly, if shipped by UPS.',
 	},
 	{
-		displayName: 'Latitude',
-		name: 'latitude',
+		displayName: 'UTC Offset',
+		name: 'utcoffset',
 		type: 'number',
 		typeOptions: {
-			maxValue: 90,
-			minValue: -90,
-			numberPrecision: 6,
+			maxValue: 1500,
+			minValue: -1500,
 		},
 		default: '',
-	},
-	{
-		displayName: 'Longitude',
-		name: 'longitude',
-		type: 'number',
-		typeOptions: {
-			maxValue: 180,
-			minValue: -180,
-			numberPrecision: 6,
-		},
-		default: '',
+		description:
+			'The time zone, or UTC offset, for this address so that other people can reference it when they contact someone at this address.',
 	},
 ];
 
@@ -327,6 +342,34 @@ export function getAccountFields(): INodeProperties[] {
 							default: '',
 						},
 						...addressFields,
+						{
+							displayName: 'Freight Terms',
+							name: 'freighttermscode',
+							type: 'options',
+							typeOptions: {
+								loadOptionsMethod: 'getAccountAddressFreightTermsCodes',
+							},
+							default: '',
+							description:
+								'The freight terms for the address to make sure shipping orders are processed correctly. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+						},
+						{
+							displayName: 'Primary Contact Name',
+							name: 'primarycontactname',
+							type: 'string',
+							default: '',
+						},
+						{
+							displayName: 'Shipping Method',
+							name: 'shippingmethodcode',
+							type: 'options',
+							typeOptions: {
+								loadOptionsMethod: 'getAccountAddressShippingMethodCodes',
+							},
+							default: '',
+							description:
+								'Shipping method for deliveries sent to this address. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+						},
 					],
 				},
 			],
@@ -455,7 +498,7 @@ export function getAccountFields(): INodeProperties[] {
 				maxValue: 1000000000,
 				minValue: 0,
 			},
-			default: 0,
+			default: '',
 			description:
 				'Number of employees that work at the account for use in marketing segmentation and demographic analysis.',
 		},
@@ -660,6 +703,17 @@ export function getLeadFields(): INodeProperties[] {
 							default: '',
 						},
 						...addressFields,
+						{
+							displayName: 'Shipping Method',
+							name: 'shippingmethodcode',
+							type: 'options',
+							typeOptions: {
+								loadOptionsMethod: 'getLeadAddressShippingMethodCodes',
+							},
+							default: '',
+							description:
+								'Shipping method for deliveries sent to this address. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+						},
 					],
 				},
 			],
@@ -702,9 +756,20 @@ export function getLeadFields(): INodeProperties[] {
 			typeOptions: {
 				loadOptionsMethod: 'getBooleanOptions',
 			},
-			default: 0,
+			default: '',
 			description:
 				'Whether the lead confirmed interest in your offerings. This helps in determining the lead quality. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Decision Maker?',
+			name: 'decisionmaker',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadDecisionMakerOptions',
+			},
+			default: '',
+			description:
+				'Whether your notes include information about who makes the purchase decisions at the lead’s company. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Description',
@@ -715,7 +780,73 @@ export function getLeadFields(): INodeProperties[] {
 			},
 			default: '',
 			description:
-				'Additional information to describe the lead, such as an excerpt from the company’s website.',
+				'Additional information to describe the lead, such as an excerpt from the company’s website. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Do not allow Bulk Emails',
+			name: 'donotbulkemail',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead accepts bulk email sent through marketing campaigns or quick campaigns. If Do Not Allow is selected, the lead can be added to marketing lists, but will be excluded from the email. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Do not allow Emails',
+			name: 'donotemail',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead allows direct email sent from Microsoft Dynamics 365. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Do not allow Faxes',
+			name: 'donotfax',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead allows faxes. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Do not allow Phone Calls',
+			name: 'donotphone',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead allows phone calls. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Do not allow Mails',
+			name: 'donotpostalmail',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead allows direct mail. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Marketing Material',
+			name: 'donotsendmm',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getAllowOptions',
+			},
+			default: '',
+			description:
+				'Whether the lead accepts marketing materials, such as brochures or catalogs. Leads that opt out can be excluded from marketing initiatives. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Email Address 1',
@@ -766,7 +897,7 @@ export function getLeadFields(): INodeProperties[] {
 			typeOptions: {
 				loadOptionsMethod: 'getBooleanOptions',
 			},
-			default: 0,
+			default: '',
 			description:
 				'Whether the fit between the lead’s requirements and your offerings was evaluated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 		},
@@ -784,6 +915,28 @@ export function getLeadFields(): INodeProperties[] {
 			default: '',
 			description:
 				'First name of the primary contact for the lead to make sure the prospect is addressed correctly in sales calls, email, and marketing campaigns.',
+		},
+		{
+			displayName: 'Follow Email Activity',
+			name: 'followemail',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadFollowEmailOptions',
+			},
+			default: '',
+			description:
+				'Whether to allow following email activity like opens, attachment views and link clicks for emails sent to the lead. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Import Sequence Number',
+			name: 'importsequencenumber',
+			type: 'number',
+			typeOptions: {
+				maxValue: 2147483647,
+				minValue: -2147483648,
+			},
+			default: '',
+			description: 'Sequence number of the import that created this record.',
 		},
 		{
 			displayName: 'Industry Name or ID',
@@ -835,7 +988,7 @@ export function getLeadFields(): INodeProperties[] {
 				maxValue: 1000000,
 				minValue: 0,
 			},
-			default: 0,
+			default: '',
 			description:
 				'number of employees that work at the company associated with the lead, for use in marketing segmentation and demographic analysis.',
 		},
@@ -849,6 +1002,28 @@ export function getLeadFields(): INodeProperties[] {
 			default: '',
 			description:
 				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+		},
+		{
+			displayName: 'Rating',
+			name: 'leadqualitycode',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadQualityCodes',
+			},
+			default: '',
+			description:
+				'Rating value to indicate the lead’s potential to become a customer. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Lead Source',
+			name: 'leadsourcecode',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadSourceCodes',
+			},
+			default: '',
+			description:
+				'The primary marketing source that prompted the lead to contact you. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Revenue',
@@ -949,6 +1124,23 @@ export function getLeadFields(): INodeProperties[] {
 }
 
 export const sort = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
+
+export const formatFields = (fields: IField[]) => {
+	const isSelectable = (field: IField) =>
+		field.IsValidForRead &&
+		field.CanBeSecuredForRead &&
+		field.IsValidODataAttribute &&
+		field.LogicalName !== 'slaid';
+
+	return fields
+		.filter(isSelectable)
+		.filter((field) => field.DisplayName.UserLocalizedLabel?.Label)
+		.map((field) => ({
+			name: field.DisplayName.UserLocalizedLabel.Label,
+			value: field.LogicalName,
+		}))
+		.sort(sort);
+};
 
 export interface ICustomField {
 	name: string;

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/GenericFunctions.ts
@@ -5,11 +5,125 @@ import type { IExecuteFunctions, IExecuteSingleFunctions, ILoadOptionsFunctions 
 import type { IDataObject, INodeProperties, INodePropertyOptions } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+const addressFields: INodeProperties[] = [
+	{
+		displayName: 'Line1',
+		name: 'line1',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Line2',
+		name: 'line2',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Line3',
+		name: 'line3',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'City',
+		name: 'city',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'State or Province',
+		name: 'stateorprovince',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Country',
+		name: 'country',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'County',
+		name: 'county',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Postal Code',
+		name: 'postalcode',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Post Office Box',
+		name: 'postofficebox',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Primary Contact Name',
+		name: 'primarycontactname',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Telephone 1',
+		name: 'telephone1',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Telephone 2',
+		name: 'telephone2',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Telephone 3',
+		name: 'telephone3',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Fax',
+		name: 'fax',
+		type: 'string',
+		default: '',
+	},
+	{
+		displayName: 'Latitude',
+		name: 'latitude',
+		type: 'number',
+		typeOptions: {
+			maxValue: 90,
+			minValue: -90,
+			numberPrecision: 6,
+		},
+		default: '',
+	},
+	{
+		displayName: 'Longitude',
+		name: 'longitude',
+		type: 'number',
+		typeOptions: {
+			maxValue: 180,
+			minValue: -180,
+			numberPrecision: 6,
+		},
+		default: '',
+	},
+];
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	method: string,
 	resource: string,
-
 	body: any = {},
 	qs: IDataObject = {},
 	uri?: string,
@@ -47,11 +161,10 @@ export async function microsoftApiRequest(
 }
 
 export async function microsoftApiRequestAllItems(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
+	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	propertyName: string,
 	method: string,
 	endpoint: string,
-
 	body: any = {},
 	query: IDataObject = {},
 ): Promise<any> {
@@ -98,8 +211,40 @@ export async function getEntityFields(
 	return value;
 }
 
+export function buildQs({
+	options = {},
+	filters = {},
+	requiredReturnFields = [],
+}: {
+	options?: IDataObject;
+	filters?: IDataObject;
+	requiredReturnFields?: string[];
+}): IDataObject {
+	const qs: IDataObject = {};
+	const returnFields = requiredReturnFields;
+
+	if (options.returnFields) {
+		returnFields.push(...(options.returnFields as string[]));
+	}
+
+	if (returnFields.length) {
+		qs.$select = [...new Set(returnFields)].join(',');
+	}
+
+	if (options.expandFields) {
+		qs.$expand = (options.expandFields as string[]).join(',');
+	}
+
+	if (filters.query) {
+		qs.$filter = filters.query as string;
+	}
+
+	return qs;
+}
+
 export function adjustAddresses(addresses: [{ [key: string]: string }]) {
 	const results: { [key: string]: any } = {};
+
 	for (const [index, address] of addresses.entries()) {
 		for (const key of Object.keys(address)) {
 			if (address[key] !== '') {
@@ -107,7 +252,29 @@ export function adjustAddresses(addresses: [{ [key: string]: string }]) {
 			}
 		}
 	}
+
 	return results;
+}
+
+export function adjustBody(body: IRawBody = {}): IDataObject {
+	const { addresses, customFields } = body;
+
+	if (addresses?.address) {
+		Object.assign(body, adjustAddresses(addresses.address));
+
+		//@ts-ignore
+		delete body.addresses;
+	}
+
+	if (customFields) {
+		customFields.map(({ name, value }) => {
+			body[name] = value;
+		});
+
+		delete body.customFields;
+	}
+
+	return body;
 }
 
 export function getAccountFields(): INodeProperties[] {
@@ -155,82 +322,11 @@ export function getAccountFields(): INodeProperties[] {
 							description:
 								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
 							typeOptions: {
-								loadOptionsMethod: 'getAddressTypes',
+								loadOptionsMethod: 'getAccountAddressTypes',
 							},
 							default: '',
 						},
-						{
-							displayName: 'Line1',
-							name: 'line1',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Line2',
-							name: 'line2',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Line3',
-							name: 'line3',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'City',
-							name: 'city',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'State or Province',
-							name: 'stateorprovince',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Country',
-							name: 'country',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Name',
-							name: 'name',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Postalcode',
-							name: 'postalcode',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Primary Contact Name',
-							name: 'primarycontactname',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Telephone1',
-							name: 'telephone1',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Telephone2',
-							name: 'telephone2',
-							type: 'string',
-							default: '',
-						},
-						{
-							displayName: 'Fax',
-							name: 'fax',
-							type: 'string',
-							default: '',
-						},
+						...addressFields,
 					],
 				},
 			],
@@ -272,6 +368,9 @@ export function getAccountFields(): INodeProperties[] {
 			displayName: 'Description',
 			name: 'description',
 			type: 'string',
+			typeOptions: {
+				rows: 3,
+			},
 			default: '',
 			description:
 				'Additional information to describe the account, such as an excerpt from the company’s website',
@@ -316,7 +415,7 @@ export function getAccountFields(): INodeProperties[] {
 			name: 'industrycode',
 			type: 'options',
 			typeOptions: {
-				loadOptionsMethod: 'getIndustryCodes',
+				loadOptionsMethod: 'getAccountIndustryCodes',
 			},
 			default: '',
 			description:
@@ -339,6 +438,11 @@ export function getAccountFields(): INodeProperties[] {
 			displayName: 'Credit Limit',
 			name: 'creditlimit',
 			type: 'number',
+			typeOptions: {
+				maxValue: 100000000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
 			default: '',
 			description:
 				'Credit limit of the account. This is a useful reference when you address invoice and accounting issues with the customer.',
@@ -347,9 +451,13 @@ export function getAccountFields(): INodeProperties[] {
 			displayName: 'Number Of Employees',
 			name: 'numberofemployees',
 			type: 'number',
+			typeOptions: {
+				maxValue: 1000000000,
+				minValue: 0,
+			},
 			default: 0,
 			description:
-				'Number of employees that work at the account for use in marketing segmentation and demographic analysis',
+				'Number of employees that work at the account for use in marketing segmentation and demographic analysis.',
 		},
 		{
 			displayName: 'Payment Terms Name or ID',
@@ -389,7 +497,7 @@ export function getAccountFields(): INodeProperties[] {
 			name: 'preferredcontactmethodcode',
 			type: 'options',
 			typeOptions: {
-				loadOptionsMethod: 'getPreferredContactMethodCodes',
+				loadOptionsMethod: 'getAccountPreferredContactMethodCodes',
 			},
 			default: '',
 			description:
@@ -411,14 +519,24 @@ export function getAccountFields(): INodeProperties[] {
 			displayName: 'Revenue',
 			name: 'revenue',
 			type: 'number',
+			typeOptions: {
+				maxValue: 100000000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
 			default: '',
 			description:
-				'The annual revenue for the account, used as an indicator in financial performance analysis',
+				'The annual revenue for the account, used as an indicator in financial performance analysis.',
 		},
 		{
 			displayName: 'Shares Outstanding',
 			name: 'sharesoutstanding',
 			type: 'number',
+			typeOptions: {
+				maxValue: 1000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
 			default: '',
 			description:
 				'The number of shares available to the public for the account. This number is used as an indicator in financial performance analysis.',
@@ -440,7 +558,7 @@ export function getAccountFields(): INodeProperties[] {
 			type: 'string',
 			default: '',
 			description:
-				'The Standard Industrial Classification (SIC) code that indicates the account’s primary industry of business, for use in marketing segmentation and demographic analysis',
+				'The Standard Industrial Classification (SIC) code that indicates the account’s primary industry of business, for use in marketing segmentation and demographic analysis.',
 		},
 		{
 			displayName: 'Stage ID',
@@ -501,7 +619,7 @@ export function getAccountFields(): INodeProperties[] {
 			name: 'websiteurl',
 			type: 'string',
 			default: '',
-			description: 'The account’s website URL to get quick details about the company profile',
+			description: 'The account’s website URL to get quick details about the company profile.',
 		},
 		{
 			displayName: 'Yomi Name',
@@ -514,16 +632,317 @@ export function getAccountFields(): INodeProperties[] {
 	];
 }
 
-export const sort = (a: { name: string }, b: { name: string }) => {
-	if (a.name < b.name) {
-		return -1;
-	}
-	if (a.name > b.name) {
-		return 1;
-	}
-	return 0;
-};
+export function getLeadFields(): INodeProperties[] {
+	return [
+		{
+			displayName: 'Address',
+			name: 'addresses',
+			type: 'fixedCollection',
+			default: {},
+			typeOptions: {
+				multipleValues: true,
+			},
+			placeholder: 'Add Address Field',
+			options: [
+				{
+					displayName: 'Address Fields',
+					name: 'address',
+					values: [
+						{
+							displayName: 'Address Type Name or ID',
+							name: 'addresstypecode',
+							type: 'options',
+							description:
+								'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+							typeOptions: {
+								loadOptionsMethod: 'getLeadAddressTypes',
+							},
+							default: '',
+						},
+						...addressFields,
+					],
+				},
+			],
+		},
+		{
+			displayName: 'Budget Amount',
+			name: 'budgetamount',
+			type: 'number',
+			typeOptions: {
+				maxValue: 1000000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
+			default: '',
+			description: 'Information about the budget amount of the lead’s company or organization.',
+		},
+		{
+			displayName: 'Budget',
+			name: 'budgetstatus',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadBudgetStatuses',
+			},
+			default: '',
+			description:
+				'Information about the budget status of the lead’s company or organization. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Company Name',
+			name: 'companyname',
+			type: 'string',
+			default: '',
+			description:
+				'Name of the company associated with the lead. This becomes the account name when the lead is qualified and converted to a customer account.',
+		},
+		{
+			displayName: 'Confirm Interest',
+			name: 'confirminterest',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getBooleanOptions',
+			},
+			default: 0,
+			description:
+				'Whether the lead confirmed interest in your offerings. This helps in determining the lead quality. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Description',
+			name: 'description',
+			type: 'string',
+			typeOptions: {
+				rows: 3,
+			},
+			default: '',
+			description:
+				'Additional information to describe the lead, such as an excerpt from the company’s website.',
+		},
+		{
+			displayName: 'Email Address 1',
+			name: 'emailaddress1',
+			type: 'string',
+			default: '',
+			description: 'The primary email address for the account',
+		},
+		{
+			displayName: 'Email Address 2',
+			name: 'emailaddress2',
+			type: 'string',
+			default: '',
+			description: 'The secondary email address for the account',
+		},
+		{
+			displayName: 'Email Address 3',
+			name: 'emailaddress3',
+			type: 'string',
+			default: '',
+			description: 'Alternate email address for the account',
+		},
+		{
+			displayName: 'Est. Value',
+			name: 'estimatedamount',
+			type: 'number',
+			typeOptions: {
+				maxValue: 1000000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
+			default: '',
+			description:
+				'Estimated revenue value that this lead will generate to assist in sales forecasting and planning.',
+		},
+		{
+			displayName: 'Est. Close Date',
+			name: 'estimatedclosedate',
+			type: 'dateTime',
+			default: '',
+			description:
+				'Expected close date for the lead, so that the sales team can schedule timely follow-up meetings to move the prospect to the next sales stage.',
+		},
+		{
+			displayName: 'Evaluate Fit',
+			name: 'evaluatefit',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getBooleanOptions',
+			},
+			default: 0,
+			description:
+				'Whether the fit between the lead’s requirements and your offerings was evaluated. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Fax',
+			name: 'fax',
+			type: 'string',
+			default: '',
+			description: 'Fax number for the primary contact for the lead.',
+		},
+		{
+			displayName: 'First Name',
+			name: 'firstname',
+			type: 'string',
+			default: '',
+			description:
+				'First name of the primary contact for the lead to make sure the prospect is addressed correctly in sales calls, email, and marketing campaigns.',
+		},
+		{
+			displayName: 'Industry Name or ID',
+			name: 'industrycode',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadIndustryCodes',
+			},
+			default: '',
+			description:
+				'Primary industry in which the lead’s business is focused, for use in marketing segmentation and demographic analysis. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		},
+		{
+			displayName: 'Job Title',
+			name: 'jobtitle',
+			type: 'string',
+			default: '',
+			description:
+				'Job title of the primary contact for this lead to make sure the prospect is addressed correctly in sales calls, email, and marketing campaigns.',
+		},
+		{
+			displayName: 'Last Name',
+			name: 'lastname',
+			type: 'string',
+			default: '',
+			description:
+				'Last name of the primary contact for the lead to make sure the prospect is addressed correctly in sales calls, email, and marketing campaigns',
+		},
+		{
+			displayName: 'Number Of Employees',
+			name: 'numberofemployees',
+			type: 'number',
+			typeOptions: {
+				maxValue: 1000000,
+				minValue: 0,
+			},
+			default: 0,
+			description:
+				'number of employees that work at the company associated with the lead, for use in marketing segmentation and demographic analysis.',
+		},
+		{
+			displayName: 'Preferred Contact Method Name or ID',
+			name: 'preferredcontactmethodcode',
+			type: 'options',
+			typeOptions: {
+				loadOptionsMethod: 'getLeadPreferredContactMethodCodes',
+			},
+			default: '',
+			description:
+				'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+		},
+		{
+			displayName: 'Revenue',
+			name: 'revenue',
+			type: 'number',
+			typeOptions: {
+				maxValue: 100000000000000,
+				minValue: 0,
+				numberPrecision: 2,
+			},
+			default: '',
+			description:
+				'The annual revenue of the company associated with the lead to provide an understanding of the prospect’s business.',
+		},
+		{
+			displayName: 'SIC',
+			name: 'sic',
+			type: 'string',
+			default: '',
+			description:
+				'The Standard Industrial Classification (SIC) code that indicates the lead’s primary industry of business for use in marketing segmentation and demographic analysis.',
+		},
+		{
+			displayName: 'SLA',
+			name: 'slaid',
+			type: 'string',
+			default: '',
+			description: 'The service level agreement (SLA) that you want to apply to the Lead record.',
+		},
+		{
+			displayName: 'Stage ID',
+			name: 'stageid',
+			type: 'string',
+			default: '',
+			description: 'The ID of the stage where the entity is located.',
+		},
+		{
+			displayName: 'Topic',
+			name: 'subject',
+			type: 'string',
+			default: '',
+			description:
+				'Subject or descriptive name, such as the expected order, company name, or marketing source list, to identify the lead.',
+		},
+		{
+			displayName: 'Telephone 1',
+			name: 'telephone1',
+			type: 'string',
+			default: '',
+			description: 'The main phone number for this account',
+		},
+		{
+			displayName: 'Telephone 2',
+			name: 'telephone2',
+			type: 'string',
+			default: '',
+			description: 'The second phone number for this account',
+		},
+		{
+			displayName: 'Telephone 3',
+			name: 'telephone3',
+			type: 'string',
+			default: '',
+			description: 'The third phone number for this account',
+		},
+		{
+			displayName: 'Website URL',
+			name: 'websiteurl',
+			type: 'string',
+			default: '',
+			description: 'The website URL for the company associated with this lead.',
+		},
+		{
+			displayName: 'Yomi Company Name',
+			name: 'yomicompanyname',
+			type: 'string',
+			default: '',
+			description:
+				'The phonetic spelling of the lead’s company name, if the name is specified in Japanese, to make sure the name is pronounced correctly in phone calls with the prospect.',
+		},
+		{
+			displayName: 'Yomi First Name',
+			name: 'yomifirstname',
+			type: 'string',
+			default: '',
+			description:
+				'The phonetic spelling of the lead’s first name, if the name is specified in Japanese, to make sure the name is pronounced correctly in phone calls with the prospect.',
+		},
+		{
+			displayName: 'Yomi Last Name',
+			name: 'yomilastname',
+			type: 'string',
+			default: '',
+			description:
+				'The phonetic spelling of the lead’s last name, if the name is specified in Japanese, to make sure the name is pronounced correctly in phone calls with the prospect.',
+		},
+	];
+}
 
+export const sort = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name);
+
+export interface ICustomField {
+	name: string;
+	value: string;
+}
+
+export interface ICustomFields {
+	customFields: ICustomField[];
+}
 export interface IField {
 	IsRetrievable: boolean;
 	LogicalName: string;
@@ -540,4 +959,16 @@ export interface IField {
 			Label: string;
 		};
 	};
+}
+
+export interface IOperationFunction {
+	(
+		this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
+		index: number,
+	): Promise<any>;
+}
+
+export interface IRawBody extends IDataObject {
+	addresses?: { address: [{ [key: string]: any }] };
+	customFields?: ICustomField[];
 }

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
@@ -163,8 +163,8 @@ const operations: { [key: string]: IOperationFunction } = {
 
 export class MicrosoftDynamicsCrm implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Microsoft Dynamics CRM v2',
-		name: 'microsoftDynamicsCrmV2',
+		displayName: 'Microsoft Dynamics CRM',
+		name: 'microsoftDynamicsCrm',
 		icon: 'file:dynamicsCrm.svg',
 		group: ['input'],
 		version: 1,

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/AccountDescription.ts
@@ -76,6 +76,42 @@ export const accountFields: INodeProperties[] = [
 		},
 		options: [...getAccountFields()],
 	},
+	{
+		displayName: 'Custom Fields',
+		name: 'customFields',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Custom Field',
+				name: 'customFields',
+				values: [
+					{
+						displayName: 'Name',
+						name: 'name',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
+	},
 	// ----------------------------------------
 	//             account:get
 	// ----------------------------------------
@@ -203,6 +239,42 @@ export const accountFields: INodeProperties[] = [
 			},
 		},
 		options: [...getAccountFields()],
+	},
+	{
+		displayName: 'Custom Fields',
+		name: 'customFields',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['account'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Custom Field',
+				name: 'customFields',
+				values: [
+					{
+						displayName: 'Name',
+						name: 'name',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
 	},
 	{
 		displayName: 'Options',

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/LeadDescription.ts
@@ -87,7 +87,7 @@ export const leadFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['lead'],
-				operation: ['create', 'update'],
+				operation: ['create'],
 			},
 		},
 		options: [

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/LeadDescription.ts
@@ -1,0 +1,107 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import { getLeadFields } from '../GenericFunctions';
+
+export const leadOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['lead'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				action: 'Create a lead',
+			},
+		],
+		default: 'create',
+	},
+];
+
+export const leadFields: INodeProperties[] = [
+	// ----------------------------------------
+	//             lead:create
+	// ----------------------------------------
+	{
+		displayName: 'Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['lead'],
+				operation: ['create'],
+			},
+		},
+		options: [...getLeadFields()],
+	},
+	{
+		displayName: 'Custom Fields',
+		name: 'customFields',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['lead'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Custom Field',
+				name: 'customFields',
+				values: [
+					{
+						displayName: 'Name',
+						name: 'name',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['lead'],
+				operation: ['create', 'update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Return Field Names or IDs',
+				name: 'returnFields',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getLeadFields',
+				},
+				default: [],
+				description:
+					'Fields the response will include. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+			},
+		],
+	},
+];

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/descriptions/index.ts
@@ -1,1 +1,2 @@
 export * from './AccountDescription';
+export * from './LeadDescription';


### PR DESCRIPTION
Microsoft Dynamics CRM node currently supports the `Account` resource only while `Lead` entity type should be more useful. `Create` operation was added for the `Lead` resource according to the [documentation](https://learn.microsoft.com/en-us/dynamics365/customerengagement/on-premises/developer/entities/lead).