### PR TITLE
style(editor): add message about which items will be outputted while pinning

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -739,7 +739,7 @@
 	"ndv.title.rename": "Rename",
 	"ndv.title.renameNode": "Rename node",
 	"ndv.pinData.pin.title": "Pin data",
-	"ndv.pinData.pin.description": "Node will always output this data instead of executing.",
+	"ndv.pinData.pin.description": "Node will always output this data instead of executing. Output will be limited to 10 items.",
 	"ndv.pinData.pin.link": "More info",
 	"ndv.pinData.pin.multipleRuns.title": "Run #{index} was pinned",
 	"ndv.pinData.pin.multipleRuns.description": "This run will be outputted each time the node is run.",

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -739,7 +739,7 @@
 	"ndv.title.rename": "Rename",
 	"ndv.title.renameNode": "Rename node",
 	"ndv.pinData.pin.title": "Pin data",
-	"ndv.pinData.pin.description": "Node will always output this data instead of executing. Output will be limited to 10 items.",
+	"ndv.pinData.pin.description": "Node will always output the data of the current page instead of executing.",
 	"ndv.pinData.pin.link": "More info",
 	"ndv.pinData.pin.multipleRuns.title": "Run #{index} was pinned",
 	"ndv.pinData.pin.multipleRuns.description": "This run will be outputted each time the node is run.",


### PR DESCRIPTION
When you have a node with an output larger than 10 items, for instance, 50, you can see it like:

![2023_08_25-10_11_28](https://github.com/n8n-io/n8n/assets/986235/5ef76e61-6fc6-4d07-9711-ac00867384de)

Once you pin that output, it is automatically limited to 10 items:

![2023_08_25-10_12_57](https://github.com/n8n-io/n8n/assets/986235/f13dee60-2489-408b-8897-927bd0e0bac1)

Not having this behaviour documented has produced some confusions and being explicit about it could help out. This PR just add this information explicitly in the pin item help tooltip 👼