### PR TITLE
fix(editor): Add missing string for worker in log streaming

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1492,6 +1492,7 @@
 	"settings.log-streaming.eventGroup.n8n.user": "User",
 	"settings.log-streaming.eventGroup.n8n.node": "Node Executions",
 	"settings.log-streaming.eventGroup.n8n.node.info": "Will send step-wise execution events every time a node executes. Please note that this can lead to a high frequency of logged events and is probably not suitable for general use.",
+	"settings.log-streaming.eventGroup.n8n.worker": "Worker",
 	"settings.log-streaming.$$AbstractMessageEventBusDestination": "Generic",
 	"settings.log-streaming.$$MessageEventBusDestinationWebhook": "Webhook",
 	"settings.log-streaming.$$MessageEventBusDestinationSentry": "Sentry",


### PR DESCRIPTION
## Summary
Add missing string for worker in log streaming

Before: https://share.cleanshot.com/bN9ydg7N
After: https://share.cleanshot.com/sFLnFMJK

...

#### How to test the change:
1. ...


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

...


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).