### PR TITLE
ci: Update ReadBinaryFile Documentation URL (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.json
+++ b/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.json
@@ -6,7 +6,7 @@
 	"resources": {
 		"primaryDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.readbinaryfile/"
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.readbinaryfiles/"
 			}
 		],
 		"generic": [


### PR DESCRIPTION
this is a follow up on https://github.com/n8n-io/n8n/pull/5490

Fixes the failing CI check for documentation URLs https://github.com/n8n-io/n8n/actions/workflows/check-documentation-urls.yml