### PR TITLE
ci(core): Reduce memory usage in tests (part-3) (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "@types/supertest": "^2.0.12",
     "@vitest/coverage-v8": "^0.33.0",
     "cross-env": "^7.0.3",
-    "cypress-otp": "^1.0.3",
     "cypress": "^12.17.2",
+    "cypress-otp": "^1.0.3",
     "cypress-real-events": "^1.9.1",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",
@@ -95,7 +95,8 @@
       "@sentry/cli@2.17.0": "patches/@sentry__cli@2.17.0.patch",
       "pkce-challenge@3.0.0": "patches/pkce-challenge@3.0.0.patch",
       "pyodide@0.23.4": "patches/pyodide@0.23.4.patch",
-      "@types/ws@8.5.4": "patches/@types__ws@8.5.4.patch"
+      "@types/ws@8.5.4": "patches/@types__ws@8.5.4.patch",
+      "typeorm@0.3.17": "patches/typeorm@0.3.17.patch"
     }
   }
 }

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -12,13 +12,14 @@ import * as Db from '@/Db';
 import { N8nInstanceType } from '@/Interfaces';
 import type { IExternalHooksClass } from '@/Interfaces';
 import { ExternalHooks } from '@/ExternalHooks';
-import { send, sendErrorResponse, ServiceUnavailableError } from '@/ResponseHelper';
+import { send, sendErrorResponse } from '@/ResponseHelper';
 import { rawBodyReader, bodyParser, corsMiddleware } from '@/middlewares';
 import { TestWebhooks } from '@/TestWebhooks';
 import { WaitingWebhooks } from '@/WaitingWebhooks';
 import { webhookRequestHandler } from '@/WebhookHelpers';
 import { generateHostInstanceId } from './databases/utils/generators';
 import { Logger } from '@/Logger';
