### PR TITLE
fix(editor): Display correct error message

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -461,10 +461,14 @@ export class WorkflowDataProxy {
 				get(target, name, receiver) {
 					if (name === 'isProxy') return true;
 
-					if (
-						typeof process === 'undefined' || // env vars are inaccessible to frontend
-						process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true'
-					) {
+					if (typeof process === 'undefined') {
+						throw new ExpressionError('not accessible via UI, please run node', {
+							runIndex: that.runIndex,
+							itemIndex: that.itemIndex,
+							failExecution: true,
+						});
+					}
+					if (process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true') {
 						throw new ExpressionError('access to env vars denied', {
 							causeDetailed:
 								'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',


### PR DESCRIPTION
When `$env` is currently used in the UI, it always displays the error message `access to env vars denied` even if access is actually possible.

This fix is not perfect, but at least tells people that access is not possible via the UI and they have to run the node. Depending on the settings, will it then either return the correct value or, if really deactivated display the correct error message.

Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/add-actual-information-about-env-vars-handling-to-documentation/23829
https://community.n8n.io/t/how-to-get-hostname/21037
https://community.n8n.io/t/no-access-to-env/20665