### PR TITLE
fix(core): Account for activation error caused by follower `main` instance

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -471,7 +471,13 @@ export type IPushData =
 	| PushDataActiveWorkflowUsersChanged
 	| PushDataWorkerStatusMessage
 	| PushDataWorkflowActivated
-	| PushDataWorkflowDeactivated;
+	| PushDataWorkflowDeactivated
+	| PushDataWorkflowFailedToActivate;
+
+type PushDataWorkflowFailedToActivate = {
+	data: IWorkflowFailedToActivate;
+	type: 'workflowFailedToActivate';
+};
 
 type PushDataWorkflowActivated = {
 	data: IActiveWorkflowChanged;
@@ -559,6 +565,11 @@ export interface IActiveWorkflowUsersChanged {
 
 interface IActiveWorkflowChanged {
 	workflowId: Workflow['id'];
+}
+
+interface IWorkflowFailedToActivate {
+	workflowId: Workflow['id'];
+	errorMessage: string;
 }
 
 export interface IPushDataExecutionRecovered {

--- a/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
+++ b/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
@@ -112,11 +112,21 @@ export class MultiMainSetup extends SingleMainSetup {
 		workflowId: string;
 		oldState: boolean;
 		newState: boolean;
+		versionId: string;
 	}) {
 		if (!this.sanityCheck()) return;
 
 		await this.redisPublisher.publishToCommandChannel({
 			command: 'workflowActiveStateChanged',
+			payload,
+		});
+	}
+
+	async broadcastWorkflowFailedToActivate(payload: { workflowId: string; errorMessage: string }) {
+		if (!this.sanityCheck()) return;
+
+		await this.redisPublisher.publishToCommandChannel({
+			command: 'workflowFailedToActivate',
 			payload,
 		});
 	}

--- a/packages/cli/src/services/redis/RedisServiceCommands.ts
+++ b/packages/cli/src/services/redis/RedisServiceCommands.ts
@@ -7,7 +7,8 @@ export type RedisServiceCommand =
 	| 'stopWorker'
 	| 'reloadLicense'
 	| 'reloadExternalSecretsProviders'
-	| 'workflowActiveStateChanged'; // multi-main only
+	| 'workflowActiveStateChanged' // multi-main only
+	| 'workflowFailedToActivate'; // multi-main only
 
 /**
  * An object to be sent via Redis pub/sub from the main process to the workers.

--- a/packages/cli/src/workflows/workflows.services.ts
+++ b/packages/cli/src/workflows/workflows.services.ts
@@ -382,6 +382,7 @@ export class WorkflowsService {
 					workflowId,
 					oldState,
 					newState: updatedWorkflow.active,
+					versionId: shared.workflow.versionId,
 				});
 			}
 		}

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -421,7 +421,8 @@ export type IPushData =
 	| PushDataExecutionRecovered
 	| PushDataWorkerStatusMessage
 	| PushDataActiveWorkflowAdded
-	| PushDataActiveWorkflowRemoved;
+	| PushDataActiveWorkflowRemoved
+	| PushDataWorkflowFailedToActivate;
 
 type PushDataActiveWorkflowAdded = {
 	data: IActiveWorkflowAdded;
@@ -431,6 +432,11 @@ type PushDataActiveWorkflowAdded = {
 type PushDataActiveWorkflowRemoved = {
 	data: IActiveWorkflowRemoved;
 	type: 'workflowDeactivated';
+};
+
+type PushDataWorkflowFailedToActivate = {
+	data: IWorkflowFailedToActivate;
+	type: 'workflowFailedToActivate';
 };
 
 type PushDataExecutionRecovered = {
@@ -507,6 +513,11 @@ export interface IActiveWorkflowAdded {
 
 export interface IActiveWorkflowRemoved {
 	workflowId: string;
+}
+
+export interface IWorkflowFailedToActivate {
+	workflowId: string;
+	errorMessage: string;
 }
 
 export interface IPushDataUnsavedExecutionFinished {

--- a/packages/editor-ui/src/mixins/pushConnection.ts
+++ b/packages/editor-ui/src/mixins/pushConnection.ts
@@ -291,6 +291,20 @@ export const pushConnection = defineComponent({
 				}
 			}
 
+			if (receivedData.type === 'workflowFailedToActivate') {
+				this.workflowsStore.setWorkflowInactive(receivedData.data.workflowId);
+				this.workflowsStore.setActive(false);
+
+				this.showError(
+					new Error(receivedData.data.errorMessage),
+					this.$locale.baseText('workflowActivator.showError.title', {
+						interpolate: { newStateName: 'deactivated' },
+					}) + ':',
+				);
+
+				return true;
+			}
+
 			if (receivedData.type === 'workflowActivated') {
 				this.workflowsStore.setWorkflowActive(receivedData.data.workflowId);
 				return true;


### PR DESCRIPTION
This PR accounts for the edge case where the user on a FE connected to a follower `main` instance leads to an activation failure. The follower performs the DB update, skips activation in `ActiveWorkflows`, instructs leader to perform activation in `ActiveWorkflows`, leader fails to activate and reverts the DB update and communicates activation error to follower, which broadcasts the event to all connected FEs, which update their stores and display the activation error.

To reproduce, create a workflow with a trigger with an invalid credential and attempt to activate on both leader and follower to trigger the activation error - behavior should be identical on both.