### PR TITLE
fix: Show error when referencing node that exist but has not been executed

### DIFF
--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -188,7 +188,11 @@ describe('Data mapping', () => {
 		ndv.getters
 			.inlineExpressionEditorInput()
 			.should('have.text', `{{ $('${SCHEDULE_TRIGGER_NODE_NAME}').item.json.input[0].count }}`);
-		ndv.getters.parameterExpressionPreview('value').should('not.exist');
+		ndv.getters
+			.parameterExpressionPreview('value')
+			.invoke('text')
+			.invoke('replace', /\u00a0/g, ' ')
+			.should('equal', '[ERROR: no data, execute "Schedule Trigger" node first]');
 
 		ndv.actions.switchInputMode('Table');
 		ndv.actions.mapDataFromHeader(1, 'value');

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -943,6 +943,10 @@ export class WorkflowDataProxy {
 					throw createExpressionError(`"${nodeName}" node doesn't exist`);
 				}
 
+				if (!that?.runExecutionData?.resultData?.runData.hasOwnProperty(nodeName)) {
+					throw createExpressionError(`no data, execute "${nodeName}" node first`);
+				}
+
 				return new Proxy(
 					{},
 					{

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -2,6 +2,7 @@ import type { IConnections, IExecuteData, INode, IRunExecutionData } from '@/Int
 import { Workflow } from '@/Workflow';
 import { WorkflowDataProxy } from '@/WorkflowDataProxy';
 import * as Helpers from './Helpers';
+import { ExpressionError } from '@/ExpressionError';
 
 describe('WorkflowDataProxy', () => {
 	describe('test data proxy', () => {
@@ -37,11 +38,19 @@ describe('WorkflowDataProxy', () => {
 				position: [460, 200],
 			},
 			{
-				name: 'End',
+				name: 'Set',
 				type: 'test.set',
 				parameters: {},
 				typeVersion: 1,
 				id: 'uuid-4',
+				position: [640, 200],
+			},
+			{
+				name: 'End',
+				type: 'test.set',
+				parameters: {},
+				typeVersion: 1,
+				id: 'uuid-5',
 				position: [640, 200],
 			},
 		];
@@ -280,6 +289,14 @@ describe('WorkflowDataProxy', () => {
 
 		test('test $("NodeName").params', () => {
 			expect(proxy.$('Rename').params).toEqual({ value1: 'data', value2: 'initialName' });
+		});
+
+		test('$("NodeName")', () => {
+			expect(() => proxy.$('doNotExist')).toThrowError(ExpressionError);
+		});
+
+		test('$("NodeName")', () => {
+			expect(() => proxy.$('Set')).toThrowError(ExpressionError);
 		});
 
 		test('test $input.all()', () => {


### PR DESCRIPTION
### **Currently:**

Referencing node that exists but has not been executed:

<img width="383" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/1a6ef94e-0b84-401b-b8c4-831f612c7b32">

Executing node that references node that exists but has not been executed:

<img width="842" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/3fd8679a-9d1f-4ce5-8438-d1d05b4087b8">

### **With this change**

Referencing node that exists but has not been executed:

<img width="486" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/0caf43de-7598-41d6-9c3a-fd304fe6201a">

Executing node that references node that exists but has not been executed:

<img width="901" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/2a920a00-d83b-4936-a753-e276087fdf9e">


Fixes ADO-713
