### PR TITLE
fix(core): Fix `import:credential` on postgres (no-changelog)

### DIFF
--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import glob from 'fast-glob';
 import { Container } from 'typedi';
 import type { EntityManager } from 'typeorm';
-import config from '@/config';
 import * as Db from '@/Db';
 import type { User } from '@db/entities/User';
 import { SharedCredentials } from '@db/entities/SharedCredentials';
@@ -168,12 +167,6 @@ export class ImportCredentialsCommand extends BaseCommand {
 			},
 			['credentialsId', 'userId'],
 		);
-		if (config.getEnv('database.type') === 'postgresdb') {
-			const tablePrefix = config.getEnv('database.tablePrefix');
-			await this.transactionManager.query(
-				`SELECT setval('${tablePrefix}credentials_entity_id_seq', (SELECT MAX(id) from ${tablePrefix}credentials_entity))`,
-			);
-		}
 	}
 
 	private async getOwner() {


### PR DESCRIPTION
Since we switched to string ids, we don't need to update the `_seq` values for postgres.

We removed this bit for the `import:workflow` [here](https://github.com/n8n-io/n8n/pull/6345/files#diff-ff45b1d8db8d3dc67d19aa34e4d066e4156ddcd311c0b8d75a3d082009065197L230), but missed updating this file.
