### PR TITLE
refactor(core): Setup layered caching for webhooks

### DIFF
--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -1,6 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-
-import { Container, Service } from 'typedi';
+import { Service } from 'typedi';
 import type {
 	IDeferredPromise,
 	IExecuteResponsePromiseData,
@@ -28,7 +26,10 @@ export class ActiveExecutions {
 		[index: string]: IExecutingWorkflowData;
 	} = {};
 
-	constructor(private readonly logger: Logger) {}
+	constructor(
+		private readonly logger: Logger,
+		private readonly executionRepository: ExecutionRepository,
+	) {}
 
 	/**
 	 * Add a new active execution
@@ -60,7 +61,7 @@ export class ActiveExecutions {
 				fullExecutionData.workflowId = workflowId;
 			}
 
-			executionId = await Container.get(ExecutionRepository).createNewExecution(fullExecutionData);
+			executionId = await this.executionRepository.createNewExecution(fullExecutionData);
 			if (executionId === undefined) {
 				throw new ApplicationError('There was an issue assigning an execution id to the execution');
 			}
@@ -75,7 +76,7 @@ export class ActiveExecutions {
 				status: executionStatus,
 			};
 
-			await Container.get(ExecutionRepository).updateExistingExecution(executionId, execution);
+			await this.executionRepository.updateExistingExecution(executionId, execution);
 		}
 
 		this.activeExecutions[executionId] = {
@@ -212,10 +213,10 @@ export class ActiveExecutions {
 			data = this.activeExecutions[id];
 			returnData.push({
 				id,
-				retryOf: data.executionData.retryOf as string | undefined,
+				retryOf: data.executionData.retryOf,
 				startedAt: data.startedAt,
 				mode: data.executionData.executionMode,
-				workflowId: data.executionData.workflowData.id! as string,
+				workflowId: data.executionData.workflowData.id!,
 				status: data.status,
 			});
 		}

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -273,7 +273,7 @@ export interface WebhookAccessControlOptions {
 
 export interface IWebhookManager {
 	/** Gets all request methods associated with a webhook path*/
-	getWebhookMethods?: (path: string) => Promise<IHttpRequestMethods[]>;
+	getWebhookMethods?: (path: string) => IHttpRequestMethods[];
 
 	/** Find the CORS options matching a path and method */
 	findAccessControlOptions?: (

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -279,7 +279,7 @@ export interface IWebhookManager {
 	findAccessControlOptions?: (
 		path: string,
 		httpMethod: IHttpRequestMethods,
-	) => Promise<WebhookAccessControlOptions | undefined>;
+	) => WebhookAccessControlOptions | undefined;
 
 	executeWebhook(req: WebhookRequest, res: Response): Promise<IResponseCallbackData>;
 }

--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -80,7 +80,7 @@ export class TestWebhooks implements IWebhookManager {
 			webhookData = activeWebhooks.get(httpMethod, pathElements.join('/'), webhookId);
 			if (webhookData === undefined) {
 				// The requested webhook is not registered
-				const methods = await this.getWebhookMethods(path);
+				const methods = this.getWebhookMethods(path);
 				throw new NotFoundError(
 					webhookNotFoundErrorMessage(path, httpMethod, methods),
 					WEBHOOK_TEST_UNREGISTERED_HINT,
@@ -108,7 +108,7 @@ export class TestWebhooks implements IWebhookManager {
 		// TODO: Clean that duplication up one day and improve code generally
 		if (testWebhookData[webhookKey] === undefined) {
 			// The requested webhook is not registered
-			const methods = await this.getWebhookMethods(path);
+			const methods = this.getWebhookMethods(path);
 			throw new NotFoundError(
 				webhookNotFoundErrorMessage(path, httpMethod, methods),
 				WEBHOOK_TEST_UNREGISTERED_HINT,
@@ -165,7 +165,7 @@ export class TestWebhooks implements IWebhookManager {
 		});
 	}
 
-	async getWebhookMethods(path: string): Promise<IHttpRequestMethods[]> {
+	getWebhookMethods(path: string): IHttpRequestMethods[] {
 		const webhookMethods = this.activeWebhooks.getWebhookMethods(path);
 		if (!webhookMethods.length) {
 			// The requested webhook is not registered

--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -175,7 +175,7 @@ export class TestWebhooks implements IWebhookManager {
 		return webhookMethods;
 	}
 
-	async findAccessControlOptions(path: string, httpMethod: IHttpRequestMethods) {
+	findAccessControlOptions(path: string, httpMethod: IHttpRequestMethods) {
 		const webhookKey = Object.keys(this.testWebhookData).find(
 			(key) => key.includes(path) && key.startsWith(httpMethod),
 		);

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -95,7 +95,7 @@ export const webhookRequestHandler =
 		if ('origin' in req.headers) {
 			if (webhookManager.getWebhookMethods) {
 				try {
-					const allowedMethods = await webhookManager.getWebhookMethods(path);
+					const allowedMethods = webhookManager.getWebhookMethods(path);
 					res.header('Access-Control-Allow-Methods', ['OPTIONS', ...allowedMethods].join(', '));
 				} catch (error) {
 					return ResponseHelper.sendErrorResponse(res, error as Error);
@@ -243,10 +243,6 @@ export async function executeWebhook(
 		throw new InternalServerError(errorMessage);
 	}
 
-	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
-		$executionId: executionId,
-	};
-
 	let user: User;
 	if (
 		(workflowData as WorkflowEntity).shared?.length &&
@@ -261,63 +257,15 @@ export async function executeWebhook(
 		}
 	}
 
+	const nodeVersion = workflowStartNode.typeVersion;
+	const { responseMode, responseCode, responseData, binaryData } = webhookData;
+
 	// Prepare everything that is needed to run the workflow
 	const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id);
-
-	// Get the responseMode
-	const responseMode = workflow.expression.getSimpleParameterValue(
-		workflowStartNode,
-		webhookData.webhookDescription.responseMode,
-		executionMode,
-		additionalKeys,
-		undefined,
-		'onReceived',
-	);
-	const responseCode = workflow.expression.getSimpleParameterValue(
-		workflowStartNode,
-		webhookData.webhookDescription.responseCode,
-		executionMode,
-		additionalKeys,
-		undefined,
-		200,
-	) as number;
-
-	const responseData = workflow.expression.getSimpleParameterValue(
-		workflowStartNode,
-		webhookData.webhookDescription.responseData,
-		executionMode,
-		additionalKeys,
-		undefined,
-		'firstEntryJson',
-	);
-
-	if (!['onReceived', 'lastNode', 'responseNode'].includes(responseMode as string)) {
-		// If the mode is not known we error. Is probably best like that instead of using
-		// the default that people know as early as possible (probably already testing phase)
-		// that something does not resolve properly.
-		const errorMessage = `The response mode '${responseMode}' is not valid!`;
-		responseCallback(new Error(errorMessage), {});
-		throw new InternalServerError(errorMessage);
-	}
 
 	// Add the Response and Request so that this data can be accessed in the node
 	additionalData.httpRequest = req;
 	additionalData.httpResponse = res;
-
-	let binaryData;
-
-	const nodeVersion = workflowStartNode.typeVersion;
-	if (nodeVersion === 1) {
-		// binaryData option is removed in versions higher than 1
-		binaryData = workflow.expression.getSimpleParameterValue(
-			workflowStartNode,
-			'={{$parameter["options"]["binaryData"]}}',
-			executionMode,
-			additionalKeys,
-			undefined,
-			false,
-		);
-	}
 
 	let didSendResponse = false;
 	let runExecutionDataMerge = {};

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -107,7 +107,7 @@ export const webhookRequestHandler =
 					? (req.headers['access-control-request-method'] as IHttpRequestMethods)
 					: method;
 			if (webhookManager.findAccessControlOptions && requestedMethod) {
-				const options = await webhookManager.findAccessControlOptions(path, requestedMethod);
+				const options = webhookManager.findAccessControlOptions(path, requestedMethod);
 				const { allowedOrigins } = options ?? {};
 
 				res.header(

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command';
 import { sleep } from 'n8n-workflow';
 import config from '@/config';
+import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import { ActiveExecutions } from '@/ActiveExecutions';
 import { WebhookServer } from '@/WebhookServer';
 import { Queue } from '@/Queue';
@@ -20,6 +21,8 @@ export class Webhook extends BaseCommand {
 	};
 
 	protected server = new WebhookServer();
+
+	protected activeWorkflowRunner: ActiveWorkflowRunner;
 
 	constructor(argv: string[], cmdConfig: IConfig) {
 		super(argv, cmdConfig);
@@ -93,6 +96,7 @@ export class Webhook extends BaseCommand {
 		this.logger.debug(`Queue mode id: ${this.queueModeId}`);
 
 		await super.init();
+		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
 		await this.initLicense();
 		this.logger.debug('License init complete');
@@ -109,6 +113,7 @@ export class Webhook extends BaseCommand {
 	async run() {
 		await Container.get(Queue).init();
 		await this.server.start();
+		await this.activeWorkflowRunner.initWebhooks();
 		this.logger.debug(`Webhook listener ID: ${this.server.uniqueInstanceId}`);
 		this.logger.info('Webhook listener waiting for requests.');
 

--- a/packages/cli/src/databases/entities/WebhookEntity.ts
+++ b/packages/cli/src/databases/entities/WebhookEntity.ts
@@ -34,10 +34,6 @@ export class WebhookEntity {
 			: this.webhookPath;
 	}
 
-	get cacheKey() {
-		return `webhook:${this.method}-${this.uniquePath}`;
-	}
-
 	get staticSegments() {
 		return this.webhookPath.split('/').filter((s) => !s.startsWith(':'));
 	}

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -25,7 +25,7 @@ import type {
 import config from '@/config';
 import type { IGetExecutionsQueryFilter } from '@/executions/executions.service';
 import { isAdvancedExecutionFiltersEnabled } from '@/executions/executionHelpers';
-import type { ExecutionData } from '../entities/ExecutionData';
+import { ExecutionData } from '../entities/ExecutionData';
 import { ExecutionEntity } from '../entities/ExecutionEntity';
 import { ExecutionMetadata } from '../entities/ExecutionMetadata';
 import { ExecutionDataRepository } from './executionData.repository';

--- a/packages/cli/src/services/webhook.service.ts
+++ b/packages/cli/src/services/webhook.service.ts
@@ -1,100 +1,53 @@
-import { WebhookRepository } from '@db/repositories/webhook.repository';
 import { Service } from 'typedi';
-import { CacheService } from './cache.service';
-import type { WebhookEntity } from '@db/entities/WebhookEntity';
-import type { IHttpRequestMethods } from 'n8n-workflow';
 import type { DeepPartial } from 'typeorm';
+import type { IHttpRequestMethods, INode, INodeType, IWebhookData, Workflow } from 'n8n-workflow';
+import type { WebhookEntity } from '@db/entities/WebhookEntity';
+import { WebhookRepository } from '@db/repositories/webhook.repository';
+import { NodeTypes } from '@/NodeTypes';
+import { InternalServerError } from '@/ResponseHelper';
 
 type Method = NonNullable<IHttpRequestMethods>;
 
+interface RegisteredWebhook {
+	isDynamic: boolean;
+	webhookPath: string;
+	workflow: Workflow;
+	webhookData: IWebhookData;
+	node: INode;
+	nodeType: INodeType;
+}
+
+const UUID_REGEXP =
+	/^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+
 @Service()
 export class WebhookService {
+	private registered = new Map<string, Map<IHttpRequestMethods, RegisteredWebhook>>();
+
 	constructor(
-		private webhookRepository: WebhookRepository,
-		private cacheService: CacheService,
+		private readonly webhookRepository: WebhookRepository,
+		private readonly nodeTypes: NodeTypes,
 	) {}
 
-	async populateCache() {
-		const allWebhooks = await this.webhookRepository.find();
-
-		if (!allWebhooks) return;
-
-		void this.cacheService.setMany(allWebhooks.map((w) => [w.cacheKey, w]));
+	findWebhook(method: Method, path: string) {
+		const webhookGroup = this.getWebhookGroup(path);
+		return webhookGroup?.get(method);
 	}
 
-	private async findCached(method: Method, path: string) {
-		const cacheKey = `webhook:${method}-${path}`;
-
-		const cachedWebhook = await this.cacheService.get(cacheKey);
-
-		if (cachedWebhook) return this.webhookRepository.create(cachedWebhook);
-
-		let dbWebhook = await this.findStaticWebhook(method, path);
-
-		if (dbWebhook === null) {
-			dbWebhook = await this.findDynamicWebhook(method, path);
-		}
-
-		void this.cacheService.set(cacheKey, dbWebhook);
-
-		return dbWebhook;
-	}
-
-	/**
-	 * Find a matching webhook with zero dynamic path segments, e.g. `<uuid>` or `user/profile`.
-	 */
-	private async findStaticWebhook(method: Method, path: string) {
-		return this.webhookRepository.findOneBy({ webhookPath: path, method });
-	}
-
-	/**
-	 * Find a matching webhook with one or more dynamic path segments, e.g. `<uuid>/user/:id/posts`.
-	 * It is mandatory for dynamic webhooks to have `<uuid>/` at the base.
-	 */
-	private async findDynamicWebhook(method: Method, path: string) {
-		const [uuidSegment, ...otherSegments] = path.split('/');
-
-		const dynamicWebhooks = await this.webhookRepository.findBy({
-			webhookId: uuidSegment,
-			method,
-			pathLength: otherSegments.length,
-		});
-
-		if (dynamicWebhooks.length === 0) return null;
-
-		const requestSegments = new Set(otherSegments);
-
-		const { webhook } = dynamicWebhooks.reduce<{
-			webhook: WebhookEntity | null;
-			maxMatches: number;
-		}>(
-			(acc, dw) => {
-				const allStaticSegmentsMatch = dw.staticSegments.every((s) => requestSegments.has(s));
-
-				if (allStaticSegmentsMatch && dw.staticSegments.length > acc.maxMatches) {
-					acc.maxMatches = dw.staticSegments.length;
-					acc.webhook = dw;
-					return acc;
-				} else if (dw.staticSegments.length === 0 && !acc.webhook) {
-					acc.webhook = dw; // edge case: if path is `:var`, match on anything
-				}
-
-				return acc;
+	async storeWebhook(
+		webhook: WebhookEntity,
+		data: Omit<RegisteredWebhook, 'nodeType' | 'isDynamic' | 'webhookPath'>,
+	) {
+		const exists = await this.webhookRepository.exist({
+			where: {
+				webhookPath: webhook.webhookPath,
+				method: webhook.method,
 			},
-			{ webhook: null, maxMatches: 0 },
-		);
-
-		return webhook;
-	}
-
-	async findWebhook(method: Method, path: string) {
-		return this.findCached(method, path);
-	}
-
-	async storeWebhook(webhook: WebhookEntity) {
-		void this.cacheService.set(webhook.cacheKey, webhook);
-
-		return this.webhookRepository.insert(webhook);
+		});
+		if (!exists) {
+			await this.webhookRepository.insert(webhook);
+		}
+		this.registerWebhook(webhook, data);
 	}
 
 	createWebhook(data: DeepPartial<WebhookEntity>) {
@@ -108,14 +61,55 @@ export class WebhookService {
 	}
 
 	private async deleteWebhooks(webhooks: WebhookEntity[]) {
-		void this.cacheService.deleteMany(webhooks.map((w) => w.cacheKey));
-
+		webhooks.forEach((webhook) => this.unregisterWebhook(webhook));
 		return this.webhookRepository.remove(webhooks);
 	}
 
-	async getWebhookMethods(path: string) {
-		return this.webhookRepository
-			.find({ select: ['method'], where: { webhookPath: path } })
-			.then((rows) => rows.map((r) => r.method));
+	getWebhookMethods(path: string) {
+		const webhookGroup = this.getWebhookGroup(path);
+		return (webhookGroup && Array.from(webhookGroup.keys())) ?? [];
+	}
+
+	private getWebhookGroup(path: string) {
+		let webhookGroup = this.registered.get(path);
+		if (!webhookGroup) {
+			const possibleId = path.split('/')[0];
+			if (UUID_REGEXP.test(possibleId)) {
+				webhookGroup = this.registered.get(possibleId);
+			}
+		}
+		return webhookGroup;
+	}
+
+	private registerWebhook(
+		webhook: WebhookEntity,
+		data: Omit<RegisteredWebhook, 'nodeType' | 'isDynamic' | 'webhookPath'>,
+	) {
+		const { node } = data;
+		const nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+		if (nodeType === undefined) {
+			throw new InternalServerError(`The type of the webhook node "${node.name}" is not known`);
+		} else if (nodeType.webhook === undefined) {
+			throw new InternalServerError(`The node "${node.name}" does not have any webhooks defined.`);
+		}
+
+		const pathOrId = webhook.isDynamic ? webhook.webhookId! : webhook.webhookPath;
+		const webhookGroup =
+			this.registered.get(pathOrId) ?? new Map<IHttpRequestMethods, RegisteredWebhook>();
+		webhookGroup.set(webhook.method, {
+			...data,
+			isDynamic: webhook.isDynamic,
+			webhookPath: webhook.webhookPath,
+			nodeType,
+		});
+		this.registered.set(pathOrId, webhookGroup);
+		// TODO: update these on redis, and publish a message for others to pull the cache
+		// save pathOrId on a hash in redis
+	}
+
+	private unregisterWebhook(webhook: WebhookEntity) {
+		const pathOrId = webhook.isDynamic ? webhook.webhookId! : webhook.webhookPath;
+		const webhookGroup = this.registered.get(pathOrId);
+		webhookGroup?.delete(webhook.method);
 	}
 }

--- a/packages/cli/src/services/webhook.service.ts
+++ b/packages/cli/src/services/webhook.service.ts
@@ -4,7 +4,7 @@ import type { IHttpRequestMethods, INode, INodeType, IWebhookData, Workflow } fr
 import type { WebhookEntity } from '@db/entities/WebhookEntity';
 import { WebhookRepository } from '@db/repositories/webhook.repository';
 import { NodeTypes } from '@/NodeTypes';
-import { InternalServerError } from '@/ResponseHelper';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 
 type Method = NonNullable<IHttpRequestMethods>;
 
@@ -28,6 +28,10 @@ export class WebhookService {
 		private readonly webhookRepository: WebhookRepository,
 		private readonly nodeTypes: NodeTypes,
 	) {}
+
+	async findAll() {
+		return this.webhookRepository.find();
+	}
 
 	findWebhook(method: Method, path: string) {
 		const webhookGroup = this.getWebhookGroup(path);

--- a/packages/cli/test/unit/WebhookHelpers.test.ts
+++ b/packages/cli/test/unit/WebhookHelpers.test.ts
@@ -42,7 +42,7 @@ describe('WebhookHelpers', () => {
 				const res = mock<Response>();
 				res.status.mockReturnValue(res);
 
-				webhookManager.getWebhookMethods.mockResolvedValue(['GET', 'PATCH']);
+				webhookManager.getWebhookMethods.mockReturnValue(['GET', 'PATCH']);
 
 				await handler(req, res);
 
@@ -65,7 +65,7 @@ describe('WebhookHelpers', () => {
 				const res = mock<Response>();
 				res.status.mockReturnValue(res);
 
-				webhookManager.getWebhookMethods.mockResolvedValue(['GET', 'PATCH']);
+				webhookManager.getWebhookMethods.mockReturnValue(['GET', 'PATCH']);
 
 				await handler(req, res);
 
@@ -94,8 +94,8 @@ describe('WebhookHelpers', () => {
 				const res = mock<Response>();
 				res.status.mockReturnValue(res);
 
-				webhookManager.getWebhookMethods.mockResolvedValue(['GET', 'PATCH']);
-				webhookManager.findAccessControlOptions.mockResolvedValue({
+				webhookManager.getWebhookMethods.mockReturnValue(['GET', 'PATCH']);
+				webhookManager.findAccessControlOptions.mockReturnValue({
 					allowedOrigins: '*',
 				});
 
@@ -121,8 +121,8 @@ describe('WebhookHelpers', () => {
 				const res = mock<Response>();
 				res.status.mockReturnValue(res);
 
-				webhookManager.getWebhookMethods.mockResolvedValue(['GET', 'PATCH']);
-				webhookManager.findAccessControlOptions.mockResolvedValue({
+				webhookManager.getWebhookMethods.mockReturnValue(['GET', 'PATCH']);
+				webhookManager.findAccessControlOptions.mockReturnValue({
 					allowedOrigins: 'https://test.com',
 				});
 

--- a/packages/cli/test/unit/webhooks.test.ts
+++ b/packages/cli/test/unit/webhooks.test.ts
@@ -44,7 +44,7 @@ describe('WebhookServer', () => {
 			describe(`for ${key}`, () => {
 				it('should handle preflight requests', async () => {
 					const pathPrefix = config.getEnv(`endpoints.${key}`);
-					manager.getWebhookMethods.mockResolvedValueOnce(['GET']);
+					manager.getWebhookMethods.mockReturnValueOnce(['GET']);
 
 					const response = await agent
 						.options(`/${pathPrefix}/abcd`)
@@ -58,7 +58,7 @@ describe('WebhookServer', () => {
 
 				it('should handle regular requests', async () => {
 					const pathPrefix = config.getEnv(`endpoints.${key}`);
-					manager.getWebhookMethods.mockResolvedValueOnce(['GET']);
+					manager.getWebhookMethods.mockReturnValueOnce(['GET']);
 					manager.executeWebhook.mockResolvedValueOnce(
 						mockResponse({ test: true }, { key: 'value ' }),
 					);

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1660,6 +1660,10 @@ export interface IWebhookData {
 	workflowId: string;
 	workflowExecuteAdditionalData: IWorkflowExecuteAdditionalData;
 	webhookId?: string;
+	responseMode: WebhookResponseMode;
+	responseCode: number;
+	responseData: WebhookResponseData;
+	binaryData: boolean;
 }
 
 export interface IWebhookDescription {
@@ -1730,7 +1734,7 @@ export interface IWebhookResponseData {
 }
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary' | 'noData';
-export type WebhookResponseMode = 'onReceived' | 'lastNode';
+export type WebhookResponseMode = 'onReceived' | 'lastNode' | 'responseNode';
 
 export interface INodeTypes {
 	getByName(nodeType: string): INodeType | IVersionedNodeType;


### PR DESCRIPTION
## TODO:
- [ ] Fix the tests
- [ ] Synchronize `registered` state in queue mode

These changes reduce response times by about 14%.

Benchmarked with `ab -c 100 -n 200`

#### Before
![before](https://github.com/n8n-io/n8n/assets/196144/b56dd981-0c33-4c1e-8c7d-50c954a4aec9)

#### After
![after](https://github.com/n8n-io/n8n/assets/196144/15290bc3-2b1f-4f16-ab9b-99cbab98d735)


To be done in another PR
- [ ] Update `ActiveWorkflows` to track workflows with webhooks as well
- [ ] Cache `WorkflowData` to make one less query.