### PR TITLE
fix: Prevent incorrect error message when sharee opens a credential

### DIFF
--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -164,4 +164,17 @@ describe('Sharing', () => {
 		workflowsPage.getters.workflowCard('Workflow W2').click();
 		workflowPage.actions.executeWorkflow();
 	});
+
+	it('should automatically test C2 when opened by U2 sharee', () => {
+		cy.signin(users[0]);
+
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.credentialCard('Credential C2').click();
+		credentialsModal.getters.testSuccessTag().should('be.visible');
+
+		// credentialsModal.actions.changeTab('Sharing');
+		// credentialsModal.getters.userCard(instanceOwner.email).should('be.visible');
+		// credentialsModal.getters.userCard(users[0].email).should('be.visible');
+		// credentialsModal.getters.userCard(users[1].email).should('be.visible');
+	});
 });

--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -171,10 +171,5 @@ describe('Sharing', () => {
 		cy.visit(credentialsPage.url);
 		credentialsPage.getters.credentialCard('Credential C2').click();
 		credentialsModal.getters.testSuccessTag().should('be.visible');
-
-		// credentialsModal.actions.changeTab('Sharing');
-		// credentialsModal.getters.userCard(instanceOwner.email).should('be.visible');
-		// credentialsModal.getters.userCard(users[0].email).should('be.visible');
-		// credentialsModal.getters.userCard(users[1].email).should('be.visible');
 	});
 });

--- a/cypress/pages/modals/credentials-modal.ts
+++ b/cypress/pages/modals/credentials-modal.ts
@@ -10,9 +10,7 @@ export class CredentialsModal extends BasePage {
 		newCredentialTypeButton: () => cy.getByTestId('new-credential-type-button'),
 		connectionParameters: () => cy.getByTestId('credential-connection-parameter'),
 		connectionParameter: (fieldName: string) =>
-			this.getters
-				.connectionParameters()
-				.find(`:contains('${fieldName}') .n8n-input input`),
+			this.getters.connectionParameters().find(`:contains('${fieldName}') .n8n-input input`),
 		name: () => cy.getByTestId('credential-name'),
 		nameInput: () => cy.getByTestId('credential-name').find('input'),
 		// Saving of the credentials takes a while on the CI so we need to increase the timeout
@@ -27,6 +25,7 @@ export class CredentialsModal extends BasePage {
 		menu: () => this.getters.editCredentialModal().get('.menu-container'),
 		menuItem: (name: string) => this.getters.menu().get('.n8n-menu-item').contains(name),
 		usersSelect: () => cy.getByTestId('credential-sharing-modal-users-select'),
+		testSuccessTag: () => cy.getByTestId('credentials-config-container-test-success'),
 	};
 	actions = {
 		addUser: (email: string) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -58,8 +58,8 @@ Cypress.Commands.add('waitForLoad', (waitForIntercepts = true) => {
 	// These aliases are set-up before each test in cypress/support/e2e.ts
 	// we can't set them up here because at this point it would be too late
 	// and the requests would already have been made
-	if(waitForIntercepts) {
-		cy.wait(['@loadSettings', '@loadLogin'])
+	if (waitForIntercepts) {
+		cy.wait(['@loadSettings', '@loadLogin']);
 	}
 	cy.getByTestId('node-view-loader', { timeout: 20000 }).should('not.exist');
 	cy.get('.el-loading-mask', { timeout: 20000 }).should('not.exist');
@@ -243,8 +243,8 @@ Cypress.Commands.add('drag', (selector, pos, options) => {
 	element.trigger('mousedown');
 	element.trigger('mousemove', {
 		which: 1,
-		pageX: options?.abs? xDiff: originalLocation.right + xDiff,
-		pageY: options?.abs? yDiff: originalLocation.top + yDiff,
+		pageX: options?.abs ? xDiff : originalLocation.right + xDiff,
+		pageY: options?.abs ? yDiff : originalLocation.top + yDiff,
 		force: true,
 	});
 	element.trigger('mouseup', { force: true });

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -58,6 +58,7 @@
 			:buttonTitle="$locale.baseText('credentialEdit.credentialConfig.retryCredentialTest')"
 			:buttonLoading="isRetesting"
 			@click="$emit('retest')"
+			data-test-id="credentials-config-container-test-success"
 		/>
 
 		<template v-if="credentialPermissions.updateConnection">

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -256,7 +256,9 @@ export default mixins(showMessage, nodeHelpers).extend({
 
 		setTimeout(() => {
 			if (this.credentialId) {
-				if (!this.requiredPropertiesFilled) {
+				if (!this.requiredPropertiesFilled && this.credentialPermissions.isOwner === true) {
+					// sharees can't see properties, so this check would always fail for them
+					// if the credential contains required fields.
 					this.showValidationWarning = true;
 				} else {
 					this.retestCredential();
@@ -347,6 +349,10 @@ export default mixins(showMessage, nodeHelpers).extend({
 			};
 		},
 		isCredentialTestable(): boolean {
+			// Sharees can always test since they can't see the data.
+			if (this.credentialPermissions.isOwner === false) {
+				return true;
+			}
 			if (this.isOAuthType || !this.requiredPropertiesFilled) {
 				return false;
 			}


### PR DESCRIPTION
Credential testing was being prevented since sharees can't see credential data. We now bypass this check to allow credential to work properly.

Github issue / Community forum post (link here to close automatically):
