### PR TITLE
fix(editor): Remove `$if`, `$min` and `$max` from code node autocomplete

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
@@ -85,18 +85,6 @@ export const baseCompletions = (Vue as CodeNodeEditorMixin).extend({
 					info: this.$locale.baseText('codeNodeEditor.completer.$jmespath'),
 				},
 				{
-					label: `${prefix}if()`,
-					info: this.$locale.baseText('codeNodeEditor.completer.$if'),
-				},
-				{
-					label: `${prefix}min()`,
-					info: this.$locale.baseText('codeNodeEditor.completer.$min'),
-				},
-				{
-					label: `${prefix}max()`,
-					info: this.$locale.baseText('codeNodeEditor.completer.$max'),
-				},
-				{
 					label: `${prefix}runIndex`,
 					info: this.$locale.baseText('codeNodeEditor.completer.$runIndex'),
 				},


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
