### PR TITLE
feat: Add support for large files with declarative nodes

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -737,6 +737,7 @@ export async function proxyRequestToAxios(
 }
 
 function convertN8nRequestToAxios(n8nRequest: IHttpRequestOptions): AxiosRequestConfig {
+	Logger.info('convertN8nRwquestToAxios');
 	// Destructure properties with the same name first.
 	const { headers, method, timeout, auth, proxy, url } = n8nRequest;
 
@@ -747,6 +748,8 @@ function convertN8nRequestToAxios(n8nRequest: IHttpRequestOptions): AxiosRequest
 		auth,
 		proxy,
 		url,
+		maxBodyLength: Infinity,
+		maxContentLength: Infinity,
 	} as AxiosRequestConfig;
 
 	axiosRequest.params = n8nRequest.qs;

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -737,7 +737,6 @@ export async function proxyRequestToAxios(
 }
 
 function convertN8nRequestToAxios(n8nRequest: IHttpRequestOptions): AxiosRequestConfig {
-	Logger.info('convertN8nRwquestToAxios');
 	// Destructure properties with the same name first.
 	const { headers, method, timeout, auth, proxy, url } = n8nRequest;
 


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/maxbodylenght-limit-with-google-cloud-storage-node/27216

Declarative nodes don't appear to use `proxyRequestToAxios()` which was updated in `0.179.0` to allow files over 10mb to be uploaded. This PR adds the same option for the newer node style, Tested with a 32mb PDF and a 210mb zip to Google Cloud Storage.

To test...

```
export N8N_PAYLOAD_SIZE_MAX=400 
```

Test Workflow
```
{
  "meta": {
    "instanceId": "8c8c5237b8e37b006a7adce87f4369350c58e41f3ca9de16196d3197f69eabcd"
  },
  "nodes": [
    {
      "parameters": {},
      "id": "60f89e61-93e2-42ed-8ad8-405d4572e62b",
      "name": "When clicking \"Execute Workflow\"",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        540,
        420
      ]
    },
    {
      "parameters": {
        "resource": "object",
        "operation": "create",
        "bucketName": "n8n-test-bucket",
        "objectName": "=Test Object {{ $execution.id }}",
        "createData": {},
        "createQuery": {},
        "encryptionHeaders": {}
      },
      "id": "2a4906af-69da-4e3d-af93-32dfc0e0b59f",
      "name": "Google Cloud Storage",
      "type": "n8n-nodes-base.googleCloudStorage",
      "typeVersion": 1,
      "position": [
        1040,
        420
      ],
      "credentials": {
        "googleCloudStorageOAuth2Api": {
          "id": "23",
          "name": "Google Cloud Storage account"
        }
      }
    },
    {
      "parameters": {
        "url": "https://cdn1.papercut.com/web/products/ng-mf/manuals/mf/22.x/pcmf-manual-22.0.0.pdf",
        "options": {}
      },
      "id": "3e6bafbc-23f2-426d-9732-533b1e789d13",
      "name": "HTTP Request",
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.1,
      "position": [
        760,
        280
      ]
    },
    {
      "parameters": {
        "content": "30mb PDF\n",
        "height": 233,
        "width": 218
      },
      "id": "3126fd76-8ecb-4557-8fc7-089b92e16467",
      "name": "Sticky Note",
      "type": "n8n-nodes-base.stickyNote",
      "typeVersion": 1,
      "position": [
        702,
        226
      ]
    },
    {
      "parameters": {
        "url": "https://downloads.n8n.io/file/n8n-downloads/n8n-mac.zip",
        "options": {}
      },
      "id": "31bb1ff7-9b48-44b7-9098-dd1ad36f81cf",
      "name": "HTTP Request1",
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.1,
      "position": [
        760,
        560
      ]
    },
    {
      "parameters": {
        "content": "210mb zip\n",
        "height": 242
      },
      "id": "92d82298-fa7b-4f06-85be-13cb204894aa",
      "name": "Sticky Note1",
      "type": "n8n-nodes-base.stickyNote",
      "typeVersion": 1,
      "position": [
        700,
        500
      ]
    }
  ],
  "connections": {
    "When clicking \"Execute Workflow\"": {
      "main": [
        [
          {
            "node": "HTTP Request",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "HTTP Request": {
      "main": [
        [
          {
            "node": "Google Cloud Storage",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  }
}
```
