### PR TITLE
fix(editor): Fix cropped off completions docstrings

### DIFF
--- a/packages/editor-ui/src/styles/autocomplete-theme.scss
+++ b/packages/editor-ui/src/styles/autocomplete-theme.scss
@@ -17,7 +17,6 @@
 	background-color: var(--color-background-xlight) !important;
 
 	.cm-tooltip {
-		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}


### PR DESCRIPTION
https://linear.app/n8n/issue/ADO-653/most-expressions-extensions-docstrings-are-cut-off#comment-c7f1d51e

Related: https://github.com/n8n-io/n8n/pull/5910#issuecomment-1504888208