### PR TITLE
fix: Fix double hiring banner logging (no-changelog)

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -269,7 +269,6 @@ export default defineComponent({
 
 		this.loading = false;
 
-		this.logHiringBanner();
 		this.trackPage();
 		void this.externalHooks.run('app.mount');
 


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
