### PR TITLE
fix(editor): Fix issue that double incoming connection often does not resolve expression (no-changelog)

### DIFF
--- a/packages/editor-ui/src/mixins/__tests__/workflowHelpers.spec.ts
+++ b/packages/editor-ui/src/mixins/__tests__/workflowHelpers.spec.ts
@@ -1,0 +1,232 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { useSettingsStore, useWorkflowsStore } from '@/stores';
+import { setupServer } from '@/__tests__/server';
+import { executeData } from '@/mixins/workflowHelpers';
+import type { IExecutionResponse } from '@/Interface';
+
+describe('workflowHelpers', () => {
+	let server: ReturnType<typeof setupServer>;
+	let pinia: ReturnType<typeof createPinia>;
+	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
+	let settingsStore: ReturnType<typeof useSettingsStore>;
+
+	beforeAll(() => {
+		server = setupServer();
+	});
+
+	beforeEach(async () => {
+		pinia = createPinia();
+		setActivePinia(pinia);
+
+		workflowsStore = useWorkflowsStore();
+		settingsStore = useSettingsStore();
+
+		await settingsStore.getSettings();
+	});
+
+	afterAll(() => {
+		server.shutdown();
+	});
+
+	describe('executeData()', () => {
+		it('should return empty execute data if no parent nodes', () => {
+			const parentNodes: string[] = [];
+			const currentNode = 'Set';
+			const inputName = 'main';
+			const runIndex = 0;
+
+			const result = executeData(parentNodes, currentNode, inputName, runIndex);
+
+			expect(result).toEqual({
+				node: {},
+				data: {},
+				source: null,
+			});
+		});
+
+		it('should return the correct execution data with one parent node', () => {
+			const parentNodes = ['Start'];
+			const currentNode = 'Set';
+			const inputName = 'main';
+			const runIndex = 0;
+			const jsonData = {
+				name: 'Test',
+			};
+
+			workflowsStore.workflowExecutionData = {
+				data: {
+					resultData: {
+						runData: {
+							[parentNodes[0]]: [
+								{
+									startTime: 0,
+									executionTime: 0,
+									data: {
+										main: [
+											{
+												json: jsonData,
+												index: 0,
+											},
+										],
+									},
+									source: [],
+								},
+							],
+						},
+					},
+				},
+			} as unknown as IExecutionResponse;
+
+			const result = executeData(parentNodes, currentNode, inputName, runIndex);
+
+			expect(result).toEqual({
+				node: {},
+				data: {
+					main: [
+						{
+							index: 0,
+							json: jsonData,
+						},
+					],
+				},
+				source: {
+					main: [
+						{
+							previousNode: parentNodes[0],
+						},
+					],
+				},
+			});
+		});
+
+		it('should return the correct execution data with multiple parent nodes, only one with execution data', () => {
+			const parentNodes = ['Parent A', 'Parent B'];
+			const currentNode = 'Set';
+			const inputName = 'main';
+			const runIndex = 0;
+			const jsonData = {
+				name: 'Test',
+			};
+
+			workflowsStore.workflowExecutionData = {
+				data: {
+					resultData: {
+						runData: {
+							[parentNodes[1]]: [
+								{
+									startTime: 0,
+									executionTime: 0,
+									data: {
+										main: [
+											{
+												json: jsonData,
+												index: 0,
+											},
+										],
+									},
+									source: [],
+								},
+							],
+						},
+					},
+				},
+			} as unknown as IExecutionResponse;
+
+			const result = executeData(parentNodes, currentNode, inputName, runIndex);
+
+			expect(result).toEqual({
+				node: {},
+				data: {
+					main: [
+						{
+							index: 0,
+							json: jsonData,
+						},
+					],
+				},
+				source: {
+					main: [
+						{
+							previousNode: parentNodes[1],
+						},
+					],
+				},
+			});
+		});
+
+		it('should return the correct execution data with multiple parent nodes, all with execution data', () => {
+			const parentNodes = ['Parent A', 'Parent B'];
+			const currentNode = 'Set';
+			const inputName = 'main';
+			const runIndex = 0;
+
+			const jsonDataA = {
+				name: 'Test A',
+			};
+
+			const jsonDataB = {
+				name: 'Test B',
+			};
+
+			workflowsStore.workflowExecutionData = {
+				data: {
+					resultData: {
+						runData: {
+							[parentNodes[0]]: [
+								{
+									startTime: 0,
+									executionTime: 0,
+									data: {
+										main: [
+											{
+												json: jsonDataA,
+												index: 0,
+											},
+										],
+									},
+									source: [],
+								},
+							],
+							[parentNodes[1]]: [
+								{
+									startTime: 0,
+									executionTime: 0,
+									data: {
+										main: [
+											{
+												json: jsonDataB,
+												index: 0,
+											},
+										],
+									},
+									source: [],
+								},
+							],
+						},
+					},
+				},
+			} as unknown as IExecutionResponse;
+
+			const result = executeData(parentNodes, currentNode, inputName, runIndex);
+
+			expect(result).toEqual({
+				node: {},
+				data: {
+					main: [
+						{
+							index: 0,
+							json: jsonDataA,
+						},
+					],
+				},
+				source: {
+					main: [
+						{
+							previousNode: parentNodes[0],
+						},
+					],
+				},
+			});
+		});
+	});
+});

