### PR TITLE
fix: Show `Ask AI` only on Code Node

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -7,7 +7,7 @@
 	>
 		<div ref="codeNodeEditor" class="code-node-editor-input ph-no-capture"></div>
 		<n8n-button
-			v-if="isCloud && (isEditorHovered || isEditorFocused)"
+			v-if="atCodeNode && isCloud && (isEditorHovered || isEditorFocused)"
 			size="small"
 			type="tertiary"
 			:class="$style['ask-ai-button']"
@@ -50,6 +50,10 @@ export default defineComponent({
 	name: 'code-node-editor',
 	mixins: [linterExtension, completerExtension, workflowHelpers],
 	props: {
+		atCodeNode: {
+			type: Boolean,
+			default: false,
+		},
 		mode: {
 			type: String as PropType<CodeExecutionMode>,
 			validator: (value: CodeExecutionMode): boolean => CODE_EXECUTION_MODES.includes(value),

--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -7,7 +7,7 @@
 	>
 		<div ref="codeNodeEditor" class="code-node-editor-input ph-no-capture"></div>
 		<n8n-button
-			v-if="atCodeNode && isCloud && (isEditorHovered || isEditorFocused)"
+			v-if="aiButtonEnabled && (isEditorHovered || isEditorFocused)"
 			size="small"
 			type="tertiary"
 			:class="$style['ask-ai-button']"
@@ -38,7 +38,6 @@ import { workflowHelpers } from '@/mixins/workflowHelpers'; // for json field co
 import { ASK_AI_MODAL_KEY, CODE_NODE_TYPE } from '@/constants';
 import { codeNodeEditorEventBus } from '@/event-bus';
 import { useRootStore } from '@/stores/n8nRoot.store';
-import { useSettingsStore } from '@/stores/settings.store';
 
 import { readOnlyEditorExtensions, writableEditorExtensions } from './baseExtensions';
 import { CODE_PLACEHOLDERS } from './constants';
@@ -50,7 +49,7 @@ export default defineComponent({
 	name: 'code-node-editor',
 	mixins: [linterExtension, completerExtension, workflowHelpers],
 	props: {
-		atCodeNode: {
+		aiButtonEnabled: {
 			type: Boolean,
 			default: false,
 		},
@@ -101,9 +100,6 @@ export default defineComponent({
 	},
 	computed: {
 		...mapStores(useRootStore),
-		isCloud() {
-			return useSettingsStore().deploymentType === 'cloud';
-		},
 		content(): string {
 			if (!this.editor) return '';
 

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -91,6 +91,7 @@
 					:defaultValue="parameter.default"
 					:language="editorLanguage"
 					:isReadOnly="isReadOnly"
+					:atCodeNode="true"
 					@valueChanged="valueChangedDebounced"
 				/>
 

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -91,7 +91,7 @@
 					:defaultValue="parameter.default"
 					:language="editorLanguage"
 					:isReadOnly="isReadOnly"
-					:atCodeNode="true"
+					:aiButtonEnabled="settingsStore.isCloudDeployment"
 					@valueChanged="valueChangedDebounced"
 				/>
 
@@ -388,6 +388,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
+import { useSettingsStore } from '@/stores/settings.store';
 import { htmlEditorEventBus } from '@/event-bus';
 import Vue from 'vue';
 
@@ -520,7 +521,13 @@ export default defineComponent({
 		},
 	},
 	computed: {
-		...mapStores(useCredentialsStore, useNodeTypesStore, useNDVStore, useWorkflowsStore),
+		...mapStores(
+			useCredentialsStore,
+			useNodeTypesStore,
+			useNDVStore,
+			useWorkflowsStore,
+			useSettingsStore,
+		),
 		expressionDisplayValue(): string {
 			if (this.forceShowExpression) {
 				return '';


### PR DESCRIPTION
The Code Node Editor has started to be used outside the Code node. Fixing the immediate issue for now, but more generally since this is being used more widely we should refactor it to make it more generic and rename it as well in future.

https://linear.app/n8n/issue/ADO-761/bug-ask-ai-button-is-shown-in-edit-pinned-data-modal