### PR TITLE
Added DNS params into docker-compose yaml to fix time out in Mongo node

### DIFF
--- a/docker/compose/subfolderWithSSL/.env
+++ b/docker/compose/subfolderWithSSL/.env
@@ -17,3 +17,7 @@ GENERIC_TIMEZONE=Europe/Berlin
 
 # The email address to use for the SSL certificate creation
 SSL_EMAIL=user@example.com
+
+
+DNS1=8.8.8.8
+DNS2=8.8.4.4

--- a/docker/compose/subfolderWithSSL/docker-compose.yml
+++ b/docker/compose/subfolderWithSSL/docker-compose.yml
@@ -30,6 +30,9 @@ services:
     image: docker.n8n.io/n8nio/n8n
     ports:
       - '127.0.0.1:5678:5678'
+    dns:
+      - ${DNS1}
+      - ${DNS2}
     labels:
       - traefik.enable=true
       - traefik.http.routers.n8n.rule=Host(`${DOMAIN_NAME}`)


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):

* Fix Mongo node time out when trying to connect to Mongo cloud  adding resolve DNS into n8n container.
