### PR TITLE
fix(core): Support redis cluster in queue mode

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -7,7 +7,7 @@ import bodyParser from 'body-parser';
 import bodyParserXml from 'body-parser-xml';
 import compression from 'compression';
 import parseUrl from 'parseurl';
-import type { RedisOptions } from 'ioredis';
+import type { Redis, Cluster, RedisOptions } from 'ioredis';
 
 import type { WebhookHttpMethod } from 'n8n-workflow';
 import { LoggerProxy as Logger } from 'n8n-workflow';
@@ -27,6 +27,7 @@ import { corsMiddleware } from '@/middlewares';
 import { TestWebhooks } from '@/TestWebhooks';
 import { WaitingWebhooks } from '@/WaitingWebhooks';
 import { WEBHOOK_METHODS } from '@/WebhookHelpers';
+import { getRedisClusterNodes } from './GenericHelpers';
 
 const emptyBuffer = Buffer.alloc(0);
 
@@ -187,33 +188,50 @@ export abstract class AbstractServer {
 		let lastTimer = 0;
 		let cumulativeTimeout = 0;
 		const { host, port, username, password, db }: RedisOptions = config.getEnv('queue.bull.redis');
+		const clusterNodes = getRedisClusterNodes();
 		const redisConnectionTimeoutLimit = config.getEnv('queue.bull.redis.timeoutThreshold');
-
-		const redis = new Redis({
-			host,
-			port,
-			db,
-			username,
-			password,
-			retryStrategy: (): number | null => {
-				const now = Date.now();
-				if (now - lastTimer > 30000) {
-					// Means we had no timeout at all or last timeout was temporary and we recovered
-					lastTimer = now;
-					cumulativeTimeout = 0;
-				} else {
-					cumulativeTimeout += now - lastTimer;
-					lastTimer = now;
-					if (cumulativeTimeout > redisConnectionTimeoutLimit) {
-						Logger.error(
-							`Unable to connect to Redis after ${redisConnectionTimeoutLimit}. Exiting process.`,
-						);
-						process.exit(1);
-					}
-				}
-				return 500;
-			},
-		});
+		let redis: Redis | Cluster;
+		redis =
+			clusterNodes.length > 0
+				? new Redis.Cluster(
+						clusterNodes.map((node) => ({ host: node.host, port: node.port })),
+						{
+							redisOptions: {
+								db,
+								username,
+								password,
+								enableReadyCheck: false,
+								maxRetriesPerRequest: null,
+							},
+						},
+				  )
+				: new Redis({
+						host,
+						port,
+						db,
+						username,
+						password,
+						enableReadyCheck: false,
+						maxRetriesPerRequest: null,
+						retryStrategy: (): number | null => {
+							const now = Date.now();
+							if (now - lastTimer > 30000) {
+								// Means we had no timeout at all or last timeout was temporary and we recovered
+								lastTimer = now;
+								cumulativeTimeout = 0;
+							} else {
+								cumulativeTimeout += now - lastTimer;
+								lastTimer = now;
+								if (cumulativeTimeout > redisConnectionTimeoutLimit) {
+									Logger.error(
+										`Unable to connect to Redis after ${redisConnectionTimeoutLimit}. Exiting process.`,
+									);
+									process.exit(1);
+								}
+							}
+							return 500;
+						},
+				  });
 
 		redis.on('close', () => {
 			Logger.warn('Redis unavailable - trying to reconnect...');

--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -211,7 +211,7 @@ export function getRedisClusterNodes(): Array<{ host: string; port: number }> {
 }
 
 export function getRedisPrefix(): string {
-	let prefix = config.getEnv('queue.bull.redis.prefix');
+	let prefix = config.getEnv('queue.bull.prefix');
 	if (prefix && getRedisClusterNodes().length > 0) {
 		if (!prefix.startsWith('{')) {
 			prefix = '{' + prefix;

--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -199,4 +199,28 @@ export async function createErrorExecution(
 	await Container.get(ExecutionRepository).createNewExecution(fullExecutionData);
 }
 
+export function getRedisClusterNodes(): Array<{ host: string; port: number }> {
+	const clusterNodePairs = config
+		.getEnv('queue.bull.redis.clusterNodes')
+		.split(',')
+		.filter((e) => e);
+	return clusterNodePairs.map((pair) => {
+		const [host, port] = pair.split(':');
+		return { host, port: parseInt(port) };
+	});
+}
+
+export function getRedisPrefix(): string {
+	let prefix = config.getEnv('queue.bull.redis.prefix');
+	if (prefix && getRedisClusterNodes().length > 0) {
+		if (!prefix.startsWith('{')) {
+			prefix = '{' + prefix;
+		}
+		if (!prefix.endsWith('}')) {
+			prefix += '}';
+		}
+	}
+	return prefix;
+}
+
 export const DEFAULT_EXECUTIONS_GET_ALL_LIMIT = 20;

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -1,10 +1,11 @@
 import type Bull from 'bull';
-import type { RedisOptions } from 'ioredis';
+import { type RedisOptions } from 'ioredis';
 import { Service } from 'typedi';
 import type { IExecuteResponsePromiseData } from 'n8n-workflow';
 import config from '@/config';
 import { ActiveExecutions } from '@/ActiveExecutions';
 import * as WebhookHelpers from '@/WebhookHelpers';
+import { getRedisClusterNodes, getRedisPrefix } from './GenericHelpers';
 
 export type JobId = Bull.JobId;
 export type Job = Bull.Job<JobData>;
@@ -31,19 +32,46 @@ export class Queue {
 	constructor(private activeExecutions: ActiveExecutions) {}
 
 	async init() {
-		const prefix = config.getEnv('queue.bull.prefix');
-		const redisOptions: RedisOptions = config.getEnv('queue.bull.redis');
-
+		const prefix = getRedisPrefix();
+		const clusterNodes = getRedisClusterNodes();
+		const { host, port, username, password, db }: RedisOptions = config.getEnv('queue.bull.redis');
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		const { default: Bull } = await import('bull');
-
+		const { default: Redis } = await import('ioredis');
 		// Disabling ready check is necessary as it allows worker to
 		// quickly reconnect to Redis if Redis crashes or is unreachable
 		// for some time. With it enabled, worker might take minutes to realize
 		// redis is back up and resume working.
 		// More here: https://github.com/OptimalBits/bull/issues/890
 		// @ts-ignore
-		this.jobQueue = new Bull('jobs', { prefix, redis: redisOptions, enableReadyCheck: false });
+		this.jobQueue = new Bull('jobs', {
+			prefix,
+			createClient: (type, config) =>
+				clusterNodes.length > 0
+					? new Redis.Cluster(
+							clusterNodes.map((node) => ({ host: node.host, port: node.port })),
+							{
+								...config,
+								redisOptions: {
+									username,
+									password,
+									db,
+									enableReadyCheck: false,
+									maxRetriesPerRequest: null,
+								},
+							},
+					  )
+					: new Redis({
+							...config,
+							host,
+							port,
+							username,
+							password,
+							db,
+							enableReadyCheck: false,
+							maxRetriesPerRequest: null,
+					  }),
+		});
 
 		this.jobQueue.on('global:progress', (jobId, progress: WebhookResponse) => {
 			this.activeExecutions.resolveResponsePromise(

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -395,6 +395,18 @@ export const schema = {
 					default: '',
 					env: 'QUEUE_BULL_REDIS_USERNAME',
 				},
+				prefix: {
+					doc: 'Redis Bull Queue Prefix (wrap in {} for cluster mode)',
+					format: String,
+					default: 'bull',
+					env: 'QUEUE_BULL_REDIS_PREFIX',
+				},
+				clusterNodes: {
+					doc: 'Redis Cluster startup nodes (comma separated list of host:port pairs)',
+					format: String,
+					default: '',
+					env: 'QUEUE_BULL_REDIS_CLUSTER_NODES',
+				},
 			},
 			queueRecoveryInterval: {
 				doc: 'If > 0 enables an active polling to the queue that can recover for Redis crashes. Given in seconds; 0 is disabled. May increase Redis traffic significantly.',

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -355,7 +355,7 @@ export const schema = {
 			prefix: {
 				doc: 'Prefix for all queue keys (wrap in {} for cluster mode)',
 				format: String,
-				default: '',
+				default: 'bull',
 				env: 'QUEUE_BULL_PREFIX',
 			},
 			redis: {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -353,7 +353,7 @@ export const schema = {
 		},
 		bull: {
 			prefix: {
-				doc: 'Prefix for all queue keys',
+				doc: 'Prefix for all queue keys (wrap in {} for cluster mode)',
 				format: String,
 				default: '',
 				env: 'QUEUE_BULL_PREFIX',
@@ -394,12 +394,6 @@ export const schema = {
 					format: String,
 					default: '',
 					env: 'QUEUE_BULL_REDIS_USERNAME',
-				},
-				prefix: {
-					doc: 'Redis Bull Queue Prefix (wrap in {} for cluster mode)',
-					format: String,
-					default: 'bull',
-					env: 'QUEUE_BULL_REDIS_PREFIX',
 				},
 				clusterNodes: {
 					doc: 'Redis Cluster startup nodes (comma separated list of host:port pairs)',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/redis-error-blocking-execution-list-results/27261

This PR adds a new environment variable, `QUEUE_BULL_REDIS_CLUSTER_NODES` (or `queue.bull.redis.clusterNodes`) to n8n.

It expects a comma separated list of Redis Cluster nodes in the format `host:port` for the Redis client to initially connect to (this do not need to be all of your cluster nodes, but at least some for the cluster connection to be initially set up).

If you are running in `EXECUTIONS_MODE=queue`, setting e.g. `QUEUE_BULL_REDIS_CLUSTER_NODES=127.0.0.1:7002,127.0.0.1:7004` will look create a Redis Cluster client instead of a Redis client. Both `QUEUE_BULL_REDIS_HOST` and  `QUEUE_BULL_REDIS_PORT`, which are used for a single-instance Redis setup, will be ignored in this case!

So, an example for a single-instance Redis setup for use in queue mode would be:
```
EXECUTIONS_MODE=queue
QUEUE_BULL_REDIS_HOST=127.0.0.1
QUEUE_BULL_REDIS_PORT=6379
```
while the same for a Redis cluster setup would look like
```
EXECUTIONS_MODE=queue
QUEUE_BULL_PREFIX=mycluster
QUEUE_BULL_REDIS_CLUSTER_NODES=127.0.0.1:7002,127.0.0.1:7004
```

Using `QUEUE_BULL_PREFIX` is optional and will default to `bull` on single-instance mode and `{bull}` in cluster mode.