### PR TITLE
ci: Update release process to support `major` releases (no-changelog)

### DIFF
--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -7,10 +7,13 @@ import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import stream from 'stream';
 import { promisify } from 'util';
+import packageJson from '../../package.json' assert { type: 'json' };
 
 const pipeline = promisify(stream.pipeline);
 
-const changelogFile = resolve(dirname(fileURLToPath(import.meta.url)), '../../CHANGELOG.md');
+const baseDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const fullChangelogFile = resolve(baseDir, 'CHANGELOG.md');
+const versionChangelogFile = resolve(baseDir, `CHANGELOG-${packageJson.version}.md`);
 
 const changelogStream = conventionalChangelog({
 	preset: 'angular',
@@ -24,13 +27,16 @@ const changelogStream = conventionalChangelog({
 	process.exit(1);
 });
 
+// We need to duplicate the stream here to pipe the changelog into two separate files
+const stream1 = new stream.PassThrough();
+const stream2 = new stream.PassThrough();
+changelogStream.pipe(stream1);
+changelogStream.pipe(stream2);
+
+await pipeline(stream1, createWriteStream(versionChangelogFile));
+
 // Since we can't read and write from the same file at the same time,
 // we use a temporary file to output the updated changelog to.
 const tmpFile = createTempFile();
-await pipeline(
-	changelogStream,
-	addStream(createReadStream(changelogFile)),
-	createWriteStream(tmpFile),
-);
-
-await pipeline(createReadStream(tmpFile), createWriteStream(changelogFile));
+await pipeline(stream2, addStream(createReadStream(fullChangelogFile)), createWriteStream(tmpFile)),
+	await pipeline(createReadStream(tmpFile), createWriteStream(fullChangelogFile));

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -35,37 +35,33 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.base-branch }}
 
-      - name: Push the base branch
-        run: |
-          git checkout -b "release/${{ github.event.inputs.release-type }}"
-          git push -f origin "release/${{ github.event.inputs.release-type }}"
-
       - uses: pnpm/action-setup@v2.2.4
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
+
       - run: npm install --prefix=.github/scripts --no-package-lock
 
       - name: Bump package versions
         run: |
           echo "NEXT_RELEASE=$(node .github/scripts/bump-versions.mjs)" >> $GITHUB_ENV
-          pnpm i --lockfile-only
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release-type }}
 
       - name: Update Changelog
         run: node .github/scripts/update-changelog.mjs
 
+      - name: Push the base branch
+        run: |
+          git push -f origin refs/remotes/origin/${{ github.event.inputs.base-branch }}:refs/heads/release/${{ env.NEXT_RELEASE }}
+
       - name: Push the release branch, and Create the PR
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
-          base: 'release/${{ github.event.inputs.release-type }}'
-          branch: 'release/${{ env.NEXT_RELEASE }}'
+          base: 'release/${{ env.NEXT_RELEASE }}'
+          branch: '${{ env.NEXT_RELEASE }}-pr'
           commit-message: ':rocket: Release ${{ env.NEXT_RELEASE }}'
           delete-branch: true
           labels: 'release'
           title: ':rocket: Release ${{ env.NEXT_RELEASE }}'
-          # 'TODO: add generated changelog to the body. create a script to generate custom changelog'
-          body: ''
-
-      # TODO: post PR link to slack
+          body-path: 'CHANGELOG-${{ env.NEXT_RELEASE }}.md'

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,8 +5,7 @@ on:
     types:
       - closed
     branches:
-      - 'release/patch'
-      - 'release/minor'
+      - 'release/*'
 
 jobs:
   publish-release:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -49,6 +49,7 @@ jobs:
           tag: 'n8n@${{env.RELEASE}}'
           prerelease: true
           makeLatest: false
+          body: ${{github.event.pull_request.body}}
 
       - name: Trigger a release note
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages/**/.turbo
 cypress/videos/*
 cypress/screenshots/*
 *.swp
+CHANGELOG-*.md


### PR DESCRIPTION
From my fork:
* [CI job that created the PR](https://github.com/netroy/n8n/actions/runs/5390609398)
* [PR that got created](https://github.com/netroy/n8n/pull/38)
* [Release CI job](https://github.com/netroy/n8n/actions/runs/5390634187)
* [Github release created by the CI](https://github.com/netroy/n8n/releases/tag/n8n%401.0.0) 