### PR TITLE
fix(core): Fix denial errors on same-user subworkflow caller policy

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -93,14 +93,6 @@ export class PermissionChecker {
 			return;
 		}
 
-		let policy =
-			subworkflow.settings?.callerPolicy ?? config.getEnv('workflows.callerPolicyDefaultOption');
-
-		if (!isSharingEnabled()) {
-			// Community version allows only same owner workflows
-			policy = 'workflowsFromSameOwner';
-		}
-
 		const subworkflowOwner = await Container.get(OwnershipService).getWorkflowOwnerCached(
 			subworkflow.id,
 		);
@@ -111,6 +103,16 @@ export class PermissionChecker {
 				? 'Change the settings of the sub-workflow so it can be called by this one.'
 				: `${subworkflowOwner.firstName} (${subworkflowOwner.email}) can make this change. You may need to tell them the ID of this workflow, which is ${subworkflow.id}`,
 		);
+
+		let policy =
+			subworkflow.settings?.callerPolicy ?? config.getEnv('workflows.callerPolicyDefaultOption');
+
+		if (!isSharingEnabled()) {
+			// Community version allows only same owner workflows
+			policy = 'workflowsFromSameOwner';
+			errorToThrow.description =
+				'In the community version, a subworkflow can only be called by a workflow created by the same owner as the subworkflow.';
+		}
 
 		if (policy === 'none') {
 			throw errorToThrow;

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -826,7 +826,6 @@ async function executeWorkflow(
 		}
 		data = await workflowExecute.processRunExecutionData(workflow);
 	} catch (error) {
-		console.log('error', error);
 		const executionError = error ? (error as ExecutionError) : undefined;
 		const fullRunData: IRun = {
 			data: {


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically): https://community.n8n.io/t/executing-workflow-using-owner-role-created-by-another-user-fails/33443

https://linear.app/n8n/issue/PAY-992
