### PR TITLE
feat(editor): Enable saving workflow when node details view is open

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -90,6 +90,14 @@ describe('NDV', () => {
 		});
 	});
 
+	it('should save workflow using keyboard shortcut from NDV', () => {
+		workflowPage.actions.addNodeToCanvas('Manual');
+		workflowPage.actions.addNodeToCanvas('Set', true, true);
+		ndv.getters.container().should('be.visible');
+		workflowPage.actions.saveWorkflowUsingKeyboardShortcut();
+		workflowPage.getters.isWorkflowSaved();
+	})
+
 	describe('test output schema view', () => {
 		const schemaKeys = ['id', 'name', 'email', 'notes', 'country', 'created', 'objectValue', 'prop1', 'prop2'];
 		function setupSchemaWorkflow() {

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -164,7 +164,6 @@ import { useUIStore } from '@/stores/ui';
 import { useSettingsStore } from '@/stores/settings';
 import useDeviceSupport from '@/composables/useDeviceSupport';
 
-
 export default mixins(
 	externalHooks,
 	nodeHelpers,
@@ -195,7 +194,7 @@ export default mixins(
 	setup() {
 		return {
 			...useDeviceSupport(),
-		}
+		};
 	},
 	data() {
 		return {

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -28,7 +28,7 @@
 			</div>
 		</n8n-tooltip>
 
-		<div class="data-display" v-if="activeNode">
+		<div class="data-display" ref="container" v-if="activeNode" @keydown.capture="onKeyDown" tabindex="0">
 			<div @click="close" :class="$style.modalBackground"></div>
 			<NDVDraggablePanels
 				:isTriggerNode="isTriggerNode"
@@ -156,6 +156,8 @@ import { useNDVStore } from '@/stores/ndv';
 import { useNodeTypesStore } from '@/stores/nodeTypes';
 import { useUIStore } from '@/stores/ui';
 import { useSettingsStore } from '@/stores/settings';
+import useDeviceSupport from '@/composables/useDeviceSupport';
+
 
 export default mixins(
 	externalHooks,
@@ -183,6 +185,11 @@ export default mixins(
 			type: Boolean,
 			default: false,
 		},
+	},
+	setup() {
+		return {
+			...useDeviceSupport(),
+		}
 	},
 	data() {
 		return {
@@ -469,6 +476,16 @@ export default mixins(
 		},
 	},
 	methods: {
+		onKeyDown(e: KeyboardEvent) {
+			if (e.key === 's' && this.isCtrlKeyPressed(e)) {
+				e.stopPropagation();
+				e.preventDefault();
+
+				if (this.readOnly) return;
+
+				this.$emit('saveKeyboardShortcut', e);
+			}
+		},
 		onInputItemHover(e: { itemIndex: number; outputIndex: number } | null) {
 			if (!this.inputNodeName) {
 				return;

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -28,7 +28,13 @@
 			</div>
 		</n8n-tooltip>
 
-		<div class="data-display" ref="container" v-if="activeNode" @keydown.capture="onKeyDown" tabindex="0">
+		<div
+			v-if="activeNode"
+			class="data-display"
+			ref="container"
+			@keydown.capture="onKeyDown"
+			tabindex="0"
+		>
 			<div @click="close" :class="$style.modalBackground"></div>
 			<NDVDraggablePanels
 				:isTriggerNode="isTriggerNode"

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -40,6 +40,7 @@
 	"generic.unsavedWork.confirmMessage.confirmButtonText": "Save",
 	"generic.unsavedWork.confirmMessage.cancelButtonText": "Leave without saving",
 	"generic.workflow": "Workflow",
+	"generic.workflowSaved": "Workflow changes saved",
 	"generic.editor": "Editor",
 	"about.aboutN8n": "About n8n",
 	"about.close": "Close",

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1085,6 +1085,8 @@ export default mixins(
 
 				this.callDebounced('selectAllNodes', { debounceTime: 1000 });
 			} else if (e.key === 'c' && this.isCtrlKeyPressed(e)) {
+				e.stopPropagation();
+				e.preventDefault();
 				this.callDebounced('copySelectedNodes', { debounceTime: 1000 });
 			} else if (e.key === 'x' && this.isCtrlKeyPressed(e)) {
 				// Cut nodes
@@ -2620,8 +2622,8 @@ export default mixins(
 			}
 			this.historyStore.reset();
 			this.uiStore.nodeViewInitialized = true;
-			document.addEventListener('keydown', this.keyDown, true);
-			document.addEventListener('keyup', this.keyUp, true);
+			document.addEventListener('keydown', this.keyDown, { capture: true, once: false });
+			document.addEventListener('keyup', this.keyUp, { capture: true, once: false });
 
 			// allow to be overriden in e2e tests
 			// @ts-ignore

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -92,6 +92,7 @@
 				:isProductionExecutionPreview="isProductionExecutionPreview"
 				@valueChanged="valueChanged"
 				@stopExecution="stopExecution"
+				@saveKeyboardShortcut="onSaveKeyboardShortcut"
 			/>
 			<node-creation
 				v-if="!isReadOnly"
@@ -2622,8 +2623,8 @@ export default mixins(
 			}
 			this.historyStore.reset();
 			this.uiStore.nodeViewInitialized = true;
-			document.addEventListener('keydown', this.keyDown, { capture: true, once: false });
-			document.addEventListener('keyup', this.keyUp, { capture: true, once: false });
+			document.addEventListener('keydown', this.keyDown);
+			document.addEventListener('keyup', this.keyUp);
 
 			// allow to be overriden in e2e tests
 			// @ts-ignore

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1086,8 +1086,6 @@ export default mixins(
 
 				this.callDebounced('selectAllNodes', { debounceTime: 1000 });
 			} else if (e.key === 'c' && this.isCtrlKeyPressed(e)) {
-				e.stopPropagation();
-				e.preventDefault();
 				this.callDebounced('copySelectedNodes', { debounceTime: 1000 });
 			} else if (e.key === 'x' && this.isCtrlKeyPressed(e)) {
 				// Cut nodes


### PR DESCRIPTION
This one should enable saving current workflow from NDV. Please mind that saving cannot be performed while editable text inputs are focused, so this popup message should indicate when wf is saved successfully:
![image](https://user-images.githubusercontent.com/2598782/229076601-87a4b966-d672-4d0f-b48d-e154a4f0d6ae.png)

Fixes ADO-511
