### PR TITLE
fix(core): Permission check for subworkflow properly checking for workflow settings

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -129,7 +129,7 @@ export class PermissionChecker {
 		}
 
 		if (policy === 'workflowsFromSameOwner') {
-			if (!subworkflowOwner || subworkflowOwner.id !== userId) {
+			if (subworkflowOwner?.id !== userId) {
 				throw errorToThrow;
 			}
 		}

--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -1,17 +1,11 @@
 import type { INode, Workflow } from 'n8n-workflow';
-import {
-	NodeOperationError,
-	SubworkflowOperationError,
-	WorkflowOperationError,
-} from 'n8n-workflow';
+import { NodeOperationError, SubworkflowOperationError } from 'n8n-workflow';
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import * as Db from '@/Db';
 import config from '@/config';
 import type { SharedCredentials } from '@db/entities/SharedCredentials';
 import { isSharingEnabled } from './UserManagementHelper';
-import { WorkflowsService } from '@/workflows/workflows.services';
-import { UserService } from '@/services/user.service';
 import { OwnershipService } from '@/services/ownership.service';
 import Container from 'typedi';
 import { RoleService } from '@/services/role.service';
@@ -135,14 +129,7 @@ export class PermissionChecker {
 		}
 
 		if (policy === 'workflowsFromSameOwner') {
-			const user = await Container.get(UserService).findOne({ where: { id: userId } });
-			if (!user) {
-				throw new WorkflowOperationError(
-					'Fatal error: user not found. Please contact the system administrator.',
-				);
-			}
-			const sharing = await WorkflowsService.getSharing(user, subworkflow.id, ['role', 'user']);
-			if (!sharing || sharing.role.name !== 'owner') {
+			if (!subworkflowOwner || subworkflowOwner.id !== userId) {
 				throw errorToThrow;
 			}
 		}

--- a/packages/cli/test/unit/PermissionChecker.test.ts
+++ b/packages/cli/test/unit/PermissionChecker.test.ts
@@ -228,9 +228,7 @@ describe('PermissionChecker.checkSubworkflowExecutePolicy', () => {
 
 	test('sets default policy from environment when subworkflow has none', async () => {
 		config.set('workflows.callerPolicyDefaultOption', 'none');
-		jest.spyOn(ownershipService, 'getWorkflowOwnerCached').mockImplementation(async () => {
-			return fakeUser;
-		});
+		jest.spyOn(ownershipService, 'getWorkflowOwnerCached').mockResolvedValue(fakeUser);
 		jest.spyOn(UserManagementHelper, 'isSharingEnabled').mockReturnValue(true);
 
 		const subworkflow = new Workflow({
@@ -248,7 +246,7 @@ describe('PermissionChecker.checkSubworkflowExecutePolicy', () => {
 	test('if sharing is disabled, ensures that workflows are owned by same user and reject running workflows belonging to another user even if setting allows execution', async () => {
 		jest
 			.spyOn(ownershipService, 'getWorkflowOwnerCached')
-			.mockImplementation(async () => nonOwnerUser);
+			.mockResolvedValue(nonOwnerUser)
 		jest.spyOn(UserManagementHelper, 'isSharingEnabled').mockReturnValue(false);
 
 		const subworkflow = new Workflow({

--- a/packages/cli/test/unit/PermissionChecker.test.ts
+++ b/packages/cli/test/unit/PermissionChecker.test.ts
@@ -244,9 +244,7 @@ describe('PermissionChecker.checkSubworkflowExecutePolicy', () => {
 	});
 
 	test('if sharing is disabled, ensures that workflows are owned by same user and reject running workflows belonging to another user even if setting allows execution', async () => {
-		jest
-			.spyOn(ownershipService, 'getWorkflowOwnerCached')
-			.mockResolvedValue(nonOwnerUser)
+		jest.spyOn(ownershipService, 'getWorkflowOwnerCached').mockResolvedValue(nonOwnerUser);
 		jest.spyOn(UserManagementHelper, 'isSharingEnabled').mockReturnValue(false);
 
 		const subworkflow = new Workflow({


### PR DESCRIPTION
The `sharing` related code is legacy that was not removed. Subworkflow execution should check workflow settings alone, and this is now reflected in the code.

Github issue / Community forum post (link here to close automatically):
https://community.n8n.io/t/bug-when-using-the-execute-workflow-node-when-workflow-is-shared/32207