### PR TITLE
feat(core): Make postgres pool-size configurable (no-changelog)

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -91,6 +91,12 @@ export const schema = {
 				default: 'public',
 				env: 'DB_POSTGRESDB_SCHEMA',
 			},
+			poolSize: {
+				doc: 'PostgresDB Pool Size',
+				format: Number,
+				default: 2,
+				env: 'DB_POSTGRESDB_POOL_SIZE',
+			},
 
 			ssl: {
 				enabled: {

--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -61,6 +61,7 @@ export const getPostgresConnectionOptions = (): PostgresConnectionOptions => ({
 	type: 'postgres',
 	...getDBConnectionOptions('postgresdb'),
 	schema: config.getEnv('database.postgresdb.schema'),
+	poolSize: config.getEnv('database.postgresdb.poolSize'),
 	migrations: postgresMigrations,
 });
 


### PR DESCRIPTION
When we upgrade typeorm in #5151, we switched from no pooling to a default pool-size of 10. This somehow significantly deteriorates the performance of queries when the application is under load.