### PR TITLE
fix(core): Make senderId required for all command messages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -102,6 +102,7 @@
     "@n8n/client-oauth2": "workspace:*",
     "@n8n_io/license-sdk": "~2.6.0",
     "@oclif/command": "^1.8.16",
+    "@oclif/config": "^1.18.17",
     "@oclif/core": "^1.16.4",
     "@oclif/errors": "^1.3.6",
     "@rudderstack/rudder-sdk-node": "1.0.6",

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -117,7 +117,7 @@ export abstract class AbstractServer {
 
 		if (config.getEnv('executions.mode') === 'queue') {
 			// will start the redis connections
-			await Container.get(OrchestrationService).init(this.uniqueInstanceId);
+			await Container.get(OrchestrationService).init();
 		}
 	}
 

--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -1,4 +1,4 @@
-import type { TEntitlement, TLicenseBlock } from '@n8n_io/license-sdk';
+import type { TEntitlement, TFeatures, TLicenseBlock } from '@n8n_io/license-sdk';
 import { LicenseManager } from '@n8n_io/license-sdk';
 import type { ILogger } from 'n8n-workflow';
 import { getLogger } from './Logger';
@@ -50,6 +50,9 @@ export class License {
 		const saveCertStr = isMainInstance
 			? async (value: TLicenseBlock) => this.saveCertStr(value)
 			: async () => {};
+		const onFeatureChange = isMainInstance
+			? async (features: TFeatures) => this.onFeatureChange(features)
+			: async () => {};
 
 		try {
 			this.manager = new LicenseManager({
@@ -64,6 +67,7 @@ export class License {
 				loadCertStr: async () => this.loadCertStr(),
 				saveCertStr,
 				deviceFingerprint: () => instanceId,
+				onFeatureChange,
 			});
 
 			await this.manager.initialize();
@@ -89,6 +93,19 @@ export class License {
 		return databaseSettings?.value ?? '';
 	}
 
+	async onFeatureChange(_features: TFeatures): Promise<void> {
+		console.log('onFeatureChange', _features);
+		if (config.getEnv('executions.mode') === 'queue') {
+			if (!this.redisPublisher) {
+				this.logger.debug('Initializing Redis publisher for License Service');
+				this.redisPublisher = await Container.get(RedisService).getPubSubPublisher();
+			}
+			await this.redisPublisher.publishToCommandChannel({
+				command: 'reloadLicense',
+			});
+		}
+	}
+
 	async saveCertStr(value: TLicenseBlock): Promise<void> {
 		// if we have an ephemeral license, we don't want to save it to the database
 		if (config.get('license.cert')) return;
@@ -100,15 +117,6 @@ export class License {
 			},
 			['key'],
 		);
-		if (config.getEnv('executions.mode') === 'queue') {
-			if (!this.redisPublisher) {
-				this.logger.debug('Initializing Redis publisher for License Service');
-				this.redisPublisher = await Container.get(RedisService).getPubSubPublisher();
-			}
-			await this.redisPublisher.publishToCommandChannel({
-				command: 'reloadLicense',
-			});
-		}
 	}
 
 	async activate(activationKey: string): Promise<void> {

--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -94,7 +94,6 @@ export class License {
 	}
 
 	async onFeatureChange(_features: TFeatures): Promise<void> {
-		console.log('onFeatureChange', _features);
 		if (config.getEnv('executions.mode') === 'queue') {
 			if (!this.redisPublisher) {
 				this.logger.debug('Initializing Redis publisher for License Service');

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -1474,9 +1474,7 @@ export class Server extends AbstractServer {
 		// ----------------------------------------
 
 		if (!eventBus.isInitialized) {
-			await eventBus.initialize({
-				uniqueInstanceId: this.uniqueInstanceId,
-			});
+			await eventBus.initialize();
 		}
 
 		if (this.endpointPresetCredentials !== '') {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -22,7 +22,7 @@ import { PostHogClient } from '@/posthog';
 import { License } from '@/License';
 import { ExternalSecretsManager } from '@/ExternalSecrets/ExternalSecretsManager.ee';
 import { initExpressionEvaluator } from '@/ExpressionEvalator';
-import { generateHostInstanceId, generateNanoId } from '../databases/utils/generators';
+import { generateHostInstanceId } from '../databases/utils/generators';
 
 export abstract class BaseCommand extends Command {
 	protected logger = LoggerProxy.init(getLogger());
@@ -91,7 +91,7 @@ export abstract class BaseCommand extends Command {
 	protected setQueueModeId() {
 		if (config.getEnv('executions.mode') === 'queue') {
 			if (config.get('redis.queueModeId')) {
-				this.queueModeId = config.get('redis.queueModeId') as string;
+				this.queueModeId = config.get('redis.queueModeId');
 				return;
 			}
 			this.queueModeId = generateHostInstanceId(this.instanceType);

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -37,13 +37,13 @@ export abstract class BaseCommand extends Command {
 
 	protected instanceId: string;
 
-	instanceType: N8nInstanceType;
+	instanceType: N8nInstanceType = 'main';
 
 	queueModeId: string;
 
 	protected server?: AbstractServer;
 
-	async init(instanceType?: N8nInstanceType): Promise<void> {
+	async init(): Promise<void> {
 		await initErrorHandling();
 		initExpressionEvaluator();
 
@@ -52,12 +52,6 @@ export abstract class BaseCommand extends Command {
 
 		// Make sure the settings exist
 		this.userSettings = await UserSettings.prepareUserSettings();
-
-		if (instanceType) {
-			this.instanceType = instanceType;
-			this.setQueueModeId();
-			config.set('generic.instanceType', instanceType);
-		}
 
 		this.loadNodesAndCredentials = Container.get(LoadNodesAndCredentials);
 		await this.loadNodesAndCredentials.init();
@@ -94,7 +88,12 @@ export abstract class BaseCommand extends Command {
 		await Container.get(InternalHooks).init(this.instanceId);
 	}
 
-	protected setQueueModeId() {
+	protected setInstanceType(instanceType: N8nInstanceType) {
+		this.instanceType = instanceType;
+		config.set('generic.instanceType', instanceType);
+	}
+
+	protected setInstanceQueueModeId() {
 		if (config.getEnv('executions.mode') === 'queue') {
 			if (config.get('redis.queueModeId')) {
 				this.queueModeId = config.get('redis.queueModeId');

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -43,7 +43,7 @@ export abstract class BaseCommand extends Command {
 
 	protected server?: AbstractServer;
 
-	async init(): Promise<void> {
+	async init(instanceType?: N8nInstanceType): Promise<void> {
 		await initErrorHandling();
 		initExpressionEvaluator();
 
@@ -52,6 +52,12 @@ export abstract class BaseCommand extends Command {
 
 		// Make sure the settings exist
 		this.userSettings = await UserSettings.prepareUserSettings();
+
+		if (instanceType) {
+			this.instanceType = instanceType;
+			this.setQueueModeId();
+			config.set('generic.instanceType', instanceType);
+		}
 
 		this.loadNodesAndCredentials = Container.get(LoadNodesAndCredentials);
 		await this.loadNodesAndCredentials.init();
@@ -131,13 +137,9 @@ export abstract class BaseCommand extends Command {
 		await this.externalHooks.init();
 	}
 
-	async initLicense(instanceType: N8nInstanceType = 'main'): Promise<void> {
-		this.instanceType = instanceType;
-		this.setQueueModeId();
-		config.set('generic.instanceType', instanceType);
-
+	async initLicense(): Promise<void> {
 		const license = Container.get(License);
-		await license.init(this.instanceId, instanceType);
+		await license.init(this.instanceId, this.instanceType ?? 'main');
 
 		const activationKey = config.getEnv('license.activationKey');
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -66,8 +66,8 @@ export class Start extends BaseCommand {
 
 	protected server = new Server();
 
-	constructor(argv: string[], config: IConfig) {
-		super(argv, config);
+	constructor(argv: string[], cmdConfig: IConfig) {
+		super(argv, cmdConfig);
 		this.setInstanceType('main');
 		this.setInstanceQueueModeId();
 	}
@@ -205,7 +205,7 @@ export class Start extends BaseCommand {
 
 		this.logger.info('Initializing n8n process');
 		if (config.getEnv('executions.mode') === 'queue') {
-			this.logger.debug(`Main Instance running in queue mode`);
+			this.logger.debug('Main Instance running in queue mode');
 			this.logger.debug(`Queue mode id: ${this.queueModeId}`);
 		}
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -196,11 +196,11 @@ export class Start extends BaseCommand {
 	async init() {
 		await this.initCrashJournal();
 
-		await super.init();
+		await super.init('main');
 		this.logger.info('Initializing n8n process');
 		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
-		await this.initLicense('main');
+		await this.initLicense();
 		await this.initBinaryDataService();
 		await this.initExternalHooks();
 		await this.initExternalSecrets();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -30,6 +30,7 @@ import { BaseCommand } from './BaseCommand';
 import { InternalHooks } from '@/InternalHooks';
 import { License } from '@/License';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import { IConfig } from '@oclif/config';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
@@ -64,6 +65,12 @@ export class Start extends BaseCommand {
 	protected activeWorkflowRunner: ActiveWorkflowRunner;
 
 	protected server = new Server();
+
+	constructor(argv: string[], config: IConfig) {
+		super(argv, config);
+		this.setInstanceType('main');
+		this.setInstanceQueueModeId();
+	}
 
 	/**
 	 * Opens the UI in browser
@@ -196,8 +203,13 @@ export class Start extends BaseCommand {
 	async init() {
 		await this.initCrashJournal();
 
-		await super.init('main');
 		this.logger.info('Initializing n8n process');
+		if (config.getEnv('executions.mode') === 'queue') {
+			this.logger.debug(`Main Instance running in queue mode`);
+			this.logger.debug(`Queue mode id: ${this.queueModeId}`);
+		}
+
+		await super.init();
 		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
 		await this.initLicense();

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -19,8 +19,8 @@ export class Webhook extends BaseCommand {
 
 	protected server = new WebhookServer();
 
-	constructor(argv: string[], config: IConfig) {
-		super(argv, config);
+	constructor(argv: string[], cmdConfig: IConfig) {
+		super(argv, cmdConfig);
 		this.setInstanceType('webhook');
 		if (this.queueModeId) {
 			this.logger.debug(`Webhook Instance queue mode id: ${this.queueModeId}`);

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -75,9 +75,9 @@ export class Webhook extends BaseCommand {
 		}
 
 		await this.initCrashJournal();
-		await super.init();
+		await super.init('webhook');
 
-		await this.initLicense('webhook');
+		await this.initLicense();
 		await this.initBinaryDataService();
 		await this.initExternalHooks();
 		await this.initExternalSecrets();

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -6,6 +6,7 @@ import { WebhookServer } from '@/WebhookServer';
 import { Queue } from '@/Queue';
 import { BaseCommand } from './BaseCommand';
 import { Container } from 'typedi';
+import { IConfig } from '@oclif/config';
 
 export class Webhook extends BaseCommand {
 	static description = 'Starts n8n webhook process. Intercepts only production URLs.';
@@ -17,6 +18,15 @@ export class Webhook extends BaseCommand {
 	};
 
 	protected server = new WebhookServer();
+
+	constructor(argv: string[], config: IConfig) {
+		super(argv, config);
+		this.setInstanceType('webhook');
+		if (this.queueModeId) {
+			this.logger.debug(`Webhook Instance queue mode id: ${this.queueModeId}`);
+		}
+		this.setInstanceQueueModeId();
+	}
 
 	/**
 	 * Stops n8n in a graceful way.
@@ -75,7 +85,11 @@ export class Webhook extends BaseCommand {
 		}
 
 		await this.initCrashJournal();
-		await super.init('webhook');
+
+		this.logger.info('Initializing n8n webhook process');
+		this.logger.debug(`Queue mode id: ${this.queueModeId}`);
+
+		await super.init();
 
 		await this.initLicense();
 		await this.initBinaryDataService();

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -249,11 +249,13 @@ export class Worker extends BaseCommand {
 
 	async init() {
 		await this.initCrashJournal();
-		await super.init();
+		await super.init('worker');
+
 		this.logger.debug(`Worker ID: ${this.queueModeId}`);
 		this.logger.debug('Starting n8n worker...');
 
-		await this.initLicense('worker');
+		await this.initLicense();
+
 		await this.initBinaryDataService();
 		await this.initExternalHooks();
 		await this.initExternalSecrets();

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -248,8 +248,8 @@ export class Worker extends BaseCommand {
 		};
 	}
 
-	constructor(argv: string[], config: IConfig) {
-		super(argv, config);
+	constructor(argv: string[], cmdConfig: IConfig) {
+		super(argv, cmdConfig);
 		this.setInstanceType('worker');
 		this.setInstanceQueueModeId();
 	}

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -37,6 +37,7 @@ import { RedisServicePubSubPublisher } from '../services/redis/RedisServicePubSu
 import { RedisServicePubSubSubscriber } from '../services/redis/RedisServicePubSubSubscriber';
 import { EventMessageGeneric } from '../eventbus/EventMessageClasses/EventMessageGeneric';
 import { getWorkerCommandReceivedHandler } from '../worker/workerCommandHandler';
+import { IConfig } from '@oclif/config';
 
 export class Worker extends BaseCommand {
 	static description = '\nStarts a n8n worker';
@@ -247,12 +248,19 @@ export class Worker extends BaseCommand {
 		};
 	}
 
+	constructor(argv: string[], config: IConfig) {
+		super(argv, config);
+		this.setInstanceType('worker');
+		this.setInstanceQueueModeId();
+	}
+
 	async init() {
 		await this.initCrashJournal();
-		await super.init('worker');
 
-		this.logger.debug(`Worker ID: ${this.queueModeId}`);
 		this.logger.debug('Starting n8n worker...');
+		this.logger.debug(`Queue mode id: ${this.queueModeId}`);
+
+		await super.init();
 
 		await this.initLicense();
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1138,6 +1138,12 @@ export const schema = {
 			default: 'n8n',
 			env: 'N8N_REDIS_KEY_PREFIX',
 		},
+		queueModeId: {
+			doc: 'Unique ID for this n8n instance, is usually set automatically by n8n during startup',
+			format: String,
+			default: '',
+			env: 'N8N_QUEUE_MODE_ID',
+		},
 	},
 
 	cache: {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1142,7 +1142,6 @@ export const schema = {
 			doc: 'Unique ID for this n8n instance, is usually set automatically by n8n during startup',
 			format: String,
 			default: '',
-			env: 'N8N_QUEUE_MODE_ID',
 		},
 	},
 

--- a/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
@@ -50,7 +50,6 @@ export interface MessageWithCallback {
 export interface MessageEventBusInitializeOptions {
 	skipRecoveryPass?: boolean;
 	workerId?: string;
-	uniqueInstanceId?: string;
 }
 
 @Service()
@@ -58,8 +57,6 @@ export class MessageEventBus extends EventEmitter {
 	private static instance: MessageEventBus;
 
 	isInitialized: boolean;
-
-	uniqueInstanceId: string;
 
 	redisPublisher: RedisServicePubSubPublisher;
 
@@ -93,12 +90,10 @@ export class MessageEventBus extends EventEmitter {
 	 *
 	 * Sets `isInitialized` to `true` once finished.
 	 */
-	async initialize(options: MessageEventBusInitializeOptions): Promise<void> {
+	async initialize(options?: MessageEventBusInitializeOptions): Promise<void> {
 		if (this.isInitialized) {
 			return;
 		}
-
-		this.uniqueInstanceId = options?.uniqueInstanceId ?? '';
 
 		if (config.getEnv('executions.mode') === 'queue') {
 			this.redisPublisher = await Container.get(RedisService).getPubSubPublisher();
@@ -267,10 +262,11 @@ export class MessageEventBus extends EventEmitter {
 
 	async handleRedisCommandMessage(messageString: string) {
 		const message = messageToRedisServiceCommandObject(messageString);
+		const queueModeId = config.get('redis.queueModeId') as string;
 		if (message) {
 			if (
-				message.senderId === this.uniqueInstanceId ||
-				(message.targets && !message.targets.includes(this.uniqueInstanceId))
+				message.senderId === queueModeId ||
+				(message.targets && !message.targets.includes(queueModeId))
 			) {
 				LoggerProxy.debug(
 					`Skipping command message ${message.command} because it's not for this instance.`,
@@ -291,7 +287,6 @@ export class MessageEventBus extends EventEmitter {
 	async broadcastRestartEventbusAfterDestinationUpdate() {
 		if (config.getEnv('executions.mode') === 'queue') {
 			await this.redisPublisher.publishToCommandChannel({
-				senderId: this.uniqueInstanceId,
 				command: 'restartEventBus',
 			});
 		}

--- a/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
@@ -32,13 +32,9 @@ import { ExecutionRepository, WorkflowRepository } from '@/databases/repositorie
 import { RedisService } from '@/services/redis.service';
 import type { RedisServicePubSubPublisher } from '@/services/redis/RedisServicePubSubPublisher';
 import type { RedisServicePubSubSubscriber } from '@/services/redis/RedisServicePubSubSubscriber';
-import {
-	COMMAND_REDIS_CHANNEL,
-	EVENT_BUS_REDIS_CHANNEL,
-} from '@/services/redis/RedisServiceHelper';
+import { EVENT_BUS_REDIS_CHANNEL } from '@/services/redis/RedisServiceHelper';
 import type { AbstractEventMessageOptions } from '../EventMessageClasses/AbstractEventMessageOptions';
 import { getEventMessageObjectByType } from '../EventMessageClasses/Helpers';
-import { messageToRedisServiceCommandObject } from '@/services/orchestration/helpers';
 
 export type EventMessageReturnMode = 'sent' | 'unsent' | 'all' | 'unfinished';
 

--- a/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriter.ts
+++ b/packages/cli/src/eventbus/MessageEventBusWriter/MessageEventBusLogWriter.ts
@@ -18,7 +18,7 @@ import {
 	isEventMessageConfirm,
 } from '../EventMessageClasses/EventMessageConfirm';
 import { once as eventOnce } from 'events';
-import { inTest } from '../../constants';
+import { inTest } from '@/constants';
 
 interface MessageEventBusLogWriterConstructorOptions {
 	logBaseName?: string;

--- a/packages/cli/src/services/orchestration/handleCommandMessage.ts
+++ b/packages/cli/src/services/orchestration/handleCommandMessage.ts
@@ -1,6 +1,8 @@
 import { LoggerProxy } from 'n8n-workflow';
 import { messageToRedisServiceCommandObject } from './helpers';
 import config from '@/config';
+import { MessageEventBus } from '../../eventbus/MessageEventBus/MessageEventBus';
+import Container from 'typedi';
 
 // this function handles commands sent to the MAIN instance. the workers handle their own commands
 export async function handleCommandMessage(messageString: string) {
@@ -11,6 +13,7 @@ export async function handleCommandMessage(messageString: string) {
 			message.senderId === queueModeId ||
 			(message.targets && !message.targets.includes(queueModeId))
 		) {
+			// Skipping command message because it's not for this instance
 			LoggerProxy.debug(
 				`Skipping command message ${message.command} because it's not for this instance.`,
 			);
@@ -26,6 +29,8 @@ export async function handleCommandMessage(messageString: string) {
 				// once multiple main instances are supported, this command should be handled
 				// await Container.get(License).reload();
 				break;
+			case 'restartEventBus':
+				await Container.get(MessageEventBus).restart();
 			default:
 				break;
 		}

--- a/packages/cli/src/services/orchestration/handleCommandMessage.ts
+++ b/packages/cli/src/services/orchestration/handleCommandMessage.ts
@@ -6,7 +6,7 @@ import Container from 'typedi';
 
 // this function handles commands sent to the MAIN instance. the workers handle their own commands
 export async function handleCommandMessage(messageString: string) {
-	const queueModeId = config.get('redis.queueModeId') as string;
+	const queueModeId = config.get('redis.queueModeId');
 	const message = messageToRedisServiceCommandObject(messageString);
 	if (message) {
 		if (

--- a/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
+++ b/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
@@ -2,6 +2,7 @@ import type Redis from 'ioredis';
 import type { Cluster } from 'ioredis';
 import { getDefaultRedisClient } from './RedisServiceHelper';
 import { LoggerProxy } from 'n8n-workflow';
+import config from '@/config';
 
 export type RedisClientType =
 	| 'subscriber'
@@ -57,8 +58,9 @@ class RedisServiceBase {
 export abstract class RedisServiceBaseSender extends RedisServiceBase {
 	senderId: string;
 
-	setSenderId(senderId?: string): void {
-		this.senderId = senderId ?? '';
+	async init(type: RedisClientType = 'client'): Promise<void> {
+		await super.init(type);
+		this.senderId = config.get('redis.queueModeId') as string;
 	}
 }
 

--- a/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
+++ b/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
@@ -60,7 +60,7 @@ export abstract class RedisServiceBaseSender extends RedisServiceBase {
 
 	async init(type: RedisClientType = 'client'): Promise<void> {
 		await super.init(type);
-		this.senderId = config.get('redis.queueModeId') as string;
+		this.senderId = config.get('redis.queueModeId');
 	}
 }
 

--- a/packages/cli/src/services/redis/RedisServiceCommands.ts
+++ b/packages/cli/src/services/redis/RedisServiceCommands.ts
@@ -12,7 +12,7 @@ export type RedisServiceCommand =
  * @field payload: Optional arguments to be sent with the command.
  */
 type RedisServiceBaseCommand = {
-	senderId?: string;
+	senderId: string;
 	command: RedisServiceCommand;
 	payload?: {
 		[key: string]: string | number | boolean | string[] | number[] | boolean[];

--- a/packages/cli/src/services/redis/RedisServiceListSender.ts
+++ b/packages/cli/src/services/redis/RedisServiceListSender.ts
@@ -5,9 +5,8 @@ import { RedisServiceBaseSender } from './RedisServiceBaseClasses';
 
 @Service()
 export class RedisServiceListSender extends RedisServiceBaseSender {
-	async init(senderId?: string): Promise<void> {
+	async init(): Promise<void> {
 		await super.init('list-sender');
-		this.setSenderId(senderId);
 	}
 
 	async prepend(list: string, message: string): Promise<void> {

--- a/packages/cli/src/services/redis/RedisServicePubSubPublisher.ts
+++ b/packages/cli/src/services/redis/RedisServicePubSubPublisher.ts
@@ -13,9 +13,8 @@ import { RedisServiceBaseSender } from './RedisServiceBaseClasses';
 
 @Service()
 export class RedisServicePubSubPublisher extends RedisServiceBaseSender {
-	async init(senderId?: string): Promise<void> {
+	async init(): Promise<void> {
 		await super.init('publisher');
-		this.setSenderId(senderId);
 	}
 
 	async publish(channel: string, message: string): Promise<void> {
@@ -29,8 +28,12 @@ export class RedisServicePubSubPublisher extends RedisServiceBaseSender {
 		await this.publish(EVENT_BUS_REDIS_CHANNEL, message.toString());
 	}
 
-	async publishToCommandChannel(message: RedisServiceCommandObject): Promise<void> {
-		await this.publish(COMMAND_REDIS_CHANNEL, JSON.stringify(message));
+	async publishToCommandChannel(
+		message: Omit<RedisServiceCommandObject, 'senderId'>,
+	): Promise<void> {
+		const messageWithSenderId = message as RedisServiceCommandObject;
+		messageWithSenderId.senderId = this.senderId;
+		await this.publish(COMMAND_REDIS_CHANNEL, JSON.stringify(messageWithSenderId));
 	}
 
 	async publishToWorkerChannel(message: RedisServiceWorkerResponseObject): Promise<void> {

--- a/packages/cli/src/services/redis/RedisServiceStreamProducer.ts
+++ b/packages/cli/src/services/redis/RedisServiceStreamProducer.ts
@@ -14,9 +14,8 @@ import { RedisServiceBaseSender } from './RedisServiceBaseClasses';
 
 @Service()
 export class RedisServiceStreamProducer extends RedisServiceBaseSender {
-	async init(senderId?: string): Promise<void> {
+	async init(): Promise<void> {
 		await super.init('producer');
-		this.setSenderId(senderId);
 	}
 
 	async add(streamName: string, values: RedisValue[]): Promise<void> {

--- a/packages/cli/src/worker/workerCommandHandler.ts
+++ b/packages/cli/src/worker/workerCommandHandler.ts
@@ -7,7 +7,7 @@ import Container from 'typedi';
 import { License } from '@/License';
 
 export function getWorkerCommandReceivedHandler(options: {
-	uniqueInstanceId: string;
+	queueModeId: string;
 	instanceId: string;
 	redisPublisher: RedisServicePubSubPublisher;
 	getRunningJobIds: () => string[];
@@ -25,16 +25,16 @@ export function getWorkerCommandReceivedHandler(options: {
 				return;
 			}
 			if (message) {
-				if (message.targets && !message.targets.includes(options.uniqueInstanceId)) {
+				if (message.targets && !message.targets.includes(options.queueModeId)) {
 					return; // early return if the message is not for this worker
 				}
 				switch (message.command) {
 					case 'getStatus':
 						await options.redisPublisher.publishToWorkerChannel({
-							workerId: options.uniqueInstanceId,
+							workerId: options.queueModeId,
 							command: message.command,
 							payload: {
-								workerId: options.uniqueInstanceId,
+								workerId: options.queueModeId,
 								runningJobs: options.getRunningJobIds(),
 								freeMem: os.freemem(),
 								totalMem: os.totalmem(),
@@ -53,13 +53,13 @@ export function getWorkerCommandReceivedHandler(options: {
 						break;
 					case 'getId':
 						await options.redisPublisher.publishToWorkerChannel({
-							workerId: options.uniqueInstanceId,
+							workerId: options.queueModeId,
 							command: message.command,
 						});
 						break;
 					case 'restartEventBus':
 						await options.redisPublisher.publishToWorkerChannel({
-							workerId: options.uniqueInstanceId,
+							workerId: options.queueModeId,
 							command: message.command,
 							payload: {
 								result: 'success',

--- a/packages/cli/src/worker/workerCommandHandler.ts
+++ b/packages/cli/src/worker/workerCommandHandler.ts
@@ -5,6 +5,7 @@ import type { RedisServicePubSubPublisher } from '@/services/redis/RedisServiceP
 import * as os from 'os';
 import Container from 'typedi';
 import { License } from '@/License';
+import { MessageEventBus } from '../eventbus/MessageEventBus/MessageEventBus';
 
 export function getWorkerCommandReceivedHandler(options: {
 	queueModeId: string;
@@ -58,6 +59,7 @@ export function getWorkerCommandReceivedHandler(options: {
 						});
 						break;
 					case 'restartEventBus':
+						await Container.get(MessageEventBus).restart();
 						await options.redisPublisher.publishToWorkerChannel({
 							workerId: options.queueModeId,
 							command: message.command,

--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -1,6 +1,7 @@
 import { mockInstance } from '../shared/utils/';
 import { Worker } from '@/commands/worker';
 import * as Config from '@oclif/config';
+import config from '@/config';
 import { LoggerProxy } from 'n8n-workflow';
 import { Telemetry } from '@/telemetry';
 import { getLogger } from '@/Logger';
@@ -17,10 +18,11 @@ import { InternalHooks } from '@/InternalHooks';
 import { PostHogClient } from '@/posthog';
 import { RedisService } from '@/services/redis.service';
 
-const config: Config.IConfig = new Config.Config({ root: __dirname });
+const oclifConfig: Config.IConfig = new Config.Config({ root: __dirname });
 
 beforeAll(async () => {
 	LoggerProxy.init(getLogger());
+	config.set('executions.mode', 'queue');
 	mockInstance(Telemetry);
 	mockInstance(PostHogClient);
 	mockInstance(InternalHooks);
@@ -37,7 +39,7 @@ beforeAll(async () => {
 });
 
 test('worker initializes all its components', async () => {
-	const worker = new Worker([], config);
+	const worker = new Worker([], oclifConfig);
 
 	jest.spyOn(worker, 'init');
 	jest.spyOn(worker, 'initLicense').mockImplementation(async () => {});
@@ -60,9 +62,9 @@ test('worker initializes all its components', async () => {
 
 	await worker.init();
 
-	expect(worker.uniqueInstanceId).toBeDefined();
-	expect(worker.uniqueInstanceId).toContain('worker');
-	expect(worker.uniqueInstanceId.length).toBeGreaterThan(15);
+	expect(worker.queueModeId).toBeDefined();
+	expect(worker.queueModeId).toContain('worker');
+	expect(worker.queueModeId.length).toBeGreaterThan(15);
 	expect(worker.initLicense).toHaveBeenCalled();
 	expect(worker.initBinaryDataService).toHaveBeenCalled();
 	expect(worker.initExternalHooks).toHaveBeenCalled();

--- a/packages/cli/test/unit/License.test.ts
+++ b/packages/cli/test/unit/License.test.ts
@@ -38,6 +38,7 @@ describe('License', () => {
 			logger: expect.anything(),
 			loadCertStr: expect.any(Function),
 			saveCertStr: expect.any(Function),
+			onFeatureChange: expect.any(Function),
 			server: MOCK_SERVER_URL,
 			tenantId: 1,
 		});
@@ -56,6 +57,7 @@ describe('License', () => {
 			logger: expect.anything(),
 			loadCertStr: expect.any(Function),
 			saveCertStr: expect.any(Function),
+			onFeatureChange: expect.any(Function),
 			server: MOCK_SERVER_URL,
 			tenantId: 1,
 		});

--- a/packages/cli/test/unit/services/orchestration.service.test.ts
+++ b/packages/cli/test/unit/services/orchestration.service.test.ts
@@ -9,7 +9,6 @@ import { RedisService } from '@/services/redis.service';
 import { mockInstance } from '../../integration/shared/utils';
 import { handleWorkerResponseMessage } from '../../../src/services/orchestration/handleWorkerResponseMessage';
 import { handleCommandMessage } from '../../../src/services/orchestration/handleCommandMessage';
-import { License } from '../../../src/License';
 
 const os = Container.get(OrchestrationService);
 

--- a/packages/cli/test/unit/services/orchestration.service.test.ts
+++ b/packages/cli/test/unit/services/orchestration.service.test.ts
@@ -4,7 +4,6 @@ import { LoggerProxy } from 'n8n-workflow';
 import { getLogger } from '@/Logger';
 import { OrchestrationService } from '@/services/orchestration.service';
 import type { RedisServiceWorkerResponseObject } from '@/services/redis/RedisServiceCommands';
-import { EventMessageWorkflow } from '@/eventbus/EventMessageClasses/EventMessageWorkflow';
 import { eventBus } from '@/eventbus';
 import { RedisService } from '@/services/redis.service';
 import { mockInstance } from '../../integration/shared/utils';
@@ -67,7 +66,7 @@ describe('Orchestration Service', () => {
 			});
 		});
 		setDefaultConfig();
-		queueModeId = config.get('redis.queueModeId') as string;
+		queueModeId = config.get('redis.queueModeId');
 	});
 
 	afterAll(async () => {

--- a/packages/cli/test/unit/services/orchestration.service.test.ts
+++ b/packages/cli/test/unit/services/orchestration.service.test.ts
@@ -90,9 +90,7 @@ describe('Orchestration Service', () => {
 	});
 
 	test('should handle command messages from others', async () => {
-		const license = Container.get(License);
-		license.instanceId = 'test';
-		jest.spyOn(license, 'reload');
+		jest.spyOn(LoggerProxy, 'warn');
 		const responseFalseId = await handleCommandMessage(
 			JSON.stringify({
 				senderId: 'test',
@@ -102,8 +100,8 @@ describe('Orchestration Service', () => {
 		expect(responseFalseId).toBeDefined();
 		expect(responseFalseId!.command).toEqual('reloadLicense');
 		expect(responseFalseId!.senderId).toEqual('test');
-		expect(license.reload).toHaveBeenCalled();
-		jest.spyOn(license, 'reload').mockRestore();
+		expect(LoggerProxy.warn).toHaveBeenCalled();
+		jest.spyOn(LoggerProxy, 'warn').mockRestore();
 	});
 
 	test('should reject command messages from iteslf', async () => {

--- a/packages/core/src/BinaryData/BinaryData.service.ts
+++ b/packages/core/src/BinaryData/BinaryData.service.ts
@@ -118,7 +118,7 @@ export class BinaryDataService {
 	}
 
 	async deleteManyByExecutionIds(executionIds: string[]) {
-		const manager = this.getManager(this.mode);
+		const manager = this.managers[this.mode];
 
 		if (!manager) return;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
     dependencies:
       axios:
         specifier: ^0.21.1
-        version: 0.21.4(debug@4.3.2)
+        version: 0.21.4
 
   packages/@n8n_io/eslint-config:
     devDependencies:
@@ -199,7 +199,7 @@ importers:
         version: 2.6.0
       '@oclif/command':
         specifier: ^1.8.16
-        version: 1.8.18(@oclif/config@1.18.5)(supports-color@8.1.1)
+        version: 1.8.18(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/core':
         specifier: ^1.16.4
         version: 1.16.6
@@ -217,7 +217,7 @@ importers:
         version: 7.28.1
       axios:
         specifier: ^0.21.1
-        version: 0.21.4(debug@4.3.2)
+        version: 0.21.4
       basic-auth:
         specifier: ^2.0.1
         version: 2.0.1
@@ -471,6 +471,9 @@ importers:
       '@apidevtools/swagger-cli':
         specifier: 4.0.0
         version: 4.0.0
+      '@oclif/config':
+        specifier: ^1.18.17
+        version: 1.18.17
       '@oclif/dev-cli':
         specifier: ^1.22.2
         version: 1.26.10
@@ -572,7 +575,7 @@ importers:
         version: link:../@n8n/client-oauth2
       axios:
         specifier: ^0.21.1
-        version: 0.21.4(debug@4.3.2)
+        version: 0.21.4
       concat-stream:
         specifier: ^2.0.0
         version: 2.0.0
@@ -838,7 +841,7 @@ importers:
         version: 10.2.0(vue@3.3.4)
       axios:
         specifier: ^0.21.1
-        version: 0.21.4(debug@4.3.2)
+        version: 0.21.4
       codemirror-lang-html-n8n:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4736,13 +4739,13 @@ packages:
     dev: false
     optional: true
 
-  /@oclif/command@1.8.18(@oclif/config@1.18.2):
+  /@oclif/command@1.8.18(@oclif/config@1.18.17):
     resolution: {integrity: sha512-qTad+jtiriMMbkw6ArtcUY89cwLwmwDnD4KSGT+OQiZKYtegp3NUCM9JN8lfj/aKC+0kvSitJM4ULzbgiVTKQQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@oclif/config': ^1
     dependencies:
-      '@oclif/config': 1.18.2
+      '@oclif/config': 1.18.17
       '@oclif/errors': 1.3.6
       '@oclif/help': 1.0.3(supports-color@8.1.1)
       '@oclif/parser': 3.8.8
@@ -4752,13 +4755,28 @@ packages:
       - supports-color
     dev: true
 
-  /@oclif/command@1.8.18(@oclif/config@1.18.5):
+  /@oclif/command@1.8.18(@oclif/config@1.18.17)(supports-color@8.1.1):
     resolution: {integrity: sha512-qTad+jtiriMMbkw6ArtcUY89cwLwmwDnD4KSGT+OQiZKYtegp3NUCM9JN8lfj/aKC+0kvSitJM4ULzbgiVTKQQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@oclif/config': ^1
     dependencies:
-      '@oclif/config': 1.18.5(supports-color@8.1.1)
+      '@oclif/config': 1.18.17
+      '@oclif/errors': 1.3.6
+      '@oclif/help': 1.0.3(supports-color@8.1.1)
+      '@oclif/parser': 3.8.8
+      debug: 4.3.4(supports-color@8.1.1)
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  /@oclif/command@1.8.18(@oclif/config@1.18.2):
+    resolution: {integrity: sha512-qTad+jtiriMMbkw6ArtcUY89cwLwmwDnD4KSGT+OQiZKYtegp3NUCM9JN8lfj/aKC+0kvSitJM4ULzbgiVTKQQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@oclif/config': ^1
+    dependencies:
+      '@oclif/config': 1.18.2
       '@oclif/errors': 1.3.6
       '@oclif/help': 1.0.3(supports-color@8.1.1)
       '@oclif/parser': 3.8.8
@@ -4782,10 +4800,26 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@oclif/config@1.18.17:
+    resolution: {integrity: sha512-k77qyeUvjU8qAJ3XK3fr/QVAqsZO8QOBuESnfeM5HHtPNLSyfVcwiMM2zveSW5xRdLSG3MfV8QnLVkuyCL2ENg==}
+    engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      '@oclif/errors': 1.3.6
+      '@oclif/parser': 3.8.17
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-wsl: 2.2.0
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   /@oclif/config@1.18.2:
     resolution: {integrity: sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@oclif/errors': 1.3.6
       '@oclif/parser': 3.8.8
@@ -4800,6 +4834,7 @@ packages:
   /@oclif/config@1.18.5(supports-color@8.1.1):
     resolution: {integrity: sha512-R6dBedaUVn5jtAh79aaRm7jezx4l3V7Im9NORlLmudz5BL1foMeuXEvnqm+bMiejyexVA+oi9mto6YKZPzo/5Q==}
     engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       '@oclif/errors': 1.3.6
       '@oclif/parser': 3.8.8
@@ -4849,11 +4884,11 @@ packages:
     engines: {node: '>=8.10.0'}
     hasBin: true
     dependencies:
-      '@oclif/command': 1.8.18(@oclif/config@1.18.5)
-      '@oclif/config': 1.18.5(supports-color@8.1.1)
+      '@oclif/command': 1.8.18(@oclif/config@1.18.17)
+      '@oclif/config': 1.18.17
       '@oclif/errors': 1.3.6
       '@oclif/plugin-help': 3.2.18
-      cli-ux: 5.6.7(@oclif/config@1.18.5)
+      cli-ux: 5.6.7(@oclif/config@1.18.17)
       debug: 4.3.4(supports-color@8.1.1)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
@@ -4905,6 +4940,16 @@ packages:
 
   /@oclif/linewrap@1.0.0:
     resolution: {integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==}
+
+  /@oclif/parser@3.8.17:
+    resolution: {integrity: sha512-l04iSd0xoh/16TGVpXb81Gg3z7tlQGrEup16BrVLsZBK6SEYpYHRJZnM32BwZrHI97ZSFfuSwVlzoo6HdsaK8A==}
+    engines: {node: '>=8.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    dependencies:
+      '@oclif/errors': 1.3.6
+      '@oclif/linewrap': 1.0.0
+      chalk: 4.1.2
+      tslib: 2.6.1
 
   /@oclif/parser@3.8.8:
     resolution: {integrity: sha512-OgqQAtpyq1XFJG3dvLl9aqiO+F5pubkzt7AivUDkNoa6/hNgVZ79vvTO8sqo5XAAhOm/fcTSerZ35OTnTJb1ng==}
@@ -5022,7 +5067,7 @@ packages:
     dependencies:
       '@segment/loosely-validate-event': 2.0.0
       auto-changelog: 1.16.4
-      axios: 0.21.4(debug@4.3.2)
+      axios: 0.21.4
       axios-retry: 3.3.1
       bull: 3.29.3
       lodash.clonedeep: 4.5.0
@@ -6775,7 +6820,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 3.13.1
       vue: 3.3.4
-      vue-component-type-helpers: 1.8.11
+      vue-component-type-helpers: 1.8.14
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9072,19 +9117,18 @@ packages:
       is-retry-allowed: 2.2.0
     dev: false
 
-  /axios@0.21.4(debug@4.3.2):
+  /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.2)
+      follow-redirects: 1.15.2(debug@3.2.7)
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+  /axios@0.21.4(debug@4.3.2):
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
       follow-redirects: 1.15.2(debug@4.3.2)
-      form-data: 4.0.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9110,7 +9154,7 @@ packages:
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.2)
+      follow-redirects: 1.15.2(debug@3.2.7)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -9938,12 +9982,12 @@ packages:
       string-width: 4.2.3
     dev: true
 
-  /cli-ux@5.6.7(@oclif/config@1.18.5):
+  /cli-ux@5.6.7(@oclif/config@1.18.17):
     resolution: {integrity: sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==}
     engines: {node: '>=8.0.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
-      '@oclif/command': 1.8.18(@oclif/config@1.18.5)(supports-color@8.1.1)
+      '@oclif/command': 1.8.18(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/errors': 1.3.6
       '@oclif/linewrap': 1.0.0
       '@oclif/screen': 1.0.4
@@ -18006,7 +18050,7 @@ packages:
     resolution: {integrity: sha512-aXYe/D+28kF63W8Cz53t09ypEORz+ULeDCahdAqhVrRm2scbOXFbtnn0GGhvMpYe45grepLKuwui9KxrZ2ZuMw==}
     engines: {node: '>=14.17.0'}
     dependencies:
-      axios: 0.27.2
+      axios: 0.27.2(debug@3.2.7)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -21736,8 +21780,8 @@ packages:
       vue: 3.3.4
     dev: false
 
-  /vue-component-type-helpers@1.8.11:
-    resolution: {integrity: sha512-CWItFzuEWjkSXDeMGwQEc5cFH4FaueyPQHfi1mBDe+wA2JABqNjFxFUtmZJ9WHkb0HpEwqgBg1umiXrWYXkXHw==}
+  /vue-component-type-helpers@1.8.14:
+    resolution: {integrity: sha512-veuaNIJas+dkRflRumpnY0e0HWqrUrqg5CdWxK/CbQvJ96V4uVOM5eJbj6cJX3rFNmc7+LO3ySHwvKVS8DjG5w==}
     dev: true
 
   /vue-component-type-helpers@1.8.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@oclif/command':
         specifier: ^1.8.16
         version: 1.8.18(@oclif/config@1.18.17)(supports-color@8.1.1)
+      '@oclif/config':
+        specifier: ^1.18.17
+        version: 1.18.17
       '@oclif/core':
         specifier: ^1.16.4
         version: 1.16.6
@@ -471,9 +474,6 @@ importers:
       '@apidevtools/swagger-cli':
         specifier: 4.0.0
         version: 4.0.0
-      '@oclif/config':
-        specifier: ^1.18.17
-        version: 1.18.17
       '@oclif/dev-cli':
         specifier: ^1.22.2
         version: 1.26.10
@@ -968,7 +968,7 @@ importers:
     dependencies:
       '@oclif/command':
         specifier: ^1.5.18
-        version: 1.8.18(@oclif/config@1.18.5)(supports-color@8.1.1)
+        version: 1.8.18(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/errors':
         specifier: ^1.2.2
         version: 1.3.6
@@ -4785,22 +4785,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@oclif/command@1.8.18(@oclif/config@1.18.5)(supports-color@8.1.1):
-    resolution: {integrity: sha512-qTad+jtiriMMbkw6ArtcUY89cwLwmwDnD4KSGT+OQiZKYtegp3NUCM9JN8lfj/aKC+0kvSitJM4ULzbgiVTKQQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@oclif/config': ^1
-    dependencies:
-      '@oclif/config': 1.18.5(supports-color@8.1.1)
-      '@oclif/errors': 1.3.6
-      '@oclif/help': 1.0.3(supports-color@8.1.1)
-      '@oclif/parser': 3.8.8
-      debug: 4.3.4(supports-color@8.1.1)
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@oclif/config@1.18.17:
     resolution: {integrity: sha512-k77qyeUvjU8qAJ3XK3fr/QVAqsZO8QOBuESnfeM5HHtPNLSyfVcwiMM2zveSW5xRdLSG3MfV8QnLVkuyCL2ENg==}


### PR DESCRIPTION
all commands sent between main instance and workers need to contain a server id to prevent senders from reacting to their own messages, causing loops

this PR makes sure all sent messages contain a sender id by default as part of constructing a sending redis client.


