### PR TITLE
fix(TheHive Node): Treat  `ApiKey` as a secret

### DIFF
--- a/packages/nodes-base/credentials/TheHiveApi.credentials.ts
+++ b/packages/nodes-base/credentials/TheHiveApi.credentials.ts
@@ -17,6 +17,7 @@ export class TheHiveApi implements ICredentialType {
 			displayName: 'API Key',
 			name: 'ApiKey',
 			type: 'string',
+			typeOptions: { password: true },
 			default: '',
 		},
 		{


### PR DESCRIPTION
fixes #6785