### PR TITLE
feat(core): Add Redis Hashes to cache service

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -113,7 +113,6 @@
     "bcryptjs": "^2.4.3",
     "bull": "^4.10.2",
     "cache-manager": "^5.2.3",
-    "cache-manager-ioredis-yet": "^1.2.2",
     "callsites": "^3.1.0",
     "change-case": "^4.1.1",
     "class-transformer": "^0.5.1",

--- a/packages/cli/src/services/cache/cacheManagerRedis.ts
+++ b/packages/cli/src/services/cache/cacheManagerRedis.ts
@@ -1,0 +1,169 @@
+/**
+ * Based on https://github.com/node-cache-manager/node-cache-manager-ioredis-yet
+ */
+
+import Redis from 'ioredis';
+import type { Cluster, ClusterNode, ClusterOptions, RedisOptions } from 'ioredis';
+import type { Cache, Store, Config } from 'cache-manager';
+import { jsonParse } from 'n8n-workflow';
+
+export class NoCacheableError implements Error {
+	name = 'NoCacheableError';
+
+	constructor(public message: string) {}
+}
+
+export const avoidNoCacheable = async <T>(p: Promise<T>) => {
+	try {
+		return await p;
+	} catch (e) {
+		if (!(e instanceof NoCacheableError)) throw e;
+		return undefined;
+	}
+};
+
+export interface RedisClusterConfig {
+	nodes: ClusterNode[];
+	options?: ClusterOptions;
+}
+
+export type RedisCache = Cache<RedisStore>;
+
+export interface RedisStore extends Store {
+	readonly isCacheable: (value: unknown) => boolean;
+	get client(): Redis | Cluster;
+	hget<T>(key: string, field: string): Promise<T | undefined>;
+	hgetall<T>(key: string): Promise<Record<string, T> | undefined>;
+	hset(key: string, fieldValueRecord: Record<string, unknown>): Promise<void>;
+	hkeys(key: string): Promise<string[]>;
+	hvals<T>(key: string): Promise<T[]>;
+	hexists(key: string, field: string): Promise<boolean>;
+	hdel(key: string, field: string): Promise<number>;
+}
+
+function builder(
+	redisCache: Redis | Cluster,
+	reset: () => Promise<void>,
+	keys: (pattern: string) => Promise<string[]>,
+	options?: Config,
+) {
+	const isCacheable = options?.isCacheable ?? ((value) => value !== undefined && value !== null);
+	const getVal = (value: unknown) => JSON.stringify(value) || '"undefined"';
+
+	return {
+		async get<T>(key: string) {
+			const val = await redisCache.get(key);
+			if (val === undefined || val === null) return undefined;
+			else return jsonParse<T>(val);
+		},
+		async set(key, value, ttl) {
+			// eslint-disable-next-line @typescript-eslint/no-throw-literal, @typescript-eslint/restrict-template-expressions
+			if (!isCacheable(value)) throw new NoCacheableError(`"${value}" is not a cacheable value`);
+			const t = ttl ?? options?.ttl;
+			if (t !== undefined && t !== 0) await redisCache.set(key, getVal(value), 'PX', t);
+			else await redisCache.set(key, getVal(value));
+		},
+		async mset(args, ttl) {
+			const t = ttl ?? options?.ttl;
+			if (t !== undefined && t !== 0) {
+				const multi = redisCache.multi();
+				for (const [key, value] of args) {
+					if (!isCacheable(value))
+						// eslint-disable-next-line @typescript-eslint/no-throw-literal
+						throw new NoCacheableError(`"${getVal(value)}" is not a cacheable value`);
+					multi.set(key, getVal(value), 'PX', t);
+				}
+				await multi.exec();
+			} else
+				await redisCache.mset(
+					args.flatMap(([key, value]) => {
+						if (!isCacheable(value)) throw new Error(`"${getVal(value)}" is not a cacheable value`);
+						return [key, getVal(value)] as [string, string];
+					}),
+				);
+		},
+		mget: async (...args) =>
+			redisCache
+				.mget(args)
+				.then((results) =>
+					results.map((result) =>
+						result === null || result === undefined ? undefined : jsonParse(result),
+					),
+				),
+		async mdel(...args) {
+			await redisCache.del(args);
+		},
+		async del(key) {
+			await redisCache.del(key);
+		},
+		ttl: async (key) => redisCache.pttl(key),
+		keys: async (pattern = '*') => keys(pattern),
+		reset,
+		isCacheable,
+		get client() {
+			return redisCache;
+		},
+		// Redis Hash functions
+		async hget<T>(key: string, field: string) {
+			const val = await redisCache.hget(key, field);
+			if (val === undefined || val === null) return undefined;
+			else return jsonParse<T>(val);
+		},
+		async hgetall<T>(key: string) {
+			const val = await redisCache.hgetall(key);
+			if (val === undefined || val === null) return undefined;
+			else {
+				for (const field in val) {
+					const value = val[field];
+					val[field] = jsonParse(value);
+				}
+				return val as Record<string, T>;
+			}
+		},
+		async hset(key: string, fieldValueRecord: Record<string, unknown>) {
+			for (const field in fieldValueRecord) {
+				const value = fieldValueRecord[field];
+				if (!isCacheable(fieldValueRecord[field])) {
+					// eslint-disable-next-line @typescript-eslint/no-throw-literal, @typescript-eslint/restrict-template-expressions
+					throw new NoCacheableError(`"${value}" is not a cacheable value`);
+				}
+				fieldValueRecord[field] = getVal(value);
+			}
+			await redisCache.hset(key, fieldValueRecord);
+		},
+		async hkeys(key: string) {
+			return redisCache.hkeys(key);
+		},
+		async hvals<T>(key: string): Promise<T[]> {
+			const values = await redisCache.hvals(key);
+			return values.map((value) => jsonParse<T>(value));
+		},
+		async hexists(key: string, field: string): Promise<boolean> {
+			return (await redisCache.hexists(key, field)) === 1;
+		},
+		async hdel(key: string, field: string) {
+			return redisCache.hdel(key, field);
+		},
+	} as RedisStore;
+}
+
+export function redisInsStore(redisCache: Redis | Cluster, options?: Config) {
+	const reset = async () => {
+		await redisCache.flushdb();
+	};
+	const keys = async (pattern: string) => redisCache.keys(pattern);
+
+	return builder(redisCache, reset, keys, options);
+}
+
+export async function redisStore(
+	options?: (RedisOptions | { clusterConfig: RedisClusterConfig }) & Config,
+) {
+	options ||= {};
+	const redisCache =
+		'clusterConfig' in options
+			? new Redis.Cluster(options.clusterConfig.nodes, options.clusterConfig.options)
+			: new Redis(options);
+
+	return redisInsStore(redisCache, options);
+}

