### PR TITLE
ci: Fix test workflows (no-changelog)

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -64,8 +64,7 @@ jobs:
         run: |
           cp n8n/assets/n8n-logo.png /tmp/n8n-logo.png
           cp n8n/assets/n8n-screenshot.png /tmp/n8n-screenshot.png
-          cp n8n/node_modules/pdf-parse/test/data/05-versions-space.pdf /tmp/05-versions-space.pdf
-          cp n8n/node_modules/pdf-parse/test/data/04-valid.pdf /tmp/04-valid.pdf
+          cp test-workflows/testData/pdfs/*.pdf /tmp/
         shell: bash
 
       - name: Run tests

--- a/packages/cli/src/commands/executeBatch.ts
+++ b/packages/cli/src/commands/executeBatch.ts
@@ -232,7 +232,12 @@ export class ExecuteBatch extends BaseCommand {
 		if (flags.ids !== undefined) {
 			if (fs.existsSync(flags.ids)) {
 				const contents = fs.readFileSync(flags.ids, { encoding: 'utf-8' });
-				ids.push(...contents.split(',').filter((id) => re.exec(id)));
+				ids.push(
+					...contents
+						.trimEnd()
+						.split(',')
+						.filter((id) => re.exec(id)),
+				);
 			} else {
 				const paramIds = flags.ids.split(',');
 				const matchedIds = paramIds.filter((id) => re.exec(id));
@@ -251,7 +256,12 @@ export class ExecuteBatch extends BaseCommand {
 		if (flags.skipList !== undefined) {
 			if (fs.existsSync(flags.skipList)) {
 				const contents = fs.readFileSync(flags.skipList, { encoding: 'utf-8' });
-				skipIds.push(...contents.split(',').filter((id) => re.exec(id)));
+				skipIds.push(
+					...contents
+						.trimEnd()
+						.split(',')
+						.filter((id) => re.exec(id)),
+				);
 			} else {
 				console.log('Skip list file not found. Exiting.');
 				return;


### PR DESCRIPTION
We removed `pdf-parse` in #6640, so we need to get these test PDF files from the `test-workflows` repo instead ([which has been updated to include these files](https://github.com/n8n-io/test-workflows/commit/0f6ef1c804e3f1e919b097bdf061ea9ea095b1e2))

