### PR TITLE
fix(editor): Add correct add variable button message when no variables created (no-changelog)

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1608,6 +1608,7 @@
 	"variables.heading": "Variables",
 	"variables.add": "Add Variable",
 	"variables.add.unavailable": "Upgrade plan to keep using variables",
+	"variables.add.unavailable.empty": "Upgrade plan to start using variables",
 	"variables.add.onlyOwnerCanCreate": "Only owner can create variables",
 	"variables.empty.heading": "{name}, let's set up a variable",
 	"variables.empty.heading.userNotSetup": "Set up a variable",

--- a/packages/editor-ui/src/views/VariablesView.vue
+++ b/packages/editor-ui/src/views/VariablesView.vue
@@ -236,7 +236,9 @@ function displayName(resource: EnvironmentVariable) {
 					</n8n-button>
 				</div>
 				<template #content>
-					<span v-if="!isFeatureEnabled">{{ i18n.baseText('variables.add.unavailable') }}</span>
+					<span v-if="!isFeatureEnabled">{{
+						i18n.baseText(`variables.add.unavailable${allVariables.length === 0 ? '.empty' : ''}`)
+					}}</span>
 					<span v-else>{{ i18n.baseText('variables.add.onlyOwnerCanCreate') }}</span>
 				</template>
 			</n8n-tooltip>


### PR DESCRIPTION
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/6179477/233332460-bb183d94-1f27-4e39-8cc7-66291e8c8594.png">