### PR TITLE
fix: Revert change that hid the SSH private key (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/SshPrivateKey.credentials.ts
+++ b/packages/nodes-base/credentials/SshPrivateKey.credentials.ts
@@ -35,7 +35,6 @@ export class SshPrivateKey implements ICredentialType {
 			type: 'string',
 			typeOptions: {
 				rows: 4,
-				password: true,
 			},
 			default: '',
 		},
@@ -45,6 +44,7 @@ export class SshPrivateKey implements ICredentialType {
 			type: 'string',
 			default: '',
 			description: 'Passphase used to create the key, if no passphase was used leave empty',
+			typeOptions: { password: true },
 		},
 	];
 }


### PR DESCRIPTION
In the latest n8n releases the private key credential input box displays as single line password input (as a result of #5871, a couple of months ago) rather than a multi-line text area. This is a problem as private keys are (always/almost always?) multiple lines of text. The result is that it is currently impossible to enter a SSH key in the latest versions of n8n.

This PR reverts this previous change, while also making the passphrase a password field (which I suspect was the original intent).

Github issue / Community forum post (link here to close automatically):
