### PR TITLE
fix(HTML Node): Update property fields to not use expressions on drag

### DIFF
--- a/packages/nodes-base/nodes/Html/Html.node.ts
+++ b/packages/nodes-base/nodes/Html/Html.node.ts
@@ -115,6 +115,7 @@ export class Html implements INodeType {
 				displayName: 'Binary Property',
 				name: 'dataPropertyName',
 				type: 'string',
+				requiresDataPath: 'single',
 				displayOptions: {
 					show: {
 						operation: ['extractHtmlContent'],
@@ -130,6 +131,7 @@ export class Html implements INodeType {
 				displayName: 'JSON Property',
 				name: 'dataPropertyName',
 				type: 'string',
+				requiresDataPath: 'single',
 				displayOptions: {
 					show: {
 						operation: ['extractHtmlContent'],


### PR DESCRIPTION
When dragging an expression into a "binary property" or "json property" field we should use the key name rather than the expression.
