### PR TITLE
fix(editor): Fix adding of wrong actions when filtering in the node actions panel (no-changelog)

### DIFF
--- a/cypress/e2e/4-node-creator.cy.ts
+++ b/cypress/e2e/4-node-creator.cy.ts
@@ -112,6 +112,20 @@ describe('Node Creator', () => {
 		NDVModal.getters.parameterInput('operation').should('contain.text', 'Crop');
 	})
 
+	it('should search through actions and confirm added action', () => {
+		nodeCreatorFeature.actions.openNodeCreator();
+		nodeCreatorFeature.getters.searchBar().find('input').clear().type('ftp');
+		nodeCreatorFeature.getters.searchBar().find('input').realPress('{rightarrow}');
+		nodeCreatorFeature.getters.activeSubcategory().should('have.text', 'FTP');
+		nodeCreatorFeature.getters.searchBar().find('input').clear().type('file');
+		// Navigate to rename action which should be the 4th item
+		nodeCreatorFeature.getters.searchBar().find('input').realPress('{downarrow}');
+		nodeCreatorFeature.getters.searchBar().find('input').realPress('{downarrow}');
+		nodeCreatorFeature.getters.searchBar().find('input').realPress('{downarrow}');
+		nodeCreatorFeature.getters.searchBar().find('input').realPress('{rightarrow}');
+		NDVModal.getters.parameterInput('operation').should('contain.text', 'Rename');
+	})
+
 	it('should render and select community node', () => {
 		cy.intercept('GET', '/types/nodes.json').as('nodesIntercept');
 		cy.wait('@nodesIntercept').then(() => {

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -22,8 +22,13 @@
 				v-touch:start="touchStart"
 				v-touch:end="touchEnd"
 			>
-				<i class="trigger-icon">
-					<font-awesome-icon icon="bolt" size="lg" v-if="isTriggerNode" />
+				<i class="trigger-icon" v-if="isTriggerNode">
+					<n8n-tooltip placement="bottom">
+						<template #content>
+							<span v-html="$locale.baseText('node.thisIsATriggerNode')" />
+						</template>
+						<font-awesome-icon icon="bolt" size="lg" />
+					</n8n-tooltip>
 				</i>
 				<div
 					v-if="!data.disabled"

--- a/packages/editor-ui/src/components/Node/NodeCreator/MainPanel.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/MainPanel.vue
@@ -223,7 +223,7 @@ const firstLevelItems = computed(() => (isRoot.value ? activeView.value.items : 
 
 const searchItems = computed<INodeCreateElement[]>(() => {
 	return state.activeNodeActions
-		? transformCreateElements(selectedNodeActions.value)
+		? transformCreateElements(selectedNodeActions.value, 'action')
 		: transformCreateElements(filteredMergedAppNodes.value);
 });
 
@@ -251,6 +251,7 @@ function sortActions(nodeCreateElements: INodeCreateElement[]): INodeCreateEleme
 
 function transformCreateElements(
 	createElements: Array<INodeTypeDescription | INodeActionTypeDescription>,
+	type: 'node' | 'action' = 'node',
 ): INodeCreateElement[] {
 	const sorted = [...createElements];
 
@@ -265,7 +266,7 @@ function transformCreateElements(
 		// if we have more cases like this we should add more robust logic
 		const isN8nNode = nodeType.name.includes(N8N_NODE_TYPE);
 		return {
-			type: 'node',
+			type,
 			category: nodeType.codex?.categories,
 			key: nodeType.name,
 			properties: {
@@ -274,7 +275,7 @@ function transformCreateElements(
 			},
 			includedByTrigger: isN8nNode || nodeType.group.includes('trigger'),
 			includedByRegular: isN8nNode || !nodeType.group.includes('trigger'),
-		};
+		} as INodeCreateElement;
 	});
 }
 

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -663,6 +663,7 @@
 	"ndv.pinData.error.tooLarge.description": "You can pin at most 12MB of output per workflow.",
 	"noTagsView.readyToOrganizeYourWorkflows": "Ready to organize your workflows?",
 	"noTagsView.withWorkflowTagsYouReFree": "With workflow tags, you're free to create the perfect tagging system for your flows",
+	"node.thisIsATriggerNode": "This is a Trigger node. <a target=\"_blank\" href=\"https://docs.n8n.io/workflows/components/nodes/\">Learn more</a>",
 	"node.activateDeactivateNode": "Activate/Deactivate Node",
 	"node.deleteNode": "Delete Node",
 	"node.disabled": "Disabled",


### PR DESCRIPTION
When filtering inside the `CategorizedItems` component, we're using `searchItems` as the base for filtering. But in the case of actions, these were transformed as `type: 'node'` while it should be `action` type. I added e2e test to check this. 
Also included is the tooltip for the trigger node canvas icon as it was just a minor addition. 
Github issue / Community forum post (link here to close automatically):
