### PR TITLE
fix(core): Handle filename* with quotes in Content-Disposition header

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -649,7 +649,7 @@ function parseFileName(filename?: string): string | undefined {
 
 // https://datatracker.ietf.org/doc/html/rfc5987
 function parseFileNameStar(filename?: string): string | undefined {
-	const [_encoding, _locale, content] = filename?.split("'") ?? [];
+	const [_encoding, _locale, content] = parseFileName(filename)?.split("'") ?? [];
 
 	return content;
 }

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -174,6 +174,21 @@ describe('NodeExecuteFunctions', () => {
 			});
 		});
 
+		it('parses valid content-disposition header with filename* (quoted)', () => {
+			const message = mock<IncomingMessage>({
+				headers: {
+					'content-type': undefined,
+					'content-disposition': ' attachment;filename*="utf-8\' \'test-unsplash.jpg"',
+				},
+			});
+			parseIncomingMessage(message);
+
+			expect(message.contentDisposition).toEqual({
+				filename: 'test-unsplash.jpg',
+				type: 'attachment',
+			});
+		});
+
 		it('parses valid content-disposition header with filename and trailing ";"', () => {
 			const message = mock<IncomingMessage>({
 				headers: {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
