### PR TITLE
fix(Pushover Node): default attachment filename

### DIFF
--- a/packages/nodes-base/nodes/Pushover/Pushover.node.ts
+++ b/packages/nodes-base/nodes/Pushover/Pushover.node.ts
@@ -342,7 +342,9 @@ export class Pushover implements INodeType {
 								body.attachment = {
 									value: dataBuffer,
 									options: {
-										filename: binaryData.fileName,
+										filename:
+											binaryData.fileName ?? `${binaryPropertyName}.${binaryData.fileExtension}`,
+										contentType: binaryData.mimeType,
 									},
 								};
 


### PR DESCRIPTION
When you try to send an attachment on the Pushover Node the following error happens:

![n8n](https://github.com/n8n-io/n8n/assets/49290264/1e4b868f-b0c9-4f28-87d4-05462b96c8ec)

I don't really know what it's the reason but the filename in the `binaryData` object is empty. When setting one by default the Pushover API doesn't response with the error

![n8n-after](https://github.com/n8n-io/n8n/assets/49290264/4733dd4c-b3c8-439f-8dbd-bd9d17513412)
