### PR TITLE
feat(worker): Add a way to get metrics from worker

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -350,14 +350,76 @@ export class Worker extends BaseCommand {
 		});
 	}
 
-	async setupHealthMonitor() {
-		const port = config.getEnv('queue.health.port');
+	async listenExpressServer(app: express.Application, ports: number | number[]) {
+		const safePorts = Array.isArray(ports) ? ports : [ports];
+
+		const server = http.createServer(app);
+
+		server.on('error', (error: Error & { code: string }) => {
+			if (error.code === 'EADDRINUSE') {
+				const portsOrPort = `port${safePorts.length > 1 ? 's' : ''} ${safePorts.join(', ')}`;
+				this.logger.error(
+					`n8n's ${portsOrPort} ${safePorts.join(', ')} ${
+						safePorts.length > 1 ? 'are' : 'is'
+					}  already in use. Do you have the n8n main process running on that ${portsOrPort}?`,
+				);
+				process.exit(1);
+			}
+		});
+
+		for (const port of safePorts) {
+			await new Promise<void>((resolve) => server.listen(port, () => resolve()));
+		}
+	}
+
+	async setupExpressServer() {
+		const isHealthEnpointActive = config.getEnv('queue.health.active');
+		const isMetricsEnpointActive = config.getEnv('queue.metrics.active');
+
+		const healthPort = config.getEnv('queue.health.port');
+		const metricsPort = config.getEnv('queue.health.port');
 
 		const app = express();
 		app.disable('x-powered-by');
 
-		const server = http.createServer(app);
+		if (isHealthEnpointActive) {
+			this.logger.debug(`\nHealth Check route is enabled on port ${healthPort}`);
+			await this.setupHealthMonitor(app);
+		}
 
+		if (isMetricsEnpointActive) {
+			this.logger.debug(`\nMetrics route is enabled on port ${metricsPort}`);
+			await this.setupMetricsMonitor(app);
+		}
+
+		// Case both port are equal, default case
+		if (healthPort === metricsPort) {
+			const port = healthPort;
+
+			await this.listenExpressServer(app, port);
+			this.logger.info(`\nn8n worker health & metrics check via, port ${port}`);
+		} else {
+			if (isHealthEnpointActive) {
+				await this.listenExpressServer(app, healthPort);
+				this.logger.info(`\nn8n worker health check via, port ${healthPort}`);
+			}
+
+			if (isMetricsEnpointActive) {
+				await this.listenExpressServer(app, metricsPort);
+				this.logger.info(`\nn8n worker metrics via, port ${metricsPort}`);
+			}
+		}
+
+		await this.externalHooks.run('worker.ready');
+	}
+
+	async setupMetricsMonitor(app: express.Application) {
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		const { MetricsService } = await import('@/services/metrics.service');
+		await Container.get(MetricsService).configureMetrics(app);
+	}
+
+	async setupHealthMonitor(app: express.Application) {
 		app.get(
 			'/healthz',
 
@@ -432,19 +494,6 @@ export class Worker extends BaseCommand {
 				},
 			);
 		}
-
-		server.on('error', (error: Error & { code: string }) => {
-			if (error.code === 'EADDRINUSE') {
-				this.logger.error(
-					`n8n's port ${port} is already in use. Do you have the n8n main process running on that port?`,
-				);
-				process.exit(1);
-			}
-		});
-
-		await new Promise<void>((resolve) => server.listen(port, () => resolve()));
-		await this.externalHooks.run('worker.ready');
-		this.logger.info(`\nn8n worker health check via, port ${port}`);
 	}
 
 	async run() {
@@ -456,8 +505,8 @@ export class Worker extends BaseCommand {
 		this.logger.info(` * Concurrency: ${flags.concurrency}`);
 		this.logger.info('');
 
-		if (config.getEnv('queue.health.active')) {
-			await this.setupHealthMonitor();
+		if (config.getEnv('queue.health.active') || config.getEnv('queue.metrics.active')) {
+			await this.setupExpressServer();
 		}
 
 		// Make sure that the process does not close

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -355,6 +355,20 @@ export const schema = {
 				env: 'QUEUE_HEALTH_CHECK_PORT',
 			},
 		},
+		metrics: {
+			active: {
+				doc: 'If metrics should be enabled',
+				format: 'Boolean',
+				default: false,
+				env: 'QUEUE_METRICS_ACTIVE',
+			},
+			port: {
+				doc: 'Port to serve metrics on if activated',
+				format: Number,
+				default: 5678,
+				env: 'QUEUE_METRICS_PORT',
+			},
+		},
 		bull: {
 			prefix: {
 				doc: 'Prefix for all bull queue keys',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

Based on closed https://github.com/n8n-io/n8n/issues/7146 issue and this [Feature Request Thread](https://community.n8n.io/t/monitor-workers-docker-deployment/13029).

## What did I do?

1. Added `queue.metrics.port` and `queue.metrics.active` config

> I preserve a `port` for `metrics` as `health` already have this mechanism. It imply that I had to manage cases for all combination of Health Check & Metrics port.

2. Do a unique `setupExpressServer()` method

> To have a single method that manage both Health Check & Metrics exposure.

3. Expose 1 or 2 port(s) depending on the port configurations

> in order to not break the existing Health Check behavior, I decided to listen port(s) depending on the configuration but on the same express Application