### PR TITLE
refactor(core): Replace promisify-d nodejs APIs with new native APIs (no-changelog)

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -10,8 +10,7 @@
 import type express from 'express';
 import { Container } from 'typedi';
 import get from 'lodash/get';
-import stream from 'stream';
-import { promisify } from 'util';
+import { pipeline } from 'stream/promises';
 import formidable from 'formidable';
 
 import { BinaryDataManager, NodeExecuteFunctions } from 'n8n-core';
@@ -62,8 +61,6 @@ import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import { EventsService } from '@/services/events.service';
 import { OwnershipService } from './services/ownership.service';
 import { parseBody } from './middlewares';
-
-const pipeline = promisify(stream.pipeline);
 
 export const WEBHOOK_METHODS: IHttpRequestMethods[] = [
 	'DELETE',

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -8,9 +8,8 @@ import { createReadStream, createWriteStream, existsSync } from 'fs';
 import localtunnel from 'localtunnel';
 import { TUNNEL_SUBDOMAIN_ENV, UserSettings } from 'n8n-core';
 import { flags } from '@oclif/command';
-import stream from 'stream';
+import { pipeline } from 'stream/promises';
 import replaceStream from 'replacestream';
-import { promisify } from 'util';
 import glob from 'fast-glob';
 
 import { LoggerProxy, sleep, jsonParse } from 'n8n-workflow';
@@ -31,7 +30,6 @@ import { InternalHooks } from '@/InternalHooks';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
-const pipeline = promisify(stream.pipeline);
 
 export class Start extends BaseCommand {
 	static description = 'Starts n8n. Makes Web-UI available and starts active workflows';

--- a/packages/node-dev/commands/new.ts
+++ b/packages/node-dev/commands/new.ts
@@ -3,17 +3,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import * as changeCase from 'change-case';
-import * as fs from 'fs';
+import { access } from 'fs/promises';
 import * as inquirer from 'inquirer';
 import { Command } from '@oclif/command';
 import { join } from 'path';
 
 import { createTemplate } from '../src';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { promisify } = require('util');
-
-const fsAccess = promisify(fs.access);
 
 export class New extends Command {
 	static description = 'Create new credentials/node';
@@ -113,7 +108,7 @@ export class New extends Command {
 			// Check if node with the same name already exists in target folder
 			// to not overwrite it by accident
 			try {
-				await fsAccess(destinationFilePath);
+				await access(destinationFilePath);
 
 				// File does already exist. So ask if it should be overwritten.
 				const overwriteQuestion: inquirer.QuestionCollection = [

--- a/packages/node-dev/src/Create.ts
+++ b/packages/node-dev/src/Create.ts
@@ -1,12 +1,6 @@
-import * as fs from 'fs';
+import { copyFile } from 'fs/promises';
 import type { ReplaceInFileConfig } from 'replace-in-file';
 import { replaceInFile } from 'replace-in-file';
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
-const { promisify } = require('util');
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-const fsCopyFile = promisify(fs.copyFile);
 
 /**
  * Creates a new credentials or node
@@ -22,7 +16,7 @@ export async function createTemplate(
 ): Promise<void> {
 	// Copy the file to then replace the values in it
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-	await fsCopyFile(sourceFilePath, destinationFilePath);
+	await copyFile(sourceFilePath, destinationFilePath);
 
 	// Replace the variables in the template file
 	const options: ReplaceInFileConfig = {

--- a/packages/nodes-base/nodes/Crypto/Crypto.node.ts
+++ b/packages/nodes-base/nodes/Crypto/Crypto.node.ts
@@ -11,12 +11,9 @@ import { deepCopy, BINARY_ENCODING } from 'n8n-workflow';
 
 import type { BinaryToTextEncoding } from 'crypto';
 import { createHash, createHmac, createSign, getHashes, randomBytes } from 'crypto';
-import stream from 'stream';
-import { promisify } from 'util';
+import { pipeline } from 'stream/promises';
 
 import { v4 as uuid } from 'uuid';
-
-const pipeline = promisify(stream.pipeline);
 
 const unsupportedAlgorithms = [
 	'RSA-MD4',

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -12,9 +12,7 @@ import { deepCopy } from 'n8n-workflow';
 import gm from 'gm';
 import { file } from 'tmp-promise';
 import { parse as pathParse } from 'path';
-import { writeFile as fsWriteFile } from 'fs';
-import { promisify } from 'util';
-const fsWriteFileAsync = promisify(fsWriteFile);
+import { writeFile as fsWriteFile } from 'fs/promises';
 import getSystemFonts from 'get-system-fonts';
 
 const nodeOperations: INodePropertyOptions[] = [
@@ -1119,7 +1117,7 @@ export class EditImage implements INodeType {
 
 						const { fd, path, cleanup } = await file();
 						cleanupFunctions.push(cleanup);
-						await fsWriteFileAsync(fd, binaryDataBuffer);
+						await fsWriteFile(fd, binaryDataBuffer);
 
 						if (operations[0].operation === 'create') {
 							// It seems like if the image gets created newly we have to create a new gm instance

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -15,8 +15,7 @@ import { formatPrivateKey } from '@utils/utilities';
 import { createWriteStream } from 'fs';
 import { basename, dirname } from 'path';
 import type { Readable } from 'stream';
-import { pipeline } from 'stream';
-import { promisify } from 'util';
+import { pipeline } from 'stream/promises';
 import { file as tmpFile } from 'tmp-promise';
 
 import ftpClient from 'promise-ftp';
@@ -39,8 +38,6 @@ interface ReturnFtpItem {
 	sticky?: boolean;
 	path: string;
 }
-
-const streamPipeline = promisify(pipeline);
 
 async function callRecursiveList(
 	path: string,
@@ -715,7 +712,7 @@ export class Ftp implements INodeType {
 						const binaryFile = await tmpFile({ prefix: 'n8n-sftp-' });
 						try {
 							const stream = await ftp!.get(path);
-							await streamPipeline(stream, createWriteStream(binaryFile.path));
+							await pipeline(stream, createWriteStream(binaryFile.path));
 
 							const dataPropertyNameDownload = this.getNodeParameter('binaryPropertyName', i);
 							const remoteFilePath = this.getNodeParameter('path', i) as string;


### PR DESCRIPTION
Since we have dropped support for nodejs < 18, we can start using these "new" native methods instead of manually promisifying legacy apis.  