### PR TITLE
fix(editor): Hide not supported node options

### DIFF
--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -380,120 +380,7 @@ export default defineComponent({
 			} as INodeParameters,
 			nodeValuesInitialized: false, // Used to prevent nodeValues from being overwritten by defaults on reopening ndv
 
-			nodeSettings: [
-				{
-					displayName: this.$locale.baseText('nodeSettings.alwaysOutputData.displayName'),
-					name: 'alwaysOutputData',
-					type: 'boolean',
-					default: false,
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.alwaysOutputData.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.executeOnce.displayName'),
-					name: 'executeOnce',
-					type: 'boolean',
-					default: false,
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.executeOnce.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.retryOnFail.displayName'),
-					name: 'retryOnFail',
-					type: 'boolean',
-					default: false,
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.retryOnFail.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.maxTries.displayName'),
-					name: 'maxTries',
-					type: 'number',
-					typeOptions: {
-						minValue: 2,
-						maxValue: 5,
-					},
-					default: 3,
-					displayOptions: {
-						show: {
-							retryOnFail: [true],
-						},
-					},
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.maxTries.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.waitBetweenTries.displayName'),
-					name: 'waitBetweenTries',
-					type: 'number',
-					typeOptions: {
-						minValue: 0,
-						maxValue: 5000,
-					},
-					default: 1000,
-					displayOptions: {
-						show: {
-							retryOnFail: [true],
-						},
-					},
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.waitBetweenTries.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.onError.displayName'),
-					name: 'onError',
-					type: 'options',
-					options: [
-						{
-							name: this.$locale.baseText('nodeSettings.onError.options.stopWorkflow.displayName'),
-							value: 'stopWorkflow',
-							description: this.$locale.baseText(
-								'nodeSettings.onError.options.stopWorkflow.description',
-							),
-						},
-						{
-							name: this.$locale.baseText(
-								'nodeSettings.onError.options.continueRegularOutput.displayName',
-							),
-							value: 'continueRegularOutput',
-							description: this.$locale.baseText(
-								'nodeSettings.onError.options.continueRegularOutput.description',
-							),
-						},
-						{
-							name: this.$locale.baseText(
-								'nodeSettings.onError.options.continueErrorOutput.displayName',
-							),
-							value: 'continueErrorOutput',
-							description: this.$locale.baseText(
-								'nodeSettings.onError.options.continueErrorOutput.description',
-							),
-						},
-					],
-					default: 'stopWorkflow',
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.onError.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.notes.displayName'),
-					name: 'notes',
-					type: 'string',
-					typeOptions: {
-						rows: 5,
-					},
-					default: '',
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.notes.description'),
-				},
-				{
-					displayName: this.$locale.baseText('nodeSettings.notesInFlow.displayName'),
-					name: 'notesInFlow',
-					type: 'boolean',
-					default: false,
-					noDataExpression: true,
-					description: this.$locale.baseText('nodeSettings.notesInFlow.description'),
-				},
-			] as INodeProperties[],
+			nodeSettings: [] as INodeProperties[],
 			COMMUNITY_NODES_INSTALLATION_DOCS_URL,
 			CUSTOM_NODES_DOCS_URL,
 			MAIN_NODE_PANEL_WIDTH,
@@ -537,6 +424,132 @@ export default defineComponent({
 			});
 
 			this.workflowsStore.setNodePristine(this.node.name, false);
+		},
+		populateSettings() {
+			if (this.isExecutable && !this.isTriggerNode) {
+				this.nodeSettings.push(
+					...([
+						{
+							displayName: this.$locale.baseText('nodeSettings.alwaysOutputData.displayName'),
+							name: 'alwaysOutputData',
+							type: 'boolean',
+							default: false,
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.alwaysOutputData.description'),
+						},
+						{
+							displayName: this.$locale.baseText('nodeSettings.executeOnce.displayName'),
+							name: 'executeOnce',
+							type: 'boolean',
+							default: false,
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.executeOnce.description'),
+						},
+						{
+							displayName: this.$locale.baseText('nodeSettings.retryOnFail.displayName'),
+							name: 'retryOnFail',
+							type: 'boolean',
+							default: false,
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.retryOnFail.description'),
+						},
+						{
+							displayName: this.$locale.baseText('nodeSettings.maxTries.displayName'),
+							name: 'maxTries',
+							type: 'number',
+							typeOptions: {
+								minValue: 2,
+								maxValue: 5,
+							},
+							default: 3,
+							displayOptions: {
+								show: {
+									retryOnFail: [true],
+								},
+							},
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.maxTries.description'),
+						},
+						{
+							displayName: this.$locale.baseText('nodeSettings.waitBetweenTries.displayName'),
+							name: 'waitBetweenTries',
+							type: 'number',
+							typeOptions: {
+								minValue: 0,
+								maxValue: 5000,
+							},
+							default: 1000,
+							displayOptions: {
+								show: {
+									retryOnFail: [true],
+								},
+							},
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.waitBetweenTries.description'),
+						},
+						{
+							displayName: this.$locale.baseText('nodeSettings.onError.displayName'),
+							name: 'onError',
+							type: 'options',
+							options: [
+								{
+									name: this.$locale.baseText(
+										'nodeSettings.onError.options.stopWorkflow.displayName',
+									),
+									value: 'stopWorkflow',
+									description: this.$locale.baseText(
+										'nodeSettings.onError.options.stopWorkflow.description',
+									),
+								},
+								{
+									name: this.$locale.baseText(
+										'nodeSettings.onError.options.continueRegularOutput.displayName',
+									),
+									value: 'continueRegularOutput',
+									description: this.$locale.baseText(
+										'nodeSettings.onError.options.continueRegularOutput.description',
+									),
+								},
+								{
+									name: this.$locale.baseText(
+										'nodeSettings.onError.options.continueErrorOutput.displayName',
+									),
+									value: 'continueErrorOutput',
+									description: this.$locale.baseText(
+										'nodeSettings.onError.options.continueErrorOutput.description',
+									),
+								},
+							],
+							default: 'stopWorkflow',
+							noDataExpression: true,
+							description: this.$locale.baseText('nodeSettings.onError.description'),
+						},
+					] as INodeProperties[]),
+				);
+			}
+			this.nodeSettings.push(
+				...([
+					{
+						displayName: this.$locale.baseText('nodeSettings.notes.displayName'),
+						name: 'notes',
+						type: 'string',
+						typeOptions: {
+							rows: 5,
+						},
+						default: '',
+						noDataExpression: true,
+						description: this.$locale.baseText('nodeSettings.notes.description'),
+					},
+					{
+						displayName: this.$locale.baseText('nodeSettings.notesInFlow.displayName'),
+						name: 'notesInFlow',
+						type: 'boolean',
+						default: false,
+						noDataExpression: true,
+						description: this.$locale.baseText('nodeSettings.notesInFlow.description'),
+					},
+				] as INodeProperties[]),
+			);
 		},
 		onParameterBlur(parameterName: string) {
 			this.hiddenIssuesInputs = this.hiddenIssuesInputs.filter((name) => name !== parameterName);
@@ -1003,6 +1016,7 @@ export default defineComponent({
 	},
 	mounted() {
 		this.populateHiddenIssuesSet();
+		this.populateSettings();
 		this.setNodeValues();
 		this.eventBus?.on('openSettings', this.openSettings);
 


### PR DESCRIPTION
Currently Trigger-Nodes and Sub-Nodes display options that do not make sense or work like:
- Always Output Data
- Execute Once
- On Error

This PR hides those options for nodes that can not make use of them anyway to not confuse users.

Github issue / Community forum post (link here to close automatically):
