### PR TITLE
fix: [Google/Firebase/Firestore] Handle some edge cases, Write a unit test for jsonToDocument function

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -81,17 +81,15 @@ const isValidDate = (str: string) =>
 // Great thanks to https://stackoverflow.com/users/3915246/mahindar
 export function jsonToDocument(value: string | number | IDataObject | IDataObject[]): IDataObject {
 	if (value === 'true' || value === 'false' || typeof value === 'boolean') {
-		return { booleanValue: value };
+		if (typeof value === 'string') {
+			return { booleanValue: value === 'true' };
+		}
+
+		return { booleanValue: Boolean(value) };
 	} else if (value === null) {
 		return { nullValue: null };
-	} else if (!isNaN(value as number)) {
-		if (value.toString().indexOf('.') !== -1) {
-			return { doubleValue: value };
-		} else {
-			return { integerValue: value };
-		}
 	} else if (isValidDate(value as string)) {
-		const date = new Date(Date.parse(value as string));
+		const date = moment(value as string, ['YYYY-MM-DD HH:mm:ss Z', moment.ISO_8601], true);
 		return { timestampValue: date.toISOString() };
 	} else if (typeof value === 'string') {
 		return { stringValue: value };
@@ -104,6 +102,12 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 			obj[o] = jsonToDocument(value[o] as IDataObject);
 		}
 		return { mapValue: { fields: obj } };
+	} else if (!isNaN(value as number)) {
+		if (value.toString().indexOf('.') !== -1) {
+			return { doubleValue: value };
+		} else {
+			return { integerValue: value };
+		}
 	}
 
 	return {};

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/test/GenericFunctions.test.ts
@@ -1,0 +1,61 @@
+import { jsonToDocument } from '../GenericFunctions';
+
+describe('Firebase -> jsonToDocument', () => {
+	test('returns booleanValue for boolean values', () => {
+		expect(jsonToDocument(true)).toEqual({ booleanValue: true });
+		expect(jsonToDocument(false)).toEqual({ booleanValue: false });
+		expect(jsonToDocument('true')).toEqual({ booleanValue: true });
+		expect(jsonToDocument('false')).toEqual({ booleanValue: false });
+	});
+
+	test('returns nullValue for null', () => {
+		expect(jsonToDocument(null)).toEqual({ nullValue: null });
+	});
+
+	test('returns timestampValue for valid date string', () => {
+		expect(jsonToDocument('2022-03-04T10:20:30Z')).toEqual({
+			timestampValue: '2022-03-04T10:20:30.000Z',
+		});
+	});
+
+	test('returns stringValue for string values', () => {
+		expect(jsonToDocument('')).toEqual({ stringValue: '' });
+		expect(jsonToDocument('123456789')).toEqual({ stringValue: '123456789' });
+		expect(jsonToDocument('hello')).toEqual({ stringValue: 'hello' });
+	});
+
+	test('returns arrayValue for array values', () => {
+		expect(jsonToDocument([])).toEqual({ arrayValue: { values: [] } });
+		expect(jsonToDocument([1, 'two', { three: 3 }])).toEqual({
+			arrayValue: {
+				values: [
+					{ integerValue: 1 },
+					{ stringValue: 'two' },
+					{ mapValue: { fields: { three: { integerValue: 3 } } } },
+				],
+			},
+		});
+	});
+
+	test('returns mapValue for object values', () => {
+		expect(jsonToDocument({ a: 1, b: 'two', c: { three: 3 } })).toEqual({
+			mapValue: {
+				fields: {
+					a: { integerValue: 1 },
+					b: { stringValue: 'two' },
+					c: { mapValue: { fields: { three: { integerValue: 3 } } } },
+				},
+			},
+		});
+	});
+
+	test('returns doubleValue or integerValue for numeric values', () => {
+		expect(jsonToDocument(123)).toEqual({ integerValue: 123 });
+		expect(jsonToDocument(1.23)).toEqual({ doubleValue: 1.23 });
+	});
+
+	test('returns empty object for other types', () => {
+		expect(jsonToDocument(undefined)).toEqual({});
+		expect(jsonToDocument({})).toEqual({ mapValue: { fields: {} } });
+	});
+});


### PR DESCRIPTION
There are some edge cases:

- Empty String --> { stringValue: "" }
- Empty Array --> { arrayValue: { values: [] } }
- 'true' --> { booleanValue: true }
- 'false' --> { booleanValue: false }
- '12345678' --> { stringValue: '12345678' }

[More Samples](https://github.com/germanynick/n8n/blob/00affc772009b138c829e980a831026349f17937/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/test/GenericFunctions.test.ts)