### PR TITLE
fix: Fix failing builds for external pull requests

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/units-tests-reusable.yml
     needs: install
     with:
-      ref: ${{ github.head_ref }}
+      ref: '${{ github.event.pull_request.head.ref }}'
       cacheKey: ${{ github.sha }}-base:18-test-lint
 
   lint:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/units-tests-reusable.yml
     needs: install
     with:
-      ref: '${{ github.event.pull_request.head.ref }}'
+      ref: '${{ github.head_ref }}'
       cacheKey: ${{ github.sha }}-base:18-test-lint
 
   lint:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/units-tests-reusable.yml
     needs: install
     with:
-      ref: ${{ github.event.pull_request.head.ref }}
+      ref: ${{ github.head_ref }}
       cacheKey: ${{ github.sha }}-base:18-test-lint
 
   lint:


### PR DESCRIPTION
Updated PR branch ref from `github.event.pull_request.head.ref` to `github.head_ref` which should always give us PR branch name regardless of the event.