### PR TITLE
fix(core): Fix credentials lazy-loading (no-changelog)

### DIFF
--- a/packages/cli/src/CredentialTypes.ts
+++ b/packages/cli/src/CredentialTypes.ts
@@ -26,16 +26,13 @@ export class CredentialTypes implements ICredentialTypes {
 	 * Returns all parent types of the given credential type
 	 */
 	getParentTypes(typeName: string): string[] {
-		const credentialType = this.getByName(typeName);
-		if (credentialType?.extends === undefined) return [];
-
-		const types: string[] = [];
-		credentialType.extends.forEach((type: string) => {
-			types.push(type);
-			types.push(...this.getParentTypes(type));
-		});
-
-		return types;
+		const extendsArr = this.knownCredentials[typeName]?.extends ?? [];
+		if (extendsArr.length) {
+			extendsArr.forEach((type) => {
+				extendsArr.push(...this.getParentTypes(type));
+			});
+		}
+		return extendsArr;
 	}
 
 	private getCredential(type: string): LoadedClass<ICredentialType> {

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -357,11 +357,17 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 				}
 
 				for (const type in known.credentials) {
-					const { className, sourcePath, nodesToTestWith } = known.credentials[type];
+					const {
+						className,
+						sourcePath,
+						nodesToTestWith,
+						extends: extendsArr,
+					} = known.credentials[type];
 					this.known.credentials[type] = {
 						className,
 						sourcePath: path.join(directory, sourcePath),
 						nodesToTestWith: nodesToTestWith?.map((nodeName) => `${packageName}.${nodeName}`),
+						extends: extendsArr,
 					};
 				}
 			}

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -331,7 +331,7 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 
 		for (const loader of Object.values(this.loaders)) {
 			// list of node & credential types that will be sent to the frontend
-			const { types, directory } = loader;
+			const { known, types, directory } = loader;
 			this.types.nodes = this.types.nodes.concat(types.nodes);
 			this.types.credentials = this.types.credentials.concat(types.credentials);
 
@@ -344,32 +344,30 @@ export class LoadNodesAndCredentials implements INodesAndCredentials {
 				this.loaded.credentials[credentialTypeName] = loader.credentialTypes[credentialTypeName];
 			}
 
-			// Nodes and credentials that will be lazy loaded
-			if (loader instanceof PackageDirectoryLoader) {
-				const { packageName, known } = loader;
+			for (const type in known.nodes) {
+				const { className, sourcePath } = known.nodes[type];
+				this.known.nodes[type] = {
+					className,
+					sourcePath: path.join(directory, sourcePath),
+				};
+			}
 
-				for (const type in known.nodes) {
-					const { className, sourcePath } = known.nodes[type];
-					this.known.nodes[type] = {
-						className,
-						sourcePath: path.join(directory, sourcePath),
-					};
-				}
-
-				for (const type in known.credentials) {
-					const {
-						className,
-						sourcePath,
-						nodesToTestWith,
-						extends: extendsArr,
-					} = known.credentials[type];
-					this.known.credentials[type] = {
-						className,
-						sourcePath: path.join(directory, sourcePath),
-						nodesToTestWith: nodesToTestWith?.map((nodeName) => `${packageName}.${nodeName}`),
-						extends: extendsArr,
-					};
-				}
+			for (const type in known.credentials) {
+				const {
+					className,
+					sourcePath,
+					nodesToTestWith,
+					extends: extendsArr,
+				} = known.credentials[type];
+				this.known.credentials[type] = {
+					className,
+					sourcePath: path.join(directory, sourcePath),
+					nodesToTestWith:
+						loader instanceof PackageDirectoryLoader
+							? nodesToTestWith?.map((nodeName) => `${loader.packageName}.${nodeName}`)
+							: undefined,
+					extends: extendsArr,
+				};
 			}
 		}
 	}

--- a/packages/core/bin/generate-known
+++ b/packages/core/bin/generate-known
@@ -38,6 +38,10 @@ const generate = async (kind) => {
 				else obj[name] = { className, sourcePath };
 			}
 
+			if (kind === 'credentials' && Array.isArray(instance.extends)) {
+				obj[name].extends = instance.extends;
+			}
+
 			if (kind === 'nodes') {
 				const { credentials } = instance.description;
 				if (credentials && credentials.length) {
@@ -53,6 +57,7 @@ const generate = async (kind) => {
 			}
 			return obj;
 		}, {});
+
 	LoggerProxy.info(`Detected ${Object.keys(data).length} ${kind}`);
 	await writeJSON(`known/${kind}.json`, data);
 	return data;

--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -167,6 +167,7 @@ export abstract class DirectoryLoader {
 		this.known.credentials[tempCredential.name] = {
 			className: credentialName,
 			sourcePath: filePath,
+			extends: tempCredential.extends,
 		};
 
 		this.credentialTypes[tempCredential.name] = {

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1567,6 +1567,7 @@ export type LoadingDetails = {
 
 export type CredentialLoadingDetails = LoadingDetails & {
 	nodesToTestWith?: string[];
+	extends?: string[];
 };
 
 export type NodeLoadingDetails = LoadingDetails;
@@ -1981,11 +1982,11 @@ export interface IExecutionsSummary {
 	lastNodeExecuted?: string;
 	executionError?: ExecutionError;
 	nodeExecutionStatus?: {
-		[key: string]: IExceutionSummaryNodeExecutionResult;
+		[key: string]: IExecutionSummaryNodeExecutionResult;
 	};
 }
 
-export interface IExceutionSummaryNodeExecutionResult {
+export interface IExecutionSummaryNodeExecutionResult {
 	executionStatus: ExecutionStatus;
 	errors?: Array<{
 		name?: string;


### PR DESCRIPTION
This reduces the amount of garbage generated at startup between 5 and 20%, hence improving the startup timing/performance a tiny bit.