### PR TITLE
fix(core): Improve community nodes loading

### DIFF
--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -451,7 +451,6 @@ export class CredentialsHelper extends ICredentialsHelper {
 		type: string,
 		data: ICredentialDataDecryptedObject,
 	): Promise<void> {
-		// eslint-disable-next-line @typescript-eslint/await-thenable
 		const credentials = await this.getCredentials(nodeCredentials, type);
 
 		if (!Db.isInitialized) {

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -24,12 +24,12 @@ import config from '@/config';
 import type { InstalledPackages } from '@db/entities/InstalledPackages';
 import { executeCommand } from '@/CommunityNodes/helpers';
 import {
-	CLI_DIR,
 	GENERATED_STATIC_DIR,
 	RESPONSE_ERROR_MESSAGES,
 	CUSTOM_API_CALL_KEY,
 	CUSTOM_API_CALL_NAME,
 	inTest,
+	NODES_BASE_DIR,
 } from '@/constants';
 import { CredentialsOverwrites } from '@/CredentialsOverwrites';
 import { Service } from 'typedi';
@@ -110,12 +110,7 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 	}
 
 	private async loadNodesFromBasePackages() {
-		const nodeModulesPath = await this.getNodeModulesPath();
-		const nodePackagePaths = await this.getN8nNodePackages(nodeModulesPath);
-
-		for (const packagePath of nodePackagePaths) {
-			await this.runDirectoryLoader(LazyPackageDirectoryLoader, packagePath);
-		}
+		await this.runDirectoryLoader(LazyPackageDirectoryLoader, NODES_BASE_DIR);
 	}
 
 	private async loadNodesFromDownloadedPackages(): Promise<void> {
@@ -398,28 +393,5 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 				}
 			}
 		}
-	}
-
-	private async getNodeModulesPath(): Promise<string> {
-		// Get the path to the node-modules folder to be later able
-		// to load the credentials and nodes
-		const checkPaths = [
-			// In case "n8n" package is in same node_modules folder.
-			path.join(CLI_DIR, '..', 'n8n-workflow'),
-			// In case "n8n" package is the root and the packages are
-			// in the "node_modules" folder underneath it.
-			path.join(CLI_DIR, 'node_modules', 'n8n-workflow'),
-			// In case "n8n" package is installed using npm/yarn workspaces
-			// the node_modules folder is in the root of the workspace.
-			path.join(CLI_DIR, '..', '..', 'node_modules', 'n8n-workflow'),
-		];
-		for (const checkPath of checkPaths) {
-			try {
-				await fsAccess(checkPath);
-				// Folder exists, so use it.
-				return path.dirname(checkPath);
-			} catch {} // Folder does not exist so get next one
-		}
-		throw new Error('Could not find "node_modules" folder!');
 	}
 }

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -190,7 +190,17 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 
 		const finalNodeUnpackedPath = path.join(downloadFolder, 'node_modules', packageName);
 
