### PR TITLE
fix(core): Use correct scopes-separator when generating authorization urls

### DIFF
--- a/packages/@n8n/client-oauth2/src/ClientOAuth2.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2.ts
@@ -10,28 +10,28 @@ import type { ClientOAuth2TokenData } from './ClientOAuth2Token';
 import { ClientOAuth2Token } from './ClientOAuth2Token';
 import { CodeFlow } from './CodeFlow';
 import { CredentialsFlow } from './CredentialsFlow';
-import type { Headers, Query } from './types';
+import type { Headers } from './types';
 
 export interface ClientOAuth2RequestObject {
 	url: string;
 	method: 'DELETE' | 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT';
 	body?: Record<string, any>;
-	query?: Query;
+	query?: qs.ParsedUrlQuery;
 	headers?: Headers;
 }
 
 export interface ClientOAuth2Options {
 	clientId: string;
-	clientSecret: string;
+	clientSecret?: string;
 	accessTokenUri: string;
 	authorizationUri?: string;
 	redirectUri?: string;
 	scopes?: string[];
+	scopesSeparator?: ',' | ' ';
 	authorizationGrants?: string[];
 	state?: string;
 	body?: Record<string, any>;
-	query?: Query;
-	headers?: Headers;
+	query?: qs.ParsedUrlQuery;
 }
 
 class ResponseError extends Error {

--- a/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { ClientOAuth2, ClientOAuth2Options, ClientOAuth2RequestObject } from './ClientOAuth2';
-import { auth, getRequestOptions } from './utils';
+import { auth, expects, getRequestOptions } from './utils';
 import { DEFAULT_HEADERS } from './constants';
 
 export interface ClientOAuth2TokenData extends Record<string, string | undefined> {
@@ -68,6 +68,8 @@ export class ClientOAuth2Token {
 	 */
 	async refresh(opts?: ClientOAuth2Options): Promise<ClientOAuth2Token> {
 		const options = { ...this.client.options, ...opts };
+
+		expects(options, 'clientSecret');
 
 		if (!this.refreshToken) throw new Error('No refresh token');
 

--- a/packages/@n8n/client-oauth2/src/CredentialsFlow.ts
+++ b/packages/@n8n/client-oauth2/src/CredentialsFlow.ts
@@ -1,7 +1,7 @@
 import type { ClientOAuth2, ClientOAuth2Options } from './ClientOAuth2';
 import type { ClientOAuth2Token, ClientOAuth2TokenData } from './ClientOAuth2Token';
 import { DEFAULT_HEADERS } from './constants';
-import { auth, expects, getRequestOptions, sanitizeScope } from './utils';
+import { auth, expects, getRequestOptions } from './utils';
 
 interface CredentialsFlowBody {
 	grant_type: 'client_credentials';
@@ -29,7 +29,7 @@ export class CredentialsFlow {
 		};
 
 		if (options.scopes !== undefined) {
-			body.scope = sanitizeScope(options.scopes);
+			body.scope = options.scopes.join(options.scopesSeparator ?? ' ');
 		}
 
 		const requestOptions = getRequestOptions(

--- a/packages/@n8n/client-oauth2/src/types.ts
+++ b/packages/@n8n/client-oauth2/src/types.ts
@@ -1,2 +1,1 @@
 export type Headers = Record<string, string | string[]>;
-export type Query = Record<string, string | string[]>;

--- a/packages/@n8n/client-oauth2/src/utils.ts
+++ b/packages/@n8n/client-oauth2/src/utils.ts
@@ -2,17 +2,21 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ClientOAuth2RequestObject } from './ClientOAuth2';
+import type { ClientOAuth2Options, ClientOAuth2RequestObject } from './ClientOAuth2';
 import { ERROR_RESPONSES } from './constants';
 
 /**
  * Check if properties exist on an object and throw when they aren't.
  */
-export function expects(obj: any, ...args: any[]) {
-	for (let i = 1; i < args.length; i++) {
-		const prop = args[i];
-		if (obj[prop] === null) {
-			throw new TypeError('Expected "' + prop + '" to exist');
+export function expects<Keys extends keyof ClientOAuth2Options>(
+	obj: ClientOAuth2Options,
+	...keys: Keys[]
+): asserts obj is ClientOAuth2Options & {
+	[K in Keys]: NonNullable<ClientOAuth2Options[K]>;
+} {
+	for (const key of keys) {
+		if (obj[key] === null || obj[key] === undefined) {
+			throw new TypeError('Expected "' + key + '" to exist');
 		}
 	}
 }
@@ -45,13 +49,6 @@ export function getAuthError(body: {
  */
 function toString(str: string | null | undefined) {
 	return str === null ? '' : String(str);
-}
-
-/**
- * Sanitize the scopes option to be a string.
- */
-export function sanitizeScope(scopes: string[] | string): string {
-	return Array.isArray(scopes) ? scopes.join(' ') : toString(scopes);
 }
 
 /**

--- a/packages/@n8n/client-oauth2/test/CodeFlow.test.ts
+++ b/packages/@n8n/client-oauth2/test/CodeFlow.test.ts
@@ -29,7 +29,7 @@ describe('CodeFlow', () => {
 			expect(githubAuth.code.getUri()).toEqual(
 				`${config.authorizationUri}?client_id=abc&` +
 					`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
-					'response_type=code&state=&scope=notifications',
+					'response_type=code&scope=notifications',
 			);
 		});
 
@@ -46,7 +46,7 @@ describe('CodeFlow', () => {
 				expect(authWithoutScopes.code.getUri()).toEqual(
 					`${config.authorizationUri}?client_id=abc&` +
 						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
-						'response_type=code&state=',
+						'response_type=code',
 				);
 			});
 		});
@@ -64,7 +64,7 @@ describe('CodeFlow', () => {
 			expect(authWithEmptyScopes.code.getUri()).toEqual(
 				`${config.authorizationUri}?client_id=abc&` +
 					`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
-					'response_type=code&state=&scope=',
+					'response_type=code&scope=',
 			);
 		});
 
@@ -81,7 +81,7 @@ describe('CodeFlow', () => {
 			expect(authWithEmptyScopes.code.getUri()).toEqual(
 				`${config.authorizationUri}?client_id=abc&` +
 					`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
-					'response_type=code&state=&scope=',
+					'response_type=code&scope=',
 			);
 		});
 
@@ -99,7 +99,7 @@ describe('CodeFlow', () => {
 				expect(authWithParams.code.getUri()).toEqual(
 					`${config.authorizationUri}?bar=qux&client_id=abc&` +
 						`redirect_uri=${encodeURIComponent(config.redirectUri)}&` +
-						'response_type=code&state=&scope=notifications',
+						'response_type=code&scope=notifications',
 				);
 			});
 		});


### PR DESCRIPTION
fixes N8N-6337 & [HELP-227](https://linear.app/n8n/issue/HELP-227)

extracted from https://github.com/n8n-io/n8n/pull/5973
