### PR TITLE
feat(core): Add base64 and HTML entity encoding/decoding extensions

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -53,6 +53,7 @@
     "ast-types": "0.15.2",
     "crypto-js": "4.2.0",
     "deep-equal": "2.2.0",
+    "entities": "^4.5.0",
     "esprima-next": "5.8.4",
     "form-data": "4.0.0",
     "jmespath": "0.16.0",

--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -3,8 +3,9 @@ import { titleCase } from 'title-case';
 import * as ExpressionError from '../ExpressionError';
 import type { ExtensionMap } from './Extensions';
 import CryptoJS from 'crypto-js';
-import { encode } from 'js-base64';
+import { toBase64, fromBase64 } from 'js-base64';
 import { transliterate } from 'transliteration';
+import { encodeHTML, encodeNonAsciiHTML, decodeHTMLStrict } from 'entities';
 
 const hashFunctions: Record<string, typeof CryptoJS.MD5> = {
 	md5: CryptoJS.MD5,
@@ -118,7 +119,7 @@ function hash(value: string, extraArgs?: unknown): string {
 	if (algorithm.toLowerCase() === 'base64') {
 		// We're using a library instead of btoa because btoa only
 		// works on ASCII
-		return encode(value);
+		return toBase64(value);
 	}
 	const hashFunction = hashFunctions[algorithm.toLowerCase()];
 	if (!hashFunction) {
@@ -217,6 +218,29 @@ function urlEncode(value: string, extraArgs: boolean[]): string {
 		return encodeURI(value.toString());
 	}
 	return encodeURIComponent(value.toString());
+}
+
+function b64Encode(value: string, extraArgs: boolean[]): string {
+	const [urlMode = false] = extraArgs;
+	return toBase64(value, urlMode);
+}
+
+function b64Decode(value: string): string {
+	return fromBase64(value);
+}
+
+function htmlEncode(value: string, extraArgs: boolean[]): string {
+	const [allChars = false] = extraArgs;
+
+	if (allChars) {
+		return encodeHTML(value);
+	}
+
+	return encodeNonAsciiHTML(value);
+}
+
+function htmlDecode(value: string): string {
+	return decodeHTMLStrict(value);
 }
 
 function toInt(value: string, extraArgs: Array<number | undefined>) {
@@ -433,6 +457,41 @@ urlDecode.doc = {
 		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-urlDecode',
 };
 
+b64Encode.doc = {
+	name: 'b64Encode',
+	description: 'Encodes a string in base64 format.',
+	args: [{ name: 'urlMode?', type: 'boolean' }],
+	returnType: 'string',
+	docURL:
+		'https://docs.n8n.io/code-examples/expressions/data-transformation-functions/strings/#string-b64Encode',
+};
+
+b64Decode.doc = {
+	name: 'b64Decode',
+	description: 'Decodes a base64-encoded string.',
+	returnType: 'string',
+	docURL:
+		'https://docs.n8n.io/code-examples/expressions/data-transformation-functions/strings/#string-b64Decode',
+};
+
+htmlEncode.doc = {
+	name: 'htmlEncode',
+	description:
+		'Encodes text replacing characters that are not valid in HTML. If allChars is true, all non-ASCII characters are replaced.',
+	args: [{ name: 'allChars?', type: 'boolean' }],
+	returnType: 'string',
+	docURL:
+		'https://docs.n8n.io/code-examples/expressions/data-transformation-functions/strings/#string-htmlEncode',
+};
+
+htmlDecode.doc = {
+	name: 'htmlDecode',
+	description: 'Decodes text replacing HTML entities with their respective characters.',
+	returnType: 'string',
+	docURL:
+		'https://docs.n8n.io/code-examples/expressions/data-transformation-functions/strings/#string-htmlDecode',
+};
+
 replaceSpecialChars.doc = {
 	name: 'replaceSpecialChars',
 	description: 'Replaces non-ASCII characters in a string with an ASCII representation.',
@@ -561,5 +620,9 @@ export const stringExtensions: ExtensionMap = {
 		extractEmail,
 		extractDomain,
 		extractUrl,
+		b64Encode,
+		b64Decode,
+		htmlEncode,
+		htmlDecode,
 	},
 };

--- a/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
@@ -51,6 +51,40 @@ describe('Data Transformation Functions', () => {
 			);
 		});
 
+		test('.b64Encode should work correctly on a string', () => {
+			expect(evaluate('={{ "A".b64Encode() }}')).toEqual('QQ==');
+			expect(evaluate('={{ "�ø®".b64Encode(false) }}')).toEqual('77+9w7jCrg==');
+			expect(evaluate('={{ "�ø®".b64Encode(true) }}')).toEqual('77-9w7jCrg');
+		});
+
+		test('.b64Decode should work correctly on a string', () => {
+			expect(evaluate('={{ "QQ==".b64Decode() }}')).toEqual('A');
+			expect(evaluate('={{ "QQ".b64Decode() }}')).toEqual('A');
+			expect(evaluate('={{ "QQ".b64Decode(true) }}')).toEqual('A');
+			expect(evaluate('={{ "QQ==".b64Decode(true) }}')).toEqual('A');
+			expect(evaluate('={{ "77+9w7jCrg==".b64Decode(false) }}')).toEqual('�ø®');
+			expect(evaluate('={{ "77-9w7jCrg".b64Decode(true) }}')).toEqual('�ø®');
+		});
+
+		test('.htmlEncode should work correctly on special chars', () => {
+			expect(evaluate('={{ "&\\"\'<>".htmlEncode(false) }}')).toEqual('&amp;&quot;&apos;&lt;&gt;');
+		});
+
+		test('.htmlEncode NonAscii output should work correctly', () => {
+			expect(evaluate('={{ "!@#$%^&*()".htmlEncode(false) }}')).toEqual('!@#&dollar;%^&amp;*()');
+		});
+		test('.htmlEncode should work correctly', () => {
+			expect(evaluate('={{ "!@#$%^&*()".htmlEncode(true) }}')).toEqual(
+				'&excl;&commat;&num;&dollar;&percnt;&Hat;&amp;&ast;&lpar;&rpar;',
+			);
+		});
+
+		test('.htmlDecode should work correctly on all chars', () => {
+			expect(
+				evaluate('={{ "&amp;&quot;&#039;&lt;&gt;&#65533;&#248;&#174;".htmlDecode(true) }}'),
+			).toEqual('&"\'<>�ø®');
+		});
+
 		test('.removeTags should work correctly on a string', () => {
 			expect(evaluate('={{ "<html><head>test</head></html>".removeTags() }}')).toEqual('test');
 		});


### PR DESCRIPTION
This PR add string extensions to
- base64 encode/decode (with an argument to support base64url)
- HTML entity encode/decode (with an argument to convert all non-printable chars)

The only problem, which is why this may not be implemented already, is that the UI won't show an immediate preview for b64Encode/b64Decode, presumably something to do with the frontend and Buffer 🤷‍♂️. However the output is still correct when executed.

<img width="840" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/1731bd74-1b2d-4d92-a0d7-bca1abf41dbd">

<img width="548" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/6ee4148f-ef2b-4739-9164-e36cb0bc971d">
