### PR TITLE
fix(Postgres Trigger Node): Increase manual trigger timeout from 30 to 60 seconds

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -307,7 +307,7 @@ export class PostgresTrigger implements INodeType {
 							})(),
 						),
 					);
-				}, 30000);
+				}, 60000);
 				connection.client.on('notification', async (data: IDataObject) => {
 					if (data.payload) {
 						try {


### PR DESCRIPTION
## Summary
Changing manual trigger time from 30 to 60 seconds based on outcome from node team meeting