### PR TITLE
fix: Add only necessary information to executions (no-changelog)

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -61,6 +61,7 @@ import type {
 	WorkflowTagMappingRepository,
 } from '@db/repositories';
 import type { LICENSE_FEATURES, LICENSE_QUOTAS } from './constants';
+import { WorkflowWithSharingsAndCredentials } from './workflows/workflows.types';
 
 export interface IActivationError {
 	time: number;
@@ -194,7 +195,7 @@ export interface IExecutionResponse extends IExecutionBase {
 	retryOf?: string;
 	retrySuccessId?: string;
 	waitTill?: Date | null;
-	workflowData: IWorkflowBase;
+	workflowData: IWorkflowBase | WorkflowWithSharingsAndCredentials;
 }
 
 // Flatted data to save memory when saving in database or transferring

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -61,7 +61,7 @@ import type {
 	WorkflowTagMappingRepository,
 } from '@db/repositories';
 import type { LICENSE_FEATURES, LICENSE_QUOTAS } from './constants';
-import { WorkflowWithSharingsAndCredentials } from './workflows/workflows.types';
+import type { WorkflowWithSharingsAndCredentials } from './workflows/workflows.types';
 
 export interface IActivationError {
 	time: number;

--- a/packages/cli/src/executions/executions.service.ee.ts
+++ b/packages/cli/src/executions/executions.service.ee.ts
@@ -4,6 +4,7 @@ import { ExecutionsService } from './executions.service';
 import type { ExecutionRequest } from '@/requests';
 import type { IExecutionResponse, IExecutionFlattedResponse } from '@/Interfaces';
 import { EEWorkflowsService as EEWorkflows } from '../workflows/workflows.services.ee';
+import { WorkflowWithSharingsAndCredentials } from '@/workflows/workflows.types';
 
 export class EEExecutionsService extends ExecutionsService {
 	/**
@@ -22,13 +23,21 @@ export class EEExecutionsService extends ExecutionsService {
 		if (!execution) return;
 
 		const relations = ['shared', 'shared.user', 'shared.role'];
-		const workflow = await EEWorkflows.get({ id: execution.workflowId }, { relations });
+		const workflow = (await EEWorkflows.get(
+			{ id: execution.workflowId },
+			{ relations },
+		)) as WorkflowWithSharingsAndCredentials;
 		if (!workflow) return;
 
 		EEWorkflows.addOwnerAndSharings(workflow);
 		await EEWorkflows.addCredentialsToWorkflow(workflow, req.user);
 
-		execution.workflowData = workflow;
+		execution.workflowData = {
+			...execution.workflowData,
+			ownedBy: workflow.ownedBy,
+			sharedWith: workflow.sharedWith,
+			usedCredentials: workflow.usedCredentials,
+		} as WorkflowWithSharingsAndCredentials;
 
 		return execution;
 	}

--- a/packages/cli/src/executions/executions.service.ee.ts
+++ b/packages/cli/src/executions/executions.service.ee.ts
@@ -4,7 +4,7 @@ import { ExecutionsService } from './executions.service';
 import type { ExecutionRequest } from '@/requests';
 import type { IExecutionResponse, IExecutionFlattedResponse } from '@/Interfaces';
 import { EEWorkflowsService as EEWorkflows } from '../workflows/workflows.services.ee';
-import { WorkflowWithSharingsAndCredentials } from '@/workflows/workflows.types';
+import type { WorkflowWithSharingsAndCredentials } from '@/workflows/workflows.types';
 
 export class EEExecutionsService extends ExecutionsService {
 	/**


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

The goal of this PR is that we need `sharedWith`, `ownedBy` and `usedCredentials` in executions to properly display the data, but we cannot override the execution's version of the workflow with the one currently in db as they might differ. This PR fetches only the necessary attributes.