### PR TITLE
ci: Add support for Node.js 18

### DIFF
--- a/.github/workflows/check-documentation-urls.yml
+++ b/.github/workflows/check-documentation-urls.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -14,10 +14,10 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.4
 
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
             /github/home/.pnpm-store
             ./node_modules
             ./packages
-          key: ${{ github.sha }}-base:16.18.1-test-lint
+          key: ${{ github.sha }}-base:18-test-lint
 
   unit-test:
     name: Unit tests
@@ -54,14 +54,14 @@ jobs:
             /github/home/.pnpm-store
             ./node_modules
             ./packages
-          key: ${{ github.sha }}-base:16.18.1-test-lint
+          key: ${{ github.sha }}-base:18-test-lint
 
       - uses: pnpm/action-setup@v2.2.4
 
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - name: Test
@@ -90,14 +90,14 @@ jobs:
             /github/home/.pnpm-store
             ./node_modules
             ./packages
-          key: ${{ github.sha }}-base:16.18.1-test-lint
+          key: ${{ github.sha }}-base:18-test-lint
 
       - uses: pnpm/action-setup@v2.2.4
 
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: pnpm
 
       - name: Fetch base branch for `git diff`
@@ -109,13 +109,12 @@ jobs:
         run: pnpm lint
 
   smoke-test:
-    name: E2E [Electron/Node 16]
+    name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
     with:
       branch: ${{ github.event.pull_request.base.ref }}
       user: ${{ github.event.inputs.user || 'PR User' }}
       spec: ${{ github.event.inputs.spec || 'e2e/0-smoke.cy.ts' }}
-      run-env: browsers:node16.18.0-chrome107-ff106-edge
       record: false
       parallel: false
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -5,9 +5,12 @@ on:
     inputs:
       node_version:
         description: 'Node.js version to build this image with.'
-        type: string
+        type: choice
         required: true
         default: '16'
+        options:
+          - '16'
+          - '18'
 
 jobs:
   build:

--- a/.github/workflows/docker-image-v1-rc.yml
+++ b/.github/workflows/docker-image-v1-rc.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm install --prefix=.github/scripts --no-package-lock
 
       - name: Bump package versions to 1.0.0

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -20,7 +20,7 @@ on:
       run-env:
         description: 'Node env version to run tests with.'
         required: false
-        default: 'browsers:node16.18.0-chrome90-ff88'
+        default: 'browsers:node18.12.0-chrome107'
         type: string
       cache-key:
         description: 'Cache key for modules and build artifacts.'
@@ -54,7 +54,6 @@ on:
       tests_passed:
         description: 'True if all E2E tests passed, otherwise false'
         value: ${{ jobs.check_testing_matrix.outputs.all_tests_passed }}
-
 
 jobs:
   # single job that generates and outputs a common id
@@ -163,7 +162,7 @@ jobs:
           # We have to provide custom ci-build-id key to make sure that this workflow could be run multiple times
           # in the same parent workflow
           ci-build-id: ${{ needs.prepare.outputs.uuid }}
-          spec: "/__w/n8n/n8n/cypress/${{ inputs.spec }}"
+          spec: '/__w/n8n/n8n/cypress/${{ inputs.spec }}'
           config-file: /__w/n8n/n8n/cypress.config.js
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -165,6 +165,7 @@ jobs:
           spec: '/__w/n8n/n8n/cypress/${{ inputs.spec }}'
           config-file: /__w/n8n/n8n/cypress.config.js
         env:
+          NODE_OPTIONS: --dns-result-order=ipv4first
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           E2E_TESTS: true

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -8,20 +8,19 @@ on:
 
 jobs:
   run-e2e-tests:
-    name: E2E [Electron/Node 16]
+    name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
     if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'community') }}
     with:
       branch: ${{ github.event.pull_request.head.ref }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}
       spec: 'e2e/*'
-      run-env: base:16.18.1
     secrets:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
   post-e2e-tests:
     runs-on: ubuntu-latest
