### PR TITLE
fix(editor): Separate cloud endpoint calls

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -144,8 +144,9 @@ export default defineComponent({
 				console.log(HIRING_BANNER);
 			}
 		},
-		async checkForCloudPlanData() {
-			return this.cloudPlanStore.checkForCloudPlanData();
+		async checkForCloudData() {
+			await this.cloudPlanStore.checkForCloudPlanData();
+			await this.cloudPlanStore.fetchUserCloudAccount();
 		},
 		async initialize(): Promise<void> {
 			await this.initSettings();
@@ -237,7 +238,7 @@ export default defineComponent({
 		await this.authenticate();
 		await this.redirectIfNecessary();
 		void this.checkForNewVersions();
-		await this.checkForCloudPlanData();
+		await this.checkForCloudData();
 		void this.postAuthenticate();
 
 		this.loading = false;

--- a/packages/editor-ui/src/stores/__tests__/ui.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/ui.test.ts
@@ -123,7 +123,8 @@ describe('UI store', () => {
 			.spyOn(cloudPlanApi, 'getCloudUserInfo')
 			.mockResolvedValue(getUserCloudInfo(true));
 		setupOwnerAndCloudDeployment();
-		await cloudPlanStore.getOwnerCurrentPlan();
+		await cloudPlanStore.checkForCloudPlanData();
+		await cloudPlanStore.fetchUserCloudAccount();
 		expect(fetchCloudSpy).toHaveBeenCalled();
 		expect(fetchUserCloudAccountSpy).toHaveBeenCalled();
 		expect(uiStore.bannerStack).toContain('TRIAL');
@@ -137,7 +138,8 @@ describe('UI store', () => {
 			.spyOn(cloudPlanApi, 'getCloudUserInfo')
 			.mockResolvedValue(getUserCloudInfo(true));
 		setupOwnerAndCloudDeployment();
-		await cloudPlanStore.getOwnerCurrentPlan();
+		await cloudPlanStore.checkForCloudPlanData();
+		await cloudPlanStore.fetchUserCloudAccount();
 		expect(fetchCloudSpy).toHaveBeenCalled();
 		expect(fetchUserCloudAccountSpy).toHaveBeenCalled();
 		expect(uiStore.bannerStack).toContain('TRIAL_OVER');
@@ -151,7 +153,8 @@ describe('UI store', () => {
 			.spyOn(cloudPlanApi, 'getCloudUserInfo')
 			.mockResolvedValue(getUserCloudInfo(false));
 		setupOwnerAndCloudDeployment();
-		await cloudPlanStore.getOwnerCurrentPlan();
+		await cloudPlanStore.checkForCloudPlanData();
+		await cloudPlanStore.fetchUserCloudAccount();
 		expect(fetchCloudSpy).toHaveBeenCalled();
 		expect(fetchUserCloudAccountSpy).toHaveBeenCalled();
 		expect(uiStore.bannerStack).toContain('TRIAL_OVER');


### PR DESCRIPTION
This PR untangles calls to cloud endpoints so failure in one of them doesn't stop others to go through.