### PR TITLE
ci: Use `--chown=node:node` in COPY commands in the custom docker image (no-changelog)

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -3,14 +3,13 @@ ARG NODE_VERSION=16
 # 1. Create an image to build n8n
 FROM n8nio/base:${NODE_VERSION} as builder
 
-COPY turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml jest.config.js tsconfig.json ./
-COPY scripts ./scripts
-COPY packages ./packages
-COPY patches ./patches
+COPY --chown=node:node turbo.json package.json .npmrc pnpm-lock.yaml pnpm-workspace.yaml jest.config.js tsconfig.json ./
+COPY --chown=node:node scripts ./scripts
+COPY --chown=node:node packages ./packages
+COPY --chown=node:node patches ./patches
 
 RUN apk add --update libc6-compat jq
 RUN corepack enable && corepack prepare --activate
-RUN chown -R node:node .
 USER node
 
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
By adding `--chown=node:node` when copying the source and removing `RUN chown -R node:node .`, we save several minutes during the image building process.

Github issue / Community forum post (link here to close automatically):
