### PR TITLE
feat(core): Add license:info command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -116,7 +116,7 @@
     "tsconfig-paths": "^4.1.2"
   },
   "dependencies": {
-    "@n8n_io/license-sdk": "~2.1.0",
+    "@n8n_io/license-sdk": "~2.3.0",
     "@oclif/command": "^1.8.16",
     "@oclif/core": "^1.16.4",
     "@oclif/errors": "^1.3.6",

--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -12,34 +12,6 @@ import {
 } from './constants';
 import { Service } from 'typedi';
 
-async function loadCertStr(): Promise<TLicenseBlock> {
-	// if we have an ephemeral license, we don't want to load it from the database
-	const ephemeralLicense = config.get('license.cert');
-	if (ephemeralLicense) {
-		return ephemeralLicense;
-	}
-	const databaseSettings = await Db.collections.Settings.findOne({
-		where: {
-			key: SETTINGS_LICENSE_CERT_KEY,
-		},
-	});
-
-	return databaseSettings?.value ?? '';
-}
-
-async function saveCertStr(value: TLicenseBlock): Promise<void> {
-	// if we have an ephemeral license, we don't want to save it to the database
-	if (config.get('license.cert')) return;
-	await Db.collections.Settings.upsert(
-		{
-			key: SETTINGS_LICENSE_CERT_KEY,
-			value,
-			loadOnStartup: false,
-		},
-		['key'],
-	);
-}
-
 @Service()
 export class License {
 	private logger: ILogger;
@@ -67,8 +39,8 @@ export class License {
 				autoRenewEnabled,
 				autoRenewOffset,
 				logger: this.logger,
-				loadCertStr,
-				saveCertStr,
+				loadCertStr: async () => this.loadCertStr(),
+				saveCertStr: async (value: TLicenseBlock) => this.saveCertStr(value),
 				deviceFingerprint: () => instanceId,
 			});
 
@@ -78,6 +50,34 @@ export class License {
 				this.logger.error('Could not initialize license manager sdk', e);
 			}
 		}
