### PR TITLE
fix(Odoo Node): Update the Odoo node to fetch models and fields correctly

### DIFF
--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -168,7 +168,7 @@ export class Odoo implements INodeType {
 					return {
 						name: model.name,
 						value: model.model,
-						description: `model: ${model.model}<br> modules: ${model.modules}`,
+						description: `model: ${model.model}`,
 					};
 				});
 				return options as INodePropertyOptions[];

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -39,7 +39,6 @@ import {
 	processNameValueFields,
 } from './GenericFunctions';
 
-import { capitalCase } from 'change-case';
 export class Odoo implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Odoo',
@@ -117,19 +116,18 @@ export class Odoo implements INodeType {
 				const userID = await odooGetUserID.call(this, db, username, password, url);
 
 				const responce = await odooGetModelFields.call(this, db, userID, password, resource, url);
-				const options = Object.values(responce).map((field) => {
-					const optionField = field as { [key: string]: string };
-					let name = '';
+        const options = Object.entries(responce).map(([key, field]) => {
+					const optionField = field as { [key: string]: string};
 					try {
-						name = capitalCase(optionField.name);
+						optionField.name = optionField.string;
 					} catch (error) {
-						name = optionField.name;
+						optionField.name = optionField.string;
 					}
 					return {
-						name,
-						value: optionField.name,
+						name: optionField.name,
+						value: key,
 						// nodelinter-ignore-next-line
-						description: `name: ${optionField?.name}, type: ${optionField?.type} required: ${optionField?.required}`,
+						description: `name: ${key}, type: ${optionField?.type} required: ${optionField?.required}`,
 					};
 				});
 

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -156,7 +156,7 @@ export class Odoo implements INodeType {
 							'ir.model',
 							'search_read',
 							[],
-							['name', 'model', 'modules'],
+							['name', 'model'],
 						],
 					},
 					id: Math.floor(Math.random() * 100),


### PR DESCRIPTION
Removes the `modules` fields in the `search_read` operation when trying to fetch models, as only administrators are allowed to read installed modules.

Github issue / Community forum post (link here to close automatically):
https://github.com/n8n-io/n8n/issues/5804