### PR TITLE
refactor(core): Remove ID-less workflow reporting (no-changelog)

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -13,13 +13,7 @@ import type {
 	INodeTypes,
 	IRun,
 } from 'n8n-workflow';
-import {
-	Workflow,
-	NodeOperationError,
-	sleep,
-	ApplicationError,
-	ErrorReporterProxy as EventReporter,
-} from 'n8n-workflow';
+import { Workflow, NodeOperationError, sleep, ApplicationError } from 'n8n-workflow';
 
 import * as Db from '@/Db';
 import * as ResponseHelper from '@/ResponseHelper';

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -138,13 +138,6 @@ export class Worker extends BaseCommand {
 		}
 		const workflowId = fullExecutionData.workflowData.id!; // @tech_debt Ensure this is not optional
 
-		if (!workflowId) {
-			EventReporter.report('Detected ID-less workflow', {
-				level: 'info',
-				extra: { execution: fullExecutionData },
-			});
-		}
-
 		this.logger.info(
 			`Start job: ${job.id} (Workflow ID: ${workflowId} | Execution: ${executionId})`,
 		);

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -95,13 +95,6 @@ export class Workflow {
 		settings?: IWorkflowSettings;
 		pinData?: IPinData;
 	}) {
-		if (!parameters.id) {
-			EventReporter.report('Detected ID-less workflow', {
-				level: 'info',
-				extra: { parameters },
-			});
-		}
-
 		this.id = parameters.id as string; // @tech_debt Ensure this is not optional
 		this.name = parameters.name;
 		this.nodeTypes = parameters.nodeTypes;

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -52,7 +52,6 @@ import { RoutingNode } from './RoutingNode';
 import { Expression } from './Expression';
 import { NODES_WITH_RENAMABLE_CONTENT } from './Constants';
 import { ApplicationError } from './errors/application.error';
-import * as EventReporter from './ErrorReporterProxy';
 
 function dedupe<T>(arr: T[]): T[] {
 	return [...new Set(arr)];


### PR DESCRIPTION
We added ID-less workflow reporting at #8031, which has already produced multiple reports coming from internal, enough info to tackle [this story](https://linear.app/n8n/issue/PAY-1147). To prevent an overwhelming number of reports from cloud, this PR removes the reporting for now.