### PR TITLE
fix(core): Ensure failed executions are saved in queue mode

### DIFF
--- a/packages/cli/src/executionLifecycleHooks/shared/sharedHookFunctions.ts
+++ b/packages/cli/src/executionLifecycleHooks/shared/sharedHookFunctions.ts
@@ -10,8 +10,12 @@ import { Logger } from '@/Logger';
 export function determineFinalExecutionStatus(runData: IRun): ExecutionStatus {
 	const workflowHasCrashed = runData.status === 'crashed';
 	const workflowWasCanceled = runData.status === 'canceled';
+	const workflowHasFailed = runData.status === 'failed';
 	const workflowDidSucceed =
-		!runData.data.resultData?.error && !workflowHasCrashed && !workflowWasCanceled;
+		!runData.data.resultData?.error &&
+		!workflowHasCrashed &&
+		!workflowWasCanceled &&
+		!workflowHasFailed;
 	let workflowStatusFinal: ExecutionStatus = workflowDidSucceed ? 'success' : 'failed';
 	if (workflowHasCrashed) workflowStatusFinal = 'crashed';
 	if (workflowWasCanceled) workflowStatusFinal = 'canceled';


### PR DESCRIPTION
This PR adds `status` to run data so that `determineFinalExecutionStatus` resolves correctly on execution failure and removes the cleanup that is being duplicated in a worker hook.

Followup to https://github.com/n8n-io/n8n/pull/7138

Should fix:
- https://github.com/n8n-io/n8n/issues/7705
- https://linear.app/n8n/issue/PAY-964/no-execution-found-after-execution-fails
- https://linear.app/n8n/issue/PAY-1010/execution-deletion-in-queue-mode-not-complying-with-settings