### PR TITLE
ci: Debug e2e pipeline (no-changelog)

### DIFF
--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -48,5 +48,5 @@ jobs:
         run: exit 0
 
       - name: Fail job if run-e2e-tests failed
-        if: needs.run-e2e-tests.result == 'failure'
+        if: ${{ github.event.review.state != 'approved' || needs.run-e2e-tests.result == 'failure' }}
         run: exit 1

--- a/packages/editor-ui/src/plugins/i18n/docs/README.md
+++ b/packages/editor-ui/src/plugins/i18n/docs/README.md
@@ -507,3 +507,4 @@ After changing the dynamic text file:
 If a `headerText` section was changed, re-run `pnpm build:translations` in `/nodes-base`.
 
 > **Note**: To translate base and dynamic text simultaneously, run three terminals following the steps from both sections (first terminal running only once) and browse `http://localhost:8080`.
+


### PR DESCRIPTION
We have observed instances where the `post-e2e-tests` workflow was passing even when the `run-e2e-tests` job did not execute. This anomaly allowed PRs to be merged without a successful e2e pipeline, which is not the intended behavior. The problem was due to the `if: always()` condition in the `post-e2e-tests` job, which executed it following any `pull_request_review` event (for example, when changes were requested).

To rectify this issue, we have implemented an additional condition, `github.event.review.state != 'approved'` to the fail job. This condition ensures that the required checks will consistently fail if the PR is not approved, thus preventing untested merges.