### PR TITLE
fix(core): Fix RemoveResetPasswordColumns migration for sqlite (no-changelog)

### DIFF
--- a/packages/cli/src/databases/migrations/common/1690000000030-RemoveResetPasswordColumns.ts
+++ b/packages/cli/src/databases/migrations/common/1690000000030-RemoveResetPasswordColumns.ts
@@ -2,28 +2,27 @@ import type { MigrationContext, ReversibleMigration } from '@db/types';
 import { TableColumn } from 'typeorm';
 
 export class RemoveResetPasswordColumns1690000000030 implements ReversibleMigration {
+	transaction = false as const;
+
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
-		await queryRunner.dropColumn(`${tablePrefix}user`, 'resetPasswordToken');
-		await queryRunner.dropColumn(`${tablePrefix}user`, 'resetPasswordTokenExpiration');
+		await queryRunner.dropColumns(`${tablePrefix}user`, [
+			'resetPasswordToken',
+			'resetPasswordTokenExpiration',
+		]);
 	}
 
 	async down({ queryRunner, tablePrefix }: MigrationContext) {
-		await queryRunner.addColumn(
-			`${tablePrefix}user`,
+		await queryRunner.addColumns(`${tablePrefix}user`, [
 			new TableColumn({
 				name: 'resetPasswordToken',
 				type: 'varchar',
 				isNullable: true,
 			}),
-		);
-
-		await queryRunner.addColumn(
-			`${tablePrefix}user`,
 			new TableColumn({
 				name: 'resetPasswordTokenExpiration',
 				type: 'int',
 				isNullable: true,
 			}),
-		);
+		]);
 	}
 }

--- a/packages/cli/src/databases/migrations/common/1690000000030-RemoveResetPasswordColumns.ts
+++ b/packages/cli/src/databases/migrations/common/1690000000030-RemoveResetPasswordColumns.ts
@@ -2,8 +2,6 @@ import type { MigrationContext, ReversibleMigration } from '@db/types';
 import { TableColumn } from 'typeorm';
 
 export class RemoveResetPasswordColumns1690000000030 implements ReversibleMigration {
-	transaction = false as const;
-
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		await queryRunner.dropColumns(`${tablePrefix}user`, [
 			'resetPasswordToken',

--- a/packages/cli/src/databases/migrations/sqlite/1690000000030-RemoveResetPasswordColumns.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1690000000030-RemoveResetPasswordColumns.ts
@@ -1,0 +1,5 @@
+import { RemoveResetPasswordColumns1690000000030 as BaseMigration } from '../common/1690000000030-RemoveResetPasswordColumns';
+
+export class RemoveResetPasswordColumns1690000000030 extends BaseMigration {
+	transaction = false as const;
+}

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -39,7 +39,7 @@ import { MigrateIntegerKeysToString1690000000002 } from './1690000000002-Migrate
 import { SeparateExecutionData1690000000010 } from './1690000000010-SeparateExecutionData';
 import { RemoveSkipOwnerSetup1681134145997 } from './1681134145997-RemoveSkipOwnerSetup';
 import { FixMissingIndicesFromStringIdMigration1690000000020 } from './1690000000020-FixMissingIndicesFromStringIdMigration';
-import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
+import { RemoveResetPasswordColumns1690000000030 } from './1690000000030-RemoveResetPasswordColumns';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,


### PR DESCRIPTION
[`dropColumn` in typeorm's sqlite driver recreates the table](https://github.com/typeorm/typeorm/blob/master/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts#L752-L776), despite sqlite supporting drop column for over two years now. This causes an `FOREIGN KEY constraint failed` when when the database has some any workflows or credentials.
By setting `transaction` to `false`, we disable the foreign key constraints during this migration.

PS: this way we ensure a transaction ourselves when `transaction` is set to `false`. Unfortunately we can't (yet) rename this property to something else as we use this to disable the transaction management inside typeorm, so that we can take that over.

[DB Tests](https://github.com/n8n-io/n8n/actions/runs/5659223145/job/15332305570)