### PR TITLE
fix(core): Fix data decryption on credentials import

### DIFF
--- a/packages/cli/test/integration/commands/credentials.cmd.test.ts
+++ b/packages/cli/test/integration/commands/credentials.cmd.test.ts
@@ -42,5 +42,6 @@ test('import:credentials should import a credential', async () => {
 	expect(after.length).toBe(1);
 	expect(after[0].name).toBe('cred-aws-test');
 	expect(after[0].id).toBe('123');
+	expect(after[0].nodesAccess).toStrictEqual([]);
 	mockExit.mockRestore();
 });

--- a/packages/cli/test/integration/commands/credentials.cmd.test.ts
+++ b/packages/cli/test/integration/commands/credentials.cmd.test.ts
@@ -1,0 +1,46 @@
+import * as Config from '@oclif/config';
+
+import { InternalHooks } from '@/InternalHooks';
+import { ImportCredentialsCommand } from '@/commands/import/credentials';
+import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
+import * as testDb from '../shared/testDb';
+import { mockInstance } from '../shared/utils';
+
+beforeAll(async () => {
+	mockInstance(InternalHooks);
+	mockInstance(LoadNodesAndCredentials);
+	await testDb.init();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['Credentials']);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+test('import:credentials should import a credential', async () => {
+	const config: Config.IConfig = new Config.Config({ root: __dirname });
+	const before = await testDb.getAllCredentials();
+	expect(before.length).toBe(0);
+	const importer = new ImportCredentialsCommand(
+		['--input=./test/integration/commands/importCredentials/credentials.json'],
+		config,
+	);
+	const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+		throw new Error('process.exit');
+	});
+
+	await importer.init();
+	try {
+		await importer.run();
+	} catch (error) {
+		expect(error.message).toBe('process.exit');
+	}
+	const after = await testDb.getAllCredentials();
+	expect(after.length).toBe(1);
+	expect(after[0].name).toBe('cred-aws-test');
+	expect(after[0].id).toBe('123');
+	mockExit.mockRestore();
+});

--- a/packages/cli/test/integration/commands/importCredentials/credentials.json
+++ b/packages/cli/test/integration/commands/importCredentials/credentials.json
@@ -1,0 +1,15 @@
+[
+	{
+		"createdAt": "2023-07-10T14:50:49.193Z",
+		"updatedAt": "2023-10-27T13:34:42.917Z",
+		"id": "123",
+		"name": "cred-aws-test",
+		"data": {
+			"region": "eu-west-1",
+			"accessKeyId": "999999999999",
+			"secretAccessKey": "aaaaaaaaaaaaa"
+		},
+		"type": "aws",
+		"nodesAccess": ""
+	}
+]

--- a/packages/cli/test/integration/shared/testDb.ts
+++ b/packages/cli/test/integration/shared/testDb.ts
@@ -181,6 +181,10 @@ export function affixRoleToSaveCredential(role: Role) {
 		saveCredential(credentialPayload, { user, role });
 }
 
+export async function getAllCredentials() {
+	return Db.collections.Credentials.find();
+}
+
 // ----------------------------------
 //           user creation
 // ----------------------------------

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -23,6 +23,11 @@ export class Credentials extends ICredentials {
 	 * Sets new credential object
 	 */
 	setData(data: ICredentialDataDecryptedObject): void {
+		// when this function is being called via the object prototype, cipher is undefined
+		if (!this.cipher) {
+			this.data = Container.get(Cipher).encrypt(data);
+			return;
+		}
 		this.data = this.cipher.encrypt(data);
 	}
 

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -23,11 +23,6 @@ export class Credentials extends ICredentials {
 	 * Sets new credential object
 	 */
 	setData(data: ICredentialDataDecryptedObject): void {
-		// when this function is being called via the object prototype, cipher is undefined
-		if (!this.cipher) {
-			this.data = Container.get(Cipher).encrypt(data);
-			return;
-		}
 		this.data = this.cipher.encrypt(data);
 	}
 


### PR DESCRIPTION
Due to a change, during the credentials import command, the core's Credential object is being called through its prototype. This causes the Credential's cipher variable to not be set, thus no cipher service being available during import. This fix catches this edge case and provides a fix.
