### PR TITLE
fix(core): Fix execution pruning queries

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -212,7 +212,9 @@ async function pruneExecutionData(this: WorkflowHooks): Promise<void> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const utcDate = DateUtils.mixedDateToUtcDatetimeString(date);
 
-		const toPrune: FindOptionsWhere<IExecutionFlattedDb> = { stoppedAt: LessThanOrEqual(utcDate) };
+		const toPrune: Array<FindOptionsWhere<IExecutionFlattedDb>> = [
+			{ stoppedAt: LessThanOrEqual(utcDate) },
+		];
 
 		if (maxCount > 0) {
 			const executions = await Db.collections.Execution.find({
@@ -223,7 +225,7 @@ async function pruneExecutionData(this: WorkflowHooks): Promise<void> {
 			});
 
 			if (executions[0]) {
-				toPrune.id = LessThanOrEqual(executions[0].id);
+				toPrune.push({ id: LessThanOrEqual(executions[0].id) });
 			}
 		}
 

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -231,13 +231,11 @@ async function pruneExecutionData(this: WorkflowHooks): Promise<void> {
 
 		const isBinaryModeDefaultMode = config.getEnv('binaryDataManager.mode') === 'default';
 		try {
-			const executions = isBinaryModeDefaultMode
-				? []
-				: await Db.collections.Execution.find({
-						select: ['id'],
-						where: toPrune,
-				  });
-			await Db.collections.Execution.delete(toPrune);
+			const executions = await Db.collections.Execution.find({
+				select: ['id'],
+				where: toPrune,
+			});
+			await Db.collections.Execution.remove(executions, { chunk: 100 });
 			setTimeout(() => {
 				throttling = false;
 			}, timeout * 1000);


### PR DESCRIPTION
1. Use `OR` operator when looking for executions based on age, and ids
2. Delete executions in chunks to avoid sqlite error when there are over a 1000 executions to delete.
3. Reduce the memory usage of the pruning operation significantly on larger databases

Fixes https://github.com/n8n-io/n8n/issues/5543#issuecomment-1443158810