### PR TITLE
ci: Release process improvements (no-changelog)

### DIFF
--- a/.github/workflows/check-documentation-urls.yml
+++ b/.github/workflows/check-documentation-urls.yml
@@ -1,9 +1,8 @@
 name: Check Documentation URLs
 
 on:
-  push:
-    tags:
-      - n8n@*
+  release:
+    types: [published]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,9 +1,8 @@
 name: Docker Image CI
 
 on:
-  push:
-    tags:
-      - n8n@*
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       base-branch:
-        description: 'The branch to create this release PR from.'
+        description: 'The branch, tag, or commit to create this release PR from.'
         required: true
         default: 'master'
 
@@ -36,7 +36,8 @@ jobs:
 
       - name: Push the base branch
         run: |
-          git push -f origin ${{ github.event.inputs.base-branch }}:"release/${{ github.event.inputs.release-type }}"
+          git checkout -b "release/${{ github.event.inputs.release-type }}"
+          git push -f origin "release/${{ github.event.inputs.release-type }}"
 
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3


### PR DESCRIPTION
1. Trigger docker release automatically by switching over to the "release:published" event.
2. Allow creating new releases from tags and commits as well.