### PR TITLE
fix(core): Do not allow arbitrary path traversal in the credential-translation endpoint

### DIFF
--- a/packages/cli/src/TranslationHelpers.ts
+++ b/packages/cli/src/TranslationHelpers.ts
@@ -1,7 +1,6 @@
 import { join, dirname } from 'path';
 import { readdir } from 'fs/promises';
 import type { Dirent } from 'fs';
-import { NODES_BASE_DIR } from '@/constants';
 
 const ALLOWED_VERSIONED_DIRNAME_LENGTH = [2, 3]; // e.g. v1, v10
 
@@ -46,19 +45,4 @@ export async function getNodeTranslationPath({
 	return maxVersion
 		? join(nodeDir, `v${maxVersion}`, 'translations', locale, `${nodeType}.json`)
 		: join(nodeDir, 'translations', locale, `${nodeType}.json`);
-}
-
-/**
- * Get the full path to a credential translation file in `/dist`.
- */
-export function getCredentialTranslationPath({
-	locale,
-	credentialType,
-}: {
-	locale: string;
-	credentialType: string;
-}): string {
-	const credsPath = join(NODES_BASE_DIR, 'dist', 'credentials');
-
-	return join(credsPath, 'translations', locale, `${credentialType}.json`);
 }

--- a/packages/cli/src/controllers/index.ts
+++ b/packages/cli/src/controllers/index.ts
@@ -2,4 +2,5 @@ export { AuthController } from './auth.controller';
 export { MeController } from './me.controller';
 export { OwnerController } from './owner.controller';
 export { PasswordResetController } from './passwordReset.controller';
+export { TranslationController } from './translation.controller';
 export { UsersController } from './users.controller';

--- a/packages/cli/src/controllers/translation.controller.ts
+++ b/packages/cli/src/controllers/translation.controller.ts
@@ -1,0 +1,54 @@
+import type { Request } from 'express';
+import { ICredentialTypes } from 'n8n-workflow';
+import { join } from 'path';
+import { access } from 'fs/promises';
+import { Get, RestController } from '@/decorators';
+import { BadRequestError, InternalServerError } from '@/ResponseHelper';
+import { Config } from '@/config';
+import { NODES_BASE_DIR } from '@/constants';
+
+const credentialTranslationsDir = join(NODES_BASE_DIR, 'dist/credentials/translations');
+const nodeHeadersPath = join(NODES_BASE_DIR, 'dist/nodes/headers');
+
+@RestController('/')
+export class TranslationController {
+	constructor(private config: Config, private credentialTypes: ICredentialTypes) {}
+
+	@Get('/credential-translation')
+	async getCredentialTranslation(req: Request & { query: { credentialType: string } }) {
+		const { credentialType } = req.query;
+
+		if (!this.credentialTypes.recognizes(credentialType))
+			throw new BadRequestError(`Invalid Credential type ${credentialType}`);
+
+		const defaultLocale = this.config.getEnv('defaultLocale');
+		const translationPath = join(
+			credentialTranslationsDir,
+			defaultLocale,
+			`${credentialType}.json`,
+		);
+
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return await import(translationPath);
+		} catch (error) {
+			return null;
+		}
+	}
+
+	@Get('/node-translation-headers')
+	async getNodeTranslationHeaders() {
+		try {
+			await access(`${nodeHeadersPath}.js`);
+		} catch (_) {
+			return; // no headers available
+		}
+
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+			return await import(nodeHeadersPath);
+		} catch (error) {
+			throw new InternalServerError('Failed to load headers file');
+		}
+	}
+}

--- a/packages/cli/src/controllers/translation.controller.ts
+++ b/packages/cli/src/controllers/translation.controller.ts
@@ -7,30 +7,34 @@ import { BadRequestError, InternalServerError } from '@/ResponseHelper';
 import { Config } from '@/config';
 import { NODES_BASE_DIR } from '@/constants';
 
