### PR TITLE
fix(editor): Keep NodeView component alive for `TEMPLATE_IMPORT` and `WORKFLOW_ONBOARDING` routes (no-changelog)

### DIFF
--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -328,6 +328,7 @@ export const routes = [
 		},
 		meta: {
 			templatesEnabled: true,
+			keepWorkflowAlive: true,
 			getRedirect: getTemplatesRedirect,
 			permissions: {
 				allow: {
@@ -346,6 +347,7 @@ export const routes = [
 		},
 		meta: {
 			templatesEnabled: true,
+			keepWorkflowAlive: true,
 			getRedirect: () => getTemplatesRedirect(VIEWS.NEW_WORKFLOW),
 			permissions: {
 				allow: {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