--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -49,7 +49,7 @@ import { nodeHelpers } from '@/mixins/nodeHelpers';
 import { genericHelpers } from '@/mixins/genericHelpers';
 import { useToast, useMessage } from '@/composables';
 
-import { isEqual } from 'lodash-es';
+import { get, isEqual } from 'lodash-es';
 
 import { v4 as uuid } from 'uuid';
 import { getSourceItems } from '@/utils';
@@ -306,7 +306,7 @@ function connectionInputData(
 }
 
 function executeData(
-	parentNode: string[],
+	parentNodes: string[],
 	currentNode: string,
 	inputName: string,
 	runIndex: number,
@@ -317,12 +317,10 @@ function executeData(
 		source: null,
 	} as IExecuteData;
 
-	if (parentNode.length) {
-		// Add the input data to be able to also resolve the short expression format
-		// which does not use the node name
-		const parentNodeName = parentNode[0];
-		const workflowsStore = useWorkflowsStore();
+	const workflowsStore = useWorkflowsStore();
 
+	// Find the parent node which has data
+	for (const parentNodeName of parentNodes) {
 		if (workflowsStore.shouldReplaceInputDataWithPinData) {
 			const parentPinData = workflowsStore.getPinData![parentNodeName];
 
@@ -337,7 +335,6 @@ function executeData(
 		}
 
 		// populate `executeData` from `runData`
-
 		const workflowRunData = workflowsStore.getWorkflowRunData;
 		if (workflowRunData === null) {
 			return executeData;
@@ -368,6 +365,7 @@ function executeData(
 					],
 				};
 			}
+			return executeData;
 		}
 	}
 

--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -305,7 +305,7 @@ function connectionInputData(
 	return connectionInputData;
 }
 
-function executeData(
+export function executeData(
 	parentNodes: string[],
 	currentNode: string,
 	inputName: string,

--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -49,7 +49,7 @@ import { nodeHelpers } from '@/mixins/nodeHelpers';
 import { genericHelpers } from '@/mixins/genericHelpers';
 import { useToast, useMessage } from '@/composables';
 
-import { get, isEqual } from 'lodash-es';
+import { isEqual } from 'lodash-es';
 
 import { v4 as uuid } from 'uuid';
 import { getSourceItems } from '@/utils';


### PR DESCRIPTION
Cherry-picked from AI Tool Creation branch

https://community.n8n.io/t/error-can-t-get-data-for-expression-on-set-node-variable-preview-when-connected-to-both-ends-of-if-node/26495/28