### PR TITLE
fix(editor): Do not flag dynamic load options issue on expression

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -735,7 +735,7 @@ export default defineComponent({
 						issues.parameters[this.parameter.name] = [issue];
 					}
 				}
-			} else if (this.remoteParameterOptionsLoadingIssues !== null) {
+			} else if (this.remoteParameterOptionsLoadingIssues !== null && !this.isValueExpression) {
 				if (issues.parameters === undefined) {
 					issues.parameters = {};
 				}


### PR DESCRIPTION
Story: https://linear.app/n8n/issue/PAY-631

1. Set a Linear node to update an issue.
2. Add an invalid Linear cred.
3. In `Update Fields`, set `State Name or ID` to an expression. → No loading issue should be flagged.
4. Switch back to fixed mode. → Loading issue should be flagged.

<img width="289" alt="Capture 2023-08-15 at 15 58 53@2x" src="https://github.com/n8n-io/n8n/assets/44588767/0e34220c-0e62-417f-90c6-5a48aa12bf4b">

<img width="373" alt="Capture 2023-08-15 at 15 58 38@2x" src="https://github.com/n8n-io/n8n/assets/44588767/137c8f5a-1ece-4f02-ae0d-e1bc56e9c9dd">
