### PR TITLE
fix(editor): Fix locale plularisation if count is 0

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsUsage.vue
+++ b/packages/editor-ui/src/components/ExecutionsUsage.vue
@@ -16,7 +16,7 @@
 					<n8n-text size="small" :bold="true" color="warning">
 						{{
 							locale.baseText('executionUsage.currentUsage.count', {
-								adjustToNumber: daysLeftOnTrial,
+								adjustToNumber: daysLeftOnTrial || 0,
 							})
 						}}
 					</n8n-text>

--- a/packages/editor-ui/src/plugins/i18n/index.ts
+++ b/packages/editor-ui/src/plugins/i18n/index.ts
@@ -64,7 +64,7 @@ export class I18nClass {
 		key: BaseTextKey,
 		options?: { adjustToNumber?: number; interpolate?: { [key: string]: string } },
 	): string {
-		if (options && options.adjustToNumber) {
+		if (options?.adjustToNumber !== undefined) {
 			return this.i18n.tc(key, options.adjustToNumber, options && options.interpolate).toString();
 		}
 


### PR DESCRIPTION
The `if (options && options.adjustToNumber)` condition would evaluate to false if `adjustToNumber === 0` so instead we just check for undefined.
Github issue / Community forum post (link here to close automatically):
