### PR TITLE
test(core): Add test for suppressing error on non-existing filepath (no-changelog)

### DIFF
--- a/packages/core/test/FileSystem.manager.test.ts
+++ b/packages/core/test/FileSystem.manager.test.ts
@@ -151,6 +151,18 @@ describe('deleteMany()', () => {
 
 		expect(fsp.rm).toHaveBeenCalledTimes(2);
 	});
+
+	it('should suppress error on non-existing filepath', async () => {
+		const ids = [{ workflowId: 'does-not-exist', executionId: 'does-not-exist' }];
+
+		fsp.rm = jest.fn().mockResolvedValue(undefined);
+
+		const promise = fsManager.deleteMany(ids);
+
+		await expect(promise).resolves.not.toThrow();
+
+		expect(fsp.rm).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('rename()', () => {


### PR DESCRIPTION
Follow-up to #7411