+import { ServiceUnavailableError } from './ResponseErrors';
 
 export abstract class AbstractServer {
 	protected logger: Logger;

--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -40,7 +40,7 @@ import type {
 	IWorkflowExecutionDataProcess,
 	WebhookRequest,
 } from '@/Interfaces';
-import * as ResponseHelper from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import * as WebhookHelpers from '@/WebhookHelpers';
 import * as WorkflowExecuteAdditionalData from '@/WorkflowExecuteAdditionalData';
 
@@ -169,7 +169,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		const webhook = await this.webhookService.findWebhook(httpMethod, path);
 
 		if (webhook === null) {
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				webhookNotFoundErrorMessage(path, httpMethod),
 				WEBHOOK_PROD_UNREGISTERED_HINT,
 			);
@@ -195,9 +195,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		});
 
 		if (workflowData === null) {
-			throw new ResponseHelper.NotFoundError(
-				`Could not find workflow with id "${webhook.workflowId}"`,
-			);
+			throw new NotFoundError(`Could not find workflow with id "${webhook.workflowId}"`);
 		}
 
 		const workflow = new Workflow({
@@ -226,7 +224,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		const workflowStartNode = workflow.getNode(webhookData.node);
 
 		if (workflowStartNode === null) {
-			throw new ResponseHelper.NotFoundError('Could not find node to process webhook.');
+			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
 		return new Promise((resolve, reject) => {

--- a/packages/cli/src/ExternalSecrets/ExternalSecrets.controller.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecrets.controller.ee.ts
@@ -1,6 +1,6 @@
 import { Authorized, Get, Post, RestController } from '@/decorators';
 import { ExternalSecretsRequest } from '@/requests';
-import { NotFoundError } from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import { Response } from 'express';
 import { Service } from 'typedi';
 import { ProviderNotFoundError, ExternalSecretsService } from './ExternalSecrets.service.ee';

--- a/packages/cli/src/GenericHelpers.ts
+++ b/packages/cli/src/GenericHelpers.ts
@@ -11,7 +11,6 @@ import { Container } from 'typedi';
 import { Like } from 'typeorm';
 import config from '@/config';
 import type { ExecutionPayload, ICredentialsDb, IWorkflowDb } from '@/Interfaces';
-import * as ResponseHelper from '@/ResponseHelper';
 import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import type { TagEntity } from '@db/entities/TagEntity';
@@ -20,6 +19,7 @@ import type { UserUpdatePayload } from '@/requests';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { ExecutionRepository } from '@db/repositories/execution.repository';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
+import { BadRequestError } from '@/ResponseErrors';
 
 /**
  * Returns the base URL n8n is reachable from
@@ -109,7 +109,7 @@ export async function validateEntity(
 		.join(' | ');
 
 	if (errorMessages) {
-		throw new ResponseHelper.BadRequestError(errorMessages);
+		throw new BadRequestError(errorMessages);
 	}
 }
 

--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -29,7 +29,7 @@ import {
 	isLdapCurrentAuthenticationMethod,
 	setCurrentAuthenticationMethod,
 } from '@/sso/ssoHelpers';
-import { BadRequestError, InternalServerError } from '../ResponseHelper';
+import { BadRequestError, InternalServerError } from '@/ResponseErrors';
 import { RoleService } from '@/services/role.service';
 import { Logger } from '@/Logger';
 import { UserRepository } from '@db/repositories/user.repository';

--- a/packages/cli/src/ResponseErrors.ts
+++ b/packages/cli/src/ResponseErrors.ts
@@ -1,0 +1,69 @@
+/**
+ * Special Error which allows to return also an error code and http status code
+ */
+export abstract class ResponseError extends Error {
+	/**
+	 * Creates an instance of ResponseError.
+	 * Must be used inside a block with `ResponseHelper.send()`.
+	 */
+	constructor(
+		message: string,
+		// The HTTP status code of  response
+		readonly httpStatusCode: number,
+		// The error code in the response
+		readonly errorCode: number = httpStatusCode,
+		// The error hint the response
+		readonly hint: string | undefined = undefined,
+	) {
+		super(message);
+		this.name = 'ResponseError';
+	}
+}
+
+export class BadRequestError extends ResponseError {
+	constructor(message: string, errorCode?: number) {
+		super(message, 400, errorCode);
+	}
+}
+
+export class AuthError extends ResponseError {
+	constructor(message: string, errorCode?: number) {
+		super(message, 401, errorCode);
+	}
+}
+
+export class UnauthorizedError extends ResponseError {
+	constructor(message: string, hint: string | undefined = undefined) {
+		super(message, 403, 403, hint);
+	}
+}
+
+export class NotFoundError extends ResponseError {
+	constructor(message: string, hint: string | undefined = undefined) {
+		super(message, 404, 404, hint);
+	}
+}
+
+export class ConflictError extends ResponseError {
+	constructor(message: string, hint: string | undefined = undefined) {
+		super(message, 409, 409, hint);
+	}
+}
+
+export class UnprocessableRequestError extends ResponseError {
+	constructor(message: string, hint: string | undefined = undefined) {
+		super(message, 422, 422, hint);
+	}
+}
+
+export class InternalServerError extends ResponseError {
+	constructor(message: string, errorCode = 500) {
+		super(message, 500, errorCode);
+	}
+}
+
+export class ServiceUnavailableError extends ResponseError {
+	constructor(message: string, errorCode = 503) {
+		super(message, 503, errorCode);
+	}
+}

--- a/packages/cli/src/ResponseHelper.ts
+++ b/packages/cli/src/ResponseHelper.ts
@@ -12,76 +12,7 @@ import type {
 	IWorkflowDb,
 } from '@/Interfaces';
 import { inDevelopment } from '@/constants';
-
-/**
- * Special Error which allows to return also an error code and http status code
- */
-abstract class ResponseError extends Error {
-	/**
-	 * Creates an instance of ResponseError.
-	 * Must be used inside a block with `ResponseHelper.send()`.
-	 */
-	constructor(
-		message: string,
-		// The HTTP status code of  response
-		readonly httpStatusCode: number,
-		// The error code in the response
-		readonly errorCode: number = httpStatusCode,
-		// The error hint the response
-		readonly hint: string | undefined = undefined,
-	) {
-		super(message);
-		this.name = 'ResponseError';
-	}
-}
-
-export class BadRequestError extends ResponseError {
-	constructor(message: string, errorCode?: number) {
-		super(message, 400, errorCode);
-	}
-}
-
-export class AuthError extends ResponseError {
-	constructor(message: string, errorCode?: number) {
-		super(message, 401, errorCode);
-	}
-}
-
-export class UnauthorizedError extends ResponseError {
-	constructor(message: string, hint: string | undefined = undefined) {
-		super(message, 403, 403, hint);
-	}
-}
-
-export class NotFoundError extends ResponseError {
-	constructor(message: string, hint: string | undefined = undefined) {
-		super(message, 404, 404, hint);
-	}
-}
-
-export class ConflictError extends ResponseError {
-	constructor(message: string, hint: string | undefined = undefined) {
-		super(message, 409, 409, hint);
-	}
-}
-
-export class UnprocessableRequestError extends ResponseError {
-	constructor(message: string, hint: string | undefined = undefined) {
-		super(message, 422, 422, hint);
-	}
-}
-
-export class InternalServerError extends ResponseError {
-	constructor(message: string, errorCode = 500) {
-		super(message, 500, errorCode);
-	}
-}
-
-export class ServiceUnavailableError extends ResponseError {
-	constructor(message: string, errorCode = 503) {
-		super(message, 503, errorCode);
-	}
-}
+import { ResponseError } from './ResponseErrors';
 
 export function sendSuccessResponse(
 	res: Response,

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -134,6 +134,7 @@ import { RoleService } from './services/role.service';
 import { UserService } from './services/user.service';
 import { OrchestrationController } from './controllers/orchestration.controller';
 import { WorkflowHistoryController } from './workflows/workflowHistory/workflowHistory.controller.ee';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 
 const exec = promisify(callbackExec);
 
@@ -517,9 +518,7 @@ export class Server extends AbstractServer {
 					const { path, methodName } = req.query;
 
 					if (!req.query.currentNodeParameters) {
-						throw new ResponseHelper.BadRequestError(
-							'Parameter currentNodeParameters is required.',
-						);
+						throw new BadRequestError('Parameter currentNodeParameters is required.');
 					}
 
 					const currentNodeParameters = jsonParse(
@@ -554,7 +553,7 @@ export class Server extends AbstractServer {
 						);
 					}
 
-					throw new ResponseHelper.BadRequestError('Parameter methodName is required.');
+					throw new BadRequestError('Parameter methodName is required.');
 				},
 			),
 		);
@@ -573,9 +572,7 @@ export class Server extends AbstractServer {
 					const { path, methodName } = req.query;
 
 					if (!req.query.currentNodeParameters) {
-						throw new ResponseHelper.BadRequestError(
-							'Parameter currentNodeParameters is required.',
-						);
+						throw new BadRequestError('Parameter currentNodeParameters is required.');
 					}
 
 					const currentNodeParameters = jsonParse(
@@ -644,9 +641,7 @@ export class Server extends AbstractServer {
 						userId: req.user.id,
 					});
 
-					throw new ResponseHelper.BadRequestError(
-						`Workflow with ID "${workflowId}" could not be found.`,
-					);
+					throw new BadRequestError(`Workflow with ID "${workflowId}" could not be found.`);
 				}
 
 				return this.activeWorkflowRunner.getActivationError(workflowId);
@@ -669,7 +664,7 @@ export class Server extends AbstractServer {
 						const parameters = toHttpNodeParameters(curlCommand);
 						return ResponseHelper.flattenObject(parameters, 'parameters');
 					} catch (e) {
-						throw new ResponseHelper.BadRequestError('Invalid cURL command');
+						throw new BadRequestError('Invalid cURL command');
 					}
 				},
 			),
@@ -802,7 +797,7 @@ export class Server extends AbstractServer {
 				const sharedWorkflowIds = await getSharedWorkflowIds(req.user);
 
 				if (!sharedWorkflowIds.length) {
-					throw new ResponseHelper.NotFoundError('Execution not found');
+					throw new NotFoundError('Execution not found');
 				}
 
 				const fullExecutionData = await Container.get(ExecutionRepository).findSingleExecution(
@@ -815,7 +810,7 @@ export class Server extends AbstractServer {
 				);
 
 				if (!fullExecutionData) {
-					throw new ResponseHelper.NotFoundError('Execution not found');
+					throw new NotFoundError('Execution not found');
 				}
 
 				if (config.getEnv('executions.mode') === 'queue') {

--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -18,7 +18,7 @@ import type {
 	WebhookRequest,
 } from '@/Interfaces';
 import { Push } from '@/push';
-import * as ResponseHelper from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import * as WebhookHelpers from '@/WebhookHelpers';
 import { webhookNotFoundErrorMessage } from './utils';
 
@@ -77,7 +77,7 @@ export class TestWebhooks implements IWebhookManager {
 			if (webhookData === undefined) {
 				// The requested webhook is not registered
 				const methods = await this.getWebhookMethods(path);
-				throw new ResponseHelper.NotFoundError(
+				throw new NotFoundError(
 					webhookNotFoundErrorMessage(path, httpMethod, methods),
 					WEBHOOK_TEST_UNREGISTERED_HINT,
 				);
@@ -105,7 +105,7 @@ export class TestWebhooks implements IWebhookManager {
 		if (testWebhookData[webhookKey] === undefined) {
 			// The requested webhook is not registered
 			const methods = await this.getWebhookMethods(path);
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				webhookNotFoundErrorMessage(path, httpMethod, methods),
 				WEBHOOK_TEST_UNREGISTERED_HINT,
 			);
@@ -118,7 +118,7 @@ export class TestWebhooks implements IWebhookManager {
 		// get additional data
 		const workflowStartNode = workflow.getNode(webhookData.node);
 		if (workflowStartNode === null) {
-			throw new ResponseHelper.NotFoundError('Could not find node to process webhook.');
+			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
 		return new Promise(async (resolve, reject) => {
@@ -168,10 +168,7 @@ export class TestWebhooks implements IWebhookManager {
 		const webhookMethods = this.activeWebhooks.getWebhookMethods(path);
 		if (!webhookMethods.length) {
 			// The requested webhook is not registered
-			throw new ResponseHelper.NotFoundError(
-				webhookNotFoundErrorMessage(path),
-				WEBHOOK_TEST_UNREGISTERED_HINT,
-			);
+			throw new NotFoundError(webhookNotFoundErrorMessage(path), WEBHOOK_TEST_UNREGISTERED_HINT);
 		}
 
 		return webhookMethods;

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -2,7 +2,7 @@ import { In } from 'typeorm';
 import { compare, genSaltSync, hash } from 'bcryptjs';
 import { Container } from 'typedi';
 
-import * as ResponseHelper from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { WhereClause } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '@db/entities/User';
@@ -43,7 +43,7 @@ export function generateUserInviteUrl(inviterId: string, inviteeId: string): str
 // TODO: Enforce at model level
 export function validatePassword(password?: string): string {
 	if (!password) {
-		throw new ResponseHelper.BadRequestError('Password is mandatory');
+		throw new BadRequestError('Password is mandatory');
 	}
 
 	const hasInvalidLength =
@@ -70,7 +70,7 @@ export function validatePassword(password?: string): string {
 			message.push('Password must contain at least 1 uppercase letter.');
 		}
 
-		throw new ResponseHelper.BadRequestError(message.join(' '));
+		throw new BadRequestError(message.join(' '));
 	}
 
 	return password;

--- a/packages/cli/src/WaitingWebhooks.ts
+++ b/packages/cli/src/WaitingWebhooks.ts
@@ -2,7 +2,7 @@ import { NodeHelpers, Workflow } from 'n8n-workflow';
 import { Service } from 'typedi';
 import type express from 'express';
 
-import * as ResponseHelper from '@/ResponseHelper';
+import { ConflictError, NotFoundError } from '@/ResponseErrors';
 import * as WebhookHelpers from '@/WebhookHelpers';
 import { NodeTypes } from '@/NodeTypes';
 import type {
@@ -43,11 +43,11 @@ export class WaitingWebhooks implements IWebhookManager {
 		});
 
 		if (!execution) {
-			throw new ResponseHelper.NotFoundError(`The execution "${executionId} does not exist.`);
+			throw new NotFoundError(`The execution "${executionId} does not exist.`);
 		}
 
 		if (execution.finished || execution.data.resultData.error) {
-			throw new ResponseHelper.ConflictError(`The execution "${executionId} has finished already.`);
+			throw new ConflictError(`The execution "${executionId} has finished already.`);
 		}
 
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
@@ -79,12 +79,12 @@ export class WaitingWebhooks implements IWebhookManager {
 		try {
 			workflowOwner = await this.ownershipService.getWorkflowOwnerCached(workflowData.id!);
 		} catch (error) {
-			throw new ResponseHelper.NotFoundError('Could not find workflow');
+			throw new NotFoundError('Could not find workflow');
 		}
 
 		const workflowStartNode = workflow.getNode(lastNodeExecuted);
 		if (workflowStartNode === null) {
-			throw new ResponseHelper.NotFoundError('Could not find node to process webhook.');
+			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(workflowOwner.id);
@@ -103,7 +103,7 @@ export class WaitingWebhooks implements IWebhookManager {
 			// If no data got found it means that the execution can not be started via a webhook.
 			// Return 404 because we do not want to give any data if the execution exists or not.
 			const errorMessage = `The workflow for execution "${executionId}" does not contain a waiting webhook with a matching path/method.`;
-			throw new ResponseHelper.NotFoundError(errorMessage);
+			throw new NotFoundError(errorMessage);
 		}
 
 		const runExecutionData = execution.data;

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -52,6 +52,7 @@ import type {
 } from '@/Interfaces';
 import * as GenericHelpers from '@/GenericHelpers';
 import * as ResponseHelper from '@/ResponseHelper';
+import { InternalServerError, NotFoundError, UnprocessableRequestError } from '@/ResponseErrors';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
 import { WorkflowRunner } from '@/WorkflowRunner';
 import * as WorkflowExecuteAdditionalData from '@/WorkflowExecuteAdditionalData';
@@ -216,7 +217,7 @@ export async function executeWebhook(
 	if (nodeType === undefined) {
 		const errorMessage = `The type of the webhook node "${workflowStartNode.name}" is not known`;
 		responseCallback(new Error(errorMessage), {});
-		throw new ResponseHelper.InternalServerError(errorMessage);
+		throw new InternalServerError(errorMessage);
 	}
 
 	const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
@@ -233,7 +234,7 @@ export async function executeWebhook(
 		try {
 			user = await Container.get(OwnershipService).getWorkflowOwnerCached(workflowData.id);
 		} catch (error) {
-			throw new ResponseHelper.NotFoundError('Cannot find workflow');
+			throw new NotFoundError('Cannot find workflow');
 		}
 	}
 
@@ -273,7 +274,7 @@ export async function executeWebhook(
 		// that something does not resolve properly.
 		const errorMessage = `The response mode '${responseMode}' is not valid!`;
 		responseCallback(new Error(errorMessage), {});
-		throw new ResponseHelper.InternalServerError(errorMessage);
+		throw new InternalServerError(errorMessage);
 	}
 
 	// Add the Response and Request so that this data can be accessed in the node
@@ -760,13 +761,13 @@ export async function executeWebhook(
 						responseCallback(new Error('There was a problem executing the workflow'), {});
 					}
 
-					throw new ResponseHelper.InternalServerError(e.message);
+					throw new InternalServerError(e.message);
 				});
 		}
 		return executionId;
 	} catch (e) {
 		const error =
-			e instanceof ResponseHelper.UnprocessableRequestError
+			e instanceof UnprocessableRequestError
 				? e
 				: new Error('There was a problem executing the workflow', { cause: e });
 		if (didSendResponse) throw error;

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -5,10 +5,10 @@ import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import type { JwtPayload, JwtToken } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import config from '@/config';
-import * as ResponseHelper from '@/ResponseHelper';
 import { License } from '@/License';
 import { Container } from 'typedi';
 import { UserRepository } from '@db/repositories/user.repository';
+import { AuthError, UnauthorizedError } from '@/ResponseErrors';
 
 export function issueJWT(user: User): JwtToken {
 	const { id, email, password } = user;
@@ -26,7 +26,7 @@ export function issueJWT(user: User): JwtToken {
 		!user.isOwner &&
 		!isWithinUsersLimit
 	) {
-		throw new ResponseHelper.UnauthorizedError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED);
+		throw new UnauthorizedError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED);
 	}
 	if (password) {
 		payload.password = createHash('sha256')
@@ -63,7 +63,7 @@ export async function resolveJwtContent(jwtPayload: JwtPayload): Promise<User> {
 	// currently only LDAP users during synchronization
 	// can be set to disabled
 	if (user?.disabled) {
-		throw new ResponseHelper.AuthError('Unauthorized');
+		throw new AuthError('Unauthorized');
 	}
 
 	if (!user || jwtPayload.password !== passwordHash || user.email !== jwtPayload.email) {

--- a/packages/cli/src/auth/methods/email.ts
+++ b/packages/cli/src/auth/methods/email.ts
@@ -1,10 +1,10 @@
 import type { User } from '@db/entities/User';
 import { compareHash } from '@/UserManagement/UserManagementHelper';
-import * as ResponseHelper from '@/ResponseHelper';
 import { Container } from 'typedi';
 import { InternalHooks } from '@/InternalHooks';
 import { isLdapLoginEnabled } from '@/Ldap/helpers';
 import { UserRepository } from '@db/repositories/user.repository';
+import { AuthError } from '@/ResponseErrors';
 
 export const handleEmailLogin = async (
 	email: string,
@@ -27,7 +27,7 @@ export const handleEmailLogin = async (
 			user_id: user.id,
 		});
 
-		throw new ResponseHelper.AuthError('Reset your password to gain access to the instance.');
+		throw new AuthError('Reset your password to gain access to the instance.');
 	}
 
 	return undefined;

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -40,6 +40,7 @@ import { IConfig } from '@oclif/config';
 import { OrchestrationHandlerWorkerService } from '@/services/orchestration/worker/orchestration.handler.worker.service';
 import { OrchestrationWorkerService } from '@/services/orchestration/worker/orchestration.worker.service';
 import type { WorkerJobStatusSummary } from '../services/orchestration/worker/types';
+import { ServiceUnavailableError } from '@/ResponseErrors';
 
 export class Worker extends BaseCommand {
 	static description = '\nStarts a n8n worker';
@@ -413,7 +414,7 @@ export class Worker extends BaseCommand {
 					await connection.query('SELECT 1');
 				} catch (e) {
 					this.logger.error('No Database connection!', e as Error);
-					const error = new ResponseHelper.ServiceUnavailableError('No Database connection!');
+					const error = new ServiceUnavailableError('No Database connection!');
 					return ResponseHelper.sendErrorResponse(res, error);
 				}
 
@@ -424,7 +425,7 @@ export class Worker extends BaseCommand {
 					await Worker.jobQueue.ping();
 				} catch (e) {
 					this.logger.error('No Redis connection!', e as Error);
-					const error = new ResponseHelper.ServiceUnavailableError('No Redis connection!');
+					const error = new ServiceUnavailableError('No Redis connection!');
 					return ResponseHelper.sendErrorResponse(res, error);
 				}
 

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -7,7 +7,7 @@ import {
 	BadRequestError,
 	InternalServerError,
 	UnauthorizedError,
-} from '@/ResponseHelper';
+} from '@/ResponseErrors';
 import { issueCookie, resolveJwt } from '@/auth/jwt';
 import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { Request, Response } from 'express';

--- a/packages/cli/src/controllers/communityPackages.controller.ts
+++ b/packages/cli/src/controllers/communityPackages.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@/constants';
 import { Authorized, Delete, Get, Middleware, Patch, Post, RestController } from '@/decorators';
 import { NodeRequest } from '@/requests';
-import { BadRequestError, InternalServerError } from '@/ResponseHelper';
+import { BadRequestError, InternalServerError } from '@/ResponseErrors';
 import type { InstalledPackages } from '@db/entities/InstalledPackages';
 import type { CommunityPackages } from '@/Interfaces';
 import { InternalHooks } from '@/InternalHooks';

--- a/packages/cli/src/controllers/ldap.controller.ts
+++ b/packages/cli/src/controllers/ldap.controller.ts
@@ -4,7 +4,7 @@ import { getLdapConfig, getLdapSynchronizations, updateLdapConfig } from '@/Ldap
 import { LdapService } from '@/Ldap/LdapService.ee';
 import { LdapSync } from '@/Ldap/LdapSync.ee';
 import { LdapConfiguration } from '@/Ldap/types';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import { NON_SENSIBLE_LDAP_CONFIG_PROPERTIES } from '@/Ldap/constants';
 import { InternalHooks } from '@/InternalHooks';
 

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -5,7 +5,7 @@ import { Service } from 'typedi';
 import { randomBytes } from 'crypto';
 import { Authorized, Delete, Get, Patch, Post, RestController } from '@/decorators';
 import { compareHash, hashPassword, validatePassword } from '@/UserManagement/UserManagementHelper';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import { validateEntity } from '@/GenericHelpers';
 import { issueCookie } from '@/auth/jwt';
 import type { User } from '@db/entities/User';

--- a/packages/cli/src/controllers/mfa.controller.ts
+++ b/packages/cli/src/controllers/mfa.controller.ts
@@ -1,7 +1,7 @@
 import { Service } from 'typedi';
 import { Authorized, Delete, Get, Post, RestController } from '@/decorators';
 import { AuthenticatedRequest, MFA } from '@/requests';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import { MfaService } from '@/Mfa/mfa.service';
 
 @Service()

--- a/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
+++ b/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
@@ -9,7 +9,7 @@ import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.
 import type { ICredentialsDb } from '@/Interfaces';
 import { getInstanceBaseUrl } from '@/UserManagement/UserManagementHelper';
 import type { OAuthRequest } from '@/requests';
-import { BadRequestError, NotFoundError } from '@/ResponseHelper';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { CredentialsHelper } from '@/CredentialsHelper';
 import * as WorkflowExecuteAdditionalData from '@/WorkflowExecuteAdditionalData';

--- a/packages/cli/src/controllers/oauth/oAuth1Credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oAuth1Credential.controller.ts
@@ -8,7 +8,8 @@ import { createHmac } from 'crypto';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { Authorized, Get, RestController } from '@/decorators';
 import { OAuthRequest } from '@/requests';
-import { NotFoundError, sendErrorResponse, ServiceUnavailableError } from '@/ResponseHelper';
+import { NotFoundError, ServiceUnavailableError } from '@/ResponseErrors';
+import { sendErrorResponse } from '@/ResponseHelper';
 import { AbstractOAuthController } from './abstractOAuth.controller';
 
 interface OAuth1CredentialData {

--- a/packages/cli/src/controllers/owner.controller.ts
+++ b/packages/cli/src/controllers/owner.controller.ts
@@ -1,7 +1,7 @@
 import validator from 'validator';
 import { validateEntity } from '@/GenericHelpers';
 import { Authorized, Post, RestController } from '@/decorators';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import { hashPassword, validatePassword } from '@/UserManagement/UserManagementHelper';
 import { issueCookie } from '@/auth/jwt';
 import { Response } from 'express';

--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -11,7 +11,7 @@ import {
 	NotFoundError,
 	UnauthorizedError,
 	UnprocessableRequestError,
-} from '@/ResponseHelper';
+} from '@/ResponseErrors';
 import {
 	getInstanceBaseUrl,
 	hashPassword,

--- a/packages/cli/src/controllers/tags.controller.ts
+++ b/packages/cli/src/controllers/tags.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import config from '@/config';
 import { Authorized, Delete, Get, Middleware, Patch, Post, RestController } from '@/decorators';
 import { TagService } from '@/services/tag.service';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import { TagsRequest } from '@/requests';
 import { Service } from 'typedi';
 

--- a/packages/cli/src/controllers/translation.controller.ts
+++ b/packages/cli/src/controllers/translation.controller.ts
@@ -3,7 +3,7 @@ import { ICredentialTypes } from 'n8n-workflow';
 import { join } from 'path';
 import { access } from 'fs/promises';
 import { Authorized, Get, RestController } from '@/decorators';
-import { BadRequestError, InternalServerError } from '@/ResponseHelper';
+import { BadRequestError, InternalServerError } from '@/ResponseErrors';
 import { Config } from '@/config';
 import { NODES_BASE_DIR } from '@/constants';
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -18,7 +18,7 @@ import {
 	InternalServerError,
 	NotFoundError,
 	UnauthorizedError,
-} from '@/ResponseHelper';
+} from '@/ResponseErrors';
 import { Response } from 'express';
 import { ListQuery, UserRequest, UserSettingsUpdatePayload } from '@/requests';
 import { UserManagementMailer } from '@/UserManagement/email';

--- a/packages/cli/src/controllers/workflowStatistics.controller.ts
+++ b/packages/cli/src/controllers/workflowStatistics.controller.ts
@@ -7,7 +7,7 @@ import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.reposi
 import { WorkflowStatisticsRepository } from '@db/repositories/workflowStatistics.repository';
 import { ExecutionRequest } from '@/requests';
 import { whereClause } from '@/UserManagement/UserManagementHelper';
-import { NotFoundError } from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import type { IWorkflowStatisticsDataLoaded } from '@/Interfaces';
 import { Logger } from '@/Logger';
 

--- a/packages/cli/src/credentials/credentials.controller.ee.ts
+++ b/packages/cli/src/credentials/credentials.controller.ee.ts
@@ -3,6 +3,7 @@ import type { INodeCredentialTestResult } from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
 import * as Db from '@/Db';
 import * as ResponseHelper from '@/ResponseHelper';
+import { BadRequestError, NotFoundError, UnauthorizedError } from '@/ResponseErrors';
 
 import type { CredentialRequest } from '@/requests';
 import { isSharingEnabled, rightDiff } from '@/UserManagement/UserManagementHelper';
@@ -40,7 +41,7 @@ EECredentialsController.get(
 		)) as CredentialsEntity;
 
 		if (!credential) {
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				'Could not load the credential. If you think this is an error, ask the owner to share it with you again',
 			);
 		}
@@ -48,7 +49,7 @@ EECredentialsController.get(
 		const userSharing = credential.shared?.find((shared) => shared.user.id === req.user.id);
 
 		if (!userSharing && req.user.globalRole.name !== 'owner') {
-			throw new ResponseHelper.UnauthorizedError('Forbidden.');
+			throw new UnauthorizedError('Forbidden.');
 		}
 
 		credential = Container.get(OwnershipService).addOwnedByAndSharedWith(credential);
@@ -82,7 +83,7 @@ EECredentialsController.post(
 		const sharing = await EECredentials.getSharing(req.user, credentialId);
 		if (!ownsCredential) {
 			if (!sharing) {
-				throw new ResponseHelper.UnauthorizedError('Forbidden');
+				throw new UnauthorizedError('Forbidden');
 			}
 
 			const decryptedData = EECredentials.decrypt(sharing.credentials);
@@ -115,12 +116,12 @@ EECredentialsController.put(
 			!Array.isArray(shareWithIds) ||
 			!shareWithIds.every((userId) => typeof userId === 'string')
 		) {
-			throw new ResponseHelper.BadRequestError('Bad request');
+			throw new BadRequestError('Bad request');
 		}
 
 		const { ownsCredential, credential } = await EECredentials.isOwned(req.user, credentialId);
 		if (!ownsCredential || !credential) {
-			throw new ResponseHelper.UnauthorizedError('Forbidden');
+			throw new UnauthorizedError('Forbidden');
 		}
 
 		let amountRemoved: number | null = null;

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -4,6 +4,7 @@ import { deepCopy } from 'n8n-workflow';
 
 import * as GenericHelpers from '@/GenericHelpers';
 import * as ResponseHelper from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import config from '@/config';
 import { EECredentialsController } from './credentials.controller.ee';
 import { CredentialsService } from './credentials.service';
@@ -60,9 +61,7 @@ credentialsController.get(
 		const sharing = await CredentialsService.getSharing(req.user, credentialId, ['credentials']);
 
 		if (!sharing) {
-			throw new ResponseHelper.NotFoundError(
-				`Credential with ID "${credentialId}" could not be found.`,
-			);
+			throw new NotFoundError(`Credential with ID "${credentialId}" could not be found.`);
 		}
 
 		const { credentials: credential } = sharing;
@@ -145,7 +144,7 @@ credentialsController.patch(
 					userId: req.user.id,
 				},
 			);
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				'Credential to be updated not found. You can only update credentials owned by you',
 			);
 		}
@@ -165,9 +164,7 @@ credentialsController.patch(
 		const responseData = await CredentialsService.update(credentialId, newCredentialData);
 
 		if (responseData === null) {
-			throw new ResponseHelper.NotFoundError(
-				`Credential ID "${credentialId}" could not be found to be updated.`,
-			);
+			throw new NotFoundError(`Credential ID "${credentialId}" could not be found to be updated.`);
 		}
 
 		// Remove the encrypted data as it is not needed in the frontend
@@ -197,7 +194,7 @@ credentialsController.delete(
 					userId: req.user.id,
 				},
 			);
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				'Credential to be deleted not found. You can only removed credentials owned by you',
 			);
 		}

--- a/packages/cli/src/environments/sourceControl/sourceControl.controller.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControl.controller.ee.ts
@@ -12,9 +12,9 @@ import { SourceControlPreferencesService } from './sourceControlPreferences.serv
 import type { SourceControlPreferences } from './types/sourceControlPreferences';
 import type { SourceControlledFile } from './types/sourceControlledFile';
 import { SOURCE_CONTROL_API_ROOT, SOURCE_CONTROL_DEFAULT_BRANCH } from './constants';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { ImportResult } from './types/importResult';
-import { InternalHooks } from '../../InternalHooks';
+import { InternalHooks } from '@/InternalHooks';
 import { getRepoType } from './sourceControlHelper.ee';
 import { SourceControlGetStatus } from './types/sourceControlGetStatus';
 

--- a/packages/cli/src/environments/sourceControl/sourceControl.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControl.service.ee.ts
@@ -17,7 +17,7 @@ import {
 import { SourceControlGitService } from './sourceControlGit.service.ee';
 import type { PushResult } from 'simple-git';
 import { SourceControlExportService } from './sourceControlExport.service.ee';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { ImportResult } from './types/importResult';
 import type { SourceControlPushWorkFolder } from './types/sourceControlPushWorkFolder';
 import type { SourceControllPullOptions } from './types/sourceControlPullWorkFolder';

--- a/packages/cli/src/environments/variables/variables.controller.ee.ts
+++ b/packages/cli/src/environments/variables/variables.controller.ee.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { Container } from 'typedi';
 
 import * as ResponseHelper from '@/ResponseHelper';
+import { AuthError, BadRequestError } from '@/ResponseErrors';
 import type { VariablesRequest } from '@/requests';
 import {
 	VariablesLicenseError,
@@ -32,7 +33,7 @@ EEVariablesController.post(
 					userId: req.user.id,
 				},
 			);
-			throw new ResponseHelper.AuthError('Unauthorized');
+			throw new AuthError('Unauthorized');
 		}
 		const variable = req.body;
 		delete variable.id;
@@ -40,9 +41,9 @@ EEVariablesController.post(
 			return await Container.get(EEVariablesService).create(variable);
 		} catch (error) {
 			if (error instanceof VariablesLicenseError) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			} else if (error instanceof VariablesValidationError) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			}
 			throw error;
 		}
@@ -61,7 +62,7 @@ EEVariablesController.patch(
 					userId: req.user.id,
 				},
 			);
-			throw new ResponseHelper.AuthError('Unauthorized');
+			throw new AuthError('Unauthorized');
 		}
 		const variable = req.body;
 		delete variable.id;
@@ -69,9 +70,9 @@ EEVariablesController.patch(
 			return await Container.get(EEVariablesService).update(id, variable);
 		} catch (error) {
 			if (error instanceof VariablesLicenseError) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			} else if (error instanceof VariablesValidationError) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			}
 			throw error;
 		}

--- a/packages/cli/src/environments/variables/variables.controller.ts
+++ b/packages/cli/src/environments/variables/variables.controller.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { Container } from 'typedi';
 
 import * as ResponseHelper from '@/ResponseHelper';
+import { AuthError, BadRequestError, NotFoundError } from '@/ResponseErrors';
 import type { VariablesRequest } from '@/requests';
 import { VariablesService } from './variables.service';
 import { EEVariablesController } from './variables.controller.ee';
@@ -22,7 +23,7 @@ variablesController.get(
 variablesController.post(
 	'/',
 	ResponseHelper.send(async () => {
-		throw new ResponseHelper.BadRequestError('No variables license found');
+		throw new BadRequestError('No variables license found');
 	}),
 );
 
@@ -32,7 +33,7 @@ variablesController.get(
 		const id = req.params.id;
 		const variable = await Container.get(VariablesService).getCached(id);
 		if (variable === null) {
-			throw new ResponseHelper.NotFoundError(`Variable with id ${req.params.id} not found`);
+			throw new NotFoundError(`Variable with id ${req.params.id} not found`);
 		}
 		return variable;
 	}),
@@ -41,7 +42,7 @@ variablesController.get(
 variablesController.patch(
 	'/:id(\\w+)',
 	ResponseHelper.send(async () => {
-		throw new ResponseHelper.BadRequestError('No variables license found');
+		throw new BadRequestError('No variables license found');
 	}),
 );
 
@@ -57,7 +58,7 @@ variablesController.delete(
 					userId: req.user.id,
 				},
 			);
-			throw new ResponseHelper.AuthError('Unauthorized');
+			throw new AuthError('Unauthorized');
 		}
 		await Container.get(VariablesService).delete(id);
 

--- a/packages/cli/src/eventbus/eventBus.controller.ee.ts
+++ b/packages/cli/src/eventbus/eventBus.controller.ee.ts
@@ -9,7 +9,7 @@ import {
 	MessageEventBusDestinationSyslog,
 } from './MessageEventBusDestination/MessageEventBusDestinationSyslog.ee';
 import { MessageEventBusDestinationWebhook } from './MessageEventBusDestination/MessageEventBusDestinationWebhook.ee';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type {
 	MessageEventBusDestinationWebhookOptions,
 	MessageEventBusDestinationOptions,

--- a/packages/cli/src/eventbus/eventBus.controller.ts
+++ b/packages/cli/src/eventbus/eventBus.controller.ts
@@ -9,7 +9,7 @@ import type { EventMessageTypes, FailedEventSummary } from './EventMessageClasse
 import { eventNamesAll } from './EventMessageClasses';
 import type { EventMessageAuditOptions } from './EventMessageClasses/EventMessageAudit';
 import { EventMessageAudit } from './EventMessageClasses/EventMessageAudit';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { IRunExecutionData } from 'n8n-workflow';
 import { EventMessageTypeNames } from 'n8n-workflow';
 import type { EventMessageNodeOptions } from './EventMessageClasses/EventMessageNode';

--- a/packages/cli/src/executions/executions.service.ts
+++ b/packages/cli/src/executions/executions.service.ts
@@ -15,7 +15,7 @@ import type {
 import { NodeTypes } from '@/NodeTypes';
 import { Queue } from '@/Queue';
 import type { ExecutionRequest } from '@/requests';
-import * as ResponseHelper from '@/ResponseHelper';
+import { InternalServerError, NotFoundError } from '@/ResponseErrors';
 import { getSharedWorkflowIds } from '@/WorkflowHelpers';
 import { WorkflowRunner } from '@/WorkflowRunner';
 import * as GenericHelpers from '@/GenericHelpers';
@@ -114,9 +114,7 @@ export class ExecutionsService {
 					userId: req.user.id,
 					filter: req.query.filter,
 				});
-				throw new ResponseHelper.InternalServerError(
-					'Parameter "filter" contained invalid JSON string.',
-				);
+				throw new InternalServerError('Parameter "filter" contained invalid JSON string.');
 			}
 		}
 
@@ -231,9 +229,7 @@ export class ExecutionsService {
 					executionId,
 				},
 			);
-			throw new ResponseHelper.NotFoundError(
-				`The execution with the ID "${executionId}" does not exist.`,
-			);
+			throw new NotFoundError(`The execution with the ID "${executionId}" does not exist.`);
 		}
 
 		if (execution.finished) {
@@ -351,9 +347,7 @@ export class ExecutionsService {
 					requestFilters = requestFiltersRaw as IGetExecutionsQueryFilter;
 				}
 			} catch (error) {
-				throw new ResponseHelper.InternalServerError(
-					'Parameter "filter" contained invalid JSON string.',
-				);
+				throw new InternalServerError('Parameter "filter" contained invalid JSON string.');
 			}
 		}
 

--- a/packages/cli/src/license/license.controller.ts
+++ b/packages/cli/src/license/license.controller.ts
@@ -3,6 +3,7 @@ import { Container } from 'typedi';
 
 import { Logger } from '@/Logger';
 import * as ResponseHelper from '@/ResponseHelper';
+import { BadRequestError, UnauthorizedError } from '@/ResponseErrors';
 import type { ILicensePostResponse, ILicenseReadResponse } from '@/Interfaces';
 import { LicenseService } from './License.service';
 import { License } from '@/License';
@@ -24,9 +25,7 @@ licenseController.use((req: AuthenticatedRequest, res, next) => {
 			});
 			ResponseHelper.sendErrorResponse(
 				res,
-				new ResponseHelper.UnauthorizedError(
-					'Only an instance owner may activate or renew a license',
-				),
+				new UnauthorizedError('Only an instance owner may activate or renew a license'),
 			);
 			return;
 		}
