### PR TITLE
fix(editor): Fix settings initialisation

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -101,13 +101,18 @@ export default defineComponent({
 	data() {
 		return {
 			postAuthenticateDone: false,
+			settingsInitialised: false,
 			loading: true,
 		};
 	},
 	methods: {
 		async initSettings(): Promise<void> {
+			// The settings should only be initialized once
+			if(this.settingsInitialised) return;
+
 			try {
 				await this.settingsStore.getSettings();
+				this.settingsInitialised = true;
 			} catch (e) {
 				this.showToast({
 					title: this.$locale.baseText('startupError'),
@@ -139,7 +144,6 @@ export default defineComponent({
 			}
 		},
 		async initialize(): Promise<void> {
-			await this.initSettings();
 			await Promise.all([this.loginWithCookie(), this.initTemplates()]);
 		},
 		trackPage(): void {
@@ -250,7 +254,7 @@ export default defineComponent({
 			this.postAuthenticateDone = true;
 		},
 	},
-	async mounted() {
+	async created() {
 		this.setTheme();
 		await this.initialize();
 		this.logHiringBanner();
@@ -264,7 +268,8 @@ export default defineComponent({
 		void this.postAuthenticate();
 
 		this.loading = false;
-
+	},
+	async mounted() {
 		this.trackPage();
 		void this.externalHooks.run('app.mount');
 
@@ -278,7 +283,8 @@ export default defineComponent({
 				void this.postAuthenticate();
 			}
 		},
-		$route(route) {
+		async $route(route) {
+			await this.initSettings();
 			this.authenticate();
 			this.redirectIfNecessary();
 


### PR DESCRIPTION
We are using settings store within the router to decide whether a redirect is necessary or not. Currently, loading these settings during on App's `mount` hook happens too late. To solve this issue, I've repositioned the initialization functions that do not require DOM to the `created` lifecycle hook.
Also, to ensure that settings are accessible before executing `redirectIfNecessary`, I have arranged for them to be initiated upon every `$route` change. However, this only occurs once to prevent constant refetching of settings with each route change.
Github issue / Community forum post (link here to close automatically):

