### PR TITLE
refactor(editor): Combine type imports in `editor-ui` (no-changelog)

### DIFF
--- a/packages/editor-ui/src/stores/segment.ts
+++ b/packages/editor-ui/src/stores/segment.ts
@@ -6,10 +6,9 @@ import {
 	SET_NODE_TYPE,
 	WEBHOOK_NODE_TYPE,
 } from '@/constants';
-import type { ITelemetryTrackProperties } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useSettingsStore } from '@/stores/settings';
-import type { INodeTypeDescription, IRun } from 'n8n-workflow';
+import type { INodeTypeDescription, IRun, ITelemetryTrackProperties } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows';
 import { useNodeTypesStore } from '@/stores/nodeTypes';
 

--- a/packages/editor-ui/src/stores/workflows.ts
+++ b/packages/editor-ui/src/stores/workflows.ts
@@ -36,6 +36,7 @@ import type {
 	IAbstractEventMessage,
 	IConnection,
 	IConnections,
+	IDataObject,
 	IExecutionsSummary,
 	INode,
 	INodeConnections,
@@ -53,7 +54,6 @@ import type {
 	ITaskData,
 	IWorkflowSettings,
 } from 'n8n-workflow';
-import type { IDataObject } from 'n8n-workflow';
 import { deepCopy, NodeHelpers, Workflow } from 'n8n-workflow';
 import Vue from 'vue';
 

--- a/packages/editor-ui/src/utils/typeGuards.ts
+++ b/packages/editor-ui/src/utils/typeGuards.ts
@@ -1,6 +1,5 @@
-import type { NewCredentialsModal } from './../Interface';
 import type { INodeParameterResourceLocator } from 'n8n-workflow';
-import type { ICredentialsResponse } from '@/Interface';
+import type { ICredentialsResponse, NewCredentialsModal } from '@/Interface';
 
 /*
 	Type guards used in editor-ui project

--- a/packages/editor-ui/src/utils/userUtils.ts
+++ b/packages/editor-ui/src/utils/userUtils.ts
@@ -68,8 +68,10 @@ import type {
 	IPersonalizationSurveyAnswersV4,
 	IPersonalizationSurveyVersions,
 	IUser,
+	ILogInStatus,
+	IRole,
+	IUserPermissions,
 } from '@/Interface';
-import type { ILogInStatus, IRole, IUserPermissions } from '@/Interface';
 
 /*
 	Utility functions used to handle users in n8n


### PR DESCRIPTION
Followup to #6060, to address the combine-imports comments in [this review](https://github.com/n8n-io/n8n/pull/6060#pullrequestreview-1397629697).

The unused-imports comments are covered by #6073.