### PR TITLE
fix(editor): Fix dialogVisibleChanged hooks event when meta.value is undefined (no-changelog)

### DIFF
--- a/packages/editor-ui/src/hooks/cloud.ts
+++ b/packages/editor-ui/src/hooks/cloud.ts
@@ -268,7 +268,7 @@ export const n8nCloudHooks: PartialDeep<ExternalHooks> = {
 		dialogVisibleChanged: [
 			(_, meta) => {
 				const segmentStore = useSegment();
-				const currentValue = meta.value.slice(1);
+				const currentValue = meta.value?.slice(1) ?? '';
 				let isValueDefault = false;
 
 				switch (typeof meta.parameter.default) {


### PR DESCRIPTION
## Summary
Provide details about your pull request and what it adds, fixes, or changes. Photos and videos are recommended.

In specific scenarios `meta.value` can come as `undefined`, causing the hook to fail.

#### How to test the change:
1. Close Expression editor modal dialog with empty value


## Issues fixed
Include links to Github issue or Community forum post or **Linear ticket**:
> Important in order to close automatically and provide context to reviewers

https://linear.app/n8n/issue/N8N-7084/typeerror-evalueslice-is-not-a-function-in-evalueslice1-evalueslice-is
https://n8nio.sentry.io/issues/4715787194/


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. 
  >
  > *(internal)* You can use Slack commands to trigger [e2e tests](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#a39f9e5ba64a48b58a71d81c837e8227) or [deploy test instance](https://www.notion.so/n8n/How-to-use-Test-Instances-d65f49dfc51f441ea44367fb6f67eb0a?pvs=4#f6a177d32bde4b57ae2da0b8e454bfce) or [deploy early access version on Cloud](https://www.notion.so/n8n/Cloudbot-3dbe779836004972b7057bc989526998?pvs=4#fef2d36ab02247e1a0f65a74f6fb534e).