### PR TITLE
fix(editor): Add missing workflow id from route (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionsList.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionsList.vue
@@ -445,7 +445,14 @@ export default defineComponent({
 						})
 						.catch(() => {});
 				} else if (this.executions.length === 0) {
-					this.$router.push({ name: VIEWS.EXECUTION_HOME }).catch(() => {});
+					this.$router
+						.push({
+							name: VIEWS.EXECUTION_HOME,
+							params: {
+								name: this.currentWorkflow,
+							},
+						})
+						.catch(() => {});
 					this.workflowsStore.activeWorkflowExecution = null;
 				}
 			}


### PR DESCRIPTION
## Summary
Fixes missing workflow id from route.

#### How to test the change:
1. Go to executions page for a workflow without executions
2. Wait for autoRefresh to start
3. Error appears in console due to missing `name` parameter


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

https://linear.app/n8n/issue/N8N-7075/error-missing-required-param-name


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).