### PR TITLE
fix(cli): reject webhooks with unsupported content types

### DIFF
--- a/packages/cli/src/middlewares/bodyParser.ts
+++ b/packages/cli/src/middlewares/bodyParser.ts
@@ -49,7 +49,9 @@ export const rawBodyReader: RequestHandler = async (req, res, next) => {
 export const parseBody = async (req: Request) => {
 	await req.readRawBody();
 	const { rawBody, contentType, encoding } = req;
-	if (rawBody?.length) {
+	if (!rawBody.length) {
+		return;
+	}
 		try {
 			if (contentType === 'application/json') {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -74,7 +76,6 @@ export const parseBody = async (req: Request) => {
 				'unknown content-type ' + contentType,
 			);
 		}
-	}
 };
 
 export const bodyParser: RequestHandler = async (req, res, next) => {

--- a/packages/cli/src/middlewares/bodyParser.ts
+++ b/packages/cli/src/middlewares/bodyParser.ts
@@ -52,30 +52,31 @@ export const parseBody = async (req: Request) => {
 	if (!rawBody.length) {
 		return;
 	}
-		try {
-			if (contentType === 'application/json') {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				req.body = jsonParse(rawBody.toString(encoding));
-			} else if (contentType?.endsWith('/xml') || contentType?.endsWith('+xml')) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				req.body = await xmlParser.parseStringPromise(rawBody.toString(encoding));
-			} else if (contentType === 'application/x-www-form-urlencoded') {
-				req.body = parseQueryString(rawBody.toString(encoding), undefined, undefined, {
-					maxKeys: 1000,
-				});
-			} else if (contentType === 'text/plain') {
-				req.body = rawBody.toString(encoding);
-			}
-		} catch (error) {
-			throw new UnprocessableRequestError('Failed to parse request body', (error as Error).message);
-		}
 
-		if (!req.body) {
-			throw new UnprocessableRequestError(
-				'Failed to parse request body',
-				'unknown content-type ' + contentType,
-			);
+	try {
+		if (contentType === 'application/json') {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			req.body = jsonParse(rawBody.toString(encoding));
+		} else if (contentType?.endsWith('/xml') || contentType?.endsWith('+xml')) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			req.body = await xmlParser.parseStringPromise(rawBody.toString(encoding));
+		} else if (contentType === 'application/x-www-form-urlencoded') {
+			req.body = parseQueryString(rawBody.toString(encoding), undefined, undefined, {
+				maxKeys: 1000,
+			});
+		} else if (contentType === 'text/plain') {
+			req.body = rawBody.toString(encoding);
 		}
+	} catch (error) {
+		throw new UnprocessableRequestError('Failed to parse request body', (error as Error).message);
+	}
+
+	if (!req.body) {
+		throw new UnprocessableRequestError(
+			'Failed to parse request body',
+			'unknown content-type ' + contentType,
+		);
+	}
 };
 
 export const bodyParser: RequestHandler = async (req, res, next) => {

--- a/packages/cli/src/middlewares/bodyParser.ts
+++ b/packages/cli/src/middlewares/bodyParser.ts
@@ -67,6 +67,13 @@ export const parseBody = async (req: Request) => {
 		} catch (error) {
 			throw new UnprocessableRequestError('Failed to parse request body', (error as Error).message);
 		}
+
+		if (!req.body) {
+			throw new UnprocessableRequestError(
+				'Failed to parse request body',
+				'unknown content-type ' + contentType,
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
If there is no actual body, the content-type doesn't matter. This way, the webhook is not started with an empty body. 

To be backwards compatible, we should maybe only throw if an option on the node is enabled (maybe some workflows don't care about the body and will break if we merge this as if). WDYT?

## Summary

If webhook requests come in with an unsupported content-type, the request get rejected. Before this change, the request would be accepted and the workflow would start without a body property as non of the branches would trigger. This can cause hard to understand workflow failures.

## Related tickets and issues
Fixes https://github.com/n8n-io/n8n/issues/7700
Fixes NODE-927

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 