### PR TITLE
feat(core): Add alias for Agent node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -140,7 +140,13 @@ export class Agent implements INodeType {
 			color: '#404040',
 		},
 		codex: {
-			alias: ['LangChain'],
+			alias: [
+				'LangChain',
+				'sql agent',
+				'react agent',
+				'openai functions agent',
+				'conversational agent',
+			],
 			categories: ['AI'],
 			subcategories: {
 				AI: ['Agents'],


### PR DESCRIPTION
Adds SQL Agent, React Agent, OpenAI Functions Agent and Conversational Agent as aliases for the Agent node.