### PR TITLE
feat(Salesforce Node): Add fax field to lead option

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
@@ -229,6 +229,13 @@ export const leadFields: INodeProperties[] = [
 				description: 'Email address for the lead',
 			},
 			{
+				displayName: 'Fax',
+				name: 'fax',
+				type: 'number',
+				default: '',
+				description: 'Fax number of the lead.',
+			},
+			{
 				displayName: 'First Name',
 				name: 'firstname',
 				type: 'string',
@@ -242,6 +249,14 @@ export const leadFields: INodeProperties[] = [
 				default: false,
 				description:
 					'Whether the lead doesn’t want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.',
+			},
+			{
+				displayName: 'Has Opted Out of Fax',
+				name: 'hasOptedOutOfFax',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether the lead doesn’t want to receive fax from Salesforce (true) or does (false). Label is Email Opt Out.',
 			},
 			{
 				displayName: 'Industry',
@@ -498,6 +513,13 @@ export const leadFields: INodeProperties[] = [
 				description: 'Email address for the lead',
 			},
 			{
+				displayName: 'Fax',
+				name: 'fax',
+				type: 'number',
+				default: '',
+				description: 'Fax Number of the lead',
+			},
+			{
 				displayName: 'First Name',
 				name: 'firstname',
 				type: 'string',
@@ -511,6 +533,14 @@ export const leadFields: INodeProperties[] = [
 				default: false,
 				description:
 					'Whether the lead doesn’t want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.',
+			},
+			{
+				displayName: 'Has Opted Out of Fax',
+				name: 'HasOptedOutOfFax',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether the lead doesn’t want to receive fax from Salesforce (true) or does (false). Label is Fax Opt Out.',
 			},
 			{
 				displayName: 'Industry',

--- a/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadDescription.ts
@@ -233,7 +233,7 @@ export const leadFields: INodeProperties[] = [
 				name: 'fax',
 				type: 'number',
 				default: '',
-				description: 'Fax number of the lead.',
+				description: 'Fax number of the lead',
 			},
 			{
 				displayName: 'First Name',

--- a/packages/nodes-base/nodes/Salesforce/LeadInterface.ts
+++ b/packages/nodes-base/nodes/Salesforce/LeadInterface.ts
@@ -3,6 +3,7 @@ export interface ILead {
 	Company?: string;
 	LastName?: string;
 	Email?: string;
+	Fax?: number;
 	City?: string;
 	Phone?: string;
 	State?: string;
@@ -25,4 +26,5 @@ export interface ILead {
 	NumberOfEmployees?: number;
 	MobilePhone?: string;
 	HasOptedOutOfEmail?: boolean;
+	HasOptedOutOfFax?: boolean;
 }

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1084,6 +1084,9 @@ export class Salesforce implements INodeType {
 						if (additionalFields.hasOptedOutOfEmail !== undefined) {
 							body.HasOptedOutOfEmail = additionalFields.hasOptedOutOfEmail as boolean;
 						}
+						if (additionalFields.hasOptedOutOfFax !== undefined) {
+							body.HasOptedOutOfFax = additionalFields.hasOptedOutOfFax as boolean;
+						}
 						if (additionalFields.email !== undefined) {
 							body.Email = additionalFields.email as string;
 						}
@@ -1125,6 +1128,9 @@ export class Salesforce implements INodeType {
 						}
 						if (additionalFields.firstname !== undefined) {
 							body.FirstName = additionalFields.firstname as string;
+						}
+						if (additionalFields.fax !== undefined) {
+							body.Fax = additionalFields.fax as number;
 						}
 						if (additionalFields.leadSource !== undefined) {
 							body.LeadSource = additionalFields.leadSource as string;
@@ -1190,6 +1196,9 @@ export class Salesforce implements INodeType {
 						if (updateFields.hasOptedOutOfEmail !== undefined) {
 							body.HasOptedOutOfEmail = updateFields.hasOptedOutOfEmail as boolean;
 						}
+						if (updateFields.hasOptedOutOfFax !== undefined) {
+							body.hasOptedOutOfFax = updateFields.hasOptedOutOfFax as boolean;
+						}
 						if (updateFields.lastname !== undefined) {
 							body.LastName = updateFields.lastname as string;
 						}
@@ -1237,6 +1246,9 @@ export class Salesforce implements INodeType {
 						}
 						if (updateFields.firstname !== undefined) {
 							body.FirstName = updateFields.firstname as string;
+						}
+						if (updateFields.fax !== undefined) {
+							body.Fax = updateFields.fax as number;
 						}
 						if (updateFields.leadSource !== undefined) {
 							body.LeadSource = updateFields.leadSource as string;

--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -1126,11 +1126,11 @@ export class Salesforce implements INodeType {
 						if (additionalFields.industry !== undefined) {
 							body.Industry = additionalFields.industry as string;
 						}
-						if (additionalFields.firstname !== undefined) {
-							body.FirstName = additionalFields.firstname as string;
-						}
 						if (additionalFields.fax !== undefined) {
 							body.Fax = additionalFields.fax as number;
+						}
+						if (additionalFields.firstname !== undefined) {
+							body.FirstName = additionalFields.firstname as string;
 						}
 						if (additionalFields.leadSource !== undefined) {
 							body.LeadSource = additionalFields.leadSource as string;


### PR DESCRIPTION
Closes: https://community.n8n.io/t/there-is-no-fax-field-in-the-saleforce-lead-cretion/29829
