### PR TITLE
refactor(core): Move getInstaceBaseUrl to the InstanceService (no-changelog)

### DIFF
--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -11,11 +11,11 @@ import type { OpenAPIV3 } from 'openapi-types';
 import type { JsonObject } from 'swagger-ui-express';
 
 import config from '@/config';
-import { getInstanceBaseUrl } from '@/UserManagement/UserManagementHelper';
 import { Container } from 'typedi';
 import { InternalHooks } from '@/InternalHooks';
 import { License } from '@/License';
 import { UserRepository } from '@db/repositories/user.repository';
+import { InstanceService } from '@/services/instance.service';
 
 async function createApiRouter(
 	version: string,
@@ -29,7 +29,9 @@ async function createApiRouter(
 	// from the Swagger UI
 	swaggerDocument.server = [
 		{
-			url: `${getInstanceBaseUrl()}/${publicApiEndpoint}/${version}}`,
+			url: `${Container.get(
+				InstanceService,
+			).getInstanceBaseUrl()}/${publicApiEndpoint}/${version}}`,
 		},
 	];
 	const apiController = express.Router();

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -6,9 +6,7 @@ import * as ResponseHelper from '@/ResponseHelper';
 import type { WhereClause } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } from '@db/entities/User';
-import config from '@/config';
 import { License } from '@/License';
-import { getWebhookBaseUrl } from '@/WebhookHelpers';
 import { RoleService } from '@/services/role.service';
 import { UserRepository } from '@db/repositories/user.repository';
 
@@ -25,19 +23,6 @@ export async function getInstanceOwner() {
 			globalRoleId: globalOwnerRole.id,
 		},
 	});
-}
-
-/**
- * Return the n8n instance base URL without trailing slash.
- */
-export function getInstanceBaseUrl(): string {
-	const n8nBaseUrl = config.getEnv('editorBaseUrl') || getWebhookBaseUrl();
-
-	return n8nBaseUrl.endsWith('/') ? n8nBaseUrl.slice(0, n8nBaseUrl.length - 1) : n8nBaseUrl;
-}
-
-export function generateUserInviteUrl(inviterId: string, inviteeId: string): string {
-	return `${getInstanceBaseUrl()}/signup?inviterId=${inviterId}&inviteeId=${inviteeId}`;
 }
 
 // TODO: Enforce at model level

--- a/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
+++ b/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
@@ -7,7 +7,6 @@ import type { User } from '@db/entities/User';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import type { ICredentialsDb } from '@/Interfaces';
-import { getInstanceBaseUrl } from '@/UserManagement/UserManagementHelper';
 import type { OAuthRequest } from '@/requests';
 import { BadRequestError, NotFoundError } from '@/ResponseHelper';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
@@ -15,6 +14,7 @@ import { CredentialsHelper } from '@/CredentialsHelper';
 import * as WorkflowExecuteAdditionalData from '@/WorkflowExecuteAdditionalData';
 import { Logger } from '@/Logger';
 import { ExternalHooks } from '@/ExternalHooks';
