### PR TITLE
fix: Initialize license in queue mode correctly

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -98,6 +98,7 @@ export class License {
 
 	isFeatureEnabled(feature: string): boolean {
 		if (!this.manager) {
+			getLogger().warn('License manager not initialized');
 			return false;
 		}
 

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -19,6 +19,7 @@ import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
 import type { IExternalHooksClass } from '@/Interfaces';
 import { InternalHooks } from '@/InternalHooks';
 import { PostHogClient } from '@/posthog';
+import { License } from '@/License';
 
 export const UM_FIX_INSTRUCTION =
 	'Please fix the database by running ./packages/cli/bin/n8n user-management:reset';
@@ -117,6 +118,28 @@ export abstract class BaseCommand extends Command {
 	protected async initExternalHooks() {
 		this.externalHooks = Container.get(ExternalHooks);
 		await this.externalHooks.init();
+	}
+
+	async initLicense(): Promise<void> {
+		const license = Container.get(License);
+		await license.init(this.instanceId);
+
+		const activationKey = config.getEnv('license.activationKey');
+
+		if (activationKey) {
+			const hasCert = (await license.loadCertStr()).length > 0;
+
+			if (hasCert) {
+				return LoggerProxy.debug('Skipping license activation');
+			}
+
+			try {
+				LoggerProxy.debug('Attempting license activation');
+				await license.activate(activationKey);
+			} catch (e) {
+				LoggerProxy.error('Could not activate license', e as Error);
+			}
+		}
 	}
 
 	async finally(error: Error | undefined) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -28,7 +28,6 @@ import { EDITOR_UI_DIST_DIR, GENERATED_STATIC_DIR } from '@/constants';
 import { eventBus } from '@/eventbus';
 import { BaseCommand } from './BaseCommand';
 import { InternalHooks } from '@/InternalHooks';
-import { License } from '@/License';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
@@ -184,28 +183,6 @@ export class Start extends BaseCommand {
 		await compileFile('index.html');
 		const files = await glob('**/*.{css,js}', { cwd: EDITOR_UI_DIST_DIR });
 		await Promise.all(files.map(compileFile));
-	}
-
-	async initLicense(): Promise<void> {
-		const license = Container.get(License);
-		await license.init(this.instanceId);
-
-		const activationKey = config.getEnv('license.activationKey');
-
-		if (activationKey) {
-			const hasCert = (await license.loadCertStr()).length > 0;
-
-			if (hasCert) {
-				return LoggerProxy.debug('Skipping license activation');
-			}
-
-			try {
-				LoggerProxy.debug('Attempting license activation');
-				await license.activate(activationKey);
-			} catch (e) {
-				LoggerProxy.error('Could not activate license', e as Error);
-			}
-		}
 	}
 
 	async init() {

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -77,6 +77,7 @@ export class Webhook extends BaseCommand {
 		await this.initCrashJournal();
 		await super.init();
 
+		await this.initLicense();
 		await this.initBinaryManager();
 		await this.initExternalHooks();
 	}

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -224,6 +224,7 @@ export class Worker extends BaseCommand {
 		await super.init();
 		this.logger.debug('Starting n8n worker...');
 
+		await this.initLicense();
 		await this.initBinaryManager();
 		await this.initExternalHooks();
 	}


### PR DESCRIPTION
Failing to initialize the license server causes the queue mode to not detect sharing enabled and thus shared workflows and credentials could fail to run.

Github issue / Community forum post (link here to close automatically):
