### PR TITLE
fix(HTTP Request Node): Do not create circular references in HTTP request node output

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -993,6 +993,7 @@ export class HttpRequestV1 implements INodeType {
 			}
 
 			response = response.value;
+			delete response.request;
 
 			const options = this.getNodeParameter('options', itemIndex, {});
 

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -1046,6 +1046,7 @@ export class HttpRequestV2 implements INodeType {
 			}
 
 			response = response.value;
+			delete response.request;
 
 			const options = this.getNodeParameter('options', itemIndex, {});
 

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -1767,6 +1767,7 @@ export class HttpRequestV3 implements INodeType {
 
 			// eslint-disable-next-line prefer-const
 			for (let [index, response] of Object.entries(responses)) {
+				delete response.request;
 				if (this.getMode() === 'manual' && index === '0') {
 					// For manual executions save the first response in the context
 					// so that we can use it in the frontend and so make it easier for


### PR DESCRIPTION
## Summary
Remove unused `response.request` circular reference in http response objects

## Related tickets
[PAY-1119](https://linear.app/n8n/issue/PAY-1119)

## Review / Merge checklist
- [x] PR title and summary are descriptive.