### PR TITLE
fix(core): Replace throw with warning when deactivating a non-active workflow

### DIFF
--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -920,8 +920,10 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		// if it's active in memory then it's a trigger
 		// so remove from list of actives workflows
 		if (this.activeWorkflows.isActive(workflowId)) {
-			await this.activeWorkflows.remove(workflowId);
-			Logger.verbose(`Successfully deactivated workflow "${workflowId}"`, { workflowId });
+			const removalSuccess = await this.activeWorkflows.remove(workflowId);
+			if (removalSuccess) {
+				Logger.verbose(`Successfully deactivated workflow "${workflowId}"`, { workflowId });
+			}
 		}
 	}
 }

--- a/packages/core/src/ActiveWorkflows.ts
+++ b/packages/core/src/ActiveWorkflows.ts
@@ -200,9 +200,10 @@ export class ActiveWorkflows {
 	async remove(id: string): Promise<void> {
 		if (!this.isActive(id)) {
 			// Workflow is currently not registered
-			throw new Error(
+			Logger.warn(
 				`The workflow with the id "${id}" is currently not active and can so not be removed`,
 			);
+			return;
 		}
 
 		const workflowData = this.workflowData[id];

--- a/packages/core/src/ActiveWorkflows.ts
+++ b/packages/core/src/ActiveWorkflows.ts
@@ -197,13 +197,13 @@ export class ActiveWorkflows {
 	 *
 	 * @param {string} id The id of the workflow to deactivate
 	 */
-	async remove(id: string): Promise<void> {
+	async remove(id: string): Promise<boolean> {
 		if (!this.isActive(id)) {
 			// Workflow is currently not registered
 			Logger.warn(
 				`The workflow with the id "${id}" is currently not active and can so not be removed`,
 			);
-			return;
+			return false;
 		}
 
 		const workflowData = this.workflowData[id];
@@ -245,5 +245,7 @@ export class ActiveWorkflows {
 		}
 
 		delete this.workflowData[id];
+
+		return true;
 	}
 }


### PR DESCRIPTION
Replaces a throw with a warning message instead, since the failure in question is not serious enough to warrant stopping the application.