### PR TITLE
fix(editor): Remove tooltip about SMTP being required to invite user (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/InviteUsersModal.vue
+++ b/packages/editor-ui/src/components/InviteUsersModal.vue
@@ -38,18 +38,6 @@
 				@input="onInput"
 				@submit="onSubmit"
 			/>
-			<n8n-info-tip v-if="!settingsStore.isSmtpSetup" class="mt-s">
-				<i18n path="settings.users.setupSMTPInfo">
-					<template #link>
-						<a
-							href="https://docs.n8n.io/reference/user-management.html#step-one-smtp"
-							target="_blank"
-						>
-							{{ $locale.baseText('settings.users.setupSMTPInfo.link') }}
-						</a>
-					</template>
-				</i18n>
-			</n8n-info-tip>
 		</template>
 		<template v-if="!showInviteUrls" #footer>
 			<n8n-button

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1231,8 +1231,6 @@
 	"settings.users.setupMyAccount": "Set up my owner account",
 	"settings.users.setupToInviteUsers": "To invite users, set up your own account",
 	"settings.users.setupToInviteUsersInfo": "Invited users won’t be able to see workflows and credentials of other users unless you upgrade. <a href=\"https://docs.n8n.io/user-management/\" target=\"_blank\">More info</a> <br /> <br />",
-	"settings.users.setupSMTPInfo": "You will need details of an {link} to complete the setup.",
-	"settings.users.setupSMTPInfo.link": "SMTP server",
 	"settings.users.smtpToAddUsersWarning": "Set up SMTP before adding users (so that n8n can send them invitation emails). <a target=\"_blank\" href=\"https://docs.n8n.io/hosting/authentication/user-management-self-hosted/\">Instructions</a>",
 	"settings.users.transferWorkflowsAndCredentials": "Transfer their workflows and credentials to another user",
 	"settings.users.transferredToUser": "Data transferred to {user}",


### PR DESCRIPTION
`You will need details of an SMTP server to complete the setup.` is not true anymore since the introduction of SMTP-less user invitation.

![image](https://github.com/n8n-io/n8n/assets/12082258/a02cbd3d-502e-4279-957a-3ab63ea22d5d)