-    name: E2E [Electron/Node 16] - Checks
+    name: E2E [Electron/Node 18] - Checks
     needs: [run-e2e-tests]
     if: always()
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,13 +40,12 @@ jobs:
         shell: bash
 
   run-e2e-tests:
-    name: E2E [Electron/Node 16]
+    name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
       user: ${{ github.event.inputs.user || 'PR User' }}
       spec: ${{ github.event.inputs.spec || 'e2e/*' }}
-      run-env: base:16.18.1
     secrets:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm install --prefix=.github/scripts --no-package-lock
 
       - name: Bump package versions

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm dist-tag add n8n@${{ github.event.inputs.version }} ${{ github.event.inputs.release-channel }}

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -11,9 +11,6 @@ jobs:
 
     timeout-minutes: 30
 
-    strategy:
-      matrix:
-        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,10 +27,9 @@ jobs:
         with:
           version: 8.1.0
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           cache: 'pnpm'
           cache-dependency-path: 'n8n/pnpm-lock.yaml'
 

--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16
+ARG NODE_VERSION=18
 
 # 1. Create an image to build n8n
 FROM n8nio/base:${NODE_VERSION} as builder

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "worker": "./packages/cli/bin/n8n worker",
     "cypress:install": "cypress install",
     "cypress:open": "CYPRESS_BASE_URL=http://localhost:8080 cypress open",
-    "test:e2e:ui": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico 'cypress open'",
-    "test:e2e:dev": "cross-env E2E_TESTS=true CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico 'cypress open'",
-    "test:e2e:smoke": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico 'cypress run --headless --spec \"cypress/e2e/0-smoke.cy.ts\"'",
-    "test:e2e:all": "cross-env E2E_TESTS=true start-server-and-test start http://localhost:5678/favicon.ico 'cypress run --headless'"
+    "test:e2e:ui": "cross-env E2E_TESTS=true NODE_OPTIONS=--dns-result-order=ipv4first start-server-and-test start http://localhost:5678/favicon.ico 'cypress open'",
+    "test:e2e:dev": "cross-env E2E_TESTS=true NODE_OPTIONS=--dns-result-order=ipv4first  CYPRESS_BASE_URL=http://localhost:8080 start-server-and-test dev http://localhost:8080/favicon.ico 'cypress open'",
+    "test:e2e:smoke": "cross-env E2E_TESTS=true NODE_OPTIONS=--dns-result-order=ipv4first  start-server-and-test start http://localhost:5678/favicon.ico 'cypress run --headless --spec \"cypress/e2e/0-smoke.cy.ts\"'",
+    "test:e2e:all": "cross-env E2E_TESTS=true NODE_OPTIONS=--dns-result-order=ipv4first  start-server-and-test start http://localhost:5678/favicon.ico 'cypress run --headless'"
   },
   "dependencies": {
     "n8n": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "vue-demi"
     ],
     "overrides": {
-      "@types/node": "^16.18.12",
+      "@types/node": "^18.16.16",
       "browserslist": "^4.21.4",
       "chokidar": "3.5.2",
       "decode-uri-component": "0.2.2",

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,22 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 0.232.0
+
+### What changed?
+
+Due to Node.js/OpenSSL upgrade, the following crypto algorithms are not supported anymore.
+- RSA-MD4
+- RSA-MDC2
+- md4
+- md4WithRSAEncryption
+- mdc2
+- mdc2WithRSA
+
+### When is action necessary?
+
+If you're using any of the above mentioned crypto algorithms in Crypto node in any of your workflows, then please update the algorithm property in the node to one of the supported values.
+
 ## 0.226.0
 
 ### What changed?

--- a/packages/nodes-base/nodes/Crypto/test/CryptoTest.workflow.json
+++ b/packages/nodes-base/nodes/Crypto/test/CryptoTest.workflow.json
@@ -33,12 +33,12 @@
 			"parameters": {
 				"action": "sign",
 				"value": "test",
-				"algorithm": "RSA-MD4",
+				"algorithm": "RSA-MD5",
 				"encoding": "base64",
 				"privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu\nKUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm\no3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k\nTQIhAKMSvzIBnni7ot/OSie2TmJLY4SwTQAevXysE2RbFDYdAiEBCUEaRQnMnbp7\n9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy\nv/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs\n/5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00\n-----END RSA PRIVATE KEY-----"
 			},
 			"id": "4ec3781a-433d-4b68-bc94-3fbe6ed55a0e",
-			"name": "Crypto Sign data with RSA-MDA4",
+			"name": "Crypto Sign data with RSA-MD5",
 			"type": "n8n-nodes-base.crypto",
 			"typeVersion": 1,
 			"position": [80, 860]
@@ -137,10 +137,10 @@
 		}
 	],
 	"pinData": {
-		"Crypto Sign data with RSA-MDA4": [
+		"Crypto Sign data with RSA-MD5": [
 			{
 				"json": {
-					"data": "SmzCKZlC8g0EnB8cXbRJIdwsN8sDWIxtUEeMvwEJNfrrJynahyNkdIbdcTO/ciwH7aBFN+roa47J8QEYWDc6Dg=="
+					"data": "MVr+iZiOFtHVwO0iKC+CF+QlrZZKcGk7zBvUrWHC1fHBeS6IoWa8B/wrMvazV5H1YR8tbK8baZHD/vUNdfvjiA=="
 				}
 			}
 		],
@@ -195,7 +195,7 @@
 						"index": 0
 					},
 					{
-						"node": "Crypto Sign data with RSA-MDA4",
+						"node": "Crypto Sign data with RSA-MD5",
 						"type": "main",
 						"index": 0
 					},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ onlyBuiltDependencies:
   - vue-demi
 
 overrides:
-  '@types/node': ^16.18.12
+  '@types/node': ^18.16.16
   browserslist: ^4.21.4
   chokidar: 3.5.2
   decode-uri-component: 0.2.2
@@ -123,7 +123,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.0.4
-        version: 4.0.4(@types/node@16.18.12)
+        version: 4.0.4(@types/node@18.16.16)
       vitest:
         specifier: ^0.28.5
         version: 0.28.5
@@ -5101,7 +5101,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -5122,14 +5122,14 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@16.18.12)
+      jest-config: 29.5.0(@types/node@18.16.16)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -5156,7 +5156,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-mock: 29.5.0
     dev: true
 
