### PR TITLE
docs: Fix typo in AWS S3 and S3 nodes for parent folder key

### DIFF
--- a/packages/nodes-base/nodes/Aws/S3/FileDescription.ts
+++ b/packages/nodes-base/nodes/Aws/S3/FileDescription.ts
@@ -531,7 +531,7 @@ export const fileFields: INodeProperties[] = [
 				name: 'parentFolderKey',
 				type: 'string',
 				default: '',
-				description: 'Parent file you want to create the file in',
+				description: 'Parent folder you want to create the file in',
 			},
 			{
 				displayName: 'Requester Pays',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://github.com/n8n-io/n8n/issues/5932
