### PR TITLE
ci: Fix new user patching endpoint tests (no-changelog)

### DIFF
--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -499,9 +499,11 @@ describe('PATCH /users/:id/role', () => {
 		});
 
 		test('should receive 404 on unknown target user', async () => {
-			const response = await authAdminAgent.patch('/users/99999/role').send({
-				newRole: { scope: 'global', name: 'member' },
-			});
+			const response = await authAdminAgent
+				.patch('/users/c2317ff3-7a9f-4fd4-ad2b-7331f6359260/role')
+				.send({
+					newRole: { scope: 'global', name: 'member' },
+				});
 
 			expect(response.statusCode).toBe(404);
 			expect(response.body.message).toBe(NO_USER);


### PR DESCRIPTION
user ids are uuids, and in the future we should add proper input validation to prevent invalid user ids reaching the DB like this.

