### PR TITLE
fix(editor): Fix an issue with zoom and canvas nodes connections

### DIFF
--- a/packages/editor-ui/src/plugins/endpoints/N8nPlusEndpointType.ts
+++ b/packages/editor-ui/src/plugins/endpoints/N8nPlusEndpointType.ts
@@ -18,7 +18,8 @@ interface N8nPlusEndpointParams extends EndpointRepresentationParams {
 }
 export const PlusStalkOverlay = 'plus-stalk';
 export const HoverMessageOverlay = 'hover-message';
-
+export const N8nPlusEndpointType = 'N8nPlus';
+export const EVENT_PLUS_ENDPOINT_CLICK = 'eventPlusEndpointClick';
 export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpoint> {
 	params: N8nPlusEndpointParams;
 	label: string;
@@ -38,7 +39,7 @@ export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpo
 		this.bindEvents();
 	}
 
-	static type = 'N8nPlus';
+	static type = N8nPlusEndpointType;
 	type = N8nPlusEndpoint.type;
 
 	setupOverlays() {
@@ -100,7 +101,7 @@ export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpo
 	};
 	fireClickEvent = (endpoint: Endpoint) => {
 		if (endpoint === this.endpoint) {
-			this.instance.fire('plusEndpointClick', this.endpoint);
+			this.instance.fire(EVENT_PLUS_ENDPOINT_CLICK, this.endpoint);
 		}
 	};
 	setHoverMessageVisible = (endpoint: Endpoint) => {

--- a/packages/editor-ui/src/stores/canvas.ts
+++ b/packages/editor-ui/src/stores/canvas.ts
@@ -28,6 +28,9 @@ import {
 	PLACEHOLDER_TRIGGER_NODE_SIZE,
 	CONNECTOR_FLOWCHART_TYPE,
 	GRID_SIZE,
+	CONNECTOR_PAINT_STYLE_DEFAULT,
+	CONNECTOR_PAINT_STYLE_PRIMARY,
+	CONNECTOR_ARROW_OVERLAYS,
 } from '@/utils/nodeViewUtils';
 import { PointXY } from '@jsplumb/util';
 
@@ -153,6 +156,13 @@ export const useCanvasStore = defineStore('canvas', () => {
 			container,
 			connector: CONNECTOR_FLOWCHART_TYPE,
 			resizeObserver: false,
+			endpoint: {
+				type: 'Dot',
+				options: { radius: 5 },
+			},
+			paintStyle: CONNECTOR_PAINT_STYLE_DEFAULT,
+			hoverPaintStyle: CONNECTOR_PAINT_STYLE_PRIMARY,
+			connectionOverlays: CONNECTOR_ARROW_OVERLAYS,
 			dragOptions: {
 				cursor: 'pointer',
 				grid: { w: GRID_SIZE, h: GRID_SIZE },


### PR DESCRIPTION
We can't detach all the events when deactivating the NodeView component, because it breaks the dragging event that is added on JsPlumb initialization. For this, we have to unbind all the events manually and also make sure that all the endpoints events are also destroyed.

Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/bug-dragging-nodes-around/23265
