### PR TITLE
feat(core): Make queue mode settings configurable

### DIFF
--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -54,6 +54,7 @@ export class Queue {
 		// More here: https://github.com/OptimalBits/bull/issues/890
 		this.jobQueue = new Bull('jobs', {
 			prefix,
+			settings: config.get('queue.bull.settings'),
 			createClient: (type, clientConfig) =>
 				usesRedisCluster
 					? getRedisClusterClient(Redis, clientConfig, (type + '(bull)') as RedisClientType)

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -438,6 +438,32 @@ export const schema = {
 				default: 30,
 				env: 'QUEUE_WORKER_TIMEOUT',
 			},
+			settings: {
+				lockDuration: {
+					doc: 'How long (ms) is the lease period for a worker to work on a message',
+					format: Number,
+					default: 30000,
+					env: 'QUEUE_WORKER_LOCK_DURATION',
+				},
+				lockRenewTime: {
+					doc: 'How frequently (ms) should a worker renew the lease time',
+					format: Number,
+					default: 15000,
+					env: 'QUEUE_WORKER_LOCK_RENEW_TIME',
+				},
+				stalledInterval: {
+					doc: 'How often check for stalled jobs (use 0 for never checking)',
+					format: Number,
+					default: 30000,
+					env: 'QUEUE_WORKER_STALLED_INTERVAL',
+				},
+				maxStalledCount: {
+					doc: 'Max amount of times a stalled job will be re-processed',
+					format: Number,
+					default: 1,
+					env: 'QUEUE_WORKER_MAX_STALLED_COUNT',
+				},
+			},
 		},
 	},
 


### PR DESCRIPTION
This PR allows users to configure the settings to Bull, possibly reducing the errors with `maxStalledCount` and other issues, that usually happen either when a worker crashes or when the event loop is super busy. Increasing the lease time and the `maxStalledCount` settings might improve UX.

Github issue / Community forum post (link here to close automatically):
