### PR TITLE
fix(editor): Fix Luxon date parsing of ExecutionsUsage component

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -193,7 +193,7 @@ export default defineComponent({
 		},
 		async checkForCloudPlanData(): Promise<void> {
 			try {
-				await this.cloudPlanStore.getOwnerCurrentPLan();
+				await this.cloudPlanStore.getOwnerCurrentPlan();
 				if (!this.cloudPlanStore.userIsTrialing) return;
 				await this.cloudPlanStore.getInstanceCurrentUsage();
 				this.startPollingInstanceUsageData();

--- a/packages/editor-ui/src/mixins/nodeHelpers.ts
+++ b/packages/editor-ui/src/mixins/nodeHelpers.ts
@@ -36,6 +36,7 @@ import { mapStores } from 'pinia';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useRootStore } from '@/stores';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
 import { defineComponent } from 'vue';
@@ -49,6 +50,7 @@ export const nodeHelpers = defineComponent({
 			useSettingsStore,
 			useWorkflowsStore,
 			useUsersStore,
+			useRootStore,
 		),
 	},
 	methods: {
@@ -524,6 +526,9 @@ export const nodeHelpers = defineComponent({
 					data as INode,
 					nodeType.subtitle,
 					'internal',
+					this.rootStore.timezone,
+					{},
+					undefined,
 					PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 				) as string | undefined;
 			}

--- a/packages/editor-ui/src/stores/cloudPlan.store.ts
+++ b/packages/editor-ui/src/stores/cloudPlan.store.ts
@@ -45,8 +45,8 @@ export const useCloudPlanStore = defineStore('cloudPlan', () => {
 		return state.usage?.executions >= state.data?.monthlyExecutionsLimit;
 	});
 
-		const cloudUserId = settingsStore.settings.n8nMetadata?.userId;
 	const getOwnerCurrentPlan = async () => {
+		const cloudUserId = settingsStore.settings.n8nMetadata?.userId;
 		const hasCloudPlan =
 			usersStore.currentUser?.isOwner && settingsStore.isCloudDeployment && cloudUserId;
 		if (!hasCloudPlan) throw new Error('User does not have a cloud plan');

--- a/packages/editor-ui/src/stores/cloudPlan.store.ts
+++ b/packages/editor-ui/src/stores/cloudPlan.store.ts
@@ -45,8 +45,8 @@ export const useCloudPlanStore = defineStore('cloudPlan', () => {
 		return state.usage?.executions >= state.data?.monthlyExecutionsLimit;
 	});
 
-	const getOwnerCurrentPLan = async () => {
 		const cloudUserId = settingsStore.settings.n8nMetadata?.userId;
+	const getOwnerCurrentPlan = async () => {
 		const hasCloudPlan =
 			usersStore.currentUser?.isOwner && settingsStore.isCloudDeployment && cloudUserId;
 		if (!hasCloudPlan) throw new Error('User does not have a cloud plan');
@@ -72,7 +72,7 @@ export const useCloudPlanStore = defineStore('cloudPlan', () => {
 
 	return {
 		state,
-		getOwnerCurrentPLan,
+		getOwnerCurrentPlan,
 		getInstanceCurrentUsage,
 		userIsTrialing,
 		currentPlanData,


### PR DESCRIPTION
We have identified an issue where users, under certain circumstances, were presented with a `{n} day left. | {n} days left.` fallback locale. This problem originated from the incorrect parsing of the `daysLeftOnTrial` computation in the `ExecutionsUsage` component. Specifically, the error surfaced only on canvas when a node contained a subtitle.

The root cause of this problem was traced back to an improper call to `getSimpleParameterValue` in `nodeHelpers.ts`. Here, `PLACEHOLDER_FILLED_AT_EXECUTION_TIME` was inaccurately passed as the fourth argument, which should have been the timezone instead.

Subsequently, this timezone argument was incorrectly utilized to establish the global Luxon `Settings.defaultZone` within the `WorkflowDataProxy` constructor. This action resulted in an error, as `PLACEHOLDER_FILLED_AT_EXECUTION_TIME` is not a recognized timezone.

Github issue / Community forum post (link here to close automatically):
