### PR TITLE
feat(Telegram Node): Add possibility to send message to forum topic

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1635,6 +1635,31 @@ export class Telegram implements INodeType {
 							'Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.',
 					},
 					{
+						displayName: 'Topic ID',
+						name: 'message_thread_id',
+						type: 'number',
+						default: 0,
+						displayOptions: {
+							show: {
+								operation: [
+									'sendAnimation',
+									'sendAudio',
+									'sendChatAction',
+									'sendDocument',
+									'sendLocation',
+									'sendMessage',
+									'sendMediaGroup',
+									'sendPhoto',
+									'sendSticker',
+									'sendVideo',
+								],
+								resource: ['message'],
+							},
+						},
+						description:
+							'Unique identifier for the target Topic of the target Chat. It comes as "message_thread_id".',
+					},
+					{
 						displayName: 'Width',
 						name: 'width',
 						type: 'number',


### PR DESCRIPTION
Telegram added the ability to [topics within groups](https://telegram.org/blog/topics-in-groups-collectible-usernames/es?ln=a#topics-in-groups).

More technical information can be found at [this link](https://core.telegram.org/bots/api#forumtopic),
  and finally, the main parameter to add to the `sendMessage` method is `message_thread_id`, according to the [API documentation](https://core.telegram.org/bots/api#sendmessage).

This PR differs from the already proposed https://github.com/n8n-io/n8n/pull/5746/ in that:
-  The Topic ID field is an **Additional field**. 
-  It also includes `sendChatAction` within the list of operations.
-  And suggests clearer descriptions.
