### PR TITLE
🪝 Add Any/All method matching for webhooks

### DIFF
--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -233,6 +233,11 @@ export class Wait implements INodeType {
 				},
 				options: [
 					{
+						name: 'All',
+						value: '*',
+						description: 'Match all HTTP methods',
+					},
+					{
 						name: 'DELETE',
 						value: 'DELETE',
 					},

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -479,7 +479,7 @@ export class Wait implements INodeType {
 						type: 'boolean',
 						displayOptions: {
 							show: {
-								'/httpMethod': ['PATCH', 'PUT', 'POST'],
+								'/httpMethod': ['PATCH', 'PUT', 'POST', '*'],
 							},
 						},
 						default: false,

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -284,7 +284,7 @@ export class Webhook implements INodeType {
 						type: 'boolean',
 						displayOptions: {
 							show: {
-								'/httpMethod': ['PATCH', 'PUT', 'POST'],
+								'/httpMethod': ['PATCH', 'PUT', 'POST', '*'],
 							},
 						},
 						default: false,

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -128,6 +128,11 @@ export class Webhook implements INodeType {
 				type: 'options',
 				options: [
 					{
+						name: 'All',
+						value: '*',
+						description: 'Match all HTTP methods',
+					},
+					{
 						name: 'DELETE',
 						value: 'DELETE',
 					},


### PR DESCRIPTION
Common cause of issues where the webhook method doesn't match the sending service. Allow a single webhook trigger to match all methods.

Probably a suboptimal solution, but works OK in testing:

<details>
<summary>Expand workflow JSON</summary>

```json
{
  "nodes": [
    {
      "parameters": {
        "values": {
          "string": [
            {
              "name": "res",
              "value": "={{ $prevNode.name }}"
            }
          ]
        },
        "options": {}
      },
      "name": "Set1",
      "type": "n8n-nodes-base.set",
      "typeVersion": 1,
      "position": [
        800,
        220
      ]
    },
    {
      "parameters": {
        "path": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "1: GET",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        460,
        -40
      ],
      "webhookId": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc"
    },
    {
      "parameters": {
        "httpMethod": "PUT",
        "path": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "1: PUT",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        360,
        80
      ],
      "webhookId": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc"
    },
    {
      "parameters": {
        "httpMethod": "*",
        "path": "/:variable1/path/:variable2",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "Dynamic: All",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        460,
        480
      ],
      "webhookId": "413cb7ac-87e8-4bbf-a215-c1403657baae"
    },
    {
      "parameters": {
        "httpMethod": "*",
        "path": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "1: All",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        620,
        -80
      ],
      "webhookId": "1e6d2b16-3105-4d3c-a456-ed889a0e39cc"
    },
    {
      "parameters": {
        "path": "/:variable1/path/:variable2",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "Dynamic: Get",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        360,
        360
      ],
      "webhookId": "413cb7ac-87e8-4bbf-a215-c1403657baae"
    },
    {
      "parameters": {
        "httpMethod": "*",
        "path": "c0ea031a-703b-41cb-9121-d41fe6bb649c",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {}
      },
      "name": "2: All",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        300,
        220
      ],
      "webhookId": "c0ea031a-703b-41cb-9121-d41fe6bb649c"
    }
  ],
  "connections": {
    "1: GET": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "1: PUT": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Dynamic: All": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "1: All": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Dynamic: Get": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "2: All": {
      "main": [
        [
          {
            "node": "Set1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
```
</details>