### PR TITLE
fix(editor): Show credential share info only to appropriate users

### DIFF
--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -131,7 +131,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		credentialsModal.getters.testSuccessTag().should('be.visible');
 	});
 
-	it.only('should work for admin role on credentials created by others (also can share it with themselves)', () => {
+	it('should work for admin role on credentials created by others (also can share it with themselves)', () => {
 		cy.signin(INSTANCE_MEMBERS[0]);
 
 		cy.visit(credentialsPage.url);

--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -150,6 +150,9 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		credentialsModal.getters.testSuccessTag().should('be.visible');
 		cy.get('input').should('not.have.length');
 		credentialsModal.actions.changeTab('Sharing');
+		cy.contains(
+			'You can view this credential because you have permission to read and share',
+		).should('be.visible');
 
 		credentialsModal.getters.usersSelect().click();
 		cy.getByTestId('user-email')

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -41,7 +41,15 @@
 					})
 				}}
 			</n8n-info-tip>
-			<n8n-info-tip v-if="credentialPermissions.read" class="mb-s" :bold="false">
+			<n8n-info-tip
+				v-if="
+					credentialPermissions.read &&
+					credentialPermissions.share &&
+					!credentialPermissions.isOwner
+				"
+				class="mb-s"
+				:bold="false"
+			>
 				<i18n-t keypath="credentialEdit.credentialSharing.info.reader">
 					<template v-if="!isCredentialSharedWithCurrentUser" #notShared>
 						{{ $locale.baseText('credentialEdit.credentialSharing.info.notShared') }}

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -420,7 +420,7 @@
 	"credentialEdit.oAuthButton.signInWithGoogle": "Sign in with Google",
 	"credentialEdit.credentialSharing.info.owner": "Sharing a credential allows people to use it in their workflows. They cannot access credential details.",
 	"credentialEdit.credentialSharing.info.reader": "You can view this credential because you have permission to read and share (and rename or delete it too).{notShared}",
-	"credentialEdit.credentialSharing.info.notShared": "To use it in a workflow, ask the credential owner to share it with you.",
+	"credentialEdit.credentialSharing.info.notShared": "To use it in a workflow you need to share it with yourself.",
 	"credentialEdit.credentialSharing.info.sharee": "Only {credentialOwnerName} can change who this credential is shared with",
 	"credentialEdit.credentialSharing.info.sharee.fallback": "the owner",
 	"credentialEdit.credentialSharing.select.placeholder": "Add users...",


### PR DESCRIPTION
## Summary
The credential owner should not see the sharing info box

![image](https://github.com/n8n-io/n8n/assets/5410822/d85b47f8-f4cf-4009-beaf-03bc62008feb)
