### PR TITLE
fix(editor): Fix memory leak in Node Detail View by correctly unsubscribing from event buses

### DIFF
--- a/cypress/e2e/14-data-transformation-expressions.cy.ts
+++ b/cypress/e2e/14-data-transformation-expressions.cy.ts
@@ -12,11 +12,12 @@ describe('Data transformation expressions', () => {
 	beforeEach(() => {
 		wf.actions.visit();
 
-		cy.window()
-			// @ts-ignore
-			.then(
-				(win) => win.onBeforeUnloadNodeView && win.removeEventListener('beforeunload', win.onBeforeUnloadNodeView),
-			);
+		cy.window().then(
+			(win) => {
+				// @ts-ignore
+				win.preventNodeViewBeforeUnload = true;
+			},
+		);
 	});
 
 	it('$json + native string methods', () => {

--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -17,11 +17,12 @@ describe('Data mapping', () => {
 	beforeEach(() => {
 		workflowPage.actions.visit();
 
-		cy.window()
-			// @ts-ignore
-			.then(
-				(win) => win.onBeforeUnloadNodeView && win.removeEventListener('beforeunload', win.onBeforeUnloadNodeView),
-			);
+		cy.window().then(
+			(win) => {
+				// @ts-ignore
+				win.preventNodeViewBeforeUnload = true;
+			},
+		);
 	});
 
 	it('maps expressions from table header', () => {

--- a/cypress/e2e/16-webhook-node.cy.ts
+++ b/cypress/e2e/16-webhook-node.cy.ts
@@ -99,11 +99,12 @@ describe('Webhook Trigger node', async () => {
 	beforeEach(() => {
 		workflowPage.actions.visit();
 
-		cy.window()
-			// @ts-ignore
-			.then(
-				(win) => win.onBeforeUnloadNodeView && win.removeEventListener('beforeunload', win.onBeforeUnloadNodeView),
-			);
+		cy.window().then(
+			(win) => {
+				// @ts-ignore
+				win.preventNodeViewBeforeUnload = true;
+			},
+		);
 	});
 
 	it('should listen for a GET request', () => {

--- a/packages/editor-ui/src/components/ExpandableInput/ExpandableInputEdit.vue
+++ b/packages/editor-ui/src/components/ExpandableInput/ExpandableInputEdit.vue
@@ -37,12 +37,10 @@ export default Vue.extend({
 		if (this.autofocus && this.$refs.input) {
 			this.focus();
 		}
-
-		if (this.eventBus) {
-			this.eventBus.on('focus', () => {
-				this.focus();
-			});
-		}
+		this.eventBus?.on('focus', this.focus);
+	},
+	destroyed() {
+		this.eventBus?.off('focus', this.focus);
 	},
 	methods: {
 		focus() {

--- a/packages/editor-ui/src/components/Modal.vue
+++ b/packages/editor-ui/src/components/Modal.vue
@@ -121,15 +121,8 @@ export default Vue.extend({
 	mounted() {
 		window.addEventListener('keydown', this.onWindowKeydown);
 
-		if (this.eventBus) {
-			this.eventBus.on('close', () => {
-				this.closeDialog();
-			});
-
-			this.eventBus.on('closeAll', () => {
-				this.uiStore.closeAllModals();
-			});
-		}
+		this.eventBus?.on('close', this.closeDialog);
+		this.eventBus?.on('closeAll', this.uiStore.closeAllModals);
 
 		const activeElement = document.activeElement as HTMLElement;
 		if (activeElement) {
@@ -137,6 +130,8 @@ export default Vue.extend({
 		}
 	},
 	beforeDestroy() {
+		this.eventBus?.off('close', this.closeDialog);
+		this.eventBus?.off('closeAll', this.uiStore.closeAllModals);
 		window.removeEventListener('keydown', this.onWindowKeydown);
 	},
 	computed: {

--- a/packages/editor-ui/src/components/ModalDrawer.vue
+++ b/packages/editor-ui/src/components/ModalDrawer.vue
@@ -53,12 +53,7 @@ export default Vue.extend({
 	},
 	mounted() {
 		window.addEventListener('keydown', this.onWindowKeydown);
-
-		if (this.eventBus) {
-			this.eventBus.on('close', () => {
-				this.close();
-			});
-		}
+		this.eventBus?.on('close', this.close);
 
 		const activeElement = document.activeElement as HTMLElement;
 		if (activeElement) {
@@ -66,6 +61,7 @@ export default Vue.extend({
 		}
 	},
 	beforeDestroy() {
+		this.eventBus?.off('close', this.close);
 		window.removeEventListener('keydown', this.onWindowKeydown);
 	},
 	computed: {

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -211,15 +211,10 @@ export default mixins(
 		};
 	},
 	mounted() {
-		dataPinningEventBus.on(
-			'data-pinning-discovery',
-			({ isTooltipVisible }: { isTooltipVisible: boolean }) => {
-				this.pinDataDiscoveryTooltipVisible = isTooltipVisible;
-			},
-		);
+		dataPinningEventBus.on('data-pinning-discovery', this.setIsTooltipVisible);
 	},
 	destroyed() {
-		dataPinningEventBus.off('data-pinning-discovery');
+		dataPinningEventBus.off('data-pinning-discovery', this.setIsTooltipVisible);
 	},
 	computed: {
 		...mapStores(useNodeTypesStore, useNDVStore, useUIStore, useWorkflowsStore, useSettingsStore),
@@ -480,6 +475,9 @@ export default mixins(
 		},
 	},
 	methods: {
+		setIsTooltipVisible({ isTooltipVisible }: { isTooltipVisible: boolean }) {
+			this.pinDataDiscoveryTooltipVisible = isTooltipVisible;
+		},
 		onKeyDown(e: KeyboardEvent) {
 			if (e.key === 's' && this.isCtrlKeyPressed(e)) {
 				e.stopPropagation();

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -895,18 +895,24 @@ export default mixins(externalHooks, nodeHelpers).extend({
 		onStopExecution() {
 			this.$emit('stopExecution');
 		},
+		openSettings() {
+			this.openPanel = 'settings';
+		},
 	},
 	mounted() {
 		this.populateHiddenIssuesSet();
 		this.setNodeValues();
 		if (this.eventBus) {
-			this.eventBus.on('openSettings', () => {
-				this.openPanel = 'settings';
-			});
+			this.eventBus.on('openSettings', this.openSettings);
 		}
 
 		this.updateNodeParameterIssues(this.node as INodeUi, this.nodeType);
 	},
+	destroyed() {
+		if (this.eventBus) {
+			this.eventBus.off('openSettings', this.openSettings);
+		}
+	}
 });
 </script>
 

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -912,7 +912,7 @@ export default mixins(externalHooks, nodeHelpers).extend({
 		if (this.eventBus) {
 			this.eventBus.off('openSettings', this.openSettings);
 		}
-	}
+	},
 });
 </script>
 

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -902,16 +902,12 @@ export default mixins(externalHooks, nodeHelpers).extend({
 	mounted() {
 		this.populateHiddenIssuesSet();
 		this.setNodeValues();
-		if (this.eventBus) {
-			this.eventBus.on('openSettings', this.openSettings);
-		}
+		this.eventBus?.on('openSettings', this.openSettings);
 
 		this.updateNodeParameterIssues(this.node as INodeUi, this.nodeType);
 	},
 	destroyed() {
-		if (this.eventBus) {
-			this.eventBus.off('openSettings', this.openSettings);
-		}
+		this.eventBus?.off('openSettings', this.openSettings);
 	},
 });
 </script>

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -585,7 +585,6 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 			currentPage: 1,
 			pageSize: 10,
 			pageSizes: [10, 25, 50, 100],
-			eventBus: dataPinningEventBus,
 
 			pinDataDiscoveryTooltipVisible: false,
 			isControlledPinDataTooltip: false,
@@ -595,8 +594,8 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 		this.init();
 
 		if (!this.isPaneTypeInput) {
-			this.eventBus.on('data-pinning-error', this.onDataPinningError);
-			this.eventBus.on('data-unpinning', this.onDataUnpinning);
+			dataPinningEventBus.on('data-pinning-error', this.onDataPinningError);
+			dataPinningEventBus.on('data-unpinning', this.onDataUnpinning);
 
 			this.showPinDataDiscoveryTooltip(this.jsonData);
 		}
@@ -609,8 +608,8 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 	},
 	destroyed() {
 		this.hidePinDataDiscoveryTooltip();
-		this.eventBus.off('data-pinning-error', this.onDataPinningError);
-		this.eventBus.off('data-unpinning', this.onDataUnpinning);
+		dataPinningEventBus.off('data-pinning-error', this.onDataPinningError);
+		dataPinningEventBus.off('data-unpinning', this.onDataUnpinning);
 	},
 	computed: {
 		...mapStores(useNodeTypesStore, useNDVStore, useWorkflowsStore),
@@ -908,7 +907,7 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 				setTimeout(() => {
 					this.isControlledPinDataTooltip = true;
 					this.pinDataDiscoveryTooltipVisible = true;
-					this.eventBus.emit('data-pinning-discovery', { isTooltipVisible: true });
+					dataPinningEventBus.emit('data-pinning-discovery', { isTooltipVisible: true });
 				}, 500); // Wait for NDV to open
 			}
 		},
@@ -916,7 +915,7 @@ export default mixins(externalHooks, genericHelpers, nodeHelpers, pinData).exten
 			if (this.pinDataDiscoveryTooltipVisible) {
 				this.isControlledPinDataTooltip = false;
 				this.pinDataDiscoveryTooltipVisible = false;
-				this.eventBus.emit('data-pinning-discovery', { isTooltipVisible: false });
+				dataPinningEventBus.emit('data-pinning-discovery', { isTooltipVisible: false });
 			}
 		},
 		pinDataDiscoveryComplete() {

--- a/packages/editor-ui/src/components/SettingsLogStreaming/EventDestinationCard.ee.vue
+++ b/packages/editor-ui/src/components/SettingsLogStreaming/EventDestinationCard.ee.vue
@@ -92,15 +92,10 @@ export default mixins(showMessage).extend({
 			deepCopy(defaultMessageEventBusDestinationOptions),
 			this.destination,
 		);
-		this.eventBus.on('destinationWasSaved', () => {
-			const updatedDestination = this.logStreamingStore.getDestination(this.destination.id);
-			if (updatedDestination) {
-				this.nodeParameters = Object.assign(
-					deepCopy(defaultMessageEventBusDestinationOptions),
-					this.destination,
-				);
-			}
-		});
+		this.eventBus?.on('destinationWasSaved', this.onDestinationWasSaved);
+	},
+	destroyed() {
+		this.eventBus?.off('destinationWasSaved', this.onDestinationWasSaved);
 	},
 	computed: {
 		...mapStores(useLogStreamingStore),
@@ -124,6 +119,15 @@ export default mixins(showMessage).extend({
 		},
 	},
 	methods: {
+		onDestinationWasSaved() {
+			const updatedDestination = this.logStreamingStore.getDestination(this.destination.id);
+			if (updatedDestination) {
+				this.nodeParameters = Object.assign(
+					deepCopy(defaultMessageEventBusDestinationOptions),
+					this.destination,
+				);
+			}
+		},
 		async onClick(event?: PointerEvent) {
 			if (
 				event &&

--- a/packages/editor-ui/src/components/TagsDropdown.vue
+++ b/packages/editor-ui/src/components/TagsDropdown.vue
@@ -117,14 +117,12 @@ export default mixins(showMessage).extend({
 			}
 		}
 
-		if (this.eventBus) {
-			this.eventBus.on('focus', () => {
-				this.focusOnInput();
-				this.focusOnTopOption();
-			});
-		}
+		this.eventBus?.on('focus', this.onBusFocus);
 
 		this.tagsStore.fetchAll();
+	},
+	destroyed() {
+		this.eventBus?.off('focus', this.onBusFocus);
 	},
 	computed: {
 		...mapStores(useTagsStore, useUIStore),
@@ -144,6 +142,10 @@ export default mixins(showMessage).extend({
 		},
 	},
 	methods: {
+		onBusFocus() {
+			this.focusOnInput();
+			this.focusOnTopOption();
+		},
 		filterOptions(filter = '') {
 			this.$data.filter = filter.trim();
 			this.$nextTick(() => this.focusOnTopOption());

--- a/packages/editor-ui/src/views/SettingsLogStreamingView.vue
+++ b/packages/editor-ui/src/views/SettingsLogStreamingView.vue
@@ -135,18 +135,16 @@ export default mixins().extend({
 			}
 		});
 		// refresh when a modal closes
-		this.eventBus.on('destinationWasSaved', async () => {
-			this.$forceUpdate();
-		});
+		this.eventBus.on('destinationWasSaved', this.$forceUpdate);
 		// listen to remove emission
-		this.eventBus.on('remove', async (destinationId: string) => {
-			await this.onRemove(destinationId);
-		});
+		this.eventBus.on('remove', this.onRemove);
 		// listen to modal closing and remove nodes from store
-		this.eventBus.on('closing', async (destinationId: string) => {
-			this.workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });
-			this.uiStore.stateIsDirty = false;
-		});
+		this.eventBus.on('closing', this.onBusClosing);
+	},
+	destroyed() {
+		this.eventBus.off('destinationWasSaved', this.$forceUpdate);
+		this.eventBus.off('remove', this.onRemove);
+		this.eventBus.off('closing', this.onBusClosing);
 	},
 	computed: {
 		...mapStores(
@@ -173,6 +171,10 @@ export default mixins().extend({
 		},
 	},
 	methods: {
+		onBusClosing() {
+			this.workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });
+			this.uiStore.stateIsDirty = false;
+		},
 		async getDestinationDataFromBackend(): Promise<void> {
 			this.logStreamingStore.clearEventNames();
 			this.logStreamingStore.clearDestinationItemTrees();

--- a/packages/editor-ui/src/views/SettingsLogStreamingView.vue
+++ b/packages/editor-ui/src/views/SettingsLogStreamingView.vue
@@ -135,14 +135,14 @@ export default mixins().extend({
 			}
 		});
 		// refresh when a modal closes
-		this.eventBus.on('destinationWasSaved', this.$forceUpdate);
+		this.eventBus.on('destinationWasSaved', this.onDestinationWasSaved);
 		// listen to remove emission
 		this.eventBus.on('remove', this.onRemove);
 		// listen to modal closing and remove nodes from store
 		this.eventBus.on('closing', this.onBusClosing);
 	},
 	destroyed() {
-		this.eventBus.off('destinationWasSaved', this.$forceUpdate);
+		this.eventBus.off('destinationWasSaved', this.onDestinationWasSaved);
 		this.eventBus.off('remove', this.onRemove);
 		this.eventBus.off('closing', this.onBusClosing);
 	},
@@ -171,6 +171,9 @@ export default mixins().extend({
 		},
 	},
 	methods: {
+		onDestinationWasSaved() {
+			this.$forceUpdate()
+		},
 		onBusClosing() {
 			this.workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });
 			this.uiStore.stateIsDirty = false;

--- a/packages/editor-ui/src/views/SettingsLogStreamingView.vue
+++ b/packages/editor-ui/src/views/SettingsLogStreamingView.vue
@@ -172,7 +172,7 @@ export default mixins().extend({
 	},
 	methods: {
 		onDestinationWasSaved() {
-			this.$forceUpdate()
+			this.$forceUpdate();
 		},
 		onBusClosing() {
 			this.workflowsStore.removeAllNodes({ setStateDirty: false, removePinData: true });


### PR DESCRIPTION
This PR addresses two issues related to eventBus subscriptions and the implementation of `onBeforeUnload` in NodeView.

1. Unsubscribing from eventBus: There's several instances where `eventBus.on` was used without properly unsubscribing using `eventBus.off`, or where `eventBus.off` was called without an appropriate handler. This PR ensures correct event bus unsubscription to prevent memory leaks.

2. Modifying `onBeforeUnload` in NodeView: The previous implementation involved appending the `onBeforeUnload` handler to the global window object, so it could later be disabled from e2e tests. Instead, we now check if the `preventNodeViewBeforeUnload` property exists in the window object, and terminate the handler if true.

Github issue / Community forum post (link here to close automatically):
