### PR TITLE
ci: Fix Docker build and use multi-step approach (no-changelog)

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -9,15 +9,18 @@ ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=stable
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN wget -qO- "https://raw.githubusercontent.com/n8n-io/n8n/n8n@${N8N_VERSION}/packages/cli/package.json" > ./cli_package.json
 
-RUN corepack enable && corepack prepare pnpm@8.9.0 --activate
+RUN apk add --update jq
+RUN corepack enable
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 	'armv7') apk --no-cache add --virtual build-dependencies python3 build-base;; \
 	esac && \
-	pnpm install -g sqlite3@5.1.6 && \
-	pnpm install -g --ignore-scripts n8n@${N8N_VERSION}  && \
+	SQLITE_VERSION=$(jq -r '.dependencies.sqlite3 // .devDependencies.sqlite3' ./cli_package.json) && \
+	pnpm install -g sqlite3@$SQLITE_VERSION --prod && \
+	pnpm install -g n8n@${N8N_VERSION} --prod --ignore-scripts  && \
 	case "$apkArch" in \
 	'armv7') apk del build-dependencies;; \
 	esac && \

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,39 +1,38 @@
 ARG NODE_VERSION=18
-FROM n8nio/base:${NODE_VERSION}
+FROM n8nio/base:${NODE_VERSION} as builder
 
 ARG N8N_VERSION
 RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" ; exit 1; fi
 
-ENV N8N_VERSION=${N8N_VERSION}
-ENV NODE_ENV=production
-ENV N8N_RELEASE_TYPE=stable
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN wget -qO- "https://raw.githubusercontent.com/n8n-io/n8n/n8n@${N8N_VERSION}/packages/cli/package.json" > ./cli_package.json
-
-RUN apk add --update jq
-RUN corepack enable
 RUN set -eux; \
-	apkArch="$(apk --print-arch)"; \
-	case "$apkArch" in \
-	'armv7') apk --no-cache add --virtual build-dependencies python3 build-base;; \
-	esac && \
-	SQLITE_VERSION=$(jq -r '.dependencies.sqlite3 // .devDependencies.sqlite3' ./cli_package.json) && \
-	pnpm install -g sqlite3@$SQLITE_VERSION --prod && \
-	pnpm install -g n8n@${N8N_VERSION} --prod --ignore-scripts  && \
-	case "$apkArch" in \
-	'armv7') apk del build-dependencies;; \
-	esac && \
+	apk --no-cache add --virtual build-dependencies python3 build-base && \
+	npm install -g --omit=dev n8n@${N8N_VERSION} && \
+	ls -la /usr/local/lib/node_modules/n8n && \
+	ls -la /usr/local/lib/node_modules/n8n/bin && \
+	apk del build-dependencies build-base  && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/@n8n/chat && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/n8n-design-system && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/n8n-editor-ui/node_modules && \
 	find /usr/local/lib/node_modules/n8n -type f -name "*.ts" -o -name "*.js.map" -o -name "*.vue" | xargs rm -f && \
 	rm -rf /root/.npm
 
+# Final clean image
+FROM n8nio/base:${NODE_VERSION}
+COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
+RUN ls -la /usr/local/lib/node_modules
+RUN ls -la /usr/local/lib/node_modules/n8n
+RUN ls -la /usr/local/lib/node_modules/n8n/bin/n8n
+RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n
+
 COPY docker-entrypoint.sh /
 
 RUN \
 	mkdir .n8n && \
 	chown node:node .n8n
+
+ENV N8N_VERSION=${N8N_VERSION}
+ENV NODE_ENV=production
+ENV N8N_RELEASE_TYPE=stable
+
 USER node
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -7,12 +7,17 @@ RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" 
 ENV N8N_VERSION=${N8N_VERSION}
 ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=stable
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable && corepack prepare pnpm@8.9.0 --activate
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 	'armv7') apk --no-cache add --virtual build-dependencies python3 build-base;; \
 	esac && \
-	npm install -g --omit=dev n8n@${N8N_VERSION} && \
+	pnpm install -g sqlite3@5.1.6 && \
+	pnpm install -g --ignore-scripts n8n@${N8N_VERSION}  && \
 	case "$apkArch" in \
 	'armv7') apk del build-dependencies;; \
 	esac && \

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -7,8 +7,6 @@ RUN if [ -z "$N8N_VERSION" ] ; then echo "The N8N_VERSION argument is missing!" 
 RUN set -eux; \
 	apk --no-cache add --virtual build-dependencies python3 build-base && \
 	npm install -g --omit=dev n8n@${N8N_VERSION} && \
-	ls -la /usr/local/lib/node_modules/n8n && \
-	ls -la /usr/local/lib/node_modules/n8n/bin && \
 	apk del build-dependencies build-base  && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/@n8n/chat && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/n8n-design-system && \
@@ -19,9 +17,6 @@ RUN set -eux; \
 # Final clean image
 FROM n8nio/base:${NODE_VERSION}
 COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
-RUN ls -la /usr/local/lib/node_modules
-RUN ls -la /usr/local/lib/node_modules/n8n
-RUN ls -la /usr/local/lib/node_modules/n8n/bin/n8n
 RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n
 
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
Due to new dependencies released in `1.19`, the docker build is failing due to missing build dependencie. To get around this, we split the build into two phases. In the building phase, we install the build dependencies required to compile new module bindings and copy the result in the second phase.

Github issue / Community forum post (link here to close automatically):
