### PR TITLE
fix(editor): Support backspacing with modifier key

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/baseExtensions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/baseExtensions.ts
@@ -15,6 +15,7 @@ import {
 	insertNewlineAndIndent,
 	toggleComment,
 	redo,
+	deleteCharBackward,
 } from '@codemirror/commands';
 import { lintGutter } from '@codemirror/lint';
 
@@ -38,6 +39,7 @@ export const baseExtensions = [
 		{ key: 'Enter', run: acceptCompletion },
 		{ key: 'Mod-/', run: toggleComment },
 		{ key: 'Mod-Shift-z', run: redo },
+		{ key: 'Backspace', run: deleteCharBackward, shift: deleteCharBackward },
 		indentWithTab,
 	]),
 	EditorView.lineWrapping,


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-453/code-node-deletes-code-if-you-minimise-code-and-delete-a-line-above-it