### PR TITLE
fix(HubSpot Trigger Node): Developer API key is required for webhooks

### DIFF
--- a/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotDeveloperApi.credentials.ts
@@ -58,6 +58,7 @@ export class HubspotDeveloperApi implements ICredentialType {
 			displayName: 'Developer API Key',
 			name: 'apiKey',
 			type: 'string',
+			required: true,
 			typeOptions: { password: true },
 			default: '',
 		},


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
