### PR TITLE
fix(core): Fix shutdown if terminating before hooks are initialized

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -26,7 +26,7 @@ import { WorkflowHistoryManager } from '@/workflows/workflowHistory/workflowHist
 export abstract class BaseCommand extends Command {
 	protected logger = Container.get(Logger);
 
-	protected externalHooks: IExternalHooksClass;
+	protected externalHooks?: IExternalHooksClass;
 
 	protected nodeTypes: NodeTypes;
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -101,7 +101,7 @@ export class Start extends BaseCommand {
 			// Stop with trying to activate workflows that could not be activated
 			this.activeWorkflowRunner.removeAllQueuedWorkflowActivations();
 
-			await this.externalHooks.run('n8n.stop', []);
+			await this.externalHooks?.run('n8n.stop', []);
 
 			setTimeout(async () => {
 				// In case that something goes wrong with shutdown we

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -39,7 +39,7 @@ export class Webhook extends BaseCommand {
 		this.logger.info('\nStopping n8n...');
 
 		try {
-			await this.externalHooks.run('n8n.stop', []);
+			await this.externalHooks?.run('n8n.stop', []);
 
 			setTimeout(async () => {
 				// In case that something goes wrong with shutdown we

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -79,7 +79,7 @@ export class Worker extends BaseCommand {
 		await Worker.jobQueue.pause(true);
 
 		try {
-			await this.externalHooks.run('n8n.stop', []);
+			await this.externalHooks?.run('n8n.stop', []);
 
 			const maxStopTime = config.getEnv('queue.bull.gracefulShutdownTimeout') * 1000;
 
@@ -483,7 +483,7 @@ export class Worker extends BaseCommand {
 		});
 
 		await new Promise<void>((resolve) => server.listen(port, () => resolve()));
-		await this.externalHooks.run('worker.ready');
+		await this.externalHooks?.run('worker.ready');
 		this.logger.info(`\nn8n worker health check via, port ${port}`);
 	}
 


### PR DESCRIPTION
## Summary

If the app receives termination signal before hooks have been initialised, the would be objet is undefined error. This PR fixes that.


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1609/fix-issues-in-shutdown-if-termination-is-started-before-app-is-fully


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 