### PR TITLE
fix(editor): Only show push to git menu item to owners

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -4,6 +4,8 @@ import {
 	META_KEY,
 	SCHEDULE_TRIGGER_NODE_NAME,
 	EDIT_FIELDS_SET_NODE_NAME,
+	INSTANCE_MEMBERS,
+	INSTANCE_OWNER,
 } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
@@ -274,5 +276,21 @@ describe('Workflow Actions', () => {
 
 		WorkflowPage.getters.canvasNodePlusEndpointByName(EDIT_FIELDS_SET_NODE_NAME).click();
 		WorkflowPage.getters.nodeCreatorSearchBar().should('be.visible');
+	});
+});
+
+describe('Menu entry Push To Git', () => {
+	it('should not show up in the menu for members', () => {
+		cy.signin(INSTANCE_MEMBERS[0]);
+		cy.visit(WorkflowPages.url);
+		WorkflowPage.actions.visit();
+		WorkflowPage.getters.workflowMenuItemGitPush().should('not.exist');
+	});
+
+	it('should show up for owners', () => {
+		cy.signin(INSTANCE_OWNER);
+		cy.visit(WorkflowPages.url);
+		WorkflowPage.actions.visit();
+		WorkflowPage.getters.workflowMenuItemGitPush().should('exist');
 	});
 });

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -71,6 +71,7 @@ export class WorkflowPage extends BasePage {
 		workflowMenuItemImportFromFile: () => cy.getByTestId('workflow-menu-item-import-from-file'),
 		workflowMenuItemSettings: () => cy.getByTestId('workflow-menu-item-settings'),
 		workflowMenuItemDelete: () => cy.getByTestId('workflow-menu-item-delete'),
+		workflowMenuItemGitPush: () => cy.getByTestId('workflow-menu-item-push'),
 		// Workflow settings dialog elements
 		workflowSettingsModal: () => cy.getByTestId('workflow-settings-dialog'),
 		workflowSettingsErrorWorkflowSelect: () => cy.getByTestId('workflow-settings-error-workflow'),

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -241,6 +241,9 @@ export default defineComponent({
 		currentUser(): IUser | null {
 			return this.usersStore.currentUser;
 		},
+		currentUserIsOwner(): boolean {
+			return this.usersStore.currentUser?.isOwner ?? false;
+		},
 		contextBasedTranslationKeys(): NestedRecord<string> {
 			return this.uiStore.contextBasedTranslationKeys;
 		},
@@ -321,15 +324,18 @@ export default defineComponent({
 				);
 			}
 
-			actions.push({
-				id: WORKFLOW_MENU_ACTIONS.PUSH,
-				label: this.$locale.baseText('menuActions.push'),
-				disabled:
-					!this.sourceControlStore.isEnterpriseSourceControlEnabled ||
-					!this.onWorkflowPage ||
-					this.onExecutionsTab ||
-					this.readOnlyEnv,
-			});
+			if (this.currentUserIsOwner) {
+				actions.push({
+					id: WORKFLOW_MENU_ACTIONS.PUSH,
+					label: this.$locale.baseText('menuActions.push'),
+					disabled:
+						!this.sourceControlStore.isEnterpriseSourceControlEnabled ||
+						!this.onWorkflowPage ||
+						this.onExecutionsTab ||
+						this.readOnlyEnv ||
+						!this.currentUserIsOwner,
+				});
+			}
 
 			actions.push({
 				id: WORKFLOW_MENU_ACTIONS.SETTINGS,


### PR DESCRIPTION
Removes the menu entry of "Push to Git" from the workflow menu for non-owners, since they would not be able to push in the first place.