### PR TITLE
test(editor): Prevent node view unload by default in e2e run

### DIFF
--- a/cypress/e2e/14-data-transformation-expressions.cy.ts
+++ b/cypress/e2e/14-data-transformation-expressions.cy.ts
@@ -6,11 +6,6 @@ const ndv = new NDV();
 describe('Data transformation expressions', () => {
 	beforeEach(() => {
 		wf.actions.visit();
-
-		cy.window().then((win) => {
-			// @ts-ignore
-			win.preventNodeViewBeforeUnload = true;
-		});
 	});
 
 	it('$json + native string methods', () => {

--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -12,11 +12,6 @@ const ndv = new NDV();
 describe('Data mapping', () => {
 	beforeEach(() => {
 		workflowPage.actions.visit();
-
-		cy.window().then((win) => {
-			// @ts-ignore
-			win.preventNodeViewBeforeUnload = true;
-		});
 	});
 
 	it('maps expressions from table header', () => {

--- a/cypress/e2e/16-webhook-node.cy.ts
+++ b/cypress/e2e/16-webhook-node.cy.ts
@@ -79,11 +79,6 @@ const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
 describe('Webhook Trigger node', async () => {
 	beforeEach(() => {
 		workflowPage.actions.visit();
-
-		cy.window().then((win) => {
-			// @ts-ignore
-			win.preventNodeViewBeforeUnload = true;
-		});
 	});
 
 	it('should listen for a GET request', () => {

--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -23,11 +23,6 @@ function checkStickiesStyle(
 describe('Canvas Actions', () => {
 	beforeEach(() => {
 		workflowPage.actions.visit();
-
-		cy.window().then((win) => {
-			// @ts-ignore
-			win.preventNodeViewBeforeUnload = true;
-		});
 	});
 
 	it('adds sticky to canvas with default text and position', () => {

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -115,9 +115,13 @@ export class WorkflowPage extends BasePage {
 		editorTabButton: () => cy.getByTestId('radio-button-workflow'),
 	};
 	actions = {
-		visit: () => {
+		visit: (preventNodeViewUnload = true) => {
 			cy.visit(this.url);
 			cy.waitForLoad();
+			cy.window().then((win) => {
+				// @ts-ignore
+				win.preventNodeViewBeforeUnload = preventNodeViewUnload;
+			});
 		},
 		addInitialNodeToCanvas: (nodeDisplayName: string, { keepNdvOpen } = { keepNdvOpen: false }) => {
 			this.getters.canvasPlusButton().click();


### PR DESCRIPTION
In NodeView, we require a confirmation when a user attempts to close a window or tab while the state is dirty. This is achieved by integrating with the `beforeunload` window event. However, during end-to-end tests, unless we are specifically testing this feature, we should bypass this functionality to avoid receiving a confirmation dialog upon test exit. This can be accomplished by setting `window.preventNodeViewBeforeUnload = true`.

Previously, we would apply this setting individually for each specification. However, in this PR, I have revised it so that it is always set upon visiting the canvas route. This adjustment aims to counter an issue where the browser may freeze during testing, pending confirmation following a real-event call.

The necessity for this is due to the fact that the `beforeunload` event will only be triggered under specific circumstances. According to [the spec](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event), the confirmation request will be omitted if the user hasn't performed any actions within the frame or page since its loading.

This is why we would only see the hanging behaviour when state was set to dirty(by pasting workflow) and `real-cypress-event` call.


Github issue / Community forum post (link here to close automatically):