+import { InstanceService } from '@/services/instance.service';
 
 @Service()
 export abstract class AbstractOAuthController {
@@ -26,10 +26,13 @@ export abstract class AbstractOAuthController {
 		private readonly credentialsHelper: CredentialsHelper,
 		private readonly credentialsRepository: CredentialsRepository,
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
+		private readonly instanceService: InstanceService,
 	) {}
 
 	get baseUrl() {
-		const restUrl = `${getInstanceBaseUrl()}/${config.getEnv('endpoints.rest')}`;
+		const restUrl = `${this.instanceService.getInstanceBaseUrl()}/${config.getEnv(
+			'endpoints.rest',
+		)}`;
 		return `${restUrl}/oauth${this.oauthVersion}-credential`;
 	}
 

--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -12,11 +12,7 @@ import {
 	UnauthorizedError,
 	UnprocessableRequestError,
 } from '@/ResponseHelper';
-import {
-	getInstanceBaseUrl,
-	hashPassword,
-	validatePassword,
-} from '@/UserManagement/UserManagementHelper';
+import { hashPassword, validatePassword } from '@/UserManagement/UserManagementHelper';
 import { UserManagementMailer } from '@/UserManagement/email';
 import { PasswordResetRequest } from '@/requests';
 import { issueCookie } from '@/auth/jwt';
@@ -29,6 +25,7 @@ import { MfaService } from '@/Mfa/mfa.service';
 import { Logger } from '@/Logger';
 import { ExternalHooks } from '@/ExternalHooks';
 import { InternalHooks } from '@/InternalHooks';
+import { InstanceService } from '@/services/instance.service';
 
 const throttle = rateLimit({
 	windowMs: 5 * 60 * 1000, // 5 minutes
@@ -47,6 +44,7 @@ export class PasswordResetController {
 		private readonly userService: UserService,
 		private readonly mfaService: MfaService,
 		private readonly license: License,
+		private readonly instanceService: InstanceService,
 	) {}
 
 	/**
@@ -131,7 +129,7 @@ export class PasswordResetController {
 				firstName,
 				lastName,
 				passwordResetUrl: url,
-				domain: getInstanceBaseUrl(),
+				domain: this.instanceService.getInstanceBaseUrl(),
 			});
 		} catch (error) {
 			void this.internalHooks.onEmailFailed({

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -17,7 +17,6 @@ import { CredentialsOverwrites } from '@/CredentialsOverwrites';
 import { CredentialTypes } from '@/CredentialTypes';
 import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
 import { License } from '@/License';
-import { getInstanceBaseUrl } from '@/UserManagement/UserManagementHelper';
 import * as WebhookHelpers from '@/WebhookHelpers';
 import config from '@/config';
 import { getCurrentAuthenticationMethod } from '@/sso/ssoHelpers';
@@ -31,6 +30,7 @@ import {
 import { UserManagementMailer } from '@/UserManagement/email';
 import type { CommunityPackagesService } from '@/services/communityPackages.service';
 import { Logger } from '@/Logger';
+import { InstanceService } from '@/services/instance.service';
 
 @Service()
 export class FrontendService {
@@ -46,6 +46,7 @@ export class FrontendService {
 		private readonly license: License,
 		private readonly mailer: UserManagementMailer,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly instanceService: InstanceService,
 	) {
 		loadNodesAndCredentials.addPostProcessor(async () => this.generateTypes());
 		void this.generateTypes();
@@ -61,7 +62,7 @@ export class FrontendService {
 	}
 
 	private initSettings() {
-		const instanceBaseUrl = getInstanceBaseUrl();
+		const instanceBaseUrl = this.instanceService.getInstanceBaseUrl();
 		const restEndpoint = config.getEnv('endpoints.rest');
 
 		const telemetrySettings: ITelemetrySettings = {
@@ -218,7 +219,7 @@ export class FrontendService {
 		const restEndpoint = config.getEnv('endpoints.rest');
 
 		// Update all urls, in case `WEBHOOK_URL` was updated by `--tunnel`
-		const instanceBaseUrl = getInstanceBaseUrl();
+		const instanceBaseUrl = this.instanceService.getInstanceBaseUrl();
 		this.settings.urlBaseWebhook = WebhookHelpers.getWebhookBaseUrl();
 		this.settings.urlBaseEditor = instanceBaseUrl;
 		this.settings.oauthCallbackUrls = {

--- a/packages/cli/src/services/instance.service.ts
+++ b/packages/cli/src/services/instance.service.ts
@@ -1,0 +1,36 @@
+import { Service } from 'typedi';
+import config from '@/config';
+
+@Service()
+export class InstanceService {
+	/**
+	 * Return the n8n instance base URL without trailing slash.
+	 */
+	getInstanceBaseUrl(): string {
+		const n8nBaseUrl = config.getEnv('editorBaseUrl') || this.getWebhookBaseUrl();
+		return n8nBaseUrl.endsWith('/') ? n8nBaseUrl.slice(0, n8nBaseUrl.length - 1) : n8nBaseUrl;
+	}
+
+	getWebhookBaseUrl() {
+		let urlBaseWebhook = process.env.WEBHOOK_URL ?? this.getBaseUrl();
+		if (!urlBaseWebhook.endsWith('/')) {
+			urlBaseWebhook += '/';
+		}
+		return urlBaseWebhook;
+	}
+
+	/**
+	 * Returns the base URL n8n is reachable from
+	 */
+	private getBaseUrl() {
+		const protocol = config.getEnv('protocol');
+		const host = config.getEnv('host');
+		const port = config.getEnv('port');
+		const path = config.getEnv('path');
+
+		if ((protocol === 'http' && port === 80) || (protocol === 'https' && port === 443)) {
+			return `${protocol}://${host}${path}`;
+		}
+		return `${protocol}://${host}:${port}${path}`;
+	}
+}

--- a/packages/cli/src/sso/saml/samlHelpers.ts
+++ b/packages/cli/src/sso/saml/samlHelpers.ts
@@ -21,6 +21,7 @@ import type { SamlConfiguration } from './types/requests';
 import { RoleService } from '@/services/role.service';
 import { UserRepository } from '@db/repositories/user.repository';
 import { AuthIdentityRepository } from '@db/repositories/authIdentity.repository';
+import { InstanceService } from '@/services/instance.service';
 /**
  *  Check whether the SAML feature is licensed and enabled in the instance
  */
@@ -178,5 +179,8 @@ export function getMappedSamlAttributesFromFlowResult(
 }
 
 export function isConnectionTestRequest(req: SamlConfiguration.AcsRequest): boolean {
-	return req.body.RelayState === getServiceProviderConfigTestReturnUrl();
+	return (
+		req.body.RelayState ===
+		getServiceProviderConfigTestReturnUrl(Container.get(InstanceService).getInstanceBaseUrl())
+	);
 }

--- a/packages/cli/src/sso/saml/serviceProvider.ee.ts
+++ b/packages/cli/src/sso/saml/serviceProvider.ee.ts
@@ -1,21 +1,22 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { getInstanceBaseUrl } from '@/UserManagement/UserManagementHelper';
 import type { ServiceProviderInstance } from 'samlify';
 import { SamlUrls } from './constants';
 import type { SamlPreferences } from './types/samlPreferences';
+import { InstanceService } from '@/services/instance.service';
+import Container from 'typedi';
 
 let serviceProviderInstance: ServiceProviderInstance | undefined;
 
-export function getServiceProviderEntityId(): string {
-	return getInstanceBaseUrl() + SamlUrls.restMetadata;
+export function getServiceProviderEntityId(baseUrl: string): string {
+	return baseUrl + SamlUrls.restMetadata;
 }
 
-export function getServiceProviderReturnUrl(): string {
-	return getInstanceBaseUrl() + SamlUrls.restAcs;
+export function getServiceProviderReturnUrl(baseUrl: string): string {
+	return baseUrl + SamlUrls.restAcs;
 }
 
-export function getServiceProviderConfigTestReturnUrl(): string {
-	return getInstanceBaseUrl() + SamlUrls.configTestReturn;
+export function getServiceProviderConfigTestReturnUrl(baseUrl: string): string {
+	return baseUrl + SamlUrls.configTestReturn;
 }
 
 // TODO:SAML: make these configurable for the end user
@@ -24,9 +25,11 @@ export function getServiceProviderInstance(
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	samlify: typeof import('samlify'),
 ): ServiceProviderInstance {
+	const baseUrl = Container.get(InstanceService).getInstanceBaseUrl();
+
 	if (serviceProviderInstance === undefined) {
 		serviceProviderInstance = samlify.ServiceProvider({
-			entityID: getServiceProviderEntityId(),
+			entityID: getServiceProviderEntityId(baseUrl),
 			authnRequestsSigned: prefs.authnRequestsSigned,
 			wantAssertionsSigned: prefs.wantAssertionsSigned,
 			wantMessageSigned: prefs.wantMessageSigned,
@@ -37,12 +40,12 @@ export function getServiceProviderInstance(
 				{
 					isDefault: prefs.acsBinding === 'post',
 					Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-					Location: getServiceProviderReturnUrl(),
+					Location: getServiceProviderReturnUrl(baseUrl),
 				},
 				{
 					isDefault: prefs.acsBinding === 'redirect',
 					Binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-REDIRECT',
-					Location: getServiceProviderReturnUrl(),
+					Location: getServiceProviderReturnUrl(baseUrl),
 				},
 			],
 		});


### PR DESCRIPTION
Was trying to break a dependency cycle in the `UserService` and ended up needing to extract the `getInstaceBaseUrl` and move it into its own service. Feel free to drop it if this is not the right approach. Ideally we would keep extracting everything from the` UsermanagmentHelpers.ts` file and remove it. This change also allows to inject the `UserService` to the ExternalHooks without trowing `ReferenceError: Cannot inject an `undefined` dependency. Possibly a circular dependency detected` 