### PR TITLE
ci: Adjust Postgres/MySQL failure notification (no-changelog)

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -47,9 +47,9 @@ jobs:
         working-directory: packages/cli
         run: DB_POSTGRESDB_SCHEMA=alt_schema DB_TABLE_PREFIX=test_ pnpm test:postgres
 
-      - name: Notify Slack on failure
+      - name: Notify Slack on master failure
         uses: act10ns/slack@v2.0.0
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/master'
         with:
           status: ${{ job.status }}
           channel: '#updates-build-alerts'


### PR DESCRIPTION
Prevent DB test runs on PRs from spamming the build alerts channel.

Ref: https://github.com/n8n-io/n8n/actions/runs/6298825743