### PR TITLE
ci: Remove `master` from autocancelling redundant CI jobs (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-concurrency:
-  group: master
-  cancel-in-progress: true
-
 jobs:
   install-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Autocancelling redundant CI jobs for `master` makes it harder to track health of `master`, in exchange for minor savings.

Context: https://n8nio.slack.com/archives/C03MZF137FV/p1701771923477659?thread_ts=1699522038.290849&cid=C03MZF137FV

...

#### How to test the change:
1. ...


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

...


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).