### PR TITLE
fix(editor): Remove explicit parameter name scanning for code editors

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -87,7 +87,7 @@
 				<code-node-editor
 					v-if="editorType === 'codeNodeEditor' && isCodeNode(node)"
 					:mode="node.parameters.mode"
-					:value="editorContent"
+					:value="value"
 					:defaultValue="parameter.default"
 					:language="editorLanguage"
 					:isReadOnly="isReadOnly"
@@ -97,7 +97,7 @@
 
 				<html-editor
 					v-else-if="editorType === 'htmlEditor'"
-					:html="editorContent"
+					:html="value"
 					:isReadOnly="isReadOnly"
 					:rows="getArgument('rows')"
 					:disableExpressionColoring="!isHtmlNode(node)"
@@ -107,7 +107,7 @@
 
 				<sql-editor
 					v-else-if="editorType === 'sqlEditor'"
-					:query="editorContent"
+					:query="value"
 					:dialect="getArgument('sqlDialect')"
 					:isReadOnly="isReadOnly"
 					@valueChanged="valueChangedDebounced"
@@ -365,7 +365,6 @@ import type {
 	IParameterLabel,
 	EditorType,
 	CodeNodeEditorLanguage,
-	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeHelpers } from 'n8n-workflow';
 
@@ -820,22 +819,6 @@ export default defineComponent({
 		},
 		remoteParameterOptionsKeys(): string[] {
 			return (this.remoteParameterOptions || []).map((o) => o.name);
-		},
-		nodeType(): INodeTypeDescription | null {
-			if (!this.node) return null;
-			return this.nodeTypesStore.getNodeType(this.node.type, this.node.typeVersion);
-		},
-		editorContent(): string | undefined {
-			if (!this.nodeType) {
-				return;
-			}
-			const editorProp = this.nodeType.properties.find(
-				(p) => p.typeOptions?.editor === (this.editorType as string),
-			);
-			if (!editorProp) {
-				return;
-			}
-			return this.node.parameters[editorProp.name] as string;
 		},
 	},
 	methods: {


### PR DESCRIPTION
The correct value to display in an editor is already passed in to `ParameterInput`. We do not need to scan for the correct parameter name again. This also fixes the issue of us accidentally using `jsCode` as the parameter name in the Code node when the language is set to Python.

NODE-558
https://community.n8n.io/t/python-code-is-not-saved-once-the-configuration-dialog-is-dismissed/26586
https://community.n8n.io/t/python-support-and-release-versions/26291/6?u=jan
