### PR TITLE
Generate versionId in workflow creation by public api

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -2,7 +2,7 @@ import type express from 'express';
 import { Container } from 'typedi';
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
-
+import { v4 as uuid } from 'uuid';
 import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import config from '@/config';
 import { WorkflowEntity } from '@db/entities/WorkflowEntity';
@@ -34,6 +34,7 @@ export = {
 			const workflow = req.body;
 
 			workflow.active = false;
+			workflow.versionId = uuid();
 
 			await replaceInvalidCredentials(workflow);
 


### PR DESCRIPTION
## Description

When a workflow is created by public API doesn't generate a versionId the the workflow can't make any execution

## Summary

Creation handler add versionId to workflow
