### PR TITLE
fix(core): Do not user `util.types.isProxy` for tracking of augmented objects

### DIFF
--- a/packages/workflow/src/AugmentObject.ts
+++ b/packages/workflow/src/AugmentObject.ts
@@ -1,14 +1,17 @@
 import type { IDataObject } from './Interfaces';
-import util from 'util';
 
+const augmentedObjects = new WeakSet<object>();
 function augment<T>(value: T): T {
 	if (
 		typeof value !== 'object' ||
 		value === null ||
-		util.types.isProxy(value) ||
-		value instanceof RegExp
+		value instanceof RegExp ||
+		augmentedObjects.has(value)
 	)
 		return value;
+
+	// Track augmented objects to prevent infinite recursion in cases where an object contains circular references
+	augmentedObjects.add(value);
 
 	if (value instanceof Date) return new Date(value.valueOf()) as T;
 


### PR DESCRIPTION
This PR updates the `augment` function in `utils.ts` to use a `WeakSet` to track objects that have already been augmented. This prevents infinite recursion in cases where an object contains circular references.
Previously, the `augment` function used the `isProxy` function from the `util` module to check if an object had already been augmented. However, this caused issues when running in browser environment where the `util` module was not available.


Github issue / Community forum post (link here to close automatically): https://github.com/n8n-io/n8n/issues/5769
