### PR TITLE
fix(editor): Only treat as CTRL pressed by default on touch devices for MouseEvent

### DIFF
--- a/packages/editor-ui/src/composables/useDeviceSupport.ts
+++ b/packages/editor-ui/src/composables/useDeviceSupport.ts
@@ -19,7 +19,7 @@ export default function useDeviceSupportHelpers(): DeviceSupportHelpers {
 	const controlKeyCode = ref(isMacOs.value ? 'Meta' : 'Control');
 
 	function isCtrlKeyPressed(e: MouseEvent | KeyboardEvent): boolean {
-		if (isTouchDevice.value === true) {
+		if (isTouchDevice.value === true && e instanceof MouseEvent) {
 			return true;
 		}
 		if (isMacOs.value) {

--- a/packages/editor-ui/src/mixins/deviceSupportHelpers.ts
+++ b/packages/editor-ui/src/mixins/deviceSupportHelpers.ts
@@ -19,7 +19,7 @@ export const deviceSupportHelpers = Vue.extend({
 	},
 	methods: {
 		isCtrlKeyPressed(e: MouseEvent | KeyboardEvent): boolean {
-			if (this.isTouchDevice === true) {
+			if (this.isTouchDevice === true && e instanceof MouseEvent) {
 				return true;
 			}
 			if (this.isMacOs) {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
