### PR TITLE
fix(core): Prevent object deletion request on no prefix match

### DIFF
--- a/packages/core/src/ObjectStore/ObjectStore.service.ee.ts
+++ b/packages/core/src/ObjectStore/ObjectStore.service.ee.ts
@@ -149,6 +149,8 @@ export class ObjectStoreService {
 	async deleteMany(prefix: string) {
 		const objects = await this.list(prefix);
 
+		if (objects.length === 0) return;
+
 		const innerXml = objects.map(({ key }) => `<Object><Key>${key}</Key></Object>`).join('\n');
 
 		const body = ['<Delete>', innerXml, '</Delete>'].join('\n');

--- a/packages/core/test/ObjectStore.service.test.ts
+++ b/packages/core/test/ObjectStore.service.test.ts
@@ -248,6 +248,14 @@ describe('deleteMany()', () => {
 		);
 	});
 
+	it('should not send a deletion request if no prefix match', async () => {
+		objectStoreService.list = jest.fn().mockResolvedValue([]);
+
+		const result = await objectStoreService.deleteMany('non-matching-prefix');
+
+		expect(result).toBeUndefined();
+	});
+
 	it('should throw an error on request failure', async () => {
 		mockAxios.request.mockRejectedValue(mockError);
 


### PR DESCRIPTION
Found on internal:

```
2023-10-06T11:00:03.482298448Z 2023-10-06T11:00:03.481Z | error    | Request to S3 failed: Request failed with status code 400 "{\n  config: {\n    method: 'POST',\n    url: 'https://s3.eu-west-3.amazonaws.com/aws-s3-binary-data-test/?delete',\n    headers: {\n      'Content-Type': 'application/xml',\n      'Content-Length': 19,\n      'Content-MD5': 'lZ7YugbLfRGHlqM2R/3UVg==',\n      Host: 's3.eu-west-3.amazonaws.com',\n      'X-Amz-Content-Sha256': '64da4e19625c5d2c74549d48107569031b91fb12024f7c206f3d3888392ae5d3',\n      'X-Amz-Date': '20231006T110002Z',\n      Authorization: 'AWS4-HMAC-SHA256 Credential=AKIAYYUAM3RAQNZ2AGPC/20231006/eu-west-3/s3/aws4_request, SignedHeaders=content-length;content-md5;content-type;host;x-amz-content-sha256;x-amz-date, Signature=5492eb5b65106f83ec5d2da47688df51f3c5d9240c798b487d8d5285672d82fc'\n    },\n    data: '<Delete>\\n\\n</Delete>'\n  },\n  file: 'ObjectStore.service.ee.js',\n  function: 'request'\n}"
```