### PR TITLE
refactor(core): Adjust index handling in new migrations DSL (no-changelog)

### DIFF
--- a/packages/cli/src/databases/dsl/Indices.ts
+++ b/packages/cli/src/databases/dsl/Indices.ts
@@ -17,6 +17,7 @@ abstract class IndexOperation extends LazyPromise<void> {
 		protected tableName: string,
 		protected columnNames: string[],
 		queryRunner: QueryRunner,
+		protected customIndexName?: string,
 	) {
 		super((resolve) => {
 			void this.execute(queryRunner).then(resolve);
@@ -31,9 +32,9 @@ export class CreateIndex extends IndexOperation {
 		columnNames: string[],
 		protected isUnique: boolean,
 		queryRunner: QueryRunner,
-		protected customIndexName?: string,
+		customIndexName?: string,
 	) {
-		super(tablePrefix, tableName, columnNames, queryRunner);
+		super(tablePrefix, tableName, columnNames, queryRunner, customIndexName);
 	}
 
 	async execute(queryRunner: QueryRunner) {
@@ -47,6 +48,6 @@ export class CreateIndex extends IndexOperation {
 
 export class DropIndex extends IndexOperation {
 	async execute(queryRunner: QueryRunner) {
-		return queryRunner.dropIndex(this.fullTableName, this.fullIndexName);
+		return queryRunner.dropIndex(this.fullTableName, this.customIndexName ?? this.fullIndexName);
 	}
 }

--- a/packages/cli/src/databases/dsl/Indices.ts
+++ b/packages/cli/src/databases/dsl/Indices.ts
@@ -31,6 +31,7 @@ export class CreateIndex extends IndexOperation {
 		columnNames: string[],
 		protected isUnique: boolean,
 		queryRunner: QueryRunner,
+		protected customIndexName?: string,
 	) {
 		super(tablePrefix, tableName, columnNames, queryRunner);
 	}
@@ -39,7 +40,7 @@ export class CreateIndex extends IndexOperation {
 		const { columnNames, isUnique } = this;
 		return queryRunner.createIndex(
 			this.fullTableName,
-			new TableIndex({ name: this.fullIndexName, columnNames, isUnique }),
+			new TableIndex({ name: this.customIndexName ?? this.fullIndexName, columnNames, isUnique }),
 		);
 	}
 }

--- a/packages/cli/src/databases/dsl/Indices.ts
+++ b/packages/cli/src/databases/dsl/Indices.ts
@@ -4,10 +4,18 @@ import LazyPromise from 'p-lazy';
 abstract class IndexOperation extends LazyPromise<void> {
 	abstract execute(queryRunner: QueryRunner): Promise<void>;
 
+	get fullTableName() {
+		return [this.tablePrefix, this.tableName].join('');
+	}
+
+	get fullIndexName() {
+		return ['IDX', `${this.tablePrefix}${this.tableName}`, ...this.columnNames].join('_');
+	}
+
 	constructor(
-		protected name: string,
+		protected tablePrefix: string,
 		protected tableName: string,
-		protected prefix: string,
+		protected columnNames: string[],
 		queryRunner: QueryRunner,
 	) {
 		super((resolve) => {
@@ -18,28 +26,26 @@ abstract class IndexOperation extends LazyPromise<void> {
 
 export class CreateIndex extends IndexOperation {
 	constructor(
-		name: string,
+		tablePrefix: string,
 		tableName: string,
-		protected columnNames: string[],
+		columnNames: string[],
 		protected isUnique: boolean,
-		prefix: string,
 		queryRunner: QueryRunner,
 	) {
-		super(name, tableName, prefix, queryRunner);
+		super(tablePrefix, tableName, columnNames, queryRunner);
 	}
 
 	async execute(queryRunner: QueryRunner) {
-		const { tableName, name, columnNames, prefix, isUnique } = this;
+		const { columnNames, isUnique } = this;
 		return queryRunner.createIndex(
-			`${prefix}${tableName}`,
-			new TableIndex({ name: `IDX_${prefix}${name}`, columnNames, isUnique }),
+			this.fullTableName,
+			new TableIndex({ name: this.fullIndexName, columnNames, isUnique }),
 		);
 	}
 }
 
 export class DropIndex extends IndexOperation {
 	async execute(queryRunner: QueryRunner) {
-		const { tableName, name, prefix } = this;
-		return queryRunner.dropIndex(`${prefix}${tableName}`, `IDX_${prefix}${name}`);
+		return queryRunner.dropIndex(this.fullTableName, this.fullIndexName);
 	}
 }

--- a/packages/cli/src/databases/dsl/index.ts
+++ b/packages/cli/src/databases/dsl/index.ts
@@ -18,8 +18,8 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 		customIndexName?: string,
 	) => new CreateIndex(tablePrefix, tableName, columnNames, isUnique, queryRunner, customIndexName),
 
-	dropIndex: (tableName: string, columnNames: string[]) =>
-		new DropIndex(tablePrefix, tableName, columnNames, queryRunner),
+	dropIndex: (tableName: string, columnNames: string[], customIndexName?: string) =>
+		new DropIndex(tablePrefix, tableName, columnNames, queryRunner, customIndexName),
 
 	/* eslint-enable */
 });

--- a/packages/cli/src/databases/dsl/index.ts
+++ b/packages/cli/src/databases/dsl/index.ts
@@ -11,8 +11,12 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 
 	dropTable: (tableName: string) => new DropTable(tableName, tablePrefix, queryRunner),
 
-	createIndex: (tableName: string, columnNames: string[], isUnique = false) =>
-		new CreateIndex(tablePrefix, tableName, columnNames, isUnique, queryRunner),
+	createIndex: (
+		tableName: string,
+		columnNames: string[],
+		isUnique = false,
+		customIndexName?: string,
+	) => new CreateIndex(tablePrefix, tableName, columnNames, isUnique, queryRunner, customIndexName),
 
 	dropIndex: (tableName: string, columnNames: string[]) =>
 		new DropIndex(tablePrefix, tableName, columnNames, queryRunner),

--- a/packages/cli/src/databases/dsl/index.ts
+++ b/packages/cli/src/databases/dsl/index.ts
@@ -7,11 +7,15 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 	column: (name: string) => new Column(name),
 	/* eslint-disable @typescript-eslint/promise-function-async */
 	// NOTE: Do not add `async` to these functions, as that messes up the lazy-evaluation of LazyPromise
-	createTable: (name: string) => new CreateTable(name, tablePrefix, queryRunner),
-	dropTable: (name: string) => new DropTable(name, tablePrefix, queryRunner),
-	createIndex: (name: string, tableName: string, columnNames: string[], isUnique = false) =>
-		new CreateIndex(name, tableName, columnNames, isUnique, tablePrefix, queryRunner),
-	dropIndex: (name: string, tableName: string) =>
-		new DropIndex(name, tableName, tablePrefix, queryRunner),
+	createTable: (tableName: string) => new CreateTable(tableName, tablePrefix, queryRunner),
+
+	dropTable: (tableName: string) => new DropTable(tableName, tablePrefix, queryRunner),
+
+	createIndex: (tableName: string, columnNames: string[], isUnique = false) =>
+		new CreateIndex(tablePrefix, tableName, columnNames, isUnique, queryRunner),
+
+	dropIndex: (tableName: string, columnNames: string[]) =>
+		new DropIndex(tablePrefix, tableName, columnNames, queryRunner),
+
 	/* eslint-enable */
 });

--- a/packages/cli/src/databases/migrations/common/1691088862123-CreateWorkflowNameIndex.ts
+++ b/packages/cli/src/databases/migrations/common/1691088862123-CreateWorkflowNameIndex.ts
@@ -1,13 +1,11 @@
 import type { MigrationContext, ReversibleMigration } from '@db/types';
 
 export class CreateWorkflowNameIndex1691088862123 implements ReversibleMigration {
-	private indexName = '48f450ec4a8536fbd7d8e7d094';
-
 	async up({ schemaBuilder: { createIndex } }: MigrationContext) {
-		await createIndex(this.indexName, 'workflow_entity', ['name']);
+		await createIndex('workflow_entity', ['name']);
 	}
 
 	async down({ schemaBuilder: { dropIndex } }: MigrationContext) {
-		await dropIndex(this.indexName, 'workflow_entity');
+		await dropIndex('workflow_entity', ['name']);
 	}
 }


### PR DESCRIPTION
- Derive index name from table prefix, table name and column names.
- Expand arg names to avoid potentially confusing ones like `name` or `prefix`.
- Reorder args to table prefix, table name, column names. (Natural order?)
- Add getters for full index name and full table name.