### PR TITLE
fix(core): Remove circular references before serializing executions in public API

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -1,4 +1,6 @@
 import type express from 'express';
+import { Container } from 'typedi';
+import { replaceCircularReferences } from 'n8n-workflow';
 
 import { getExecutions, getExecutionInWorkflows, getExecutionsCount } from './executions.service';
 import { ActiveExecutions } from '@/ActiveExecutions';
@@ -6,7 +8,6 @@ import { authorize, validCursor } from '../../shared/middlewares/global.middlewa
 import type { ExecutionRequest } from '../../../types';
 import { getSharedWorkflowIds } from '../workflows/workflows.service';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
-import { Container } from 'typedi';
 import { InternalHooks } from '@/InternalHooks';
 import { ExecutionRepository } from '@db/repositories/execution.repository';
 
@@ -38,7 +39,7 @@ export = {
 
 			execution.id = id;
 
-			return res.json(execution);
+			return res.json(replaceCircularReferences(execution));
 		},
 	],
 	getExecution: [
@@ -67,7 +68,7 @@ export = {
 				public_api: true,
 			});
 
-			return res.json(execution);
+			return res.json(replaceCircularReferences(execution));
 		},
 	],
 	getExecutions: [
@@ -118,7 +119,7 @@ export = {
 			});
 
 			return res.json({
-				data: executions,
+				data: replaceCircularReferences(executions),
 				nextCursor: encodeNextCursor({
 					lastId: newLastId,
 					limit,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,6 @@
     "cron": "1.7.2",
     "fast-glob": "3.2.12",
     "file-type": "16.5.4",
-    "flatted": "3.2.7",
     "form-data": "4.0.0",
     "lodash": "4.17.21",
     "mime-types": "2.1.35",

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -28,6 +28,7 @@ export {
 	deepCopy,
 	jsonParse,
 	jsonStringify,
+	replaceCircularReferences,
 	sleep,
 	fileTypeFromMimeType,
 	assert,

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -89,7 +89,7 @@ type JSONStringifyOptions = {
 	replaceCircularRefs?: boolean;
 };
 
-const replaceCircularReferences = <T>(value: T, knownObjects = new WeakSet()): T => {
+export const replaceCircularReferences = <T>(value: T, knownObjects = new WeakSet()): T => {
 	if (typeof value !== 'object' || value === null || value instanceof RegExp) return value;
 	if ('toJSON' in value && typeof value.toJSON === 'function') return value.toJSON() as T;
 	if (knownObjects.has(value)) return '[Circular Reference]' as T;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -832,9 +832,6 @@ importers:
       file-type:
         specifier: 16.5.4
         version: 16.5.4
-      flatted:
-        specifier: 3.2.7
-        version: 3.2.7
       form-data:
         specifier: 4.0.0
         version: 4.0.0


### PR DESCRIPTION
## Summary
Handle circular references in the public API for executions created prior to the fix from #8030

## Related tickets
[PAY-1119](https://linear.app/n8n/issue/PAY-1119)

## Review / Merge checklist
- [x] PR title and summary are descriptive.