### PR TITLE
ci: Conditionally re-enable coverage for frontend packages (no-changelog)

### DIFF
--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -12,6 +12,7 @@ export const vitestConfig = defineVitestConfig({
 		...(process.env.COVERAGE_ENABLED === 'true'
 			? {
 					coverage: {
+						enabled: true,
 						provider: 'v8',
 						reporter: require('../../jest.config.js').coverageReporters,
 						all: true,


### PR DESCRIPTION
Disabled coverage in https://github.com/n8n-io/n8n/pull/7637, but forgot to conditionally re-enable them for builds on `master`