### PR TITLE
refactor(editor): Remove CTA for errored node

### DIFF
--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -227,9 +227,6 @@
 							interpolate: { nodeName: node.name },
 						})
 					}}
-					<n8n-link @click="goToErroredNode">
-						{{ $locale.baseText('nodeErrorView.inputPanel.previousNodeError.text') }}
-					</n8n-link>
 				</n8n-text>
 				<NodeErrorView
 					v-else
@@ -1301,11 +1298,6 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 				} as INodeUpdatePropertiesInformation;
 
 				this.workflowsStore.updateNodeProperties(updateInformation);
-			}
-		},
-		goToErroredNode() {
-			if (this.node) {
-				this.ndvStore.activeNodeName = this.node.name;
 			}
 		},
 		setDisplayMode() {

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -794,7 +794,6 @@
 	"nodeErrorView.theErrorCauseIsTooLargeToBeDisplayed": "The error cause is too large to be displayed",
 	"nodeErrorView.time": "Time",
 	"nodeErrorView.inputPanel.previousNodeError.title": "Error running node '{nodeName}'",
-	"nodeErrorView.inputPanel.previousNodeError.text": "View error",
 	"nodeHelpers.credentialsUnset": "Credentials for '{credentialType}' are not set.",
 	"nodeSettings.alwaysOutputData.description": "If active, will output a single, empty item when the output would have been empty. Use to prevent the workflow finishing on this node.",
 	"nodeSettings.alwaysOutputData.displayName": "Always Output Data",


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-366/bug-going-back-to-error-breaks-ndv