@@ -5197,7 +5197,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -5230,7 +5230,7 @@ packages:
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -5317,7 +5317,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: true
@@ -5329,7 +5329,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/yargs': 17.0.19
       chalk: 4.1.2
     dev: true
@@ -6471,7 +6471,7 @@ packages:
       '@storybook/router': 7.0.7(react-dom@18.2.0)(react@17.0.2)
       '@storybook/store': 7.0.7
       '@storybook/theming': 7.0.7(react-dom@18.2.0)(react@17.0.2)
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/semver': 7.3.13
       babel-loader: 9.1.2(@babel/core@7.20.12)(webpack@5.75.0)
       babel-plugin-named-exports-order: 0.0.2
@@ -6676,7 +6676,7 @@ packages:
     dependencies:
       '@storybook/node-logger': 7.0.7
       '@storybook/types': 7.0.7
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/pretty-hrtime': 1.0.1
       chalk: 4.1.2
       esbuild: 0.17.18
@@ -6725,7 +6725,7 @@ packages:
       '@storybook/telemetry': 7.0.7
       '@storybook/types': 7.0.7
       '@types/detect-port': 1.3.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/node-fetch': 2.6.2
       '@types/pretty-hrtime': 1.0.1
       '@types/semver': 7.3.13
@@ -6765,7 +6765,7 @@ packages:
       '@storybook/core-common': 7.0.7
       '@storybook/node-logger': 7.0.7
       '@storybook/types': 7.0.7
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -6900,7 +6900,7 @@ packages:
       '@babel/core': 7.21.8
       '@storybook/core-webpack': 7.0.7
       '@storybook/docs-tools': 7.0.7
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       babel-loader: 9.1.2(@babel/core@7.21.8)(webpack@5.75.0)
       css-loader: 6.7.3(webpack@5.75.0)
       ts-loader: 9.4.2(typescript@5.0.3)(webpack@5.75.0)
