### PR TITLE
feat(editor): Move template credentials setup behind feature flag

### DIFF
--- a/packages/editor-ui/src/utils/featureFlag.ts
+++ b/packages/editor-ui/src/utils/featureFlag.ts
@@ -1,0 +1,16 @@
+// Feature flags
+export const enum FeatureFlag {
+	templateCredentialsSetup = 'template-credentials-setup',
+}
+
+const hasLocaleStorageKey = (key: string): boolean => {
+	try {
+		// Local storage might not be available in all envs e.g. when user has
+		// disabled it in their browser
+		return !!localStorage.getItem(key);
+	} catch (e) {
+		return false;
+	}
+};
+
+export const isFeatureFlagEnabled = (flag: FeatureFlag): boolean => hasLocaleStorageKey(flag);

--- a/packages/editor-ui/src/views/TemplatesWorkflowView.vue
+++ b/packages/editor-ui/src/views/TemplatesWorkflowView.vue
@@ -68,6 +68,7 @@ import { setPageTitle } from '@/utils';
 import { VIEWS } from '@/constants';
 import { useTemplatesStore } from '@/stores/templates.store';
 import { usePostHog } from '@/stores/posthog.store';
+import { FeatureFlag, isFeatureFlagEnabled } from '@/utils/featureFlag';
 
 export default defineComponent({
 	name: 'TemplatesWorkflowView',
@@ -105,12 +106,23 @@ export default defineComponent({
 			this.$telemetry.track('User inserted workflow template', telemetryPayload, {
 				withPostHog: true,
 			});
-			if (e.metaKey || e.ctrlKey) {
-				const route = this.$router.resolve({ name: VIEWS.TEMPLATE_SETUP, params: { id } });
-				window.open(route.href, '_blank');
-				return;
+
+			if (isFeatureFlagEnabled(FeatureFlag.templateCredentialsSetup)) {
+				if (e.metaKey || e.ctrlKey) {
+					const route = this.$router.resolve({ name: VIEWS.TEMPLATE_SETUP, params: { id } });
+					window.open(route.href, '_blank');
+					return;
+				} else {
+					void this.$router.push({ name: VIEWS.TEMPLATE_SETUP, params: { id } });
+				}
 			} else {
-				void this.$router.push({ name: VIEWS.TEMPLATE_SETUP, params: { id } });
+				if (e.metaKey || e.ctrlKey) {
+					const route = this.$router.resolve({ name: VIEWS.TEMPLATE_IMPORT, params: { id } });
+					window.open(route.href, '_blank');
+					return;
+				} else {
+					void this.$router.push({ name: VIEWS.TEMPLATE_IMPORT, params: { id } });
+				}
 			}
 		},
 		onHidePreview() {


### PR DESCRIPTION
To enable the flag do:

```js
localStorage.setItem('template-credentials-setup', 'true')
```