### PR TITLE
fix(core): Filter out workflows that failed to activate on startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,7 @@
 			"name": "Launch n8n with debug",
 			"program": "${workspaceFolder}/packages/cli/bin/n8n",
 			"cwd": "${workspaceFolder}/packages/cli/bin",
+			// "args": ["start", "--tunnel"],
 			"request": "launch",
 			"skipFiles": ["<node_internals>/**"],
 			"type": "node",


### PR DESCRIPTION
To test manually:
1. Set up workflow 1 with a trigger with an invalid cred.
2. Set up workflow 2 with an error trigger. Set this workflow to save executions.
3. Set workflow 1 to have workflow 2 as error workflow.
4. In DB edit `workflow_entity.active` for workflow 1 to `true`
5. Run `packages/cli/bin/n8n start --tunnel`

Expected:
- ~Workflow 1 should be deactivated and displayed as inactive on canvas.~ Workflow 1 should be shown with red activator on canvas.
- Workflow 1 should not keep retrying to activate.
- Workflow 2 should have executed.