### PR TITLE
fix(editor): Add back credential `use` permission

### DIFF
--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -98,6 +98,26 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		ndv.actions.close();
 	});
 
+	it('should open W1, add node using C2 as U2', () => {
+		cy.signin(INSTANCE_MEMBERS[0]);
+
+		cy.visit(workflowsPage.url);
+		workflowsPage.getters.workflowCards().should('have.length', 2);
+		workflowsPage.getters.workflowCard('Workflow W1').click();
+		workflowPage.actions.addNodeToCanvas('Airtable', true, true);
+		ndv.getters.credentialInput().find('input').should('have.value', 'Credential C2');
+		ndv.actions.close();
+		workflowPage.actions.saveWorkflowOnButtonClick();
+
+		workflowPage.actions.openNode('Notion');
+		ndv.getters
+			.credentialInput()
+			.find('input')
+			.should('have.value', 'Credential C1')
+			.should('be.enabled');
+		ndv.actions.close();
+	});
+
 	it('should not have access to W2, as U3', () => {
 		cy.signin(INSTANCE_MEMBERS[1]);
 
@@ -131,7 +151,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		credentialsModal.getters.testSuccessTag().should('be.visible');
 	});
 
-	it.only('should work for admin role on credentials created by others (also can share it with themselves)', () => {
+	it('should work for admin role on credentials created by others (also can share it with themselves)', () => {
 		cy.signin(INSTANCE_MEMBERS[0]);
 
 		cy.visit(credentialsPage.url);

--- a/packages/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/editor-ui/src/composables/useNodeHelpers.ts
@@ -420,7 +420,7 @@ export function useNodeHelpers() {
 					.getCredentialsByType(credentialTypeDescription.name)
 					.filter((credential: ICredentialsResponse) => {
 						const permissions = getCredentialPermissions(currentUser, credential);
-						return permissions.read;
+						return permissions.use;
 					});
 
 				if (userCredentials === null) {

--- a/packages/editor-ui/src/permissions.ts
+++ b/packages/editor-ui/src/permissions.ts
@@ -101,6 +101,10 @@ export const getCredentialPermissions = (user: IUser | null, credential: ICreden
 			test: (permissions) =>
 				hasPermission(['rbac'], { rbac: { scope: 'credential:delete' } }) || !!permissions.isOwner,
 		},
+		{
+			name: 'use',
+			test: (permissions) => !!permissions.isOwner || !!permissions.isSharee,
+		},
 	];
 
 	return parsePermissionsTable(user, table);

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -95,7 +95,7 @@ export const useUsersStore = defineStore(STORES.USERS, {
 			return (resource: ICredentialsResponse): boolean => {
 				const permissions = getCredentialPermissions(this.currentUser, resource);
 
-				return permissions.read;
+				return permissions.use;
 			};
 		},
 	},


### PR DESCRIPTION
## Summary
A shared credential is not selectable in NDV

Aim

If a credential is shared with a user they should be able to select it in node details view