### PR TITLE
fix(editor): Ensure execution data overrides pinned data when copying in executions view

### DIFF
--- a/packages/editor-ui/src/components/RunDataJsonActions.vue
+++ b/packages/editor-ui/src/components/RunDataJsonActions.vue
@@ -163,7 +163,6 @@ export default defineComponent({
 			return { path, startPath };
 		},
 		handleCopyClick(commandData: { command: string }) {
-			console.log('handleCopyClick');
 			let value: string;
 			if (commandData.command === 'value') {
 				value = this.getJsonValue();

--- a/packages/editor-ui/src/components/RunDataJsonActions.vue
+++ b/packages/editor-ui/src/components/RunDataJsonActions.vue
@@ -118,7 +118,10 @@ export default defineComponent({
 		getJsonValue(): string {
 			let selectedValue = jp.query(this.jsonData, `$${this.normalisedJsonPath}`)[0];
 			if (this.noSelection) {
-				if (this.hasPinData) {
+				const inExecutionsFrame =
+					window !== window.parent && window.parent.location.pathname.includes('/executions');
+
+				if (this.hasPinData && !inExecutionsFrame) {
 					selectedValue = clearJsonKey(this.pinData as object);
 				} else {
 					selectedValue = executionDataToJson(
@@ -160,6 +163,7 @@ export default defineComponent({
 			return { path, startPath };
 		},
 		handleCopyClick(commandData: { command: string }) {
+			console.log('handleCopyClick');
 			let value: string;
 			if (commandData.command === 'value') {
 				value = this.getJsonValue();


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1063

https://community.n8n.io/t/execution-history-node-output-copy-to-clipboard-copies-pinned-data-instead-of-executed-node-output/33248?u=mutedjam