### PR TITLE
fix(core): Restrict updating/deleting of shared but not owned credentials

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -15,6 +15,7 @@ import { InternalHooks } from '@/InternalHooks';
 import { listQueryMiddleware } from '@/middlewares';
 import { Logger } from '@/Logger';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { UnauthorizedError } from '@/errors/response-errors/unauthorized.error';
 
 export const credentialsController = express.Router();
 credentialsController.use('/', EECredentialsController);
@@ -142,10 +143,15 @@ credentialsController.patch(
 	ResponseHelper.send(async (req: CredentialRequest.Update): Promise<ICredentialsDb> => {
 		const { id: credentialId } = req.params;
 
-		const sharing = await CredentialsService.getSharing(req.user, credentialId, {
-			allowGlobalScope: true,
-			globalScope: 'credential:update',
-		});
+		const sharing = await CredentialsService.getSharing(
+			req.user,
+			credentialId,
+			{
+				allowGlobalScope: true,
+				globalScope: 'credential:update',
+			},
+			['credentials', 'role'],
+		);
 
 		if (!sharing) {
 			Container.get(Logger).info(
@@ -158,6 +164,17 @@ credentialsController.patch(
 			throw new NotFoundError(
 				'Credential to be updated not found. You can only update credentials owned by you',
 			);
+		}
+
+		if (sharing.role.name !== 'owner' && !(await req.user.hasGlobalScope('credential:update'))) {
+			Container.get(Logger).info(
+				'Attempt to delete credential blocked due to lack of permissions',
+				{
+					credentialId,
+					userId: req.user.id,
+				},
+			);
+			throw new UnauthorizedError('You can only update credentials owned by you');
 		}
 
 		const { credentials: credential } = sharing;
@@ -195,10 +212,15 @@ credentialsController.delete(
 	ResponseHelper.send(async (req: CredentialRequest.Delete) => {
 		const { id: credentialId } = req.params;
 
-		const sharing = await CredentialsService.getSharing(req.user, credentialId, {
-			allowGlobalScope: true,
-			globalScope: 'credential:delete',
-		});
+		const sharing = await CredentialsService.getSharing(
+			req.user,
+			credentialId,
+			{
+				allowGlobalScope: true,
+				globalScope: 'credential:delete',
+			},
+			['credentials', 'role'],
+		);
 
 		if (!sharing) {
 			Container.get(Logger).info(
@@ -211,6 +233,17 @@ credentialsController.delete(
 			throw new NotFoundError(
 				'Credential to be deleted not found. You can only removed credentials owned by you',
 			);
+		}
+
+		if (sharing.role.name !== 'owner' && !(await req.user.hasGlobalScope('credential:delete'))) {
+			Container.get(Logger).info(
+				'Attempt to delete credential blocked due to lack of permissions',
+				{
+					credentialId,
+					userId: req.user.id,
+				},
+			);
+			throw new UnauthorizedError('You can only remove credentials owned by you');
 		}
 
 		const { credentials: credential } = sharing;

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -168,7 +168,7 @@ credentialsController.patch(
 
 		if (sharing.role.name !== 'owner' && !(await req.user.hasGlobalScope('credential:update'))) {
 			Container.get(Logger).info(
-				'Attempt to delete credential blocked due to lack of permissions',
+				'Attempt to update credential blocked due to lack of permissions',
 				{
 					credentialId,
 					userId: req.user.id,

--- a/packages/cli/src/permissions/roles.ts
+++ b/packages/cli/src/permissions/roles.ts
@@ -4,7 +4,6 @@ export const ownerPermissions: Scope[] = [
 	'auditLogs:manage',
 	'credential:create',
 	'credential:read',
-	'credential:update',
 	'credential:delete',
 	'credential:list',
 	'credential:share',

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -2,7 +2,7 @@ import type { SuperAgentTest } from 'supertest';
 import { In } from 'typeorm';
 import type { IUser } from 'n8n-workflow';
 
-import type { Credentials } from '@/requests';
+import type { ListQuery } from '@/requests';
 import * as UserManagementHelpers from '@/UserManagement/UserManagementHelper';
 import type { Role } from '@db/entities/Role';
 import type { User } from '@db/entities/User';
@@ -99,10 +99,10 @@ describe('GET /credentials', () => {
 		expect(response.statusCode).toBe(200);
 		expect(response.body.data).toHaveLength(2); // owner retrieved owner cred and member cred
 		const ownerCredential = response.body.data.find(
-			(e: Credentials.WithOwnedByAndSharedWith) => e.ownedBy?.id === owner.id,
+			(e: ListQuery.Credentials.WithOwnedByAndSharedWith) => e.ownedBy?.id === owner.id,
 		);
 		const memberCredential = response.body.data.find(
-			(e: Credentials.WithOwnedByAndSharedWith) => e.ownedBy?.id === member1.id,
+			(e: ListQuery.Credentials.WithOwnedByAndSharedWith) => e.ownedBy?.id === member1.id,
 		);
 
 		validateMainCredentialData(ownerCredential);
@@ -540,7 +540,7 @@ describe('PUT /credentials/:id/share', () => {
 	});
 });
 
-function validateMainCredentialData(credential: Credentials.WithOwnedByAndSharedWith) {
+function validateMainCredentialData(credential: ListQuery.Credentials.WithOwnedByAndSharedWith) {
 	expect(typeof credential.name).toBe('string');
 	expect(typeof credential.type).toBe('string');
 	expect(typeof credential.nodesAccess[0].nodeType).toBe('string');


### PR DESCRIPTION
## Summary

Fix shared members being able to edit and delete credentials they don't own

#### How to test the change:
1. ...


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

...


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).