### PR TITLE
fix(core): Optionally block http calls to link-local addresses

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "file-type": "^16.5.4",
     "flatted": "^3.2.4",
     "form-data": "^4.0.0",
+    "ipaddr.js": "^2.1.0",
     "lodash.get": "^4.4.2",
     "lodash.pick": "^4.4.0",
     "mime-types": "^2.1.27",

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -212,5 +212,19 @@ describe('NodeExecuteFunctions', () => {
 				node,
 			]);
 		});
+
+		test('should throw on link-local requests if access is blocked', async () => {
+			process.env.N8N_BLOCK_LINK_LOCAL_REQUESTS = 'true';
+			const testUrl = 'http://169.254.169.254/testing';
+			try {
+				await proxyRequestToAxios(workflow, additionalData, node, testUrl);
+			} catch (error) {
+				expect(error.message).toEqual('Access to link-local IP addressed is blocked');
+				expect(error.statusCode).toBeUndefined();
+				expect(error.request).toBeUndefined();
+				expect(error.response).toBeUndefined();
+			}
+			expect(hooks.executeHookFunctions).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,6 +678,9 @@ importers:
       form-data:
         specifier: ^4.0.0
         version: 4.0.0
+      ipaddr.js:
+        specifier: ^2.1.0
+        version: 2.1.0
       lodash.get:
         specifier: ^4.4.2
         version: 4.4.2
@@ -14719,6 +14722,11 @@ packages:
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  /ipaddr.js@2.1.0:
+    resolution: {integrity: sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==}
+    engines: {node: '>= 10'}
+    dev: false
 
   /is-absolute-url@3.0.3:
     resolution: {integrity: sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==}


### PR DESCRIPTION
This adds an option for an n8n instance to block all http calls to link-local address, which are usually used by cloud providers to return instance metadata, and role-based temporary credentials. 

[Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service)
[AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)
[GCP](https://cloud.google.com/compute/docs/metadata/overview)

N8N-6488

TODO: 
- [ ] Add a new env variable to pass in an CIDR block-list
- [ ] Blocks calls after DNS resolution