### PR TITLE
docs(editor): Update .round() function in NumberExtensions.ts for clarity

### DIFF
--- a/packages/workflow/src/Extensions/NumberExtensions.ts
+++ b/packages/workflow/src/Extensions/NumberExtensions.ts
@@ -88,7 +88,7 @@ format.doc = {
 round.doc = {
 	name: 'round',
 	description:
-		'Returns the value of a number rounded to the nearest whole number. Defaults to 0 decimal places if no argument is given.',
+		'Returns the value of a number rounded to the nearest whole number, unless a decimal place is specified. Defaults to 0 decimal places if no argument is given.',
 	returnType: 'number',
 	args: [{ name: 'decimalPlaces?', type: 'number' }],
 	docURL:


### PR DESCRIPTION
As per the forum post, we should probably specify when a whole number is returned, and when it isn't.

Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/round-description-is-possibly-wrong/30382/
