### PR TITLE
feat(Local File Trigger Node): Add polling option typically good to watch network files/folders

### DIFF
--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -180,6 +180,14 @@ export class LocalFileTrigger implements INodeType {
 						default: -1,
 						description: 'How deep into the folder structure to watch for changes',
 					},
+					{
+						displayName: 'Use Polling',
+						name: 'usePolling',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to use polling for watching. Typically necessary to successfully watch files over a network.',
+					},
 				],
 			},
 		],
@@ -206,6 +214,7 @@ export class LocalFileTrigger implements INodeType {
 			depth: [-1, undefined].includes(options.depth as number)
 				? undefined
 				: (options.depth as number),
+			usePolling: options.usePolling as boolean,
 		});
 
 		const executeTrigger = (event: string, pathString: string) => {

--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -126,6 +126,13 @@ export class LocalFileTrigger implements INodeType {
 				default: {},
 				options: [
 					{
+						displayName: 'Await Write Finish',
+						name: 'awaitWriteFinish',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to wait until files finished writing to avoid partially read',
+					},
+					{
 						displayName: 'Include Linked Files/Folders',
 						name: 'followSymlinks',
 						type: 'boolean',
@@ -142,7 +149,13 @@ export class LocalFileTrigger implements INodeType {
 						description:
 							'Files or paths to ignore. The whole path is tested, not just the filename. Supports <a href="https://github.com/micromatch/anymatch">Anymatch</a>- syntax.',
 					},
-
+					{
+						displayName: 'Ignore Existing Files/Folders',
+						name: 'ignoreInitial',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to ignore existing files/folders to not trigger an event',
+					},
 					{
 						displayName: 'Max Folder Depth',
 						name: 'depth',
@@ -208,13 +221,15 @@ export class LocalFileTrigger implements INodeType {
 		const watcher = watch(path, {
 			ignored: options.ignored === '' ? undefined : options.ignored,
 			persistent: true,
-			ignoreInitial: true,
+			ignoreInitial:
+				options.ignoreInitial === undefined ? true : (options.ignoreInitial as boolean),
 			followSymlinks:
 				options.followSymlinks === undefined ? true : (options.followSymlinks as boolean),
 			depth: [-1, undefined].includes(options.depth as number)
 				? undefined
 				: (options.depth as number),
 			usePolling: options.usePolling as boolean,
+			awaitWriteFinish: options.awaitWriteFinish as boolean,
 		});
 
 		const executeTrigger = (event: string, pathString: string) => {


### PR DESCRIPTION
Adding more chokidar options to watch files/folders especially usePolling typically good to watch network volumes. Inspired by [https://github.com/n8n-io/n8n/pull/4914/files](https://github.com/n8n-io/n8n/pull/4914/files)