### PR TITLE
fix(Postgres Node): Node requires comma-separated string even when using a single parameter through an expression

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -63,7 +63,11 @@ export async function execute(
 
 		let values: Array<IDataObject | string> = [];
 
-		const queryReplacement = this.getNodeParameter('options.queryReplacement', i, '');
+		let queryReplacement = this.getNodeParameter('options.queryReplacement', i, '');
+
+		if (typeof queryReplacement === 'number') {
+			queryReplacement = String(queryReplacement);
+		}
 
 		if (typeof queryReplacement === 'string') {
 			const node = this.getNode();


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
