### PR TITLE
Fix:When there is no corresponding translation, empty json is returned in…

### DIFF
--- a/packages/cli/src/controllers/translation.controller.ts
+++ b/packages/cli/src/controllers/translation.controller.ts
@@ -40,7 +40,7 @@ export class TranslationController {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return require(translationPath);
 		} catch (error) {
-			return null;
+			return {};
 		}
 	}
 


### PR DESCRIPTION
When there is no corresponding translation, empty json is returned instead of null to avoid front-end exceptions.

Github issue / Community forum post (link here to close automatically):
