### PR TITLE
ci: Enable ARM64 builds for beta images (no-changelog)

### DIFF
--- a/.github/workflows/docker-image-beta.yml
+++ b/.github/workflows/docker-image-beta.yml
@@ -37,7 +37,7 @@ jobs:
           file: ./docker/images/n8n-custom/Dockerfile
           build-args: |
             N8N_RELEASE_TYPE=beta
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           provenance: false
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ github.event.inputs.tag || 'ai-beta' }}


### PR DESCRIPTION
Fixes #7389
