### PR TITLE
fix(editor): Fix post-migration CSS inconsistencies (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nTooltip/Tooltip.vue
+++ b/packages/design-system/src/components/N8nTooltip/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-	<el-tooltip v-bind="{ ...$props, ...$attrs }">
+	<el-tooltip v-bind="{ ...$props, ...$attrs }" popper-class="n8n-tooltip">
 		<slot />
 		<template #content>
 			<slot name="content">

--- a/packages/design-system/src/css/index.scss
+++ b/packages/design-system/src/css/index.scss
@@ -30,7 +30,7 @@
 // @use "./time-select.scss";
 // @use "./time-picker.scss";
 @use './popover.scss';
-@use './tooltip.scss';
+//@use './tooltip.scss';
 @use './message-box.scss';
 // @use "./breadcrumb.scss";
 // @use "./breadcrumb-item.scss";

--- a/packages/design-system/src/css/popper.scss
+++ b/packages/design-system/src/css/popper.scss
@@ -150,3 +150,8 @@
 		}
 	}
 }
+
+.el-popper.n8n-tooltip {
+	max-width: 180px;
+	line-height: var(--font-line-height-regular) !important;
+}

--- a/packages/design-system/src/css/tooltip.scss
+++ b/packages/design-system/src/css/tooltip.scss
@@ -2,6 +2,8 @@
 @use './common/var';
 
 @include mixins.b(tooltip) {
+	max-width: 200px;
+
 	&:focus:not(.focusing),
 	&:focus:hover {
 		outline-width: 0;

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<span>
+	<div>
 		<n8n-tooltip placement="bottom" :disabled="!disabledHint">
 			<template #content>
 				<div>{{ disabledHint }}</div>
@@ -17,7 +17,7 @@
 				/>
 			</div>
 		</n8n-tooltip>
-	</span>
+	</div>
 </template>
 
 <script lang="ts">

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -1010,6 +1010,7 @@ export default defineComponent({
 	}
 
 	.node-parameters-wrapper {
+		min-height: 100%;
 		overflow-y: auto;
 		padding: 0 20px 200px 20px;
 	}

--- a/packages/editor-ui/src/n8n-theme.scss
+++ b/packages/editor-ui/src/n8n-theme.scss
@@ -224,7 +224,3 @@
 		}
 	}
 }
-
-.el-popper:not(.el-popover) {
-  max-width: 265px;
-}

--- a/packages/editor-ui/src/views/CanvasAddButton.vue
+++ b/packages/editor-ui/src/views/CanvasAddButton.vue
@@ -16,7 +16,7 @@
 				<font-awesome-icon icon="plus" size="lg" />
 			</button>
 			<template #content>
-				<p v-text="$locale.baseText('nodeView.canvasAddButton.addATriggerNodeBeforeExecuting')" />
+				{{ $locale.baseText('nodeView.canvasAddButton.addATriggerNodeBeforeExecuting') }}
 			</template>
 		</n8n-tooltip>
 		<p :class="$style.label" v-text="$locale.baseText('nodeView.canvasAddButton.addFirstStep')" />
@@ -79,10 +79,6 @@ const containerCssVars = computed(() => ({
 			fill: var(--color-foreground-xdark);
 		}
 	}
-}
-
-:root .tooltip {
-	max-width: 180px;
 }
 
 .label {


### PR DESCRIPTION
<img width="231" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/e6b00865-f735-41e9-b568-3fd91f29aeae">
<img width="207" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/f63b7f0c-7c53-4bde-91d7-faeb20119299">
<img width="379" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/2c2d7a2d-7490-45ec-827d-5db2b89b69dd">
<img width="469" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/91f98b55-fb15-4126-999a-4a480b6ca3ab">
<img width="409" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/433a5d58-d914-48e7-bba4-e0bd07c9439d">

