### PR TITLE
fix(editor): Fix unscrollable node settings

### DIFF
--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -962,7 +962,7 @@ export default mixins(externalHooks, nodeHelpers).extend({
 	.node-parameters-wrapper {
 		height: 100%;
 		overflow-y: auto;
-		padding: 0 20px;
+		padding: 0 20px 200px 20px;
 	}
 
 	&.dragging {


### PR DESCRIPTION
https://linear.app/n8n/issue/N8N-6392/scrolling-is-cut-off-in-02260

https://n8nio.slack.com/archives/C03594NKD7W/p1682594926893729

https://community.n8n.io/t/bug-interface-can-not-scroll-node-settings/25724

Fix https://github.com/n8n-io/n8n/issues/6115
