### PR TITLE
Add opencontainer image spec labels to dockerfile

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.source="https://github.com/n8n-io/n8n"
 ARG NODE_VERSION=16
 FROM node:${NODE_VERSION}-alpine
 

--- a/docker/images/n8n-debian/Dockerfile
+++ b/docker/images/n8n-debian/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.source="https://github.com/n8n-io/n8n"
 FROM node:16
 
 ARG N8N_VERSION

--- a/docker/images/n8n-rhel7/Dockerfile
+++ b/docker/images/n8n-rhel7/Dockerfile
@@ -1,3 +1,4 @@
+LABEL org.opencontainers.image.source="https://github.com/n8n-io/n8n"
 FROM richxsl/rhel7
 
 ARG N8N_VERSION


### PR DESCRIPTION
Hi, 

This commit will add the label ´org.opencontainers.image.source="https://github.com/n8n-io/n8n"´ to the base dockerfile and the ones not extending the former. https://github.com/opencontainers/image-spec/blob/main/annotations.md

The PR will ensure better integration with eg. dependency bots using that piece of information to gather changelog from github to put it into a PR, one such example is renovate https://docs.renovatebot.com/modules/datasource/docker/

The label will extend from the base to the extendees pr label docs https://docs.docker.com/engine/reference/builder/#label