### PR TITLE
fix(core): Add recoveryInProgress flag file

### DIFF
--- a/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriter.ts
+++ b/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriter.ts
@@ -98,6 +98,22 @@ export class MessageEventBusLogWriter {
 		}
 	}
 
+	startRecoveryProcess() {
+		if (this.worker) {
+			this.worker.postMessage({ command: 'startRecoveryProcess', data: {} });
+		}
+	}
+
+	isRecoveryProcessRunning(): boolean {
+		return existsSync(this.getRecoveryInProgressFileName());
+	}
+
+	endRecoveryProcess() {
+		if (this.worker) {
+			this.worker.postMessage({ command: 'endRecoveryProcess', data: {} });
+		}
+	}
+
 	private async startThread() {
 		if (this.worker) {
 			await this.close();
@@ -238,6 +254,10 @@ export class MessageEventBusLogWriter {
 		} else {
 			return `${MessageEventBusLogWriter.options.logFullBasePath}.log`;
 		}
+	}
+
+	getRecoveryInProgressFileName(): string {
+		return `${MessageEventBusLogWriter.options.logFullBasePath}.recoveryInProgress`;
 	}
 
 	cleanAllLogs() {

--- a/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriterWorker.ts
+++ b/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriterWorker.ts
@@ -25,6 +25,24 @@ function setKeepFiles(keepNumberOfFiles: number) {
 	keepFiles = keepNumberOfFiles;
 }
 
+function buildRecoveryInProgressFileName(): string {
+	return `${logFileBasePath}.recoveryInProgress`;
+}
+
+function startRecoveryProcess() {
+	if (existsSync(buildRecoveryInProgressFileName())) {
+		return false;
+	}
+	openSync(buildRecoveryInProgressFileName(), 'a');
+	return true;
+}
+
+function endRecoveryProcess() {
+	if (existsSync(buildRecoveryInProgressFileName())) {
+		rmSync(buildRecoveryInProgressFileName());
+	}
+}
+
 function buildLogFileNameWithCounter(counter?: number): string {
 	if (counter) {
 		return `${logFileBasePath}-${counter}.log`;
@@ -111,6 +129,14 @@ if (!isMainThread) {
 				case 'cleanLogs':
 					cleanAllLogs();
 					parentPort?.postMessage('cleanedAllLogs');
+					break;
+				case 'startRecoveryProcess':
+					const recoveryStarted = startRecoveryProcess();
+					parentPort?.postMessage({ command, data: recoveryStarted });
+					break;
+				case 'endRecoveryProcess':
+					endRecoveryProcess();
+					parentPort?.postMessage({ command, data: true });
 					break;
 				default:
 					break;

--- a/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriterWorker.ts
+++ b/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriterWorker.ts
@@ -33,7 +33,8 @@ function startRecoveryProcess() {
 	if (existsSync(buildRecoveryInProgressFileName())) {
 		return false;
 	}
-	openSync(buildRecoveryInProgressFileName(), 'a');
+	const fileHandle = openSync(buildRecoveryInProgressFileName(), 'a');
+	closeSync(fileHandle);
 	return true;
 }
 


### PR DESCRIPTION
Issue: during startup, unfinished executions trigger a recovery process that, under certain circumstances, can in itself crash the instance (e.g. by running our of memory), resulting in an infinite recovery loop

This PR aims to change this behaviour by writing a flag file when the recovery process starts, and removing it when it finishes. In the case of a crash, this flag will persist and upon the next attempt, the recovery will instead do the absolute minimal (marking executions as 'crashed'), without attempting any 'crashable' actions.

