### PR TITLE
refactor: Enable `cred-class-field-documentation-url-missing` (no-changelog)

### DIFF
--- a/packages/nodes-base/.eslintrc.js
+++ b/packages/nodes-base/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
 				'n8n-nodes-base/cred-class-field-authenticate-type-assertion': 'error',
 				'n8n-nodes-base/cred-class-field-display-name-missing-oauth2': 'error',
 				'n8n-nodes-base/cred-class-field-display-name-miscased': 'error',
+				'n8n-nodes-base/cred-class-field-documentation-url-missing': 'error',
 				'n8n-nodes-base/cred-class-field-name-missing-oauth2': 'error',
 				'n8n-nodes-base/cred-class-field-name-unsuffixed': 'error',
 				'n8n-nodes-base/cred-class-field-name-uppercase-first-char': 'error',


### PR DESCRIPTION
https://github.com/ivov/eslint-plugin-n8n-nodes-base/blob/master/docs/rules/cred-class-field-documentation-url-missing.md