### PR TITLE
fix(core): Prevent prototype pollution on injectable services

### DIFF
--- a/patches/typedi@0.10.0.patch
+++ b/patches/typedi@0.10.0.patch
@@ -1,8 +1,16 @@
 diff --git a/cjs/container-instance.class.js b/cjs/container-instance.class.js
-index e473b1e652aa0b6e7462f7ba93fcef2812483b20..1e2ac7e5cb7943f5226a2bc25fa83bee0470f90c 100644
+index e473b1e652aa0b6e7462f7ba93fcef2812483b20..1e406113d68c401ee170c997afb53e5f71edeee2 100644
 --- a/cjs/container-instance.class.js
 +++ b/cjs/container-instance.class.js
-@@ -234,6 +234,7 @@ class ContainerInstance {
+@@ -209,6 +209,7 @@ class ContainerInstance {
+             // this allows us to support javascript where we don't have decorators and emitted metadata about dependencies
+             // need to be injected, and user can use provided container to get instances he needs
+             params.push(this);
++            if (process.env.NODE_ENV === 'production') Object.freeze(constructableTargetType.prototype);
+             value = new constructableTargetType(...params);
+             // TODO: Calling this here, leads to infinite loop, because @Inject decorator registerds a handler
+             // TODO: which calls Container.get, which will check if the requested type has a value set and if not
+@@ -234,6 +235,7 @@ class ContainerInstance {
       */
      initializeParams(target, paramTypes) {
          return paramTypes.map((paramType, index) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ patchedDependencies:
     hash: prckukfdop5sl2her6de25cod4
     path: patches/element-ui@2.15.12.patch
   typedi@0.10.0:
-    hash: syy565ld7euwcedfbmx53j2qc4
+    hash: 62r6bc2crgimafeyruodhqlgo4
     path: patches/typedi@0.10.0.patch
 
 importers:
@@ -456,7 +456,7 @@ importers:
         version: 1.1.1
       typedi:
         specifier: ^0.10.0
-        version: 0.10.0(patch_hash=syy565ld7euwcedfbmx53j2qc4)
+        version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
       typeorm:
         specifier: ^0.3.12
         version: 0.3.12(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6)
@@ -21852,7 +21852,7 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typedi@0.10.0(patch_hash=syy565ld7euwcedfbmx53j2qc4):
+  /typedi@0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4):
     resolution: {integrity: sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==}
     dev: false
     patched: true


### PR DESCRIPTION
This helps prevent classes from being tampered by external-hooks or community nodes

