### PR TITLE
fix(Sendy Node): Fix issue with brand id not being sent

### DIFF
--- a/packages/nodes-base/nodes/Sendy/Sendy.node.ts
+++ b/packages/nodes-base/nodes/Sendy/Sendy.node.ts
@@ -86,6 +86,11 @@ export class Sendy implements INodeType {
 
 					const additionalFields = this.getNodeParameter('additionalFields', i);
 
+					let brandId = null;
+					if (!sendCampaign) {
+						brandId = this.getNodeParameter('brandId', i) as string;
+					}
+
 					const body: IDataObject = {
 						from_name: fromName,
 						from_email: fromEmail,
@@ -95,6 +100,10 @@ export class Sendy implements INodeType {
 						send_campaign: sendCampaign ? 1 : 0,
 						html_text: htmlText,
 					};
+
+					if (brandId) {
+						body.brand_id = brandId as string;
+					}
 
 					if (additionalFields.plainText) {
 						body.plain_text = additionalFields.plainText;
@@ -114,10 +123,6 @@ export class Sendy implements INodeType {
 
 					if (additionalFields.excludeSegmentIds) {
 						body.exclude_segments_ids = additionalFields.excludeSegmentIds as string;
-					}
-
-					if (additionalFields.brandId) {
-						body.brand_id = additionalFields.brandId as string;
 					}
 
 					if (additionalFields.queryString) {


### PR DESCRIPTION
The Sendy node did not include the brand_id parameter in the request because it tried to grab the value from the additional fields while this parameter wasn't present under the additional fields.

I chose to check whether the sendCampaign parameter is because the brand_id only needs to be sent when this isn't the case.

The changes have been tested using a Sendy instance and using a request catcher to check the contents of the request body.