### PR TITLE
fix(workflowExecute): support pinning data for nodes with multiple outputs

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -943,8 +943,10 @@ export class WorkflowExecute {
 
 							if (pinData && !executionNode.disabled && pinData[executionNode.name] !== undefined) {
 								const nodePinData = pinData[executionNode.name];
-
-								nodeSuccessData = [nodePinData]; // always zeroth runIndex
+								nodeSuccessData = [];
+								for (const pinnedData of nodePinData) {
+									nodeSuccessData.push([pinnedData]);
+								}
 							} else {
 								Logger.debug(`Running node "${executionNode.name}" started`, {
 									node: executionNode.name,


### PR DESCRIPTION
The execution logic lacks a way to support pinning data for nodes with multiple outputs and forces pinned result data to have one element only. This commit fixes that so that n8n at least honors the pinned data length. Work will have to be conducted further to allow it from the UI as well.

