### PR TITLE
[Feature] Add backward-compatible TLS unauthorized support to Redis bull connections

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -396,6 +396,56 @@ export const schema = {
 					default: '',
 					env: 'QUEUE_BULL_REDIS_USERNAME',
 				},
+				secure: {
+					doc: 'Redis secure (TLS) flag',
+					format: Boolean,
+					default: false,
+					env: 'QUEUE_BULL_REDIS_SECURE',
+				},
+				tls: {
+					rejectUnauthorized: {
+						doc: 'Reject uanathorized certificate',
+						format: Boolean,
+						default: true,
+						env: 'QUEUE_BULL_REDIS_TLS_REJECTANUTHORIZEDT',
+					},
+					cert: {
+						doc: 'Cert in PEM format',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_CERT',
+					},
+					cert_file: {
+						doc: 'Cert file in PEM format, used only if "cert" value is not specified',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_CERT_FILE',
+					},
+					key: {
+						doc: 'Private key',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_KEY',
+					},
+					key_file: {
+						doc: 'Private key file',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_KEY_FILE',
+					},
+					ca: {
+						doc: 'Trusted CA certificates',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_CA',
+					},
+					ca_file: {
+						doc: 'Trusted CA certificates',
+						format: String,
+						default: '',
+						env: 'QUEUE_BULL_REDIS_TLS_CA_FILE',
+					},
+				},
 			},
 			queueRecoveryInterval: {
 				doc: 'If > 0 enables an active polling to the queue that can recover for Redis crashes. Given in seconds; 0 is disabled. May increase Redis traffic significantly.',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

Supplementary from this PR: https://github.com/n8n-io/n8n/pull/3113

Code all copied from this community post: https://community.n8n.io/t/redis-tls-support-for-bull-in-queue-mode/17522

The code is backward-compatible and opens support for modern Redis servers. 