### PR TITLE
ci: Update the release process for v1 release

### DIFF
--- a/.github/workflows/docker-image-v1-rc.yml
+++ b/.github/workflows/docker-image-v1-rc.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: release-v1
 
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -16,6 +16,7 @@ on:
         options:
           - patch
           - minor
+          - major
 
 jobs:
   create-release-pr:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -55,12 +55,12 @@ jobs:
         continue-on-error: true
         run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/trigger-release-note' --header 'Content-Type:application/json' --data '{"version":"${{env.RELEASE}}"}'
 
-      - name: Merge Release into 'master'
-        run: |
-          git fetch origin
-          git checkout --track origin/master
-          git config user.name "Jan Oberhauser"
-          git config user.email jan.oberhauser@gmail.com
-          git merge --ff n8n@${{env.RELEASE}}
-          git push origin master
-          git push origin :${{github.event.pull_request.base.ref}}
+      # - name: Merge Release into 'master'
+      #   run: |
+      #     git fetch origin
+      #     git checkout --track origin/master
+      #     git config user.name "Jan Oberhauser"
+      #     git config user.email jan.oberhauser@gmail.com
+      #     git merge --ff n8n@${{env.RELEASE}}
+      #     git push origin master
+      #     git push origin :${{github.event.pull_request.base.ref}}


### PR DESCRIPTION
1. release nightly `1.0.0-rc` from `release-v1` branch.
2. Allow creating `major` release PRs.
3. Remove the `merged back into master` step. it doesn't work.