### PR TITLE
fix: Fix replacing node empty string value with default value (no-changelog)

### DIFF
--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -635,7 +635,7 @@ export function getNodeParameters(
 							: { __rl: true, ...nodeProperties.default };
 				} else {
 					nodeParameters[nodeProperties.name] =
-						nodeValues[nodeProperties.name] || nodeProperties.default;
+						nodeValues[nodeProperties.name] ?? nodeProperties.default;
 				}
 				nodeParametersFull[nodeProperties.name] = nodeParameters[nodeProperties.name];
 			} else if (


### PR DESCRIPTION
Because the parameter model value actually works properly now, the multiple calls to `getNodeParameters` update the view every time. This causes the empty string value to get replaced by the default parameter value.