### PR TITLE
feat(OpenAI Node): Add dall-e-3 support

### DIFF
--- a/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
@@ -62,7 +62,7 @@ const completeOperations: INodeProperties[] = [
 							{
 								type: 'filter',
 								properties: {
-									pass: "={{ $responseItem.id.startsWith('gpt-') }}",
+									pass: "={{ $responseItem.id.startsWith('gpt-') && !$responseItem.id.startsWith('gpt-4-vision') }}",
 								},
 							},
 							{

--- a/packages/nodes-base/nodes/OpenAi/ImageDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/ImageDescription.ts
@@ -66,6 +66,64 @@ const createOperations: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Model',
+		name: 'model',
+		type: 'options',
+		default: 'dall-e-2',
+		description: 'The model to use for image generation',
+		typeOptions: {
+			loadOptions: {
+				routing: {
+					request: {
+						method: 'GET',
+						url: '/v1/models',
+					},
+					output: {
+						postReceive: [
+							{
+								type: 'rootProperty',
+								properties: {
+									property: 'data',
+								},
+							},
+							{
+								type: 'filter',
+								properties: {
+									pass: "={{ $responseItem.id.startsWith('dall-') }}",
+								},
+							},
+							{
+								type: 'setKeyValue',
+								properties: {
+									name: '={{$responseItem.id}}',
+									value: '={{$responseItem.id}}',
+								},
+							},
+							{
+								type: 'sort',
+								properties: {
+									key: 'name',
+								},
+							},
+						],
+					},
+				},
+			},
+		},
+		displayOptions: {
+			show: {
+				resource: ['image'],
+				operation: ['create'],
+			},
+		},
+		routing: {
+			send: {
+				type: 'body',
+				property: 'model',
+			},
+		},
+	},
+	{
 		displayName: 'Response Format',
 		name: 'responseFormat',
 		type: 'options',
@@ -151,6 +209,33 @@ const createOperations: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Quality',
+				name: 'quality',
+				type: 'options',
+				options: [
+					{
+						name: 'HD',
+						value: 'hd',
+					},
+					{
+						name: 'Standard',
+						value: 'standard',
+					},
+				],
+				displayOptions: {
+					show: {
+						'/model': ['dall-e-3'],
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'quality',
+					},
+				},
+				default: 'standard',
+			},
+			{
 				displayName: 'Resolution',
 				name: 'size',
 				type: 'options',
@@ -168,6 +253,11 @@ const createOperations: INodeProperties[] = [
 						value: '1024x1024',
 					},
 				],
+				displayOptions: {
+					show: {
+						'/model': ['dall-e-2'],
+					},
+				},
 				routing: {
 					send: {
 						type: 'body',
@@ -175,6 +265,64 @@ const createOperations: INodeProperties[] = [
 					},
 				},
 				default: '1024x1024',
+			},
+			{
+				displayName: 'Resolution',
+				name: 'size',
+				type: 'options',
+				options: [
+					{
+						name: '1024x1024',
+						value: '1024x1024',
+					},
+					{
+						name: '1792x1024',
+						value: '1792x1024',
+					},
+					{
+						name: '1024x1792',
+						value: '1024x1792',
+					},
+				],
+				displayOptions: {
+					show: {
+						'/model': ['dall-e-3'],
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'size',
+					},
+				},
+				default: '1024x1024',
+			},
+			{
+				displayName: 'Style',
+				name: 'style',
+				type: 'options',
+				options: [
+					{
+						name: 'Natural',
+						value: 'natural',
+					},
+					{
+						name: 'Vivid',
+						value: 'vivid',
+					},
+				],
+				displayOptions: {
+					show: {
+						'/model': ['dall-e-3'],
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'style',
+					},
+				},
+				default: 'vivid',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/OpenAi/TextDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/TextDescription.ts
@@ -88,7 +88,7 @@ const completeOperations: INodeProperties[] = [
 							{
 								type: 'filter',
 								properties: {
-									pass: "={{ !$responseItem.id.startsWith('audio-') && !$responseItem.id.startsWith('gpt-') && !$responseItem.id.startsWith('whisper-') && !['cushman:2020-05-03', 'davinci-if:3.0.0', 'davinci-instruct-beta:2.0.0', 'if'].includes($responseItem.id) && !$responseItem.id.includes('-edit-') && !$responseItem.id.endsWith(':001') }}",
+									pass: "={{ !$responseItem.id.startsWith('audio-') && !$responseItem.id.startsWith('gpt-') && !$responseItem.id.startsWith('dall-') && !$responseItem.id.startsWith('tts-') && !$responseItem.id.startsWith('whisper-') && !['cushman:2020-05-03', 'davinci-if:3.0.0', 'davinci-instruct-beta:2.0.0', 'if'].includes($responseItem.id) && !$responseItem.id.includes('-edit-') && !$responseItem.id.endsWith(':001') }}",
 								},
 							},
 							{


### PR DESCRIPTION
Adds support for dall-e-3 under Image
Removes GPT 4 Vision from Chat completion for now
Cleans up Model list for text completion by removing dall-e and tts

> OpenAI currently have an API outage so this is currently not fully tested: https://status.openai.com/