### PR TITLE
fix(core): Invalid NODES_INCLUDE should not crash the app

### DIFF
--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -371,7 +371,9 @@ export class LazyPackageDirectoryLoader extends PackageDirectoryLoader {
 			if (this.includeNodes.length) {
 				const allowedNodes: typeof this.known.nodes = {};
 				for (const nodeName of this.includeNodes) {
-					allowedNodes[nodeName] = this.known.nodes[nodeName];
+					if (nodeName in this.known.nodes) {
+						allowedNodes[nodeName] = this.known.nodes[nodeName];
+					}
 				}
 				this.known.nodes = allowedNodes;
 


### PR DESCRIPTION
Fixes #6683

