### PR TITLE
feat(core): Initial support for two-way communication over websockets

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -505,52 +505,52 @@ export type IPushData =
 	| PushDataNodeDescriptionUpdated
 	| PushDataExecutionRecovered;
 
-type PushDataExecutionRecovered = {
+export type PushDataExecutionRecovered = {
 	data: IPushDataExecutionRecovered;
 	type: 'executionRecovered';
 };
 
-type PushDataExecutionFinished = {
+export type PushDataExecutionFinished = {
 	data: IPushDataExecutionFinished;
 	type: 'executionFinished';
 };
 
-type PushDataExecutionStarted = {
+export type PushDataExecutionStarted = {
 	data: IPushDataExecutionStarted;
 	type: 'executionStarted';
 };
 
-type PushDataExecuteAfter = {
+export type PushDataExecuteAfter = {
 	data: IPushDataNodeExecuteAfter;
 	type: 'nodeExecuteAfter';
 };
 
-type PushDataExecuteBefore = {
+export type PushDataExecuteBefore = {
 	data: IPushDataNodeExecuteBefore;
 	type: 'nodeExecuteBefore';
 };
 
-type PushDataConsoleMessage = {
+export type PushDataConsoleMessage = {
 	data: IPushDataConsoleMessage;
 	type: 'sendConsoleMessage';
 };
 
-type PushDataReloadNodeType = {
+export type PushDataReloadNodeType = {
 	data: IPushDataReloadNodeType;
 	type: 'reloadNodeType';
 };
 
-type PushDataRemoveNodeType = {
+export type PushDataRemoveNodeType = {
 	data: IPushDataRemoveNodeType;
 	type: 'removeNodeType';
 };
 
-type PushDataTestWebhook = {
+export type PushDataTestWebhook = {
 	data: IPushDataTestWebhook;
 	type: 'testWebhookDeleted' | 'testWebhookReceived';
 };
 
-type PushDataNodeDescriptionUpdated = {
+export type PushDataNodeDescriptionUpdated = {
 	data: undefined;
 	type: 'nodeDescriptionUpdated';
 };

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -503,7 +503,13 @@ export type IPushData =
 	| PushDataRemoveNodeType
 	| PushDataTestWebhook
 	| PushDataNodeDescriptionUpdated
-	| PushDataExecutionRecovered;
+	| PushDataExecutionRecovered
+	| PushDataActiveWorkflowUsersChanged;
+
+type PushDataActiveWorkflowUsersChanged = {
+	data: IActiveWorkflowUsersChanged;
+	type: 'activeWorkflowUsersChanged';
+};
 
 export type PushDataExecutionRecovered = {
 	data: IPushDataExecutionRecovered;
@@ -554,6 +560,16 @@ export type PushDataNodeDescriptionUpdated = {
 	data: undefined;
 	type: 'nodeDescriptionUpdated';
 };
+
+export interface IActiveWorkflowUser {
+	user: User;
+	lastSeen: Date;
+}
+
+export interface IActiveWorkflowUsersChanged {
+	workflowId: Workflow['id'];
+	activeUsers: IActiveWorkflowUser[];
+}
 
 export interface IPushDataExecutionRecovered {
 	executionId: string;

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -340,7 +340,7 @@ export class LoadNodesAndCredentials {
 				loader.reset();
 				await loader.loadAll();
 				await this.postProcessLoaders();
-				push.send('nodeDescriptionUpdated', undefined);
+				push.broadcast('nodeDescriptionUpdated');
 			}, 100);
 
 			const toWatch = loader.isLazyLoaded

--- a/packages/cli/src/collaboration/collaboration.message.ts
+++ b/packages/cli/src/collaboration/collaboration.message.ts
@@ -1,0 +1,23 @@
+export type CollaborationMessage = WorkflowOpenedMessage | WorkflowClosedMessage;
+
+export type WorkflowOpenedMessage = {
+	type: 'workflowOpened';
+	workflowId: string;
+};
+
+export type WorkflowClosedMessage = {
+	type: 'workflowClosed';
+	workflowId: string;
+};
+
+const isWorkflowMessage = (msg: unknown): msg is CollaborationMessage => {
+	return typeof msg === 'object' && msg !== null && 'type' in msg;
+};
+
+export const isWorkflowOpenedMessage = (msg: unknown): msg is WorkflowOpenedMessage => {
+	return isWorkflowMessage(msg) && msg.type === 'workflowOpened';
+};
+
+export const isWorkflowClosedMessage = (msg: unknown): msg is WorkflowClosedMessage => {
+	return isWorkflowMessage(msg) && msg.type === 'workflowClosed';
+};

--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -21,6 +21,13 @@ export class CollaborationService {
 		private readonly state: CollaborationState,
 		private readonly userService: UserService,
 	) {
+		if (!push.isBidirectional) {
+			logger.warn(
+				'Collaboration features are disabled because push is configured unidirectional. Use N8N_PUSH_BACKEND=websocket environment variable to enable them.',
+			);
+			return;
+		}
+
 		this.push.on('message', async (event: OnPushMessageEvent) => {
 			try {
 				await this.handleUserMessage(event.userId, event.msg);

--- a/packages/cli/src/collaboration/collaboration.service.ts
+++ b/packages/cli/src/collaboration/collaboration.service.ts
@@ -1,0 +1,80 @@
+import type { Workflow } from 'n8n-workflow';
+import { Service } from 'typedi';
+import { Push } from '../push';
+import { Logger } from '@/Logger';
+import type { WorkflowClosedMessage, WorkflowOpenedMessage } from './collaboration.message';
+import { isWorkflowClosedMessage, isWorkflowOpenedMessage } from './collaboration.message';
+import { UserService } from '../services/user.service';
+import type { IActiveWorkflowUsersChanged } from '../Interfaces';
+import type { OnPushMessageEvent } from '@/push/types';
+import { CollaborationState } from '@/collaboration/collaboration.state';
+
+/**
+ * Service for managing collaboration feature between users. E.g. keeping
+ * track of active users for a workflow.
+ */
+@Service()
+export class CollaborationService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly push: Push,
+		private readonly state: CollaborationState,
+		private readonly userService: UserService,
+	) {
+		this.push.on('message', async (event: OnPushMessageEvent) => {
+			try {
+				await this.handleUserMessage(event.userId, event.msg);
+			} catch (error) {
+				this.logger.error('Error handling user message', {
+					error: error as unknown,
+					msg: event.msg,
+					userId: event.userId,
+				});
+			}
+		});
+	}
+
+	async handleUserMessage(userId: string, msg: unknown) {
+		if (isWorkflowOpenedMessage(msg)) {
+			await this.handleWorkflowOpened(userId, msg);
+		} else if (isWorkflowClosedMessage(msg)) {
+			await this.handleWorkflowClosed(userId, msg);
+		}
+	}
+
+	private async handleWorkflowOpened(userId: string, msg: WorkflowOpenedMessage) {
+		const { workflowId } = msg;
+
+		this.state.addActiveWorkflowUser(workflowId, userId);
+
+		await this.sendWorkflowUsersChangedMessage(workflowId);
+	}
+
+	private async handleWorkflowClosed(userId: string, msg: WorkflowClosedMessage) {
+		const { workflowId } = msg;
+
+		this.state.removeActiveWorkflowUser(workflowId, userId);
+
+		await this.sendWorkflowUsersChangedMessage(workflowId);
+	}
+
+	private async sendWorkflowUsersChangedMessage(workflowId: Workflow['id']) {
+		const activeWorkflowUsers = this.state.getActiveWorkflowUsers(workflowId);
+		const workflowUserIds = activeWorkflowUsers.map((user) => user.userId);
+
+		if (workflowUserIds.length === 0) {
+			return;
+		}
+		const users = await this.userService.getByIds(this.userService.getManager(), workflowUserIds);
+
+		const msgData: IActiveWorkflowUsersChanged = {
+			workflowId,
+			activeUsers: users.map((user) => ({
+				user,
+				lastSeen: activeWorkflowUsers.find((activeUser) => activeUser.userId === user.id)!.lastSeen,
+			})),
+		};
+
+		this.push.sendToUsers('activeWorkflowUsersChanged', msgData, workflowUserIds);
+	}
+}

--- a/packages/cli/src/collaboration/collaboration.state.ts
+++ b/packages/cli/src/collaboration/collaboration.state.ts
@@ -1,0 +1,62 @@
+import type { User } from '@/databases/entities/User';
+import type { Workflow } from 'n8n-workflow';
+import { Service } from 'typedi';
+
+type ActiveWorkflowUser = {
+	userId: User['id'];
+	lastSeen: Date;
+};
+
+type UserStateByUserId = Map<User['id'], ActiveWorkflowUser>;
+
+type State = {
+	activeUsersByWorkflowId: Map<Workflow['id'], UserStateByUserId>;
+};
+
+/**
+ * State management for the collaboration service
+ */
+@Service()
+export class CollaborationState {
+	private state: State = {
+		activeUsersByWorkflowId: new Map(),
+	};
+
+	addActiveWorkflowUser(workflowId: Workflow['id'], userId: User['id']) {
+		const { activeUsersByWorkflowId } = this.state;
+
+		let activeUsers = activeUsersByWorkflowId.get(workflowId);
+		if (!activeUsers) {
+			activeUsers = new Map();
+			activeUsersByWorkflowId.set(workflowId, activeUsers);
+		}
+
+		activeUsers.set(userId, {
+			userId,
+			lastSeen: new Date(),
+		});
+	}
+
+	removeActiveWorkflowUser(workflowId: Workflow['id'], userId: User['id']) {
+		const { activeUsersByWorkflowId } = this.state;
+
+		const activeUsers = activeUsersByWorkflowId.get(workflowId);
+		if (!activeUsers) {
+			return;
+		}
+
+		activeUsers.delete(userId);
+		if (activeUsers.size === 0) {
+			activeUsersByWorkflowId.delete(workflowId);
+		}
+	}
+
+	getActiveWorkflowUsers(workflowId: Workflow['id']): ActiveWorkflowUser[] {
+		const workflowState = this.state.activeUsersByWorkflowId.get(workflowId);
+		if (!workflowState) {
+			return [];
+		}
+
+		return [...workflowState.values()];
+	}
+}

--- a/packages/cli/src/controllers/communityPackages.controller.ts
+++ b/packages/cli/src/controllers/communityPackages.controller.ts
@@ -129,7 +129,7 @@ export class CommunityPackagesController {
 
 		// broadcast to connected frontends that node list has been updated
 		installedPackage.installedNodes.forEach((node) => {
-			this.push.send('reloadNodeType', {
+			this.push.broadcast('reloadNodeType', {
 				name: node.type,
 				version: node.latestVersion,
 			});
@@ -218,7 +218,7 @@ export class CommunityPackagesController {
 
 		// broadcast to connected frontends that node list has been updated
 		installedPackage.installedNodes.forEach((node) => {
-			this.push.send('removeNodeType', {
+			this.push.broadcast('removeNodeType', {
 				name: node.type,
 				version: node.latestVersion,
 			});
@@ -257,14 +257,14 @@ export class CommunityPackagesController {
 
 			// broadcast to connected frontends that node list has been updated
 			previouslyInstalledPackage.installedNodes.forEach((node) => {
-				this.push.send('removeNodeType', {
+				this.push.broadcast('removeNodeType', {
 					name: node.type,
 					version: node.latestVersion,
 				});
 			});
 
 			newInstalledPackage.installedNodes.forEach((node) => {
-				this.push.send('reloadNodeType', {
+				this.push.broadcast('reloadNodeType', {
 					name: node.name,
 					version: node.latestVersion,
 				});
@@ -283,7 +283,7 @@ export class CommunityPackagesController {
 			return newInstalledPackage;
 		} catch (error) {
 			previouslyInstalledPackage.installedNodes.forEach((node) => {
-				this.push.send('removeNodeType', {
+				this.push.broadcast('removeNodeType', {
 					name: node.type,
 					version: node.latestVersion,
 				});

--- a/packages/cli/src/eventbus/MessageEventBus/recoverEvents.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/recoverEvents.ts
@@ -195,7 +195,7 @@ export async function recoverExecutionDataFromEventLogMessages(
 			push.once('editorUiConnected', function handleUiBackUp() {
 				// add a small timeout to make sure the UI is back up
 				setTimeout(() => {
-					push.send('executionRecovered', { executionId });
+					push.broadcast('executionRecovered', { executionId });
 				}, 1000);
 			});
 		}

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -69,16 +69,18 @@ export abstract class AbstractPush<T> extends EventEmitter {
 		}
 	}
 
-	send<D>(type: IPushDataType, data: D, sessionId: string | undefined) {
+	broadcast<D>(type: IPushDataType, data?: D) {
+		this.sendToSessions(type, data, Object.keys(this.connections));
+	}
+
+	send<D>(type: IPushDataType, data: D, sessionId: string) {
 		const { connections } = this;
-		if (sessionId !== undefined && connections[sessionId] === undefined) {
+		if (connections[sessionId] === undefined) {
 			this.logger.error(`The session "${sessionId}" is not registered.`, { sessionId });
 			return;
 		}
 
-		const connectionsToSend = sessionId === undefined ? Object.keys(connections) : [sessionId];
-
-		this.sendToSessions(type, data, connectionsToSend);
+		this.sendToSessions(type, data, [sessionId]);
 	}
 
 	/**

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -10,7 +10,7 @@ import type { User } from '@/databases/entities/User';
  *
  * @emits message when a message is received from a client
  */
-export abstract class AbstractBidirectionalPush<T> extends EventEmitter {
+export abstract class AbstractPush<T> extends EventEmitter {
 	protected connections: Record<string, T> = {};
 
 	protected userIdBySessionId: Record<string, string> = {};

--- a/packages/cli/src/push/abstractBidirectional.push.ts
+++ b/packages/cli/src/push/abstractBidirectional.push.ts
@@ -10,7 +10,7 @@ import type { User } from '@/databases/entities/User';
  *
  * @emits message when a message is received from a client
  */
-export abstract class AbstractPush<T> extends EventEmitter {
+export abstract class AbstractBidirectionalPush<T> extends EventEmitter {
 	protected connections: Record<string, T> = {};
 
 	protected userIdBySessionId: Record<string, string> = {};

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -7,6 +7,7 @@ import { Server as WSServer } from 'ws';
 import { parse as parseUrl } from 'url';
 import { Container, Service } from 'typedi';
 import config from '@/config';
+import { Logger } from '@/Logger';
 import { resolveJwt } from '@/auth/jwt';
 import { AUTH_COOKIE_NAME } from '@/constants';
 import { SSEPush } from './sse.push';
@@ -27,6 +28,16 @@ const useWebSockets = config.getEnv('push.backend') === 'websocket';
 @Service()
 export class Push extends EventEmitter {
 	private backend = useWebSockets ? Container.get(WebSocketPush) : Container.get(SSEPush);
+
+	constructor(private readonly logger: Logger) {
+		super();
+
+		if (!useWebSockets) {
+			this.logger.warn(
+				'Using SSE as the push backend. Bidirectional communication is not available',
+			);
+		}
+	}
 
 	handleRequest(req: SSEPushRequest | WebSocketPushRequest, res: PushResponse) {
 		if (req.ws) {

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -13,6 +13,7 @@ import { SSEPush } from './sse.push';
 import { WebSocketPush } from './websocket.push';
 import type { PushResponse, SSEPushRequest, WebSocketPushRequest } from './types';
 import type { IPushDataType } from '@/Interfaces';
+import type { User } from '@/databases/entities/User';
 
 const useWebSockets = config.getEnv('push.backend') === 'websocket';
 
@@ -43,6 +44,10 @@ export class Push extends EventEmitter {
 
 	send<D>(type: IPushDataType, data: D, sessionId: string | undefined = undefined) {
 		this.backend.send(type, data, sessionId);
+	}
+
+	sendToUsers<D>(type: IPushDataType, data: D, userIds: Array<User['id']>) {
+		this.backend.sendToUsers(type, data, userIds);
 	}
 }
 

--- a/packages/cli/src/push/sse.push.ts
+++ b/packages/cli/src/push/sse.push.ts
@@ -1,14 +1,14 @@
 import SSEChannel from 'sse-channel';
 import { Service } from 'typedi';
 import { Logger } from '@/Logger';
-import { AbstractPush } from './abstract.push';
+import { AbstractBidirectionalPush } from './abstractBidirectional.push';
 import type { PushRequest, PushResponse } from './types';
 import type { User } from '@/databases/entities/User';
 
 type Connection = { req: PushRequest; res: PushResponse };
 
 @Service()
-export class SSEPush extends AbstractPush<Connection> {
+export class SSEPush extends AbstractBidirectionalPush<Connection> {
 	readonly channel = new SSEChannel();
 
 	readonly connections: Record<string, Connection> = {};

--- a/packages/cli/src/push/sse.push.ts
+++ b/packages/cli/src/push/sse.push.ts
@@ -3,6 +3,7 @@ import { Service } from 'typedi';
 import { Logger } from '@/Logger';
 import { AbstractPush } from './abstract.push';
 import type { PushRequest, PushResponse } from './types';
+import type { User } from '@/databases/entities/User';
 
 type Connection = { req: PushRequest; res: PushResponse };
 
@@ -19,8 +20,8 @@ export class SSEPush extends AbstractPush<Connection> {
 		});
 	}
 
-	add(sessionId: string, connection: Connection) {
-		super.add(sessionId, connection);
+	add(sessionId: string, userId: User['id'], connection: Connection) {
+		super.add(sessionId, userId, connection);
 		this.channel.addClient(connection.req, connection.res);
 	}
 

--- a/packages/cli/src/push/sse.push.ts
+++ b/packages/cli/src/push/sse.push.ts
@@ -1,14 +1,14 @@
 import SSEChannel from 'sse-channel';
 import { Service } from 'typedi';
 import { Logger } from '@/Logger';
-import { AbstractBidirectionalPush } from './abstractBidirectional.push';
+import { AbstractPush } from './abstract.push';
 import type { PushRequest, PushResponse } from './types';
 import type { User } from '@/databases/entities/User';
 
 type Connection = { req: PushRequest; res: PushResponse };
 
 @Service()
-export class SSEPush extends AbstractBidirectionalPush<Connection> {
+export class SSEPush extends AbstractPush<Connection> {
 	readonly channel = new SSEChannel();
 
 	readonly connections: Record<string, Connection> = {};

--- a/packages/cli/src/push/types.ts
+++ b/packages/cli/src/push/types.ts
@@ -1,3 +1,4 @@
+import type { User } from '@/databases/entities/User';
 import type { Request, Response } from 'express';
 import type { WebSocket } from 'ws';
 
@@ -5,7 +6,13 @@ import type { WebSocket } from 'ws';
 
 export type PushRequest = Request<{}, {}, {}, { sessionId: string }>;
 
-export type SSEPushRequest = PushRequest & { ws: undefined };
-export type WebSocketPushRequest = PushRequest & { ws: WebSocket };
+export type SSEPushRequest = PushRequest & { ws: undefined; userId: User['id'] };
+export type WebSocketPushRequest = PushRequest & { ws: WebSocket; userId: User['id'] };
 
 export type PushResponse = Response & { req: PushRequest };
+
+export type OnPushMessageEvent = {
+	sessionId: string;
+	userId: User['id'];
+	msg: unknown;
+};

--- a/packages/cli/src/push/websocket.push.ts
+++ b/packages/cli/src/push/websocket.push.ts
@@ -1,7 +1,7 @@
 import type WebSocket from 'ws';
 import { Service } from 'typedi';
 import { Logger } from '@/Logger';
-import { AbstractPush } from './abstract.push';
+import { AbstractBidirectionalPush } from './abstractBidirectional.push';
 import type { User } from '@/databases/entities/User';
 
 function heartbeat(this: WebSocket) {
@@ -9,7 +9,7 @@ function heartbeat(this: WebSocket) {
 }
 
 @Service()
-export class WebSocketPush extends AbstractPush<WebSocket> {
+export class WebSocketPush extends AbstractBidirectionalPush<WebSocket> {
 	constructor(logger: Logger) {
 		super(logger);
 

--- a/packages/cli/src/push/websocket.push.ts
+++ b/packages/cli/src/push/websocket.push.ts
@@ -1,7 +1,7 @@
 import type WebSocket from 'ws';
 import { Service } from 'typedi';
 import { Logger } from '@/Logger';
-import { AbstractBidirectionalPush } from './abstractBidirectional.push';
+import { AbstractPush } from './abstract.push';
 import type { User } from '@/databases/entities/User';
 
 function heartbeat(this: WebSocket) {
@@ -9,7 +9,7 @@ function heartbeat(this: WebSocket) {
 }
 
 @Service()
-export class WebSocketPush extends AbstractBidirectionalPush<WebSocket> {
+export class WebSocketPush extends AbstractPush<WebSocket> {
 	constructor(logger: Logger) {
 		super(logger);
 

--- a/packages/cli/test/unit/collaboration/collaboration.service.test.ts
+++ b/packages/cli/test/unit/collaboration/collaboration.service.test.ts
@@ -1,0 +1,149 @@
+import { CollaborationService } from '@/collaboration/collaboration.service';
+import type { Logger } from '@/Logger';
+import type { User } from '@/databases/entities/User';
+import type { UserService } from '@/services/user.service';
+import { CollaborationState } from '@/collaboration/collaboration.state';
+import type { Push } from '@/push';
+import type {
+	WorkflowClosedMessage,
+	WorkflowOpenedMessage,
+} from '@/collaboration/collaboration.message';
+
+describe('CollaborationService', () => {
+	let collaborationService: CollaborationService;
+	let mockLogger: Logger;
+	let mockUserService: jest.Mocked<UserService>;
+	let state: CollaborationState;
+	let push: Push;
+
+	const sessionId = 'test-session';
+
+	beforeEach(() => {
+		mockLogger = {} as Logger;
+		mockUserService = {
+			getByIds: jest.fn(),
+			getManager: jest.fn(),
+		} as unknown as jest.Mocked<UserService>;
+
+		push = {
+			on: jest.fn(),
+			sendToUsers: jest.fn(),
+		} as unknown as Push;
+		state = new CollaborationState();
+		collaborationService = new CollaborationService(mockLogger, push, state, mockUserService);
+	});
+
+	describe('workflow opened message', () => {
+		const userId = 'test-user';
+		const workflowId = 'test-workflow';
+
+		const message: WorkflowOpenedMessage = {
+			type: 'workflowOpened',
+			workflowId,
+		};
+
+		const expectActiveUsersChangedMessage = (userIds: string[]) => {
+			expect(push.sendToUsers).toHaveBeenCalledWith(
+				'activeWorkflowUsersChanged',
+				{
+					workflowId,
+					activeUsers: [
+						{
+							user: { id: userId },
+							lastSeen: expect.any(Date),
+						},
+					],
+				},
+				[userId],
+			);
+		};
+
+		describe('user is not yet active', () => {
+			it('updates state correctly', async () => {
+				mockUserService.getByIds.mockResolvedValueOnce([{ id: userId } as User]);
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(state.getActiveWorkflowUsers(workflowId)).toEqual([
+					{
+						lastSeen: expect.any(Date),
+						userId,
+					},
+				]);
+			});
+
+			it('sends active workflow users changed message', async () => {
+				mockUserService.getByIds.mockResolvedValueOnce([{ id: userId } as User]);
+				await collaborationService.handleUserMessage(userId, message);
+
+				expectActiveUsersChangedMessage([userId]);
+			});
+		});
+
+		describe('user is already active', () => {
+			beforeEach(() => {
+				state.addActiveWorkflowUser(workflowId, userId);
+			});
+
+			it('updates state correctly', async () => {
+				mockUserService.getByIds.mockResolvedValueOnce([{ id: userId } as User]);
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(state.getActiveWorkflowUsers(workflowId)).toEqual([
+					{
+						lastSeen: expect.any(Date),
+						userId,
+					},
+				]);
+			});
+
+			it('sends active workflow users changed message', async () => {
+				mockUserService.getByIds.mockResolvedValueOnce([{ id: userId } as User]);
+				await collaborationService.handleUserMessage(userId, message);
+
+				expectActiveUsersChangedMessage([userId]);
+			});
+		});
+	});
+
+	describe('workflow closed message', () => {
+		const userId = 'test-user';
+		const workflowId = 'test-workflow';
+
+		const message: WorkflowClosedMessage = {
+			type: 'workflowClosed',
+			workflowId,
+		};
+
+		describe('user is active', () => {
+			beforeEach(() => {
+				state.addActiveWorkflowUser(workflowId, userId);
+			});
+
+			it('updates state correctly', async () => {
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(state.getActiveWorkflowUsers(workflowId)).toEqual([]);
+			});
+
+			it('does not send active workflow users changed message', async () => {
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(push.sendToUsers).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('user is not active', () => {
+			it('updates state correctly', async () => {
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(state.getActiveWorkflowUsers(workflowId)).toEqual([]);
+			});
+
+			it('does not send active workflow users changed message', async () => {
+				await collaborationService.handleUserMessage(userId, message);
+
+				expect(push.sendToUsers).not.toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/packages/cli/test/unit/collaboration/collaboration.service.test.ts
+++ b/packages/cli/test/unit/collaboration/collaboration.service.test.ts
@@ -16,10 +16,11 @@ describe('CollaborationService', () => {
 	let state: CollaborationState;
 	let push: Push;
 
-	const sessionId = 'test-session';
-
 	beforeEach(() => {
-		mockLogger = {} as Logger;
+		mockLogger = {
+			warn: jest.fn(),
+			error: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
 		mockUserService = {
 			getByIds: jest.fn(),
 			getManager: jest.fn(),

--- a/packages/cli/test/unit/push/websocket.push.test.ts
+++ b/packages/cli/test/unit/push/websocket.push.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { EventEmitter } from 'events';
+import type WebSocket from 'ws';
+import { WebSocketPush } from '@/push/websocket.push';
+import type { Logger } from '@/Logger';
+import type { User } from '@/databases/entities/User';
+import type { PushDataExecutionRecovered } from '@/Interfaces';
+
+jest.useFakeTimers();
+
+class MockWebSocket extends EventEmitter {
+	public isAlive = true;
+
+	public ping = jest.fn();
+
+	public send = jest.fn();
+
+	public terminate = jest.fn();
+
+	public close = jest.fn();
+}
+
+const createMockWebSocket = (): jest.Mocked<WebSocket> => {
+	return new MockWebSocket() as unknown as jest.Mocked<WebSocket>;
+};
+
+describe('WebSocketPush', () => {
+	let webSocketPush: WebSocketPush;
+	let mockWebSocket1: jest.Mocked<WebSocket>;
+	let mockWebSocket2: jest.Mocked<WebSocket>;
+	let mockLogger: Logger;
+
+	const sessionId1 = 'test-session1';
+	const sessionId2 = 'test-session2';
+	const userId: User['id'] = 'test-user';
+
+	beforeEach(() => {
+		mockWebSocket1 = createMockWebSocket();
+		mockWebSocket2 = createMockWebSocket();
+		mockLogger = {
+			debug: jest.fn(),
+			error: jest.fn(),
+			warn: jest.fn(),
+			info: jest.fn(),
+			verbose: jest.fn(),
+		} as unknown as jest.Mocked<Logger>;
+
+		webSocketPush = new WebSocketPush(mockLogger);
+	});
+
+	it('can add a connection', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+
+		expect(mockWebSocket1.listenerCount('close')).toBe(1);
+		expect(mockWebSocket1.listenerCount('pong')).toBe(1);
+		expect(mockWebSocket1.listenerCount('message')).toBe(1);
+	});
+
+	it('closes a connection', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+
+		mockWebSocket1.emit('close');
+
+		expect(mockWebSocket1.listenerCount('close')).toBe(0);
+		expect(mockWebSocket1.listenerCount('pong')).toBe(0);
+		expect(mockWebSocket1.listenerCount('message')).toBe(0);
+	});
+
+	it('sends data to one connection', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+		webSocketPush.add(sessionId2, userId, mockWebSocket2);
+		const data: PushDataExecutionRecovered = {
+			type: 'executionRecovered',
+			data: {
+				executionId: 'test-execution-id',
+			},
+		};
+
+		webSocketPush.send('executionRecovered', data, sessionId1);
+
+		expect(mockWebSocket1.send).toHaveBeenCalledWith(
+			JSON.stringify({
+				type: 'executionRecovered',
+				data: {
+					type: 'executionRecovered',
+					data: {
+						executionId: 'test-execution-id',
+					},
+				},
+			}),
+		);
+		expect(mockWebSocket2.send).not.toHaveBeenCalled();
+	});
+
+	it('sends data to all connections', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+		webSocketPush.add(sessionId2, userId, mockWebSocket2);
+		const data: PushDataExecutionRecovered = {
+			type: 'executionRecovered',
+			data: {
+				executionId: 'test-execution-id',
+			},
+		};
+
+		webSocketPush.send('executionRecovered', data, undefined);
+
+		const expectedMsg = JSON.stringify({
+			type: 'executionRecovered',
+			data: {
+				type: 'executionRecovered',
+				data: {
+					executionId: 'test-execution-id',
+				},
+			},
+		});
+		expect(mockWebSocket1.send).toHaveBeenCalledWith(expectedMsg);
+		expect(mockWebSocket2.send).toHaveBeenCalledWith(expectedMsg);
+	});
+
+	it('pings all connections', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+		webSocketPush.add(sessionId2, userId, mockWebSocket2);
+
+		jest.runOnlyPendingTimers();
+
+		expect(mockWebSocket1.ping).toHaveBeenCalled();
+		expect(mockWebSocket2.ping).toHaveBeenCalled();
+	});
+
+	it('emits message event when connection receives data', () => {
+		const mockOnMessageReceived = jest.fn();
+		webSocketPush.on('message', mockOnMessageReceived);
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+		webSocketPush.add(sessionId2, userId, mockWebSocket2);
+
+		const data = { test: 'data' };
+		const buffer = Buffer.from(JSON.stringify(data));
+
+		mockWebSocket1.emit('message', buffer);
+
+		expect(mockOnMessageReceived).toHaveBeenCalledWith({
+			msg: data,
+			sessionId: sessionId1,
+			userId,
+		});
+	});
+});

--- a/packages/cli/test/unit/push/websocket.push.test.ts
+++ b/packages/cli/test/unit/push/websocket.push.test.ts
@@ -117,6 +117,31 @@ describe('WebSocketPush', () => {
 		expect(mockWebSocket2.send).toHaveBeenCalledWith(expectedMsg);
 	});
 
+	it('sends data to all users connections', () => {
+		webSocketPush.add(sessionId1, userId, mockWebSocket1);
+		webSocketPush.add(sessionId2, userId, mockWebSocket2);
+		const data: PushDataExecutionRecovered = {
+			type: 'executionRecovered',
+			data: {
+				executionId: 'test-execution-id',
+			},
+		};
+
+		webSocketPush.sendToUsers('executionRecovered', data, [userId]);
+
+		const expectedMsg = JSON.stringify({
+			type: 'executionRecovered',
+			data: {
+				type: 'executionRecovered',
+				data: {
+					executionId: 'test-execution-id',
+				},
+			},
+		});
+		expect(mockWebSocket1.send).toHaveBeenCalledWith(expectedMsg);
+		expect(mockWebSocket2.send).toHaveBeenCalledWith(expectedMsg);
+	});
+
 	it('pings all connections', () => {
 		webSocketPush.add(sessionId1, userId, mockWebSocket1);
 		webSocketPush.add(sessionId2, userId, mockWebSocket2);


### PR DESCRIPTION
- Enable two-way communication with web sockets
- Enable sending push messages to specific users
- Add collaboration service for managing active users for workflow

Missing things:
- State is currently kept only in memory, making this not work in multi-master setups
- Removing a user from active users in situations where they go inactive or we miss the "workflow closed" message
  - I think a timer based solution for this would cover most edge cases. I.e. have FE ping every X minutes, BE removes the user unless they have received a ping in Y minutes, where Y > X
- FE changes to be added later by @MiloradFilipovic 

Github issue / Community forum post (link here to close automatically):
