### PR TITLE
fix(Webhook Node): Backward compatible form-data parsing for non-array files

### DIFF
--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -190,6 +190,15 @@ export function encodeWebhookResponse(
 	return response;
 }
 
+const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
+	for (const key in values) {
+		const value = values[key];
+		if (Array.isArray(value) && value.length === 1) {
+			values[key] = value[0];
+		}
+	}
+};
+
 /**
  * Executes a webhook
  */
@@ -310,11 +319,8 @@ export async function executeWebhook(
 				});
 				req.body = await new Promise((resolve) => {
 					form.parse(req, async (err, data, files) => {
-						for (const key in data) {
-							if (Array.isArray(data[key]) && data[key].length === 1) {
-								data[key] = data[key][0];
-							}
-						}
+						normalizeFormData(data);
+						normalizeFormData(files);
 						resolve({ data, files });
 					});
 				});

--- a/packages/cli/test/integration/webhooks.api.test.ts
+++ b/packages/cli/test/integration/webhooks.api.test.ts
@@ -116,20 +116,21 @@ describe('Webhook API', () => {
 				.field('field1', 'value1')
 				.field('field2', 'value2')
 				.field('field2', 'value3')
-				.attach('file', Buffer.from('random-text'))
+				.attach('file1', Buffer.from('random-text'))
+				.attach('file2', Buffer.from('random-text'))
+				.attach('file2', Buffer.from('random-text'))
 				.set('content-type', 'multipart/form-data');
 
 			expect(response.statusCode).toEqual(200);
 			expect(response.body.type).toEqual('multipart/form-data');
-			const {
-				data,
-				files: {
-					file: [file],
-				},
-			} = response.body.body;
+			const { data, files } = response.body.body;
 			expect(data).toEqual({ field1: 'value1', field2: ['value2', 'value3'] });
-			expect(file.mimetype).toEqual('application/octet-stream');
-			expect(readFileSync(file.filepath, 'utf-8')).toEqual('random-text');
+
+			expect(files.file1).not.toBeInstanceOf(Array);
+			expect(files.file1.mimetype).toEqual('application/octet-stream');
+			expect(readFileSync(files.file1.filepath, 'utf-8')).toEqual('random-text');
+			expect(files.file2).toBeInstanceOf(Array);
+			expect(files.file2.length).toEqual(2);
 		});
 	});
 


### PR DESCRIPTION
Fixes https://community.n8n.io/t/possible-bug-0-added-to-end-of-files-sent-via-webhook/31169


