### PR TITLE
refactor(Code Node): Constently handle various kinds of data returned by user code

### DIFF
--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -66,7 +66,7 @@ export class Code implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		let items = this.getInputData();
+		const items = this.getInputData();
 
 		const nodeMode = this.getNodeParameter('mode', 0) as CodeNodeMode;
 		const workflowMode = this.getMode();
@@ -80,24 +80,25 @@ export class Code implements INodeType {
 
 			const context = getSandboxContext.call(this);
 			context.items = context.$input.all();
-			const sandbox = new Sandbox(context, workflowMode, nodeMode, this.helpers);
+			const sandbox = new Sandbox(context, jsCodeAllItems, workflowMode, this.helpers);
 
 			if (workflowMode === 'manual') {
 				sandbox.on('console.log', this.sendMessageToUI);
 			}
 
+			let result: INodeExecutionData[];
 			try {
-				items = await sandbox.runCode(jsCodeAllItems);
+				result = await sandbox.runCodeAllItems();
 			} catch (error) {
 				if (!this.continueOnFail()) return Promise.reject(error);
-				items = [{ json: { error: error.message } }];
+				result = [{ json: { error: error.message } }];
 			}
 
-			for (const item of items) {
+			for (const item of result) {
 				standardizeOutput(item.json);
 			}
 
-			return this.prepareOutputData(items);
+			return this.prepareOutputData(result);
 		}
 
 		// ----------------------------------
@@ -107,30 +108,29 @@ export class Code implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 
 		for (let index = 0; index < items.length; index++) {
-			let item = items[index];
-
 			const jsCodeEachItem = this.getNodeParameter('jsCode', index) as string;
 
 			const context = getSandboxContext.call(this, index);
 			context.item = context.$input.item;
-			const sandbox = new Sandbox(context, workflowMode, nodeMode, this.helpers);
+			const sandbox = new Sandbox(context, jsCodeEachItem, workflowMode, this.helpers);
 
 			if (workflowMode === 'manual') {
 				sandbox.on('console.log', this.sendMessageToUI);
 			}
 
+			let result: INodeExecutionData | undefined;
 			try {
-				item = await sandbox.runCode(jsCodeEachItem, index);
+				result = await sandbox.runCodeEachItem(index);
 			} catch (error) {
 				if (!this.continueOnFail()) return Promise.reject(error);
 				returnData.push({ json: { error: error.message } });
 			}
 
-			if (item) {
+			if (result) {
 				returnData.push({
-					json: standardizeOutput(item.json),
+					json: standardizeOutput(result.json),
 					pairedItem: { item: index },
-					...(item.binary && { binary: item.binary }),
+					...(result.binary && { binary: result.binary }),
 				});
 			}
 		}

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -66,8 +66,6 @@ export class Code implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		const items = this.getInputData();
-
 		const nodeMode = this.getNodeParameter('mode', 0) as CodeNodeMode;
 		const workflowMode = this.getMode();
 
@@ -106,6 +104,8 @@ export class Code implements INodeType {
 		// ----------------------------------
 
 		const returnData: INodeExecutionData[] = [];
+
+		const items = this.getInputData();
 
 		for (let index = 0; index < items.length; index++) {
 			const jsCodeEachItem = this.getNodeParameter('jsCode', index) as string;

--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -1,4 +1,3 @@
-import type { NodeVMOptions } from 'vm2';
 import { NodeVM } from 'vm2';
 import { ValidationError } from './ValidationError';
 import { ExecutionError } from './ExecutionError';
@@ -12,33 +11,32 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 
+interface SandboxContext extends IWorkflowDataProxyData {
+	$getNodeParameter: IExecuteFunctions['getNodeParameter'];
+	$getWorkflowStaticData: IExecuteFunctions['getWorkflowStaticData'];
+	helpers: IExecuteFunctions['helpers'];
+}
+
+const { NODE_FUNCTION_ALLOW_BUILTIN: builtIn, NODE_FUNCTION_ALLOW_EXTERNAL: external } =
+	process.env;
+
 export class Sandbox extends NodeVM {
 	private itemIndex: number | undefined = undefined;
 
 	constructor(
-		context: ReturnType<typeof getSandboxContext>,
+		context: SandboxContext,
 		private jsCode: string,
 		workflowMode: WorkflowExecuteMode,
 		private helpers: IExecuteFunctions['helpers'],
 	) {
-		super(Sandbox.getSandboxOptions(context, workflowMode));
-	}
-
-	static getSandboxOptions(
-		context: ReturnType<typeof getSandboxContext>,
-		workflowMode: WorkflowExecuteMode,
-	): NodeVMOptions {
-		const { NODE_FUNCTION_ALLOW_BUILTIN: builtIn, NODE_FUNCTION_ALLOW_EXTERNAL: external } =
-			process.env;
-
-		return {
+		super({
 			console: workflowMode === 'manual' ? 'redirect' : 'inherit',
 			sandbox: context,
 			require: {
 				builtin: builtIn ? builtIn.split(',') : [],
 				external: external ? { modules: external.split(','), transitive: false } : false,
 			},
-		};
+		});
 	}
 
 	async runCodeAllItems(): Promise<INodeExecutionData[]> {
@@ -145,13 +143,6 @@ export class Sandbox extends NodeVM {
 			});
 		}
 
-		this.validateResult(executionResult);
-
-		// If at least one top-level key is a supported item key (`json`, `binary`, etc.),
-		// and another top-level key is unrecognized, then the user mis-added a property
-		// directly on the item, when they intended to add it on the `json` property
-		this.validateTopLevelKeys(executionResult);
-
 		if (Array.isArray(executionResult)) {
 			const firstSentence =
 				executionResult.length > 0
@@ -165,7 +156,15 @@ export class Sandbox extends NodeVM {
 			});
 		}
 
-		return executionResult.json ? executionResult : { json: executionResult };
+		const [returnData] = this.helpers.normalizeItems([executionResult]);
+		this.validateResult(returnData);
+
+		// If at least one top-level key is a supported item key (`json`, `binary`, etc.),
+		// and another top-level key is unrecognized, then the user mis-added a property
+		// directly on the item, when they intended to add it on the `json` property
+		this.validateTopLevelKeys(returnData);
+
+		return returnData;
 	}
 
 	private validateResult({ json, binary }: INodeExecutionData) {
@@ -198,23 +197,14 @@ export class Sandbox extends NodeVM {
 	}
 }
 
-export function getSandboxContext(this: IExecuteFunctions, index?: number) {
-	const sandboxContext: Record<string, unknown> & {
-		$item: (i: number) => IWorkflowDataProxyData;
-		$input: any;
-	} = {
+export function getSandboxContext(this: IExecuteFunctions, index?: number): SandboxContext {
+	return {
 		// from NodeExecuteFunctions
 		$getNodeParameter: this.getNodeParameter,
 		$getWorkflowStaticData: this.getWorkflowStaticData,
 		helpers: this.helpers,
 
 		// to bring in all $-prefixed vars and methods from WorkflowDataProxy
-		$item: this.getWorkflowDataProxy,
-		$input: null,
+		...this.getWorkflowDataProxy(index ?? 0),
 	};
-
-	// $node, $items(), $parameter, $json, $env, etc.
-	Object.assign(sandboxContext, sandboxContext.$item(index ?? 0));
-
-	return sandboxContext;
 }

--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -171,7 +171,7 @@ export class Sandbox extends NodeVM {
 	}
 
 	private validateResult({ json, binary }: INodeExecutionData) {
-		if (json !== undefined && !isObject(json)) {
+		if (json === undefined || !isObject(json)) {
 			throw new ValidationError({
 				message: "A 'json' property isn't an object",
 				description: "In the returned data, every key named 'json' must point to an object",

--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -83,17 +83,15 @@ export class Sandbox extends NodeVM {
 			);
 
 			for (const item of executionResult) {
-				this.validateResult(item);
-
 				if (mustHaveTopLevelN8nKey) {
 					this.validateTopLevelKeys(item);
 				}
 			}
-		} else {
-			this.validateResult(executionResult);
 		}
 
-		return this.helpers.normalizeItems(executionResult as INodeExecutionData[]);
+		const returnData = this.helpers.normalizeItems(executionResult);
+		returnData.forEach((item) => this.validateResult(item));
+		return returnData;
 	}
 
 	async runCodeEachItem(itemIndex: number): Promise<INodeExecutionData | undefined> {

--- a/packages/nodes-base/nodes/Code/test/Code.node.test.ts
+++ b/packages/nodes-base/nodes/Code/test/Code.node.test.ts
@@ -1,5 +1,136 @@
+import { anyNumber, mock } from 'jest-mock-extended';
+import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+import { normalizeItems } from 'n8n-core';
 import { testWorkflows, getWorkflowFilenames } from '../../../test/nodes/Helpers';
+import { Code } from '../Code.node';
+import { Sandbox } from '../Sandbox';
+import { ValidationError } from '../ValidationError';
 
 const workflows = getWorkflowFilenames(__dirname);
 
 describe('Test Code Node', () => testWorkflows(workflows));
+
+describe('Code Node unit test', () => {
+	const node = new Code();
+	const thisArg = mock<IExecuteFunctions>({
+		helpers: { normalizeItems },
+		prepareOutputData: NodeHelpers.prepareOutputData,
+	});
+	const workflowDataProxy = mock<IWorkflowDataProxyData>({ $input: mock() });
+	thisArg.getWorkflowDataProxy.mockReturnValue(workflowDataProxy);
+
+	describe('runOnceForAllItems', () => {
+		beforeEach(() => {
+			thisArg.getNodeParameter.calledWith('mode', 0).mockReturnValueOnce('runOnceForAllItems');
+		});
+
+		describe('valid return data', () => {
+			const tests: Record<string, [object | null, object]> = {
+				'should handle null': [null, []],
+				'should handle pre-normalized result': [
+					[{ json: { count: 42 } }],
+					[{ json: { count: 42 } }],
+				],
+				'should handle when returned data is not an array': [
+					{ json: { count: 42 } },
+					[{ json: { count: 42 } }],
+				],
+				'should handle when returned data is an array with items missing `json` key': [
+					[{ count: 42 }],
+					[{ json: { count: 42 } }],
+				],
+				'should handle when returned data missing `json` key': [
+					{ count: 42 },
+					[{ json: { count: 42 } }],
+				],
+			};
+
+			Object.entries(tests).forEach(([title, [input, expected]]) =>
+				test(title, async () => {
+					jest.spyOn(Sandbox.prototype, 'run').mockResolvedValueOnce(input);
+
+					const output = await node.execute.call(thisArg);
+					expect(output).toEqual([expected]);
+				}),
+			);
+		});
+
+		describe('invalid return data', () => {
+			const tests = {
+				undefined,
+				null: null,
+				date: new Date(),
+				string: 'string',
+				boolean: true,
+				array: [],
+			};
+
+			Object.entries(tests).forEach(([title, returnData]) =>
+				test(`return error if \`.json\` is ${title}`, async () => {
+					jest.spyOn(Sandbox.prototype, 'run').mockResolvedValueOnce([{ json: returnData }]);
+
+					try {
+						await node.execute.call(thisArg);
+						throw new Error("Validation error wasn't thrown");
+					} catch (error) {
+						expect(error).toBeInstanceOf(ValidationError);
+						expect(error.message).toEqual("A 'json' property isn't an object");
+					}
+				}),
+			);
+		});
+	});
+
+	describe('runOnceForEachItem', () => {
+		beforeEach(() => {
+			thisArg.getNodeParameter.calledWith('mode', 0).mockReturnValueOnce('runOnceForEachItem');
+			thisArg.getNodeParameter.calledWith('jsCode', anyNumber()).mockReturnValueOnce('');
+			thisArg.getInputData.mockReturnValueOnce([{ json: {} }]);
+		});
+
+		describe('valid return data', () => {
+			const tests: Record<string, [object | null, { json: any } | null]> = {
+				'should handle pre-normalized result': [{ json: { count: 42 } }, { json: { count: 42 } }],
+				'should handle when returned data missing `json` key': [
+					{ count: 42 },
+					{ json: { count: 42 } },
+				],
+			};
+
+			Object.entries(tests).forEach(([title, [input, expected]]) =>
+				test(title, async () => {
+					jest.spyOn(Sandbox.prototype, 'run').mockResolvedValueOnce(input);
+
+					const output = await node.execute.call(thisArg);
+					expect(output).toEqual([[{ json: expected?.json, pairedItem: { item: 0 } }]]);
+				}),
+			);
+		});
+
+		describe('invalid return data', () => {
+			const tests = {
+				undefined,
+				null: null,
+				date: new Date(),
+				string: 'string',
+				boolean: true,
+				array: [],
+			};
+
+			Object.entries(tests).forEach(([title, returnData]) =>
+				test(`return error if \`.json\` is ${title}`, async () => {
+					jest.spyOn(Sandbox.prototype, 'run').mockResolvedValueOnce({ json: returnData });
+
+					try {
+						await node.execute.call(thisArg);
+						throw new Error("Validation error wasn't thrown");
+					} catch (error) {
+						expect(error).toBeInstanceOf(ValidationError);
+						expect(error.message).toEqual("A 'json' property isn't an object [item 0]");
+					}
+				}),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Code/utils.ts
+++ b/packages/nodes-base/nodes/Code/utils.ts
@@ -1,7 +1,9 @@
 import type { IDataObject } from 'n8n-workflow';
 
 export function isObject(maybe: unknown): maybe is { [key: string]: unknown } {
-	return typeof maybe === 'object' && maybe !== null && !Array.isArray(maybe);
+	return (
+		typeof maybe === 'object' && maybe !== null && !Array.isArray(maybe) && !(maybe instanceof Date)
+	);
 }
 
 function isTraversable(maybe: unknown): maybe is IDataObject {

--- a/packages/nodes-base/nodes/Code/utils.ts
+++ b/packages/nodes-base/nodes/Code/utils.ts
@@ -13,7 +13,6 @@ function isTraversable(maybe: unknown): maybe is IDataObject {
  */
 export function standardizeOutput(output: IDataObject) {
 	function standardizeOutputRecursive(obj: IDataObject, knownObjects = new WeakSet()): IDataObject {
-		if (obj === undefined || obj === null) return obj;
 		for (const [key, value] of Object.entries(obj)) {
 			if (!isTraversable(value)) continue;
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1462,21 +1462,30 @@ export interface IWebhookDescription {
 	restartWebhook?: boolean;
 }
 
+export interface ProxyInput {
+	all: () => INodeExecutionData[];
+	context: any;
+	first: () => INodeExecutionData | undefined;
+	item: INodeExecutionData | undefined;
+	last: () => INodeExecutionData | undefined;
+	params?: INodeParameters;
+}
+
 export interface IWorkflowDataProxyData {
 	[key: string]: any;
-	$binary: any;
+	$binary: INodeExecutionData['binary'];
 	$data: any;
 	$env: any;
-	$evaluateExpression: any;
-	$item: any;
-	$items: any;
-	$json: any;
+	$evaluateExpression: (expression: string, itemIndex?: number) => NodeParameterValueType;
+	$item: (itemIndex: number, runIndex?: number) => IWorkflowDataProxyData;
+	$items: (nodeName?: string, outputIndex?: number, runIndex?: number) => INodeExecutionData[];
+	$json: INodeExecutionData['json'];
 	$node: any;
-	$parameter: any;
-	$position: any;
+	$parameter: INodeParameters;
+	$position: number;
 	$workflow: any;
 	$: any;
-	$input: any;
+	$input: ProxyInput;
 	$thisItem: any;
 	$thisRunIndex: number;
 	$thisItemIndex: number;


### PR DESCRIPTION
This reverts #5989, and instead of silently ignoring invalid return data, this adds a clear validation error.

<img src="https://user-images.githubusercontent.com/196144/232790791-ddcec3d6-9bad-4ada-84f0-208e3365c3d3.png" width="577">

<details>
  <summary>A test workflow</summary>
  
  ```json
  {
  "nodes": [
    {
      "parameters": {
        "jsCode": "const items = $input.all();\nitems.forEach((i) => {\n  if (i.json.code === 2) i.json = undefined;\n});\nreturn items;"
      },
      "id": "52b31c80-2ca8-4626-be97-0490d656fe39",
      "name": "Code",
      "type": "n8n-nodes-base.code",
      "typeVersion": 1,
      "position": [
        1100,
        460
      ],
      "alwaysOutputData": false
    },
    {
      "parameters": {},
      "id": "159e9b5e-4b0d-4704-9096-a421bba4758a",
      "name": "When clicking \"Execute Workflow\"",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        880,
        460
      ]
    }
  ],
  "connections": {
    "When clicking \"Execute Workflow\"": {
      "main": [
        [
          {
            "node": "Code",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
  ```
</details>



Fixes: ADO-513