### PR TITLE
fix(editor): Fix App loading & auth 

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -157,7 +157,7 @@ export default defineComponent({
 
 			this.$telemetry.page(this.$route);
 		},
-		authenticate() {
+		async authenticate() {
 			// redirect to setup page. user should be redirected to this only once
 			if (this.settingsStore.showSetupPage) {
 				if (this.$route.name === VIEWS.SETUP) {

--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -164,8 +164,7 @@ export default defineComponent({
 					return;
 				}
 
-				void this.$router.replace({ name: VIEWS.SETUP });
-				return;
+				return this.$router.replace({ name: VIEWS.SETUP });
 			}
 
 			if (this.canUserAccessCurrentRoute()) {
@@ -178,8 +177,7 @@ export default defineComponent({
 				const redirect =
 					this.$route.query.redirect ||
 					encodeURIComponent(`${window.location.pathname}${window.location.search}`);
-				void this.$router.replace({ name: VIEWS.SIGNIN, query: { redirect } });
-				return;
+				return this.$router.replace({ name: VIEWS.SIGNIN, query: { redirect } });
 			}
 
 			// if cannot access page and is logged in, respect signin redirect
@@ -187,13 +185,12 @@ export default defineComponent({
 				const redirect = decodeURIComponent(this.$route.query.redirect);
 				if (redirect.startsWith('/')) {
 					// protect against phishing
-					void this.$router.replace(redirect);
-					return;
+					return this.$router.replace(redirect);
 				}
 			}
 
 			// if cannot access page and is logged in
-			void this.$router.replace({ name: VIEWS.HOMEPAGE });
+			return this.$router.replace({ name: VIEWS.HOMEPAGE });
 		},
 		redirectIfNecessary() {
 			const redirect =
@@ -201,7 +198,7 @@ export default defineComponent({
 				typeof this.$route.meta.getRedirect === 'function' &&
 				this.$route.meta.getRedirect();
 			if (redirect) {
-				void this.$router.replace(redirect);
+				return this.$router.replace(redirect);
 			}
 		},
 		setTheme() {
@@ -255,11 +252,11 @@ export default defineComponent({
 			this.postAuthenticateDone = true;
 		},
 	},
-	async created() {
+	async mounted() {
 		this.setTheme();
 		await this.initialize();
 		this.logHiringBanner();
-		this.authenticate();
+		await this.authenticate();
 		this.redirectIfNecessary();
 		void this.checkForNewVersions();
 		await this.checkForCloudPlanData();
@@ -269,8 +266,8 @@ export default defineComponent({
 		void this.postAuthenticate();
 
 		this.loading = false;
-	},
-	async mounted() {
+
+		this.logHiringBanner();
 		this.trackPage();
 		void this.externalHooks.run('app.mount');
 
@@ -286,7 +283,6 @@ export default defineComponent({
 		},
 		async $route(route) {
 			await this.initSettings();
-			this.authenticate();
 			this.redirectIfNecessary();
 
 			this.trackPage();

--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -192,14 +192,16 @@ export default defineComponent({
 			// if cannot access page and is logged in
 			return this.$router.replace({ name: VIEWS.HOMEPAGE });
 		},
-		redirectIfNecessary() {
+		async redirectIfNecessary() {
 			const redirect =
 				this.$route.meta &&
 				typeof this.$route.meta.getRedirect === 'function' &&
 				this.$route.meta.getRedirect();
+
 			if (redirect) {
 				return this.$router.replace(redirect);
 			}
+			return;
 		},
 		setTheme() {
 			const theme = window.localStorage.getItem(LOCAL_STORAGE_THEME);
@@ -257,7 +259,7 @@ export default defineComponent({
 		await this.initialize();
 		this.logHiringBanner();
 		await this.authenticate();
-		this.redirectIfNecessary();
+		await this.redirectIfNecessary();
 		void this.checkForNewVersions();
 		await this.checkForCloudPlanData();
 		await this.initBanners();
@@ -283,7 +285,7 @@ export default defineComponent({
 		},
 		async $route(route) {
 			await this.initSettings();
-			this.redirectIfNecessary();
+			await this.redirectIfNecessary();
 
 			this.trackPage();
 		},

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -876,7 +876,7 @@ export default defineComponent({
 				}
 			} catch (error) {
 				this.showError(error, this.$locale.baseText('nodeView.couldntImportWorkflow'));
-				void this.$router.replace({ name: VIEWS.NEW_WORKFLOW });
+				await this.$router.replace({ name: VIEWS.NEW_WORKFLOW });
 				return;
 			}
 
@@ -889,7 +889,7 @@ export default defineComponent({
 			});
 
 			this.blankRedirect = true;
-			void this.$router.replace({ name: VIEWS.NEW_WORKFLOW, query: { templateId } });
+			await this.$router.replace({ name: VIEWS.NEW_WORKFLOW, query: { templateId } });
 
 			await this.addNodes(data.workflow.nodes, data.workflow.connections);
 			this.workflowData = (await this.workflowsStore.getNewWorkflowData(data.name)) || {};


### PR DESCRIPTION
We need to return and await `$router.replace` to make sure methods that run on `$route` have all the data from previous steps. This would cause issues with initial loading of template because the addNodes would be called before the route replace would finish
Github issue / Community forum post (link here to close automatically):
