### PR TITLE
feat(LinkedIn Node): Add support for Article thumbnails

### DIFF
--- a/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
+++ b/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
@@ -167,6 +167,30 @@ export class LinkedIn implements INodeType {
 								},
 								commentary: text,
 							};
+
+							if (additionalFields.thumbnailBinaryPropertyName) {
+								const registerRequest = {
+									initializeUploadRequest: {
+										owner: authorUrn,
+									},
+								};
+
+								const registerObject = await linkedInApiRequest.call(
+									this,
+									'POST',
+									'/images?action=initializeUpload',
+									registerRequest,
+								);
+
+								const binaryPropertyName = additionalFields.thumbnailBinaryPropertyName as string;
+								this.helpers.assertBinaryData(i, binaryPropertyName);
+
+								const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+								const { uploadUrl, image } = registerObject.value;
+								await linkedInApiRequest.call(this, 'POST', uploadUrl as string, buffer, true);
+								Object.assign(articleBody.content.article, { thumbnail: image });
+							}
+
 							Object.assign(body, articleBody);
 							if (description === '') {
 								delete body.description;

--- a/packages/nodes-base/nodes/LinkedIn/PostDescription.ts
+++ b/packages/nodes-base/nodes/LinkedIn/PostDescription.ts
@@ -173,6 +173,18 @@ export const postFields: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Thumbnail Binary Property',
+				name: 'thumbnailBinaryPropertyName',
+				type: 'string',
+				default: 'data',
+				description: 'Object property name which holds binary data for the article thumbnail',
+				displayOptions: {
+					show: {
+						'/shareMediaCategory': ['ARTICLE'],
+					},
+				},
+			},
+			{
 				displayName: 'Title',
 				name: 'title',
 				type: 'string',


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/linkedin-post-not-showing-image-for-url/10789/

![image](https://github.com/n8n-io/n8n/assets/4688521/5142b984-f531-4731-8510-c7136087861e)

This adds a new property to add a thumbnail binary property for articles this fixes the previews no longer working because of the LinkedIn API change.
![image](https://github.com/n8n-io/n8n/assets/4688521/76271525-5791-4bdc-ae73-1fdbb3986694)

