### PR TITLE
feat(Google Calendar Trigger Node): Add support for cancelled events

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendarTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendarTrigger.node.ts
@@ -7,9 +7,9 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
-import { getCalendars, googleApiRequest, googleApiRequestAllItems } from './GenericFunctions';
-
 import moment from 'moment';
+
+import { getCalendars, googleApiRequest, googleApiRequestAllItems } from './GenericFunctions';
 
 export class GoogleCalendarTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -81,6 +81,10 @@ export class GoogleCalendarTrigger implements INodeType {
 				required: true,
 				default: '',
 				options: [
+					{
+						name: 'Event Cancelled',
+						value: 'eventCancelled',
+					},
 					{
 						name: 'Event Created',
 						value: 'eventCreated',
@@ -160,10 +164,15 @@ export class GoogleCalendarTrigger implements INodeType {
 
 		let events;
 
-		if (triggerOn === 'eventCreated' || triggerOn === 'eventUpdated') {
+		if (
+			triggerOn === 'eventCreated' ||
+			triggerOn === 'eventUpdated' ||
+			triggerOn === 'eventCancelled'
+		) {
 			Object.assign(qs, {
 				updatedMin: startDate,
 				orderBy: 'updated',
+				showDeleted: triggerOn === 'eventCancelled',
 			});
 		} else if (triggerOn === 'eventStarted' || triggerOn === 'eventEnded') {
 			Object.assign(qs, {
@@ -201,13 +210,16 @@ export class GoogleCalendarTrigger implements INodeType {
 				events = events.filter((event: { created: string }) =>
 					moment(event.created).isBetween(startDate, endDate),
 				);
-			} else if (triggerOn === 'eventUpdated') {
+			} else if (triggerOn === 'eventUpdated' || triggerOn === 'eventCancelled') {
 				events = events.filter(
 					(event: { created: string; updated: string }) =>
 						!moment(moment(event.created).format('YYYY-MM-DDTHH:mm:ss')).isSame(
 							moment(event.updated).format('YYYY-MM-DDTHH:mm:ss'),
 						),
 				);
+				if (triggerOn === 'eventCancelled') {
+					events = events.filter((event: { status: string }) => event.status === 'cancelled');
+				}
 			} else if (triggerOn === 'eventStarted') {
 				events = events.filter((event: { start: { dateTime: string } }) =>
 					moment(event.start.dateTime).isBetween(startDate, endDate, null, '[]'),


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/google-calendar-trigger-deleted-events/10612

This PR adds support for triggering workflows when Google Calendar events are cancelled.