### PR TITLE
fix(editor): Fix canvas loading when page gets restored from bfcache

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3777,6 +3777,12 @@ export default defineComponent({
 				this.disableNodes([node]);
 			}
 		},
+		onPageShow(e: PageTransitionEvent) {
+			// Page was restored from the bfcache (back-forward cache)
+			if (e.persisted) {
+				this.stopLoading();
+			}
+		}
 	},
 	async mounted() {
 		this.resetWorkspace();
@@ -3880,6 +3886,7 @@ export default defineComponent({
 		document.addEventListener('keydown', this.keyDown);
 		document.addEventListener('keyup', this.keyUp);
 		window.addEventListener('message', this.onPostMessageReceived);
+		window.addEventListener('pageshow', this.onPageShow);
 
 		this.$root.$on('newWorkflow', this.newWorkflow);
 		this.$root.$on('importWorkflowData', this.onImportWorkflowDataEvent);
@@ -3904,6 +3911,7 @@ export default defineComponent({
 		document.removeEventListener('keyup', this.keyUp);
 		window.removeEventListener('message', this.onPostMessageReceived);
 		window.removeEventListener('beforeunload', this.onBeforeUnload);
+		window.removeEventListener('pageshow', this.onPageShow);
 
 		this.$root.$off('newWorkflow', this.newWorkflow);
 		this.$root.$off('importWorkflowData', this.onImportWorkflowDataEvent);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3782,7 +3782,7 @@ export default defineComponent({
 			if (e.persisted) {
 				this.stopLoading();
 			}
-		}
+		},
 	},
 	async mounted() {
 		this.resetWorkspace();


### PR DESCRIPTION
We found a problem with the 'beforeunload' event listener on our node view. This feature shows a 'redirecting' loading sign when a user leaves the page. However, if the user is on a browser that supports back-forward cache (like Safari or Chrome), our app stays in memory. This means when they navigate back to the app, it gets stuck in the loading state.

To fix this, we're adding a new event handler for the 'pageshow' event. This handler will check if the page came back from the back-forward cache. If it did, the handler will stop the loading process.

Github issue / Community forum post (link here to close automatically):
