### PR TITLE
fix(core): Do not display error when stopping jobless execution in queue mode

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -687,8 +687,8 @@ export class Server extends AbstractServer {
 					const job = currentJobs.find((job) => job.data.executionId === req.params.id);
 
 					if (!job) {
-						throw new ApplicationError('Could not stop job because it is no longer in queue.', {
-							extra: { jobId: req.params.id },
+						this.logger.debug('Could not stop job because it is no longer in queue', {
+							jobId: req.params.id,
 						});
 					} else {
 						await queue.stopJob(job);

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -27,7 +27,7 @@ import type {
 	IExecutionsSummary,
 	IN8nUISettings,
 } from 'n8n-workflow';
-import { ApplicationError, jsonParse } from 'n8n-workflow';
+import { jsonParse } from 'n8n-workflow';
 
 // @ts-ignore
 import timezones from 'google-timezones-json';


### PR DESCRIPTION
No need to surface error to user when stopping a job no longer in queue.

https://linear.app/n8n/issue/PAY-1104