### PR TITLE
fix(editor): Fix formatting on editors (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -42,8 +42,9 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
-import jsParser from 'prettier/parser-babel';
-import prettier from 'prettier/standalone';
+import jsParser from 'prettier/plugins/babel';
+import { format } from 'prettier';
+import * as estree from 'prettier/plugins/estree';
 import { mapStores } from 'pinia';
 import type { LanguageSupport } from '@codemirror/language';
 import type { Extension, Line } from '@codemirror/state';
@@ -203,9 +204,9 @@ export default defineComponent({
 			return true;
 		},
 		async onReplaceCode(code: string) {
-			const formattedCode = prettier.format(code, {
+			const formattedCode = await format(code, {
 				parser: 'babel',
-				plugins: [jsParser],
+				plugins: [jsParser, estree],
 			});
 
 			this.editor?.dispatch({


### PR DESCRIPTION
Prettier 3 has a [new package structure](https://prettier.io/blog/2023/07/05/3.0.0.html#npm-package-file-structures-changed-12740httpsgithubcomprettierprettierpull12740-by-fiskerhttpsgithubcomfisker-13530httpsgithubcomprettierprettierpull13530-by-fiskerhttpsgithubcomfisker-14570httpsgithubcomprettierprettierpull14570-by-fiskerhttpsgithubcomfisker), made `format` async, and requires `estree` in specific cases.

e2e run: https://github.com/n8n-io/n8n/actions/runs/5889270624