### PR TITLE
fix: Improve executions list polling performance

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -327,7 +327,7 @@ export default defineComponent({
 			allVisibleSelected: false,
 			allExistingSelected: false,
 			autoRefresh: true,
-			autoRefreshInterval: undefined as undefined | NodeJS.Timer,
+			autoRefreshTimeout: undefined as undefined | NodeJS.Timer,
 
 			filter: {} as ExecutionFilterType,
 
@@ -919,15 +919,16 @@ export default defineComponent({
 				this.selectAllVisibleExecutions();
 			}
 		},
-		startAutoRefreshInterval() {
+		async startAutoRefreshInterval() {
 			if (this.autoRefresh) {
-				this.autoRefreshInterval = setInterval(() => this.loadAutoRefresh(), 4 * 1000); // refresh data every 4 secs
+				await this.loadAutoRefresh();
+				this.autoRefreshTimeout = setTimeout(this.startAutoRefreshInterval, 4 * 1000); // refresh data every 4 secs
 			}
 		},
 		stopAutoRefreshInterval() {
-			if (this.autoRefreshInterval) {
-				clearInterval(this.autoRefreshInterval);
-				this.autoRefreshInterval = undefined;
+			if (this.autoRefreshTimeout) {
+				clearTimeout(this.autoRefreshTimeout);
+				this.autoRefreshTimeout = undefined;
 			}
 		},
 		onDocumentVisibilityChange() {

--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -350,7 +350,7 @@ export default defineComponent({
 	mounted() {
 		setPageTitle(`n8n - ${this.pageTitle}`);
 
-		this.handleAutoRefreshToggle();
+		void this.handleAutoRefreshToggle();
 		document.addEventListener('visibilitychange', this.onDocumentVisibilityChange);
 	},
 	async created() {
@@ -417,9 +417,9 @@ export default defineComponent({
 			});
 			window.open(route.href, '_blank');
 		},
-		handleAutoRefreshToggle() {
+		async handleAutoRefreshToggle() {
 			this.stopAutoRefreshInterval(); // Clear any previously existing intervals (if any - there shouldn't)
-			this.startAutoRefreshInterval();
+			void this.startAutoRefreshInterval();
 		},
 		handleCheckAllExistingChange() {
 			this.allExistingSelected = !this.allExistingSelected;
@@ -495,7 +495,7 @@ export default defineComponent({
 			});
 
 			this.handleClearSelection();
-			this.refreshData();
+			await this.refreshData();
 		},
 		handleClearSelection(): void {
 			this.allVisibleSelected = false;
@@ -508,14 +508,14 @@ export default defineComponent({
 			this.handleClearSelection();
 			this.isMounting = false;
 		},
-		handleActionItemClick(commandData: { command: string; execution: IExecutionsSummary }) {
+		async handleActionItemClick(commandData: { command: string; execution: IExecutionsSummary }) {
 			if (['currentlySaved', 'original'].includes(commandData.command)) {
 				let loadWorkflow = false;
 				if (commandData.command === 'currentlySaved') {
 					loadWorkflow = true;
 				}
 
-				this.retryExecution(commandData.execution, loadWorkflow);
+				await this.retryExecution(commandData.execution, loadWorkflow);
 
 				this.$telemetry.track('User clicked retry execution button', {
 					workflow_id: this.workflowsStore.workflowId,
@@ -524,7 +524,7 @@ export default defineComponent({
 				});
 			}
 			if (commandData.command === 'delete') {
-				this.deleteExecution(commandData.execution);
+				await this.deleteExecution(commandData.execution);
 			}
 		},
 		getWorkflowName(workflowId: string): string | undefined {
@@ -874,7 +874,7 @@ export default defineComponent({
 					type: 'success',
 				});
 
-				this.refreshData();
+				await this.refreshData();
 			} catch (error) {
 				this.showError(
 					error,
@@ -932,7 +932,9 @@ export default defineComponent({
 		async startAutoRefreshInterval() {
 			if (this.autoRefresh) {
 				await this.loadAutoRefresh();
-				this.autoRefreshTimeout = setTimeout(() => this.startAutoRefreshInterval(), 4 * 1000); // refresh data every 4 secs
+				this.autoRefreshTimeout = setTimeout(() => {
+					void this.startAutoRefreshInterval();
+				}, 4 * 1000); // refresh data every 4 secs
 			}
 		},
 		stopAutoRefreshInterval() {
@@ -945,7 +947,7 @@ export default defineComponent({
 			if (document.visibilityState === 'hidden') {
 				this.stopAutoRefreshInterval();
 			} else {
-				this.startAutoRefreshInterval();
+				void this.startAutoRefreshInterval();
 			}
 		},
 	},

--- a/packages/editor-ui/src/components/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsList.vue
@@ -922,7 +922,7 @@ export default defineComponent({
 		async startAutoRefreshInterval() {
 			if (this.autoRefresh) {
 				await this.loadAutoRefresh();
-				this.autoRefreshTimeout = setTimeout(this.startAutoRefreshInterval, 4 * 1000); // refresh data every 4 secs
+				this.autoRefreshTimeout = setTimeout(() => this.startAutoRefreshInterval(), 4 * 1000); // refresh data every 4 secs
 			}
 		},
 		stopAutoRefreshInterval() {

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionsList.vue
@@ -349,7 +349,7 @@ export default defineComponent({
 		async startAutoRefreshInterval() {
 			if (this.autoRefresh) {
 				await this.loadAutoRefresh();
-				this.autoRefreshTimeout = setTimeout(this.startAutoRefreshInterval, 4000);
+				this.autoRefreshTimeout = setTimeout(() => this.startAutoRefreshInterval(), 4000);
 			}
 		},
 		stopAutoRefreshInterval() {


### PR DESCRIPTION
**Description:**
Because setInterval does not have the concept of async/await executions, I've implemented a custom async polling function that only runs the refresh functions 4 seconds after the previous load promise has finished executing.