### PR TITLE
refactor(core): Load `cookieParser` middleware only once (no-changelog)

### DIFF
--- a/packages/cli/src/middlewares/auth.ts
+++ b/packages/cli/src/middlewares/auth.ts
@@ -1,6 +1,5 @@
 import type { Application, NextFunction, Request, RequestHandler, Response } from 'express';
 import jwt from 'jsonwebtoken';
-import cookieParser from 'cookie-parser';
 import passport from 'passport';
 import { Strategy } from 'passport-jwt';
 import { sync as globSync } from 'fast-glob';
@@ -78,8 +77,6 @@ export const setupAuthMiddlewares = (
 	ignoredEndpoints: Readonly<string[]>,
 	restEndpoint: string,
 ) => {
-	// needed for testing; not adding overhead since it directly returns if req.cookies exists
-	app.use(cookieParser());
 	app.use(userManagementJwtAuth());
 
 	app.use(async (req: Request, res: Response, next: NextFunction) => {

--- a/packages/cli/test/integration/shared/utils.ts
+++ b/packages/cli/test/integration/shared/utils.ts
@@ -2,6 +2,7 @@ import { Container } from 'typedi';
 import { randomBytes } from 'crypto';
 import { existsSync } from 'fs';
 
+import cookieParser from 'cookie-parser';
 import bodyParser from 'body-parser';
 import { CronJob } from 'cron';
 import express from 'express';
@@ -121,6 +122,7 @@ export async function initTestServer({
 
 	testServer.app.use(bodyParser.json());
 	testServer.app.use(bodyParser.urlencoded({ extended: true }));
+	testServer.app.use(cookieParser());
 
 	config.set('userManagement.jwtSecret', 'My JWT secret');
 	config.set('userManagement.isInstanceOwnerSetUp', false);


### PR DESCRIPTION
[Server.ts already explicitly loads `cookieParser`](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/Server.ts#L571)

