### PR TITLE
fix(core): Fix `hasOwnProperty` on augmented objects

### DIFF
--- a/packages/workflow/src/AugmentObject.ts
+++ b/packages/workflow/src/AugmentObject.ts
@@ -143,7 +143,8 @@ export function augmentObject<T extends object>(data: T): T {
 		},
 
 		getOwnPropertyDescriptor(target, key) {
-			return Object.getOwnPropertyDescriptor(data, key) ?? defaultPropertyDescriptor;
+			if (deletedProperties.indexOf(key) !== -1) return undefined;
+			return Object.getOwnPropertyDescriptor(key in newData ? newData : data, key);
 		},
 	});
 

--- a/packages/workflow/test/AugmentObject.test.ts
+++ b/packages/workflow/test/AugmentObject.test.ts
@@ -528,5 +528,34 @@ describe('AugmentObject', () => {
 			const augmentedObject = augmentObject(originalObject);
 			expect(Object.keys(augmentedObject)).toEqual(['a', 'b']);
 		});
+
+		test('should return property descriptors', () => {
+			const originalObject = {
+				x: {
+					y: {},
+					z: {},
+				},
+			};
+			const augmentedObject = augmentObject(originalObject);
+
+			expect(Object.getOwnPropertyDescriptor(augmentedObject.x, 'y')).toEqual({
+				configurable: true,
+				enumerable: true,
+				value: {},
+				writable: true,
+			});
+
+			delete augmentedObject.x.y;
+			expect(augmentedObject.x.hasOwnProperty('y')).toEqual(false);
+
+			augmentedObject.x.y = 42;
+			expect(augmentedObject.x.hasOwnProperty('y')).toEqual(true);
+			expect(Object.getOwnPropertyDescriptor(augmentedObject.x, 'y')).toEqual({
+				configurable: true,
+				enumerable: true,
+				value: 42,
+				writable: true,
+			});
+		});
 	});
 });


### PR DESCRIPTION
N8N-6333

Fixes 

- https://community.n8n.io/t/bug-faulty-javascript-being-implemented-in-the-code-node-after-update-to-v0-222-3/25346
- https://community.n8n.io/t/checking-for-value-in-webhook-body-with-hasownproperty/25068/11
