### PR TITLE
fix(editor): Ensure default credential values are not detected as dirty state

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -670,7 +670,7 @@ export default defineComponent({
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		onDataChange({ name, value }: { name: string; value: any }) {
-			// disregard default value being set on component mount
+			// skip update if new value matches the current
 			if (this.credentialData[name] === value) return;
 
 			this.hasUnsavedChanges = true;

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -727,7 +727,6 @@ export default defineComponent({
 		},
 
 		async retestCredential() {
-			console.log('[retestCredential]');
 			if (!this.isCredentialTestable) {
 				this.authError = '';
 				this.testedSuccessfully = false;
@@ -754,7 +753,6 @@ export default defineComponent({
 		},
 
 		async testCredential(credentialDetails: ICredentialsDecrypted) {
-			console.log('[testCredential]');
 			const result = await this.credentialsStore.testCredential(credentialDetails);
 			if (result.status === 'Error') {
 				this.authError = result.message;

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -670,6 +670,9 @@ export default defineComponent({
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		onDataChange({ name, value }: { name: string; value: any }) {
+			// disregard default value being set on component mount
+			if (this.credentialData[name] === value) return;
+
 			this.hasUnsavedChanges = true;
 
 			const { oauthTokenData, ...credData } = this.credentialData;
@@ -724,6 +727,7 @@ export default defineComponent({
 		},
 
 		async retestCredential() {
+			console.log('[retestCredential]');
 			if (!this.isCredentialTestable) {
 				this.authError = '';
 				this.testedSuccessfully = false;
@@ -750,6 +754,7 @@ export default defineComponent({
 		},
 
 		async testCredential(credentialDetails: ICredentialsDecrypted) {
+			console.log('[testCredential]');
 			const result = await this.credentialsStore.testCredential(credentialDetails);
 			if (result.status === 'Error') {
 				this.authError = result.message;


### PR DESCRIPTION
To verify, go to the credential creation modal for a cred having default values (e.g. RabbitMQ) and close the modal. There should be no prompt asking about unsaved changes.