### PR TITLE
ci: Downgrade prettier (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nock": "^13.3.2",
     "nodemon": "^3.0.1",
     "p-limit": "^3.1.0",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "run-script-os": "^1.0.7",
     "start-server-and-test": "^2.0.0",

--- a/packages/editor-ui/.eslintrc.js
+++ b/packages/editor-ui/.eslintrc.js
@@ -17,7 +17,6 @@ module.exports = {
 		'import/order': 'off',
 		'import/no-cycle': 'warn',
 		'import/no-duplicates': 'warn',
-		indent: 'warn',
 		'@typescript-eslint/ban-types': 'warn',
 		'@typescript-eslint/dot-notation': 'warn',
 		'@typescript-eslint/lines-between-class-members': 'warn',

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -65,7 +65,7 @@
     "n8n-workflow": "workspace:*",
     "normalize-wheel": "^1.0.1",
     "pinia": "^2.1.6",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "stream-browserify": "^3.0.0",
     "timeago.js": "^4.0.2",
     "uuid": "^8.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
       rimraf:
         specifier: ^5.0.1
         version: 5.0.1
@@ -868,8 +868,8 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6(typescript@5.1.6)(vue@3.3.4)
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
@@ -17117,12 +17117,12 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /prettier@3.0.0:
     resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}


### PR DESCRIPTION
Prettier 3.x is having some issues with `eslint-config-prettier`. 