### PR TITLE
fix(core): Correct permissions for getstatus

### DIFF
--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -4,7 +4,7 @@ import { Service } from 'typedi';
 import { SingleMainInstancePublisher } from '@/services/orchestration/main/SingleMainInstance.publisher';
 import { License } from '../License';
 
-@Authorized(['global', 'owner'])
+@Authorized('any')
 @RestController('/orchestration')
 @Service()
 export class OrchestrationController {


### PR DESCRIPTION
These endpoints are required for the new worker view to request status updates from the workers. Since the view is not limited to owners, but open to regular users, and the requests are read-only, these endpoints need to be accessible to any registered user