### PR TITLE
fix: Return scopes on invitation accept endpoint (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -179,6 +179,6 @@ export class InvitationController {
 		await this.externalHooks.run('user.profile.update', [invitee.email, publicInvitee]);
 		await this.externalHooks.run('user.password.update', [invitee.email, invitee.password]);
 
-		return this.userService.toPublic(updatedUser, { posthog: this.postHog });
+		return this.userService.toPublic(updatedUser, { posthog: this.postHog, withScopes: true });
 	}
 }

--- a/packages/cli/test/integration/invitations.api.test.ts
+++ b/packages/cli/test/integration/invitations.api.test.ts
@@ -81,6 +81,7 @@ describe('POST /invitations/:id/accept', () => {
 			globalRole,
 			isPending,
 			apiKey,
+			globalScopes,
 		} = response.body.data;
 
 		expect(validator.isUUID(id)).toBe(true);
@@ -93,6 +94,8 @@ describe('POST /invitations/:id/accept', () => {
 		expect(globalRole.scope).toBe('global');
 		expect(globalRole.name).toBe('member');
 		expect(apiKey).not.toBeDefined();
+		expect(globalScopes).toBeDefined();
+		expect(globalScopes).not.toHaveLength(0);
 
 		const authToken = utils.getAuthToken(response);
 		expect(authToken).toBeDefined();
@@ -132,6 +135,7 @@ describe('POST /invitations/:id/accept', () => {
 			globalRole,
 			isPending,
 			apiKey,
+			globalScopes,
 		} = response.body.data;
 
 		expect(validator.isUUID(id)).toBe(true);
@@ -144,6 +148,8 @@ describe('POST /invitations/:id/accept', () => {
 		expect(globalRole.scope).toBe('global');
 		expect(globalRole.name).toBe('admin');
 		expect(apiKey).not.toBeDefined();
+		expect(globalScopes).toBeDefined();
+		expect(globalScopes).not.toHaveLength(0);
 
 		const authToken = utils.getAuthToken(response);
 		expect(authToken).toBeDefined();


### PR DESCRIPTION
## Summary
Return scopes on the invitation accept endpoint. The UI uses information until the user refreshes the pages so it's causing inconsistency for the new admin role.

#### How to test the change:
1. ...


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

...


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).