### PR TITLE
fix: Fix credential setup for templates with unnamed credentials (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/templates/__tests__/templateTransforms.test.ts
+++ b/packages/editor-ui/src/utils/templates/__tests__/templateTransforms.test.ts
@@ -1,0 +1,47 @@
+import {
+	keyFromCredentialTypeAndName,
+	replaceAllTemplateNodeCredentials,
+} from '@/utils/templates/templateTransforms';
+import { newWorkflowTemplateNode } from '@/utils/testData/templateTestData';
+
+describe('templateTransforms', () => {
+	describe('replaceAllTemplateNodeCredentials', () => {
+		it('should replace credentials of nodes that have credentials', () => {
+			const node = newWorkflowTemplateNode({
+				type: 'n8n-nodes-base.twitter',
+				credentials: {
+					twitterOAuth1Api: 'old1',
+				},
+			});
+
+			const toReplaceWith = {
+				[keyFromCredentialTypeAndName('twitterOAuth1Api', 'old1')]: {
+					id: 'new1',
+					name: 'Twitter creds',
+				},
+			};
+
+			const [replacedNode] = replaceAllTemplateNodeCredentials([node], toReplaceWith);
+
+			expect(replacedNode.credentials).toEqual({
+				twitterOAuth1Api: { id: 'new1', name: 'Twitter creds' },
+			});
+		});
+
+		it('should not replace credentials of nodes that do not have credentials', () => {
+			const node = newWorkflowTemplateNode({
+				type: 'n8n-nodes-base.twitter',
+			});
+			const toReplaceWith = {
+				[keyFromCredentialTypeAndName('twitterOAuth1Api', 'old1')]: {
+					id: 'new1',
+					name: 'Twitter creds',
+				},
+			};
+
+			const [replacedNode] = replaceAllTemplateNodeCredentials([node], toReplaceWith);
+
+			expect(replacedNode.credentials).toBeUndefined();
+		});
+	});
+});

--- a/packages/editor-ui/src/utils/templates/templateActions.ts
+++ b/packages/editor-ui/src/utils/templates/templateActions.ts
@@ -5,6 +5,7 @@ import type { useRootStore } from '@/stores/n8nRoot.store';
 import type { useWorkflowsStore } from '@/stores/workflows.store';
 import { FeatureFlag, isFeatureFlagEnabled } from '@/utils/featureFlag';
 import { getFixedNodesList } from '@/utils/nodeViewUtils';
+import type { TemplateCredentialKey } from '@/utils/templates/templateTransforms';
 import { replaceAllTemplateNodeCredentials } from '@/utils/templates/templateTransforms';
 import type { INodeCredentialsDetails } from 'n8n-workflow';
 import type { RouteLocationRaw, Router } from 'vue-router';
@@ -14,7 +15,7 @@ import type { RouteLocationRaw, Router } from 'vue-router';
  */
 export async function createWorkflowFromTemplate(
 	template: IWorkflowTemplate,
-	credentialOverrides: Record<string, INodeCredentialsDetails>,
+	credentialOverrides: Record<TemplateCredentialKey, INodeCredentialsDetails>,
 	rootStore: ReturnType<typeof useRootStore>,
 	workflowsStore: ReturnType<typeof useWorkflowsStore>,
 ) {

--- a/packages/editor-ui/src/utils/testData/templateTestData.ts
+++ b/packages/editor-ui/src/utils/testData/templateTestData.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { faker } from '@faker-js/faker/locale/en';
+import type { IWorkflowTemplateNode } from '@/Interface';
+
+export const newWorkflowTemplateNode = ({
+	type,
+	...optionalOpts
+}: Pick<IWorkflowTemplateNode, 'type'> &
+	Partial<IWorkflowTemplateNode>): IWorkflowTemplateNode => ({
+	type,
+	name: faker.commerce.productName(),
+	position: [0, 0],
+	parameters: {},
+	typeVersion: 1,
+	...optionalOpts,
+});

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import type { PropType } from 'vue';
 import { computed } from 'vue';
 import N8nHeading from 'n8n-design-system/components/N8nHeading';
 import NodeIcon from '@/components/NodeIcon.vue';
 import CredentialPicker from '@/components/CredentialPicker/CredentialPicker.vue';
 import IconSuccess from './IconSuccess.vue';
-import { assert } from '@/utils/assert';
 import { getAppNameFromNodeName } from '@/utils/nodeTypesUtils';
 import { formatList } from '@/utils/formatters/listFormatter';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+import type { CredentialUsages } from '@/views/SetupWorkflowFromTemplateView/setupTemplate.store';
 import { useSetupTemplateStore } from '@/views/SetupWorkflowFromTemplateView/setupTemplate.store';
 import type { IWorkflowTemplateNode } from '@/Interface';
 import { useI18n } from '@/composables/useI18n';
@@ -18,8 +19,8 @@ const props = defineProps({
 		type: Number,
 		required: true,
 	},
-	credentialName: {
-		type: String,
+	credentials: {
+		type: Object as PropType<CredentialUsages>,
 		required: true,
 	},
 });
@@ -31,19 +32,11 @@ const i18n = useI18n();
 
 //#region Computed
 
-const credentials = computed(() => {
-	const credential = setupTemplateStore.credentialsByName.get(props.credentialName);
-	assert(credential);
-	return credential;
-});
-
-const node = computed(() => credentials.value.usedBy[0]);
+const node = computed(() => props.credentials.usedBy[0]);
 
 const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(node.value.type, node.value.typeVersion),
 );
-
-const credentialType = computed(() => credentials.value.credentialType);
 
 const appName = computed(() =>
 	nodeType.value ? getAppNameFromNodeName(nodeType.value.displayName) : node.value.type,
@@ -51,14 +44,14 @@ const appName = computed(() =>
 
 const nodeNames = computed(() => {
 	const formatNodeName = (nodeToFormat: IWorkflowTemplateNode) => `<b>${nodeToFormat.name}</b>`;
-	return formatList(credentials.value.usedBy, {
+	return formatList(props.credentials.usedBy, {
 		formatFn: formatNodeName,
 		i18n,
 	});
 });
 
 const selectedCredentialId = computed(
-	() => setupTemplateStore.selectedCredentialIdByName[props.credentialName],
+	() => setupTemplateStore.selectedCredentialIdByKey[props.credentials.key],
 );
 
 //#endregion Computed
@@ -66,11 +59,11 @@ const selectedCredentialId = computed(
 //#region Methods
 
 const onCredentialSelected = (credentialId: string) => {
-	setupTemplateStore.setSelectedCredentialId(props.credentialName, credentialId);
+	setupTemplateStore.setSelectedCredentialId(props.credentials.key, credentialId);
 };
 
 const onCredentialDeselected = () => {
-	setupTemplateStore.unsetSelectedCredential(props.credentialName);
+	setupTemplateStore.unsetSelectedCredential(props.credentials.key);
 };
 
 //#endregion Methods
@@ -101,7 +94,7 @@ const onCredentialDeselected = () => {
 			<CredentialPicker
 				:class="$style.credentialPicker"
 				:app-name="appName"
-				:credentialType="credentialType"
+				:credentialType="props.credentials.credentialType"
 				:selectedCredentialId="selectedCredentialId"
 				@credential-selected="onCredentialSelected"
 				@credential-deselected="onCredentialDeselected"

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -120,11 +120,10 @@ onMounted(async () => {
 						<ol v-if="isReady" :class="$style.appCredentialsContainer">
 							<SetupTemplateFormStep
 								:class="$style.appCredential"
-								v-bind:key="credentials.credentialName"
+								:key="credentials.key"
 								v-for="(credentials, index) in setupTemplateStore.credentialUsages"
 								:order="index + 1"
 								:credentials="credentials"
-								:credentialName="credentials.credentialName"
 							/>
 						</ol>
 						<div v-else :class="$style.appCredentialsContainer">

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -19,9 +19,13 @@ import type {
 import type { Telemetry } from '@/plugins/telemetry';
 import { VIEWS } from '@/constants';
 import { createWorkflowFromTemplate } from '@/utils/templates/templateActions';
-import type { IWorkflowTemplateNodeWithCredentials } from '@/utils/templates/templateTransforms';
+import type {
+	TemplateCredentialKey,
+	IWorkflowTemplateNodeWithCredentials,
+} from '@/utils/templates/templateTransforms';
 import {
 	hasNodeCredentials,
+	keyFromCredentialTypeAndName,
 	normalizeTemplateNodeCredentials,
 } from '@/utils/templates/templateTransforms';
 
@@ -37,6 +41,11 @@ export type RequiredCredentials = {
 };
 
 export type CredentialUsages = {
+	/**
+	 * Key is a combination of the credential name and the credential type name,
+	 * e.g. "twitter-twitterOAuth1Api"
+	 */
+	key: TemplateCredentialKey;
 	credentialName: string;
 	credentialType: string;
 	nodeTypeName: string;
@@ -65,30 +74,32 @@ export const getNodesRequiringCredentials = (
 	return template.workflow.nodes.filter(hasNodeCredentials);
 };
 
-export const groupNodeCredentialsByName = (nodes: IWorkflowTemplateNodeWithCredentials[]) => {
-	const credentialsByName = new Map<string, CredentialUsages>();
+export const groupNodeCredentialsByKey = (nodes: IWorkflowTemplateNodeWithCredentials[]) => {
+	const credentialsByTypeName = new Map<TemplateCredentialKey, CredentialUsages>();
 
 	for (const node of nodes) {
 		const normalizedCreds = normalizeTemplateNodeCredentials(node.credentials);
 		for (const credentialType in normalizedCreds) {
 			const credentialName = normalizedCreds[credentialType];
+			const key = keyFromCredentialTypeAndName(credentialType, credentialName);
 
-			let credentialUsages = credentialsByName.get(credentialName);
+			let credentialUsages = credentialsByTypeName.get(key);
 			if (!credentialUsages) {
 				credentialUsages = {
+					key,
 					nodeTypeName: node.type,
 					credentialName,
 					credentialType,
 					usedBy: [],
 				};
-				credentialsByName.set(credentialName, credentialUsages);
+				credentialsByTypeName.set(key, credentialUsages);
 			}
 
 			credentialUsages.usedBy.push(node);
 		}
 	}
 
-	return credentialsByName;
+	return credentialsByTypeName;
 };
 
 export const getAppCredentials = (
@@ -154,8 +165,8 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 	 * Credentials user has selected from the UI. Map from credential
 	 * name in the template to the credential ID.
 	 */
-	const selectedCredentialIdByName = ref<
-		Record<CredentialUsages['credentialName'], ICredentialsResponse['id']>
+	const selectedCredentialIdByKey = ref<
+		Record<CredentialUsages['key'], ICredentialsResponse['id']>
 	>({});
 
 	//#endregion State
@@ -185,12 +196,12 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		return nodeType ? getAppNameFromNodeName(nodeType.displayName) : nodeTypeName;
 	};
 
-	const credentialsByName = computed(() => {
-		return groupNodeCredentialsByName(nodesRequiringCredentialsSorted.value);
+	const credentialsByKey = computed(() => {
+		return groupNodeCredentialsByKey(nodesRequiringCredentialsSorted.value);
 	});
 
 	const credentialUsages = computed(() => {
-		return Array.from(credentialsByName.value.values());
+		return Array.from(credentialsByKey.value.values());
 	});
 
 	const appCredentials = computed(() => {
@@ -198,20 +209,16 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 	});
 
 	const credentialOverrides = computed(() => {
-		const overrides: Record<string, INodeCredentialsDetails> = {};
+		const overrides: Record<TemplateCredentialKey, INodeCredentialsDetails> = {};
 
-		for (const credentialNameInTemplate of Object.keys(selectedCredentialIdByName.value)) {
-			const credentialId = selectedCredentialIdByName.value[credentialNameInTemplate];
-			if (!credentialId) {
-				continue;
-			}
-
+		for (const [key, credentialId] of Object.entries(selectedCredentialIdByKey.value)) {
 			const credential = credentialsStore.getCredentialById(credentialId);
 			if (!credential) {
 				continue;
 			}
 
-			overrides[credentialNameInTemplate] = {
+			// Object.entries fails to give the more accurate key type
+			overrides[key as TemplateCredentialKey] = {
 				id: credentialId,
 				name: credential.name,
 			};
@@ -221,7 +228,7 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 	});
 
 	const numCredentialsLeft = computed(() => {
-		return credentialUsages.value.length - Object.keys(selectedCredentialIdByName.value).length;
+		return credentialUsages.value.length - Object.keys(selectedCredentialIdByKey.value).length;
 	});
 
 	//#endregion Getters
@@ -255,7 +262,7 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 			const availableCreds = credentialsStore.getCredentialsByType(credUsage.credentialType);
 
 			if (availableCreds.length === 1) {
-				selectedCredentialIdByName.value[credUsage.credentialName] = availableCreds[0].id;
+				selectedCredentialIdByKey.value[credUsage.key] = availableCreds[0].id;
 			}
 		}
 	};
@@ -279,7 +286,7 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 	const init = async () => {
 		isLoading.value = true;
 		try {
-			selectedCredentialIdByName.value = {};
+			selectedCredentialIdByKey.value = {};
 
 			await Promise.all([
 				credentialsStore.fetchAllCredentials(),
@@ -349,26 +356,27 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		}
 	};
 
-	const setSelectedCredentialId = (credentialName: string, credentialId: string) => {
-		selectedCredentialIdByName.value[credentialName] = credentialId;
+	const setSelectedCredentialId = (credentialKey: TemplateCredentialKey, credentialId: string) => {
+		selectedCredentialIdByKey.value[credentialKey] = credentialId;
 	};
 
-	const unsetSelectedCredential = (credentialName: string) => {
-		delete selectedCredentialIdByName.value[credentialName];
+	const unsetSelectedCredential = (credentialKey: TemplateCredentialKey) => {
+		delete selectedCredentialIdByKey.value[credentialKey];
 	};
 
 	//#endregion Actions
 
 	return {
-		credentialsByName,
+		credentialsByKey,
 		isLoading,
 		isSaving,
 		appCredentials,
 		nodesRequiringCredentialsSorted,
 		template,
 		credentialUsages,
-		selectedCredentialIdByName,
+		selectedCredentialIdByKey,
 		numCredentialsLeft,
+		credentialOverrides,
 		createWorkflow,
 		skipSetup,
 		init,


### PR DESCRIPTION
The template credentials were matched before solely based on the credential name on the template. This fixes the matching to use both credential type name and credential name.

**Before**:

![image](https://github.com/n8n-io/n8n/assets/10324676/ae0f21a6-b9b5-45f7-8474-a3e900a6a85e)


**After**:

![image](https://github.com/n8n-io/n8n/assets/10324676/b574871a-4b23-42a6-b8a0-8b137b26cdd0)
