### PR TITLE
fix(Webhook Node): Backward compatible form-data parsing for non-array fields

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -309,6 +309,11 @@ export async function executeWebhook(
 				});
 				req.body = await new Promise((resolve) => {
 					form.parse(req, async (err, data, files) => {
+						for (const key in data) {
+							if (Array.isArray(data[key]) && data[key].length === 1) {
+								data[key] = data[key][0];
+							}
+						}
 						resolve({ data, files });
 					});
 				});

--- a/packages/cli/test/integration/webhooks.api.test.ts
+++ b/packages/cli/test/integration/webhooks.api.test.ts
@@ -113,7 +113,9 @@ describe('Webhook API', () => {
 		test('should handle multipart/form-data', async () => {
 			const response = await agent
 				.post('/webhook/abcd')
-				.field('field', 'value')
+				.field('field1', 'value1')
+				.field('field2', 'value2')
+				.field('field2', 'value3')
 				.attach('file', Buffer.from('random-text'))
 				.set('content-type', 'multipart/form-data');
 
@@ -125,7 +127,7 @@ describe('Webhook API', () => {
 					file: [file],
 				},
 			} = response.body.body;
-			expect(data).toEqual({ field: ['value'] });
+			expect(data).toEqual({ field1: 'value1', field2: ['value2', 'value3'] });
 			expect(file.mimetype).toEqual('application/octet-stream');
 			expect(readFileSync(file.filepath, 'utf-8')).toEqual('random-text');
 		});

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -127,7 +127,7 @@ export class Webhook extends Node {
 		const response: INodeExecutionData = {
 			json: {
 				headers: req.headers,
-				params: req.params,
+				params: {},
 				query: req.query,
 				body: req.body,
 			},
@@ -207,7 +207,7 @@ export class Webhook extends Node {
 			binary: {},
 			json: {
 				headers: req.headers,
-				params: req.params,
+				params: {},
 				query: req.query,
 				body: data,
 			},
@@ -263,7 +263,7 @@ export class Webhook extends Node {
 				binary: {},
 				json: {
 					headers: req.headers,
-					params: req.params,
+					params: {},
 					query: req.query,
 					body: {},
 				},


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/breaking-changes-in-webhook-format-after-upgrade/29461