### PR TITLE
ci: Fix build (no-changelog)

### DIFF
--- a/packages/design-system/src/utils/__tests__/event-bus.spec.ts
+++ b/packages/design-system/src/utils/__tests__/event-bus.spec.ts
@@ -1,5 +1,11 @@
 import { createEventBus } from '../event-bus';
 
+// @TODO: Remove when conflicting vitest and jest globals are reconciled
+declare global {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const vi: typeof import('vitest')['vitest'];
+}
+
 describe('createEventBus()', () => {
 	const eventBus = createEventBus();
 


### PR DESCRIPTION
Ref: https://github.com/n8n-io/n8n/actions/runs/5174889842

`vitest` and `jest` globals are conflicting:

```
// node_modules/vitest/globals.d.ts
Definitions of the following identifiers conflict with those in another file: test, describe, it, expect, beforeAll, afterAll, beforeEach, afterEachts(6200)

index.d.ts(33, 1): Conflicts are in this file.
// node_modules/@types/jest/index.d.ts
```

This is preventing TS from seeing `vitest` globals:

```
Cannot find type definition file for 'vitest/globals'.
```

This causes TS to default `vi` to `any`:

```
Cannot find name 'vi'.ts(2304)
```

This is triggering the lint issues.

Patching the global for now to fix the build, but the preexisting root cause remains.
