### PR TITLE
fix(editor): Show nice error when environment is not set up

### DIFF
--- a/packages/cli/src/environments/sourceControl/middleware/sourceControlEnabledMiddleware.ee.ts
+++ b/packages/cli/src/environments/sourceControl/middleware/sourceControlEnabledMiddleware.ee.ts
@@ -8,7 +8,14 @@ export const sourceControlLicensedAndEnabledMiddleware: RequestHandler = (req, r
 	if (sourceControlPreferencesService.isSourceControlLicensedAndEnabled()) {
 		next();
 	} else {
-		res.status(401).json({ status: 'error', message: 'Unauthorized' });
+		if (!sourceControlPreferencesService.isSourceControlConnected()) {
+			res.status(412).json({
+				status: 'error',
+				message: 'source_control_not_connected',
+			});
+		} else {
+			res.status(401).json({ status: 'error', message: 'Unauthorized' });
+		}
 	}
 };
 

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -587,7 +587,22 @@ export default defineComponent({
 							data: { eventBus: this.eventBus, status },
 						});
 					} catch (error) {
-						this.showError(error, this.$locale.baseText('error'));
+						if ('message' in error) {
+							// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+							switch (error.message) {
+								case 'source_control_not_connected':
+									this.showError(
+										{ ...error, message: '' },
+										this.$locale.baseText('settings.sourceControl.error.not.connected.title'),
+										this.$locale.baseText('settings.sourceControl.error.not.connected.message'),
+									);
+									break;
+								default:
+									this.showError(error, this.$locale.baseText('error'));
+							}
+						} else {
+							this.showError(error, this.$locale.baseText('error'));
+						}
 					} finally {
 						this.stopLoading();
 					}

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -587,21 +587,17 @@ export default defineComponent({
 							data: { eventBus: this.eventBus, status },
 						});
 					} catch (error) {
-						if ('message' in error) {
-							// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-							switch (error.message) {
-								case 'source_control_not_connected':
-									this.showError(
-										{ ...error, message: '' },
-										this.$locale.baseText('settings.sourceControl.error.not.connected.title'),
-										this.$locale.baseText('settings.sourceControl.error.not.connected.message'),
-									);
-									break;
-								default:
-									this.showError(error, this.$locale.baseText('error'));
-							}
-						} else {
-							this.showError(error, this.$locale.baseText('error'));
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+						switch (error.message) {
+							case 'source_control_not_connected':
+								this.showError(
+									{ ...error, message: '' },
+									this.$locale.baseText('settings.sourceControl.error.not.connected.title'),
+									this.$locale.baseText('settings.sourceControl.error.not.connected.message'),
+								);
+								break;
+							default:
+								this.showError(error, this.$locale.baseText('error'));
 						}
 					} finally {
 						this.stopLoading();

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1654,6 +1654,8 @@
 	"settings.sourceControl.docs.setup.ssh.url": "https://docs.n8n.io/source-control-environments/setup/#step-3-set-up-a-deploy-key",
 	"settings.sourceControl.docs.using.url": "https://docs.n8n.io/source-control-environments/using/",
 	"settings.sourceControl.docs.using.pushPull.url": "https://docs.n8n.io/source-control-environments/using/push-pull",
+	"settings.sourceControl.error.not.connected.title": "Environments have not been enabled",
+	"settings.sourceControl.error.not.connected.message": "Please head over to <a href='/settings/environments'>environment settings</a> to connect a git repository first to activate this functionality.",
 	"showMessage.cancel": "@:_reusableBaseText.cancel",
 	"settings.auditLogs.title": "Audit Logs",
 	"settings.auditLogs.actionBox.title": "Available on the Enterprise plan",


### PR DESCRIPTION
Adds a nicer error message with a link for owners who press Push to Git without having a repository connected yet.