### PR TITLE
fix: Account for nanoid workflow ids for subworkflow execute policy

### DIFF
--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -22,7 +22,7 @@
     "lintfix": "eslint src --ext .js,.ts,.vue --fix",
     "format": "prettier --write . --ignore-path ../../.prettierignore",
     "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev",
-    "test": "vitest run --coverage",
+    "test": "vitest WorkflowSettings",
     "test:dev": "vitest"
   },
   "dependencies": {

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -22,7 +22,7 @@
     "lintfix": "eslint src --ext .js,.ts,.vue --fix",
     "format": "prettier --write . --ignore-path ../../.prettierignore",
     "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev",
-    "test": "vitest WorkflowSettings",
+    "test": "vitest run --coverage",
     "test:dev": "vitest"
   },
   "dependencies": {

--- a/packages/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/editor-ui/src/components/WorkflowSettings.vue
@@ -374,13 +374,11 @@ import {
 
 import type { WorkflowSettings } from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
-import {
-	useWorkflowsStore,
-	useSettingsStore,
-	useRootStore,
-	useWorkflowsEEStore,
-	useUsersStore,
-} from '@/stores';
+import { useSettingsStore } from '@/stores/settings.store';
+import { useUsersStore } from '@/stores/users.store';
+import { useRootStore } from '@/stores/n8nRoot.store';
+import { useWorkflowsEEStore } from '@/stores/workflows.ee.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
 import { createEventBus } from 'n8n-design-system/utils';
 
 export default defineComponent({

--- a/packages/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/editor-ui/src/components/WorkflowSettings.vue
@@ -67,7 +67,7 @@
 						</n8n-select>
 					</el-col>
 				</el-row>
-				<div v-if="isSharingEnabled">
+				<div v-if="isSharingEnabled" data-test-id="workflow-caller-policy">
 					<el-row>
 						<el-col :span="10" class="setting-name">
 							{{ $locale.baseText('workflowSettings.callerPolicy') + ':' }}
@@ -114,6 +114,7 @@
 								type="text"
 								v-model="workflowSettings.callerIds"
 								@update:modelValue="onCallerIdsInput"
+								data-test-id="workflow-caller-policy-workflow-ids"
 							/>
 						</el-col>
 					</el-row>

--- a/packages/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/editor-ui/src/components/WorkflowSettings.vue
@@ -566,9 +566,9 @@ export default defineComponent({
 	},
 	methods: {
 		onCallerIdsInput(str: string) {
-			this.workflowSettings.callerIds = /^[0-9,\s]+$/.test(str)
+			this.workflowSettings.callerIds = /^[a-zA-Z0-9,\s]+$/.test(str)
 				? str
-				: str.replace(/[^0-9,\s]/g, '');
+				: str.replace(/[^a-zA-Z0-9,\s]/g, '');
 		},
 		closeDialog() {
 			this.modalBus.emit('close');

--- a/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
@@ -14,6 +14,8 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { STORES, WORKFLOW_SETTINGS_MODAL_KEY } from '@/constants';
 
+import { nextTick } from 'vue';
+
 let rootStore: ReturnType<typeof useRootStore>;
 let workflowsEEStore: ReturnType<typeof useWorkflowsEEStore>;
 let workflowsStore: ReturnType<typeof useWorkflowsStore>;
@@ -72,12 +74,13 @@ describe('WorkflowSettingsVue', () => {
 		server.shutdown();
 	});
 
-	it.only('should render correctly', () => {
+	it.only('should render correctly', async () => {
 		const wrapper = renderComponent({
 			props: {
 				data: workflowDataUpdate,
 			},
 		});
+		await nextTick();
 		expect(wrapper.getByTestId('workflow-settings-dialog')).toBeVisible();
 	});
 

--- a/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
@@ -1,0 +1,130 @@
+import WorkflowSettingsVue from '../WorkflowSettings.vue';
+import type { EnvironmentVariable, IWorkflowDataUpdate } from '@/Interface';
+import { fireEvent } from '@testing-library/vue';
+import { setupServer } from '@/__tests__/server';
+import { afterAll, beforeAll } from 'vitest';
+
+import { useSettingsStore } from '@/stores/settings.store';
+import { useUsersStore } from '@/stores/users.store';
+import { useRootStore } from '@/stores/n8nRoot.store';
+import { useWorkflowsEEStore } from '@/stores/workflows.ee.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import { createTestingPinia } from '@pinia/testing';
+import { STORES, WORKFLOW_SETTINGS_MODAL_KEY } from '@/constants';
+
+let rootStore: ReturnType<typeof useRootStore>;
+let workflowsEEStore: ReturnType<typeof useWorkflowsEEStore>;
+let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+
+const renderComponent = createComponentRenderer(WorkflowSettingsVue, {
+	pinia: createTestingPinia({
+		initialState: {
+			[STORES.UI]: {
+				modals: {
+					[WORKFLOW_SETTINGS_MODAL_KEY]: {
+						open: true,
+					},
+				},
+			},
+			[STORES.SETTINGS]: {
+				settings: {
+					enterprise: {
+						sharing: true,
+					},
+				},
+			},
+		},
+	}),
+	global: {
+		stubs: ['n8n-tooltip'],
+	},
+});
+
+const workflowDataUpdate: IWorkflowDataUpdate = {
+	id: '1',
+	name: 'Test Workflow',
+	nodes: [],
+	connections: {},
+	tags: [],
+	active: true,
+};
+
+describe('WorkflowSettingsVue', () => {
+	let server: ReturnType<typeof setupServer>;
+
+	beforeAll(() => {
+		server = setupServer();
+	});
+
+	beforeEach(async () => {
+		await useSettingsStore().getSettings();
+		await useUsersStore().loginWithCookie();
+		rootStore = useRootStore();
+		workflowsEEStore = useWorkflowsEEStore();
+		workflowsStore = useWorkflowsStore();
+		vi.spyOn(workflowsStore, 'workflowName', 'get').mockResolvedValue(workflowDataUpdate.name!);
+		vi.spyOn(workflowsStore, 'workflowId', 'get').mockResolvedValue(workflowDataUpdate.id!);
+	});
+
+	afterAll(() => {
+		server.shutdown();
+	});
+
+	it.only('should render correctly', () => {
+		const wrapper = renderComponent({
+			props: {
+				data: workflowDataUpdate,
+			},
+		});
+		expect(wrapper.getByTestId('workflow-settings-dialog')).toBeVisible();
+	});
+
+	it('should show edit and delete buttons on hover', async () => {
+		const wrapper = renderComponent({
+			props: {
+				data: workflowDataUpdate,
+			},
+		});
+
+		await fireEvent.mouseEnter(wrapper.container);
+
+		expect(wrapper.getByTestId('variable-row-edit-button')).toBeVisible();
+		expect(wrapper.getByTestId('variable-row-delete-button')).toBeVisible();
+	});
+
+	it('should show key and value inputs in edit mode', async () => {
+		const wrapper = renderComponent({
+			props: {
+				data: environmentVariable,
+				editing: true,
+			},
+		});
+
+		await fireEvent.mouseEnter(wrapper.container);
+
+		expect(wrapper.getByTestId('variable-row-key-input')).toBeVisible();
+		expect(wrapper.getByTestId('variable-row-key-input').querySelector('input')).toHaveValue(
+			environmentVariable.key,
+		);
+		expect(wrapper.getByTestId('variable-row-value-input')).toBeVisible();
+		expect(wrapper.getByTestId('variable-row-value-input').querySelector('input')).toHaveValue(
+			environmentVariable.value,
+		);
+	});
+
+	it('should show cancel and save buttons in edit mode', async () => {
+		const wrapper = renderComponent({
+			props: {
+				data: environmentVariable,
+				editing: true,
+			},
+		});
+
+		await fireEvent.mouseEnter(wrapper.container);
+
+		expect(wrapper.getByTestId('variable-row-cancel-button')).toBeVisible();
+		expect(wrapper.getByTestId('variable-row-save-button')).toBeVisible();
+	});
+});

--- a/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/WorkflowSettings.spec.ts
@@ -1,133 +1,152 @@
+import { createPinia, setActivePinia } from 'pinia';
 import WorkflowSettingsVue from '../WorkflowSettings.vue';
-import type { EnvironmentVariable, IWorkflowDataUpdate } from '@/Interface';
-import { fireEvent } from '@testing-library/vue';
+
 import { setupServer } from '@/__tests__/server';
 import { afterAll, beforeAll } from 'vitest';
+import { within, fireEvent } from '@testing-library/vue';
 
-import { useSettingsStore } from '@/stores/settings.store';
-import { useUsersStore } from '@/stores/users.store';
-import { useRootStore } from '@/stores/n8nRoot.store';
-import { useWorkflowsEEStore } from '@/stores/workflows.ee.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useSettingsStore } from '@/stores/settings.store';
+import { useUIStore } from '@/stores/ui.store';
 
 import { createComponentRenderer } from '@/__tests__/render';
-import { createTestingPinia } from '@pinia/testing';
-import { STORES, WORKFLOW_SETTINGS_MODAL_KEY } from '@/constants';
+import { EnterpriseEditionFeature, WORKFLOW_SETTINGS_MODAL_KEY } from '@/constants';
 
 import { nextTick } from 'vue';
 
-let rootStore: ReturnType<typeof useRootStore>;
-let workflowsEEStore: ReturnType<typeof useWorkflowsEEStore>;
+let pinia: ReturnType<typeof createPinia>;
 let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+let settingsStore: ReturnType<typeof useSettingsStore>;
+let uiStore: ReturnType<typeof useUIStore>;
 
-const renderComponent = createComponentRenderer(WorkflowSettingsVue, {
-	pinia: createTestingPinia({
-		initialState: {
-			[STORES.UI]: {
-				modals: {
-					[WORKFLOW_SETTINGS_MODAL_KEY]: {
-						open: true,
-					},
-				},
-			},
-			[STORES.SETTINGS]: {
-				settings: {
-					enterprise: {
-						sharing: true,
-					},
-				},
-			},
-		},
-	}),
+const createComponent = createComponentRenderer(WorkflowSettingsVue, {
 	global: {
 		stubs: ['n8n-tooltip'],
 	},
 });
 
-const workflowDataUpdate: IWorkflowDataUpdate = {
-	id: '1',
-	name: 'Test Workflow',
-	nodes: [],
-	connections: {},
-	tags: [],
-	active: true,
-};
-
 describe('WorkflowSettingsVue', () => {
 	let server: ReturnType<typeof setupServer>;
-
 	beforeAll(() => {
 		server = setupServer();
 	});
 
 	beforeEach(async () => {
-		await useSettingsStore().getSettings();
-		await useUsersStore().loginWithCookie();
-		rootStore = useRootStore();
-		workflowsEEStore = useWorkflowsEEStore();
+		pinia = createPinia();
+		setActivePinia(pinia);
+
 		workflowsStore = useWorkflowsStore();
-		vi.spyOn(workflowsStore, 'workflowName', 'get').mockResolvedValue(workflowDataUpdate.name!);
-		vi.spyOn(workflowsStore, 'workflowId', 'get').mockResolvedValue(workflowDataUpdate.id!);
+		settingsStore = useSettingsStore();
+		uiStore = useUIStore();
+
+		await settingsStore.getSettings();
+
+		vi.spyOn(workflowsStore, 'workflowName', 'get').mockReturnValue('Test Workflow');
+		vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('1');
+		vi.spyOn(workflowsStore, 'workflow', 'get').mockReturnValue({
+			id: '1',
+			name: 'Test Workflow',
+			active: true,
+			nodes: [],
+			connections: {},
+			createdAt: 1,
+			updatedAt: 1,
+			versionId: '123',
+		} as IWorkflowDb);
+
+		uiStore.modals[WORKFLOW_SETTINGS_MODAL_KEY] = {
+			open: true,
+		};
 	});
 
 	afterAll(() => {
 		server.shutdown();
 	});
 
-	it.only('should render correctly', async () => {
-		const wrapper = renderComponent({
-			props: {
-				data: workflowDataUpdate,
-			},
-		});
+	it('should render correctly', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = false;
+		const wrapper = createComponent({ pinia });
 		await nextTick();
 		expect(wrapper.getByTestId('workflow-settings-dialog')).toBeVisible();
 	});
 
-	it('should show edit and delete buttons on hover', async () => {
-		const wrapper = renderComponent({
-			props: {
-				data: workflowDataUpdate,
-			},
-		});
+	it('should not render workflow caller policy when sharing is not enabled', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = false;
+		const wrapper = createComponent({ pinia });
 
-		await fireEvent.mouseEnter(wrapper.container);
+		await nextTick();
 
-		expect(wrapper.getByTestId('variable-row-edit-button')).toBeVisible();
-		expect(wrapper.getByTestId('variable-row-delete-button')).toBeVisible();
+		expect(
+			within(wrapper.getByTestId('workflow-settings-dialog')).queryByTestId(
+				'workflow-caller-policy',
+			),
+		).not.toBeInTheDocument();
 	});
 
-	it('should show key and value inputs in edit mode', async () => {
-		const wrapper = renderComponent({
-			props: {
-				data: environmentVariable,
-				editing: true,
-			},
-		});
+	it('should render workflow caller policy when sharing is enabled', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const wrapper = createComponent({ pinia });
 
-		await fireEvent.mouseEnter(wrapper.container);
+		await nextTick();
 
-		expect(wrapper.getByTestId('variable-row-key-input')).toBeVisible();
-		expect(wrapper.getByTestId('variable-row-key-input').querySelector('input')).toHaveValue(
-			environmentVariable.key,
+		expect(wrapper.getByTestId('workflow-caller-policy')).toBeVisible();
+	});
+
+	it('should render list of workflows field when policy is set to workflowsFromAList', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const wrapper = createComponent({ pinia });
+
+		await nextTick();
+
+		await fireEvent.click(wrapper.getByTestId('workflow-caller-policy'));
+		console.log(window.document.querySelectorAll('.el-select-dropdown__item')[4].innerHTML);
+		await fireEvent.click(window.document.querySelectorAll('.el-select-dropdown__item')[4]);
+
+		expect(wrapper.getByTestId('workflow-caller-policy-workflow-ids')).toBeVisible();
+	});
+
+	it('should not remove valid workflow ID characters', async () => {
+		const validWorkflowList = '1234567890, abcde, efgh, 1234';
+
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const wrapper = createComponent({ pinia });
+
+		await nextTick();
+
+		await fireEvent.click(wrapper.getByTestId('workflow-caller-policy'));
+		console.log(window.document.querySelectorAll('.el-select-dropdown__item')[4].innerHTML);
+		await fireEvent.click(window.document.querySelectorAll('.el-select-dropdown__item')[4]);
+
+		await fireEvent.update(
+			wrapper.getByTestId('workflow-caller-policy-workflow-ids'),
+			validWorkflowList,
 		);
-		expect(wrapper.getByTestId('variable-row-value-input')).toBeVisible();
-		expect(wrapper.getByTestId('variable-row-value-input').querySelector('input')).toHaveValue(
-			environmentVariable.value,
+
+		expect(wrapper.getByTestId('workflow-caller-policy-workflow-ids')).toHaveValue(
+			validWorkflowList,
 		);
 	});
 
-	it('should show cancel and save buttons in edit mode', async () => {
-		const wrapper = renderComponent({
-			props: {
-				data: environmentVariable,
-				editing: true,
-			},
-		});
+	it('should remove invalid workflow ID characters', async () => {
+		const invalidWorkflowList = '1234567890@, abc/de, ef*gh, 12%34';
+		const cleanedUpWorkflowList = '1234567890, abcde, efgh, 1234';
 
-		await fireEvent.mouseEnter(wrapper.container);
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const wrapper = createComponent({ pinia });
 
-		expect(wrapper.getByTestId('variable-row-cancel-button')).toBeVisible();
-		expect(wrapper.getByTestId('variable-row-save-button')).toBeVisible();
+		await nextTick();
+
+		await fireEvent.click(wrapper.getByTestId('workflow-caller-policy'));
+		console.log(window.document.querySelectorAll('.el-select-dropdown__item')[4].innerHTML);
+		await fireEvent.click(window.document.querySelectorAll('.el-select-dropdown__item')[4]);
+
+		await fireEvent.update(
+			wrapper.getByTestId('workflow-caller-policy-workflow-ids'),
+			invalidWorkflowList,
+		);
+
+		expect(wrapper.getByTestId('workflow-caller-policy-workflow-ids')).toHaveValue(
+			cleanedUpWorkflowList,
+		);
 	});
 });

--- a/packages/editor-ui/src/composables/useExternalHooks.ts
+++ b/packages/editor-ui/src/composables/useExternalHooks.ts
@@ -1,6 +1,6 @@
 import type { IExternalHooks } from '@/Interface';
 import type { IDataObject } from 'n8n-workflow';
-import { useWebhooksStore } from '@/stores';
+import { useWebhooksStore } from '@/stores/webhooks.store';
 import { runExternalHook } from '@/utils';
 
 export function useExternalHooks(): IExternalHooks {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

Since the change to allow workflow IDs to become strings in Nano ID formats, this input broke.

This PR allows all characters that comprise workflow IDs.