### PR TITLE
fix: Correctly save executions that failed when polling as error instead of new

### DIFF
--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -191,7 +191,7 @@ export async function createErrorExecution(
 		workflowData,
 		workflowId: workflow.id,
 		stoppedAt: new Date(),
-		status: 'new',
+		status: 'error',
 	};
 
 	const execution = ResponseHelper.flattenExecutionData(fullExecutionData);


### PR DESCRIPTION


Github issue / Community forum post (link here to close automatically):
