### PR TITLE
ci: Auto-cancel redundant CI jobs (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: master
+  cancel-in-progress: true
+
 jobs:
   install-and-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - packages/cli/src/databases/migrations/**
 
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Install & Build

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -6,6 +6,10 @@ on:
     branch:
       - 'master'
 
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-e2e-tests:
     name: E2E [Electron/Node 18]


### PR DESCRIPTION
This should help us reduce the load on CI workers to some extend.
