### PR TITLE
refactor(core): Warn on sqlite DB detected during init on queue mode

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -81,10 +81,9 @@ export abstract class BaseCommand extends Command {
 		}
 
 		if (config.getEnv('executions.mode') === 'queue' && dbType === 'sqlite') {
-			this.logger.error(
-				'Queue mode is incompatible with sqlite. Please switch to PostgreSQL. Exiting...',
+			this.logger.warn(
+				'Queue mode is not officially supported with sqlite. Please switch to PostgreSQL.',
 			);
-			await this.exitSuccessFully();
 		}
 
 		if (

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -80,6 +80,13 @@ export abstract class BaseCommand extends Command {
 			);
 		}
 
+		if (config.getEnv('executions.mode') === 'queue' && dbType === 'sqlite') {
+			this.logger.error(
+				'Queue mode is incompatible with sqlite. Please switch to PostgreSQL. Exiting...',
+			);
+			await this.exitSuccessFully();
+		}
+
 		if (
 			process.env.N8N_BINARY_DATA_TTL ??
 			process.env.N8N_PERSISTED_BINARY_DATA_TTL ??

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -282,18 +282,6 @@ export class Worker extends BaseCommand {
 		super(argv, cmdConfig);
 		this.setInstanceType('worker');
 		this.setInstanceQueueModeId();
-
-		const dbType = config.getEnv('database.type');
-
-		if (['mysqldb', 'mariadb'].includes(dbType)) {
-			this.logger.warn(
-				'Support for MySQL/MariaDB has been deprecated and will be removed with an upcoming version of n8n. Please migrate to PostgreSQL.',
-			);
-		}
-
-		if (dbType === 'sqlite') {
-			this.logger.warn('Queue mode is not compatible with sqlite. Please use PostgreSQL.');
-		}
 	}
 
 	async init() {

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -282,6 +282,18 @@ export class Worker extends BaseCommand {
 		super(argv, cmdConfig);
 		this.setInstanceType('worker');
 		this.setInstanceQueueModeId();
+
+		const dbType = config.getEnv('database.type');
+
+		if (['mysqldb', 'mariadb'].includes(dbType)) {
+			this.logger.warn(
+				'Support for MySQL/MariaDB has been deprecated and will be removed with an upcoming version of n8n. Please migrate to PostgreSQL.',
+			);
+		}
+
+		if (dbType === 'sqlite') {
+			this.logger.warn('Queue mode is not compatible with sqlite. Please use PostgreSQL.');
+		}
 	}
 
 	async init() {


### PR DESCRIPTION
When setting up queue mode, it is easy to overlook that not exporting Postgres env vars will default the worker to use sqlite, which will fail during execution with a non-obvious error. Hence add warnings when starting a worker with an incompatible DB type.