### PR TITLE
ci: Disable provenance attestation on docker images to work around docker/buildx#1533

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -34,6 +34,7 @@ jobs:
           build-args: |
             NODE_VERSION=${{github.event.inputs.node_version}}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          provenance: false
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/base:${{ github.event.inputs.node_version }}

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -75,6 +75,7 @@ jobs:
           context: .
           file: ./docker/images/n8n-custom/Dockerfile
           platforms: linux/amd64
+          provenance: false
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ github.event.inputs.tag || 'nightly' }}
           no-cache: true

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -45,6 +45,7 @@ jobs:
           build-args: |
             N8N_VERSION=${{ steps.vars.outputs.tag }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          provenance: false
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/n8n:${{ steps.vars.outputs.tag }}${{ matrix.docker-context }}


### PR DESCRIPTION
Fixes https://github.com/n8n-io/n8n/issues/5394

Cause https://github.com/docker/buildx/issues/1533