### PR TITLE
fix: reading name of undefined on objectToError

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -76,8 +76,8 @@ export function objectToError(errorObject: unknown, workflow: Workflow): Error {
 	} else if (errorObject && typeof errorObject === 'object' && 'message' in errorObject) {
 		// If it's an object with a 'message' property, create a new Error instance.
 		let error: Error | undefined;
-		if ('node' in errorObject) {
-			const node = workflow.getNode((errorObject.node as { name: string }).name);
+		if ('node' in errorObject && typeof errorObject.node === 'object' && errorObject.node !== null && 'name' in errorObject.node && typeof errorObject.node.name === 'string') {
+			const node = workflow.getNode(errorObject.node.name);
 			if (node) {
 				error = new NodeOperationError(
 					node,


### PR DESCRIPTION
This fixes a issue I'm having on the error handling. It should not assume `.node` property will always have a `.name` string property.

```
TypeError: Cannot read properties of undefined (reading 'name')
    at objectToError (/usr/local/lib/node_modules/n8n/dist/WorkflowExecuteAdditionalData.js:61:60)
    at Object.executeWorkflow (/usr/local/lib/node_modules/n8n/dist/WorkflowExecuteAdditionalData.js:643:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /home/node/.n8n/src/MyCustomNode/MyCustomNode.node.ts:229:35
    at async Promise.all (index 2)
    at Object.execute (/home/node/.n8n/src/MyCustomNode/MyCustomNode.node.ts:212:23)
    at Workflow.runNode (/usr/local/lib/node_modules/n8n/node_modules/n8n-workflow/dist/Workflow.js:670:19)
    at /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/WorkflowExecute.js:652:53
```