### PR TITLE
fix(editor): More dark-mode fixes (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -289,6 +289,14 @@ export default defineComponent({
 	padding-bottom: var(--spacing-xl);
 }
 
+.qrContainer {
+	text-align: center;
+
+	canvas {
+		border: 4px solid var(--prim-gray-10);
+	}
+}
+
 .headerContainer {
 	text-align: center;
 }

--- a/packages/editor-ui/src/components/SSOLogin.vue
+++ b/packages/editor-ui/src/components/SSOLogin.vue
@@ -53,7 +53,7 @@ const onSSOLogin = async () => {
 		position: relative;
 		display: inline-block;
 		padding: var(--spacing-xl) var(--spacing-l);
-		background: var(--color-foreground-xlight);
+		background: var(--color-background-xlight);
 	}
 }
 </style>

--- a/packages/editor-ui/src/views/MfaView.vue
+++ b/packages/editor-ui/src/views/MfaView.vue
@@ -219,16 +219,8 @@ body {
 	justify-content: center;
 }
 
-.textContainer {
-	text-align: center;
-}
-
 .formContainer {
 	padding-bottom: var(--spacing-xl);
-}
-
-.qrContainer {
-	text-align: center;
 }
 
 .headerContainer {


### PR DESCRIPTION
This fixes:
1. The `OR` divider background when SSO Login is enabled
2. Scanning of QR code in settings in dark mode