### PR TITLE
fix(core): Restore body parsing for all content-types for non webhook routes

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -11,7 +11,7 @@ import { N8nInstanceType } from '@/Interfaces';
 import type { IExternalHooksClass } from '@/Interfaces';
 import { ExternalHooks } from '@/ExternalHooks';
 import { send, sendErrorResponse, ServiceUnavailableError } from '@/ResponseHelper';
-import { rawBody, jsonParser, corsMiddleware } from '@/middlewares';
+import { rawBodyReader, bodyParser, corsMiddleware } from '@/middlewares';
 import { TestWebhooks } from '@/TestWebhooks';
 import { WaitingWebhooks } from '@/WaitingWebhooks';
 import { webhookRequestHandler } from '@/WebhookHelpers';
@@ -98,7 +98,7 @@ export abstract class AbstractServer {
 		this.app.use(compression());
 
 		// Read incoming data into `rawBody`
-		this.app.use(rawBody);
+		this.app.use(rawBodyReader);
 	}
 
 	private setupDevMiddlewares() {
@@ -274,8 +274,8 @@ export abstract class AbstractServer {
 			this.setupDevMiddlewares();
 		}
 
-		// Setup JSON parsing middleware after the webhook handlers are setup
-		this.app.use(jsonParser);
+		// Setup body parsing middleware after the webhook handlers are setup
+		this.app.use(bodyParser);
 
 		await this.configure();
 

--- a/packages/cli/test/integration/shared/utils/testServer.ts
+++ b/packages/cli/test/integration/shared/utils/testServer.ts
@@ -30,7 +30,7 @@ import {
 	TagsController,
 	UsersController,
 } from '@/controllers';
-import { rawBody, jsonParser, setupAuthMiddlewares } from '@/middlewares';
+import { rawBodyReader, bodyParser, setupAuthMiddlewares } from '@/middlewares';
 
 import { InternalHooks } from '@/InternalHooks';
 import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
@@ -118,7 +118,7 @@ export const setupTestServer = ({
 	enabledFeatures,
 }: SetupProps): TestServer => {
 	const app = express();
-	app.use(rawBody);
+	app.use(rawBodyReader);
 	app.use(cookieParser());
 
 	const testServer: TestServer = {
@@ -153,7 +153,7 @@ export const setupTestServer = ({
 
 		if (!endpointGroups) return;
 
-		app.use(jsonParser);
+		app.use(bodyParser);
 
 		const [routerEndpoints, functionEndpoints] = classifyEndpointGroups(endpointGroups);
 


### PR DESCRIPTION
Changes in https://github.com/n8n-io/n8n/pull/6394 removed xml body parsing for all non-webhook routes. 
This broke SAML endpoints as they need the XML body parser to function correctly.
