### PR TITLE
fix(editor): Resolve vue 3 related console-warnings

### DIFF
--- a/packages/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/design-system/src/components/N8nPopover/Popover.vue
@@ -14,10 +14,12 @@ export default defineComponent({
 </script>
 
 <template>
-	<el-popover v-bind="{ ...$props, ...$attrs }">
-		<template #reference>
-			<slot name="reference" />
-		</template>
-		<slot />
-	</el-popover>
+	<span>
+		<el-popover v-bind="{ ...$props, ...$attrs }">
+			<template #reference>
+				<slot name="reference" />
+			</template>
+			<slot />
+		</el-popover>
+	</span>
 </template>

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<span>
 		<n8n-tooltip placement="bottom" :disabled="!disabledHint">
 			<template #content>
 				<div>{{ disabledHint }}</div>
@@ -17,7 +17,7 @@
 				/>
 			</div>
 		</n8n-tooltip>
-	</div>
+	</span>
 </template>
 
 <script lang="ts">

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -1,21 +1,23 @@
 <template>
-	<n8n-tooltip placement="bottom" :disabled="!disabledHint">
-		<template #content>
-			<div>{{ disabledHint }}</div>
-		</template>
-		<div>
-			<n8n-button
-				v-bind="$attrs"
-				:loading="nodeRunning && !isListeningForEvents && !isListeningForWorkflowEvents"
-				:disabled="disabled || !!disabledHint"
-				:label="buttonLabel"
-				:type="type"
-				:size="size"
-				:transparentBackground="transparent"
-				@click="onClick"
-			/>
-		</div>
-	</n8n-tooltip>
+	<div>
+		<n8n-tooltip placement="bottom" :disabled="!disabledHint">
+			<template #content>
+				<div>{{ disabledHint }}</div>
+			</template>
+			<div>
+				<n8n-button
+					v-bind="$attrs"
+					:loading="nodeRunning && !isListeningForEvents && !isListeningForWorkflowEvents"
+					:disabled="disabled || !!disabledHint"
+					:label="buttonLabel"
+					:type="type"
+					:size="size"
+					:transparentBackground="transparent"
+					@click="onClick"
+				/>
+			</div>
+		</n8n-tooltip>
+	</div>
 </template>
 
 <script lang="ts">

--- a/packages/editor-ui/src/components/WarningTooltip.vue
+++ b/packages/editor-ui/src/components/WarningTooltip.vue
@@ -1,10 +1,12 @@
 <template>
-	<n8n-tooltip content=" " placement="top">
-		<template #content>
-			<slot />
-		</template>
-		<font-awesome-icon :class="$style['icon']" icon="exclamation-triangle"></font-awesome-icon>
-	</n8n-tooltip>
+	<span>
+		<n8n-tooltip content=" " placement="top">
+			<template #content>
+				<slot />
+			</template>
+			<font-awesome-icon :class="$style['icon']" icon="exclamation-triangle"></font-awesome-icon>
+		</n8n-tooltip>
+	</span>
 </template>
 
 <style lang="scss" module>

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -731,7 +731,7 @@
 	"node.waitingForYouToCreateAnEventIn": "Waiting for you to create an event in {nodeType}",
 	"node.discovery.pinData.canvas": "You can pin this output instead of waiting for a test event. Open node to do so.",
 	"node.discovery.pinData.ndv": "You can pin this output instead of waiting for a test event.",
-	"nodeBase.clickToAddNodeOrDragToConnect": "Click to add node<br />or drag to connect",
+	"nodeBase.clickToAddNodeOrDragToConnect": "Click to add node \n or drag to connect",
 	"nodeCreator.actionsPlaceholderNode.scheduleTrigger": "On a Schedule",
 	"nodeCreator.actionsPlaceholderNode.webhook": "On a Webhook call",
 	"nodeCreator.actionsCategory.actions": "Actions",


### PR DESCRIPTION
We need to wrap n8n-tooltip in an element because its root element is a `<template>`
![CleanShot 2023-07-28 at 11 49 32](https://github.com/n8n-io/n8n/assets/12657221/84d75de7-ddee-4bf4-b322-e3e3f2ef5d8d)
![CleanShot 2023-07-28 at 11 49 08](https://github.com/n8n-io/n8n/assets/12657221/7e9bc1eb-047a-42c4-b0a1-d3a3d80846c1)
![CleanShot 2023-07-28 at 11 48 52](https://github.com/n8n-io/n8n/assets/12657221/c8470267-b373-426c-aa9b-7151d26ad49f)

