### PR TITLE
fix(editor): Fix close and cancel operations on useMessage (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useMessage.ts
+++ b/packages/editor-ui/src/composables/useMessage.ts
@@ -2,6 +2,11 @@ import type { ElMessageBoxOptions } from 'element-ui/types/message-box';
 import { Message, MessageBox } from 'element-ui';
 
 export function useMessage() {
+	const handleCancelOrClose = (e: unknown) => {
+		if (e instanceof Error) throw e;
+		else return e;
+	};
+
 	async function alert(
 		message: string,
 		configOrTitle?: string | ElMessageBoxOptions,
@@ -14,9 +19,9 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.alert(message, configOrTitle, resolvedConfig);
+			return MessageBox.alert(message, configOrTitle, resolvedConfig).catch(handleCancelOrClose);
 		}
-		return MessageBox.alert(message, resolvedConfig);
+		return MessageBox.alert(message, resolvedConfig).catch(handleCancelOrClose);
 	}
 
 	async function confirm(
@@ -34,9 +39,9 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.confirm(message, configOrTitle, resolvedConfig);
+			return MessageBox.confirm(message, configOrTitle, resolvedConfig).catch(handleCancelOrClose);
 		}
-		return MessageBox.confirm(message, resolvedConfig);
+		return MessageBox.confirm(message, resolvedConfig).catch(handleCancelOrClose);
 	}
 
 	async function prompt(
@@ -51,9 +56,9 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.prompt(message, configOrTitle, resolvedConfig);
+			return MessageBox.prompt(message, configOrTitle, resolvedConfig).catch(handleCancelOrClose);
 		}
-		return MessageBox.prompt(message, resolvedConfig);
+		return MessageBox.prompt(message, resolvedConfig).catch(handleCancelOrClose);
 	}
 
 	return {


### PR DESCRIPTION
[awaiting on `MessageBox` `.` `alert`/`confirm`/`prompt` throws the action, instead of returning it.](https://github.com/ElemeFE/element/blob/master/packages/message-box/src/main.js#L64)