### PR TITLE
fix(core): Fix the url sent in the password-reset emails

### DIFF
--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -131,14 +131,14 @@ export class PasswordResetController {
 
 		const baseUrl = getInstanceBaseUrl();
 		const { id, firstName, lastName } = user;
-		const url = UserService.generatePasswordResetUrl(user);
+		const url = await UserService.generatePasswordResetUrl(user);
 
 		try {
 			await this.mailer.passwordReset({
 				email,
 				firstName,
 				lastName,
-				passwordResetUrl: url.toString(),
+				passwordResetUrl: url,
 				domain: baseUrl,
 			});
 		} catch (error) {


### PR DESCRIPTION
Fixes #6465

Broke [here](https://github.com/n8n-io/n8n/pull/6328/files#diff-1a434b440b3865be28c06705fb1a6863ca9c49028915a9d70f1a05e3e712c852R134).
So, all versions above and including `0.231.0` have this bug.