### PR TITLE
ci: Fix the concurrency group for db tests (no-changelog)

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -9,7 +9,7 @@ on:
       - packages/cli/src/databases/migrations/**
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  group: db-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The CI concurrency group was incorrectly named in https://github.com/n8n-io/n8n/pull/7656. 
This PR fixes that.