### PR TITLE
refactor(core): Make pruning via lifecycle configuration in S3 mode mandatory

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -989,6 +989,12 @@ export const schema = {
 					doc: 'Access secret in S3-compatible external storage',
 				},
 			},
+			skipPruningRequests: {
+				format: Boolean,
+				default: false,
+				env: 'N8N_EXTERNAL_STORAGE_S3_SKIP_PRUNING_REQUESTS',
+				doc: 'Skip requests sent by n8n to S3 to remove binary data files during pruning. Enable this setting if you have set a bucket-level TTL, to minimize requests to S3.',
+			},
 		},
 	},
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -989,12 +989,6 @@ export const schema = {
 					doc: 'Access secret in S3-compatible external storage',
 				},
 			},
-			skipPruningRequests: {
-				format: Boolean,
-				default: false,
-				env: 'N8N_EXTERNAL_STORAGE_S3_SKIP_PRUNING_REQUESTS',
-				doc: 'Skip requests sent by n8n to S3 to remove binary data files during pruning. Enable this setting if you have set a bucket-level TTL, to minimize requests to S3.',
-			},
 		},
 	},
 

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -106,14 +106,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 		if (!this.isMainInstance || inTest) return;
 
-		const isFileSytemMode = config.getEnv('binaryDataManager.mode') === 'filesystem';
-
-		const isS3PruningEnabled =
-			config.getEnv('binaryDataManager.mode') === 's3' &&
-			!config.getEnv('externalStorage.s3.skipPruningRequests');
-
-		this.shouldPruneBinaryData = isFileSytemMode || isS3PruningEnabled;
-
 		if (this.isPruningEnabled) this.setSoftDeletionInterval();
 
 		this.setHardDeletionInterval();
@@ -575,7 +567,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			return;
 		}
 
-		if (this.shouldPruneBinaryData) {
+		if (config.getEnv('binaryDataManager.mode') === 'filesystem') {
+			// pruning in S3 mode is delegated to bucket TTL
 			await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds);
 		}
 

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -304,10 +304,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	 * Permanently remove a single execution and its binary data.
 	 */
 	async hardDelete(ids: { workflowId: string; executionId: string }) {
-		return Promise.all([
-			this.binaryDataService.deleteMany([ids]),
-			this.delete({ id: ids.executionId }),
-		]);
+		return Promise.all([this.delete(ids.executionId), this.binaryDataService.deleteMany([ids])]);
 	}
 
 	async updateExistingExecution(executionId: string, execution: Partial<IExecutionResponse>) {

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -565,7 +565,15 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			return;
 		}
 
