### PR TITLE
refactor: Patch to adjust `consistent-type-imports` (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "patchedDependencies": {
       "element-ui@2.15.12": "patches/element-ui@2.15.12.patch",
       "typedi@0.10.0": "patches/typedi@0.10.0.patch",
-      "@sentry/cli@2.17.0": "patches/@sentry__cli@2.17.0.patch"
+      "@sentry/cli@2.17.0": "patches/@sentry__cli@2.17.0.patch",
+      "@typescript-eslint/eslint-plugin@5.45.0": "patches/@typescript-eslint__eslint-plugin@5.45.0.patch"
     }
   }
 }

--- a/patches/@typescript-eslint__eslint-plugin@5.45.0.patch
+++ b/patches/@typescript-eslint__eslint-plugin@5.45.0.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/rules/consistent-type-imports.js b/dist/rules/consistent-type-imports.js
+index fe6eaf80a1285b62ed93b0c32b74c889788c5164..de4e2ca30c131948e030b7d6dbce4ff50e3eff26 100644
+--- a/dist/rules/consistent-type-imports.js
++++ b/dist/rules/consistent-type-imports.js
+@@ -87,6 +87,8 @@ exports.default = util.createRule({
+                 ImportDeclaration(node) {
+                     var _a;
+                     const source = node.source.value;
++                    if (source.endsWith('.vue')) return;
++                    
+                     // sourceImports is the object containing all the specifics for a particular import source, type or value
+                     const sourceImports = (_a = sourceImportsMap[source]) !== null && _a !== void 0 ? _a : (sourceImportsMap[source] = {
+                         source,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ patchedDependencies:
   '@sentry/cli@2.17.0':
     hash: nchnoezkq6p37qaiku3vrpwraq
     path: patches/@sentry__cli@2.17.0.patch
+  '@typescript-eslint/eslint-plugin@5.45.0':
+    hash: dd54h3bsflbrys5h3bbkqmbvea
+    path: patches/@typescript-eslint__eslint-plugin@5.45.0.patch
   element-ui@2.15.12:
     hash: prckukfdop5sl2her6de25cod4
     path: patches/element-ui@2.15.12.patch
@@ -117,7 +120,7 @@ importers:
         version: 8.4.6
       '@typescript-eslint/eslint-plugin':
         specifier: ~5.45
-        version: 5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
+        version: 5.45.0(patch_hash=dd54h3bsflbrys5h3bbkqmbvea)(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
       '@typescript-eslint/parser':
         specifier: ~5.45
         version: 5.45.0(eslint@8.28.0)(typescript@5.0.3)
@@ -7042,7 +7045,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3):
+  /@typescript-eslint/eslint-plugin@5.45.0(patch_hash=dd54h3bsflbrys5h3bbkqmbvea)(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3):
     resolution: {integrity: sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7068,6 +7071,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+    patched: true
 
   /@typescript-eslint/parser@5.45.0(eslint@8.28.0)(typescript@5.0.3):
     resolution: {integrity: sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==}
@@ -7441,7 +7445,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.45.0(patch_hash=dd54h3bsflbrys5h3bbkqmbvea)(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
       '@typescript-eslint/parser': 5.45.0(eslint@8.28.0)(typescript@5.0.3)
       eslint: 8.28.0
       eslint-plugin-vue: 7.17.0(eslint@8.28.0)
@@ -11133,7 +11137,7 @@ packages:
       eslint: ^7.32.0 || ^8.2.0
       eslint-plugin-import: ^2.25.3
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.45.0(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.45.0(patch_hash=dd54h3bsflbrys5h3bbkqmbvea)(@typescript-eslint/parser@5.45.0)(eslint@8.28.0)(typescript@5.0.3)
       '@typescript-eslint/parser': 5.45.0(eslint@8.28.0)(typescript@5.0.3)
       eslint: 8.28.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.26.0)(eslint@8.28.0)


### PR DESCRIPTION
`consistent-type-imports` is unable to detect usage of components inside Vue templates, causing misfixes of component imports to type imports. This patch for the rule skips over imports where the path ends in `.vue`, preventing misdetection. This assumes `.vue` imports are always needed as value imports.

To test: 
- Add `'@typescript-eslint/consistent-type-imports': 'error'` to `packages/@n8n_io/eslint-config/base.js`
- Restart ESLint server
- Check e.g. `packages/editor-ui/src/components/Node/NodeCreator/CategorizedItems.vue` at L102 → Line `import SearchBar from './SearchBar.vue';` should not be flagged.

Related: https://github.com/n8n-io/n8n/pull/5951