### PR TITLE
fix(editor): Prevent Code node linter from erroring on `null` parse

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/linter.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/linter.ts
@@ -63,6 +63,8 @@ export const linterExtension = defineComponent({
 				}
 			}
 
+			if (ast === null) return [];
+
 			const lintings: Diagnostic[] = [];
 
 			/**


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-717