### PR TITLE
fix(core): Ensure pruning starts only after migrations have completed

### DIFF
--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -41,7 +41,6 @@ import {
 	WorkflowStatisticsRepository,
 	WorkflowTagMappingRepository,
 } from '@db/repositories';
-import { PruningService } from '@/services/pruning.service';
 
 export const collections = {} as IDatabaseCollections;
 
@@ -192,10 +191,6 @@ export async function init(testConnectionOptions?: ConnectionOptions): Promise<v
 	collections.Settings = Container.get(SettingsRepository);
 	collections.Credentials = Container.get(CredentialsRepository);
 	collections.Workflow = Container.get(WorkflowRepository);
-
-	const pruningService = Container.get(PruningService);
-
-	if (await pruningService.isPruningEnabled()) pruningService.startPruning();
 }
 
 export async function migrate() {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -22,6 +22,7 @@ import { ExternalSecretsManager } from '@/ExternalSecrets/ExternalSecretsManager
 import { initExpressionEvaluator } from '@/ExpressionEvalator';
 import { generateHostInstanceId } from '../databases/utils/generators';
 import { WorkflowHistoryManager } from '@/workflows/workflowHistory/workflowHistoryManager.ee';
+import { PruningService } from '@/services/pruning.service';
 
 export abstract class BaseCommand extends Command {
 	protected logger = Container.get(Logger);
@@ -60,6 +61,12 @@ export abstract class BaseCommand extends Command {
 		await Db.migrate().catch(async (error: Error) =>
 			this.exitWithCrash('There was an error running database migrations', error),
 		);
+
+		const pruningService = Container.get(PruningService);
+
+		if (await pruningService.isPruningEnabled()) {
+			pruningService.startPruning();
+		}
 
 		const dbType = config.getEnv('database.type');
 

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -22,7 +22,6 @@ import { ExternalSecretsManager } from '@/ExternalSecrets/ExternalSecretsManager
 import { initExpressionEvaluator } from '@/ExpressionEvalator';
 import { generateHostInstanceId } from '../databases/utils/generators';
 import { WorkflowHistoryManager } from '@/workflows/workflowHistory/workflowHistoryManager.ee';
-import { PruningService } from '@/services/pruning.service';
 
 export abstract class BaseCommand extends Command {
 	protected logger = Container.get(Logger);
@@ -61,12 +60,6 @@ export abstract class BaseCommand extends Command {
 		await Db.migrate().catch(async (error: Error) =>
 			this.exitWithCrash('There was an error running database migrations', error),
 		);
-
-		const pruningService = Container.get(PruningService);
-
-		if (await pruningService.isPruningEnabled()) {
-			pruningService.startPruning();
-		}
 
 		const dbType = config.getEnv('database.type');
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -65,6 +65,8 @@ export class Start extends BaseCommand {
 
 	protected server = new Server();
 
+	private pruningService = Container.get(PruningService);
+
 	constructor(argv: string[], cmdConfig: IConfig) {
 		super(argv, cmdConfig);
 		this.setInstanceType('main');
@@ -110,9 +112,9 @@ export class Start extends BaseCommand {
 			// Note: While this saves a new license cert to DB, the previous entitlements are still kept in memory so that the shutdown process can complete
 			await Container.get(License).shutdown();
 
-			const pruningService = Container.get(PruningService);
-
-			if (await pruningService.isPruningEnabled()) await pruningService.stopPruning();
+			if (await this.pruningService.isPruningEnabled()) {
+				await this.pruningService.stopPruning();
+			}
 
 			if (config.getEnv('leaderSelection.enabled')) {
 				const { MultiMainInstancePublisher } = await import(
@@ -330,6 +332,10 @@ export class Start extends BaseCommand {
 		}
 
 		await this.server.start();
+
+		if (await this.pruningService.isPruningEnabled()) {
+			this.pruningService.startPruning();
+		}
 
 		// Start to get active workflows and run their triggers
 		await this.activeWorkflowRunner.init();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -65,7 +65,7 @@ export class Start extends BaseCommand {
 
 	protected server = new Server();
 
-	private pruningService = Container.get(PruningService);
+	private pruningService: PruningService;
 
 	constructor(argv: string[], cmdConfig: IConfig) {
 		super(argv, cmdConfig);
@@ -333,6 +333,7 @@ export class Start extends BaseCommand {
 
 		await this.server.start();
 
+		this.pruningService = Container.get(PruningService);
 		if (await this.pruningService.isPruningEnabled()) {
 			this.pruningService.startPruning();
 		}

--- a/packages/cli/src/services/pruning.service.ts
+++ b/packages/cli/src/services/pruning.service.ts
@@ -56,6 +56,9 @@ export class PruningService {
 		return true;
 	}
 
+	/**
+	 * @important Call only after DB connection is established and migrations have completed.
+	 */
 	startPruning() {
 		this.setSoftDeletionInterval();
 		this.scheduleHardDeletion();


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-986/bug-execution-pruning-timer-is-started-before-the-database-is-ready