### PR TITLE
fix: Show NodeIcon tooltips by removing pointer-events: none

### DIFF
--- a/packages/design-system/src/components/N8nNodeIcon/NodeIcon.vue
+++ b/packages/design-system/src/components/N8nNodeIcon/NodeIcon.vue
@@ -126,11 +126,15 @@ export default defineComponent({
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	pointer-events: none;
 
 	svg {
 		max-width: 100%;
 		max-height: 100%;
+	}
+
+	img,
+	svg {
+		pointer-events: none;
 	}
 }
 .nodeIconPlaceholder {


### PR DESCRIPTION
<img width="1594" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/1c16c175-e5e3-4f8a-9881-1ba27470003b">