@@ -7070,7 +7070,7 @@ packages:
       '@storybook/core-common': 7.0.7
       '@storybook/preset-vue-webpack': 7.0.7(@babel/core@7.21.8)(@babel/preset-env@7.21.5)(babel-loader@9.1.2)(css-loader@6.7.3)(esbuild@0.17.18)(typescript@5.0.3)(vue-loader@15.10.1)(vue-template-compiler@2.7.14)(vue@2.7.14)
       '@storybook/vue': 7.0.7(@babel/core@7.21.8)(babel-loader@9.1.2)(css-loader@6.7.3)(vue@2.7.14)
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       babel-loader: 9.1.2(@babel/core@7.21.8)(webpack@5.75.0)
       css-loader: 6.7.3(webpack@5.75.0)
       react: 17.0.2
@@ -7199,7 +7199,7 @@ packages:
   /@types/amqplib@0.10.1:
     resolution: {integrity: sha512-j6ANKT79ncUDnAs/+9r9eDujxbeJoTjoVu33gHHcaPfmLQaMhvfbH2GqSe8KUM444epAp1Vl3peVOQfZk3UIqA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/aria-query@4.2.2:
@@ -7209,12 +7209,12 @@ packages:
   /@types/asn1@0.2.0:
     resolution: {integrity: sha512-5TMxIpYbIA9c1J0hYQjQDX3wr+rTgQEAXaW2BI8ECM8FO53wSW4HFZplTalrKSHuZUc76NtXcePRhwuOHqGD5g==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
 
   /@types/aws4@1.11.2:
     resolution: {integrity: sha512-x0f96eBPrCCJzJxdPbUvDFRva4yPpINJzTuXXpmS2j9qLUpF2nyGzvXPlRziuGbCsPukwY4JfuO+8xwsoZLzGw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/babel__core@7.20.0:
@@ -7249,7 +7249,7 @@ packages:
   /@types/basic-auth@1.1.3:
     resolution: {integrity: sha512-W3rv6J0IGlxqgE2eQ2pTb0gBjaGtejQpJ6uaCjz3UQ65+TFTPC5/lAE+POfx1YLdjtxvejJzsIAfd3MxWiVmfg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/bcryptjs@2.4.2:
@@ -7266,7 +7266,7 @@ packages:
       '@types/body-parser': 1.19.2
       '@types/connect': 3.4.35
       '@types/express-serve-static-core': 4.17.31
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/xml2js': 0.4.11
     dev: true
 
@@ -7274,7 +7274,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
 
   /@types/canvas-confetti@1.6.0:
     resolution: {integrity: sha512-Yq6rIccwcco0TLD5SMUrIM7Fk7Fe/C0jmNRxJJCLtAF6gebDkPuUjK5EHedxecm69Pi/aA+It39Ux4OHmFhjRw==}
@@ -7297,7 +7297,7 @@ packages:
   /@types/cheerio@0.22.31:
     resolution: {integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/compression@1.0.1:
@@ -7309,25 +7309,25 @@ packages:
   /@types/concat-stream@2.0.0:
     resolution: {integrity: sha512-t3YCerNM7NTVjLuICZo5gYAXYoDvpuuTceCcFQWcDQz26kxUR5uIWolxbIR5jRNIXpMqhOpW/b8imCR1LEmuJw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/connect-history-api-fallback@1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.31
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
 
   /@types/convict@6.1.1:
     resolution: {integrity: sha512-R+JLaTvhsD06p4jyjUDtbd5xMtZTRE3c0iI+lrFWZogSVEjgTWPYwvJPVf+t92E+yrlbXa4X4Eg9ro6gPdUt4w==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/cookie-parser@1.4.3:
@@ -7343,7 +7343,7 @@ packages:
   /@types/cron@1.7.3:
     resolution: {integrity: sha512-iPmUXyIJG1Js+ldPYhOQcYU3kCAQ2FWrSkm1FJPoii2eYSn6wEW6onPukNTT0bfiflexNSRPl6KWmAIqS+36YA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       moment: 2.29.4
     dev: true
 
@@ -7374,7 +7374,7 @@ packages:
   /@types/es-aggregate-error@1.0.2:
     resolution: {integrity: sha512-erqUpFXksaeR2kejKnhnjZjbFxUpGZx4Z7ydNL9ie8tEhXPiZTsLeUDJ6aR1F8j5wWUAtOAQWUqkc7givBJbBA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: false
 
   /@types/eslint-scope@3.7.4:
@@ -7406,7 +7406,7 @@ packages:
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -7429,38 +7429,38 @@ packages:
   /@types/formidable@1.2.5:
     resolution: {integrity: sha512-zu3mQJa4hDNubEMViSj937602XdDGzK7Q5pJ5QmLUbNxclbo9tZGt5jtwM352ssZ+pqo5V4H14TBvT/ALqQQcA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/ftp@0.3.33:
     resolution: {integrity: sha512-L7wFlX3t9GsGgNS0oxLt6zbAZZGgsdptMmciL4cdxHmbL3Hz4Lysh8YqAR34eHsJ1uacJITcZBBDl5XpQlxPpQ==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/generic-pool@3.1.11:
     resolution: {integrity: sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/glob@8.0.0:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/gm@1.25.0:
     resolution: {integrity: sha512-y0nI4vp+0Vtsve+daADIHeSckm11TnWAdC4CBq2BEXTg+CfJiolnsnzsXeIEuIpBCksjN26LUZlvQKJDpthw5g==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/html-minifier-terser@6.1.0:
@@ -7475,13 +7475,13 @@ packages:
     resolution: {integrity: sha512-Sfu70sdFXzVIhivsflpanlED8gZr4VRzz2AVU9i1ARU8gskr9nDd4tVGkqYtxfwajQfZDklkXbeHSOZYEeJmTQ==}
     dependencies:
       '@types/imap': 0.8.35
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/imap@0.8.35:
     resolution: {integrity: sha512-4Tk8lGFvRFYCEaHxb2BZFZPs2XiYBSboEbb1Kq1oBqA2aRqPV0pjzyXGpMKi9jILsDPlrG7s0EFnnh8qb3h3ww==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/inquirer@6.5.0:
@@ -7536,7 +7536,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.1
     dev: true
@@ -7559,7 +7559,7 @@ packages:
   /@types/jsonwebtoken@9.0.1:
     resolution: {integrity: sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
 
   /@types/linkify-it@3.0.2:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
@@ -7869,7 +7869,7 @@ packages:
   /@types/mailparser@2.7.4:
     resolution: {integrity: sha512-JGIV4RtcjBO1jsD0RTDoXOmm1zzHr07rWPmNREBBM1oAjjfy99Ne4Y7s/akVSZoksm/JWQMcFQ42LbsufHRVfg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/markdown-it-emoji@2.0.2:
@@ -7917,7 +7917,7 @@ packages:
   /@types/mssql@6.0.8:
     resolution: {integrity: sha512-N3dr3o1c6EXhHhhNRaKpLTdAoXT/s6qDEJET5FID2gFCj58vIV9q/7RtkvYdE6ntpkJF5F9hpURhxT/oC62yLw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/tedious': 4.0.9
     dev: true
 
@@ -7930,24 +7930,24 @@ packages:
   /@types/node-fetch@2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       form-data: 3.0.1
 
   /@types/node-ssh@7.0.1:
     resolution: {integrity: sha512-98EuH7UQl/WWwwDxpbANQ76HwBdzcSnC9zLSdrtVW7jjYeOTQ6TxBygbGwzZR4ho1agbd941UnHCdrXz2sS8JQ==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/ssh2': 1.11.6
       '@types/ssh2-streams': 0.1.9
     dev: true
 
-  /@types/node@16.18.12:
-    resolution: {integrity: sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==}
+  /@types/node@18.16.16:
+    resolution: {integrity: sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==}
 
   /@types/nodemailer@6.4.6:
     resolution: {integrity: sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -7965,7 +7965,7 @@ packages:
   /@types/parseurl@1.3.1:
     resolution: {integrity: sha512-sAfjGAYgJ/MZsk95f3ByThfJgasZk1hWJROghBwfKnLLNANEAG/WHckAcT6HNqx2sHwVlci7OAX7k1KYpOcgMw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/passport-jwt@3.0.7:
@@ -8010,7 +8010,7 @@ packages:
     dependencies:
       '@types/bluebird': 3.5.37
       '@types/ftp': 0.3.33
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/promise-ftp-common': 1.1.0
     dev: true
 
@@ -8039,7 +8039,7 @@ packages:
   /@types/redis@2.8.32:
     resolution: {integrity: sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/replacestream@4.0.1:
@@ -8056,7 +8056,7 @@ packages:
     resolution: {integrity: sha512-whjk1EDJPcAR2kYHRbFl/lKeeKYTi05A15K9bnLInCVroNDCtXce57xKdI0/rQaA3K+6q0eFyUBPmqfSndUZdQ==}
     dependencies:
       '@types/caseless': 0.12.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/tough-cookie': 4.0.2
       form-data: 2.5.1
     dev: true
@@ -8079,20 +8079,20 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/serve-static@1.15.0:
     resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
 
   /@types/shelljs@0.8.11:
     resolution: {integrity: sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==}
     dependencies:
       '@types/glob': 8.0.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/showdown@1.9.4:
@@ -8111,7 +8111,7 @@ packages:
     resolution: {integrity: sha512-hf7YoxKjdk22VtKBR7/vCSYSv/YyHhbkTiZ+Dk/UnC83GMYOFaXbZktt0cIP98rmhk4V8nGpbpEivV4y6GUFNw==}
     dependencies:
       '@types/generic-pool': 3.1.11
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/ssh2-sftp-client@5.3.2:
@@ -8123,20 +8123,20 @@ packages:
   /@types/ssh2-streams@0.1.9:
     resolution: {integrity: sha512-I2J9jKqfmvXLR5GomDiCoHrEJ58hAOmFrekfFqmCFd+A6gaEStvWnPykoWUwld1PNg4G5ag1LwdA+Lz1doRJqg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/ssh2@1.11.6:
     resolution: {integrity: sha512-8Mf6bhzYYBLEB/G6COux7DS/F5bCWwojv/qFo2yH/e4cLzAavJnxvFXrYW59iKfXdhG6OmzJcXDasgOb/s0rxw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/sshpk@1.17.1:
     resolution: {integrity: sha512-bOJek/W++DvWRNAeHmpvgX8Q1ypAq4nmeVi3nJ+pjDcMB214S8kSGkxRUw/Uz+zau4VwxcfNp0xUq4s/3DLjLw==}
     dependencies:
       '@types/asn1': 0.2.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/stack-utils@2.0.1:
@@ -8147,7 +8147,7 @@ packages:
     resolution: {integrity: sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/supertest@2.0.12:
@@ -8166,13 +8166,13 @@ packages:
   /@types/syslog-client@1.1.2:
     resolution: {integrity: sha512-X8MwGedXYNmYltPDaZQCM9X6cSdfFbJZWhrU81gWKsg+Q6mSgRWs/12Mq9nHaUV4wqMYDNrnytbwbMUiVnWegw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/tedious@4.0.9:
     resolution: {integrity: sha512-ipwFvfy9b2m0gjHsIX0D6NAAwGCKokzf5zJqUZHUGt+7uWVlBIy6n2eyMgiKQ8ChLFVxic/zwQUhjLYNzbHDRA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/testing-library__jest-dom@5.14.5:
@@ -8184,7 +8184,7 @@ packages:
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/tmp@0.2.3:
@@ -8198,7 +8198,7 @@ packages:
   /@types/tunnel@0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: false
 
   /@types/unist@2.0.6:
@@ -8236,20 +8236,20 @@ packages:
   /@types/whatwg-url@8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/webidl-conversions': 7.0.0
     dev: false
 
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/xml2js@0.4.11:
     resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
 
   /@types/yamljs@0.2.31:
@@ -8275,7 +8275,7 @@ packages:
   /@types/yauzl@2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
     dev: true
     optional: true
 
@@ -8608,7 +8608,7 @@ packages:
       vite: ^3.0.0 || ^4.0.0
       vue: ^2.7.0-0
     dependencies:
-      vite: 4.0.4(@types/node@16.18.12)
+      vite: 4.0.4(@types/node@18.16.16)
       vue: 2.7.14
     dev: true
 
@@ -11516,7 +11516,7 @@ packages:
     dependencies:
       '@cypress/request': 2.88.10
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
       arch: 2.2.0
@@ -15226,7 +15226,7 @@ packages:
       '@jest/expect': 29.5.0
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -15263,7 +15263,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@16.18.12)
+      jest-config: 29.5.0(@types/node@18.16.16)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -15274,7 +15274,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@16.18.12):
+  /jest-config@29.5.0(@types/node@18.16.16):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -15289,7 +15289,7 @@ packages:
       '@babel/core': 7.21.8
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       babel-jest: 29.5.0(@babel/core@7.21.8)
       chalk: 4.1.2
       ci-info: 3.7.1
@@ -15374,7 +15374,7 @@ packages:
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-mock: 29.5.0
       jest-util: 29.5.0
       jsdom: 20.0.2
@@ -15391,7 +15391,7 @@ packages:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-mock: 29.5.0
       jest-util: 29.5.0
     dev: true
@@ -15421,7 +15421,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -15533,7 +15533,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-util: 29.5.0
     dev: true
 
@@ -15588,7 +15588,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -15619,7 +15619,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -15674,7 +15674,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -15699,7 +15699,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -15711,7 +15711,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -15720,7 +15720,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -16263,7 +16263,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@types/asn1': 0.2.0
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@types/uuid': 9.0.0
       asn1: 0.2.6
       debug: 4.3.4(supports-color@8.1.1)
@@ -22455,7 +22455,7 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
-  /vite-node@0.28.5(@types/node@16.18.12):
+  /vite-node@0.28.5(@types/node@18.16.16):
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -22467,7 +22467,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.0.4(@types/node@16.18.12)
+      vite: 4.0.4(@types/node@18.16.16)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -22478,7 +22478,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.0.4(@types/node@16.18.12):
+  /vite@4.0.4(@types/node@18.16.16):
     resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -22503,7 +22503,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
@@ -22536,7 +22536,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 16.18.12
+      '@types/node': 18.16.16
       '@vitest/expect': 0.28.5
       '@vitest/runner': 0.28.5
       '@vitest/spy': 0.28.5
@@ -22555,8 +22555,8 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.1
       tinyspy: 1.0.2
-      vite: 4.0.4(@types/node@16.18.12)
-      vite-node: 0.28.5(@types/node@16.18.12)
+      vite: 4.0.4(@types/node@18.16.16)
+      vite-node: 0.28.5(@types/node@18.16.16)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Node.js 18 became the active LTS on 2022-10-25, and Node.js 16 went into maintenance mode.
https://github.com/nodejs/Release#release-schedule

We should also slowly deprecate node 16 support, [as support for it is ends much earlier now, due to support for openssl 1.1.1 ending](https://nodejs.org/en/blog/announcements/nodejs16-eol).
