### PR TITLE
fix(Postgres Node): For select queries, empty result should not be replaced with `{"success":true}`

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
@@ -17,6 +17,7 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 	const credentials = await this.getCredentials('postgres');
 	const options = this.getNodeParameter('options', 0, {});
 	options.nodeVersion = this.getNode().typeVersion;
+	options.operation = operation;
 
 	const { db, pgp, sshClient } = await configurePostgres(credentials, options);
 

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -208,6 +208,7 @@ export function configureQueryRunner(
 ) {
 	return async (queries: QueryWithValues[], items: INodeExecutionData[], options: IDataObject) => {
 		let returnData: INodeExecutionData[] = [];
+		const emptyReturnData = options.operation === 'select' ? [] : [{ json: { success: true } }];
 
 		const queryBatching = (options.queryBatching as QueryMode) || 'single';
 
@@ -220,10 +221,7 @@ export function configureQueryRunner(
 						});
 					})
 					.flat();
-				returnData =
-					options.operation === 'select' || returnData.length
-						? returnData
-						: [{ json: { success: true } }];
+				returnData = returnData.length ? returnData : emptyReturnData;
 			} catch (err) {
 				const error = parsePostgresError(node, err, queries);
 				if (!continueOnFail) throw error;
@@ -250,11 +248,7 @@ export function configureQueryRunner(
 						);
 
 						const executionData = this.helpers.constructExecutionMetaData(
-							wrapData(
-								options.operation === 'select' || transactionResult.length
-									? transactionResult
-									: [{ success: true }],
-							),
+							wrapData(transactionResult.length ? transactionResult : emptyReturnData),
 							{ itemData: { item: i } },
 						);
 
@@ -281,11 +275,7 @@ export function configureQueryRunner(
 						);
 
 						const executionData = this.helpers.constructExecutionMetaData(
-							wrapData(
-								options.operation === 'select' || transactionResult.length
-									? transactionResult
-									: [{ success: true }],
-							),
+							wrapData(transactionResult.length ? transactionResult : emptyReturnData),
 							{ itemData: { item: i } },
 						);
 

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -220,7 +220,10 @@ export function configureQueryRunner(
 						});
 					})
 					.flat();
-				returnData = returnData.length ? returnData : [{ json: { success: true } }];
+				returnData =
+					options.operation === 'select' || returnData.length
+						? returnData
+						: [{ json: { success: true } }];
 			} catch (err) {
 				const error = parsePostgresError(node, err, queries);
 				if (!continueOnFail) throw error;
@@ -247,7 +250,11 @@ export function configureQueryRunner(
 						);
 
 						const executionData = this.helpers.constructExecutionMetaData(
-							wrapData(transactionResult.length ? transactionResult : [{ success: true }]),
+							wrapData(
+								options.operation === 'select' || transactionResult.length
+									? transactionResult
+									: [{ success: true }],
+							),
 							{ itemData: { item: i } },
 						);
 
@@ -274,7 +281,11 @@ export function configureQueryRunner(
 						);
 
 						const executionData = this.helpers.constructExecutionMetaData(
-							wrapData(transactionResult.length ? transactionResult : [{ success: true }]),
+							wrapData(
+								options.operation === 'select' || transactionResult.length
+									? transactionResult
+									: [{ success: true }],
+							),
 							{ itemData: { item: i } },
 						);
 


### PR DESCRIPTION
NODE-643