### PR TITLE
fix(editor): Only fetch new versions at app launch

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -46,8 +46,9 @@ import { useRootStore } from './stores/n8nRootStore';
 import { useTemplatesStore } from './stores/templates';
 import { useNodeTypesStore } from './stores/nodeTypes';
 import { historyHelper } from '@/mixins/history';
+import { newVersions } from '@/mixins/newVersions';
 
-export default mixins(showMessage, userHelpers, restApi, historyHelper).extend({
+export default mixins(newVersions, showMessage, userHelpers, restApi, historyHelper).extend({
 	name: 'App',
 	components: {
 		LoadingView,
@@ -186,6 +187,7 @@ export default mixins(showMessage, userHelpers, restApi, historyHelper).extend({
 		this.logHiringBanner();
 		this.authenticate();
 		this.redirectIfNecessary();
+		this.checkForNewVersions();
 
 		this.loading = false;
 

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -208,7 +208,6 @@ import { restApi } from '@/mixins/restApi';
 import useGlobalLinkActions from '@/composables/useGlobalLinkActions';
 import { showMessage } from '@/mixins/showMessage';
 import { titleChange } from '@/mixins/titleChange';
-import { newVersions } from '@/mixins/newVersions';
 
 import { workflowHelpers } from '@/mixins/workflowHelpers';
 import { workflowRun } from '@/mixins/workflowRun';
@@ -327,7 +326,6 @@ export default mixins(
 	titleChange,
 	workflowHelpers,
 	workflowRun,
-	newVersions,
 	debounceHelper,
 ).extend({
 	name: 'NodeView',
@@ -3885,7 +3883,6 @@ export default mixins(
 
 			setTimeout(() => {
 				this.usersStore.showPersonalizationSurvey();
-				this.checkForNewVersions();
 				this.addPinDataConnections(this.workflowsStore.getPinData || ({} as IPinData));
 			}, 0);
 		});

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -119,7 +119,6 @@
 
 <script lang="ts">
 import { showMessage } from '@/mixins/showMessage';
-import { newVersions } from '@/mixins/newVersions';
 import mixins from 'vue-typed-mixins';
 
 import SettingsView from './SettingsView.vue';
@@ -148,7 +147,7 @@ const StatusFilter = {
 	ALL: '',
 };
 
-const WorkflowsView = mixins(showMessage, debounceHelper, newVersions).extend({
+const WorkflowsView = mixins(showMessage, debounceHelper).extend({
 	name: 'WorkflowsView',
 	components: {
 		ResourcesListLayout,
@@ -277,7 +276,6 @@ const WorkflowsView = mixins(showMessage, debounceHelper, newVersions).extend({
 		},
 	},
 	mounted() {
-		this.checkForNewVersions();
 		this.usersStore.showPersonalizationSurvey();
 	},
 });


### PR DESCRIPTION
The component that check for new version also managed displaying a popup for critical versions update. The way it works right now, the popup is shown every time the user goes back to the workflows listing page