### PR TITLE
fix: Fist name to First Name in certain nodes (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Affinity/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Affinity/PersonDescription.ts
@@ -52,7 +52,7 @@ export const personFields: INodeProperties[] = [
 	/*                                person:create                               */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Fist Name',
+		displayName: 'First Name',
 		name: 'firstName',
 		type: 'string',
 		required: true,
@@ -154,7 +154,7 @@ export const personFields: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Fist Name',
+				displayName: 'First Name',
 				name: 'firstName',
 				type: 'string',
 				default: '',

--- a/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
@@ -229,7 +229,7 @@ export const leadFields: INodeProperties[] = [
 				description: 'Email address for the lead',
 			},
 			{
-				displayName: 'Fist Name',
+				displayName: 'First Name',
 				name: 'firstname',
 				type: 'string',
 				default: '',
@@ -498,7 +498,7 @@ export const leadFields: INodeProperties[] = [
 				description: 'Email address for the lead',
 			},
 			{
-				displayName: 'Fist Name',
+				displayName: 'First Name',
 				name: 'firstname',
 				type: 'string',
 				default: '',

--- a/packages/nodes-base/nodes/Uplead/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Uplead/PersonDescription.ts
@@ -41,7 +41,7 @@ export const personFields: INodeProperties[] = [
 		description: 'Email address (e.g – mbenioff@salesforce.com)',
 	},
 	{
-		displayName: 'Fist Name',
+		displayName: 'First Name',
 		name: 'firstname',
 		type: 'string',
 		default: '',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): Not on forums, but Ticket#762440


Affinity, Salesforce, and Uplead base nodes all had a typo of "Fist name" instead of "First Name". This PR fixes that.
