### PR TITLE
ci: Always run e2e tests on PR approval (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -111,7 +111,6 @@ jobs:
   smoke-test:
     name: E2E [Electron/Node 16]
     uses: ./.github/workflows/e2e-reusable.yml
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
     with:
       branch: ${{ github.event.pull_request.head.ref }}
       user: ${{ github.event.inputs.user || 'PR User' }}

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -1,4 +1,4 @@
-name: PR E2E (skip with label skip-e2e)
+name: PR E2E
 
 on:
   pull_request_review:
@@ -24,7 +24,7 @@ jobs:
   run-e2e-tests:
     name: E2E [Electron/Node 16]
     uses: ./.github/workflows/e2e-reusable.yml
-    if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
+    if: ${{ github.event.review.state == 'approved' }}
     with:
       branch: ${{ github.event.pull_request.head.ref }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,6 @@ jobs:
   run-e2e-tests:
     name: E2E [Electron/Node 16]
     uses: ./.github/workflows/e2e-reusable.yml
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
       user: ${{ github.event.inputs.user || 'PR User' }}


### PR DESCRIPTION
Disable the `skip-e2e` label functionality when running PR approved e2e tests
Github issue / Community forum post (link here to close automatically):
