### PR TITLE
fix(editor): Fix code node highlight error

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -166,7 +166,7 @@ export default defineComponent({
 
 			if (lineNumber === 'final') {
 				this.editor.dispatch({
-					selection: { anchor: this.content.length },
+					selection: { anchor: (this.modelValue ?? this.content).length },
 				});
 				return;
 			}


### PR DESCRIPTION
When switching code `mode` the content of editor is not updated immediately. So the highligh method gets wrong range as it's basing it on content length. To fix this we preferably use `modelValue`.
Github issue / Community forum post (link here to close automatically):
