### PR TITLE
fix(core): Handle empty keys in cache service (no-changelog)

### DIFF
--- a/packages/cli/src/services/cache.service.ts
+++ b/packages/cli/src/services/cache.service.ts
@@ -80,6 +80,9 @@ export class CacheService {
 			refreshTtl?: number;
 		} = {},
 	): Promise<unknown> {
+		if (!key || key.length === 0) {
+			return;
+		}
 		const value = await this.cache?.store.get(key);
 		if (value !== undefined) {
 			return value;
@@ -113,6 +116,9 @@ export class CacheService {
 			refreshTtl?: number;
 		} = {},
 	): Promise<unknown[]> {
+		if (keys.length === 0) {
+			return [];
+		}
 		let values = await this.cache?.store.mget(...keys);
 		if (values === undefined) {
 			values = keys.map(() => undefined);
@@ -163,6 +169,9 @@ export class CacheService {
 		if (!this.cache) {
 			await this.init();
 		}
+		if (!key || key.length === 0) {
+			return;
+		}
 		if (value === undefined || value === null) {
 			return;
 		}
@@ -183,8 +192,13 @@ export class CacheService {
 		if (!this.cache) {
 			await this.init();
 		}
+		if (values.length === 0) {
+			return;
+		}
 		// eslint-disable-next-line @typescript-eslint/naming-convention
-		const nonNullValues = values.filter(([_key, value]) => value !== undefined && value !== null);
+		const nonNullValues = values.filter(
+			([key, value]) => value !== undefined && value !== null && key && key.length > 0,
+		);
 		if (this.isRedisCache()) {
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			nonNullValues.forEach(([_key, value]) => {
@@ -201,6 +215,9 @@ export class CacheService {
 	 * @param key The key to delete
 	 */
 	async delete(key: string): Promise<void> {
+		if (!key || key.length === 0) {
+			return;
+		}
 		await this.cache?.store.del(key);
 	}
 
@@ -209,6 +226,9 @@ export class CacheService {
 	 * @param keys List of keys to delete
 	 */
 	async deleteMany(keys: string[]): Promise<void> {
+		if (keys.length === 0) {
+			return;
+		}
 		return this.cache?.store.mdel(...keys);
 	}
 

--- a/packages/cli/test/unit/services/cache-mock.service.test.ts
+++ b/packages/cli/test/unit/services/cache-mock.service.test.ts
@@ -1,0 +1,41 @@
+import Container from 'typedi';
+import { CacheService } from '@/services/cache.service';
+
+const cacheService = Container.get(CacheService);
+
+describe('cacheService (Mock)', () => {
+	test('should prevent use of empty keys', async () => {
+		const cache = await cacheService.getCache();
+		expect(cache).toBeDefined();
+		if (!cache) {
+			throw new Error('cache is undefined');
+		}
+
+		const spyGet = jest.spyOn(cache.store, 'get').mockImplementation(() => {
+			throw new Error('should not be called');
+		});
+
+		const spySet = jest.spyOn(cache.store, 'set').mockImplementation(() => {
+			throw new Error('should not be called');
+		});
+
+		// confirm mock is working
+		try {
+			await cacheService.set('test', 'test');
+		} catch {
+			expect(spySet).toThrowError();
+		}
+
+		await cacheService.set('', 'test');
+
+		await expect(cacheService.get('')).resolves.toBeUndefined();
+		await cacheService.setMany([
+			['', 'something'],
+			['', 'something'],
+		]);
+		await expect(cacheService.getMany([''])).resolves.toStrictEqual([undefined]);
+		await cacheService.setMany([]);
+		await expect(cacheService.getMany([])).resolves.toStrictEqual([]);
+		expect(spyGet).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/test/unit/services/cache-mock.service.test.ts
+++ b/packages/cli/test/unit/services/cache-mock.service.test.ts
@@ -1,10 +1,9 @@
 import Container from 'typedi';
-import type { RedisStore } from 'cache-manager-ioredis-yet';
 import { mock } from 'jest-mock-extended';
 import { CacheService } from '@/services/cache.service';
 
 const cacheService = Container.get(CacheService);
-const store = mock<RedisStore>({ isCacheable: () => true });
+const store = mock<NonNullable<CacheService['cache']>['store']>({ isCacheable: () => true });
 Object.assign(cacheService, { cache: { store } });
 
 describe('CacheService (Mock)', () => {

--- a/packages/cli/test/unit/services/cache.service.test.ts
+++ b/packages/cli/test/unit/services/cache.service.test.ts
@@ -339,4 +339,33 @@ describe('cacheService', () => {
 		await expect(cacheService.get('undefValue')).resolves.toBeUndefined();
 		await expect(cacheService.get('nullValue')).resolves.toBeUndefined();
 	});
+
+	test('should handle setting empty keys', async () => {
+		await cacheService.set('', null);
+		await expect(cacheService.get('')).resolves.toBeUndefined();
+		await cacheService.setMany([
+			['', 'something'],
+			['', 'something'],
+		]);
+		await expect(cacheService.getMany([''])).resolves.toStrictEqual([undefined]);
+		await cacheService.setMany([]);
+		await expect(cacheService.getMany([])).resolves.toStrictEqual([]);
+	});
+
+	test('should handle setting empty keys (redis)', async () => {
+		config.set('cache.backend', 'redis');
+		config.set('executions.mode', 'queue');
+		await cacheService.destroy();
+		await cacheService.init();
+
+		await cacheService.set('', null);
+		await expect(cacheService.get('')).resolves.toBeUndefined();
+		await cacheService.setMany([
+			['', 'something'],
+			['', 'something'],
+		]);
+		await expect(cacheService.getMany([''])).resolves.toStrictEqual([undefined]);
+		await cacheService.setMany([]);
+		await expect(cacheService.getMany([])).resolves.toStrictEqual([]);
+	});
 });


### PR DESCRIPTION
Fixes the case where an empty key name was passed to the cache service. The underlying caching library did not filter out empty keys and in turn passed them on to Redis, which would throw as a result.
This now filters out empty strings and arrays from caching requests (since they made no sense  anyway)