### PR TITLE
fix(editor): Fix n8n reference toggle tracking (no-changelog)

### DIFF
--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -192,7 +192,7 @@ export class Telemetry {
 		if (this.rudderStack) {
 			switch (nodeType) {
 				case SLACK_NODE_TYPE:
-					if (change.name === 'parameters.includeLinkToWorkflow') {
+					if (change.name === 'parameters.otherOptions.includeLinkToWorkflow') {
 						this.track('User toggled n8n reference option');
 					}
 					break;


### PR DESCRIPTION
The method to track node parameters values changes was looking for `parameters.includeLinkToWorkflow` while the property is `parameters.otherOptions.includeLinkToWorkflow`. The rest of the changes are auto-linting induced. 

