### PR TITLE
ci: Fix master build on Nodejs 20 (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.5]
 
     steps:
       - uses: actions/checkout@v3.5.3
@@ -44,7 +44,7 @@ jobs:
     needs: install-and-build
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.5]
     steps:
       - uses: actions/checkout@v3.5.3
         with:
@@ -82,7 +82,7 @@ jobs:
     needs: install-and-build
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.5]
     steps:
       - uses: actions/checkout@v3.5.3
         with:


### PR DESCRIPTION
[`shelljs` is broken on Nodejs 20.6](https://github.com/shelljs/shelljs/issues/1133). Until that is resolved, we should fix the version to 20.5

