### PR TITLE
fix(ActiveCampaign Node): Fix pagination issue when loading tags

### DIFF
--- a/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
+++ b/packages/nodes-base/nodes/ActiveCampaign/ActiveCampaign.node.ts
@@ -285,13 +285,15 @@ export class ActiveCampaign implements INodeType {
 			// select them easily
 			async getTags(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const { tags } = await activeCampaignApiRequest.call(
+				const tags = await activeCampaignApiRequestAllItems.call(
 					this,
 					'GET',
 					'/api/3/tags',
 					{},
 					{ limit: 100 },
+					'tags',
 				);
+
 				for (const tag of tags) {
 					returnData.push({
 						name: tag.tag,


### PR DESCRIPTION
## Summary
Changes the getTags method to use the paginated API call. 


## Related tickets and issues
https://community.n8n.io/t/activecampaign-node-is-not-loading-all-tags/34169
