### PR TITLE
fix(editor): Fix Vite dev mode (no-changelog)

### DIFF
--- a/packages/editor-ui/vite.config.ts
+++ b/packages/editor-ui/vite.config.ts
@@ -51,11 +51,14 @@ const lodashAliases = ['orderBy', 'camelCase', 'cloneDeep', 'isEqual', 'startCas
 	replacement: require.resolve(`lodash-es/${name}`),
 }));
 
+const { NODE_ENV } = process.env;
+
 export default mergeConfig(
 	defineConfig({
 		define: {
 			// This causes test to fail but is required for actually running it
-			...(process.env.NODE_ENV !== 'test' ? { global: 'globalThis' } : {}),
+			...(NODE_ENV !== 'test' ? { global: 'globalThis' } : {}),
+			...(NODE_ENV === 'development' ? { process: { env: {} } } : {}),
 			BASE_PATH: `'${publicPath}'`,
 		},
 		plugins: [


### PR DESCRIPTION
because of the updated dev tooling in https://github.com/n8n-io/n8n/pull/5454, vite dev mode is crashing because of the `util` package looking for `process.env`.
