### PR TITLE
fix(core): Initialize queue once in queue mode

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -292,7 +292,6 @@ export class Worker extends BaseCommand {
 		this.logger.debug('Queue init complete');
 		await this.initOrchestration();
 		this.logger.debug('Orchestration init complete');
-		await this.initQueue();
 
 		await Container.get(OrchestrationWorkerService).publishToEventLog(
 			new EventMessageGeneric({

--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -65,15 +65,15 @@ test('worker initializes all its components', async () => {
 	expect(worker.queueModeId).toBeDefined();
 	expect(worker.queueModeId).toContain('worker');
 	expect(worker.queueModeId.length).toBeGreaterThan(15);
-	expect(worker.initLicense).toHaveBeenCalled();
-	expect(worker.initBinaryDataService).toHaveBeenCalled();
-	expect(worker.initExternalHooks).toHaveBeenCalled();
-	expect(worker.initExternalSecrets).toHaveBeenCalled();
-	expect(worker.initEventBus).toHaveBeenCalled();
-	expect(worker.initOrchestration).toHaveBeenCalled();
-	expect(OrchestrationHandlerWorkerService.prototype.initSubscriber).toHaveBeenCalled();
-	expect(OrchestrationWorkerService.prototype.publishToEventLog).toHaveBeenCalled();
-	expect(worker.initQueue).toHaveBeenCalled();
+	expect(worker.initLicense).toHaveBeenCalledTimes(1);
+	expect(worker.initBinaryDataService).toHaveBeenCalledTimes(1);
+	expect(worker.initExternalHooks).toHaveBeenCalledTimes(1);
+	expect(worker.initExternalSecrets).toHaveBeenCalledTimes(1);
+	expect(worker.initEventBus).toHaveBeenCalledTimes(1);
+	expect(worker.initOrchestration).toHaveBeenCalledTimes(1);
+	expect(OrchestrationHandlerWorkerService.prototype.initSubscriber).toHaveBeenCalledTimes(1);
+	expect(OrchestrationWorkerService.prototype.publishToEventLog).toHaveBeenCalledTimes(1);
+	expect(worker.initQueue).toHaveBeenCalledTimes(1);
 
 	jest.restoreAllMocks();
 });


### PR DESCRIPTION
We're initializing the queue twice because of a [bad merge](https://github.com/n8n-io/n8n/pull/7303/commits/2c6347453806f69b9941389773c14cd0afdd7173). No associated known bugs but no need to init the queue twice. We should follow up by investigating if any pending bugs can be associated to this.