### PR TITLE
refactor(core): Stop reporting to Sentry `NodeApiError` outside 500 range (no-changelog)

### DIFF
--- a/packages/workflow/src/NodeErrors.ts
+++ b/packages/workflow/src/NodeErrors.ts
@@ -357,9 +357,6 @@ export class NodeApiError extends NodeError {
 	) {
 		super(node, error);
 
-		if (severity) this.severity = severity;
-		else if (httpCode?.charAt(0) !== '5') this.severity = 'warning';
-
 		// only for request library error
 		if (error.error) {
 			removeCircularRefs(error.error as JsonObject);
@@ -399,6 +396,12 @@ export class NodeApiError extends NodeError {
 		} else {
 			this.httpCode =
 				this.findProperty(error, ERROR_STATUS_PROPERTIES, ERROR_NESTING_PROPERTIES) ?? null;
+		}
+
+		if (severity) {
+			this.severity = severity;
+		} else if (this.httpCode?.charAt(0) !== '5') {
+			this.severity = 'warning';
 		}
 
 		// set description of this error


### PR DESCRIPTION
https://n8nio.sentry.io/issues/4312838883 (and many others)

Followup to https://github.com/n8n-io/n8n/pull/7662