### PR TITLE
fix(core): Fix binary data manager check on pruning

### DIFF
--- a/packages/core/src/BinaryData/BinaryData.service.ts
+++ b/packages/core/src/BinaryData/BinaryData.service.ts
@@ -118,7 +118,7 @@ export class BinaryDataService {
 	}
 
 	async deleteManyByExecutionIds(executionIds: string[]) {
-		const manager = this.getManager(this.mode);
+		const manager = this.managers[this.mode];
 
 		if (!manager) return;
 


### PR DESCRIPTION
Ensure that we do not attempt to prune binary data in `default` binary data mode.