### PR TITLE
fix(editor): Fix completions for `.json` on quoted node name in Code node

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -275,7 +275,16 @@ export const jsonFieldCompletions = defineComponent({
 		 * `index` is only passed for `all()`.
 		 */
 		getJsonOutput(quotedNodeName: string, options?: { accessor?: string; index?: number }) {
-			const nodeName = quotedNodeName.replace(/['"]/g, '');
+			let nodeName = quotedNodeName;
+
+			const isSingleQuoteWrapped = quotedNodeName.startsWith("'") && quotedNodeName.endsWith("'");
+			const isDoubleQuoteWrapped = quotedNodeName.startsWith('"') && quotedNodeName.endsWith('"');
+
+			if (isSingleQuoteWrapped) {
+				nodeName = quotedNodeName.replace(/^'/, '').replace(/'$/, '');
+			} else if (isDoubleQuoteWrapped) {
+				nodeName = quotedNodeName.replace(/^"/, '').replace(/"$/, '');
+			}
 
 			const pinData: IPinData | undefined = this.workflowsStore.getPinData;
 


### PR DESCRIPTION
To reproduce, request completion with `$input.first().json.` from a node with a quote in the name, e.g. `When clicking "Execute Workflow"`.

Context: https://linear.app/n8n/issue/PAY-635/autocomplete-only-supports-3-levels-of-children#comment-234f738b