+	}
+
+	async loadCertStr(): Promise<TLicenseBlock> {
+		// if we have an ephemeral license, we don't want to load it from the database
+		const ephemeralLicense = config.get('license.cert');
+		if (ephemeralLicense) {
+			return ephemeralLicense;
+		}
+		const databaseSettings = await Db.collections.Settings.findOne({
+			where: {
+				key: SETTINGS_LICENSE_CERT_KEY,
+			},
+		});
+
+		return databaseSettings?.value ?? '';
+	}
+
+	async saveCertStr(value: TLicenseBlock): Promise<void> {
+		// if we have an ephemeral license, we don't want to save it to the database
+		if (config.get('license.cert')) return;
+		await Db.collections.Settings.upsert(
+			{
+				key: SETTINGS_LICENSE_CERT_KEY,
+				value,
+				loadOnStartup: false,
+			},
+			['key'],
+		);
 	}
 
 	async activate(activationKey: string): Promise<void> {
@@ -184,5 +184,13 @@ export class License {
 
 	getPlanName(): string {
 		return (this.getFeatureValue('planName') ?? 'Community') as string;
+	}
+
+	getInfo(): string {
+		if (!this.manager) {
+			return 'n/a';
+		}
+
+		return this.manager.toString();
 	}
 }

--- a/packages/cli/src/commands/license/info.ts
+++ b/packages/cli/src/commands/license/info.ts
@@ -1,0 +1,22 @@
+import { License } from '@/License';
+import { Container } from 'typedi';
+import { BaseCommand } from '../BaseCommand';
+
+export class ClearLicenseCommand extends BaseCommand {
+	static description = 'Print license information';
+
+	static examples = ['$ n8n license:info'];
+
+	async run() {
+		const license = Container.get(License);
+		await license.init(this.instanceId);
+
+		this.logger.info('Printing license information:\n' + license.getInfo());
+	}
+
+	async catch(error: Error) {
+		this.logger.error('\nGOT ERROR');
+		this.logger.info('====================================');
+		this.logger.error(error.message);
+	}
+}

--- a/packages/cli/src/commands/license/info.ts
+++ b/packages/cli/src/commands/license/info.ts
@@ -2,7 +2,7 @@ import { License } from '@/License';
 import { Container } from 'typedi';
 import { BaseCommand } from '../BaseCommand';
 
-export class ClearLicenseCommand extends BaseCommand {
+export class LicenseInfoCommand extends BaseCommand {
 	static description = 'Print license information';
 
 	static examples = ['$ n8n license:info'];

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -188,19 +188,12 @@ export class Start extends BaseCommand {
 		const license = Container.get(License);
 		await license.init(this.instanceId);
 
-		const hasCert = (await license.loadCertStr()).length > 0;
 		const activationKey = config.getEnv('license.activationKey');
-
 		if (activationKey) {
-			if (hasCert) {
-				LoggerProxy.info('Skipping license activation');
-			} else {
-				try {
-					LoggerProxy.debug('Attempting license activation');
-					await license.activate(activationKey);
-				} catch (e) {
-					LoggerProxy.error('Could not activate license', e as Error);
-				}
+			try {
+				await license.activate(activationKey);
+			} catch (e) {
+				LoggerProxy.error('Could not activate license', e as Error);
 			}
 		}
 	}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -188,12 +188,19 @@ export class Start extends BaseCommand {
 		const license = Container.get(License);
 		await license.init(this.instanceId);
 
+		const hasCert = (await license.loadCertStr()).length > 0;
 		const activationKey = config.getEnv('license.activationKey');
+
 		if (activationKey) {
-			try {
-				await license.activate(activationKey);
-			} catch (e) {
-				LoggerProxy.error('Could not activate license', e as Error);
+			if (hasCert) {
+				LoggerProxy.info('Skipping license activation');
+			} else {
+				try {
+					LoggerProxy.debug('Attempting license activation');
+					await license.activate(activationKey);
+				} catch (e) {
+					LoggerProxy.error('Could not activate license', e as Error);
+				}
 			}
 		}
 	}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1130,7 +1130,7 @@ export const schema = {
 			format: Boolean,
 			default: true,
 			env: 'N8N_LICENSE_AUTO_RENEW_ENABLED',
-			doc: 'Whether autorenew for licenses is enabled.',
+			doc: 'Whether auto renewal for licenses is enabled.',
 		},
 		autoRenewOffset: {
 			format: Number,

--- a/packages/cli/src/license/license.controller.ts
+++ b/packages/cli/src/license/license.controller.ts
@@ -75,6 +75,7 @@ licenseController.post(
 		} catch (e) {
 			const error = e as Error & { errorId?: string };
 
+			//override specific error messages (to map License Server vocabulary to n8n terms)
 			switch (error.errorId ?? 'UNSPECIFIED') {
 				case 'SCHEMA_VALIDATION':
 					error.message = 'Activation key is in the wrong format';
@@ -92,7 +93,7 @@ licenseController.post(
 					break;
 			}
 
-			throw new ResponseHelper.BadRequestError((e as Error).message);
+			throw new ResponseHelper.BadRequestError(error.message);
 		}
 
 		// Return the read data, plus the management JWT
@@ -115,10 +116,12 @@ licenseController.post(
 		try {
 			await license.renew();
 		} catch (e) {
+			const error = e as Error & { errorId?: string };
+
 			// not awaiting so as not to make the endpoint hang
 			void Container.get(InternalHooks).onLicenseRenewAttempt({ success: false });
-			if (e instanceof Error) {
-				throw new ResponseHelper.BadRequestError(e.message);
+			if (error instanceof Error) {
+				throw new ResponseHelper.BadRequestError(error.message);
 			}
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
   packages/cli:
     dependencies:
       '@n8n_io/license-sdk':
-        specifier: ~2.1.0
-        version: 2.1.0
+        specifier: ~2.3.0
+        version: 2.3.0
       '@oclif/command':
         specifier: ^1.8.16
         version: 1.8.18(@oclif/config@1.18.5)(supports-color@8.1.1)
@@ -4297,8 +4297,8 @@ packages:
     dev: false
     optional: true
 
-  /@n8n_io/license-sdk@2.1.0:
-    resolution: {integrity: sha512-SwIm9b6a30/fAvl1aY0a6cgoSyQBgKHX44M4Ykesn45VSGBKlzO5uuIiIcEPdVjjLEelm7u6wLoDFdIVG37b7Q==}
+  /@n8n_io/license-sdk@2.3.0:
+    resolution: {integrity: sha512-1qOg4VEi2mZzhAJ5Uh9IT9Jn/b3xCaxyFbovYLtymzy3ObafUyWieUrSQri3BrCbW1dwQHz99DEVFxYCq1Je0Q==}
     engines: {node: '>=14.0.0', npm: '>=7.10.0'}
     dependencies:
       crypto-js: 4.1.1


### PR DESCRIPTION
This PR adds a `license:info` command that prints out information about the instance's license certificate (see below)

```
2023-04-21T07:43:14.854Z | info     | Printing license information:
## CONSUMER CONFIG ##
tenantId: 1001
productIdentifier: n8n-0.225.0
deviceFingerprint: 1c80059f3d82d22a985f35324da517592ba3e58152d5d36a0fe577593fd069f0
--
## LICENSE CERT ##
version: 2
tenantId: 1 
consumerId: e49c5cc0-a804-4e7d-9e9b-35df541ca172
deviceFingerprint: 6d80059f3d82d22a985f36384da517592ba3e48252d5d36a0fe577595fd069f0 
createdAt: Thu Apr 20 2023 23:40:55 GMT+0200 (Central European Summer Time)
issuedAt: Thu Apr 20 2023 23:40:55 GMT+0200 (Central European Summer Time)
expiresAt: Sun Apr 30 2023 23:40:55 GMT+0200 (Central European Summer Time)
terminatesAt: Mon Apr 13 2048 23:40:55 GMT+0200 (Central European Summer Time)
isEphemeral: false
isValid: true
isRenewalDue: false
entitlements: 1
--
## ENTITLEMENT 1 ##
id: 2ac7cc57-3c53-4dca-b593-bc56c68c5efb
productId: 239e5ce0-c380-4f0c-8dbc-35280d6d8a64
validFrom: Thu Apr 20 2023 23:40:55 GMT+0200 (Central European Summer Time)
validTo: Thu Apr 20 2023 23:42:55 GMT+0200 (Central European Summer Time)
features: {"planName":"Enterprise","feat:ldap":true,"quota:users":-1,"feat:sharing":true,"feat:logStreaming":true,"quota:activeWorkflows":-1}
featureOverrides: {"quota:activeWorkflows":50}
```