### PR TITLE
fix(editor): Pass n8n reference toggle tracking to Posthog (no-changelog)

### DIFF
--- a/packages/editor-ui/src/api/ai.ts
+++ b/packages/editor-ui/src/api/ai.ts
@@ -15,6 +15,8 @@ export async function generateCodeForPrompt(
 		context,
 		model,
 		n8nVersion,
+		sessionId,
+		instanceId,
 	}: {
 		question: string;
 		context: {
@@ -23,6 +25,8 @@ export async function generateCodeForPrompt(
 		};
 		model: string;
 		n8nVersion: string;
+		sessionId: string;
+		instanceId: string;
 	},
 ): Promise<{ code: string; usage: Usage }> {
 	return makeRestApiRequest(ctx, 'POST', '/ask-ai', {
@@ -30,5 +34,7 @@ export async function generateCodeForPrompt(
 		context,
 		model,
 		n8nVersion,
+		sessionId,
+		instanceId,
 	} as IDataObject);
 }

--- a/packages/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -151,7 +151,7 @@ async function onSubmit() {
 	startLoading();
 
 	try {
-		const version = useRootStore().versionCli;
+		const { versionCli, sessionId, instanceId } = useRootStore();
 		const model =
 			usePostHog().getVariant(ASK_AI_EXPERIMENT.name) === ASK_AI_EXPERIMENT.gpt4
 				? 'gpt-4'
@@ -161,7 +161,9 @@ async function onSubmit() {
 			question: prompt.value,
 			context: { schema: schemas.parentNodesSchemas, inputSchema: schemas.inputSchema! },
 			model,
-			n8nVersion: version,
+			n8nVersion: versionCli,
+			sessionId,
+			instanceId,
 		});
 
 		stopLoading();

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -12,6 +12,7 @@ import { usePostHog } from '@/stores/posthog.store';
 
 export class Telemetry {
 	private pageEventQueue: Array<{ route: RouteLocation }>;
+
 	private previousPath: string;
 
 	private get rudderStack() {
@@ -110,16 +111,15 @@ export class Telemetry {
 			const pageName = route.name;
 			let properties: { [key: string]: string } = {};
 			if (
-				route.meta &&
-				route.meta.telemetry &&
+				route.meta?.telemetry &&
 				typeof route.meta.telemetry.getProperties === 'function'
 			) {
 				properties = route.meta.telemetry.getProperties(route);
 			}
 
 			const category =
-				(route.meta && route.meta.telemetry && route.meta.telemetry.pageCategory) || 'Editor';
-			this.rudderStack.page(category, pageName!, properties);
+				(route.meta?.telemetry?.pageCategory) || 'Editor';
+			this.rudderStack.page(category, pageName, properties);
 		} else {
 			this.pageEventQueue.push({
 				route,
@@ -228,7 +228,14 @@ export class Telemetry {
 			switch (nodeType) {
 				case SLACK_NODE_TYPE:
 					if (change.name === 'parameters.otherOptions.includeLinkToWorkflow') {
-						this.track('User toggled n8n reference option');
+						this.track(
+							'User toggled n8n reference option',
+							{
+								node: nodeType,
+								toValue: change.value,
+							},
+							{ withPostHog: true },
+						);
 					}
 					break;
 


### PR DESCRIPTION
`User toggled n8n reference option` event should be sent to Posthog and include `toValue` and `node` properties.

Github issue / Community forum post (link here to close automatically):
