### PR TITLE
fix(core): Disable Node.js custom inspection to address CVE-2023-37903

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -32,6 +32,10 @@ if (![18, 20].includes(nodeVersionMajor)) {
 // Prevent oclif from loading ts-node and typescript
 process.env.OCLIF_TS_NODE = '0';
 
+// Disable nodejs custom inspection across the app
+const { inspect } = require('util');
+inspect.defaultOptions.customInspect = false;
+
 require('express-async-errors');
 require('source-map-support').install();
 require('reflect-metadata');


### PR DESCRIPTION
This seems like a better fix than #7122