### PR TITLE
fix(OpenAI Node): Update OpenAI Text Moderate input placeholder text

### DIFF
--- a/packages/nodes-base/nodes/OpenAi/TextDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/TextDescription.ts
@@ -247,7 +247,7 @@ const moderateOperations: INodeProperties[] = [
 		displayName: 'Input',
 		name: 'input',
 		type: 'string',
-		placeholder: 'e.g. I want to kill them',
+		placeholder: 'e.g. My cat is adorable ❤️❤️',
 		description: 'The input text to classify',
 		displayOptions: {
 			show: {


### PR DESCRIPTION
I thought this was a weird input placeholder to see: 

<img width="438" alt="image" src="https://user-images.githubusercontent.com/399776/228744967-26127a91-62fc-4b96-b9df-9fa5fc9aaa36.png">

So I grabbed a more chill example from https://platform.openai.com/examples/default-adv-tweet-classifier.