### PR TITLE
fix(editor): Send correct telemetry events in credential setup (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -9,10 +9,12 @@ import SetupTemplateFormStep from './SetupTemplateFormStep.vue';
 import TemplatesView from '../TemplatesView.vue';
 import { VIEWS } from '@/constants';
 import { useI18n } from '@/composables/useI18n';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 // Store
 const setupTemplateStore = useSetupTemplateStore();
 const i18n = useI18n();
+const telemetry = useTelemetry();
 
 // Router
 const route = useRoute();
@@ -58,14 +60,17 @@ const onSkipSetup = async (event: MouseEvent) => {
 const skipIfTemplateHasNoCreds = async () => {
 	const isTemplateLoaded = !!setupTemplateStore.template;
 	if (!isTemplateLoaded) {
-		return;
+		return false;
 	}
 
 	if (setupTemplateStore.credentialUsages.length === 0) {
 		await setupTemplateStore.skipSetup({
 			router,
 		});
+		return true;
 	}
+
+	return false;
 };
 
 //#endregion Methods
@@ -76,7 +81,12 @@ setupTemplateStore.setTemplateId(templateId.value);
 
 onMounted(async () => {
 	await setupTemplateStore.init();
-	await skipIfTemplateHasNoCreds();
+	const wasSkipped = await skipIfTemplateHasNoCreds();
+	if (!wasSkipped) {
+		telemetry.track('User opened cred setup', undefined, {
+			withPostHog: true,
+		});
+	}
 });
 
 //#endregion Lifecycle hooks
@@ -124,7 +134,7 @@ onMounted(async () => {
 						size="large"
 						:label="i18n.baseText('templateSetup.continue.button')"
 						:disabled="setupTemplateStore.isSaving"
-						@click="setupTemplateStore.createWorkflow(router)"
+						@click="setupTemplateStore.createWorkflow({ router })"
 						data-test-id="continue-button"
 					/>
 					<div v-else>

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -304,15 +304,14 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		const externalHooks = useExternalHooks();
 		const telemetry = useTelemetry();
 
-		const telemetryPayload = {
+		await externalHooks.run('templatesWorkflowView.openWorkflow', {
 			source: 'workflow',
 			template_id: templateId.value,
 			wf_template_repo_session_id: templatesStore.currentSessionId,
-		};
+		});
 
-		await externalHooks.run('templatesWorkflowView.openWorkflow', telemetryPayload);
-		telemetry.track('User inserted workflow template', telemetryPayload, {
-			withPostHog: true,
+		telemetry.track('User closed cred setup', {
+			completed: false,
 		});
 
 		// Replace the URL so back button doesn't come back to this setup view
@@ -325,7 +324,10 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 	/**
 	 * Creates a workflow from the template and navigates to the workflow view.
 	 */
-	const createWorkflow = async ($router: Router) => {
+	const createWorkflow = async (opts: { router: Router }) => {
+		const { router } = opts;
+		const telemetry = useTelemetry();
+
 		if (!template.value) {
 			return;
 		}
@@ -340,8 +342,12 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 				workflowsStore,
 			);
 
+			telemetry.track('User closed cred setup', {
+				completed: true,
+			});
+
 			// Replace the URL so back button doesn't come back to this setup view
-			await $router.replace({
+			await router.replace({
 				name: VIEWS.WORKFLOW,
 				params: { name: createdWorkflow.id },
 			});


### PR DESCRIPTION
## Summary

Send the `User opened cred setup` and `User closed cred setup` events specified [here](https://www.notion.so/n8n/Handoff-a1150c38f6e042db91fdf61c56900967?pvs=4)

#### How to test the change:
1. Open the template credential setup page
2. Observe the correct event sent
3. Skip/Complete the credential setup
4. Observe the correct event sent


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).