### PR TITLE
ci: Fix wrong ref in PR workflows which broke external builds

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
         with:
           repository: n8n-io/n8n
-          ref: ${{ inputs.branch }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - uses: pnpm/action-setup@v2.4.0
 
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/units-tests-reusable.yml
     needs: install
     with:
-      ref: ${{ github.event.pull_request.head.ref }}
+      ref: refs/pull/${{ github.event.pull_request.number }}/merge
       cacheKey: ${{ github.sha }}-base:18-test-lint
 
   lint:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
         with:
           repository: n8n-io/n8n
-          ref: ${{ inputs.branch }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - uses: pnpm/action-setup@v2.4.0
 

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/e2e-reusable.yml
     if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'community') }}
     with:
-      branch: ${{ github.event.pull_request.head.ref }}
+      pr_number: ${{ github.event.pull_request.number }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}
       spec: 'e2e/*'
     secrets:


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): #7423

This PR updates reference passed to the `checkout` action by the `cy-pull-request.ym`. This should fix three existing issues:
- Failing unit tests for external pull requests
- Failing e2e tests for external PRs
- Passing empty `ref` to `lint` job which makes linter run on a wrong branch
