### PR TITLE
fix(editor): Fix LDAP view info tip color (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/SettingsLdapView.vue
+++ b/packages/editor-ui/src/views/SettingsLdapView.vue
@@ -6,7 +6,7 @@
 			</n8n-heading>
 		</div>
 
-		<n8n-info-tip type="note" theme="info-light" tooltipPlacement="right" class="mb-l">
+		<n8n-info-tip type="note" theme="info" tooltipPlacement="right" class="mb-l">
 			{{ $locale.baseText('settings.ldap.note') }}
 		</n8n-info-tip>
 		<n8n-action-box


### PR DESCRIPTION
<img width="1556" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/b1b021f5-d0df-4183-84ae-8b698112957d">