### PR TITLE
fix(core): Route `/rest/workflows/new` correctly (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflows.controller.ee.ts
+++ b/packages/cli/src/workflows/workflows.controller.ee.ts
@@ -87,6 +87,7 @@ EEWorkflowController.put(
 
 EEWorkflowController.get(
 	'/:id(\\w+)',
+	(req, res, next) => (req.params.id === 'new' ? next('router') : next()), // skip ee router and use free one for naming
 	ResponseHelper.send(async (req: WorkflowRequest.Get) => {
 		const { id: workflowId } = req.params;
 

--- a/packages/cli/test/integration/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows.controller.ee.test.ts
@@ -196,6 +196,23 @@ describe('GET /workflows', () => {
 	});
 });
 
+describe('GET /workflows/new', () => {
+	[true, false].forEach((sharingEnabled) => {
+		test(`should return an auto-incremented name, even when sharing is ${
+			sharingEnabled ? 'enabled' : 'disabled'
+		}`, async () => {
+			sharingSpy.mockReturnValueOnce(sharingEnabled);
+
+			await createWorkflow({ name: 'My workflow' }, owner);
+			await createWorkflow({ name: 'My workflow 7' }, owner);
+
+			const response = await authOwnerAgent.get('/workflows/new');
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.name).toEqual('My workflow 8');
+		});
+	});
+});
+
 describe('GET /workflows/:id', () => {
 	test('GET should fail with invalid id due to route rule', async () => {
 		const response = await authOwnerAgent.get('/workflows/potatoes');


### PR DESCRIPTION
PAY-590