### PR TITLE
fix(editor): Fix broken expression highlight in SQL editor

### DIFF
--- a/packages/editor-ui/src/mixins/expressionManager.ts
+++ b/packages/editor-ui/src/mixins/expressionManager.ts
@@ -91,7 +91,7 @@ export const expressionManager = defineComponent({
 			fullTree.cursor().iterate((node) => {
 				const text = this.editor.state.sliceDoc(node.from, node.to);
 
-				if (skipSegments.includes(node.type.name)) return;
+				if (text === '' || skipSegments.includes(node.type.name)) return;
 
 				rawSegments.push({
 					from: node.from,


### PR DESCRIPTION
I removed this check while addressing [latest review feedback](https://github.com/n8n-io/n8n/pull/6282#discussion_r1238166113) but it turns out this breaks rsolvable highlight with `.` in front of an expression:

![SCR-20230622-nza](https://github.com/n8n-io/n8n/assets/2598782/1c97fa3f-3954-415c-9196-588fbd0c9664)
