### PR TITLE
feat(editor): Add user opened cred modal telemetry event (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
+++ b/packages/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
@@ -24,6 +24,7 @@ const props = defineProps({
 const $emit = defineEmits({
 	credentialSelected: (_credentialId: string) => true,
 	credentialDeselected: () => true,
+	credentialModalOpened: () => true,
 });
 
 const uiStore = useUIStore();
@@ -47,10 +48,12 @@ const onCredentialSelected = (credentialId: string) => {
 };
 const createNewCredential = () => {
 	uiStore.openNewCredential(props.credentialType, true);
+	$emit('credentialModalOpened');
 };
 const editCredential = () => {
 	assert(props.selectedCredentialId);
 	uiStore.openExistingCredential(props.selectedCredentialId);
+	$emit('credentialModalOpened');
 };
 
 listenForCredentialChanges({

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
@@ -12,6 +12,7 @@ import type { CredentialUsages } from '@/views/SetupWorkflowFromTemplateView/set
 import { useSetupTemplateStore } from '@/views/SetupWorkflowFromTemplateView/setupTemplate.store';
 import type { IWorkflowTemplateNode } from '@/Interface';
 import { useI18n } from '@/composables/useI18n';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 // Props
 const props = defineProps({
@@ -29,6 +30,7 @@ const props = defineProps({
 const setupTemplateStore = useSetupTemplateStore();
 const nodeTypesStore = useNodeTypesStore();
 const i18n = useI18n();
+const telemetry = useTelemetry();
 
 //#region Computed
 
@@ -66,6 +68,20 @@ const onCredentialDeselected = () => {
 	setupTemplateStore.unsetSelectedCredential(props.credentials.key);
 };
 
+const onCredentialModalOpened = () => {
+	telemetry.track(
+		'User opened Credential modal',
+		{
+			source: 'cred_setup',
+			credentialType: props.credentials.credentialType,
+			new_credential: !selectedCredentialId.value,
+		},
+		{
+			withPostHog: true,
+		},
+	);
+};
+
 //#endregion Methods
 </script>
 
@@ -98,6 +114,7 @@ const onCredentialDeselected = () => {
 				:selectedCredentialId="selectedCredentialId"
 				@credential-selected="onCredentialSelected"
 				@credential-deselected="onCredentialDeselected"
+				@credential-modal-opened="onCredentialModalOpened"
 			/>
 
 			<IconSuccess


### PR DESCRIPTION
## Summary

Add `User opened Credential modal` telemetry event to the template credential setup page, as specified [here](https://www.notion.so/n8n/Handoff-a1150c38f6e042db91fdf61c56900967?pvs=4)


#### How to test the change:

```
localStorage.setItem('template-credentials-setup', 'true')
```

1. Create / Edit credentials on the template credential page
2. Observe the event


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).