### PR TITLE
fix(editor): Redraw node connections if adding more than one node to canvas

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3762,6 +3762,7 @@ export default defineComponent({
 				const actionWatcher = this.workflowsStore.$onAction(({ name, after, args }) => {
 					if (name === 'addNode' && args[0].type === nodeTypeName) {
 						after(async () => {
+							this.instance?.setSuspendDrawing(true);
 							const lastAddedNode = this.nodes[this.nodes.length - 1];
 							const previouslyAddedNode = this.nodes[this.nodes.length - 2];
 
@@ -3775,6 +3776,9 @@ export default defineComponent({
 									NodeViewUtils.GRID_SIZE,
 								previouslyAddedNode.position[1],
 							];
+
+							await this.$nextTick();
+							this.instance?.setSuspendDrawing(false, true);
 							actionWatcher();
 						});
 					}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3778,7 +3778,7 @@ export default defineComponent({
 								previouslyAddedNode.position[1],
 							];
 							await this.$nextTick();
-							this.connectTwoNodes(previouslyAddedNode.name, 0, lastAddedNode.name, 0),
+							this.connectTwoNodes(previouslyAddedNode.name, 0, lastAddedNode.name, 0);
 
 							actionWatcher();
 						});

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3762,12 +3762,8 @@ export default defineComponent({
 				const actionWatcher = this.workflowsStore.$onAction(({ name, after, args }) => {
 					if (name === 'addNode' && args[0].type === nodeTypeName) {
 						after(async () => {
-							this.instance?.setSuspendDrawing(true);
 							const lastAddedNode = this.nodes[this.nodes.length - 1];
 							const previouslyAddedNode = this.nodes[this.nodes.length - 2];
-
-							await this.$nextTick();
-							this.connectTwoNodes(previouslyAddedNode.name, 0, lastAddedNode.name, 0);
 
 							// Position the added node to the right side of the previously added one
 							lastAddedNode.position = [
@@ -3776,9 +3772,9 @@ export default defineComponent({
 									NodeViewUtils.GRID_SIZE,
 								previouslyAddedNode.position[1],
 							];
-
 							await this.$nextTick();
-							this.instance?.setSuspendDrawing(false, true);
+							this.connectTwoNodes(previouslyAddedNode.name, 0, lastAddedNode.name, 0),
+
 							actionWatcher();
 						});
 					}


### PR DESCRIPTION
When we add more than one node to the canvas, we position the second node to the right of the first one. We should do the position assignment before connecting the nodes in the canvas to get them to render correctly
Github issue / Community forum post (link here to close automatically):
