### PR TITLE
refactor(editor): Update endpoint to retrieve limits (no-changelog)

### DIFF
--- a/packages/editor-ui/src/api/cloudPlans.ts
+++ b/packages/editor-ui/src/api/cloudPlans.ts
@@ -9,5 +9,5 @@ export async function getCurrentPlan(
 }
 
 export async function getCurrentUsage(context: IRestApiContext): Promise<InstanceUsage> {
-	return get(context.baseUrl, '/limits');
+	return get(context.baseUrl, '/cloud/limits');
 }


### PR DESCRIPTION
We are going to deprecate the `/limits` endpoints in the hooks in favor of `/cloud/limits`.  This PRs updates the endpoint, to start using the new one.