### PR TITLE
fix(AwsS3 Node): Fix issue if bucket name contains a '.'

### DIFF
--- a/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
@@ -215,6 +215,8 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'search') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const additionalFields = this.getNodeParameter('additionalFields', 0);
 
@@ -243,8 +245,7 @@ export class AwsS3V2 implements INodeType {
 						}
 
 						qs['list-type'] = 2;
-
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -254,9 +255,9 @@ export class AwsS3V2 implements INodeType {
 							responseData = await awsApiRequestRESTAllItems.call(
 								this,
 								'ListBucketResult.Contents',
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -267,9 +268,9 @@ export class AwsS3V2 implements INodeType {
 							qs['max-keys'] = this.getNodeParameter('limit', 0);
 							responseData = await awsApiRequestREST.call(
 								this,
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -282,6 +283,7 @@ export class AwsS3V2 implements INodeType {
 							this.helpers.returnJsonArray(responseData as IDataObject[]),
 							{ itemData: { item: i } },
 						);
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 						returnData.push(...executionData);
 					}
 				}
@@ -289,9 +291,11 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'create') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const folderName = this.getNodeParameter('folderName', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						let path = `/${folderName}/`;
+						let path = `${basePath}/${folderName}/`;
 
 						if (additionalFields.requesterPays) {
 							headers['x-amz-request-payer'] = 'requester';
@@ -304,7 +308,7 @@ export class AwsS3V2 implements INodeType {
 								additionalFields.storageClass as string,
 							).toUpperCase();
 						}
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -312,7 +316,7 @@ export class AwsS3V2 implements INodeType {
 
 						responseData = await awsApiRequestREST.call(
 							this,
-							`${bucketName}.s3`,
+							servicePath,
 							'PUT',
 							path,
 							'',
@@ -330,9 +334,11 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 					if (operation === 'delete') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const folderKey = this.getNodeParameter('folderKey', i) as string;
 
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -341,9 +347,9 @@ export class AwsS3V2 implements INodeType {
 						responseData = await awsApiRequestRESTAllItems.call(
 							this,
 							'ListBucketResult.Contents',
-							`${bucketName}.s3`,
+							servicePath,
 							'GET',
-							'/',
+							basePath,
 							'',
 							{ 'list-type': 2, prefix: folderKey },
 							{},
@@ -355,9 +361,9 @@ export class AwsS3V2 implements INodeType {
 						if (responseData.length === 0) {
 							responseData = await awsApiRequestREST.call(
 								this,
-								`${bucketName}.s3`,
+								servicePath,
 								'DELETE',
-								`/${folderKey}`,
+								`${basePath}/${folderKey}`,
 								'',
 								qs,
 								{},
@@ -393,9 +399,9 @@ export class AwsS3V2 implements INodeType {
 
 							responseData = await awsApiRequestREST.call(
 								this,
-								`${bucketName}.s3`,
+								servicePath,
 								'POST',
-								'/',
+								`${basePath}/`,
 								data,
 								{ delete: '' },
 								headers,
@@ -414,6 +420,8 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0);
 
@@ -427,7 +435,7 @@ export class AwsS3V2 implements INodeType {
 
 						qs['list-type'] = 2;
 
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -437,9 +445,9 @@ export class AwsS3V2 implements INodeType {
 							responseData = await awsApiRequestRESTAllItems.call(
 								this,
 								'ListBucketResult.Contents',
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -451,9 +459,9 @@ export class AwsS3V2 implements INodeType {
 							responseData = await awsApiRequestRESTAllItems.call(
 								this,
 								'ListBucketResult.Contents',
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -561,10 +569,12 @@ export class AwsS3V2 implements INodeType {
 						const destinationParts = destinationPath.split('/');
 
 						const bucketName = destinationParts[1];
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 
-						const destination = `/${destinationParts.slice(2, destinationParts.length).join('/')}`;
+						const destination = `${basePath}/${destinationParts.slice(2, destinationParts.length).join('/')}`;
 
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -572,7 +582,7 @@ export class AwsS3V2 implements INodeType {
 
 						responseData = await awsApiRequestREST.call(
 							this,
-							`${bucketName}.s3`,
+							servicePath,
 							'PUT',
 							destination,
 							'',
@@ -590,6 +600,8 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 					if (operation === 'download') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -602,7 +614,7 @@ export class AwsS3V2 implements INodeType {
 							);
 						}
 
-						let region = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						let region = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -610,9 +622,9 @@ export class AwsS3V2 implements INodeType {
 
 						const response = await awsApiRequestREST.call(
 							this,
-							`${bucketName}.s3`,
+							servicePath,
 							'GET',
-							`/${fileKey}`,
+							`${basePath}/${fileKey}`,
 							'',
 							qs,
 							{},
@@ -652,6 +664,8 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
 					if (operation === 'delete') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 
 						const fileKey = this.getNodeParameter('fileKey', i) as string;
 
@@ -661,7 +675,7 @@ export class AwsS3V2 implements INodeType {
 							qs.versionId = options.versionId as string;
 						}
 
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -669,9 +683,9 @@ export class AwsS3V2 implements INodeType {
 
 						responseData = await awsApiRequestREST.call(
 							this,
-							`${bucketName}.s3`,
+							servicePath,
 							'DELETE',
-							`/${fileKey}`,
+							`${basePath}/${fileKey}`,
 							'',
 							qs,
 							{},
@@ -687,6 +701,8 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 					if (operation === 'getAll') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const returnAll = this.getNodeParameter('returnAll', 0);
 						const options = this.getNodeParameter('options', 0);
 
@@ -702,7 +718,7 @@ export class AwsS3V2 implements INodeType {
 
 						qs['list-type'] = 2;
 
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 
@@ -712,9 +728,9 @@ export class AwsS3V2 implements INodeType {
 							responseData = await awsApiRequestRESTAllItems.call(
 								this,
 								'ListBucketResult.Contents',
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -726,9 +742,9 @@ export class AwsS3V2 implements INodeType {
 							responseData = await awsApiRequestRESTAllItems.call(
 								this,
 								'ListBucketResult.Contents',
-								`${bucketName}.s3`,
+								servicePath,
 								'GET',
-								'',
+								basePath,
 								'',
 								qs,
 								{},
@@ -754,12 +770,14 @@ export class AwsS3V2 implements INodeType {
 					//https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 					if (operation === 'upload') {
 						const bucketName = this.getNodeParameter('bucketName', i) as string;
+						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
+						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const fileName = this.getNodeParameter('fileName', i) as string;
 						const isBinaryData = this.getNodeParameter('binaryData', i);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const tagsValues = (this.getNodeParameter('tagsUi', i) as IDataObject)
 							.tagsValues as IDataObject[];
-						let path = '';
+						let path = `${basePath}/`;
 						let body;
 
 						const multipartHeaders: IDataObject = {};
@@ -839,7 +857,7 @@ export class AwsS3V2 implements INodeType {
 							multipartHeaders['x-amz-tagging'] = tags.join('&');
 						}
 						// Get the region of the bucket
-						responseData = await awsApiRequestREST.call(this, `${bucketName}.s3`, 'GET', '', '', {
+						responseData = await awsApiRequestREST.call(this, servicePath, 'GET', basePath, '', {
 							location: '',
 						});
 						const region = responseData.LocationConstraint._;
@@ -853,7 +871,7 @@ export class AwsS3V2 implements INodeType {
 								uploadData = this.helpers.getBinaryStream(binaryPropertyData.id, UPLOAD_CHUNK_SIZE);
 								const createMultiPartUpload = await awsApiRequestREST.call(
 									this,
-									`${bucketName}.s3`,
+									servicePath,
 									'POST',
 									`/${path}?uploads`,
 									body,
@@ -875,7 +893,7 @@ export class AwsS3V2 implements INodeType {
 									try {
 										await awsApiRequestREST.call(
 											this,
-											`${bucketName}.s3`,
+											servicePath,
 											'PUT',
 											`/${path}?partNumber=${part}&uploadId=${uploadId}`,
 											chunk,
@@ -889,7 +907,7 @@ export class AwsS3V2 implements INodeType {
 										try {
 											await awsApiRequestREST.call(
 												this,
-												`${bucketName}.s3`,
+												servicePath,
 												'DELETE',
 												`/${path}?uploadId=${uploadId}`,
 											);
@@ -902,7 +920,7 @@ export class AwsS3V2 implements INodeType {
 
 								const listParts = (await awsApiRequestREST.call(
 									this,
-									`${bucketName}.s3`,
+									servicePath,
 									'GET',
 									`/${path}?max-parts=${900}&part-number-marker=0&uploadId=${uploadId}`,
 									'',
@@ -954,7 +972,7 @@ export class AwsS3V2 implements INodeType {
 								const data = builder.buildObject(body);
 								const completeUpload = (await awsApiRequestREST.call(
 									this,
-									`${bucketName}.s3`,
+									servicePath,
 									'POST',
 									`/${path}?uploadId=${uploadId}`,
 									data,
@@ -991,7 +1009,7 @@ export class AwsS3V2 implements INodeType {
 
 								responseData = await awsApiRequestREST.call(
 									this,
-									`${bucketName}.s3`,
+									servicePath,
 									'PUT',
 									`/${path || binaryPropertyData.fileName}`,
 									body,
@@ -1019,7 +1037,7 @@ export class AwsS3V2 implements INodeType {
 
 							responseData = await awsApiRequestREST.call(
 								this,
-								`${bucketName}.s3`,
+								servicePath,
 								'PUT',
 								`/${path}`,
 								body,


### PR DESCRIPTION
They currently a bug in both v1 and v2 where if there a dot in the bucket name, you cant access the bucket. Standard AWS s3 when they no dots in the name prefixs the bucket name as a subdomain. However, with a dot then subdomain is just s3 and the bucket becomes part of the path.