### PR TITLE
fix(Discord Node): Fix wrong error message being displayed

### DIFF
--- a/packages/nodes-base/nodes/Discord/Discord.node.ts
+++ b/packages/nodes-base/nodes/Discord/Discord.node.ts
@@ -133,13 +133,13 @@ export class Discord implements INodeType {
 				try {
 					//@ts-expect-error
 					body.embeds = JSON.parse(options.embeds);
-					if (!Array.isArray(body.embeds)) {
-						throw new NodeOperationError(this.getNode(), 'Embeds must be an array of embeds.', {
-							itemIndex: i,
-						});
-					}
 				} catch (e) {
 					throw new NodeOperationError(this.getNode(), 'Embeds must be valid JSON.', {
+						itemIndex: i,
+					});
+				}
+				if (!Array.isArray(body.embeds)) {
+					throw new NodeOperationError(this.getNode(), 'Embeds must be an array of embeds.', {
 						itemIndex: i,
 					});
 				}


### PR DESCRIPTION
Displays currently error that valid JSON is not valid JSON. Reason for that is that it actually has to be an array and an error which gets trhown in an incorrect way. 
![Screenshot from 2023-02-22 15-25-14](https://user-images.githubusercontent.com/6249596/220653530-533f45ae-c5f1-412b-a550-b9d33b0b8316.png)
