### PR TITLE
feat(core): Support some of the Postgres SSL opens in AI Agent

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -11,10 +11,19 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 		username: credentials.user as string,
 		password: credentials.password as string,
 		database: credentials.database as string,
-		ssl: {
-			rejectUnauthorized: !(credentials.allowUnauthorizedCerts as boolean),
-		},
 	});
+
+	if (credentials.allowUnauthorizedCerts === true) {
+		dataSource.setOptions({
+			ssl: {
+				rejectUnauthorized: true,
+			},
+		});
+	} else {
+		dataSource.setOptions({
+			ssl: !['disable', undefined].includes(credentials.ssl as string | undefined),
+		});
+	}
 
 	return dataSource;
 }


### PR DESCRIPTION
This PR adds support for some of the SSL options when using Postgres in the SSL agent, Tested against a standard docker postgres image with no ssl support and Neon.tech which requires SSL.