### PR TITLE
ci: Increase the timeout on the release process (no-changelog)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
 
-    timeout-minutes: 10
+    timeout-minutes: 60
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We've had 2 cases of the release process timing out because the build process is taking too long. This puts us at the risk of publishing some of the packages before the job times out, which would a tricky situation to get out of without having to create an empty patch release.