### PR TITLE
feat(core): Upgrade google-timezones-json to use the correct timezone for Sao Paulo

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -149,7 +149,7 @@
     "express-prom-bundle": "^6.6.0",
     "fast-glob": "^3.2.5",
     "flatted": "^3.2.4",
-    "google-timezones-json": "^1.0.2",
+    "google-timezones-json": "^1.1.0",
     "handlebars": "4.7.7",
     "inquirer": "^7.0.1",
     "ioredis": "^5.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.7
       google-timezones-json:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.0
+        version: 1.1.0
       handlebars:
         specifier: 4.7.7
         version: 4.7.7
@@ -12664,8 +12664,8 @@ packages:
       - supports-color
     dev: false
 
-  /google-timezones-json@1.0.2:
-    resolution: {integrity: sha512-UWXQ7BpSCW8erDespU2I4cri22xsKgwOCyhsJal0OJhi2tFpwJpsYNJt4vCiFPL1p2HzCGiS713LKpNR25n9Kg==}
+  /google-timezones-json@1.1.0:
+    resolution: {integrity: sha512-6BmBx9gJVALV2jsfMks8PwmkWT5ip3+bmMyTgXu4PY+G8nKjHi61yrL7rSXpMYRsIzUXhVKpj+MnjhnwG9nung==}
     dev: false
 
   /gopd@1.0.1:


### PR DESCRIPTION
fixes #2647

https://community.n8n.io/t/brazil-timezone-is-incorrect-how-to-fix-it/2761

[This also changes `Kiev` to `Kyiv`](https://github.com/sanohin/google-timezones-json/commit/d3b9fe9be0bf9d2df45278d226ed042374ee0f09), Thanks @Joffcom