### PR TITLE
docs: Two small UI copy fixes in sub-nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/OutputParserItemList.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/OutputParserItemList.node.ts
@@ -55,7 +55,7 @@ export class OutputParserItemList implements INodeType {
 						type: 'number',
 						default: -1,
 						description:
-							'Defines many many items should be returned maximally. If set to -1, there is no limit.',
+							'Defines how many items should be returned maximally. If set to -1, there is no limit.',
 					},
 					// For that to be easily possible the metadata would have to be returned and be able to be read.
 					// Would also be possible with a wrapper but that would be even more hacky and the output types

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolSerpApi/ToolSerpApi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolSerpApi/ToolSerpApi.node.ts
@@ -97,7 +97,7 @@ export class ToolSerpApi implements INodeType {
 						type: 'string',
 						default: 'google.com',
 						description:
-							'Defines the country to use for search. Head to <a href="https://serpapi.com/google-countries">Google countries page</a> for a full list of supported countries.',
+							'Defines the domain to use for search. Head to <a href="https://serpapi.com/google-domains">Google domains page</a> for a full list of supported domains.',
 					},
 					{
 						displayName: 'Language',


### PR DESCRIPTION
## Summary
Fix UI copy in the SerpAPI and Item List Output Parser nodes

