### PR TITLE
fix(editor): Fix an issue with connections breaking during renaming

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3060,7 +3060,7 @@ export default defineComponent({
 
 				const promptResponse = (await promptResponsePromise) as MessageBoxInputData;
 
-				if (promptResponse?.action !== 'confirm') return;
+				if (promptResponse?.action !== MODAL_CONFIRM) return;
 
 				await this.renameNode(currentName, promptResponse.value, true);
 			} catch (e) {}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3060,6 +3060,8 @@ export default defineComponent({
 
 				const promptResponse = (await promptResponsePromise) as MessageBoxInputData;
 
+				if (promptResponse?.action !== 'confirm') return;
+
 				await this.renameNode(currentName, promptResponse.value, true);
 			} catch (e) {}
 		},


### PR DESCRIPTION
This pull request addresses an issue related to renaming nodes on the canvas. Previously, if a user initiated the rename process but then cancelled it, `promptResponse.value` would become `undefined`, leading to a failure in the `renameNode` function.

To remedy this, we've implemented a conditional check to ascertain that the user has indeed confirmed the renaming action. We will only proceed with the renaming operation if the user has clicked confirm. 

Github issue / Community forum post (link here to close automatically):