--- a/packages/cli/src/services/cache/cacheManagerRedis.ts
+++ b/packages/cli/src/services/cache/cacheManagerRedis.ts
@@ -147,7 +147,7 @@ function builder(
 	} as RedisStore;
 }
 
-export function redisInsStore(redisCache: Redis | Cluster, options?: Config) {
+export function redisStoreUsingClient(redisCache: Redis | Cluster, options?: Config) {
 	const reset = async () => {
 		await redisCache.flushdb();
 	};
@@ -165,5 +165,5 @@ export async function redisStore(
 			? new Redis.Cluster(options.clusterConfig.nodes, options.clusterConfig.options)
 			: new Redis(options);
 
-	return redisInsStore(redisCache, options);
+	return redisStoreUsingClient(redisCache, options);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
         version: 7.28.1
       axios:
         specifier: ^0.21.1
-        version: 0.21.4
+        version: 0.21.4(debug@4.3.2)
       basic-auth:
         specifier: ^2.0.1
         version: 2.0.1
@@ -238,9 +238,6 @@ importers:
       cache-manager:
         specifier: ^5.2.3
         version: 5.2.3
-      cache-manager-ioredis-yet:
-        specifier: ^1.2.2
-        version: 1.2.2
       callsites:
         specifier: ^3.1.0
         version: 3.1.0
@@ -5538,7 +5535,7 @@ packages:
     dependencies:
       '@segment/loosely-validate-event': 2.0.0
       auto-changelog: 1.16.4
-      axios: 0.21.4
+      axios: 0.21.4(debug@4.3.2)
       axios-retry: 3.3.1
       bull: 3.29.3
       lodash.clonedeep: 4.5.0
@@ -9072,7 +9069,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9659,7 +9656,7 @@ packages:
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2(debug@3.2.7)
+      follow-redirects: 1.15.2(debug@4.3.2)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9668,6 +9665,15 @@ packages:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
       follow-redirects: 1.15.2(debug@4.3.2)
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios@0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.2(debug@4.3.2)
+      form-data: 4.0.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9693,7 +9699,7 @@ packages:
   /axios@1.4.0:
     resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@3.2.7)
+      follow-redirects: 1.15.2(debug@4.3.2)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -10216,16 +10222,6 @@ packages:
       union-value: 1.0.1
       unset-value: 1.0.0
     dev: true
-
-  /cache-manager-ioredis-yet@1.2.2:
-    resolution: {integrity: sha512-o03N/tQxfFONZ1XLGgIxOFHuQQpjpRdnSAL1THG1YWZIVp1JMUfjU3ElSAjFN1LjbJXa55IpC8waG+VEoLUCUw==}
-    engines: {node: '>= 16.17.0'}
-    dependencies:
-      cache-manager: 5.2.3
-      ioredis: 5.3.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /cache-manager@5.2.3:
     resolution: {integrity: sha512-9OErI8fksFkxAMJ8Mco0aiZSdphyd90HcKiOMJQncSlU1yq/9lHHxrT8PDayxrmr9IIIZPOAEfXuGSD7g29uog==}
@@ -14219,7 +14215,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14503,6 +14499,7 @@ packages:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /ip@1.1.8:
     resolution: {integrity: sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==}
@@ -18512,7 +18509,7 @@ packages:
     resolution: {integrity: sha512-aXYe/D+28kF63W8Cz53t09ypEORz+ULeDCahdAqhVrRm2scbOXFbtnn0GGhvMpYe45grepLKuwui9KxrZ2ZuMw==}
     engines: {node: '>=14.17.0'}
     dependencies:
-      axios: 0.27.2(debug@3.2.7)
+      axios: 0.27.2
     transitivePeerDependencies:
       - debug
     dev: false


### PR DESCRIPTION
cache service now supports storing values as Redis Hashes. if memory cache is used, these are stored as objects.