### PR TITLE
fix: Fix word wrapping in dropdown menu items (no-changelog)

### DIFF
--- a/packages/design-system/src/css/dropdown.scss
+++ b/packages/design-system/src/css/dropdown.scss
@@ -84,7 +84,6 @@
 	box-shadow: var.$dropdown-menu-box-shadow;
 	position: relative;
 	list-style: none;
-	min-width: 180px;
 
 	@include mixins.e(item) {
 		list-style: none;
@@ -96,6 +95,7 @@
 		color: var(--color-text-dark);
 		cursor: pointer;
 		outline: none;
+		white-space: nowrap;
 		&:not(.is-disabled):hover,
 		&:focus {
 			background-color: var.$dropdown-menuItem-hover-fill;

--- a/packages/design-system/src/css/dropdown.scss
+++ b/packages/design-system/src/css/dropdown.scss
@@ -84,6 +84,7 @@
 	box-shadow: var.$dropdown-menu-box-shadow;
 	position: relative;
 	list-style: none;
+	min-width: 180px;
 
 	@include mixins.e(item) {
 		list-style: none;


### PR DESCRIPTION
<img width="447" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/f16f605a-1ace-4570-a77b-a17567f1ed6e">