### PR TITLE
fix(editor): Add missing activeNode check for redrawing (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -655,9 +655,10 @@ export default defineComponent({
 			}
 
 			if (
-				typeof this.activeNodeType?.outputs === 'string' ||
-				typeof this.activeNodeType?.inputs === 'string' ||
-				this.redrawRequired
+				this.activeNode &&
+				(typeof this.activeNodeType?.outputs === 'string' ||
+					typeof this.activeNodeType?.inputs === 'string' ||
+					this.redrawRequired)
 			) {
 				// TODO: We should keep track of if it actually changed and only do if required
 				// Whenever a node with custom inputs and outputs gets closed redraw it in case

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -669,7 +669,7 @@ export default defineComponent({
 				}, 1);
 			}
 
-			if (this.outputPanelEditMode.enabled) {
+			if (this.outputPanelEditMode.enabled && this.activeNode) {
 				const shouldPinDataBeforeClosing = await this.confirm(
 					'',
 					this.$locale.baseText('ndv.pinData.beforeClosing.title'),
@@ -681,13 +681,10 @@ export default defineComponent({
 
 				if (shouldPinDataBeforeClosing === MODAL_CONFIRM) {
 					const { value } = this.outputPanelEditMode;
-
-					if (this.activeNode) {
-						try {
-							this.setPinData(this.activeNode, jsonParse(value), 'on-ndv-close-modal');
-						} catch (error) {
-							console.error(error);
-						}
+					try {
+						this.setPinData(this.activeNode, jsonParse(value), 'on-ndv-close-modal');
+					} catch (error) {
+						console.error(error);
 					}
 				}
 


### PR DESCRIPTION
## Summary
Wasn't able to reproduce, but `activeNode` sporadically returns null in some scenarios. Added appropriate check.

## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

https://linear.app/n8n/issue/N8N-7076/typeerror-cannot-read-properties-of-null-reading-name


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).