### PR TITLE
fix: Disable continue button unless at least 1 cred has been filled (no-changelog)

### DIFF
--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -92,12 +92,16 @@ describe('Template credentials setup', () => {
 	it('can create credentials and workflow from the template', () => {
 		templateCredentialsSetupPage.actions.visit(testTemplate.id);
 
-		templateCredentialsSetupPage.getters.continueButton().should('be.enabled');
+		// Continue button should be disabled if no credentials are created
+		templateCredentialsSetupPage.getters.continueButton().should('be.disabled');
 
 		templateCredentialsSetupPage.getters.createAppCredentialsButton('Shopify').click();
 		credentialsModal.getters.editCredentialModal().find('input:first()').type('test');
 		credentialsModal.actions.save(false);
 		credentialsModal.actions.close();
+
+		// Continue button should be enabled if at least one has been created
+		templateCredentialsSetupPage.getters.continueButton().should('be.enabled');
 
 		templateCredentialsSetupPage.getters.createAppCredentialsButton('X (Formerly Twitter)').click();
 		credentialsModal.getters.editCredentialModal().find('input:first()').type('test');

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2283,5 +2283,6 @@
 	"templateSetup.instructions": "You need {0} account to setup this template",
 	"templateSetup.skip": "Skip",
 	"templateSetup.continue.button": "Continue",
-	"templateSetup.credential.description": "The credential you select will be used in the {0} node of the workflow template. | The credential you select will be used in the {0} nodes of the workflow template."
+	"templateSetup.credential.description": "The credential you select will be used in the {0} node of the workflow template. | The credential you select will be used in the {0} nodes of the workflow template.",
+	"templateSetup.continue.button.fillRemaining": "Fill remaining credentials to continue"
 }

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -129,14 +129,21 @@ onMounted(async () => {
 						i18n.baseText('templateSetup.skip')
 					}}</n8n-link>
 
-					<n8n-button
+					<n8n-tooltip
 						v-if="isReady"
-						size="large"
-						:label="i18n.baseText('templateSetup.continue.button')"
-						:disabled="setupTemplateStore.isSaving"
-						@click="setupTemplateStore.createWorkflow({ router })"
-						data-test-id="continue-button"
-					/>
+						:content="i18n.baseText('templateSetup.continue.button.fillRemaining')"
+						:disabled="setupTemplateStore.numFilledCredentials > 0"
+					>
+						<n8n-button
+							size="large"
+							:label="i18n.baseText('templateSetup.continue.button')"
+							:disabled="
+								setupTemplateStore.isSaving || setupTemplateStore.numFilledCredentials === 0
+							"
+							@click="setupTemplateStore.createWorkflow({ router })"
+							data-test-id="continue-button"
+						/>
+					</n8n-tooltip>
 					<div v-else>
 						<n8n-loading variant="button" />
 					</div>

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -227,6 +227,10 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		return overrides;
 	});
 
+	const numFilledCredentials = computed(() => {
+		return Object.keys(selectedCredentialIdByKey.value).length;
+	});
+
 	//#endregion Getters
 
 	//#region Actions
@@ -376,6 +380,7 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 		credentialUsages,
 		selectedCredentialIdByKey,
 		credentialOverrides,
+		numFilledCredentials,
 		createWorkflow,
 		skipSetup,
 		init,


### PR DESCRIPTION
## Summary

Disable the continue button in template credential setup unless at least one credential has been (pre-)filled


https://github.com/n8n-io/n8n/assets/10324676/c2dd48a3-03cb-4a93-9339-8049259636e3



#### How to test the change:

1. Run e2e tests


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).