### PR TITLE
refactor(core): Simplify marking logic in binary data manager (no-changelog)

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -1,6 +1,5 @@
 import { Service } from 'typedi';
 import { snakeCase } from 'change-case';
-import { BinaryDataManager } from 'n8n-core';
 import type {
 	AuthenticationMethod,
 	ExecutionStatus,
@@ -460,8 +459,6 @@ export class InternalHooks implements IInternalHooksClass {
 						},
 				  }),
 		);
-
-		await BinaryDataManager.getInstance().persistBinaryDataForExecutionId(executionId);
 
 		void Promise.all([...promises, this.telemetry.trackWorkflowExecution(properties)]);
 	}

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -913,12 +913,6 @@ export const schema = {
 			env: 'N8N_BINARY_DATA_TTL',
 			doc: 'TTL for binary data of unsaved executions in minutes',
 		},
-		persistedBinaryDataTTL: {
-			format: Number,
-			default: 1440,
-			env: 'N8N_PERSISTED_BINARY_DATA_TTL',
-			doc: 'TTL for persisted binary data in minutes (binary data gets deleted if not persisted before TTL expires)',
-		},
 	},
 
 	deployment: {

--- a/packages/core/src/BinaryDataManager/index.ts
+++ b/packages/core/src/BinaryDataManager/index.ts
@@ -172,12 +172,6 @@ export class BinaryDataManager {
 		}
 	}
 
-	async persistBinaryDataForExecutionId(executionId: string): Promise<void> {
-		if (this.managers[this.binaryDataMode]) {
-			await this.managers[this.binaryDataMode].persistBinaryDataForExecutionId(executionId);
-		}
-	}
-
 	async deleteBinaryDataByExecutionIds(executionIds: string[]): Promise<void> {
 		if (this.managers[this.binaryDataMode]) {
 			await this.managers[this.binaryDataMode].deleteBinaryDataByExecutionIds(executionIds);

--- a/packages/core/src/Interfaces.ts
+++ b/packages/core/src/Interfaces.ts
@@ -39,7 +39,6 @@ export interface IBinaryDataConfig {
 	availableModes: string;
 	localStoragePath: string;
 	binaryDataTTL: number;
-	persistedBinaryDataTTL: number;
 }
 
 export interface IBinaryDataManager {
@@ -57,7 +56,6 @@ export interface IBinaryDataManager {
 	deleteBinaryDataByIdentifier(identifier: string): Promise<void>;
 	duplicateBinaryDataByIdentifier(binaryDataId: string, prefix: string): Promise<string>;
 	deleteBinaryDataByExecutionIds(executionIds: string[]): Promise<string[]>;
-	persistBinaryDataForExecutionId(executionId: string): Promise<void>;
 }
 
 export namespace n8n {

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -35,7 +35,6 @@ describe('NodeExecuteFunctions', () => {
 				availableModes: 'default',
 				localStoragePath: temporaryDir,
 				binaryDataTTL: 1,
-				persistedBinaryDataTTL: 1,
 			});
 
 			// Set our binary data buffer
@@ -86,7 +85,6 @@ describe('NodeExecuteFunctions', () => {
 				availableModes: 'filesystem',
 				localStoragePath: temporaryDir,
 				binaryDataTTL: 1,
-				persistedBinaryDataTTL: 1,
 			});
 
 			// Set our binary data buffer

--- a/packages/nodes-base/test/nodes/Helpers.ts
+++ b/packages/nodes-base/test/nodes/Helpers.ts
@@ -223,7 +223,6 @@ export async function initBinaryDataManager(mode: 'default' | 'filesystem' = 'de
 		availableModes: mode,
 		localStoragePath: temporaryDir,
 		binaryDataTTL: 1,
-		persistedBinaryDataTTL: 1,
 	});
 	return temporaryDir;
 }


### PR DESCRIPTION
- For a saved execution, we write to disk binary data and metadata. These two are only ever deleted via `POST /executions/delete`. No marker file, so untouched by pruning.
- For an unsaved execution, we write to disk binary data, binary data metadata, and a marker file at `/meta`. We later delete all three during pruning.
- The third flow is legacy. Currently, if the execution is unsaved, we actually store it in the DB while running the workflow and immediately after the workflow is finished during the `onWorkflowPostExecute()` hook we delete that execution, so the second flow applies. But formerly, we did not store unsaved executions in the DB ("ephemeral executions") and so we needed to write a marker file at `/persistMeta` so that, if the ephemeral execution crashed after the step where binary data was stored, we had a way to later delete its associated dangling binary data via a second pruning cycle, and if the ephemeral execution succeeded, then we immediately cleaned up the marker file at `/persistMeta` during the `onWorkflowPostExecute()` hook.

This creation and cleanup at `/persistMeta` is still happening, but this third flow no longer has a purpose, as we now store unsaved executions in the DB and delete them immediately after. Hence the third flow can be removed.