### PR TITLE
fix(FTP Node): Use filename instead of remote filepath for downloaded binary data

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -601,11 +601,11 @@ export class Ftp implements INodeType {
 							await sftp!.get(path, createWriteStream(binaryFile.path));
 
 							const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
-							const filePathDownload = this.getNodeParameter('path', i) as string;
+							const remoteFilePath = this.getNodeParameter('path', i) as string;
 
 							items[i].binary![dataPropertyNameDownload] = await this.nodeHelpers.copyBinaryFile(
 								binaryFile.path,
-								filePathDownload,
+								basename(remoteFilePath),
 							);
 
 							const executionData = this.helpers.constructExecutionMetaData(
@@ -697,11 +697,11 @@ export class Ftp implements INodeType {
 							await streamPipeline(stream, createWriteStream(binaryFile.path));
 
 							const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
-							const filePathDownload = this.getNodeParameter('path', i) as string;
+							const remoteFilePath = this.getNodeParameter('path', i) as string;
 
 							items[i].binary![dataPropertyNameDownload] = await this.nodeHelpers.copyBinaryFile(
 								binaryFile.path,
-								filePathDownload,
+								basename(remoteFilePath),
 							);
 
 							const executionData = this.helpers.constructExecutionMetaData(


### PR DESCRIPTION
NODE-491

Fixes: #6026