### PR TITLE
fix(Slack Node): User Get / Get Many now fetches users emails

### DIFF
--- a/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/SlackOAuth2Api.credentials.ts
@@ -19,6 +19,7 @@ const userScopes = [
 	'users.profile:read',
 	'users.profile:write',
 	'users:read',
+	'users:read.email',
 ];
 
 export class SlackOAuth2Api implements ICredentialType {


### PR DESCRIPTION
Since (?), the Slack API requires the users:read.email permission in order to return emails as part of the user structure [1 - link]

My guess was that this was the intended behavior but due to Slack scope changes this probably didn't get updated ?

[1 - link]: https://api.slack.com/scopes/users:read.email