### PR TITLE
test(core): Add tests for endless execution issue

### DIFF
--- a/packages/cli/test/unit/execution.lifecycle.test.ts
+++ b/packages/cli/test/unit/execution.lifecycle.test.ts
@@ -112,7 +112,7 @@ for (const mode of ['filesystem-v2', 's3'] as const) {
 				expect(binaryDataService.rename).not.toHaveBeenCalled();
 			});
 
-			it('should do nothing if no data is undefined', async () => {
+			it('should do nothing if data is undefined', async () => {
 				const executionId = '999';
 
 				const run = toIRun({

--- a/packages/cli/test/unit/execution.lifecycle.test.ts
+++ b/packages/cli/test/unit/execution.lifecycle.test.ts
@@ -101,6 +101,32 @@ for (const mode of ['filesystem-v2', 's3'] as const) {
 				expect(binaryDataService.rename).not.toHaveBeenCalled();
 				expect(getDataId(run, 'json')).toBe(dataId);
 			});
+
+			it('should do nothing on itemless case', async () => {
+				const executionId = '999';
+
+				const promise = restoreBinaryDataId(toIRun(), executionId);
+
+				await expect(promise).resolves.not.toThrow();
+
+				expect(binaryDataService.rename).not.toHaveBeenCalled();
+			});
+
+			it('should do nothing if no data is undefined', async () => {
+				const executionId = '999';
+
+				const run = toIRun({
+					json: {
+						data: undefined,
+					},
+				});
+
+				const promise = restoreBinaryDataId(run, executionId);
+
+				await expect(promise).resolves.not.toThrow();
+
+				expect(binaryDataService.rename).not.toHaveBeenCalled();
+			});
 		});
 	});
 }


### PR DESCRIPTION
The first test ("itemless case") was originally added [here](https://github.com/n8n-io/n8n/pull/7305/files#diff-7bc4c6fd25a41ea39cef04208c96965f55787e1983e9df748fcd923672959f8bL24) but likely removed on accident.
