### PR TITLE
refactor: Accumulate `loadOptions` from all node versions to validate (no-changelog)

### DIFF
--- a/packages/core/bin/generate-ui-types
+++ b/packages/core/bin/generate-ui-types
@@ -31,7 +31,7 @@ function findReferencedMethods(obj, refs = {}, latestName = '') {
 
 (async () => {
 	const loader = new PackageDirectoryLoader(packageDir);
-	await loader.loadAll({ withLoadOptionsMethods: true });
+	await loader.loadAll();
 
 	const credentialTypes = Object.values(loader.credentialTypes).map((data) => data.type);
 
@@ -45,7 +45,12 @@ function findReferencedMethods(obj, refs = {}, latestName = '') {
 
 			const { name } = type.description;
 
-			acc[name] = acc[name] ? acc[name].push(methods) : methods;
+			if (acc[name]) {
+				acc[name] = [...new Set([...acc[name], ...methods])];
+				return;
+			}
+
+			acc[name] = methods;
 		});
 
 		return acc;

--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -44,8 +44,6 @@ export abstract class DirectoryLoader {
 
 	types: Types = { nodes: [], credentials: [] };
 
-	withLoadOptionsMethods = false; // only for validation during build
-
 	constructor(
 		readonly directory: string,
 		protected readonly excludeNodes: string[] = [],
@@ -102,10 +100,13 @@ export abstract class DirectoryLoader {
 				this.fixIconPath(versionNode.description, filePath);
 			}
 
+			for (const version of Object.values(tempNode.nodeVersions)) {
+				this.addLoadOptionsMethods(version);
+			}
+
 			const currentVersionNode = tempNode.nodeVersions[tempNode.currentVersion];
 			this.addCodex({ node: currentVersionNode, filePath, isCustom });
 			nodeVersion = tempNode.currentVersion;
-			if (this.withLoadOptionsMethods) this.addLoadOptionsMethods(currentVersionNode);
 
 			if (currentVersionNode.hasOwnProperty('executeSingle')) {
 				Logger.warn(
@@ -114,7 +115,7 @@ export abstract class DirectoryLoader {
 				);
 			}
 		} else {
-			if (this.withLoadOptionsMethods) this.addLoadOptionsMethods(tempNode);
+			this.addLoadOptionsMethods(tempNode);
 			// Short renaming to avoid type issues
 
 			nodeVersion = Array.isArray(tempNode.description.version)
@@ -306,9 +307,7 @@ export class PackageDirectoryLoader extends DirectoryLoader {
 		this.packageName = this.packageJson.name;
 	}
 
-	override async loadAll(options = { withLoadOptionsMethods: false }) {
-		this.withLoadOptionsMethods = options.withLoadOptionsMethods;
-
+	override async loadAll() {
 		await this.readPackageJson();
 
 		const { n8n } = this.packageJson;


### PR DESCRIPTION
Quick fix. In future we can tighten the check by grouping load options methods by node version.

Took the opportunity to remove `withLoadOptionsMethods`, but unneeded for the fix.

Ref: https://github.com/n8n-io/n8n/actions/runs/4741491779/jobs/8418705623?pr=4877