### PR TITLE
test(editor): Fix failing licensing related e2e specs (no-changelog)

### DIFF
--- a/cypress/e2e/10-settings-log-streaming.cy.ts
+++ b/cypress/e2e/10-settings-log-streaming.cy.ts
@@ -26,7 +26,7 @@ describe('Log Streaming Settings', () => {
 	});
 
 	it('should show the licensed view when the feature is enabled', () => {
-		cy.enableFeature('logStreaming');
+		cy.enableFeature('feat:logStreaming');
 		cy.visit('/settings/log-streaming');
 		settingsLogStreamingPage.getters.getActionBoxLicensed().should('be.visible');
 		settingsLogStreamingPage.getters.getAddFirstDestinationButton().should('be.visible');

--- a/packages/cli/src/api/e2e.api.ts
+++ b/packages/cli/src/api/e2e.api.ts
@@ -15,6 +15,7 @@ import { hashPassword } from '@/UserManagement/UserManagementHelper';
 import { eventBus } from '@/eventbus/MessageEventBus/MessageEventBus';
 import Container from 'typedi';
 import { License } from '../License';
+import { LICENSE_FEATURES } from '@/constants';
 
 if (process.env.E2E_TESTS !== 'true') {
 	console.error('E2E endpoints only allowed during E2E tests');
@@ -22,11 +23,11 @@ if (process.env.E2E_TESTS !== 'true') {
 }
 
 const enabledFeatures = {
-	sharing: true, //default to true here instead of setting it in config/index.ts for e2e
-	ldap: false,
-	saml: false,
-	logStreaming: false,
-	advancedExecutionFilters: false,
+	[LICENSE_FEATURES.SHARING]: true, //default to true here instead of setting it in config/index.ts for e2e
+	[LICENSE_FEATURES.LDAP]: false,
+	[LICENSE_FEATURES.SAML]: false,
+	[LICENSE_FEATURES.LOG_STREAMING]: false,
+	[LICENSE_FEATURES.ADVANCED_EXECUTION_FILTERS]: false,
 };
 
 type Feature = keyof typeof enabledFeatures;
@@ -93,7 +94,7 @@ const setupUserManagement = async () => {
 };
 
 const resetLogStreaming = async () => {
-	enabledFeatures.logStreaming = false;
+	enabledFeatures[LICENSE_FEATURES.LOG_STREAMING] = false;
 	for (const id in eventBus.destinations) {
 		await eventBus.removeDestination(id);
 	}


### PR DESCRIPTION
In the recent licensing features loading changes (#5808), we introduced some modifications to how they are mocked in e2e tests. However, the naming of the features was incorrect, which caused all e2e related specs to fail. Therefore, in this PR, we have fixed this issue by using the defined constants for the licensing features.
Github issue / Community forum post (link here to close automatically):
