### PR TITLE
perf(editor): Improve canvas rendering performance

### DIFF
--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -637,8 +637,7 @@ export default defineComponent({
 			// so we only update it when necessary (when node is mounted and when it's opened and closed (isActive))
 			try {
 				const nodeSubtitle =
-					this.nodeHelpers.getNodeSubtitle(this.data, this.nodeType, this.getCurrentWorkflow()) ||
-					'';
+					this.nodeHelpers.getNodeSubtitle(this.data, this.nodeType, this.workflow) || '';
 
 				this.nodeSubtitle = nodeSubtitle.includes(CUSTOM_API_CALL_KEY) ? '' : nodeSubtitle;
 			} catch (e) {

--- a/packages/editor-ui/src/plugins/i18n/index.ts
+++ b/packages/editor-ui/src/plugins/i18n/index.ts
@@ -23,6 +23,8 @@ export const i18nInstance = createI18n({
 });
 
 export class I18nClass {
+	private baseTextCache = new Map<string, string>();
+
 	private get i18n() {
 		return i18nInstance.global;
 	}
@@ -50,11 +52,25 @@ export class I18nClass {
 		key: BaseTextKey,
 		options?: { adjustToNumber?: number; interpolate?: { [key: string]: string } },
 	): string {
-		if (options?.adjustToNumber !== undefined) {
-			return this.i18n.tc(key, options.adjustToNumber, options?.interpolate).toString();
+		// Create a unique cache key
+		const cacheKey = `${key}-${JSON.stringify(options)}`;
+
+		// Check if the result is already cached
+		if (this.baseTextCache.has(cacheKey)) {
+			return this.baseTextCache.get(cacheKey) ?? key;
 		}
 
-		return this.i18n.t(key, options?.interpolate).toString();
+		let result: string;
+		if (options?.adjustToNumber !== undefined) {
+			result = this.i18n.tc(key, options.adjustToNumber, options?.interpolate ?? {}).toString();
+		} else {
+			result = this.i18n.t(key, options?.interpolate ?? {}).toString();
+		}
+
+		// Store the result in the cache
+		this.baseTextCache.set(cacheKey, result);
+
+		return result;
 	}
 
 	/**

--- a/packages/editor-ui/src/plugins/jsplumb/N8nAddInputEndpointRenderer.ts
+++ b/packages/editor-ui/src/plugins/jsplumb/N8nAddInputEndpointRenderer.ts
@@ -70,7 +70,6 @@ export const register = () => {
 			container.appendChild(unconnectedGroup);
 			container.appendChild(defaultGroup);
 
-			endpointInstance.setupOverlays();
 			endpointInstance.setVisible(false);
 
 			return container;

--- a/packages/editor-ui/src/plugins/jsplumb/N8nAddInputEndpointType.ts
+++ b/packages/editor-ui/src/plugins/jsplumb/N8nAddInputEndpointType.ts
@@ -33,11 +33,6 @@ export class N8nAddInputEndpoint extends EndpointRepresentation<ComputedN8nAddIn
 
 	type = N8nAddInputEndpoint.type;
 
-	setupOverlays() {
-		this.endpoint.instance.setSuspendDrawing(true);
-		this.endpoint.instance.setSuspendDrawing(false);
-	}
-
 	bindEvents() {
 		this.instance.bind(EVENT_ENDPOINT_CLICK, this.fireClickEvent);
 	}

--- a/packages/editor-ui/src/plugins/jsplumb/N8nPlusEndpointType.ts
+++ b/packages/editor-ui/src/plugins/jsplumb/N8nPlusEndpointType.ts
@@ -49,7 +49,6 @@ export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpo
 
 	setupOverlays() {
 		this.clearOverlays();
-		this.endpoint.instance.setSuspendDrawing(true);
 		this.stalkOverlay = this.endpoint.addOverlay({
 			type: 'Custom',
 			options: {
@@ -78,7 +77,6 @@ export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpo
 				},
 			},
 		});
-		this.endpoint.instance.setSuspendDrawing(false);
 	}
 
 	bindEvents() {
@@ -151,18 +149,14 @@ export class N8nPlusEndpoint extends EndpointRepresentation<ComputedN8nPlusEndpo
 	}
 
 	setIsVisible(visible: boolean) {
-		this.instance.setSuspendDrawing(true);
 		Object.keys(this.endpoint.getOverlays()).forEach((overlay) => {
 			this.endpoint.getOverlays()[overlay].setVisible(visible);
 		});
-
 		this.setVisible(visible);
-
 		// Re-trigger the success state if label is set
 		if (visible && this.label) {
 			this.setSuccessOutput(this.label);
 		}
-		this.instance.setSuspendDrawing(false);
 	}
 
 	setSuccessOutput(label: string) {

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -882,8 +882,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 					},
 				};
 			}
-
-			this.workflowExecutionPairedItemMappings = getPairedItemsMapping(this.workflowExecutionData);
 		},
 
 		resetAllNodesIssues(): boolean {
@@ -1118,7 +1116,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				};
 			}
 			this.workflowExecutionData.data!.resultData.runData[pushData.nodeName].push(pushData.data);
-			this.workflowExecutionPairedItemMappings = getPairedItemsMapping(this.workflowExecutionData);
 		},
 		clearNodeExecutionData(nodeName: string): void {
 			if (!this.workflowExecutionData?.data) {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2761,7 +2761,6 @@ export default defineComponent({
 						this.nodeHelpers.updateNodesInputIssues();
 						this.resetEndpointsErrors();
 						setTimeout(() => {
-							console.log('Before add connection test data', info.connection.connector);
 							NodeViewUtils.addConnectionTestData(
 								info.source,
 								info.target,
@@ -3923,19 +3922,15 @@ export default defineComponent({
 				return;
 			}
 			this.isInsertingNodes = true;
-			const startTime = performance.now();
 			// Before proceeding we must check if all nodes contain the `properties` attribute.
 			// Nodes are loaded without this information so we must make sure that all nodes
 			// being added have this information.
 			await this.loadNodesProperties(
 				nodes.map((node) => ({ name: node.type, version: node.typeVersion })),
 			);
-			const endTimeProperties = performance.now();
-			console.log('Time taken to load node properties:', endTimeProperties - startTime, 'ms');
 
 			// Add the node to the node-list
 			let nodeType: INodeTypeDescription | null;
-			const startTimeNodes = performance.now();
 			nodes.forEach((node) => {
 				if (!node.id) {
 					node.id = uuid();
@@ -3986,8 +3981,6 @@ export default defineComponent({
 					this.historyStore.pushCommandToUndo(new AddNodeCommand(node));
 				}
 			});
-			const endTime = performance.now();
-			console.log('Time taken to add Nodes:', endTime - startTimeNodes, 'ms');
 
 			// Wait for the nodes to be rendered
 			await this.$nextTick();
@@ -4003,10 +3996,8 @@ export default defineComponent({
 			this.resetEndpointsErrors();
 			this.isInsertingNodes = false;
 
-			const endTimeIssues = performance.now();
 			// Now it can draw again
 			this.instance?.setSuspendDrawing(false, true);
-			console.log('Total:', endTimeIssues - startTime, 'ms');
 		},
 		async addConnections(connections: IConnections) {
 			const batchedConnectionData: Array<[IConnection, IConnection]> = [];


### PR DESCRIPTION
## Summary
- Refactor usage of `setSuspendDrawing`, removing it from loops and only calling it after batch operations are done
- Batch adding of nodes to improve copy/paste and workflow load performance
- Cache i18n calls
- Debounce connections dragging handler if there are more than 20 nodes


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://community.n8n.io/t/slow-ui-in-big-scenarios/33830/8
