### PR TITLE
fix(core): Do not remove empty output connections arrays in PurgeInvalidWorkflowConnections migration

### DIFF
--- a/packages/cli/src/databases/migrations/mysqldb/1675940580449-PurgeInvalidWorkflowConnections.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1675940580449-PurgeInvalidWorkflowConnections.ts
@@ -58,22 +58,7 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements MigrationIn
 								!nodesThatCannotReceiveInput.includes(outgoingConnections.node),
 						);
 					});
-
-					// Filter out output connection items that are empty
-					connection[outputConnectionName] = connection[outputConnectionName].filter(
-						(item) => item.length > 0,
-					);
-
-					// Delete the output connection container if it is empty
-					if (connection[outputConnectionName].length === 0) {
-						delete connection[outputConnectionName];
-					}
 				});
-
-				// Finally delete the source node if it has no output connections
-				if (Object.keys(connection).length === 0) {
-					delete connections[sourceNodeName];
-				}
 			});
 
 			// Update database with new connections

--- a/packages/cli/src/databases/migrations/postgresdb/1675940580449-PurgeInvalidWorkflowConnections.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/1675940580449-PurgeInvalidWorkflowConnections.ts
@@ -50,22 +50,7 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements MigrationIn
 								!nodesThatCannotReceiveInput.includes(outgoingConnections.node),
 						);
 					});
-
-					// Filter out output connection items that are empty
-					connection[outputConnectionName] = connection[outputConnectionName].filter(
-						(item) => item.length > 0,
-					);
-
-					// Delete the output connection container if it is empty
-					if (connection[outputConnectionName].length === 0) {
-						delete connection[outputConnectionName];
-					}
 				});
-
-				// Finally delete the source node if it has no output connections
-				if (Object.keys(connection).length === 0) {
-					delete connections[sourceNodeName];
-				}
 			});
 
 			// Update database with new connections

--- a/packages/cli/src/databases/migrations/sqlite/1675940580449-PurgeInvalidWorkflowConnections.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1675940580449-PurgeInvalidWorkflowConnections.ts
@@ -51,22 +51,7 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements MigrationIn
 								!nodesThatCannotReceiveInput.includes(outgoingConnections.node),
 						);
 					});
-
-					// Filter out output connection items that are empty
-					connection[outputConnectionName] = connection[outputConnectionName].filter(
-						(item) => item.length > 0,
-					);
-
-					// Delete the output connection container if it is empty
-					if (connection[outputConnectionName].length === 0) {
-						delete connection[outputConnectionName];
-					}
 				});
-
-				// Finally delete the source node if it has no output connections
-				if (Object.keys(connection).length === 0) {
-					delete connections[sourceNodeName];
-				}
 			});
 
 			// Update database with new connections


### PR DESCRIPTION
The `PurgeInvalidWorkflowConnections` migration filters out empty output connections. This is not required and leads to a migration where nodes with multiple outputs(switch/if) might get indexes mixed up.
 
Github issue / Community forum post (link here to close automatically): 
- https://community.n8n.io/t/switch-node-wrong-output-numbers-after-update-0-216-0/23312
- https://github.com/n8n-io/n8n/issues/5471

