### PR TITLE
fix(core): Fix issue preventing secrets from loading if the path contains - or /

### DIFF
--- a/packages/cli/src/ExternalSecrets/constants.ts
+++ b/packages/cli/src/ExternalSecrets/constants.ts
@@ -3,4 +3,4 @@ export const EXTERNAL_SECRETS_UPDATE_INTERVAL = 5 * 60 * 1000;
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
 
-export const EXTERNAL_SECRETS_NAME_REGEX = /^[a-zA-Z0-9_]+$/;
+export const EXTERNAL_SECRETS_NAME_REGEX = /^[a-zA-Z0-9\_\/]+$/;


### PR DESCRIPTION
## Summary
Fixes an issue preventing n8n from pulling secrets from Hashicorp Vault KV stores if the secret path contained a `-` or a `/`, An example provided was `integrations/n8n-workflows` which I have tested in my local instance of Vault.

This still needs testing with Infisical to make sure nothing breaks there.