### PR TITLE
test(editor): Do not chain invoke calls after assertions in 24-ndv-paired-item e2e spec (no-changelog)

### DIFF
--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -267,7 +267,7 @@ describe('NDV', () => {
 		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
 	});
 
-	it.only ('can pair items between input and output across branches and runs', () => {
+	it('can pair items between input and output across branches and runs', () => {
 		cy.fixture('Test_workflow_5.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));
 		});

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -153,9 +153,13 @@ describe('NDV', () => {
 			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
-		ndv.getters.outputTableRow(1).should('have.text', '1111').realHover();
+		ndv.getters.outputTableRow(1).should('have.text', '1111');
+		ndv.getters.outputTableRow(1).realHover();
 
-		ndv.getters.outputTableRow(3).should('have.text', '4444').realHover();
+
+		ndv.getters.outputTableRow(3).should('have.text', '4444');
+		ndv.getters.outputTableRow(3).realHover();
+
 		ndv.getters
 			.inputTableRow(3)
 			.should('have.text', '4444')
@@ -167,7 +171,9 @@ describe('NDV', () => {
 		ndv.actions.changeOutputRunSelector('2 of 2 (6 items)');
 		cy.wait(50);
 
-		ndv.getters.inputTableRow(1).should('have.text', '1000').realHover();
+		ndv.getters.inputTableRow(1).should('have.text', '1000');
+		ndv.getters.inputTableRow(1).realHover();
+
 		ndv.getters
 			.outputTableRow(1)
 			.should('have.text', '1000')
@@ -177,7 +183,9 @@ describe('NDV', () => {
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
-		ndv.getters.outputTableRow(3).should('have.text', '2000').realHover();
+		ndv.getters.outputTableRow(3).should('have.text', '2000');
+		ndv.getters.outputTableRow(3).realHover();
+
 		ndv.getters
 			.inputTableRow(3)
 			.should('have.text', '2000')
@@ -254,11 +262,12 @@ describe('NDV', () => {
 			.inputTableRow(1)
 			.should('have.text', "This is an item, but it's empty.")
 			.realHover();
+
 		ndv.getters.outputHoveringItem().should('have.length', 6);
 		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
 	});
 
-	it('can pair items between input and output across branches and runs', () => {
+	it.only ('can pair items between input and output across branches and runs', () => {
 		cy.fixture('Test_workflow_5.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));
 		});
@@ -270,7 +279,9 @@ describe('NDV', () => {
 		ndv.actions.switchOutputMode('Table');
 
 		ndv.actions.switchOutputBranch('False Branch (2 items)');
-		ndv.getters.outputTableRow(1).should('have.text', '8888').realHover();
+		ndv.getters.outputTableRow(1).should('have.text', '8888');
+		ndv.getters.outputTableRow(1).realHover();
+
 		ndv.getters
 			.inputTableRow(5)
 			.should('have.text', '8888')
@@ -280,7 +291,8 @@ describe('NDV', () => {
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
-		ndv.getters.outputTableRow(2).should('have.text', '9999').realHover();
+		ndv.getters.outputTableRow(2).should('have.text', '9999');
+		ndv.getters.outputTableRow(2).realHover();
 
 		ndv.getters
 			.inputTableRow(6)
@@ -297,20 +309,27 @@ describe('NDV', () => {
 
 		ndv.actions.switchInputBranch('True Branch');
 		ndv.actions.changeOutputRunSelector('1 of 2 (2 items)');
-		ndv.getters.outputTableRow(1).should('have.text', '8888').realHover();
+		ndv.getters.outputTableRow(1).should('have.text', '8888')
+		ndv.getters.outputTableRow(1).realHover();
+		cy.wait(100);
 		ndv.getters.inputHoveringItem().should('not.exist');
 
-		ndv.getters.inputTableRow(1).should('have.text', '1111').realHover();
+		ndv.getters.inputTableRow(1).should('have.text', '1111')
+		ndv.getters.inputTableRow(1).realHover();
+		cy.wait(100);
 		ndv.getters.outputHoveringItem().should('not.exist');
 
 		ndv.actions.switchInputBranch('False Branch');
-		ndv.getters.inputTableRow(1).should('have.text', '8888').realHover();
+		ndv.getters.inputTableRow(1).should('have.text', '8888');
+		ndv.getters.inputTableRow(1).realHover();
 
 		ndv.actions.changeOutputRunSelector('2 of 2 (4 items)');
-		ndv.getters.outputTableRow(1).should('have.text', '1111').realHover();
+		ndv.getters.outputTableRow(1).should('have.text', '1111');
+		ndv.getters.outputTableRow(1).realHover();
 
 		ndv.actions.changeOutputRunSelector('1 of 2 (2 items)');
-		ndv.getters.inputTableRow(1).should('have.text', '8888').realHover();
+		ndv.getters.inputTableRow(1).should('have.text', '8888');
+		ndv.getters.inputTableRow(1).realHover();
 		ndv.getters.outputHoveringItem().should('have.text', '8888');
 		// todo there's a bug here need to fix ADO-534
 		// ndv.getters.outputHoveringItem().should('not.exist');

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -31,6 +31,9 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('exist')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
@@ -88,9 +91,13 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '1000')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
-		ndv.getters.inputTableRow(1).realHover();
+
+			ndv.getters.inputTableRow(1).realHover();
 		cy.wait(50);
 		ndv.getters.outputHoveringItem().should('have.text', '1000');
 		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
@@ -102,6 +109,9 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '1111')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 		ndv.getters.inputTableRow(1).realHover();
@@ -139,6 +149,8 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '1111')
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 		ndv.getters.outputTableRow(1).should('have.text', '1111').realHover();
@@ -147,6 +159,8 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(3)
 			.should('have.text', '4444')
+		ndv.getters
+			.inputTableRow(3)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
@@ -157,6 +171,9 @@ describe('NDV', () => {
 		ndv.getters
 			.outputTableRow(1)
 			.should('have.text', '1000')
+		ndv.getters
+			.outputTableRow(1)
+			.should('have.text', '1000')
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
@@ -164,6 +181,9 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(3)
 			.should('have.text', '2000')
+
+		ndv.getters
+			.inputTableRow(3)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 	});
@@ -190,6 +210,9 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '1111')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 		ndv.getters.inputTableRow(1).realHover();
@@ -201,6 +224,9 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '1000')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 		ndv.getters.outputTableRow(1).should('have.text', '1000');
@@ -212,8 +238,12 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(1)
 			.should('have.text', '6666')
+
+		ndv.getters
+			.inputTableRow(1)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
+
 		ndv.getters.outputHoveringItem().should('not.exist');
 		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
 
@@ -244,13 +274,20 @@ describe('NDV', () => {
 		ndv.getters
 			.inputTableRow(5)
 			.should('have.text', '8888')
+
+		ndv.getters
+			.inputTableRow(5)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 
 		ndv.getters.outputTableRow(2).should('have.text', '9999').realHover();
+
 		ndv.getters
 			.inputTableRow(6)
 			.should('have.text', '9999')
+
+		ndv.getters
+			.inputTableRow(6)
 			.invoke('attr', 'data-test-id')
 			.should('equal', 'hovering-item');
 


### PR DESCRIPTION
This spec is often flaky because by the time the `should` assertion after `invoke`is reached, the DOM updates and previously yielded element doesn't exist. 