### PR TITLE
fix(editor): Fix `UserStack` vertical centering (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nUserStack/UserStack.vue
+++ b/packages/design-system/src/components/N8nUserStack/UserStack.vue
@@ -99,6 +99,7 @@ const menuHeight = computed(() => {
 									v-for="user in groupUsers"
 									:key="user.id"
 									:data-test-id="`user-stack-info-${user.id}`"
+									:class="$style.userInfoContainer"
 								>
 									<n8n-user-info
 										v-bind="user"
@@ -157,6 +158,12 @@ const menuHeight = computed(() => {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-2xs);
+}
+
+.userInfoContainer {
+	display: flex;
+	padding-top: var(--spacing-5xs);
+	padding-bottom: var(--spacing-5xs);
 }
 </style>
 


### PR DESCRIPTION
Dropdown items in `UserStack`component are not properly vertically aligned. That's particularly noticeable when the items are hovered:
![image](https://github.com/n8n-io/n8n/assets/2598782/c994be3d-45e9-4b89-9973-deee5a8735ba)
