### PR TITLE
ci: Improve CI performance (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -48,7 +48,8 @@ jobs:
     with:
       ref: ${{ inputs.branch }}
       nodeVersion: ${{ matrix.node-version }}
-      cacheKey:  ${{ github.sha }}-base:${{ matrix.node-version }}-test-lint
+      cacheKey: ${{ github.sha }}-base:${{ matrix.node-version }}-test-lint
+      collectCoverage: true
 
   lint:
     name: Lint changes

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm test:frontend
 
       - name: Upload coverage to Codecov
-        if: ${{ inputs.collectCoverage === 'true' }}
+        if: ${{ inputs.collectCoverage == 'true' }}
         uses: codecov/codecov-action@v3
         with:
           files: packages/@n8n/client-oauth2/coverage/cobertura-coverage.xml,packages/cli/coverage/cobertura-coverage.xml,packages/core/coverage/cobertura-coverage.xml,packages/design-system/coverage/cobertura-coverage.xml,packages/editor-ui/coverage/cobertura-coverage.xml,packages/nodes-base/coverage/cobertura-coverage.xml,packages/workflow/coverage/cobertura-coverage.xml

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -18,11 +18,17 @@ on:
         required: false
         default: ''
         type: string
+      collectCoverage:
+        required: false
+        default: 'false'
+        type: string
 
 jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
       - uses: actions/checkout@v3.5.3
         with:
@@ -58,6 +64,7 @@ jobs:
         run: pnpm test:frontend
 
       - name: Upload coverage to Codecov
+        if: ${{ inputs.collectCoverage === 'true' }}
         uses: codecov/codecov-action@v3
         with:
           files: packages/@n8n/client-oauth2/coverage/cobertura-coverage.xml,packages/cli/coverage/cobertura-coverage.xml,packages/core/coverage/cobertura-coverage.xml,packages/design-system/coverage/cobertura-coverage.xml,packages/editor-ui/coverage/cobertura-coverage.xml,packages/nodes-base/coverage/cobertura-coverage.xml,packages/workflow/coverage/cobertura-coverage.xml

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -51,8 +51,11 @@ jobs:
           path: ./packages/**/dist
           key: ${{ inputs.cacheKey }}
 
-      - name: Test
-        run: pnpm test
+      - name: Test Backend
+        run: pnpm test:backend
+
+      - name: Test Frontend
+        run: pnpm test:frontend
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,7 @@ const config = {
 		return acc;
 	}, {}),
 	setupFilesAfterEnv: ['jest-expect-message'],
-	collectCoverage: true,
+	collectCoverage: process.env.COVERAGE_ENABLED === 'true',
 	coverageReporters: [process.env.COVERAGE_REPORT === 'true' ? 'text' : 'text-summary'],
 	collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "preinstall": "node scripts/block-npm-install.js",
     "build": "turbo run build",
+    "build:backend": "pnpm --filter=!n8n-design-system --filter=!n8n-editor-ui build",
+    "build:frontend": "pnpm --filter=n8n-design-system --filter=n8n-editor-ui build",
     "typecheck": "turbo run typecheck",
     "dev": "turbo run dev --parallel",
     "clean": "turbo run clean --parallel",
@@ -23,6 +25,8 @@
     "start:tunnel": "./packages/cli/bin/n8n start --tunnel",
     "start:windows": "cd packages/cli/bin && n8n",
     "test": "turbo run test",
+    "test:backend": "pnpm --filter=!n8n-design-system --filter=!n8n-editor-ui test",
+    "test:frontend": "pnpm --filter=n8n-design-system --filter=n8n-editor-ui test",
     "watch": "turbo run watch",
     "webhook": "./packages/cli/bin/n8n webhook",
     "worker": "./packages/cli/bin/n8n worker",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf dist .turbo",
     "build": "vite build",
     "typecheck": "vue-tsc --declaration --emitDeclarationOnly",
-    "test": "vitest run --coverage",
+    "test": "vitest run",
     "test:dev": "vitest",
     "build:storybook": "storybook build",
     "storybook": "storybook dev -p 6006",

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -1,9 +1,29 @@
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import { defineConfig, mergeConfig } from 'vite';
+import { type UserConfig } from 'vitest';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 
-const { coverageReporters } = require('../../jest.config.js');
+export const vitestConfig = defineVitestConfig({
+	test: {
+		globals: true,
+		environment: 'jsdom',
+		setupFiles: ['./src/__tests__/setup.ts'],
+		coverage:
+			process.env.COVERAGE_ENABLED === 'true'
+				? {
+						provider: 'v8',
+						reporter: require('../../jest.config.js').coverageReporters,
+						all: true,
+				  }
+				: undefined,
+		css: {
+			modules: {
+				classNameStrategy: 'non-scoped',
+			},
+		},
+	},
+}) as UserConfig;
 
 export default mergeConfig(
 	defineConfig({
@@ -35,21 +55,5 @@ export default mergeConfig(
 			},
 		},
 	}),
-	defineVitestConfig({
-		test: {
-			globals: true,
-			environment: 'jsdom',
-			setupFiles: ['./src/__tests__/setup.ts'],
-			coverage: {
-				provider: 'v8',
-				reporter: coverageReporters,
-				all: true,
-			},
-			css: {
-				modules: {
-					classNameStrategy: 'non-scoped',
-				},
-			},
-		},
-	}),
+	vitestConfig,
 );

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -9,14 +9,15 @@ export const vitestConfig = defineVitestConfig({
 		globals: true,
 		environment: 'jsdom',
 		setupFiles: ['./src/__tests__/setup.ts'],
-		coverage:
-			process.env.COVERAGE_ENABLED === 'true'
-				? {
+		...(process.env.COVERAGE_ENABLED === 'true'
+			? {
+					coverage: {
 						provider: 'v8',
 						reporter: require('../../jest.config.js').coverageReporters,
 						all: true,
-				  }
-				: undefined,
+					},
+			  }
+			: {}),
 		css: {
 			modules: {
 				classNameStrategy: 'non-scoped',

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -22,7 +22,7 @@
     "lintfix": "eslint src --ext .js,.ts,.vue --fix",
     "format": "prettier --write . --ignore-path ../../.prettierignore",
     "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev",
-    "test": "vitest run --coverage",
+    "test": "vitest run",
     "test:dev": "vitest"
   },
   "dependencies": {

--- a/packages/editor-ui/vite.config.ts
+++ b/packages/editor-ui/vite.config.ts
@@ -1,12 +1,10 @@
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import { defineConfig, mergeConfig } from 'vite';
-import { defineConfig as defineVitestConfig } from 'vitest/config';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 import packageJSON from './package.json';
-
-const { coverageReporters } = require('../../jest.config.js');
+import { vitestConfig } from '../design-system/vite.config';
 
 const vendorChunks = ['vue', 'vue-router'];
 const n8nChunks = ['n8n-workflow', 'n8n-design-system'];
@@ -115,21 +113,5 @@ export default mergeConfig(
 			},
 		},
 	}),
-	defineVitestConfig({
-		test: {
-			globals: true,
-			environment: 'jsdom',
-			setupFiles: ['./src/__tests__/setup.ts'],
-			coverage: {
-				provider: 'v8',
-				reporter: coverageReporters,
-				all: true,
-			},
-			css: {
-				modules: {
-					classNameStrategy: 'non-scoped',
-				},
-			},
-		},
-	}),
+	vitestConfig,
 );


### PR DESCRIPTION
1. Split backend and frontend tests to avoid them running in parallel
2. Enable coverage only on `master`