### PR TITLE
fix(Notion Node): Update credential test to not require user permissions

### DIFF
--- a/packages/nodes-base/credentials/NotionApi.credentials.ts
+++ b/packages/nodes-base/credentials/NotionApi.credentials.ts
@@ -26,7 +26,7 @@ export class NotionApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: 'https://api.notion.com/v1',
-			url: '/users',
+			url: '/users/me',
 		},
 	};
 


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):  https://community.n8n.io/t/connection-to-notion-api-using-key-is-failing/25260
