### PR TITLE
fix(editor): Restrict workflow and credential sharing to their owners (no-changelog)

### DIFF
--- a/packages/editor-ui/src/permissions.ts
+++ b/packages/editor-ui/src/permissions.ts
@@ -109,7 +109,7 @@ export const getWorkflowPermissions = (user: IUser | null, workflow: IWorkflowDb
 		},
 		{
 			name: 'updateSharing',
-			test: (permissions) => rbacStore.hasScope('workflow:share') || !!permissions.isOwner,
+			test: (permissions) => !!permissions.isOwner,
 		},
 		{
 			name: 'delete',

--- a/packages/editor-ui/src/permissions.ts
+++ b/packages/editor-ui/src/permissions.ts
@@ -84,7 +84,7 @@ export const getCredentialPermissions = (user: IUser | null, credential: ICreden
 		{ name: 'updateConnection', test: [UserRole.ResourceOwner] },
 		{
 			name: 'updateSharing',
-			test: (permissions) => rbacStore.hasScope('credential:share') || !!permissions.isOwner,
+			test: (permissions) => !!permissions.isOwner,
 		},
 		{ name: 'updateNodeAccess', test: [UserRole.ResourceOwner] },
 		{ name: 'delete', test: [UserRole.ResourceOwner, UserRole.InstanceOwner] },


### PR DESCRIPTION
Removing scope permission checks on workflow and credential sharing and relying only on resource ownership.
Every user can share only the workflows and credentials they created.