### PR TITLE
fix(editor): Make sure to redirect to blank canvas after personalisation modal

### DIFF
--- a/packages/editor-ui/src/components/PersonalizationModal.vue
+++ b/packages/editor-ui/src/components/PersonalizationModal.vue
@@ -122,7 +122,8 @@ import {
 	REPORTED_SOURCE_EVENT,
 	REPORTED_SOURCE_OTHER,
 	REPORTED_SOURCE_OTHER_KEY,
-} from '../constants';
+	VIEWS,
+} from '@/constants';
 import { workflowHelpers } from '@/mixins/workflowHelpers';
 import { showMessage } from '@/mixins/showMessage';
 import Modal from './Modal.vue';
@@ -606,6 +607,11 @@ export default mixins(showMessage, workflowHelpers).extend({
 	methods: {
 		closeDialog() {
 			this.modalBus.emit('close');
+			// In case the redirect to canvas for new users didn't happen
+			// we try again after closing the modal
+			if(this.$route.name !== VIEWS.NEW_WORKFLOW) {
+				this.$router.replace({ name: VIEWS.NEW_WORKFLOW });
+			}
 		},
 		onSave() {
 			this.formBus.emit('submit');

--- a/packages/editor-ui/src/components/PersonalizationModal.vue
+++ b/packages/editor-ui/src/components/PersonalizationModal.vue
@@ -609,7 +609,7 @@ export default mixins(showMessage, workflowHelpers).extend({
 			this.modalBus.emit('close');
 			// In case the redirect to canvas for new users didn't happen
 			// we try again after closing the modal
-			if(this.$route.name !== VIEWS.NEW_WORKFLOW) {
+			if (this.$route.name !== VIEWS.NEW_WORKFLOW) {
 				this.$router.replace({ name: VIEWS.NEW_WORKFLOW });
 			}
 		},


### PR DESCRIPTION
On cloud instances, there's no owner setup flow happening, so a new user might not end-up on blank canvas as intended. For this we do the router replace after closing of the personalisation modal. 
