### PR TITLE
ci: Automate `no-changelog` removal in generated changelog (no-changelog)

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
-    "conventional-changelog-cli": "^2.2.2",
-    "glob": "^10.2.7",
-    "semver": "^7.3.8",
+    "add-stream": "^1.0.0",
+    "conventional-changelog": "^4.0.0",
+    "glob": "^10.3.0",
+    "semver": "^7.5.2",
+    "tempfile": "^5.0.0",
     "typescript": "*"
   }
 }

--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -1,0 +1,36 @@
+import addStream from 'add-stream';
+import createTempFile from 'tempfile';
+import conventionalChangelog from 'conventional-changelog';
+import { resolve } from 'path';
+import { createReadStream, createWriteStream } from 'fs';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import stream from 'stream';
+import { promisify } from 'util';
+
+const pipeline = promisify(stream.pipeline);
+
+const changelogFile = resolve(dirname(fileURLToPath(import.meta.url)), '../../CHANGELOG.md');
+
+const changelogStream = conventionalChangelog({
+	preset: 'angular',
+	releaseCount: 1,
+	tagPrefix: 'n8n@',
+	transform: (commit, callback) => {
+		callback(null, commit.header.includes('(no-changelog)') ? undefined : commit);
+	},
+}).on('error', (err) => {
+	console.error(err.stack);
+	process.exit(1);
+});
+
+// Since we can't read and write from the same file at the same time,
+// we use a temporary file to output the updated changelog to.
+const tmpFile = createTempFile();
+await pipeline(
+	changelogStream,
+	addStream(createReadStream(changelogFile)),
+	createWriteStream(tmpFile),
+);
+
+await pipeline(createReadStream(tmpFile), createWriteStream(changelogFile));

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -53,8 +53,8 @@ jobs:
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release-type }}
 
-      - name: Generate Changelog
-        run: npx conventional-changelog-cli -p angular -i CHANGELOG.md -s -t n8n@
+      - name: Update Changelog
+        run: node .github/scripts/update-changelog.mjs
 
       - name: Push the release branch, and Create the PR
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
[Test run on my fork](https://github.com/netroy/n8n/actions/runs/5344491162/jobs/9688927769) created [this PR](https://github.com/netroy/n8n/pull/34).