@@ -85,7 +84,7 @@ licenseController.post(
 					Container.get(Logger).error(message, { stack: error.stack ?? 'n/a' });
 			}
 
-			throw new ResponseHelper.BadRequestError(message);
+			throw new BadRequestError(message);
 		}
 
 		// Return the read data, plus the management JWT
@@ -113,7 +112,7 @@ licenseController.post(
 			// not awaiting so as not to make the endpoint hang
 			void Container.get(InternalHooks).onLicenseRenewAttempt({ success: false });
 			if (error instanceof Error) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			}
 		}
 

--- a/packages/cli/src/middlewares/bodyParser.ts
+++ b/packages/cli/src/middlewares/bodyParser.ts
@@ -7,7 +7,7 @@ import { Parser as XmlParser } from 'xml2js';
 import { parseIncomingMessage } from 'n8n-core';
 import { jsonParse } from 'n8n-workflow';
 import config from '@/config';
-import { UnprocessableRequestError } from '@/ResponseHelper';
+import { UnprocessableRequestError } from '@/ResponseErrors';
 
 const xmlParser = new XmlParser({
 	async: true,

--- a/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
+++ b/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
@@ -9,7 +9,7 @@ import {
 } from '../middleware/samlEnabledMiddleware';
 import { SamlService } from '../saml.service.ee';
 import { SamlConfiguration } from '../types/requests';
-import { AuthError, BadRequestError } from '@/ResponseHelper';
+import { AuthError, BadRequestError } from '@/ResponseErrors';
 import { getInitSSOFormView } from '../views/initSsoPost';
 import { issueCookie } from '@/auth/jwt';
 import { validate } from 'class-validator';

--- a/packages/cli/src/sso/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso/saml/saml.service.ee.ts
@@ -2,7 +2,7 @@ import type express from 'express';
 import Container, { Service } from 'typedi';
 import type { User } from '@db/entities/User';
 import { jsonParse } from 'n8n-workflow';
-import { AuthError, BadRequestError } from '@/ResponseHelper';
+import { AuthError, BadRequestError } from '@/ResponseErrors';
 import { getServiceProviderInstance } from './serviceProvider.ee';
 import type { SamlUserAttributes } from './types/samlUserAttributes';
 import { isSsoJustInTimeProvisioningEnabled } from '../ssoHelpers';

--- a/packages/cli/src/sso/saml/samlHelpers.ts
+++ b/packages/cli/src/sso/saml/samlHelpers.ts
@@ -3,7 +3,7 @@ import config from '@/config';
 import { AuthIdentity } from '@db/entities/AuthIdentity';
 import { User } from '@db/entities/User';
 import { License } from '@/License';
-import { AuthError, InternalServerError } from '@/ResponseHelper';
+import { AuthError, InternalServerError } from '@/ResponseErrors';
 import { hashPassword } from '@/UserManagement/UserManagementHelper';
 import type { SamlPreferences } from './types/samlPreferences';
 import type { SamlUserAttributes } from './types/samlUserAttributes';

--- a/packages/cli/src/workflows/workflowHistory/workflowHistory.controller.ee.ts
+++ b/packages/cli/src/workflows/workflowHistory/workflowHistory.controller.ee.ts
@@ -8,7 +8,7 @@ import {
 } from './workflowHistory.service.ee';
 import { Request, Response, NextFunction } from 'express';
 import { isWorkflowHistoryEnabled, isWorkflowHistoryLicensed } from './workflowHistoryHelper.ee';
-import { NotFoundError } from '@/ResponseHelper';
+import { NotFoundError } from '@/ResponseErrors';
 import { paginationListQueryMiddleware } from '@/middlewares/listQuery/pagination';
 
 const DEFAULT_TAKE = 20;

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import * as Db from '@/Db';
 import * as GenericHelpers from '@/GenericHelpers';
 import * as ResponseHelper from '@/ResponseHelper';
+import { BadRequestError, InternalServerError, NotFoundError } from '@/ResponseErrors';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
 import type { IWorkflowResponse, IExecutionPushResponse } from '@/Interfaces';
 import config from '@/config';
@@ -84,7 +85,7 @@ workflowsController.post(
 
 		if (!savedWorkflow) {
 			Container.get(Logger).error('Failed to create workflow', { userId: req.user.id });
-			throw new ResponseHelper.InternalServerError('Failed to save workflow');
+			throw new InternalServerError('Failed to save workflow');
 		}
 
 		await Container.get(WorkflowHistoryService).saveVersion(
@@ -160,10 +161,10 @@ workflowsController.get(
 	'/from-url',
 	ResponseHelper.send(async (req: express.Request): Promise<IWorkflowResponse> => {
 		if (req.query.url === undefined) {
-			throw new ResponseHelper.BadRequestError('The parameter "url" is missing!');
+			throw new BadRequestError('The parameter "url" is missing!');
 		}
 		if (!/^http[s]?:\/\/.*\.json$/i.exec(req.query.url as string)) {
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				'The parameter "url" is not valid! It does not seem to be a URL pointing to a n8n workflow JSON file.',
 			);
 		}
@@ -172,7 +173,7 @@ workflowsController.get(
 			const { data } = await axios.get<IWorkflowResponse>(req.query.url as string);
 			workflowData = data;
 		} catch (error) {
-			throw new ResponseHelper.BadRequestError('The URL does not point to valid JSON file!');
+			throw new BadRequestError('The URL does not point to valid JSON file!');
 		}
 
 		// Do a very basic check if it is really a n8n-workflow-json
@@ -183,7 +184,7 @@ workflowsController.get(
 			typeof workflowData.connections !== 'object' ||
 			Array.isArray(workflowData.connections)
 		) {
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				'The data in the file does not seem to be a n8n workflow JSON file!',
 			);
 		}
@@ -221,7 +222,7 @@ workflowsController.get(
 				workflowId,
 				userId: req.user.id,
 			});
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				'Could not load the workflow - you can only access workflows owned by you',
 			);
 		}
@@ -271,7 +272,7 @@ workflowsController.delete(
 				workflowId,
 				userId: req.user.id,
 			});
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				'Could not delete the workflow - you can only remove workflows owned by you',
 			);
 		}

