### PR TITLE
fix: Strip credentials from templates so it doesnt prevent saving new workflows

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -866,6 +866,12 @@ export default defineComponent({
 
 			data.workflow.nodes = NodeViewUtils.getFixedNodesList(data.workflow.nodes) as INodeUi[];
 
+			data.workflow.nodes?.forEach((node) => {
+				if (node.credentials) {
+					delete node.credentials;
+				}
+			});
+
 			this.blankRedirect = true;
 			void this.$router.replace({ name: VIEWS.NEW_WORKFLOW, query: { templateId } });
 


### PR DESCRIPTION
This should only happen when loading a workflow from a template and trying to save it. What happens is that nodes in the workflow can contain references to a credential ID that does not exist or is not shared with a user, causing it to not work.

Since it's a template, the credential ID, in normal situations, will not exist nor match. We should remove this before loading the workflow in the canvas.

Github issue / Community forum post (link here to close automatically):
