### PR TITLE
fix: Restore expression completions

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/utils.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/utils.ts
@@ -98,11 +98,21 @@ export const isAllowedInDotNotation = (str: string) => {
 // ----------------------------------
 
 export function receivesNoBinaryData() {
-	return resolveParameter('={{ $binary }}')?.data === undefined;
+	try {
+		return resolveParameter('={{ $binary }}')?.data === undefined;
+	} catch {
+		return true;
+	}
 }
 
 export function hasNoParams(toResolve: string) {
-	const params = resolveParameter(`={{ ${toResolve}.params }}`);
+	let params;
+
+	try {
+		params = resolveParameter(`={{ ${toResolve}.params }}`);
+	} catch {
+		return true;
+	}
 
 	if (!params) return true;
 


### PR DESCRIPTION
Expression completions do not work on v1.0 because we are now [surfacing all expression errors](https://github.com/n8n-io/n8n/blob/b8458a53f66b79903f0fdb168f6febdefb36d13a/packages/workflow/src/Expression.ts#L328). This PR ensures expression completions utils that evaluate expressions do not throw when receiving unresolvable inputs.