### PR TITLE
fix(core): Ensure DB repositories are initialized before the DB migrations are run 

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -28,7 +28,7 @@ import type { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import type { WorkflowExecute } from 'n8n-core';
 
 import type PCancelable from 'p-cancelable';
-import type { FindOperator } from 'typeorm';
+import type { FindOperator, Repository } from 'typeorm';
 
 import type { ChildProcess } from 'child_process';
 
@@ -83,7 +83,7 @@ export interface ICredentialsOverwrite {
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
-export interface IDatabaseCollections {
+export interface IDatabaseCollections extends Record<string, Repository<any>> {
 	AuthIdentity: AuthIdentityRepository;
 	AuthProviderSyncHistory: AuthProviderSyncHistoryRepository;
 	Credentials: CredentialsRepository;


### PR DESCRIPTION
Moved this section to `migrate` in https://github.com/n8n-io/n8n/pull/6205 because when we close/re-open the connection, the repository instances held on to the original closed connection.
But this change broke `WorkflowRunnerProcess` which calls `Db.init()` but not `Db.migrate`.

This also removes the code to re-open sqlite db connection, as it doesn't seem to be needed anymore.

