### PR TITLE
feat(Airtable Node): Add Airtable authentication using a Personal Access Token

### DIFF
--- a/packages/nodes-base/credentials/AirtablePersonalAccessTokenApi.credentials.ts
+++ b/packages/nodes-base/credentials/AirtablePersonalAccessTokenApi.credentials.ts
@@ -1,0 +1,28 @@
+import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class AirtablePersonalAccessTokenApi implements ICredentialType {
+	name = 'airtablePersonalAccessTokenApi';
+
+	displayName = 'Airtable API - Personal Access Token';
+
+	documentationUrl = 'airtable';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Personal Access Token',
+			name: 'personalAccessToken',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+		},
+	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.personalAccessToken}}',
+			},
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Airtable/Airtable.node.ts
+++ b/packages/nodes-base/nodes/Airtable/Airtable.node.ts
@@ -27,9 +27,39 @@ export class Airtable implements INodeType {
 			{
 				name: 'airtableApi',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
+				name: 'airtablePersonalAccessTokenApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['personalAccessToken'],
+					},
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'Personal Access Token',
+						value: 'personalAccessToken',
+					},
+				],
+				default: 'apiKey',
+			},
 			{
 				displayName: 'Operation',
 				name: 'operation',

--- a/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
+++ b/packages/nodes-base/nodes/Airtable/AirtableTrigger.node.ts
@@ -28,12 +28,42 @@ export class AirtableTrigger implements INodeType {
 			{
 				name: 'airtableApi',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+			},
+			{
+				name: 'airtablePersonalAccessTokenApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['personalAccessToken'],
+					},
+				},
 			},
 		],
 		polling: true,
 		inputs: [],
 		outputs: ['main'],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						name: 'API Key',
+						value: 'apiKey',
+					},
+					{
+						name: 'Personal Access Token',
+						value: 'personalAccessToken',
+					},
+				],
+				default: 'apiKey',
+			},
 			{
 				displayName: 'Base',
 				name: 'baseId',

--- a/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/GenericFunctions.ts
@@ -59,7 +59,14 @@ export async function apiRequest(
 		delete options.body;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'airtableApi', options);
+	let credentialType = 'airtableApi';
+
+	const authenticationMethod = this.getNodeParameter('authentication', 0, 'airtableApi') as string;
+	if (authenticationMethod === 'personalAccessToken') {
+		credentialType = 'airtablePersonalAccessTokenApi';
+	}
+
+	return this.helpers.requestWithAuthentication.call(this, credentialType, options);
 }
 
 /**

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -38,6 +38,7 @@
       "dist/credentials/AffinityApi.credentials.js",
       "dist/credentials/AgileCrmApi.credentials.js",
       "dist/credentials/AirtableApi.credentials.js",
+      "dist/credentials/AirtablePersonalAccessTokenApi.credentials.js",
       "dist/credentials/Amqp.credentials.js",
       "dist/credentials/ApiTemplateIoApi.credentials.js",
       "dist/credentials/AsanaApi.credentials.js",


### PR DESCRIPTION
The current Airtable node uses an API Key to authenticate. Airtable will [no longer support API Keys from February 2024](https://airtable.com/developers/web/api/authentication). Airtable also supports [Personal Access Tokens](https://airtable.com/developers/web/guides/personal-access-tokens). I've made changes to allow support for Personal Access Tokens, which I've tested.

I'm new to n8n, but have tried to follow the way the Monday.com node handles a choice between two authentication types. If I have done this incorrectly, please let me know how I can improve the change.

Are there any tests that I should create to have this change accepted?

Should I update [this document page](https://github.com/n8n-io/n8n-docs/blob/main/docs/integrations/builtin/credentials/airtable.md) to mention Personal Access Tokens? If so, should it link to [this](https://airtable.com/developers/web/guides/personal-access-tokens#creating-a-token) or provide the current list of steps?

All current tests are passing include `Execute Airtable Node`, except for `Calculate Date: Add Day` which is adding a day in my time zone rather than at UTC.

```
n8n-nodes-base:test: FAIL nodes/DateTime/test/node/DateTime.test.ts (6.32 s)
n8n-nodes-base:test:   ● Test DateTime Node › nodes\DateTime\test\node\DateTimeWorklfow.test
n8n-nodes-base:test:
n8n-nodes-base:test:     expect(received).toEqual(expected) // deep equality
n8n-nodes-base:test:
n8n-nodes-base:test:     - Expected  - 1
n8n-nodes-base:test:     + Received  + 1
n8n-nodes-base:test:
n8n-nodes-base:test:       Array [
n8n-nodes-base:test:         Array [
n8n-nodes-base:test:           Object {
n8n-nodes-base:test:             "json": Object {
n8n-nodes-base:test:     -         "data": "2022-08-11T00:00:00.000Z",
n8n-nodes-base:test:     +         "data": "2022-08-10T23:00:00.000Z",
n8n-nodes-base:test:             },
n8n-nodes-base:test:           },
n8n-nodes-base:test:         ],
n8n-nodes-base:test:       ]
n8n-nodes-base:test:
n8n-nodes-base:test:       247 |
n8n-nodes-base:test:       248 |        resultNodeData.forEach(({ nodeName, resultData }) => {
n8n-nodes-base:test:     > 249 |                return expect(resultData).toEqual(testData.output.nodeData[nodeName]);
n8n-nodes-base:test:           |                                          ^
n8n-nodes-base:test:       250 |        });
n8n-nodes-base:test:       251 |
n8n-nodes-base:test:       252 |        expect(result.finished).toEqual(true);
n8n-nodes-base:test:
n8n-nodes-base:test:       at test/nodes/Helpers.ts:249:29
n8n-nodes-base:test:           at Array.forEach (<anonymous>)
n8n-nodes-base:test:       at equalityTest (test/nodes/Helpers.ts:248:17)
```