### PR TITLE
fix(editor): Faster reconnects for push (no-changelog)

### DIFF
--- a/packages/editor-ui/src/mixins/pushConnection.ts
+++ b/packages/editor-ui/src/mixins/pushConnection.ts
@@ -123,7 +123,7 @@ export const pushConnection = mixins(
 			this.connectRetries++;
 			this.reconnectTimeout = setTimeout(
 				this.attemptReconnect,
-				Math.min(this.connectRetries * 2000, 8000), // maximum 10 seconds backoff
+				Math.min(this.connectRetries * 2000, 8000), // maximum 8 seconds backoff
 			);
 		},
 

--- a/packages/editor-ui/src/mixins/pushConnection.ts
+++ b/packages/editor-ui/src/mixins/pushConnection.ts
@@ -123,7 +123,7 @@ export const pushConnection = mixins(
 			this.connectRetries++;
 			this.reconnectTimeout = setTimeout(
 				this.attemptReconnect,
-				Math.min(this.connectRetries * 3000, 30000), // maximum 30 seconds backoff
+				Math.min(this.connectRetries * 2000, 8000), // maximum 10 seconds backoff
 			);
 		},
 


### PR DESCRIPTION
current backoff is too aggressive, and makes it look like the backend is down when it isn't. 