### PR TITLE
fix(editor): Fix quote handling on dollar-sign variable completions

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
@@ -276,6 +276,14 @@ describe('Resolution-based completions', () => {
 			);
 		});
 
+		test('should return completions for: {{ "hello"+input.| }}', () => {
+			resolveParameterSpy.mockReturnValue($input);
+
+			expect(completions('{{ "hello"+$input.| }}')).toHaveLength(
+				Reflect.ownKeys($input).length + natives('object').length,
+			);
+		});
+
 		test("should return completions for: {{ $('nodeName').| }}", () => {
 			resolveParameterSpy.mockReturnValue($('Rename'));
 

--- a/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
@@ -440,11 +440,12 @@ export const objectGlobalOptions = () => {
 };
 
 const regexes = {
-	generalRef: /\$[^$]+\.([^{\s])*/, // $input. or $json. or similar ones
+	generalRef: /\$[^$'"]+\.([^{\s])*/, // $input. or $json. or similar ones
 	selectorRef: /\$\(['"][\S\s]+['"]\)\.([^{\s])*/, // $('nodeName').
 
 	numberLiteral: /\((\d+)\.?(\d*)\)\.([^{\s])*/, // (123). or (123.4).
-	stringLiteral: /(".+"|('.+'))\.([^{\s])*/, // 'abc'. or "abc".
+	singleQuoteStringLiteral: /('.+')\.([^'{\s])*/, // 'abc'.
+	doubleQuoteStringLiteral: /(".+")\.([^"{\s])*/, // "abc".
 	dateLiteral: /\(?new Date\(\(?.*?\)\)?\.([^{\s])*/, // new Date(). or (new Date()).
 	arrayLiteral: /(\[.+\])\.([^{\s])*/, // [1, 2, 3].
 	objectLiteral: /\(\{.*\}\)\.([^{\s])*/, // ({}).


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-510/bug-expression-autocomplete-doesnt-work-without-spaces-between