### PR TITLE
fix(editor): Fix UI dev mode (no-changelog)

### DIFF
--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -46,6 +46,7 @@
     "@jsplumb/core": "^5.13.2",
     "@jsplumb/util": "^5.13.2",
     "@lezer/common": "^1.0.4",
+    "@n8n/chat": "^0.1.4",
     "@n8n/codemirror-lang-sql": "^1.0.2",
     "@vueuse/components": "^10.2.0",
     "@vueuse/core": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@lezer/common':
         specifier: ^1.0.4
         version: 1.1.0
+      '@n8n/chat':
+        specifier: ^0.1.4
+        version: 0.1.4
       '@n8n/codemirror-lang-sql':
         specifier: ^1.0.2
         version: 1.0.2(@codemirror/view@6.5.1)(@lezer/common@1.1.0)
@@ -4651,6 +4654,15 @@ packages:
     os: [win32]
     dev: false
     optional: true
+
+  /@n8n/chat@0.1.4:
+    resolution: {integrity: sha512-BuCIFaryEDn+agvSlxLNE71PKqMymaMbj6q4Ca2MaQk8+SA673mr9tW2dOO1sgeXnuil1XJ2oCYphn0Rm+mztA==}
+    dependencies:
+      highlight.js: 11.8.0
+      uuid: 8.3.2
+      vue: 3.3.4
+      vue-markdown-render: 2.0.1
+    dev: false
 
   /@n8n/codemirror-lang-sql@1.0.2(@codemirror/view@6.5.1)(@lezer/common@1.1.0):
     resolution: {integrity: sha512-sOf/KyewSu3Ikij0CkRtzJJDhRDZcwNCEYl8UdH4U/riL0/XZGcBD7MYofCCcKszanJZiEWRZ2KU1sRp234iMg==}
@@ -9122,7 +9134,7 @@ packages:
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@3.2.7)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9151,11 +9163,12 @@ packages:
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
+    dev: true
 
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@3.2.7)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -12725,6 +12738,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -13532,6 +13546,11 @@ packages:
 
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: false
+
+  /highlight.js@11.8.0:
+    resolution: {integrity: sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==}
+    engines: {node: '>=12.0.0'}
     dev: false
 
   /homedir-polyfill@1.0.3:
@@ -18071,7 +18090,7 @@ packages:
     resolution: {integrity: sha512-aXYe/D+28kF63W8Cz53t09ypEORz+ULeDCahdAqhVrRm2scbOXFbtnn0GGhvMpYe45grepLKuwui9KxrZ2ZuMw==}
     engines: {node: '>=14.17.0'}
     dependencies:
-      axios: 0.27.2(debug@4.3.4)
+      axios: 0.27.2(debug@3.2.7)
     transitivePeerDependencies:
       - debug
     dev: false


### PR DESCRIPTION
Trying to run Vue in dev mode triggers:

```
> n8n-editor-ui@1.10.0 dev /Users/ivov/Development/n8n/packages/editor-ui
> pnpm serve


> n8n-editor-ui@1.10.0 serve /Users/ivov/Development/n8n/packages/editor-ui
> cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev


  VITE v4.4.7  ready in 374 ms

  ➜  Local:   http://localhost:8080/
  ➜  Network: http://10.17.71.191:8080/
  ➜  Network: http://192.168.224.29:8080/
  ➜  press h to show help
Error: The following dependencies are imported but could not be resolved:

  @n8n/chat (imported by /Users/ivov/Development/n8n/packages/editor-ui/src/components/ChatEmbedModal.vue?id=0)

Are they installed?
    at file:///Users/ivov/Development/n8n/node_modules/.pnpm/vite@4.4.7_less@4.1.3_sass@1.64.1/node_modules/vite/dist/node/chunks/dep-3b8eb186.js:45655:23
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/ivov/Development/n8n/node_modules/.pnpm/vite@4.4.7_less@4.1.3_sass@1.64.1/node_modules/vite/dist/node/chunks/dep-3b8eb186.js:45064:38
```