### PR TITLE
fix(GoToWebinar Node): Fix issue with timezone incorrectly being required

### DIFF
--- a/packages/nodes-base/nodes/GoToWebinar/descriptions/WebinarDescription.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/descriptions/WebinarDescription.ts
@@ -155,7 +155,6 @@ export const webinarFields: INodeProperties[] = [
 				type: 'options',
 				description:
 					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
-				required: true,
 				default: '',
 				placeholder: '2020-12-11T09:00:00Z',
 				typeOptions: {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/gotowebinar-create-registrant-asks-for-a-parameter-that-isnt-an-option/27644