-const credentialTranslationsDir = join(NODES_BASE_DIR, 'dist/credentials/translations');
-const nodeHeadersPath = join(NODES_BASE_DIR, 'dist/nodes/headers');
+export const CREDENTIAL_TRANSLATIONS_DIR = 'n8n-nodes-base/dist/credentials/translations';
+export const NODE_HEADERS_PATH = join(NODES_BASE_DIR, 'dist/nodes/headers');
+
+export declare namespace TranslationRequest {
+	export type Credential = Request<{}, {}, {}, { credentialType: string }>;
+}
 
 @RestController('/')
 export class TranslationController {
 	constructor(private config: Config, private credentialTypes: ICredentialTypes) {}
 
 	@Get('/credential-translation')
-	async getCredentialTranslation(req: Request & { query: { credentialType: string } }) {
+	async getCredentialTranslation(req: TranslationRequest.Credential) {
 		const { credentialType } = req.query;
 
 		if (!this.credentialTypes.recognizes(credentialType))
-			throw new BadRequestError(`Invalid Credential type ${credentialType}`);
+			throw new BadRequestError(`Invalid Credential type: "${credentialType}"`);
 
 		const defaultLocale = this.config.getEnv('defaultLocale');
 		const translationPath = join(
-			credentialTranslationsDir,
+			CREDENTIAL_TRANSLATIONS_DIR,
 			defaultLocale,
 			`${credentialType}.json`,
 		);
 
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return await import(translationPath);
+			return require(translationPath);
 		} catch (error) {
 			return null;
 		}
@@ -39,14 +43,14 @@ export class TranslationController {
 	@Get('/node-translation-headers')
 	async getNodeTranslationHeaders() {
 		try {
-			await access(`${nodeHeadersPath}.js`);
+			await access(`${NODE_HEADERS_PATH}.js`);
 		} catch (_) {
 			return; // no headers available
 		}
 
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return await import(nodeHeadersPath);
+			return require(NODE_HEADERS_PATH);
 		} catch (error) {
 			throw new InternalServerError('Failed to load headers file');
 		}

--- a/packages/cli/test/setup-mocks.ts
+++ b/packages/cli/test/setup-mocks.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+
 jest.mock('@sentry/node');
 jest.mock('@n8n_io/license-sdk');
 jest.mock('@/telemetry');

--- a/packages/cli/test/unit/controllers/translation.controller.test.ts
+++ b/packages/cli/test/unit/controllers/translation.controller.test.ts
@@ -1,0 +1,40 @@
+import { mock } from 'jest-mock-extended';
+import type { ICredentialTypes } from 'n8n-workflow';
+import type { Config } from '@/config';
+import {
+	TranslationController,
+	TranslationRequest,
+	CREDENTIAL_TRANSLATIONS_DIR,
+} from '@/controllers/translation.controller';
+import { BadRequestError } from '@/ResponseHelper';
+
+describe('TranslationController', () => {
+	const config = mock<Config>();
+	const credentialTypes = mock<ICredentialTypes>();
+	const controller = new TranslationController(config, credentialTypes);
+
+	describe('getCredentialTranslation', () => {
+		it('should throw 400 on invalid credential types', async () => {
+			const credentialType = 'not-a-valid-credential-type';
+			const req = mock<TranslationRequest.Credential>({ query: { credentialType } });
+			credentialTypes.recognizes.calledWith(credentialType).mockReturnValue(false);
+
+			expect(controller.getCredentialTranslation(req)).rejects.toThrowError(
+				new BadRequestError(`Invalid Credential type: "${credentialType}"`),
+			);
+		});
+
+		it('should return translation json on valid credential types', async () => {
+			const credentialType = 'credential-type';
+			const req = mock<TranslationRequest.Credential>({ query: { credentialType } });
+			config.getEnv.calledWith('defaultLocale').mockReturnValue('de');
+			credentialTypes.recognizes.calledWith(credentialType).mockReturnValue(true);
+			const response = { translation: 'string' };
+			jest.mock(`${CREDENTIAL_TRANSLATIONS_DIR}/de/credential-type.json`, () => response, {
+				virtual: true,
+			});
+
+			expect(await controller.getCredentialTranslation(req)).toEqual(response);
+		});
+	});
+});


### PR DESCRIPTION
Also:
1. Extract translation endpoints out into their own controller
2. Add Unit tests for the credential-translation endpoint