### PR TITLE
ci: Drop support for Node.js 14

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,22 +51,10 @@ jobs:
     secrets:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
-  run-e2e-tests-node-14:
-    name: E2E [Electron/Node 14]
-    uses: ./.github/workflows/e2e-reusable.yml
-    if: ${{ github.event_name == 'schedule' }}
-    with:
-      branch: ${{ github.event.inputs.branch || 'master' }}
-      user: ${{ github.event.inputs.user || 'schedule' }}
-      spec: ${{ github.event.inputs.spec || 'e2e/*' }}
-      run-env: base:14.21.1
-    secrets:
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-
   calls-success-url-notify:
     name: Calls success URL and notifies
     runs-on: ubuntu-latest
-    needs: [run-e2e-tests, run-e2e-tests-node-14]
+    needs: [run-e2e-tests]
     if: ${{ github.event.inputs.success-url != '' }}
     steps:
       - name: Notify Slack on failure

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,20 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 0.223.0
+
+### What changed?
+
+The minimum Node.js version required for n8n is now v16.
+
+### When is action necessary?
+
+If you're using n8n via npm or PM2 or if you're contributing to n8n.
+
+### How to upgrade:
+
+Update the Node.js version to v16 or above.
+
 ## 0.214.0
 
 ### What changed?

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -21,7 +21,7 @@ if (process.argv.length === 2) {
 const nodeVersion = process.versions.node;
 const nodeVersionMajor = require('semver').major(nodeVersion);
 
-if (![14, 16, 18].includes(nodeVersionMajor)) {
+if (![16, 18].includes(nodeVersionMajor)) {
 	console.log(`
 	Your Node.js version (${nodeVersion}) is currently not supported by n8n.
 	Please use Node.js v14, v16 (recommended), or v18 instead!

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -24,7 +24,7 @@ const nodeVersionMajor = require('semver').major(nodeVersion);
 if (![16, 18].includes(nodeVersionMajor)) {
 	console.log(`
 	Your Node.js version (${nodeVersion}) is currently not supported by n8n.
-	Please use Node.js v14, v16 (recommended), or v18 instead!
+	Please use Node.js v16 (recommended), or v18 instead!
 	`);
 	process.exit(1);
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "workflow"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=6.9"
   },
   "files": [
     "bin",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "workflow"
   ],
   "engines": {
-    "node": ">=6.9"
+    "node": ">=16.9"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Node.js 14 goes EOL on 2023-04-30, and support for it should be dropped. https://github.com/nodejs/Release#release-schedule

