### PR TITLE
docs: Add aliases to compare datasets node

### DIFF
--- a/packages/nodes-base/nodes/CompareDatasets/CompareDatasets.node.json
+++ b/packages/nodes-base/nodes/CompareDatasets/CompareDatasets.node.json
@@ -41,7 +41,7 @@
 			}
 		]
 	},
-	"alias": ["Join", "Concatenate", "Compare", "Dataset", "Split"],
+	"alias": ["Join", "Concatenate", "Compare", "Dataset", "Split", "Sync", "Syncing"],
 	"subcategories": {
 		"Core Nodes": ["Flow"]
 	}


### PR DESCRIPTION
## Summary
Make the Compare Datasets node findable when typing "sync" or "syncing" in the Nodes panel

https://linear.app/n8n/issue/NODE-991/make-the-compare-datasets-node-finable-when-typing-sync-or-syncing-in