### PR TITLE
fix(editor): Disable auto scroll and list size check when clicking on executions

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionsSidebar.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionsSidebar.vue
@@ -120,10 +120,6 @@ export default defineComponent({
 				this.$router.go(-1);
 			}
 		},
-		'workflowsStore.activeWorkflowExecution'() {
-			this.checkListSize();
-			this.scrollToActiveCard();
-		},
 	},
 	mounted() {
 		// On larger screens, we need to load more then first page of executions


### PR DESCRIPTION
## Summary
Auto scrolling to the active execution is unnecessary as well as checking if more items can be loaded.

#### How to test the change:
1. Open a workflow with a long list of executions (preferably with more executions that fits in the list when first rendered and need to use infinite scroll to load more items)
2. Go to executions tabs
3. Scroll to the bottom
4. Click on an item that is visible only if the list is scrolled down.

The list should not be scrolled to the active item automatically