### PR TITLE
fix: Update colors of syntax errors

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/theme.ts
@@ -99,6 +99,12 @@ export const codeNodeEditorTheme = ({
 			marginLeft: BASE_STYLING.diagnosticButton.marginLeft,
 			cursor: BASE_STYLING.diagnosticButton.cursor,
 		},
+		'.cm-diagnostic-error': {
+			backgroundColor: 'var(--color-background-base)',
+		},
+		'.cm-diagnosticText': {
+			color: 'var(--color-text-base)',
+		},
 	}),
 	syntaxHighlighting(
 		HighlightStyle.define([


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
<img width="201" alt="Screenshot 2023-11-01 at 16 58 21" src="https://github.com/n8n-io/n8n/assets/4711238/15fcbe25-2dec-4b1d-8d27-f5dc186bf2ac">
<img width="125" alt="Screenshot 2023-11-01 at 16 59 37" src="https://github.com/n8n-io/n8n/assets/4711238/414d9122-79bd-4bd6-b188-b8f26091f1ce">

