### PR TITLE
refactor: Remove outdated publicly accessible warning (no-changelog)

### DIFF
--- a/packages/cli/src/audit/constants.ts
+++ b/packages/cli/src/audit/constants.ts
@@ -116,6 +116,4 @@ export const DB_QUERY_PARAMS_DOCS_URL =
 
 export const COMMUNITY_NODES_RISKS_URL = 'https://docs.n8n.io/integrations/community-nodes/risks';
 
-export const SELF_HOSTED_AUTH_DOCS_URL = 'https://docs.n8n.io/hosting/authentication';
-
 export const NPM_PACKAGE_URL = 'https://www.npmjs.com/package';

--- a/packages/cli/src/audit/risks/instance.risk.ts
+++ b/packages/cli/src/audit/risks/instance.risk.ts
@@ -4,7 +4,6 @@ import config from '@/config';
 import { toFlaggedNode } from '@/audit/utils';
 import { separate } from '@/utils';
 import {
-	SELF_HOSTED_AUTH_DOCS_URL,
 	ENV_VARS_DOCS_URL,
 	INSTANCE_REPORT,
 	WEBHOOK_NODE_TYPE,
@@ -39,6 +38,8 @@ function getSecuritySettings() {
 	settings.telemetry = {
 		diagnosticsEnabled: config.getEnv('diagnostics.enabled'),
 	};
+
+	console.log('settings', settings);
 
 	return settings;
 }
@@ -193,12 +194,7 @@ export async function reportInstanceRisk(workflows: WorkflowEntity[]) {
 		report.sections.push({
 			title: INSTANCE_REPORT.SECTIONS.SECURITY_SETTINGS,
 			description: 'This n8n instance has the following security settings.',
-			recommendation: securitySettings.publiclyAccessibleInstance
-				? [
-						'Important! Your n8n instance is publicly accessible. Set up user management or basic/JWT auth to protect access to your n8n instance.'.toUpperCase(),
-						`See: ${SELF_HOSTED_AUTH_DOCS_URL}`,
-				  ].join(' ')
-				: `Consider adjusting the security settings for your n8n instance based on your needs. See: ${ENV_VARS_DOCS_URL}`,
+			recommendation: `Consider adjusting the security settings for your n8n instance based on your needs. See: ${ENV_VARS_DOCS_URL}`,
 			settings: securitySettings,
 		});
 	}

--- a/packages/cli/src/audit/risks/instance.risk.ts
+++ b/packages/cli/src/audit/risks/instance.risk.ts
@@ -39,8 +39,6 @@ function getSecuritySettings() {
 		diagnosticsEnabled: config.getEnv('diagnostics.enabled'),
 	};
 
-	console.log('settings', settings);
-
 	return settings;
 }
 


### PR DESCRIPTION
As of https://github.com/n8n-io/n8n/pull/6362, the instance can no longer be publicly accessible.