### PR TITLE
fix: Remove number input arrows (no-changelog)

### DIFF
--- a/packages/design-system/src/css/input-number.scss
+++ b/packages/design-system/src/css/input-number.scss
@@ -8,6 +8,18 @@
 	line-height: #{var.$input-height - 2};
 	width: 100%;
 
+	/* Chrome, Safari, Edge, Opera */
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+
+	/* Firefox */
+	input[type='number'] {
+		-moz-appearance: textfield !important;
+	}
+
 	.el-input {
 		display: block;
 


### PR DESCRIPTION
Chrome:
<img width="522" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/4f6ac7db-4c00-4cdf-ad9f-cb087419264a">

Firefox:
<img width="310" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/e39bca8a-4934-45e3-a7d4-5b082907e0a4">
