### PR TITLE
ci(editor): Do not run parallel jobs for a single spec

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -109,7 +109,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: ${{ fromJSON(inputs.containers) }}
+        # If spec is not e2e/* then we run only one container to prevent
+        # running the same tests multiple times
+        containers: "${{ fromJSON(inputs.spec == 'e2e/*' ? inputs.containers : '[1]') }}"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -135,9 +137,9 @@ jobs:
           install: false
           start: pnpm start
           wait-on: 'http://localhost:5678'
-          wait-on-timeout: 120 #
+          wait-on-timeout: 120
           record: ${{ inputs.record }}
-          parallel: ${{ inputs.parallel }}
+          parallel: "${{ inputs.spec == 'e2e/*' ? inputs.parallel : false }}"
           # We have to provide custom ci-build-id key to make sure that this workflow could be run multiple times
           # in the same parent workflow
           ci-build-id: ${{ needs.prepare.outputs.uuid }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -47,6 +47,11 @@ on:
       CYPRESS_RECORD_KEY:
         description: 'Cypress record key.'
         required: true
+    outputs:
+      tests_passed:
+        description: 'True if all E2E tests passed, otherwise false'
+        value: ${{ jobs.check_testing_matrix.outputs.all_tests_passed }}
+
 
 jobs:
   # single job that generates and outputs a common id
@@ -150,3 +155,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           E2E_TESTS: true
           COMMIT_INFO_MESSAGE: 🌳 ${{ inputs.branch }} 🖥️ ${{ inputs.run-env }} 🤖 ${{ inputs.user }} 🗃️ ${{ inputs.spec }}
+
+  # Check if all tests passed and set the output variable
+  check_testing_matrix:
+    runs-on: ubuntu-latest
+    needs: [testing]
+    outputs:
+      all_tests_passed: ${{ steps.all_tests_passed.outputs.result }}
+    steps:
+      - name: Check all tests passed
+        id: all_tests_passed
+        run: |
+          success=true
+          for status in ${{ needs.testing.result }}; do
+            if [ $status != "success" ]; then
+              success=false
+              break
+            fi
+          done
+          echo "::set-output name=result::$success"

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -111,7 +111,7 @@ jobs:
       matrix:
         # If spec is not e2e/* then we run only one container to prevent
         # running the same tests multiple times
-        containers: "${{ fromJSON(inputs.spec == 'e2e/*' ? inputs.containers : '[1]') }}"
+        containers: ${{ fromJSON( inputs.spec == 'e2e/*' && inputs.containers || '[1]' ) }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -139,7 +139,7 @@ jobs:
           wait-on: 'http://localhost:5678'
           wait-on-timeout: 120
           record: ${{ inputs.record }}
-          parallel: "${{ inputs.spec == 'e2e/*' ? inputs.parallel : false }}"
+          parallel: ${{ fromJSON( inputs.spec == 'e2e/*' && inputs.parallel || false ) }}
           # We have to provide custom ci-build-id key to make sure that this workflow could be run multiple times
           # in the same parent workflow
           ci-build-id: ${{ needs.prepare.outputs.uuid }}

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -26,7 +26,7 @@ jobs:
     if: always()
     steps:
       - name: E2E success comment
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'community') && needs.run-e2e-tests.result == 'success' }}
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'community') && needs.run-e2e-tests.outputs.tests_passed == 'true' }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -26,7 +26,7 @@ jobs:
     if: always()
     steps:
       - name: E2E success comment
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'community') || needs.run-e2e-tests.result == 'success' }}
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'community') && needs.run-e2e-tests.result == 'success' }}
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
When `spec` parameter is passed to `e2e-reusable` workflow we only want to run it on a single container and non-parallel. For this we need to conditionally set the container matrixes.
Additionally, we only want to post the "E2E Success" comment(it's a required check) after all the container specs were successful. To do this, we set output in the `e2e-reusable` job which will evaluate to true or false after all the container tests are done:
```
  check_testing_matrix:
    runs-on: ubuntu-latest
    needs: [testing]
    outputs:
      all_tests_passed: ${{ steps.all_tests_passed.outputs.result }}
    steps:
      - name: Check all tests passed
        id: all_tests_passed
        run: |
          success=true
          for status in ${{ needs.testing.result }}; do
            if [ $status != "success" ]; then
              success=false
              break
            fi
          done
          echo "::set-output name=result::$success"
```

This allows us to use the result to conditionally trigger the correct PR E2E status.
