### PR TITLE
fix(editor): Make the frontend work again when `NODE_FUNCTION_ALLOW_EXTERNAL` is set (no-changelog)

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -16,6 +16,7 @@ if (inE2ETests) {
 		N8N_PUBLIC_API_DISABLED: 'true',
 		EXTERNAL_FRONTEND_HOOKS_URLS: '',
 		N8N_PERSONALIZATION_ENABLED: 'false',
+		NODE_FUNCTION_ALLOW_EXTERNAL: 'node-fetch',
 	};
 } else if (inTest) {
 	process.env.N8N_PUBLIC_API_DISABLED = 'true';

--- a/packages/editor-ui/src/stores/settings.ts
+++ b/packages/editor-ui/src/stores/settings.ts
@@ -235,11 +235,8 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 		setPromptsData(promptsData: IN8nPrompts): void {
 			Vue.set(this, 'promptsData', promptsData);
 		},
-		setAllowedModules(allowedModules: { builtIn?: string; external?: string }): void {
-			this.settings.allowedModules = {
-				...(allowedModules.builtIn && { builtIn: allowedModules.builtIn.split(',') }),
-				...(allowedModules.external && { external: allowedModules.external.split(',') }),
-			};
+		setAllowedModules(allowedModules: { builtIn?: string[]; external?: string[] }): void {
+			this.settings.allowedModules = allowedModules;
 		},
 		async fetchPromptsData(): Promise<void> {
 			if (!this.isTelemetryEnabled) {


### PR DESCRIPTION
[We changed the response on the server-side](https://github.com/n8n-io/n8n/pull/6055/files#diff-e1c41b1f8cc627242377b30fbee7af28472c81abe5f4f41da1c513f264f128e2R316-R317), but forgot to update the client-side code.