### PR TITLE
ci: Upgrade `tough-cookie` to address CVE-2023-26136 (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
       "http-cache-semantics": "4.1.1",
       "jsonwebtoken": "9.0.0",
       "prettier": "^2.8.3",
+      "tough-cookie": "^4.1.3",
       "tslib": "^2.5.0",
       "ts-node": "^10.9.1",
       "typescript": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   http-cache-semantics: 4.1.1
   jsonwebtoken: 9.0.0
   prettier: ^2.8.3
+  tough-cookie: ^4.1.3
   tslib: ^2.5.0
   ts-node: ^10.9.1
   typescript: ^5.1.3
@@ -1493,7 +1494,7 @@ packages:
       form-data: 4.0.0
       node-fetch: 2.6.8
       process: 0.11.10
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       tslib: 2.5.0
       tunnel: 0.0.6
       uuid: 8.3.2
@@ -4191,7 +4192,7 @@ packages:
       performance-now: 2.1.0
       qs: 6.5.3
       safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
+      tough-cookie: 4.1.3
       tunnel-agent: 0.6.0
       uuid: 8.3.2
     dev: true
@@ -15490,7 +15491,7 @@ packages:
       parse5: 7.1.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       w3c-xmlserializer: 3.0.0
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
@@ -15531,7 +15532,7 @@ packages:
       parse5: 7.1.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       w3c-xmlserializer: 4.0.0
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
@@ -19214,7 +19215,7 @@ packages:
       performance-now: 2.1.0
       qs: 6.5.3
       safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
+      tough-cookie: 4.1.3
       tunnel-agent: 0.6.0
       uuid: 3.4.0
     dev: false
@@ -21010,15 +21011,8 @@ packages:
       nopt: 1.0.10
     dev: true
 
-  /tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.2.0
-
-  /tough-cookie@4.1.2:
-    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0


### PR DESCRIPTION
[GH Advisory](https://github.com/advisories/GHSA-72xf-g2v4-qvf3)