### PR TITLE
fix(core): Serialize dates and regexps when reading from augmented objects

### DIFF
--- a/packages/workflow/src/AugmentObject.ts
+++ b/packages/workflow/src/AugmentObject.ts
@@ -90,6 +90,11 @@ export function augmentObject<T extends object>(data: T): T {
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const value = Reflect.get(target, key, receiver);
+
+			if (typeof value !== 'object' || value === null) return value;
+			if (value instanceof RegExp) return value.toString();
+			if ('toJSON' in value && typeof value.toJSON === 'function') return value.toJSON() as T;
+
 			const newValue = augment(value);
 			if (newValue !== value) {
 				Object.assign(newData, { [key]: newValue });

--- a/packages/workflow/test/AugmentObject.test.ts
+++ b/packages/workflow/test/AugmentObject.test.ts
@@ -233,8 +233,8 @@ describe('AugmentObject', () => {
 				a: 9111,
 				b: '9222',
 				c: 3,
-				d: date,
-				r: regexp,
+				d: date.toJSON(),
+				r: regexp.toString(),
 			});
 		});
 


### PR DESCRIPTION
Fixes https://community.n8n.io/t/workflows-fail-when-triggered-but-succeed-when-run-manually/25575

