### PR TITLE
fix(editor): Prevent duplicate creation of credential for OAuth2

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/GoogleAuthButton.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/GoogleAuthButton.vue
@@ -2,7 +2,6 @@
 	<button
 		:class="$style.googleAuthBtn"
 		:title="$locale.baseText('credentialEdit.oAuthButton.signInWithGoogle')"
-		@click.stop.prevent="$emit('click')"
 		:style="googleAuthButtons"
 	/>
 </template>

--- a/packages/editor-ui/src/components/CredentialEdit/OauthButton.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/OauthButton.vue
@@ -1,6 +1,6 @@
 <template>
 	<div :class="$style.container">
-		<GoogleAuthButton v-if="isGoogleOAuthType" @click="$emit('click')" />
+		<GoogleAuthButton v-if="isGoogleOAuthType" @click.stop="$emit('click')" />
 		<n8n-button
 			v-else
 			:label="$locale.baseText('credentialEdit.oAuthButton.connectMyAccount')"


### PR DESCRIPTION
This PR solves the issue reported in [this ticket](https://linear.app/n8n/issue/PAY-825/click-to-connect-for-google-sheets-does-not-work-when-cred-is-not).

Basically when trying to connect OAuth2 credentials, n8n would create the credential twice, possibly causing transaction issues.

This PR prevents n8n from firing a duplicate creation request, effectively fixing the bug about duplicate creation.