### PR TITLE
fix(Postgres Node): Always return TIMESTAMP and TIMESTAMPZ as ISO string

### DIFF
--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -11,13 +11,14 @@ export class Postgres extends VersionedNodeType {
 			name: 'postgres',
 			icon: 'file:postgres.svg',
 			group: ['input'],
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 			description: 'Get, add and update data in Postgres',
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new PostgresV1(baseDescription),
 			2: new PostgresV2(baseDescription),
+			2.1: new PostgresV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
@@ -17,6 +17,7 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 
 	const credentials = await this.getCredentials('postgres');
 	const options = this.getNodeParameter('options', 0, {});
+	options.nodeVersion = this.getNode().typeVersion;
 
 	const { db, pgp, sshClient } = (await Connections.getInstance(
 		credentials,

--- a/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
@@ -8,7 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'postgres',
 	icon: 'file:postgres.svg',
 	group: ['input'],
-	version: 2,
+	version: [2, 2.1],
 	subtitle: '={{ $parameter["operation"] }}',
 	description: 'Get, add and update data in Postgres',
 	defaults: {

--- a/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
@@ -4,8 +4,9 @@ import { Connections } from '../transport';
 
 export async function schemaSearch(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials('postgres');
+	const options = { nodeVersion: this.getNode().typeVersion };
 
-	const { db } = (await Connections.getInstance(credentials)) as ConnectionsData;
+	const { db } = (await Connections.getInstance(credentials, options)) as ConnectionsData;
 
 	try {
 		const response = await db.any('SELECT schema_name FROM information_schema.schemata');
@@ -22,8 +23,9 @@ export async function schemaSearch(this: ILoadOptionsFunctions): Promise<INodeLi
 }
 export async function tableSearch(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
 	const credentials = await this.getCredentials('postgres');
+	const options = { nodeVersion: this.getNode().typeVersion };
 
-	const { db } = (await Connections.getInstance(credentials)) as ConnectionsData;
+	const { db } = (await Connections.getInstance(credentials, options)) as ConnectionsData;
 
 	const schema = this.getNodeParameter('schema', 0, {
 		extractValue: true,

--- a/packages/nodes-base/nodes/Postgres/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/loadOptions.ts
@@ -5,8 +5,9 @@ import { Connections } from '../transport';
 
 export async function getColumns(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const credentials = await this.getCredentials('postgres');
+	const options = { nodeVersion: this.getNode().typeVersion };
 
-	const { db } = (await Connections.getInstance(credentials)) as ConnectionsData;
+	const { db } = (await Connections.getInstance(credentials, options)) as ConnectionsData;
 
 	const schema = this.getNodeParameter('schema', 0, {
 		extractValue: true,

--- a/packages/nodes-base/nodes/Postgres/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/transport/index.ts
@@ -47,6 +47,15 @@ async function configurePostgres(
 ) {
 	const pgp = pgPromise();
 
+	if(typeof options.nodeVersion == 'number' && options.nodeVersion >= 2.1) {
+		// Always return dates as ISO strings
+		[pgp.pg.types.builtins.TIMESTAMP, pgp.pg.types.builtins.TIMESTAMPTZ].forEach((type) => {
+			pgp.pg.types.setTypeParser(type, (value: string) => {
+				return new Date(value).toISOString();
+			});
+		});
+	}
+
 	if (options.largeNumbersOutput === 'numbers') {
 		pgp.pg.types.setTypeParser(20, (value: string) => {
 			return parseInt(value, 10);

--- a/packages/nodes-base/nodes/Postgres/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/transport/index.ts
@@ -47,7 +47,7 @@ async function configurePostgres(
 ) {
 	const pgp = pgPromise();
 
-	if(typeof options.nodeVersion == 'number' && options.nodeVersion >= 2.1) {
+	if (typeof options.nodeVersion == 'number' && options.nodeVersion >= 2.1) {
 		// Always return dates as ISO strings
 		[pgp.pg.types.builtins.TIMESTAMP, pgp.pg.types.builtins.TIMESTAMPTZ].forEach((type) => {
 			pgp.pg.types.setTypeParser(type, (value: string) => {


### PR DESCRIPTION
In this Pull Request, I have introduced an updated version of the Postgres node to ensure that `TIMESTAMP` and `TIMESTAMPZ` values are parsed as ISO strings instead of Datetime objects. In the previous implementation (v2), these values were treated as Datetime objects on the backend, allowing for the use of standard date expression methods. However, once serialized and transmitted to the frontend via EventSource, these values were converted to ISO strings. As a result, only string methods were available.

Github issue / Community forum post (link here to close automatically):
