### PR TITLE
feat(Slack Node): Add option to include link to workflow in Slack node

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -1179,6 +1179,7 @@ export async function getBase(
 		executeWorkflow,
 		restApiUrl: urlBaseWebhook + config.getEnv('endpoints.rest'),
 		timezone,
+		instanceBaseUrl: urlBaseWebhook,
 		webhookBaseUrl,
 		webhookWaitingBaseUrl,
 		webhookTestBaseUrl,

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2160,6 +2160,7 @@ const getCommonWorkflowFunctions = (
 	getWorkflowStaticData: (type) => workflow.getStaticData(type, node),
 
 	getRestApiUrl: () => additionalData.restApiUrl,
+	getInstanceBaseUrl: () => additionalData.instanceBaseUrl,
 	getTimezone: () => getTimezone(workflow, additionalData),
 });
 

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -800,6 +800,7 @@ export default defineComponent({
 
 				this.updateNodeParameterIssues(node, nodeType);
 				this.updateNodeCredentialIssues(node);
+				this.$telemetry.trackNodeParametersValuesChange(nodeType.name, parameterData);
 			} else {
 				// A property on the node itself changed
 

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -2,11 +2,12 @@ import type _Vue from 'vue';
 import type { ITelemetrySettings, ITelemetryTrackProperties, IDataObject } from 'n8n-workflow';
 import type { Route } from 'vue-router';
 
-import type { INodeCreateElement } from '@/Interface';
+import type { INodeCreateElement, IUpdateInformation } from '@/Interface';
 import type { IUserNodesPanelSession } from './telemetry.types';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useRootStore } from '@/stores/n8nRoot.store';
 import { useTelemetryStore } from '@/stores/telemetry.store';
+import { SLACK_NODE_TYPE } from '@/constants';
 
 export class Telemetry {
 	private pageEventQueue: Array<{ route: Route }>;
@@ -191,6 +192,23 @@ export class Telemetry {
 				case 'nodeView.addSticky':
 					this.track('User inserted workflow note', properties);
 					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	// We currently do not support tracking directly from within node implementation
+	// so we are using this method as centralized way to track node parameters changes
+	trackNodeParametersValuesChange(nodeType: string, change: IUpdateInformation) {
+		if (this.rudderStack) {
+			switch (nodeType) {
+				case SLACK_NODE_TYPE:
+					if (change.name === 'parameters.includeLinkToWorkflow') {
+						this.track('User toggled n8n reference option');
+					}
+					break;
+
 				default:
 					break;
 			}

--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -14,12 +14,13 @@ export class Slack extends VersionedNodeType {
 			group: ['output'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume Slack API',
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new SlackV1(baseDescription),
 			2: new SlackV2(baseDescription),
+			2.1: new SlackV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -134,7 +134,11 @@ export function getMessageContent(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	i: number,
 ) {
-	const { includeLinkToWorkflow } = this.getNodeParameter('otherOptions', i) as IDataObject;
+	const includeLinkToWorkflow = this.getNodeParameter(
+		'otherOptions.includeLinkToWorkflow',
+		i,
+		true,
+	) as IDataObject;
 
 	const { id } = this.getWorkflow();
 	const automatedMessage = `_Automated with this <${this.getInstanceBaseUrl()}workflow/${id}|n8n workflow>_`;

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -134,10 +134,12 @@ export function getMessageContent(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	i: number,
 ) {
+	const nodeVersion = this.getNode().typeVersion;
+
 	const includeLinkToWorkflow = this.getNodeParameter(
 		'otherOptions.includeLinkToWorkflow',
 		i,
-		true,
+		nodeVersion >= 2.1 ? true : false,
 	) as IDataObject;
 
 	const { id } = this.getWorkflow();

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -136,7 +136,7 @@ export function getMessageContent(
 ) {
 	const includeLinToWorkflow = this.getNodeParameter('includeLinkToWorkflow', i) as boolean;
 	const { id } = this.getWorkflow();
-	const automatedMessage = `_Automated with this <${process.env.N8N_EDITOR_BASE_URL}/workflow/${id}|n8n workflow>_`;
+	const automatedMessage = `_Automated with this <${this.getInstanceBaseUrl()}workflow/${id}|n8n workflow>_`;
 	const messageType = this.getNodeParameter('messageType', i) as string;
 
 	let content: IDataObject = {};

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -134,7 +134,8 @@ export function getMessageContent(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	i: number,
 ) {
-	const includeLinToWorkflow = this.getNodeParameter('includeLinkToWorkflow', i) as boolean;
+	const { includeLinkToWorkflow } = this.getNodeParameter('otherOptions', i) as IDataObject;
+
 	const { id } = this.getWorkflow();
 	const automatedMessage = `_Automated with this <${this.getInstanceBaseUrl()}workflow/${id}|n8n workflow>_`;
 	const messageType = this.getNodeParameter('messageType', i) as string;
@@ -144,13 +145,13 @@ export function getMessageContent(
 	switch (messageType) {
 		case 'text':
 			content = {
-				text: includeLinToWorkflow ? `${text}\n${automatedMessage}` : text,
+				text: includeLinkToWorkflow ? `${text}\n${automatedMessage}` : text,
 			};
 			break;
 		case 'block':
 			content = jsonParse(this.getNodeParameter('blocksUi', i) as string);
 
-			if (includeLinToWorkflow && Array.isArray(content.blocks)) {
+			if (includeLinkToWorkflow && Array.isArray(content.blocks)) {
 				content.blocks.push({
 					type: 'section',
 					text: {
@@ -165,7 +166,7 @@ export function getMessageContent(
 			break;
 		case 'attachment':
 			content = { attachments: this.getNodeParameter('attachments', i) } as IDataObject;
-			if (includeLinToWorkflow && Array.isArray(content.attachments)) {
+			if (includeLinkToWorkflow && Array.isArray(content.attachments)) {
 				content.attachments.push({
 					text: automatedMessage,
 				});

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -7,7 +7,7 @@ import type {
 	IOAuth2Options,
 } from 'n8n-workflow';
 
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, jsonParse } from 'n8n-workflow';
 
 import get from 'lodash/get';
 
@@ -128,6 +128,57 @@ export async function slackApiRequestAllItems(
 			responseData[propertyName].paging.page < responseData[propertyName].paging.pages)
 	);
 	return returnData;
+}
+
+export function getMessageContent(
+	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
+	i: number,
+) {
+	const includeLinToWorkflow = this.getNodeParameter('includeLinkToWorkflow', i) as boolean;
+	const { id } = this.getWorkflow();
+	const automatedMessage = `_Automated with this <${process.env.N8N_EDITOR_BASE_URL}/workflow/${id}|n8n workflow>_`;
+	const messageType = this.getNodeParameter('messageType', i) as string;
+
+	let content: IDataObject = {};
+	const text = this.getNodeParameter('text', i, '') as string;
+	switch (messageType) {
+		case 'text':
+			content = {
+				text: includeLinToWorkflow ? `${text}\n${automatedMessage}` : text,
+			};
+			break;
+		case 'block':
+			content = jsonParse(this.getNodeParameter('blocksUi', i) as string);
+
+			if (includeLinToWorkflow && Array.isArray(content.blocks)) {
+				content.blocks.push({
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: automatedMessage,
+					},
+				});
+			}
+			if (text) {
+				content.text = text;
+			}
+			break;
+		case 'attachment':
+			content = { attachments: this.getNodeParameter('attachments', i) } as IDataObject;
+			if (includeLinToWorkflow && Array.isArray(content.attachments)) {
+				content.attachments.push({
+					text: automatedMessage,
+				});
+			}
+			break;
+		default:
+			throw new NodeOperationError(
+				this.getNode(),
+				`The message type "${messageType}" is not known!`,
+			);
+	}
+
+	return content;
 }
 
 // tslint:disable-next-line:no-any

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -347,6 +347,20 @@ export const messageFields: INodeProperties[] = [
 			'Fallback text to display in slack notifications. Supports <a href="https://api.slack.com/reference/surfaces/formatting">markdown</a> by default - this can be disabled in "Options".',
 	},
 	{
+		displayName: 'Include Link To Workflow',
+		name: 'includeLinkToWorkflow',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: ['post'],
+				resource: ['message'],
+			},
+		},
+		default: true,
+		description:
+			'Whether to append a link to this workflow at the end of the message. This is helpful if you have many workflows sending Slack messages.',
+	},
+	{
 		displayName: 'This is a legacy Slack feature. Slack advises to instead use Blocks.',
 		name: 'noticeAttachments',
 		type: 'notice',

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -553,9 +553,7 @@ export const messageFields: INodeProperties[] = [
 				resource: ['message'],
 			},
 		},
-		default: {
-			includeLinkToWorkflow: true,
-		},
+		default: {},
 		description: 'Other options to set',
 		placeholder: 'Add options',
 		options: [

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -347,20 +347,6 @@ export const messageFields: INodeProperties[] = [
 			'Fallback text to display in slack notifications. Supports <a href="https://api.slack.com/reference/surfaces/formatting">markdown</a> by default - this can be disabled in "Options".',
 	},
 	{
-		displayName: 'Include Link To Workflow',
-		name: 'includeLinkToWorkflow',
-		type: 'boolean',
-		displayOptions: {
-			show: {
-				operation: ['post'],
-				resource: ['message'],
-			},
-		},
-		default: true,
-		description:
-			'Whether to append a link to this workflow at the end of the message. This is helpful if you have many workflows sending Slack messages.',
-	},
-	{
 		displayName: 'This is a legacy Slack feature. Slack advises to instead use Blocks.',
 		name: 'noticeAttachments',
 		type: 'notice',
@@ -567,10 +553,20 @@ export const messageFields: INodeProperties[] = [
 				resource: ['message'],
 			},
 		},
-		default: {},
+		default: {
+			includeLinkToWorkflow: true,
+		},
 		description: 'Other options to set',
 		placeholder: 'Add options',
 		options: [
+			{
+				displayName: 'Include Link To Workflow',
+				name: 'includeLinkToWorkflow',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to append a link to this workflow at the end of the message. This is helpful if you have many workflows sending Slack messages.',
+			},
 			{
 				displayName: 'Custom Bot Profile Photo',
 				name: 'botProfile',

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -24,7 +24,12 @@ import { fileFields, fileOperations } from './FileDescription';
 import { reactionFields, reactionOperations } from './ReactionDescription';
 import { userGroupFields, userGroupOperations } from './UserGroupDescription';
 import { userFields, userOperations } from './UserDescription';
-import { slackApiRequest, slackApiRequestAllItems, validateJSON } from './GenericFunctions';
+import {
+	slackApiRequest,
+	slackApiRequestAllItems,
+	validateJSON,
+	getMessageContent,
+} from './GenericFunctions';
 
 import moment from 'moment';
 
@@ -747,7 +752,6 @@ export class SlackV2 implements INodeType {
 					//https://api.slack.com/methods/chat.postMessage
 					if (operation === 'post') {
 						const select = this.getNodeParameter('select', i) as string;
-						const messageType = this.getNodeParameter('messageType', i) as string;
 						let target =
 							select === 'channel'
 								? (this.getNodeParameter('channelId', i, undefined, {
@@ -764,27 +768,8 @@ export class SlackV2 implements INodeType {
 							target = target.slice(0, 1) === '@' ? target : `@${target}`;
 						}
 						const { sendAsUser } = this.getNodeParameter('otherOptions', i) as IDataObject;
-						let content: IDataObject = {};
-						const text = this.getNodeParameter('text', i, '') as string;
-						switch (messageType) {
-							case 'text':
-								content = { text };
-								break;
-							case 'block':
-								content = JSON.parse(this.getNodeParameter('blocksUi', i) as string);
-								if (text) {
-									content.text = text;
-								}
-								break;
-							case 'attachment':
-								content = { attachments: this.getNodeParameter('attachments', i) } as IDataObject;
-								break;
-							default:
-								throw new NodeOperationError(
-									this.getNode(),
-									`The message type "${messageType}" is not known!`,
-								);
-						}
+						const content = getMessageContent.call(this, i);
+
 						const body: IDataObject = {
 							channel: target,
 							...content,

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -39,7 +39,7 @@ export class SlackV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: 2,
+			version: [2, 2.1],
 			defaults: {
 				name: 'Slack',
 			},

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -729,6 +729,7 @@ export interface FunctionsBase {
 	getWorkflowStaticData(type: string): IDataObject;
 	getTimezone(): string;
 	getRestApiUrl(): string;
+	getInstanceBaseUrl(): string;
 
 	getMode?: () => WorkflowExecuteMode;
 	getActivationMode?: () => WorkflowActivateMode;
@@ -1735,6 +1736,7 @@ export interface IWorkflowExecuteAdditionalData {
 	httpResponse?: express.Response;
 	httpRequest?: express.Request;
 	restApiUrl: string;
+	instanceBaseUrl: string;
 	setExecutionStatus?: (status: ExecutionStatus) => void;
 	sendMessageToUI?: (source: string, message: any) => void;
 	timezone: string;


### PR DESCRIPTION
This PR introduces a feature enhancement to the Slack node, specifically for the post:message operation. It adds a new toggle-switch labeled "Include Link To Workflow," which, when enabled, appends an "Automated with this n8n workflow" message with a link to the workflow at the end of the Slack message. This addition aims to provide an informative tag to messages, allowing recipients to access and understand the automation's origin.

Currently, the Slack node in n8n supports three distinct message formats:

1. Simple text
2. Blocks
3. Attachments
The implementation ensures that the appended workflow link is compatible with all the above message formats by appropriately injecting the message into the content payload.

For generating the workflow URL, the node requires access to the instance's base URL. This is achieved by passing the instance base URL to the node context using the `getInstanceBaseUrl` method.

We also want to track when a user toggles this switch. Since tracking is not natively supported in nodes, I've implemented it in editor-ui. 

<img width="521" alt="CleanShot 2023-07-06 at 14 25 23@2x" src="https://github.com/n8n-io/n8n/assets/12657221/59780003-76a8-42c8-bc5d-81abb571c8b5">
