### PR TITLE
feat(editor): Do not show actions panel for single-action nodes

### DIFF
--- a/cypress/e2e/4-node-creator.cy.ts
+++ b/cypress/e2e/4-node-creator.cy.ts
@@ -105,6 +105,31 @@ describe('Node Creator', () => {
 		NDVModal.getters.parameterInput('operation').should('contain.text', 'Rename');
 	})
 
+	it('should not show actions for single action nodes', () => {
+		const singleActionNodes = [
+			'DHL',
+			'iCalendar',
+			'LingvaNex',
+			'Mailcheck',
+			'MSG91',
+			'OpenThesaurus',
+			'Spontit',
+			'Vonage',
+			'Send Email',
+			'Toggl Trigger'
+		]
+		const doubleActionNode = 'OpenWeatherMap'
+
+		nodeCreatorFeature.actions.openNodeCreator();
+		singleActionNodes.forEach((node) => {
+			nodeCreatorFeature.getters.searchBar().find('input').clear().type(node);
+			nodeCreatorFeature.getters.getCreatorItem(node).find('button[class*="panelIcon"]').should('not.exist');
+		})
+		nodeCreatorFeature.getters.searchBar().find('input').clear().type(doubleActionNode);
+		nodeCreatorFeature.getters.getCreatorItem(doubleActionNode).click();
+		nodeCreatorFeature.getters.creatorItem().should('have.length', 2);
+	})
+
 	describe('should correctly append manual trigger for regular actions', () => {
 		// For these sources, manual node should be added
 		const sourcesWithAppend = [

--- a/packages/editor-ui/src/stores/nodeCreator.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.ts
@@ -56,6 +56,8 @@ const customNodeActionsParsers: {
 };
 
 function filterActions(actions: INodeActionTypeDescription[]) {
+	// Do not show single action nodes
+	if (actions.length <= 1) return [];
 	return actions.filter(
 		(action: INodeActionTypeDescription, _: number, arr: INodeActionTypeDescription[]) => {
 			const isApiCall = action.actionKey === CUSTOM_API_CALL_KEY;


### PR DESCRIPTION
When creating a node, if it contains only a single action, we no longer display the actions panel. To achieve this, I've included a condition in the actions filtering method that returns an empty array if the length of actions is less than or equal to 1. I also added e2e tests that validate the nodes affected and confirm that the actions panel button is not displayed.