### PR TITLE
refactor: Downgrade to pnpm 8.9 due to CI failure (no-changelog)

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.4.0
         with:
-          version: 8.10.0
+          version: 8.9.0
 
       - uses: actions/setup-node@v3.7.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ dependencies are installed and the packages get linked correctly. Here's a short
 
 #### pnpm
 
-[pnpm](https://pnpm.io/) version 8.10 or newer is required for development purposes. We recommend installing it with [corepack](#corepack).
+[pnpm](https://pnpm.io/) version 8.9 or newer is required for development purposes. We recommend installing it with [corepack](#corepack).
 
 ##### pnpm workspaces
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "homepage": "https://n8n.io",
   "engines": {
     "node": ">=18.10",
-    "pnpm": ">=8.10"
+    "pnpm": ">=8.9"
   },
-  "packageManager": "pnpm@8.10.0",
+  "packageManager": "pnpm@8.9.0",
   "scripts": {
     "preinstall": "node scripts/block-npm-install.js",
     "build": "turbo run build",


### PR DESCRIPTION
Reverts n8n-io/n8n#7548

This was causing builds to fail on CI, we should fix the CI pipeline later but since we're already late on releasing `1.15` we will temporarily revert this.

cc @ivov 