### PR TITLE
fix(editor): Do not prevent closing of activation survey modal on API call failure

### DIFF
--- a/packages/editor-ui/src/components/UserActivationSurveyModal.vue
+++ b/packages/editor-ui/src/components/UserActivationSurveyModal.vue
@@ -124,9 +124,9 @@ const beforeClosingModal = async () => {
 	if (currentUser) {
 		try {
 			await userStore.updateUserSettings({ showUserActivationSurvey: false });
-		} catch {
-			showSharedFeedbackError();
-			return false;
+		} catch(e) {
+			showSharedFeedbackError(e.message);
+			return true;
 		}
 	}
 	return true;
@@ -144,10 +144,10 @@ const showSharedFeedbackSuccess = () => {
 	});
 };
 
-const showSharedFeedbackError = () => {
+const showSharedFeedbackError = (message: string) => {
 	Notification.error({
 		title: locale.baseText('userActivationSurveyModal.sharedFeedback.error'),
-		message: '',
+		message,
 		position: 'bottom-right',
 	});
 };

--- a/packages/editor-ui/src/components/UserActivationSurveyModal.vue
+++ b/packages/editor-ui/src/components/UserActivationSurveyModal.vue
@@ -124,7 +124,7 @@ const beforeClosingModal = async () => {
 	if (currentUser) {
 		try {
 			await userStore.updateUserSettings({ showUserActivationSurvey: false });
-		} catch(e) {
+		} catch (e) {
 			showSharedFeedbackError(e.message);
 			return true;
 		}


### PR DESCRIPTION
1. Include the error response information in the activation survey modal
2. Do not prevent closing of the modal if call to the `/me/settings` fails

Github issue / Community forum post (link here to close automatically):  https://community.n8n.io/t/congrats-your-workflow-ran-automatically-bug/26222
