### PR TITLE
feat(core): Add config option for external secret update interval

### DIFF
--- a/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
@@ -173,7 +173,6 @@ export class ExternalSecretsManager {
 	}
 
 	async updateSecrets() {
-		this.logger.info('Updating secrets');
 		if (!this.license.isExternalSecretsEnabled()) {
 			return;
 		}

--- a/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
@@ -11,13 +11,10 @@ import Container, { Service } from 'typedi';
 import { Logger } from '@/Logger';
 
 import { jsonParse, type IDataObject, ApplicationError } from 'n8n-workflow';
-import {
-	EXTERNAL_SECRETS_INITIAL_BACKOFF,
-	EXTERNAL_SECRETS_MAX_BACKOFF,
-	EXTERNAL_SECRETS_UPDATE_INTERVAL,
-} from './constants';
+import { EXTERNAL_SECRETS_INITIAL_BACKOFF, EXTERNAL_SECRETS_MAX_BACKOFF } from './constants';
 import { License } from '@/License';
 import { InternalHooks } from '@/InternalHooks';
+import { updateIntervalTime } from './externalSecretsHelper.ee';
 import { ExternalSecretsProviders } from './ExternalSecretsProviders.ee';
 import { SingleMainSetup } from '@/services/orchestration/main/SingleMainSetup';
 
@@ -51,10 +48,7 @@ export class ExternalSecretsManager {
 					this.initialized = true;
 					resolve();
 					this.initializingPromise = undefined;
-					this.updateInterval = setInterval(
-						async () => this.updateSecrets(),
-						EXTERNAL_SECRETS_UPDATE_INTERVAL,
-					);
+					this.updateInterval = setInterval(async () => this.updateSecrets(), updateIntervalTime());
 				});
 			}
 			return this.initializingPromise;
@@ -179,6 +173,7 @@ export class ExternalSecretsManager {
 	}
 
 	async updateSecrets() {
+		this.logger.info('Updating secrets');
 		if (!this.license.isExternalSecretsEnabled()) {
 			return;
 		}

--- a/packages/cli/src/ExternalSecrets/constants.ts
+++ b/packages/cli/src/ExternalSecrets/constants.ts
@@ -1,5 +1,4 @@
 export const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
-export const EXTERNAL_SECRETS_UPDATE_INTERVAL = 5 * 60 * 1000;
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
 

--- a/packages/cli/src/ExternalSecrets/externalSecretsHelper.ee.ts
+++ b/packages/cli/src/ExternalSecrets/externalSecretsHelper.ee.ts
@@ -1,5 +1,8 @@
 import { License } from '@/License';
+import config from '@/config';
 import Container from 'typedi';
+
+export const updateIntervalTime = () => config.getEnv('externalSecrets.updateInterval') * 1000;
 
 export function isExternalSecretsEnabled() {
 	const license = Container.get(License);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1007,6 +1007,15 @@ export const schema = {
 		},
 	},
 
+	externalSecrets: {
+		updateInterval: {
+			format: Number,
+			default: 300,
+			env: 'N8N_EXTERNAL_SECRETS_UPDATE_INTERVAL',
+			doc: 'How often (in seconds) to check for secret updates.',
+		},
+	},
+
 	deployment: {
 		type: {
 			format: String,


### PR DESCRIPTION
## Summary
Adds `N8N_EXTERNAL_SECRETS_UPDATE_INTERVAL` to allow enterprise users to tweak the update internal for importing new secrets.

If using a config file the value is:

```
"externalSecrets": {
  "updateInterval": 300
}
```

#### How to test the change:
1. Run as normal and check that the secret is updated every 5 minutes
2. Set `N8N_EXTERNAL_SECRETS_UPDATE_INTERVAL` to 10
3. Check the secret is reloaded after 10 seconds


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.