### PR TITLE
fix: Return scopes on owner setup endpoint (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/owner.controller.ts
+++ b/packages/cli/src/controllers/owner.controller.ts
@@ -101,7 +101,7 @@ export class OwnerController {
 
 		void this.internalHooks.onInstanceOwnerSetup({ user_id: userId });
 
-		return this.userService.toPublic(owner, { posthog: this.postHog });
+		return this.userService.toPublic(owner, { posthog: this.postHog, withScopes: true });
 	}
 
 	@Post('/dismiss-banner')

--- a/packages/cli/test/integration/owner.api.test.ts
+++ b/packages/cli/test/integration/owner.api.test.ts
@@ -60,6 +60,7 @@ describe('POST /owner/setup', () => {
 			password,
 			isPending,
 			apiKey,
+			globalScopes,
 		} = response.body.data;
 
 		expect(validator.isUUID(id)).toBe(true);
@@ -72,6 +73,7 @@ describe('POST /owner/setup', () => {
 		expect(globalRole.name).toBe('owner');
 		expect(globalRole.scope).toBe('global');
 		expect(apiKey).toBeUndefined();
+		expect(globalScopes).not.toHaveLength(0);
 
 		const storedOwner = await Container.get(UserRepository).findOneByOrFail({ id });
 		expect(storedOwner.password).not.toBe(newOwnerData.password);


### PR DESCRIPTION
Github issue / Community forum post (link here to close automatically):
