### PR TITLE
refactor(FileMaker Node): Prevent reporting to Sentry attempted `loadOptions` calls without credentials (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
+++ b/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
@@ -600,15 +600,7 @@ export class FileMaker implements INodeType {
 			// Get all the available topics to display them to user so that they can
 			// select them easily
 			async getLayouts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				let returnData: INodePropertyOptions[];
-
-				try {
-					returnData = await layoutsApiRequest.call(this);
-				} catch (error) {
-					throw new NodeOperationError(this.getNode(), error as Error);
-				}
-
-				return returnData;
+				return layoutsApiRequest.call(this);
 			},
 			async getResponseLayouts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
@@ -617,13 +609,7 @@ export class FileMaker implements INodeType {
 					value: '',
 				});
 
-				let layouts;
-				try {
-					layouts = await layoutsApiRequest.call(this);
-				} catch (error) {
-					throw new NodeOperationError(this.getNode(), error as Error);
-				}
-				for (const layout of layouts) {
+				for (const layout of await layoutsApiRequest.call(this)) {
 					returnData.push({
 						name: layout.name,
 						value: layout.name,
@@ -635,13 +621,7 @@ export class FileMaker implements INodeType {
 			async getFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				let fields;
-				try {
-					fields = await getFields.call(this);
-				} catch (error) {
-					throw new NodeOperationError(this.getNode(), error as Error);
-				}
-				for (const field of fields) {
+				for (const field of await getFields.call(this)) {
 					returnData.push({
 						name: field.name,
 						value: field.name,
@@ -653,13 +633,7 @@ export class FileMaker implements INodeType {
 			async getScripts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				let scripts;
-				try {
-					scripts = await getScripts.call(this);
-				} catch (error) {
-					throw new NodeOperationError(this.getNode(), error as Error);
-				}
-				for (const script of scripts) {
+				for (const script of await getScripts.call(this)) {
 					if (!script.isFolder) {
 						returnData.push({
 							name: script.name,
@@ -673,13 +647,7 @@ export class FileMaker implements INodeType {
 			async getPortals(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				let portals;
-				try {
-					portals = await getPortals.call(this);
-				} catch (error) {
-					throw new NodeOperationError(this.getNode(), error as Error);
-				}
-				Object.keys(portals as IDataObject).forEach((portal) => {
+				Object.keys((await getPortals.call(this)) as IDataObject).forEach((portal) => {
 					returnData.push({
 						name: portal,
 						value: portal,

--- a/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
+++ b/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
@@ -609,7 +609,9 @@ export class FileMaker implements INodeType {
 					value: '',
 				});
 
-				for (const layout of await layoutsApiRequest.call(this)) {
+				const layouts = await layoutsApiRequest.call(this);
+
+				for (const layout of layouts) {
 					returnData.push({
 						name: layout.name,
 						value: layout.name,
@@ -621,7 +623,9 @@ export class FileMaker implements INodeType {
 			async getFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				for (const field of await getFields.call(this)) {
+				const fields = await getFields.call(this);
+
+				for (const field of fields) {
 					returnData.push({
 						name: field.name,
 						value: field.name,
@@ -633,7 +637,9 @@ export class FileMaker implements INodeType {
 			async getScripts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				for (const script of await getScripts.call(this)) {
+				const scripts = await getScripts.call(this);
+
+				for (const script of scripts) {
 					if (!script.isFolder) {
 						returnData.push({
 							name: script.name,
@@ -647,7 +653,9 @@ export class FileMaker implements INodeType {
 			async getPortals(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 
-				Object.keys((await getPortals.call(this)) as IDataObject).forEach((portal) => {
+				const portals = await getPortals.call(this);
+
+				Object.keys(portals as IDataObject).forEach((portal) => {
 					returnData.push({
 						name: portal,
 						value: portal,


### PR DESCRIPTION
Severity is lost when wrapping the error, but there is no need to change the error type here.

https://n8nio.slack.com/archives/C03MZF137FV/p1698308092989739

https://n8nio.sentry.io/issues/4580938401