### PR TITLE
fix(editor): Prevent error from showing-up when duplicating unsaved workflow

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -190,37 +190,48 @@ describe('Workflow Actions', () => {
 		cy.url().should('include', '/workflow/new');
 	});
 
-	it('should duplicate workflow', () => {
-		// Stub window.open so new tab is not getting opened
-		cy.window().then((win) => {
-			cy.stub(win, 'open').as('open');
+	describe('duplicate workflow', () => {
+		function duplicateWorkflow() {
+			WorkflowPage.getters.workflowMenu().should('be.visible');
+			WorkflowPage.getters.workflowMenu().click();
+			WorkflowPage.getters.workflowMenuItemDuplicate().click();
+			WorkflowPage.getters.duplicateWorkflowModal().should('be.visible');
+			WorkflowPage.getters.duplicateWorkflowModal().find('input').first().should('be.visible');
+			WorkflowPage.getters.duplicateWorkflowModal().find('input').first().type('{selectall}');
+			WorkflowPage.getters
+				.duplicateWorkflowModal()
+				.find('input')
+				.first()
+				.type(DUPLICATE_WORKFLOW_NAME);
+			WorkflowPage.getters
+				.duplicateWorkflowModal()
+				.find('.el-select__tags input')
+				.type(DUPLICATE_WORKFLOW_TAG);
+			WorkflowPage.getters.duplicateWorkflowModal().find('.el-select__tags input').type('{enter}');
+			WorkflowPage.getters.duplicateWorkflowModal().find('.el-select__tags input').type('{enter}');
+			WorkflowPage.getters
+				.duplicateWorkflowModal()
+				.find('button')
+				.contains('Duplicate')
+				.should('be.visible');
+			WorkflowPage.getters.duplicateWorkflowModal().find('button').contains('Duplicate').click();
+			WorkflowPage.getters.errorToast().should('not.exist');
+		}
+
+		beforeEach(() => {
+			// Stub window.open so new tab is not getting opened
+			cy.window().then((win) => {
+				cy.stub(win, 'open').as('open');
+			});
+			WorkflowPage.actions.addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
 		});
 
-		WorkflowPage.actions.addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
-		WorkflowPage.actions.saveWorkflowOnButtonClick();
-		WorkflowPage.getters.workflowMenu().should('be.visible');
-		WorkflowPage.getters.workflowMenu().click();
-		WorkflowPage.getters.workflowMenuItemDuplicate().click();
-		WorkflowPage.getters.duplicateWorkflowModal().should('be.visible');
-		WorkflowPage.getters.duplicateWorkflowModal().find('input').first().should('be.visible');
-		WorkflowPage.getters.duplicateWorkflowModal().find('input').first().type('{selectall}');
-		WorkflowPage.getters
-			.duplicateWorkflowModal()
-			.find('input')
-			.first()
-			.type(DUPLICATE_WORKFLOW_NAME);
-		WorkflowPage.getters
-			.duplicateWorkflowModal()
-			.find('.el-select__tags input')
-			.type(DUPLICATE_WORKFLOW_TAG);
-		WorkflowPage.getters.duplicateWorkflowModal().find('.el-select__tags input').type('{enter}');
-		WorkflowPage.getters.duplicateWorkflowModal().find('.el-select__tags input').type('{enter}');
-		WorkflowPage.getters
-			.duplicateWorkflowModal()
-			.find('button')
-			.contains('Duplicate')
-			.should('be.visible');
-		WorkflowPage.getters.duplicateWorkflowModal().find('button').contains('Duplicate').click();
-		WorkflowPage.getters.errorToast().should('not.exist');
+		it('should duplicate unsaved workflow', () => {
+			duplicateWorkflow();
+		});
+		it('should duplicate saved workflow', () => {
+			WorkflowPage.actions.saveWorkflowOnButtonClick();
+			duplicateWorkflow();
+		});
 	});
 });

--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -89,10 +89,18 @@ export default mixins(showMessage, workflowHelpers, restApi).extend({
 	computed: {
 		...mapStores(useUsersStore, useSettingsStore, useWorkflowsStore),
 		workflowPermissions(): IPermissions {
-			return getWorkflowPermissions(
-				this.usersStore.currentUser,
-				this.workflowsStore.getWorkflowById(this.data.id),
-			);
+			const isEmptyWorkflow = this.data.id === PLACEHOLDER_EMPTY_WORKFLOW_ID;
+			const isCurrentWorkflowEmpty =
+				this.workflowsStore.workflow.id === PLACEHOLDER_EMPTY_WORKFLOW_ID;
+
+			// If the workflow to be duplicated is empty and the current workflow is also empty
+			// we need to use the current workflow to get the permissions
+			const currentWorkflow =
+				isEmptyWorkflow && isCurrentWorkflowEmpty
+					? this.workflowsStore.workflow
+					: this.workflowsStore.getWorkflowById(this.data.id);
+
+			return getWorkflowPermissions(this.usersStore.currentUser, currentWorkflow);
 		},
 	},
 	watch: {


### PR DESCRIPTION
In the `DuplicateWorkflowDialog` modal we were using `getWorkflowById` to get the current workflow data. But if the workflow is not saved, it's not stored in `workflowsById` so it can't be retrieved and would throw an error. Instead, we use the current workflow data(`workflowsStore.workflow`) if the id is `PLACEHOLDER_EMPTY_WORKFLOW_ID` and current workflows id is also `PLACEHOLDER_EMPTY_WORKFLOW_ID`.
Github issue / Community forum post (link here to close automatically):
