### PR TITLE
feat(editor): Make WF name a link on /executions

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -79,9 +79,11 @@
 							/>
 						</td>
 						<td>
-							<span class="ph-no-capture">{{
-								execution.workflowName || $locale.baseText('executionsList.unsavedWorkflow')
-							}}</span>
+							<span class="ph-no-capture" @click.stop="displayExecution(execution)"
+								><a href="#" :class="$style.link">{{
+									execution.workflowName || $locale.baseText('executionsList.unsavedWorkflow')
+								}}</a></span
+							>
 						</td>
 						<td>
 							<span>{{ formatDate(execution.startedAt) }}</span>
@@ -1178,5 +1180,10 @@ export default defineComponent({
 	width: 100%;
 	height: 48px;
 	margin-bottom: var(--spacing-2xs);
+}
+
+.link {
+	color: var(--color-test-link);
+	text-decoration: underline;
 }
 </style>

--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -1196,7 +1196,7 @@ export default defineComponent({
 }
 
 .link {
-	color: var(--color-test-link);
+	color: var(--color-text-light);
 	text-decoration: underline;
 }
 </style>

--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -1183,7 +1183,7 @@ export default defineComponent({
 }
 
 .link {
-	color: var(--color-test-link);
+	color: var(--color-text-light);
 	text-decoration: underline;
 }
 </style>

--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -79,9 +79,11 @@
 							/>
 						</td>
 						<td>
-							<span class="ph-no-capture">{{
-								execution.workflowName || $locale.baseText('executionsList.unsavedWorkflow')
-							}}</span>
+							<span class="ph-no-capture" @click.stop="displayExecution(execution)"
+								><a href="#" :class="$style.link">{{
+									execution.workflowName || $locale.baseText('executionsList.unsavedWorkflow')
+								}}</a></span
+							>
 						</td>
 						<td>
 							<span>{{ formatDate(execution.startedAt) }}</span>
@@ -1191,5 +1193,10 @@ export default defineComponent({
 	width: 100%;
 	height: 48px;
 	margin-bottom: var(--spacing-2xs);
+}
+
+.link {
+	color: var(--color-test-link);
+	text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
It would greatly improve the UX of the exec list view if the WF name text itself was a link that opens the workflow.

- In /executions table, each workflow name is a link that opens the workflow
- Link style is grey text + underline (so it's muted)
- Link should be applied only to the text, not the entire row container
- Link should take the user to the execution view

![image](https://github.com/n8n-io/n8n/assets/12082258/2934b7e0-6692-4608-bbdc-b6f145de609c)