### PR TITLE
fix(editor): Update vite legacy-plugin browser target (no-changelog)

### DIFF
--- a/packages/editor-ui/vite.config.ts
+++ b/packages/editor-ui/vite.config.ts
@@ -84,7 +84,7 @@ if (NODE_ENV === 'test') {
 const plugins = [
 	vue(),
 	legacy({
-		targets: ['defaults', 'not IE 11'],
+		targets: ['>1%', 'last 3 versions', 'not dead'],
 	}),
 	monacoEditorPlugin({
 		publicPath: 'assets/monaco-editor',


### PR DESCRIPTION
Currently the generated/bundled `polyfills-legacy-*.js` has a md5sum that conflicts with some known malware, which is making n8n instances being incorrectly marked as malware.

![image](https://user-images.githubusercontent.com/196144/231215029-bc880359-5008-4fe6-8cad-9c6264cb462f.png)


Changing the browserlist target changes the browser coverage from [88.3%](https://browsersl.ist/#q=defaults) to [88.2%](https://browsersl.ist/#q=%3E1%25%2Clast+3+versions%2Cnot+dead), and changes the md5sum from ` 7bbe04e33326032f3bf00ac7685bfccb` to `457638e9318cc92d88d45730c81724e4`.


Fixes:
1. #5743
2. [Potentially Suspicious code. Google marked site as phishing](https://community.n8n.io/t/potentially-suspicious-code-google-marked-site-as-phishing/23630)