### PR TITLE
fix(editor): Fix moving canvas on middle click preventing lasso selection

### DIFF
--- a/packages/editor-ui/src/mixins/moveNodeWorkflow.ts
+++ b/packages/editor-ui/src/mixins/moveNodeWorkflow.ts
@@ -39,7 +39,7 @@ export const moveNodeWorkflow = mixins(deviceSupportHelpers).extend({
 				return;
 			}
 
-			// Don't indicate move start just yet if middle button is pressed
+			// Prevent moving canvas on anything but middle button
 			if (e.button !== 1) {
 				this.uiStore.nodeViewMoveInProgress = true;
 			}
@@ -77,7 +77,7 @@ export const moveNodeWorkflow = mixins(deviceSupportHelpers).extend({
 			}
 
 			// Signal that moving canvas is active if middle button is pressed and mouse is moved
-			if (e.button === 1) {
+			if (e.buttons === 4) {
 				this.uiStore.nodeViewMoveInProgress = true;
 			}
 


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-540/after-using-middle-mouse-button-you-can-no-longer-select-nodes

Fixes #5931