### PR TITLE
ci: Disable e2e test parallelization within a single container (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -108,20 +108,6 @@ jobs:
           ESLINT_PLUGIN_DIFF_COMMIT: ${{ github.event.pull_request.base.ref }}
         run: pnpm lint
 
-  smoke-test:
-    name: E2E [Electron/Node 18]
-    uses: ./.github/workflows/e2e-reusable.yml
-    with:
-      branch: ${{ github.event.pull_request.base.ref }}
-      user: ${{ github.event.inputs.user || 'PR User' }}
-      spec: ${{ github.event.inputs.spec || 'e2e/0-smoke.cy.ts' }}
-      record: false
-      parallel: false
-      pr_number: ${{ github.event.number }}
-      containers: '[1]'
-    secrets:
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-
   checklist_job:
     runs-on: ubuntu-latest
     name: Checklist job

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -32,11 +32,6 @@ on:
         required: false
         default: true
         type: boolean
-      parallel:
-        description: 'Run tests in parallel.'
-        required: false
-        default: true
-        type: boolean
       containers:
         description: 'Number of containers to run tests in.'
         required: false
@@ -158,7 +153,7 @@ jobs:
           wait-on: 'http://localhost:5678'
           wait-on-timeout: 120
           record: ${{ inputs.record }}
-          parallel: ${{ fromJSON( inputs.spec == 'e2e/*' && inputs.parallel || false ) }}
+          parallel: false
           # We have to provide custom ci-build-id key to make sure that this workflow could be run multiple times
           # in the same parent workflow
           ci-build-id: ${{ needs.prepare.outputs.uuid }}


### PR DESCRIPTION
Trying to run tests parallel within individual cypress containers is causing tests to reset database while other tests are still running. This is causing occasional CI failures.

PS: e2e tests are still using 8 parallel containers. So, the overall time to run these tests isn't going to increase only by a little bit.

PPS: Also removed the smoke-test step, as that test is run with the other tests, which all run on every PR. 
