### PR TITLE
refactor(core): Don't use DB transactions on ExecutionRepository.createNewExecution

### DIFF
--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -60,9 +60,7 @@ export class ActiveExecutions {
 				fullExecutionData.workflowId = workflowId;
 			}
 
-			const executionResult =
-				await Container.get(ExecutionRepository).createNewExecution(fullExecutionData);
-			executionId = executionResult.id;
+			executionId = await Container.get(ExecutionRepository).createNewExecution(fullExecutionData);
 			if (executionId === undefined) {
 				throw new ApplicationError('There was an issue assigning an execution id to the execution');
 			}

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -25,7 +25,7 @@ import type {
 import config from '@/config';
 import type { IGetExecutionsQueryFilter } from '@/executions/executions.service';
 import { isAdvancedExecutionFiltersEnabled } from '@/executions/executionHelpers';
-import { ExecutionData } from '../entities/ExecutionData';
+import type { ExecutionData } from '../entities/ExecutionData';
 import { ExecutionEntity } from '../entities/ExecutionEntity';
 import { ExecutionMetadata } from '../entities/ExecutionMetadata';
 import { ExecutionDataRepository } from './executionData.repository';
@@ -215,27 +215,14 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 	async createNewExecution(execution: ExecutionPayload): Promise<string> {
 		const { data, workflowData, ...rest } = execution;
-		const { identifiers: inserted } = await this.manager
-			.createQueryBuilder()
-			.insert()
-			.into(ExecutionEntity)
-			.values([rest])
-			.execute();
-
+		const { identifiers: inserted } = await this.insert(rest);
 		const { id: executionId } = inserted[0] as { id: string };
 		const { connections, nodes, name } = workflowData ?? {};
-		await this.manager
-			.createQueryBuilder()
-			.insert()
-			.into(ExecutionData)
-			.values([
-				{
-					executionId,
-					workflowData: { connections, nodes, name },
-					data: stringify(data),
-				},
-			])
-			.execute();
+		await this.executionDataRepository.insert({
+			executionId,
+			workflowData: { connections, nodes, name },
+			data: stringify(data),
+		});
 		return String(executionId);
 	}
 

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -236,7 +236,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 				},
 			])
 			.execute();
-		return executionId;
+		return String(executionId);
 	}
 
 	async markAsCrashed(executionIds: string[]) {

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -1,0 +1,53 @@
+import Container from 'typedi';
+import { ExecutionRepository } from '@db/repositories/execution.repository';
+import { ExecutionDataRepository } from '@db/repositories/executionData.repository';
+import * as testDb from '../../shared/testDb';
+import { createWorkflow } from '../../shared/db/workflows';
+
+describe('ExecutionRepository', () => {
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['Workflow', 'Execution']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('createNewExecution', () => {
+		it('should save execution data', async () => {
+			const executionRepo = Container.get(ExecutionRepository);
+			const workflow = await createWorkflow();
+			const executionId = await executionRepo.createNewExecution({
+				workflowId: workflow.id,
+				data: {
+					resultData: {},
+				},
+				workflowData: workflow,
+				mode: 'manual',
+				startedAt: new Date(),
+				status: 'new',
+				finished: false,
+			});
+
+			expect(executionId).toBeDefined();
+
+			const executionEntity = await executionRepo.findOneBy({ id: executionId });
+			expect(executionEntity?.id).toEqual(executionId);
+			expect(executionEntity?.workflowId).toEqual(workflow.id);
+			expect(executionEntity?.status).toEqual('new');
+
+			const executionDataRepo = Container.get(ExecutionDataRepository);
+			const executionData = await executionDataRepo.findOneBy({ executionId });
+			expect(executionData?.workflowData).toEqual({
+				connections: workflow.connections,
+				nodes: workflow.nodes,
+				name: workflow.name,
+			});
+			expect(executionData?.data).toEqual('[{"resultData":"1"},{}]');
+		});
+	});
+});

--- a/packages/cli/test/unit/ActiveExecutions.test.ts
+++ b/packages/cli/test/unit/ActiveExecutions.test.ts
@@ -12,9 +12,7 @@ const FAKE_EXECUTION_ID = '15';
 const FAKE_SECOND_EXECUTION_ID = '20';
 
 const updateExistingExecution = jest.fn();
-const createNewExecution = jest.fn(async () => {
-	return { id: FAKE_EXECUTION_ID };
-});
+const createNewExecution = jest.fn(async () => FAKE_EXECUTION_ID);
 
 Container.set(ExecutionRepository, {
 	updateExistingExecution,


### PR DESCRIPTION
## Summary
Saving execution data is one of the slowest DB operations in the application, and is likely behind some of the sqlite transaction concurrency issues we've been seeing.
This not only remove the 2 separate transactions for saving `ExecutionEntity` and `ExecutionData`, but also remove fields from `ExecutionData.workflowData` that don't need to be saved (like `tags`, `shared`, `statistics`, `triggerCount`, etc).

## Review / Merge checklist
- [x] PR title and summary are descriptive.
- [x] Tests included. 
- [x] [DB Tests](https://github.com/n8n-io/n8n/actions/runs/7180771526)