-		const loader = await this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
+		let loader: PackageDirectoryLoader;
+		try {
+			loader = await this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
+		} catch (error) {
+			// Remove this package since loading it failed
+			const removeCommand = `npm remove ${packageName}`;
+			try {
+				await executeCommand(removeCommand);
+			} catch (_) {}
+			throw new Error(RESPONSE_ERROR_MESSAGES.PACKAGE_LOADING_FAILED, { cause: error });
+		}
 
 		if (loader.loadedNodes.length > 0) {
 			// Save info to DB
@@ -254,7 +264,17 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 
 		const finalNodeUnpackedPath = path.join(downloadFolder, 'node_modules', packageName);
 
-		const loader = await this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
+		let loader: PackageDirectoryLoader;
+		try {
+			loader = await this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
+		} catch (error) {
+			// Remove this package since loading it failed
+			const removeCommand = `npm remove ${packageName}`;
+			try {
+				await executeCommand(removeCommand);
+			} catch (_) {}
+			throw new Error(RESPONSE_ERROR_MESSAGES.PACKAGE_LOADING_FAILED, { cause: error });
+		}
 
 		if (loader.loadedNodes.length > 0) {
 			// Save info to DB

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -30,7 +30,6 @@ import {
 	CUSTOM_API_CALL_KEY,
 	CUSTOM_API_CALL_NAME,
 	inTest,
-	NODES_BASE_DIR,
 	CLI_DIR,
 } from '@/constants';
 import { CredentialsOverwrites } from '@/CredentialsOverwrites';

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -267,11 +267,10 @@ export class Start extends BaseCommand {
 					// Optimistic approach - stop if any installation fails
 					// eslint-disable-next-line no-restricted-syntax
 					for (const missingPackage of missingPackages) {
-						// eslint-disable-next-line no-await-in-loop
-						void (await this.loadNodesAndCredentials.loadNpmModule(
+						await this.loadNodesAndCredentials.installNpmModule(
 							missingPackage.packageName,
 							missingPackage.version,
-						));
+						);
 						missingPackages.delete(missingPackage);
 					}
 					LoggerProxy.info('Packages reinstalled successfully. Resuming regular initialization.');

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -45,6 +45,7 @@ export const RESPONSE_ERROR_MESSAGES = {
 	PACKAGE_NOT_FOUND: 'Package not found in npm',
 	PACKAGE_VERSION_NOT_FOUND: 'The specified package version was not found',
 	PACKAGE_DOES_NOT_CONTAIN_NODES: 'The specified package does not contain any nodes',
+	PACKAGE_LOADING_FAILED: 'The specified package could not be loaded',
 	DISK_IS_FULL: 'There appears to be insufficient disk space',
 };
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -18,7 +18,7 @@ export const CUSTOM_API_CALL_KEY = '__CUSTOM_API_CALL__';
 
 export const CLI_DIR = resolve(__dirname, '..');
 export const TEMPLATES_DIR = join(CLI_DIR, 'templates');
-export const NODES_BASE_DIR = join(CLI_DIR, '..', 'nodes-base');
+export const NODES_BASE_DIR = dirname(require.resolve('n8n-nodes-base'));
 export const GENERATED_STATIC_DIR = join(UserSettings.getUserHome(), '.cache/n8n/public');
 export const EDITOR_UI_DIST_DIR = join(dirname(require.resolve('n8n-editor-ui')), 'dist');
 

--- a/packages/cli/src/controllers/nodes.controller.ts
+++ b/packages/cli/src/controllers/nodes.controller.ts
@@ -109,7 +109,7 @@ export class NodesController {
 
 		let installedPackage: InstalledPackages;
 		try {
-			installedPackage = await this.loadNodesAndCredentials.loadNpmModule(
+			installedPackage = await this.loadNodesAndCredentials.installNpmModule(
 				parsed.packageName,
 				parsed.version,
 			);

--- a/packages/cli/src/controllers/nodes.controller.ts
+++ b/packages/cli/src/controllers/nodes.controller.ts
@@ -125,7 +125,10 @@ export class NodesController {
 				failure_reason: errorMessage,
 			});
 
-			const message = [`Error loading package "${name}"`, errorMessage].join(':');
+			let message = [`Error loading package "${name}" `, errorMessage].join(':');
+			if (error instanceof Error && error.cause instanceof Error) {
+				message += `\nCause: ${error.cause.message}`;
+			}
 
 			const clientError = error instanceof Error ? isClientError(error) : false;
 			throw new (clientError ? BadRequestError : InternalServerError)(message);

--- a/packages/cli/test/integration/nodes.api.test.ts
+++ b/packages/cli/test/integration/nodes.api.test.ts
@@ -191,7 +191,7 @@ describe('POST /nodes', () => {
 		mocked(hasPackageLoaded).mockReturnValueOnce(false);
 		mocked(checkNpmPackageStatus).mockResolvedValueOnce({ status: 'OK' });
 
-		mockLoadNodesAndCredentials.loadNpmModule.mockImplementationOnce(mockedEmptyPackage);
+		mockLoadNodesAndCredentials.installNpmModule.mockImplementationOnce(mockedEmptyPackage);
 
 		const { statusCode } = await authOwnerShellAgent.post('/nodes').send({
 			name: utils.installedPackagePayload().packageName,

--- a/packages/nodes-base/.eslintrc.js
+++ b/packages/nodes-base/.eslintrc.js
@@ -8,6 +8,8 @@ module.exports = {
 
 	...sharedOptions(__dirname),
 
+	ignorePatterns: ['index.js'],
+
 	rules: {
 		'@typescript-eslint/consistent-type-imports': 'error',
 

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -8,6 +8,7 @@
     "name": "Jan Oberhauser",
     "email": "jan@n8n.io"
   },
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/n8n-io/n8n.git"


### PR DESCRIPTION
1. use `require.resolve` to find the path for `n8n-nodes-base`
2. If a community package installs, but then fails to load, uninstall it.