### PR TITLE
Fix date check in waittracker

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -83,13 +83,17 @@ export class WaitTracker {
 		for (const execution of executions) {
 			const executionId = execution.id;
 			if (this.waitingExecutions[executionId] === undefined) {
-				const triggerTime = execution.waitTill!.getTime() - new Date().getTime();
-				this.waitingExecutions[executionId] = {
-					executionId,
-					timer: setTimeout(() => {
-						this.startExecution(executionId);
-					}, triggerTime),
-				};
+				if (execution.waitTill instanceof Date) {
+					const triggerTime = execution.waitTill!.getTime() - new Date().getTime();
+					this.waitingExecutions[executionId] = {
+						executionId,
+						timer: setTimeout(() => {
+							this.startExecution(executionId);
+						}, triggerTime),
+					};
+				} else {
+					Logger.error(`execution.waitTill is not a Date object for execution ID: ${executionId}. Value: ${execution.waitTill}`);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This pull request addresses the TypeError issue reported in #6624. The error was caused by attempting to call `getTime()` on `execution.waitTill` without verifying if it's a Date object.