### PR TITLE
fix: import workflow credential name inside the credential object

### DIFF
--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -257,15 +257,15 @@ export class ImportWorkflowsCommand extends BaseCommand {
 	private transformCredentials(node: INode, credentialsEntities: ICredentialsDb[]) {
 		if (node.credentials) {
 			const allNodeCredentials = Object.entries(node.credentials);
-			for (const [type, name] of allNodeCredentials) {
-				if (typeof name === 'string') {
+			for (const [type, nodeCredential] of allNodeCredentials) {
+				if (nodeCredential && typeof credential.name === 'string') {
 					const nodeCredentials: INodeCredentialsDetails = {
 						id: null,
-						name,
+						name: nodeCredential.name,
 					};
 
 					const matchingCredentials = credentialsEntities.filter(
-						(credentials) => credentials.name === name && credentials.type === type,
+						(credentials) => credentials.name === nodeCredential.name && credentials.type === type,
 					);
 
 					if (matchingCredentials.length === 1) {


### PR DESCRIPTION
I had a small issue when importing my workflow on another instance of n8n with the same credentials name/type.

n8n was giving me a `Could not find any entity of type "CredentialsEntity"` with the ID of the first instance of n8n and not the ID of the new instance
