### PR TITLE
ci: Set up Turborepo cache again (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -25,6 +25,9 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
 
+      - name: Configure Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
       - name: Build Backend
         run: pnpm build:backend
 

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
       - name: Restore cached build artifacts
         uses: actions/cache/restore@v3.3.1
         with:

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
       - name: Build
         if: ${{ inputs.cacheKey == '' }}
         run: pnpm build

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**"]
 		},
+		"build:backend": {},
+		"build:frontend": {},
+		"test:backend": {},
+		"test:frontend": {},
 		"typecheck": {},
 		"format": {},
 		"lint": {},


### PR DESCRIPTION
This PR sets up [this GH action](https://github.com/dtinth/setup-github-actions-caching-for-turbo) so we can use the GH runner's cache service for Turborepo runs.

The [last time](https://github.com/n8n-io/n8n/pull/6335) we had to [revert](https://github.com/n8n-io/n8n/pull/6364) but the full logs of the issue are [no longer available](https://github.com/n8n-io/n8n/actions/runs/5153965016) so we might have to end up triggering the same issue again for debugging.
