### PR TITLE
fix(core): Load WEBHOOK_URL via config to support setting the value via a file

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -48,6 +48,7 @@ import type {
 	IWorkflowDb,
 	IWorkflowExecutionDataProcess,
 } from '@/Interfaces';
+import config from '@/config';
 import * as GenericHelpers from '@/GenericHelpers';
 import * as ResponseHelper from '@/ResponseHelper';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
@@ -691,11 +692,15 @@ export async function executeWebhook(
 export function getWebhookBaseUrl() {
 	let urlBaseWebhook = GenericHelpers.getBaseUrl();
 
+	// Change required here
 	// We renamed WEBHOOK_TUNNEL_URL to WEBHOOK_URL. This is here to maintain
 	// backward compatibility. Will be deprecated and removed in the future.
-	if (process.env.WEBHOOK_TUNNEL_URL !== undefined || process.env.WEBHOOK_URL !== undefined) {
+	if (
+		process.env.WEBHOOK_TUNNEL_URL !== undefined ||
+		config.get('endpoints.webhookUrl') !== undefined
+	) {
 		// @ts-ignore
-		urlBaseWebhook = process.env.WEBHOOK_TUNNEL_URL || process.env.WEBHOOK_URL;
+		urlBaseWebhook = process.env.WEBHOOK_TUNNEL_URL || config.get('endpoints.webhookUrl');
 	}
 	if (!urlBaseWebhook.endsWith('/')) {
 		urlBaseWebhook += '/';

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -29,6 +29,7 @@ import { eventBus } from '@/eventbus';
 import { BaseCommand } from './BaseCommand';
 import { InternalHooks } from '@/InternalHooks';
 import { License } from '@/License';
+import { configure } from 'winston';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
@@ -347,8 +348,11 @@ export class Start extends BaseCommand {
 			// @ts-ignore
 			const webhookTunnel = await localtunnel(port, tunnelSettings);
 
-			process.env.WEBHOOK_URL = `${webhookTunnel.url}/`;
-			this.log(`Tunnel URL: ${process.env.WEBHOOK_URL}\n`);
+			// Change required here
+			config.set('endpoints.webhookUrl', webhookTunnel.url);
+			// process.env.WEBHOOK_URL = `${webhookTunnel.url}/`;
+
+			this.log(`Tunnel URL: ${config.get('endpoints.webhookUrl')}\n`);
 			this.log(
 				'IMPORTANT! Do not share with anybody as it would give people access to your n8n instance!',
 			);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -349,7 +349,7 @@ export class Start extends BaseCommand {
 			const webhookTunnel = await localtunnel(port, tunnelSettings);
 
 			// Change required here
-			config.set('endpoints.webhookUrl', webhookTunnel.url);
+			config.set('endpoints.webhookUrl', `${webhookTunnel.url}/`);
 			// process.env.WEBHOOK_URL = `${webhookTunnel.url}/`;
 
 			this.log(`Tunnel URL: ${config.get('endpoints.webhookUrl')}\n`);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -653,6 +653,12 @@ export const schema = {
 			env: 'N8N_ENDPOINT_WEBHOOK',
 			doc: 'Path for webhook endpoint',
 		},
+		webhookUrl: {
+			format: String,
+			default: 'webhook',
+			env: 'WEBHOOK_URL',
+			doc: 'Used to manually provide the Webhook URL when running n8n behind a reverse proxy.',
+		},
 		webhookWaiting: {
 			format: String,
 			default: 'webhook-waiting',


### PR DESCRIPTION
Fix mismatch between configuration between environment variables and json-file configuration. Updates references to WEBHOOK_URL to refer to `config.get('endpoints.webhookUrl')`. Updates the schema with endpoints.webhookUrl

Github issue / Community forum post (link here to close automatically):
