### PR TITLE
refactor(core): Limit soft-deletions to pruning only

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -31,7 +31,10 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
-			await Container.get(ExecutionRepository).softDelete(execution.id); // @TODO
+			await Container.get(ExecutionRepository).hardDelete({
+				workflowId: execution.workflowId as string,
+				executionId: execution.id,
+			});
 
 			execution.id = id;
 

--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -31,7 +31,7 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
-			await Container.get(ExecutionRepository).softDelete(execution.id);
+			await Container.get(ExecutionRepository).softDelete(execution.id); // @TODO
 
 			execution.id = id;
 

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -516,7 +516,10 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 					}
 
 					if (isManualMode && !saveManualExecutions && !fullRunData.waitTill) {
-						await Container.get(ExecutionRepository).softDelete(this.executionId);
+						await Container.get(ExecutionRepository).hardDelete({
+							workflowId: this.workflowData.id as string,
+							executionId: this.executionId,
+						});
 
 						return;
 					}
@@ -547,7 +550,10 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 								this.executionId,
 								this.retryOf,
 							);
-							await Container.get(ExecutionRepository).softDelete(this.executionId);
+							await Container.get(ExecutionRepository).hardDelete({
+								workflowId: this.workflowData.id as string,
+								executionId: this.executionId,
+							});
 
 							return;
 						}

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -645,7 +645,10 @@ export class WorkflowRunner {
 						(workflowDidSucceed && saveDataSuccessExecution === 'none') ||
 						(!workflowDidSucceed && saveDataErrorExecution === 'none')
 					) {
-						await Container.get(ExecutionRepository).softDelete(executionId);
+						await Container.get(ExecutionRepository).hardDelete({
+							workflowId: data.workflowData.id as string,
+							executionId,
+						});
 					}
 					// eslint-disable-next-line id-denylist
 				} catch (err) {

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -297,6 +297,9 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		);
 	}
 
+	/**
+	 * Permanently delete a single execution and its associated binary data.
+	 */
 	async hardDelete(ids: { workflowId: string; executionId: string }) {
 		return Promise.all([
 			this.binaryDataService.deleteMany([ids]),

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -530,7 +530,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	 * Permanently delete all soft-deleted executions and their binary data, in batches, in a pruning cycle.
 	 */
 	private async hardDeleteOnPruning() {
-		// Find ids of all executions that were deleted over an hour ago
 		const date = new Date();
 		date.setHours(date.getHours() - config.getEnv('executions.pruneDataHardDeleteBuffer'));
 

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -298,7 +298,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	/**
-	 * Permanently remove a single execution and its associated binary data.
+	 * Permanently remove a single execution and its binary data.
 	 */
 	async hardDelete(ids: { workflowId: string; executionId: string }) {
 		return Promise.all([

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -298,7 +298,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	/**
-	 * Permanently delete a single execution and its associated binary data.
+	 * Permanently remove a single execution and its associated binary data.
 	 */
 	async hardDelete(ids: { workflowId: string; executionId: string }) {
 		return Promise.all([
@@ -484,6 +484,9 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		} while (executionIds.length > 0);
 	}
 
+	/**
+	 * Mark executions as deleted based on age and count, in a pruning cycle.
+	 */
 	async softDeleteOnPruningCycle() {
 		Logger.verbose('Soft-deleting execution data from database (pruning cycle)');
 
@@ -533,7 +536,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	/**
-	 * Permanently delete all soft-deleted executions and their binary data, in batches, in a pruning cycle.
+	 * Permanently remove all soft-deleted executions and their binary data, in a pruning cycle.
 	 */
 	private async hardDeleteOnPruningCycle() {
 		const date = new Date();

--- a/packages/cli/test/integration/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/repositories/execution.repository.test.ts
@@ -57,7 +57,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -76,7 +76,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -98,7 +98,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -117,7 +117,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -145,7 +145,7 @@ describe('ExecutionRepository.prune()', () => {
 				),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -169,7 +169,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -188,7 +188,7 @@ describe('ExecutionRepository.prune()', () => {
 		])('should prune %s executions', async (status, attributes) => {
 			const execution = await testDb.createExecution({ status, ...attributes }, workflow);
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -206,7 +206,7 @@ describe('ExecutionRepository.prune()', () => {
 				await testDb.createSuccessfulExecution(workflow),
 			];
 
-			await executionRepository.prune();
+			await executionRepository.softDeleteOnPruningCycle();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([


### PR DESCRIPTION
Based on customer feedback, we should limit soft deletions to pruning only, to prevent  executions from piling up in very high volume cases.