### PR TITLE
Add running executions to the public API

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -8,7 +8,6 @@ import {
 	deleteExecution,
 	getExecutionsCount,
 } from './executions.service';
-import { ActiveExecutions } from '@/ActiveExecutions';
 import { authorize, validCursor } from '../../shared/middlewares/global.middleware';
 import type { ExecutionRequest } from '../../../types';
 import { getSharedWorkflowIds } from '../workflows/workflows.service';
@@ -95,18 +94,12 @@ export = {
 				return res.status(200).json({ data: [], nextCursor: null });
 			}
 
-			// get running workflows so we exclude them from the result
-			const runningExecutionsIds = Container.get(ActiveExecutions)
-				.getActiveExecutions()
-				.map(({ id }) => id);
-
 			const filters = {
 				status,
 				limit,
 				lastId,
 				includeData,
 				workflowIds: workflowId ? [workflowId] : sharedWorkflowsIds,
-				excludedExecutionsIds: runningExecutionsIds,
 			};
 
 			const executions = await getExecutions(filters);

--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.service.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.service.ts
@@ -10,12 +10,10 @@ import { ExecutionRepository } from '@/databases/repositories';
 function getStatusCondition(status: ExecutionStatus) {
 	const condition: Pick<FindOptionsWhere<IExecutionFlattedDb>, 'status'> = {};
 
-	if (status === 'success') {
-		condition.status = 'success';
-	} else if (status === 'waiting') {
-		condition.status = 'waiting';
-	} else if (status === 'error') {
+	if (status === 'error') {
 		condition.status = In(['error', 'crashed', 'failed']);
+	} else {
+		condition.status = status;
 	}
 
 	return condition;

--- a/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.yml
@@ -13,7 +13,7 @@ get:
       required: false
       schema:
         type: string
-        enum: ['error', 'success', 'waiting']
+        enum: ['canceled', 'crashed', 'error', 'failed', 'new', 'running', 'success', 'unknown', 'waiting']
     - name: workflowId
       in: query
       description: Workflow to filter the executions by.


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
Allow accessing running executions from `/executions`.
To make this useful, I've also expanded the number of filters available in the api call.

See here:
https://community.n8n.io/t/expand-executions-filters-in-public-api/27588

**This is a more limited version of https://github.com/n8n-io/n8n/pull/6621. No need to merge if the other one is accepted.**

