### PR TITLE
refactor(core): Switch plain errors in `workflow` to `ApplicationError` (no-changelog)

### DIFF
--- a/packages/workflow/src/ErrorReporterProxy.ts
+++ b/packages/workflow/src/ErrorReporterProxy.ts
@@ -24,7 +24,7 @@ export function init(errorReporter: ErrorReporter) {
 
 const wrap = (e: unknown) => {
 	if (e instanceof Error) return e;
-	if (typeof e === 'string') return new Error(e);
+	if (typeof e === 'string') return new ApplicationError(e);
 	return;
 };
 

--- a/packages/workflow/src/Expression.ts
+++ b/packages/workflow/src/Expression.ts
@@ -25,6 +25,7 @@ import { extendedFunctions } from './Extensions/ExtendedFunctions';
 import { extendSyntax } from './Extensions/ExpressionExtension';
 import { evaluateExpression, setErrorHandler } from './ExpressionEvaluatorProxy';
 import { getGlobalState } from './GlobalState';
+import { ApplicationError } from './errors/application.error';
 
 const IS_FRONTEND_IN_DEV_MODE =
 	typeof process === 'object' &&
@@ -75,7 +76,7 @@ export class Expression {
 		const typeName = Array.isArray(value) ? 'Array' : 'Object';
 
 		if (value instanceof DateTime && value.invalidReason !== null) {
-			throw new Error('invalid DateTime');
+			throw new ApplicationError('invalid DateTime');
 		}
 
 		let result = '';
@@ -310,12 +311,12 @@ export class Expression {
 		const extendedExpression = extendSyntax(parameterValue);
 		const returnValue = this.renderExpression(extendedExpression, data);
 		if (typeof returnValue === 'function') {
-			if (returnValue.name === '$') throw new Error('invalid syntax');
+			if (returnValue.name === '$') throw new ApplicationError('invalid syntax');
 
 			if (returnValue.name === 'DateTime')
-				throw new Error('this is a DateTime, please access its methods');
+				throw new ApplicationError('this is a DateTime, please access its methods');
 
-			throw new Error('this is a function, please add ()');
+			throw new ApplicationError('this is a function, please add ()');
 		} else if (typeof returnValue === 'string') {
 			return returnValue;
 		} else if (returnValue !== null && typeof returnValue === 'object') {
@@ -339,14 +340,14 @@ export class Expression {
 		} catch (error) {
 			if (isExpressionError(error)) throw error;
 
-			if (isSyntaxError(error)) throw new Error('invalid syntax');
+			if (isSyntaxError(error)) throw new ApplicationError('invalid syntax');
 
 			if (isTypeError(error) && IS_FRONTEND && error.message.endsWith('is not a function')) {
 				const match = error.message.match(/(?<msg>[^.]+is not a function)/);
 
 				if (!match?.groups?.msg) return null;
 
-				throw new Error(match.groups.msg);
+				throw new ApplicationError(match.groups.msg);
 			}
 		} finally {
 			Object.defineProperty(Function.prototype, 'constructor', { value: fnConstructors.sync });

--- a/packages/workflow/src/TelemetryHelpers.ts
+++ b/packages/workflow/src/TelemetryHelpers.ts
@@ -9,6 +9,7 @@ import type {
 	INodeTypes,
 	INodeType,
 } from './Interfaces';
+import { ApplicationError } from './errors/application.error';
 
 const STICKY_NODE_TYPE = 'n8n-nodes-base.stickyNote';
 
@@ -95,7 +96,7 @@ export function getDomainPath(raw: string, urlParts = URL_PARTS_REGEX): string {
 	try {
 		const url = new URL(raw);
 
-		if (!url.hostname) throw new Error('Malformed URL');
+		if (!url.hostname) throw new ApplicationError('Malformed URL');
 
 		return sanitizeRoute(url.pathname);
 	} catch {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,5 +1,6 @@
 import FormData from 'form-data';
 import type { BinaryFileType, JsonObject } from './Interfaces';
+import { ApplicationError } from './errors/application.error';
 
 const readStreamClasses = new Set(['ReadStream', 'Readable', 'ReadableStream']);
 
@@ -77,7 +78,7 @@ export const jsonParse = <T>(jsonString: string, options?: JSONParseOptions<T>):
 		if (options?.fallbackValue !== undefined) {
 			return options.fallbackValue;
 		} else if (options?.errorMessage) {
-			throw new Error(options.errorMessage);
+			throw new ApplicationError(options.errorMessage);
 		}
 
 		throw error;

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -1,3 +1,4 @@
+import { ApplicationError } from '@/errors/application.error';
 import { jsonParse, jsonStringify, deepCopy, isObjectEmpty, fileTypeFromMimeType } from '@/utils';
 
 describe('isObjectEmpty', () => {
@@ -58,7 +59,11 @@ describe('isObjectEmpty', () => {
 		const { calls } = keySpy.mock;
 
 		const assertCalls = (count: number) => {
-			if (calls.length !== count) throw new Error(`Object.keys was called ${calls.length} times`);
+			if (calls.length !== count) {
+				throw new ApplicationError('`Object.keys()` was called an unexpected number of times', {
+					extra: { times: calls.length },
+				});
+			}
 		};
 
 		assertCalls(0);


### PR DESCRIPTION
Ensure all errors in `workflow` are `ApplicationError` or children of it and contain no variables in the message, to continue normalizing all the errors we report to Sentry

Follow-up to: https://github.com/n8n-io/n8n/pull/7873
