### PR TITLE
feat(core): Add a warning to error workflows that cannot be started due to permission or settings

### DIFF
--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -1,7 +1,7 @@
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import { Container } from 'typedi';
-import type {
+import {
 	IDataObject,
 	IExecuteData,
 	INode,
@@ -10,7 +10,9 @@ import type {
 	IRunExecutionData,
 	ITaskData,
 	NodeApiError,
+	SubworkflowOperationError,
 	WorkflowExecuteMode,
+	WorkflowOperationError,
 } from 'n8n-workflow';
 import {
 	ErrorReporterProxy as ErrorReporter,
@@ -22,6 +24,7 @@ import { v4 as uuid } from 'uuid';
 import * as Db from '@/Db';
 import type {
 	ICredentialsDb,
+	IExecutionDb,
 	IWorkflowErrorData,
 	IWorkflowExecutionDataProcess,
 } from '@/Interfaces';
@@ -39,10 +42,56 @@ import { UserService } from './user/user.service';
 import type { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import type { RoleNames } from '@db/entities/Role';
 import { RoleService } from './services/role.service';
-import { RoleRepository } from './databases/repositories';
+import { ExecutionRepository, RoleRepository } from './databases/repositories';
 import { VariablesService } from './environments/variables/variables.service';
 
 const ERROR_TRIGGER_TYPE = config.getEnv('nodes.errorTriggerType');
+
+export function generateFailedExecutionFromError(
+	mode: WorkflowExecuteMode,
+	error: NodeApiError | NodeOperationError | WorkflowOperationError,
+	node: INode,
+): IRun {
+	return {
+		data: {
+			startData: {
+				destinationNode: node.name,
+				runNodeFilter: [node.name],
+			},
+			resultData: {
+				error,
+				runData: {
+					[node.name]: [
+						{
+							startTime: 0,
+							executionTime: 0,
+							error,
+							source: [],
+						},
+					],
+				},
+				lastNodeExecuted: node.name,
+			},
+			executionData: {
+				contextData: {},
+				nodeExecutionStack: [
+					{
+						node,
+						data: {},
+						source: null,
+					},
+				],
+				waitingExecution: {},
+				waitingExecutionSource: {},
+			},
+		},
+		finished: false,
+		mode,
+		startedAt: new Date(),
+		stoppedAt: new Date(),
+		status: 'failed',
+	};
+}
 
 /**
  * Returns the data of the last executed node
@@ -127,6 +176,34 @@ export async function executeErrorWorkflow(
 				workflowErrorData.workflow.id,
 			);
 		} catch (error) {
+			const initialNode = workflowInstance.getStartNode();
+			if (initialNode) {
+				const errorWorkflowPermissionError = new SubworkflowOperationError(
+					'This workflow could not be triggered due to subworkflow settings or permissions.',
+					`Another workflow with ID ${workflowErrorData.workflow.id} tried to invoke this workflow to handle errors. Please check permissions and whether this workflow allows being called by others`,
+				);
+
+				// Create a fake execution and save it to DB.
+				const fakeExecution = generateFailedExecutionFromError(
+					'error',
+					errorWorkflowPermissionError,
+					initialNode,
+				);
+
+				const fullExecutionData: IExecutionDb = {
+					data: fakeExecution.data,
+					mode: fakeExecution.mode,
+					finished: false,
+					startedAt: new Date(),
+					stoppedAt: new Date(),
+					workflowData,
+					waitTill: null,
+					status: fakeExecution.status,
+					workflowId: workflowData.id,
+				};
+
+				await Container.get(ExecutionRepository).createNewExecution(fullExecutionData);
+			}
 			Logger.info('Error workflow execution blocked due to subworkflow settings', {
 				erroredWorkflowId: workflowErrorData.workflow.id,
 				errorWorkflowId: workflowId,
@@ -443,52 +520,6 @@ export async function isBelowOnboardingThreshold(user: User): Promise<boolean> {
 	}
 
 	return belowThreshold;
-}
-
-export function generateFailedExecutionFromError(
-	mode: WorkflowExecuteMode,
-	error: NodeApiError | NodeOperationError,
-	node: INode,
-): IRun {
-	return {
-		data: {
-			startData: {
-				destinationNode: node.name,
-				runNodeFilter: [node.name],
-			},
-			resultData: {
-				error,
-				runData: {
-					[node.name]: [
-						{
-							startTime: 0,
-							executionTime: 0,
-							error,
-							source: [],
-						},
-					],
-				},
-				lastNodeExecuted: node.name,
-			},
-			executionData: {
-				contextData: {},
-				nodeExecutionStack: [
-					{
-						node,
-						data: {},
-						source: null,
-					},
-				],
-				waitingExecution: {},
-				waitingExecutionSource: {},
-			},
-		},
-		finished: false,
-		mode,
-		startedAt: new Date(),
-		stoppedAt: new Date(),
-		status: 'failed',
-	};
 }
 
 /** Get all nodes in a workflow where the node credential is not accessible to the user. */

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -180,8 +180,8 @@ export async function executeErrorWorkflow(
 			const initialNode = workflowInstance.getStartNode();
 			if (initialNode) {
 				const errorWorkflowPermissionError = new SubworkflowOperationError(
-					'This workflow could not be triggered due to subworkflow settings or permissions.',
-					`Another workflow with ID ${workflowErrorData.workflow.id} tried to invoke this workflow to handle errors. Please check permissions and whether this workflow allows being called by others`,
+					`Another workflow: (ID ${workflowErrorData.workflow.id}) tried to invoke this workflow to handle errors.`,
+					"Unfortunately current permissions do not allow this. Please check that this workflow's settings allow it to be called by others",
 				);
 
 				// Create a fake execution and save it to DB.

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -1,7 +1,6 @@
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import { Container } from 'typedi';
-import { SubworkflowOperationError } from 'n8n-workflow';
 
 import type {
 	IDataObject,
@@ -19,6 +18,7 @@ import {
 	ErrorReporterProxy as ErrorReporter,
 	LoggerProxy as Logger,
 	NodeOperationError,
+	SubworkflowOperationError,
 	Workflow,
 } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -1,7 +1,9 @@
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import { Container } from 'typedi';
-import {
+import { SubworkflowOperationError } from 'n8n-workflow';
+
+import type {
 	IDataObject,
 	IExecuteData,
 	INode,
@@ -10,7 +12,6 @@ import {
 	IRunExecutionData,
 	ITaskData,
 	NodeApiError,
-	SubworkflowOperationError,
 	WorkflowExecuteMode,
 	WorkflowOperationError,
 } from 'n8n-workflow';

--- a/packages/editor-ui/src/mixins/executionsHelpers.ts
+++ b/packages/editor-ui/src/mixins/executionsHelpers.ts
@@ -41,19 +41,15 @@ export const executionHelpers = defineComponent({
 				runningTime: '',
 			};
 
-			if (execution.status === 'waiting' || execution.waitTill) {
+			if (execution.status === 'waiting') {
 				status.name = 'waiting';
 				status.label = this.$locale.baseText('executionsList.waiting');
 			} else if (execution.status === 'canceled') {
 				status.label = this.$locale.baseText('executionsList.canceled');
-			} else if (
-				execution.status === 'running' ||
-				execution.status === 'new' ||
-				execution.stoppedAt === undefined
-			) {
+			} else if (execution.status === 'running' || execution.status === 'new') {
 				status.name = 'running';
 				status.label = this.$locale.baseText('executionsList.running');
-			} else if (execution.status === 'success' || execution.finished) {
+			} else if (execution.status === 'success') {
 				status.name = 'success';
 				status.label = this.$locale.baseText('executionsList.succeeded');
 			} else if (execution.status === 'failed' || execution.status === 'crashed') {

--- a/packages/workflow/src/WorkflowErrors.ts
+++ b/packages/workflow/src/WorkflowErrors.ts
@@ -1,9 +1,10 @@
 import type { INode } from './Interfaces';
+import { ExecutionBaseError } from './NodeErrors';
 
 /**
  * Class for instantiating an operational error, e.g. a timeout error.
  */
-export class WorkflowOperationError extends Error {
+export class WorkflowOperationError extends ExecutionBaseError {
 	node: INode | undefined;
 
 	timestamp: number;
@@ -13,7 +14,7 @@ export class WorkflowOperationError extends Error {
 	description: string | undefined;
 
 	constructor(message: string, node?: INode) {
-		super(message);
+		super(message, { cause: undefined });
 		this.name = this.constructor.name;
 		this.node = node;
 		this.timestamp = Date.now();


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

This PR aims to address an issue where an Error workflow cannot be started, either due to insufficient permissions or because its settings prevent it from being called.

The way of addressing this is by creating a failed execution for the appointed error workflow stating the error, as can be seen below.

This means the execution itself won't start, as it's prevented before the execution beings, but we save a "stub" execution to show the error.

![Screenshot 2023-08-17 at 16 17 02](https://github.com/n8n-io/n8n/assets/219272/d8ec0144-13c5-4b11-b91c-a6b440816ccf)