-		await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds);
+		const isFileSytemMode = config.getEnv('binaryDataManager.mode') === 'filesystem';
+
+		const isS3PruningEnabled =
+			config.getEnv('binaryDataManager.mode') === 's3' &&
+			!config.getEnv('externalStorage.s3.skipPruningRequests');
+
+		if (isFileSytemMode || isS3PruningEnabled) {
+			await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds);
+		}
 
 		this.logger.debug(
 			`Hard-deleting ${executionIds.length} executions from database (pruning cycle)`,

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -95,6 +95,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	private isPruningEnabled = config.getEnv('executions.pruneData');
 
+	private shouldPruneBinaryData = config.getEnv('binaryDataManager.mode') === 'filesystem';
+
 	constructor(
 		dataSource: DataSource,
 		private readonly executionDataRepository: ExecutionDataRepository,
@@ -565,8 +567,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			return;
 		}
 
-		if (config.getEnv('binaryDataManager.mode') === 'filesystem') {
-			// pruning in S3 mode is delegated to bucket TTL
+		if (this.shouldPruneBinaryData) {
 			await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds);
 		}
 

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -95,6 +95,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	private isPruningEnabled = config.getEnv('executions.pruneData');
 
+	// pruning in S3 mode is delegated to bucket lifecycle configuration
 	private shouldPruneBinaryData = config.getEnv('binaryDataManager.mode') === 'filesystem';
 
 	constructor(

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -95,9 +95,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	private isPruningEnabled = config.getEnv('executions.pruneData');
 
-	// pruning in S3 mode is delegated to bucket lifecycle configuration
-	private shouldPruneBinaryData = config.getEnv('binaryDataManager.mode') === 'filesystem';
-
 	constructor(
 		dataSource: DataSource,
 		private readonly executionDataRepository: ExecutionDataRepository,
@@ -565,9 +562,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			return;
 		}
 
-		if (this.shouldPruneBinaryData) {
-			await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds);
-		}
+		await this.binaryDataService.deleteMany(workflowIdsAndExecutionIds); // only in FS mode
 
 		this.logger.debug(
 			`Hard-deleting ${executionIds.length} executions from database (pruning cycle)`,

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -95,8 +95,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	private isPruningEnabled = config.getEnv('executions.pruneData');
 
-	private shouldPruneBinaryData = true;
-
 	constructor(
 		dataSource: DataSource,
 		private readonly executionDataRepository: ExecutionDataRepository,

--- a/packages/core/src/BinaryData/BinaryData.service.ts
+++ b/packages/core/src/BinaryData/BinaryData.service.ts
@@ -151,7 +151,7 @@ export class BinaryDataService {
 
 		if (!manager) return;
 
-		await manager.deleteMany(ids);
+		if (manager.deleteMany) await manager.deleteMany(ids);
 	}
 
 	@LogCatch((error) =>

--- a/packages/core/src/BinaryData/ObjectStore.manager.ts
+++ b/packages/core/src/BinaryData/ObjectStore.manager.ts
@@ -83,19 +83,6 @@ export class ObjectStoreManager implements BinaryData.Manager {
 		return { fileId: targetFileId, fileSize: sourceFile.length };
 	}
 
-	async deleteMany(ids: BinaryData.IdsForDeletion) {
-		const prefixes = ids.map(
-			({ workflowId, executionId }) =>
-				`workflows/${workflowId}/executions/${executionId}/binary_data/`,
-		);
-
-		await Promise.all(
-			prefixes.map(async (prefix) => {
-				await this.objectStoreService.deleteMany(prefix);
-			}),
-		);
-	}
-
 	async rename(oldFileId: string, newFileId: string) {
 		const oldFile = await this.objectStoreService.get(oldFileId, { mode: 'buffer' });
 		const oldFileMetadata = await this.objectStoreService.getMetadata(oldFileId);

--- a/packages/core/src/BinaryData/types.ts
+++ b/packages/core/src/BinaryData/types.ts
@@ -55,7 +55,10 @@ export namespace BinaryData {
 		getAsStream(fileId: string, chunkSize?: number): Promise<Readable>;
 		getMetadata(fileId: string): Promise<Metadata>;
 
-		deleteMany(ids: IdsForDeletion): Promise<void>;
+		/**
+		 * Present for `FileSystem`, absent for `ObjectStore` (delegated to S3 lifecycle config)
+		 */
+		deleteMany?(ids: IdsForDeletion): Promise<void>;
 
 		copyByFileId(workflowId: string, executionId: string, sourceFileId: string): Promise<string>;
 		copyByFilePath(

--- a/packages/core/test/ObjectStore.manager.test.ts
+++ b/packages/core/test/ObjectStore.manager.test.ts
@@ -116,21 +116,6 @@ describe('copyByFilePath()', () => {
 	});
 });
 
-describe('deleteMany()', () => {
-	it('should delete many files by prefix', async () => {
-		const ids = [
-			{ workflowId, executionId },
-			{ workflowId: otherWorkflowId, executionId: otherExecutionId },
-		];
-
-		const promise = objectStoreManager.deleteMany(ids);
-
-		await expect(promise).resolves.not.toThrow();
-
-		expect(objectStoreService.deleteMany).toHaveBeenCalledTimes(2);
-	});
-});
-
 describe('rename()', () => {
 	it('should rename a file', async () => {
 		const promise = objectStoreManager.rename(fileId, otherFileId);


### PR DESCRIPTION
Since we do not store which executions produced binary data, for pruning on S3 we need to query for binary data items for each execution in order to delete them. To minimize requests to S3, allow the user to skip pruning requests when setting TTL at bucket level.