### PR TITLE
fix(editor): Make sure LineController is registered with chart.js

### DIFF
--- a/packages/editor-ui/src/plugins/chartjs.ts
+++ b/packages/editor-ui/src/plugins/chartjs.ts
@@ -8,6 +8,7 @@ import {
 	PointElement,
 	CategoryScale,
 	LinearScale,
+	LineController,
 } from 'chart.js';
 
 export const ChartJSPlugin = {
@@ -21,6 +22,7 @@ export const ChartJSPlugin = {
 			Title,
 			Tooltip,
 			Legend,
+			LineController,
 		);
 	},
 };


### PR DESCRIPTION
Tree shaking in production build of the editor-ui package removed the LineController, this makes sure it is in the final package.