### PR TITLE
fix(core): Ensure that all non-lazy-loaded community nodes get post-processed correctly

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -60,7 +60,7 @@ export class Start extends BaseCommand {
 		}),
 	};
 
-	protected activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
+	protected activeWorkflowRunner: ActiveWorkflowRunner;
 
 	/**
 	 * Opens the UI in browser
@@ -200,6 +200,7 @@ export class Start extends BaseCommand {
 		await this.initCrashJournal();
 		await super.init();
 		this.logger.info('Initializing n8n process');
+		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
 		await this.initLicense();
 		await this.initBinaryManager();


### PR DESCRIPTION
If you install a community node with `polling: true`, activating a workflow with that node fails with an error: `WorkflowActivationError: There was a problem activating the workflow: "Could not get parameter "pollTimes"!"`.

You can test this by installing `n8n-nodes-rss-feed-trigger`, creating a workflow with the `RSS Trigger` node, and then trying to activate it. Activation will fail on `master`, but work as expected on this branch.