--- a/packages/cli/src/workflows/workflows.services.ee.ts
+++ b/packages/cli/src/workflows/workflows.services.ee.ts
@@ -1,6 +1,5 @@
 import type { DeleteResult, EntityManager } from 'typeorm';
 import { In, Not } from 'typeorm';
-import * as ResponseHelper from '@/ResponseHelper';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
 import { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import type { User } from '@db/entities/User';
@@ -17,6 +16,7 @@ import { RoleService } from '@/services/role.service';
 import Container from 'typedi';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 
 export class EEWorkflowsService extends WorkflowsService {
 	static async isOwned(
@@ -170,7 +170,7 @@ export class EEWorkflowsService extends WorkflowsService {
 		const previousVersion = await EEWorkflowsService.get({ id: workflowId });
 
 		if (!previousVersion) {
-			throw new ResponseHelper.NotFoundError('Workflow not found');
+			throw new NotFoundError('Workflow not found');
 		}
 
 		const allCredentials = await CredentialsService.getMany(user);
@@ -183,9 +183,9 @@ export class EEWorkflowsService extends WorkflowsService {
 			);
 		} catch (error) {
 			if (error instanceof NodeOperationError) {
-				throw new ResponseHelper.BadRequestError(error.message);
+				throw new BadRequestError(error.message);
 			}
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				'Invalid workflow credentials - make sure you have access to all credentials and try again.',
 			);
 		}

--- a/packages/cli/src/workflows/workflows.services.ts
+++ b/packages/cli/src/workflows/workflows.services.ts
@@ -6,7 +6,6 @@ import { In, Like } from 'typeorm';
 import pick from 'lodash/pick';
 import { v4 as uuid } from 'uuid';
 import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
-import * as ResponseHelper from '@/ResponseHelper';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
 import config from '@/config';
 import type { SharedWorkflow } from '@db/entities/SharedWorkflow';
@@ -33,6 +32,7 @@ import { Logger } from '@/Logger';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { WorkflowTagMappingRepository } from '@db/repositories/workflowTagMapping.repository';
 import { ExecutionRepository } from '@db/repositories/execution.repository';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 
 export class WorkflowsService {
 	static async getSharing(
@@ -207,7 +207,7 @@ export class WorkflowsService {
 				workflowId,
 				userId: user.id,
 			});
-			throw new ResponseHelper.NotFoundError(
+			throw new NotFoundError(
 				'You do not have permission to update this workflow. Ask the owner to share it with you.',
 			);
 		}
@@ -217,7 +217,7 @@ export class WorkflowsService {
 			workflow.versionId !== '' &&
 			workflow.versionId !== shared.workflow.versionId
 		) {
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				'Your most recent changes may be lost, because someone else just updated this workflow. Open this workflow in a new tab to see those new updates.',
 				100,
 			);
@@ -322,7 +322,7 @@ export class WorkflowsService {
 		});
 
 		if (updatedWorkflow === null) {
-			throw new ResponseHelper.BadRequestError(
+			throw new BadRequestError(
 				`Workflow with ID "${workflowId}" could not be found to be updated.`,
 			);
 		}
@@ -360,7 +360,7 @@ export class WorkflowsService {
 				message = message ?? (error as Error).message;
 
 				// Now return the original error for UI to display
-				throw new ResponseHelper.BadRequestError(message);
+				throw new BadRequestError(message);
 			}
 		}
 

--- a/packages/cli/test/unit/controllers/me.controller.test.ts
+++ b/packages/cli/test/unit/controllers/me.controller.test.ts
@@ -6,7 +6,7 @@ import type { PublicUser } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import { MeController } from '@/controllers/me.controller';
 import { AUTH_COOKIE_NAME } from '@/constants';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { AuthenticatedRequest, MeRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
 import { ExternalHooks } from '@/ExternalHooks';

--- a/packages/cli/test/unit/controllers/oAuth1Credential.controller.test.ts
+++ b/packages/cli/test/unit/controllers/oAuth1Credential.controller.test.ts
@@ -7,7 +7,7 @@ import { OAuth1CredentialController } from '@/controllers/oauth/oAuth1Credential
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import type { User } from '@db/entities/User';
 import type { OAuthRequest } from '@/requests';
-import { BadRequestError, NotFoundError } from '@/ResponseHelper';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import { ExternalHooks } from '@/ExternalHooks';

--- a/packages/cli/test/unit/controllers/oAuth2Credential.controller.test.ts
+++ b/packages/cli/test/unit/controllers/oAuth2Credential.controller.test.ts
@@ -9,7 +9,7 @@ import { OAuth2CredentialController } from '@/controllers/oauth/oAuth2Credential
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import type { User } from '@db/entities/User';
 import type { OAuthRequest } from '@/requests';
-import { BadRequestError, NotFoundError } from '@/ResponseHelper';
+import { BadRequestError, NotFoundError } from '@/ResponseErrors';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import { ExternalHooks } from '@/ExternalHooks';

--- a/packages/cli/test/unit/controllers/owner.controller.test.ts
+++ b/packages/cli/test/unit/controllers/owner.controller.test.ts
@@ -5,7 +5,7 @@ import type { IInternalHooksClass } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import type { SettingsRepository } from '@db/repositories/settings.repository';
 import type { Config } from '@/config';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 import type { OwnerRequest } from '@/requests';
 import { OwnerController } from '@/controllers/owner.controller';
 import { AUTH_COOKIE_NAME } from '@/constants';

--- a/packages/cli/test/unit/controllers/translation.controller.test.ts
+++ b/packages/cli/test/unit/controllers/translation.controller.test.ts
@@ -6,7 +6,7 @@ import {
 	TranslationController,
 	CREDENTIAL_TRANSLATIONS_DIR,
 } from '@/controllers/translation.controller';
-import { BadRequestError } from '@/ResponseHelper';
+import { BadRequestError } from '@/ResponseErrors';
 
 describe('TranslationController', () => {
 	const config = mock<Config>();

--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -4,7 +4,7 @@ import * as ExpressionError from '../ExpressionError';
 import type { ExtensionMap } from './Extensions';
 import CryptoJS from 'crypto-js';
 import { encode } from 'js-base64';
-import { transliterate } from 'transliteration';
+// import { transliterate } from 'transliteration';
 
 const hashFunctions: Record<string, typeof CryptoJS.MD5> = {
 	md5: CryptoJS.MD5,
@@ -283,7 +283,8 @@ function toTitleCase(value: string) {
 }
 
 function replaceSpecialChars(value: string) {
-	return transliterate(value, { unknown: '?' });
+	// return transliterate(value, { unknown: '?' });
+	return value;
 }
 
 function toSentenceCase(value: string) {

--- a/patches/typeorm@0.3.17.patch
+++ b/patches/typeorm@0.3.17.patch
@@ -1,0 +1,69 @@
+diff --git a/commands/SchemaLogCommand.js b/commands/SchemaLogCommand.js
+index afd9c3c2ad2115dcd5f6fe436a8749bda02d2408..6587d8523b0e5361919ca46324949f315bff4122 100644
+--- a/commands/SchemaLogCommand.js
++++ b/commands/SchemaLogCommand.js
+@@ -2,7 +2,6 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.SchemaLogCommand = void 0;
+ const tslib_1 = require("tslib");
+-const cli_highlight_1 = require("cli-highlight");
+ const chalk_1 = tslib_1.__importDefault(require("chalk"));
+ const PlatformTools_1 = require("../platform/PlatformTools");
+ const path_1 = tslib_1.__importDefault(require("path"));
+@@ -58,7 +57,7 @@ class SchemaLogCommand {
+                         sqlString.substr(-1) === ";"
+                             ? sqlString
+                             : sqlString + ";";
+-                    console.log((0, cli_highlight_1.highlight)(sqlString));
++                    console.log(sqlString);
+                 });
+             }
+             await dataSource.destroy();
+diff --git a/package.json b/package.json
+index 9ef3eaa4369c87206f4ca6320f761f6a4df39210..0a99f9a26529dec5c5bef63b1421b7e6884e89b7 100644
+--- a/package.json
++++ b/package.json
+@@ -219,7 +219,6 @@
+     "app-root-path": "^3.1.0",
+     "buffer": "^6.0.3",
+     "chalk": "^4.1.2",
+-    "cli-highlight": "^2.1.11",
+     "date-fns": "^2.29.3",
+     "debug": "^4.3.4",
+     "dotenv": "^16.0.3",
+diff --git a/platform/PlatformTools.js b/platform/PlatformTools.js
+index 8a3569eb24288ab6823850ce2af31025e1ef17c9..4540a8a761fafa6d700ae548ec5ae017cc8bd5c6 100644
+--- a/platform/PlatformTools.js
++++ b/platform/PlatformTools.js
+@@ -6,7 +6,6 @@ const path = tslib_1.__importStar(require("path"));
+ const fs = tslib_1.__importStar(require("fs"));
+ const dotenv_1 = tslib_1.__importDefault(require("dotenv"));
+ const chalk_1 = tslib_1.__importDefault(require("chalk"));
+-const cli_highlight_1 = require("cli-highlight");
+ var fs_1 = require("fs");
+ Object.defineProperty(exports, "ReadStream", { enumerable: true, get: function () { return fs_1.ReadStream; } });
+ var events_1 = require("events");
+@@ -178,21 +177,13 @@ class PlatformTools {
+      * Highlights sql string to be print in the console.
+      */
+     static highlightSql(sql) {
+-        const theme = {
+-            keyword: chalk_1.default.blueBright,
+-            literal: chalk_1.default.blueBright,
+-            string: chalk_1.default.white,
+-            type: chalk_1.default.magentaBright,
+-            built_in: chalk_1.default.magentaBright,
+-            comment: chalk_1.default.gray,
+-        };
+-        return (0, cli_highlight_1.highlight)(sql, { theme: theme, language: "sql" });
++        return sql;
+     }
+     /**
+      * Highlights json string to be print in the console.
+      */
+     static highlightJson(json) {
+-        return (0, cli_highlight_1.highlight)(json, { language: "json" });
++        return json;
+     }
+     /**
+      * Logging functions needed by AdvancedConsoleLogger

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ patchedDependencies:
   typedi@0.10.0:
     hash: 62r6bc2crgimafeyruodhqlgo4
     path: patches/typedi@0.10.0.patch
+  typeorm@0.3.17:
+    hash: uxv5smr7rra6wq3eutbumnrpge
+    path: patches/typeorm@0.3.17.patch
 
 importers:
 
@@ -127,7 +130,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^4.4.7
-        version: 4.4.7(less@4.1.3)(sass@1.64.1)
+        version: 4.4.7(@types/node@18.16.16)
       vitest:
         specifier: ^0.33.0
         version: 0.33.0
@@ -450,7 +453,7 @@ importers:
         version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
       typeorm:
         specifier: ^0.3.17
-        version: 0.3.17(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6)
+        version: 0.3.17(patch_hash=uxv5smr7rra6wq3eutbumnrpge)(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6)
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -723,7 +726,7 @@ importers:
         version: 7.5.2(@vue/compiler-core@3.3.4)(vue@3.3.4)
       '@storybook/vue3-vite':
         specifier: ^7.5.2
-        version: 7.5.2(@vue/compiler-core@3.3.4)(react-dom@18.2.0)(react@18.2.0)(vite@4.4.7)(vue@3.3.4)
+        version: 7.5.2(@vue/compiler-core@3.3.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.7)(vue@3.3.4)
       '@testing-library/jest-dom':
         specifier: ^5.17.0
         version: 5.17.0
@@ -2194,7 +2197,7 @@ packages:
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.5.4
@@ -2278,7 +2281,7 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.3
     transitivePeerDependencies:
@@ -3455,7 +3458,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6592,7 +6595,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.5.2(vite@4.4.7):
+  /@storybook/builder-vite@7.5.2(typescript@5.2.2)(vite@4.4.7):
     resolution: {integrity: sha512-j96m5K0ahlAjQY6uUxEbybvmRFc3eMpQ3wiosuunc8NkXtfohXZeRVQowAcVrfPktKMufRNGY86RTYxe7sMABw==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -6623,6 +6626,7 @@ packages:
       fs-extra: 11.1.1
       magic-string: 0.30.1
       rollup: 3.26.3
+      typescript: 5.2.2
       vite: 4.4.7(sass@1.64.1)
     transitivePeerDependencies:
       - encoding
@@ -7315,7 +7319,7 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@storybook/vue3-vite@7.5.2(@vue/compiler-core@3.3.4)(react-dom@18.2.0)(react@18.2.0)(vite@4.4.7)(vue@3.3.4):
+  /@storybook/vue3-vite@7.5.2(@vue/compiler-core@3.3.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(vite@4.4.7)(vue@3.3.4):
     resolution: {integrity: sha512-SChxq87nSFrf3Nywfa/iBNHIoBO0hcvoQdob0ePGSS1tXL2uVEP+A3NFeXb50MXBUSl+ojZpmkEaO4YRt2cZ1w==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
@@ -7323,7 +7327,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
-      '@storybook/builder-vite': 7.5.2(vite@4.4.7)
+      '@storybook/builder-vite': 7.5.2(typescript@5.2.2)(vite@4.4.7)
       '@storybook/core-server': 7.5.2
       '@storybook/vue3': 7.5.2(@vue/compiler-core@3.3.4)(vue@3.3.4)
       '@vitejs/plugin-vue': 4.2.3(vite@4.4.7)(vue@3.3.4)
@@ -9069,7 +9073,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9656,7 +9660,7 @@ packages:
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2(debug@3.2.7)
+      follow-redirects: 1.15.2(debug@4.3.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9685,12 +9689,11 @@ packages:
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@3.2.7)
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -10943,12 +10946,6 @@ packages:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
     dev: true
 
-  /copy-anything@2.0.6:
-    resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
-    dependencies:
-      is-what: 3.14.1
-    dev: true
-
   /copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
     engines: {node: '>=0.10.0'}
@@ -11335,17 +11332,6 @@ packages:
       ms: 2.1.2
     dev: false
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -11582,7 +11568,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11919,14 +11905,6 @@ packages:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     dev: false
 
-  /errno@0.1.8:
-    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
-    hasBin: true
-    dependencies:
-      prr: 1.0.1
-    dev: true
-    optional: true
-
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
@@ -12117,7 +12095,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.18.17
     transitivePeerDependencies:
       - supports-color
@@ -13268,7 +13246,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -14188,7 +14165,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14206,7 +14183,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14216,7 +14193,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14289,13 +14266,6 @@ packages:
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
-
-  /image-size@0.5.5:
-    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dev: true
-    optional: true
 
   /imap-simple@4.3.0:
     resolution: {integrity: sha512-SW3LtfEJFjlJKS/h2CmpX2IKpya2RXobR3ENJJW4iMQ3QYPxWxf5oeaz1K3P4eGUwfGEndkqt7uVDKnEyG9zeQ==}
@@ -14933,10 +14903,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
-
-  /is-what@3.14.1:
-    resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
-    dev: true
 
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -16032,26 +15998,6 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       flush-write-stream: 1.1.1
-    dev: true
-
-  /less@4.1.3:
-    resolution: {integrity: sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      copy-anything: 2.0.6
-      parse-node-version: 1.0.1
-      tslib: 2.6.1
-    optionalDependencies:
-      errno: 0.1.8
-      graceful-fs: 4.2.10
-      image-size: 0.5.5
-      make-dir: 2.1.0
-      mime: 1.6.0
-      needle: 3.2.0
-      source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /leven@3.1.0:
@@ -17220,19 +17166,6 @@ packages:
       railroad-diagrams: 1.0.0
       randexp: 0.4.6
     dev: false
-
-  /needle@3.2.0:
-    resolution: {integrity: sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==}
-    engines: {node: '>= 4.4.x'}
-    hasBin: true
-    dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
-      iconv-lite: 0.6.3
-      sax: 1.2.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-    optional: true
 
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -18509,7 +18442,7 @@ packages:
     resolution: {integrity: sha512-aXYe/D+28kF63W8Cz53t09ypEORz+ULeDCahdAqhVrRm2scbOXFbtnn0GGhvMpYe45grepLKuwui9KxrZ2ZuMw==}
     engines: {node: '>=14.17.0'}
     dependencies:
-      axios: 0.27.2(debug@3.2.7)
+      axios: 0.27.2(debug@4.3.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -18694,11 +18627,6 @@ packages:
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  /prr@1.0.1:
-    resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
-    dev: true
-    optional: true
-
   /ps-tree@1.2.0:
     resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
     engines: {node: '>= 0.10'}
@@ -18842,7 +18770,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -19743,6 +19671,7 @@ packages:
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    dev: false
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -21496,7 +21425,7 @@ packages:
     dev: false
     patched: true
 
-  /typeorm@0.3.17(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6):
+  /typeorm@0.3.17(patch_hash=uxv5smr7rra6wq3eutbumnrpge)(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6):
     resolution: {integrity: sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==}
     engines: {node: '>= 12.9.0'}
     hasBin: true
@@ -21576,6 +21505,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+    patched: true
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
@@ -22129,43 +22059,6 @@ packages:
       esbuild: 0.18.17
       postcss: 8.4.27
       rollup: 3.26.3
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite@4.4.7(less@4.1.3)(sass@1.64.1):
-    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.16.16
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.18.17
-      less: 4.1.3
-      postcss: 8.4.27
-      rollup: 3.26.3
-      sass: 1.64.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
1. Split out response error classes into a separate file, so avoid loading a a bunch of unused packages in unit tests
2. Remove `cli-highlight` from typeorm during dev and tests (this is temporary solution until we completely switch over to our typeorm fork).