### PR TITLE
fix(core): Public API support node's deprecated continueOnFail to upload old workflows (no-changelog)

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/node.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/node.yml
@@ -34,6 +34,11 @@ properties:
     type: number
   waitBetweenTries:
     type: number
+  continueOnFail:
+    type: boolean
+    example: false
+    description: 'use onError instead'
+    deprecated: true
   onError:
     type: string
     example: 'stopWorkflow'


### PR DESCRIPTION
We removed continueOnFail in [PR-7460](https://github.com/n8n-io/n8n/pull/7460) while still supporting it internally. To enable creating workflows via API using old continueOnFail configuration was readded as deprecated.

<img width="281" alt="image" src="https://github.com/n8n-io/n8n/assets/56945030/ce395bb2-813b-4d77-9af3-ebb9e553daa1">
