### PR TITLE
fix(editor): Fix typing `$` in inline expression field reloading node parameters form

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -514,10 +514,10 @@ export default defineComponent({
 		};
 	},
 	watch: {
-		dependentParametersValues() {
+		async dependentParametersValues() {
 			// Reload the remote parameters whenever a parameter
 			// on which the current field depends on changes
-			void this.loadRemoteParameterOptions();
+			await this.loadRemoteParameterOptions();
 		},
 		value() {
 			if (this.parameter.type === 'color' && this.getArgument('showAlpha') === true) {

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -129,7 +129,12 @@
 import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
 import { mapStores } from 'pinia';
-import type { INodeParameters, INodeProperties, NodeParameterValue } from 'n8n-workflow';
+import type {
+	INodeParameters,
+	INodeProperties,
+	INodeTypeDescription,
+	NodeParameterValue,
+} from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
 
 import type { INodeUi, IUpdateInformation } from '@/Interface';
@@ -236,7 +241,7 @@ export default defineComponent({
 			return index < this.filteredParameters.length ? index : this.filteredParameters.length - 1;
 		},
 		mainNodeAuthField(): INodeProperties | null {
-			return getMainAuthField(this.nodeType || undefined);
+			return getMainAuthField(this.nodeType || null);
 		},
 	},
 	methods: {

--- a/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -456,9 +456,15 @@ export default defineComponent({
 				this.$emit('input', { ...this.value, __regex: mode.extractValue.regex });
 			}
 		},
-		dependentParametersValues() {
+		dependentParametersValues(currentValue, oldValue) {
+			const isUpdated = oldValue !== null && currentValue !== null && oldValue !== currentValue;
 			// Reset value if dependent parameters change
-			if (this.value && isResourceLocatorValue(this.value) && this.value.value !== '') {
+			if (
+				isUpdated &&
+				this.value &&
+				isResourceLocatorValue(this.value) &&
+				this.value.value !== ''
+			) {
 				this.$emit('input', {
 					...this.value,
 					cachedResultName: '',

--- a/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -186,10 +186,10 @@ function getFieldDescription(field: ResourceMapperField): string {
 	return '';
 }
 
-function getParameterValue(parameterName: string) {
+function getParameterValue(parameterName: string): string | number | boolean | null {
 	const fieldName = parseResourceMapperFieldName(parameterName);
 	if (fieldName && props.paramValue.value) {
-		return props.paramValue.value[fieldName];
+		return props.paramValue.value[fieldName] || '';
 	}
 	return null;
 }

--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -19,14 +19,14 @@ import { fieldCannotBeDeleted, isResourceMapperValue, parseResourceMapperFieldNa
 import { i18n as locale } from '@/plugins/i18n';
 import { useNDVStore } from '@/stores/ndv.store';
 
-interface Props {
+type Props = {
 	parameter: INodeProperties;
 	node: INode | null;
 	path: string;
 	inputSize: string;
 	labelSize: string;
-	dependentParametersValues: string | null;
-}
+	dependentParametersValues?: string | null;
+};
 
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();


### PR DESCRIPTION
In #6101 we implemented dependent parameters support for the Resource Locator Component which reloaded RLC if any of the node parameters it depends on  is updated. However, this solution was causing a reload every time `watch` is triggered without checking if the value actually changed.

This PR fixes that and few other minor things:
- Typo in `ParameterInput`: `void` --> `await`,
- Missing import and wrong parameter type in `ParameterInputList`
- Making some props in `ResourceMapper` component optional
