### PR TITLE
fix(core): Only take into account users that active for the first time to show activation modal

### DIFF
--- a/packages/cli/src/events/WorkflowStatistics.ts
+++ b/packages/cli/src/events/WorkflowStatistics.ts
@@ -114,7 +114,7 @@ export async function workflowExecutionCompleted(
 				workflow_id: workflowId,
 			};
 
-			if (!owner.settings?.firstSuccessfulWorkflowId) {
+			if (!owner.settings?.userActivated) {
 				await UserService.updateUserSettings(owner.id, {
 					firstSuccessfulWorkflowId: workflowId,
 					userActivated: true,


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
https://linear.app/n8n/issue/ADO-548/bug-just-got-activation-modal-on-my-personal-instance