### PR TITLE
refactor: Remove `prettierPath` config option (no-changelog)

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -9,7 +9,6 @@
 	"typescript.format.enable": false,
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"workspace-default-settings.runOnActivation": true,
-	"prettier.prettierPath": "node_modules/prettier",
 	"eslint.probe": ["javascript", "typescript", "vue"],
 	"eslint.workingDirectories": [
 		{


### PR DESCRIPTION
On Prettier 3, VSCode Prettier extension v10.1.0 fails to load the Prettier config file.

<details>
<summary>
Stack trace
</summary>

```
["INFO" - 10:24:08] Extension Name: esbenp.prettier-vscode.
["INFO" - 10:24:08] Extension Version: 10.1.0.
["ERROR" - 10:24:08] Error resolving prettier configuration for /Users/ivov/Development/n8n
["ERROR" - 10:24:08] Invalid host defined options
TypeError: Invalid host defined options
    at Object.<anonymous> (/Users/ivov/Development/n8n/node_modules/.pnpm/prettier@3.0.0/node_modules/prettier/index.cjs:600:23)
    at Module.u._compile (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js:4:1271)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1243:10)
    at Module.load (node:internal/modules/cjs/loader:1058:32)
    at Module._load (node:internal/modules/cjs/loader:893:12)
    at Function.f._load (node:electron/js2c/asar_bundle:2:13330)
    at Function.l._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:28070)
    at Function.p._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:127:25404)
    at Function.u._load (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:91:22191)
    at Module.apply (node:internal/modules/cjs/loader:1082:19)
    at Module.require (/Users/ivov/.vscode/extensions/github.copilot-1.103.338/node_modules/diagnostic-channel/dist/src/patchRequire.js:16:46)
    at g (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/loader.js:4:647)
    at t.loadNodeModule (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:2829)
    at t.PrettierMainThreadInstance.import (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:17760)
    at t.ModuleResolver.getPrettierInstance (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:5728)
    at t.default.handleActiveTextEditorChanged (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:10771)
    at t.default.handleActiveTextEditorChangedSync (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:10373)
    at t.default.registerDisposables (/Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:13531)
    at /Users/ivov/.vscode/extensions/esbenp.prettier-vscode-10.1.0/dist/extension.js:1:82528
```

</details>

Removing `prettier.prettierPath` allows the config file to be found again. But from what I can tell, this option was not deprecated. So on review, please validate that this works on your own setup as well.