### PR TITLE
ci: Copy jest.config.js to the Docker container on deployment (no-changelog)

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_VERSION=16
 # 1. Create an image to build n8n
 FROM n8nio/base:${NODE_VERSION} as builder
 
-COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml jest.config.js tsconfig.json ./
 COPY scripts ./scripts
 COPY packages ./packages
 COPY patches ./patches


### PR DESCRIPTION
Docker nightly build is now failing because `jest.config.js` is missing, for this, we have to make sure it's copied into the container