### PR TITLE
fix(core): Do not throw when deleting workflows with executions without binary-data

### DIFF
--- a/packages/core/src/BinaryData/FileSystem.manager.ts
+++ b/packages/core/src/BinaryData/FileSystem.manager.ts
@@ -93,7 +93,7 @@ export class FileSystemManager implements BinaryData.Manager {
 
 		await Promise.all(
 			binaryDataDirs.map(async (dir) => {
-				await fs.rm(dir, { recursive: true });
+				await fs.rm(dir, { recursive: true, force: true });
 			}),
 		);
 	}


### PR DESCRIPTION
Fixes https://n8nio.sentry.io/issues/4508969090
