### PR TITLE
feat(Stripe Trigger Node): Add action required trigger for payment intents

### DIFF
--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -502,6 +502,11 @@ export class StripeTrigger implements INodeType {
 						description: 'Occurs when a PaymentIntent has been successfully fulfilled.',
 					},
 					{
+						name: 'Payment Intent.requires_action',
+						value: 'payment_intent.requires_action',
+						description: 'Occurs when a PaymentIntent requires an action.',
+					},
+					{
 						name: 'Payment Method.attached',
 						value: 'payment_method.attached',
 						description: 'Occurs whenever a new payment method is attached to a customer.',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/stripe-trigger-payment-intent-requires-action/27232/

Adds "require_action" to the payment_intents of the Stripe trigger. 
