### PR TITLE
fix(core): Ensure `init` before checking leader or follower in multi-main scenario

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -118,7 +118,11 @@ export class License {
 					'@/services/orchestration/main/MultiMainInstance.publisher.ee'
 				);
 
-				if (Container.get(MultiMainInstancePublisher).isFollower) {
+				const multiMainInstancePublisher = Container.get(MultiMainInstancePublisher);
+
+				await multiMainInstancePublisher.init();
+
+				if (multiMainInstancePublisher.isFollower) {
 					this.logger.debug('Instance is follower, skipping sending of reloadLicense command...');
 					return;
 				}

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -248,7 +248,11 @@ export abstract class BaseCommand extends Command {
 				'@/services/orchestration/main/MultiMainInstance.publisher.ee'
 			);
 
-			if (Container.get(MultiMainInstancePublisher).isFollower) {
+			const multiMainInstancePublisher = Container.get(MultiMainInstancePublisher);
+
+			await multiMainInstancePublisher.init();
+
+			if (multiMainInstancePublisher.isFollower) {
 				this.logger.debug('Instance is follower, skipping license initialization...');
 				return;
 			}
@@ -269,6 +273,7 @@ export abstract class BaseCommand extends Command {
 			try {
 				this.logger.debug('Attempting license activation');
 				await license.activate(activationKey);
+				this.logger.debug('License init complete');
 			} catch (e) {
 				this.logger.error('Could not activate license', e as Error);
 			}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -207,7 +207,7 @@ export class Start extends BaseCommand {
 		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
 		await this.initLicense();
-		this.logger.debug('License init complete');
+
 		await this.initOrchestration();
 		this.logger.debug('Orchestration init complete');
 		await this.initBinaryDataService();
@@ -233,15 +233,23 @@ export class Start extends BaseCommand {
 			return;
 		}
 
-		if (!Container.get(License).isMultipleMainInstancesLicensed()) {
-			throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
-		}
+		// multi-main scenario
 
 		const { MultiMainInstancePublisher } = await import(
 			'@/services/orchestration/main/MultiMainInstance.publisher.ee'
 		);
 
-		await Container.get(MultiMainInstancePublisher).init();
+		const multiMainInstancePublisher = Container.get(MultiMainInstancePublisher);
+
+		await multiMainInstancePublisher.init();
+
+		if (
+			multiMainInstancePublisher.isLeader &&
+			!Container.get(License).isMultipleMainInstancesLicensed()
+		) {
+			throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
+		}
+
 		await Container.get(OrchestrationHandlerMainService).init();
 	}
 

--- a/packages/cli/src/services/orchestration/main/MultiMainInstance.publisher.ee.ts
+++ b/packages/cli/src/services/orchestration/main/MultiMainInstance.publisher.ee.ts
@@ -28,6 +28,8 @@ export class MultiMainInstancePublisher extends SingleMainInstancePublisher {
 	private leaderCheckInterval: NodeJS.Timer | undefined;
 
 	async init() {
+		if (this.initialized) return;
+
 		await this.initPublisher();
 
 		this.initialized = true;

--- a/packages/cli/src/services/pruning.service.ts
+++ b/packages/cli/src/services/pruning.service.ts
@@ -46,7 +46,11 @@ export class PruningService {
 				'@/services/orchestration/main/MultiMainInstance.publisher.ee'
 			);
 
-			return Container.get(MultiMainInstancePublisher).isLeader;
+			const multiMainInstancePublisher = Container.get(MultiMainInstancePublisher);
+
+			await multiMainInstancePublisher.init();
+
+			return multiMainInstancePublisher.isLeader;
 		}
 
 		return true;
@@ -63,7 +67,11 @@ export class PruningService {
 				'@/services/orchestration/main/MultiMainInstance.publisher.ee'
 			);
 
-			if (Container.get(MultiMainInstancePublisher).isFollower) return;
+			const multiMainInstancePublisher = Container.get(MultiMainInstancePublisher);
+
+			await multiMainInstancePublisher.init();
+
+			if (multiMainInstancePublisher.isFollower) return;
 		}
 
 		this.logger.debug('Clearing soft-deletion interval and hard-deletion timeout (pruning cycle)');


### PR DESCRIPTION
This PR ensures `MultiMainInstancePublisher` is initialized before checking if the instance is leader or follower. Followers skip license init, license check, and pruning start and stop.