### PR TITLE
feat(MongoDB Node): add objectId fields to mongodb options

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
@@ -84,6 +84,7 @@ export function prepareItems(
 	updateKey = '',
 	useDotNotation = false,
 	dateFields: string[] = [],
+	objectIdFields: string[] = [],
 ) {
 	let data = items;
 
@@ -108,6 +109,9 @@ export function prepareItems(
 
 			if (fieldData && dateFields.includes(field)) {
 				fieldData = new Date(fieldData as string);
+			}
+			if (fieldData && objectIdFields.includes(field)) {
+				fieldData = new ObjectId(fieldData as string);
 			}
 
 			if (useDotNotation) {

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -208,6 +208,9 @@ export class MongoDb implements INodeType {
 			const dateFields = prepareFields(
 				this.getNodeParameter('options.dateFields', 0, '') as string,
 			);
+			const objectIdFields = prepareFields(
+				this.getNodeParameter('options.objectIdFields', 0, '') as string,
+			)
 
 			const updateKey = ((this.getNodeParameter('updateKey', 0) as string) || '').trim();
 
@@ -215,7 +218,7 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields);
+			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
 
 			for (const item of updateItems) {
 				try {
@@ -248,6 +251,9 @@ export class MongoDb implements INodeType {
 			const dateFields = prepareFields(
 				this.getNodeParameter('options.dateFields', 0, '') as string,
 			);
+			const objectIdFields = prepareFields(
+				this.getNodeParameter('options.objectIdFields', 0, '') as string,
+			);
 
 			const updateKey = ((this.getNodeParameter('updateKey', 0) as string) || '').trim();
 
@@ -255,7 +261,7 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields);
+			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
 
 			for (const item of updateItems) {
 				try {
@@ -289,8 +295,11 @@ export class MongoDb implements INodeType {
 				const dateFields = prepareFields(
 					this.getNodeParameter('options.dateFields', 0, '') as string,
 				);
+				const objectIdFields = prepareFields(
+					this.getNodeParameter('options.objectIdFields', 0, '') as string,
+				);
 
-				const insertItems = prepareItems(items, fields, '', useDotNotation, dateFields);
+				const insertItems = prepareItems(items, fields, '', useDotNotation, dateFields, objectIdFields);
 
 				const { insertedIds } = await mdb
 					.collection(this.getNodeParameter('collection', 0) as string)
@@ -320,6 +329,9 @@ export class MongoDb implements INodeType {
 			const dateFields = prepareFields(
 				this.getNodeParameter('options.dateFields', 0, '') as string,
 			);
+			const objectIdFields = prepareFields(
+				this.getNodeParameter('options.objectIdFields', 0, '') as string,
+			);
 
 			const updateKey = ((this.getNodeParameter('updateKey', 0) as string) || '').trim();
 
@@ -327,7 +339,7 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields);
+			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
 
 			for (const item of updateItems) {
 				try {

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -210,7 +210,7 @@ export class MongoDb implements INodeType {
 			);
 			const objectIdFields = prepareFields(
 				this.getNodeParameter('options.objectIdFields', 0, '') as string,
-			)
+			);
 
 			const updateKey = ((this.getNodeParameter('updateKey', 0) as string) || '').trim();
 
@@ -218,7 +218,14 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
+			const updateItems = prepareItems(
+				items,
+				fields,
+				updateKey,
+				useDotNotation,
+				dateFields,
+				objectIdFields,
+			);
 
 			for (const item of updateItems) {
 				try {
@@ -261,7 +268,14 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
+			const updateItems = prepareItems(
+				items,
+				fields,
+				updateKey,
+				useDotNotation,
+				dateFields,
+				objectIdFields,
+			);
 
 			for (const item of updateItems) {
 				try {
@@ -299,7 +313,14 @@ export class MongoDb implements INodeType {
 					this.getNodeParameter('options.objectIdFields', 0, '') as string,
 				);
 
-				const insertItems = prepareItems(items, fields, '', useDotNotation, dateFields, objectIdFields);
+				const insertItems = prepareItems(
+					items,
+					fields,
+					'',
+					useDotNotation,
+					dateFields,
+					objectIdFields,
+				);
 
 				const { insertedIds } = await mdb
 					.collection(this.getNodeParameter('collection', 0) as string)
@@ -339,7 +360,14 @@ export class MongoDb implements INodeType {
 				? { upsert: true }
 				: undefined;
 
-			const updateItems = prepareItems(items, fields, updateKey, useDotNotation, dateFields, objectIdFields);
+			const updateItems = prepareItems(
+				items,
+				fields,
+				updateKey,
+				useDotNotation,
+				dateFields,
+				objectIdFields,
+			);
 
 			for (const item of updateItems) {
 				try {

--- a/packages/nodes-base/nodes/MongoDb/MongoDbProperties.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDbProperties.ts
@@ -251,6 +251,13 @@ export const nodeProperties: INodeProperties[] = [
 				description: 'Comma separeted list of fields that will be parse as Mongo Date type',
 			},
 			{
+				displayName: 'ObjectId Fields',
+				name: 'objectIdFields',
+				type: 'string',
+				default: '',
+				description: 'Comma separeted list of fields that will be parse as Mongo ObjectId type',
+			},
+			{
 				displayName: 'Use Dot Notation',
 				name: 'useDotNotation',
 				type: 'boolean',


### PR DESCRIPTION
If we want to refer a document from an other collection via it's _id, we would want to set type as ObjectId of the field instead of String.

With this feature of the PR, we will be able to convert string value of desired field(s) as ObjectId.