### PR TITLE
fix(editor): Fix mouse position in workflow previews

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4703,6 +4703,7 @@ export default defineComponent({
 		});
 
 		this.readOnlyEnvRouteCheck();
+		this.canvasStore.isDemo = this.isDemo;
 	},
 	activated() {
 		const openSideMenu = this.uiStore.addFirstStepOnLoad;


### PR DESCRIPTION
This PR fixes mouse position detection in workflow previews (executions preview and workflow history view):

https://github.com/n8n-io/n8n/assets/2598782/83237b76-b099-4560-9c47-a963f0848297

**Cause**:
We were setting `isDemo` state in canvas store only when the `NodeView` component is activated, which never happens for `NodeView` instances that are kept alive (above mentioned workflow previews)

**Fix**:
This workflow updates store state also when the `NodeView` component is mounted.