### PR TITLE
fix(core): Handle all uncaught exception, not just the ones from Axios

### DIFF
--- a/packages/cli/src/ErrorReporting.ts
+++ b/packages/cli/src/ErrorReporting.ts
@@ -46,7 +46,6 @@ export const initErrorHandling = async () => {
 
 	process.on('uncaughtException', (error) => {
 		ErrorReporterProxy.error(error);
-		if (error.constructor?.name !== 'AxiosError') throw error;
 	});
 
 	ErrorReporterProxy.init({


### PR DESCRIPTION
We added uncaught exception handling [here](https://github.com/n8n-io/n8n/pull/4947/files#diff-d276b73a02e0d6ab2b478509c0190acd6d5a1081a86b93ac969a9e1cbed17f9dR36), and at the time decided to re-throw non-axios errors. But this is causing instances to crash. So, we stop re-throwing these errors, and see if it causes any trouble.