### PR TITLE
fix: Fixes an issue when saving an active workflow without triggers would cause n8n to be stuck

### DIFF
--- a/packages/cli/src/workflows/workflows.services.ts
+++ b/packages/cli/src/workflows/workflows.services.ts
@@ -332,7 +332,11 @@ export class WorkflowsService {
 				);
 			} catch (error) {
 				// If workflow could not be activated set it again to inactive
-				await Db.collections.Workflow.update(workflowId, { active: false });
+				// and revert the versionId change so UI remains consistent
+				await Db.collections.Workflow.update(workflowId, {
+					active: false,
+					versionId: shared.workflow.versionId,
+				});
 
 				// Also set it in the returned data
 				updatedWorkflow.active = false;


### PR DESCRIPTION
This PR fixes an issue that could be found if a user has an active workflow, then removes all triggers and tries to save it.

n8n would update the workflow's version ID and prevent the user from further changing the workflow, forcing a refresh.

Now when n8n fails to activate the workflow, we still tell the users that this happened but revert versionId, allowing the user to make further changes and fix the error.

Github issue / Community forum post (link here to close automatically):
