### PR TITLE
fix(core): Fix user comparison in same-user subworkflow caller policy

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -1,5 +1,5 @@
 import type { INode, Workflow } from 'n8n-workflow';
-import { ApplicationError, NodeOperationError, WorkflowOperationError } from 'n8n-workflow';
+import { NodeOperationError, WorkflowOperationError } from 'n8n-workflow';
 import type { FindOptionsWhere } from 'typeorm';
 import { In } from 'typeorm';
 import config from '@/config';
@@ -11,8 +11,6 @@ import { RoleService } from '@/services/role.service';
 import { UserRepository } from '@db/repositories/user.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
-import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import type { WorkflowEntity } from '@/databases/entities/WorkflowEntity';
 
 export class PermissionChecker {
 	/**
@@ -78,7 +76,11 @@ export class PermissionChecker {
 		});
 	}
 
-	static async checkSubworkflowExecutePolicy(subworkflow: Workflow, parentWorkflowId: string) {
+	static async checkSubworkflowExecutePolicy(
+		subworkflow: Workflow,
+		parentWorkflowId: string,
+		node?: INode,
+	) {
 		/**
 		 * Important considerations: both the current workflow and the parent can have empty IDs.
 		 * This happens when a user is executing an unsaved workflow manually running a workflow
@@ -106,24 +108,6 @@ export class PermissionChecker {
 			subworkflow.id,
 		);
 
-		let parentWorkflow: WorkflowEntity;
-
-		try {
-			parentWorkflow = await Container.get(WorkflowRepository).findOneOrFail({
-				where: { id: parentWorkflowId },
-			});
-		} catch (error) {
-			throw new ApplicationError('Failed to find parent workflow', { extra: { parentWorkflowId } });
-		}
-
-		const executeWorkflowNode = Object.values(parentWorkflow.nodes).find(
-			(node) => node.type === 'n8n-nodes-base.executeWorkflow',
-		);
-
-		if (!executeWorkflowNode) {
-			throw new ApplicationError('Failed to find `executeWorkflow` node');
-		}
-
 		const description =
 			subworkflowOwner.id === parentWorkflowOwner.id
 				? 'Change the settings of the sub-workflow so it can be called by this one.'
@@ -131,7 +115,7 @@ export class PermissionChecker {
 
 		const errorToThrow = new WorkflowOperationError(
 			`Target workflow ID ${subworkflow.id} may not be called`,
-			executeWorkflowNode,
+			node,
 			description,
 		);
 

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -93,6 +93,12 @@ export function objectToError(errorObject: unknown, workflow: Workflow): Error {
 			error = new Error(errorObject.message as string);
 		}
 
+		if ('description' in errorObject) {
+			// @ts-expect-error Error descriptions are surfaced by the UI but
+			// not all backend errors account for this property yet.
+			error.description = errorObject.description as string;
+		}
+
 		if ('stack' in errorObject) {
 			// If there's a 'stack' property, set it on the new Error instance.
 			error.stack = errorObject.stack as string;

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -775,11 +775,7 @@ async function executeWorkflow(
 	let data;
 	try {
 		await PermissionChecker.check(workflow, additionalData.userId);
-		await PermissionChecker.checkSubworkflowExecutePolicy(
-			workflow,
-			additionalData.userId,
-			options.parentWorkflowId,
-		);
+		await PermissionChecker.checkSubworkflowExecutePolicy(workflow, options.parentWorkflowId!);
 
 		// Create new additionalData to have different workflow loaded and to call
 		// different webhooks

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -730,6 +730,7 @@ async function executeWorkflow(
 	workflowInfo: IExecuteWorkflowInfo,
 	additionalData: IWorkflowExecuteAdditionalData,
 	options: {
+		node?: INode;
 		parentWorkflowId?: string;
 		inputData?: INodeExecutionData[];
 		parentExecutionId?: string;
@@ -781,7 +782,11 @@ async function executeWorkflow(
 	let data;
 	try {
 		await PermissionChecker.check(workflow, additionalData.userId);
-		await PermissionChecker.checkSubworkflowExecutePolicy(workflow, options.parentWorkflowId!);
+		await PermissionChecker.checkSubworkflowExecutePolicy(
+			workflow,
+			options.parentWorkflowId!,
+			options.node,
+		);
 
 		// Create new additionalData to have different workflow loaded and to call
 		// different webhooks

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -175,8 +175,7 @@ export async function executeErrorWorkflow(
 		try {
 			await PermissionChecker.checkSubworkflowExecutePolicy(
 				workflowInstance,
-				runningUser.id,
-				workflowErrorData.workflow.id,
+				workflowErrorData.workflow.id!,
 			);
 		} catch (error) {
 			const initialNode = workflowInstance.getStartNode();

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -173,9 +173,13 @@ export async function executeErrorWorkflow(
 		});
 
 		try {
+			const failedNode = workflowErrorData.execution?.lastNodeExecuted
+				? workflowInstance.getNode(workflowErrorData.execution?.lastNodeExecuted)
+				: undefined;
 			await PermissionChecker.checkSubworkflowExecutePolicy(
 				workflowInstance,
 				workflowErrorData.workflow.id!,
+				failedNode ?? undefined,
 			);
 		} catch (error) {
 			const initialNode = workflowInstance.getStartNode();

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -3156,6 +3156,7 @@ export function getExecuteFunctions(
 						parentWorkflowId: workflow.id?.toString(),
 						inputData,
 						parentWorkflowSettings: workflow.settings,
+						node,
 					})
 					.then(async (result) =>
 						Container.get(BinaryDataService).duplicateBinaryData(

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1888,6 +1888,7 @@ export interface IWorkflowExecuteAdditionalData {
 		workflowInfo: IExecuteWorkflowInfo,
 		additionalData: IWorkflowExecuteAdditionalData,
 		options: {
+			node?: INode;
 			parentWorkflowId?: string;
 			inputData?: INodeExecutionData[];
 			parentExecutionId?: string;

--- a/packages/workflow/src/errors/workflow-operation.error.ts
+++ b/packages/workflow/src/errors/workflow-operation.error.ts
@@ -13,10 +13,11 @@ export class WorkflowOperationError extends ExecutionBaseError {
 
 	description: string | undefined;
 
-	constructor(message: string, node?: INode) {
+	constructor(message: string, node?: INode, description?: string) {
 		super(message, { cause: undefined });
 		this.severity = 'warning';
 		this.name = this.constructor.name;
+		if (description) this.description = description;
 		this.node = node;
 		this.timestamp = Date.now();
 	}


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-992

https://community.n8n.io/t/executing-workflow-using-owner-role-created-by-another-user-fails/33443