### PR TITLE
feat(editor): Allow partial template credential setup (no-changelog)

### DIFF
--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -92,7 +92,7 @@ describe('Template credentials setup', () => {
 	it('can create credentials and workflow from the template', () => {
 		templateCredentialsSetupPage.actions.visit(testTemplate.id);
 
-		templateCredentialsSetupPage.getters.continueButton().should('be.disabled');
+		templateCredentialsSetupPage.getters.continueButton().should('be.enabled');
 
 		templateCredentialsSetupPage.getters.createAppCredentialsButton('Shopify').click();
 		credentialsModal.getters.editCredentialModal().find('input:first()').type('test');

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2281,6 +2281,5 @@
 	"templateSetup.instructions": "You need {0} account to setup this template",
 	"templateSetup.skip": "Skip",
 	"templateSetup.continue.button": "Continue",
-	"templateSetup.continue.tooltip": "Connect to {numLeft} more app to continue | Connect to {numLeft} more apps to continue",
 	"templateSetup.credential.description": "The credential you select will be used in the {0} node of the workflow template. | The credential you select will be used in the {0} nodes of the workflow template."
 }

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -38,15 +38,6 @@ const skipSetupUrl = computed(() => {
 	return resolvedRoute.fullPath;
 });
 
-const buttonTooltip = computed(() => {
-	const numLeft = setupTemplateStore.numCredentialsLeft;
-
-	return i18n.baseText('templateSetup.continue.tooltip', {
-		adjustToNumber: numLeft,
-		interpolate: { numLeft: numLeft.toString() },
-	});
-});
-
 //#endregion Computed
 
 //#region Watchers
@@ -137,19 +128,14 @@ onMounted(async () => {
 							$locale.baseText('templateSetup.skip')
 						}}</n8n-link>
 
-						<n8n-tooltip
+						<n8n-button
 							v-if="isReady"
-							:content="buttonTooltip"
-							:disabled="setupTemplateStore.numCredentialsLeft === 0"
-						>
-							<n8n-button
-								size="large"
-								:label="$locale.baseText('templateSetup.continue.button')"
-								:disabled="setupTemplateStore.numCredentialsLeft > 0 || setupTemplateStore.isSaving"
-								@click="setupTemplateStore.createWorkflow($router)"
-								data-test-id="continue-button"
-							/>
-						</n8n-tooltip>
+							size="large"
+							:label="$locale.baseText('templateSetup.continue.button')"
+							:disabled="setupTemplateStore.isSaving"
+							@click="setupTemplateStore.createWorkflow($router)"
+							data-test-id="continue-button"
+						/>
 						<div v-else>
 							<n8n-loading variant="button" />
 						</div>

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -227,10 +227,6 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		return overrides;
 	});
 
-	const numCredentialsLeft = computed(() => {
-		return credentialUsages.value.length - Object.keys(selectedCredentialIdByKey.value).length;
-	});
-
 	//#endregion Getters
 
 	//#region Actions
@@ -375,7 +371,6 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		template,
 		credentialUsages,
 		selectedCredentialIdByKey,
-		numCredentialsLeft,
 		credentialOverrides,
 		createWorkflow,
 		skipSetup,


### PR DESCRIPTION
Enable continue button even if all credentials havent been setup

<img width="660" alt="image" src="https://github.com/n8n-io/n8n/assets/10324676/3ec6e9cc-f99e-47e4-9434-988796c8d852">
