### PR TITLE
fix(Harvest Node): Fix getting invoice by state

### DIFF
--- a/packages/nodes-base/nodes/Harvest/InvoiceDescription.ts
+++ b/packages/nodes-base/nodes/Harvest/InvoiceDescription.ts
@@ -133,7 +133,7 @@ export const invoiceFields: INodeProperties[] = [
 			{
 				displayName: 'State',
 				name: 'state',
-				type: 'multiOptions',
+				type: 'options',
 				options: [
 					{
 						name: 'Draft',


### PR DESCRIPTION
Fixes: https://github.com/n8n-io/n8n/issues/7948

Technically this could be considered a breaking change as we are changing the input field type but the field is also not working at all as the API expects a single string with one state rather than an array. Happy to modify and do a quick light version instead.