### PR TITLE
fix(editor): Fix owner set-up checkbox wording

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -80,7 +80,7 @@
 	"auth.role": "Role",
 	"auth.roles.member": "Member",
 	"auth.roles.owner": "Owner",
-	"auth.agreement.label": "I’d be OK sharing my opinion on n8n (no marketing emails though)",
+	"auth.agreement.label": "Inform me about security vulnerabilities if they arise",
 	"auth.setup.confirmOwnerSetup": "Set up owner account?",
 	"auth.setup.confirmOwnerSetupMessage": "To give others access to your <b>{entities}</b>, you’ll need to share these account details with them. Or you can continue as before with no account, by going back and skipping this setup. <a href=\"https://docs.n8n.io/user-management/\" target=\"_blank\">More info</a>",
 	"auth.setup.createAccount": "Create account",


### PR DESCRIPTION
Change the wording of the checkbox on the Set-up Account owner page from "I’d be OK sharing my opinion on n8n (no marketing emails though)" to "Inform me about security vulnerabilities if they arise"