### PR TITLE
fix: Disable workflows when activation fails via public API Update action

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -190,6 +190,9 @@ export = {
 				try {
 					await workflowRunner.add(sharedWorkflow.workflowId, 'update');
 				} catch (error) {
+					// If it fails to activate, set it to inactive
+					updateData.active = false;
+					await updateWorkflow(sharedWorkflow.workflowId, updateData);
 					if (error instanceof Error) {
 						return res.status(400).json({ message: error.message });
 					}


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
