### PR TITLE
fix(core): Prevent executions from displaying Running status incorrectly

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -1591,6 +1591,7 @@ export class WorkflowExecute {
 		} else {
 			Logger.verbose('Workflow execution finished successfully', { workflowId: workflow.id });
 			fullRunData.finished = true;
+			fullRunData.status = 'success';
 		}
 
 		// Check if static data changed


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
https://linear.app/n8n/issue/HELP-338/large-number-of-long-running-executions-for-nadjalemlist#comment-18d1fc96

After investigating this issue with @ivov and @flipswitchingmonkey we've identified this missing assignment of execution status.

This is the only inconsistency we've found that could cause executions to continue displaying as `Running` even after finished.