### PR TITLE
fix(Postgres Node): Do not include id column in upsert fields selection if it's not unique

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/resourceMapping.ts
@@ -77,7 +77,7 @@ export async function getMappingColumns(
 					id: col.column_name,
 					displayName: col.column_name,
 					required: col.is_nullable !== 'YES' && !isAutoIncrement,
-					defaultMatch: col.column_name === 'id',
+					defaultMatch: (col.column_name === 'id' && canBeUsedToMatch) || false,
 					display: true,
 					type,
 					canBeUsedToMatch,


### PR DESCRIPTION
## Summary
Do not include id column in upsert fields selection if it's not unique
Forum: https://community.n8n.io/t/postgres-node-insert-or-update-unique-column-name/32520
