### PR TITLE
feat(core): Add config option to prefer GET request over LIST when using Hashicorp Vault

### DIFF
--- a/packages/cli/src/ExternalSecrets/externalSecretsHelper.ee.ts
+++ b/packages/cli/src/ExternalSecrets/externalSecretsHelper.ee.ts
@@ -3,6 +3,7 @@ import config from '@/config';
 import Container from 'typedi';
 
 export const updateIntervalTime = () => config.getEnv('externalSecrets.updateInterval') * 1000;
+export const preferGet = () => config.getEnv('externalSecrets.preferGet');
 
 export function isExternalSecretsEnabled() {
 	const license = Container.get(License);

--- a/packages/cli/src/ExternalSecrets/providers/vault.ts
+++ b/packages/cli/src/ExternalSecrets/providers/vault.ts
@@ -5,6 +5,7 @@ import type { AxiosInstance, AxiosResponse } from 'axios';
 import axios from 'axios';
 import { Logger } from '@/Logger';
 import { EXTERNAL_SECRETS_NAME_REGEX } from '../constants';
+import { preferGet } from '../externalSecretsHelper.ee';
 import { Container } from 'typedi';
 
 type VaultAuthMethod = 'token' | 'usernameAndPassword' | 'appRole';
@@ -422,10 +423,14 @@ export class VaultProvider extends SecretsProvider {
 		listPath += path;
 		let listResp: AxiosResponse<VaultResponse<VaultSecretList>>;
 		try {
+			const shouldPreferGet = preferGet();
+			const url = `${listPath}${shouldPreferGet ? '?list=true' : ''}`;
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const method = shouldPreferGet ? 'GET' : ('LIST' as any);
 			listResp = await this.#http.request<VaultResponse<VaultSecretList>>({
-				url: listPath,
+				url,
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				method: 'LIST' as any,
+				method,
 			});
 		} catch {
 			return null;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1032,6 +1032,12 @@ export const schema = {
 			env: 'N8N_EXTERNAL_SECRETS_UPDATE_INTERVAL',
 			doc: 'How often (in seconds) to check for secret updates.',
 		},
+		preferGet: {
+			format: Boolean,
+			default: false,
+			env: 'N8N_EXTERNAL_SECRETS_PREFER_GET',
+			doc: 'Whether to prefer GET over LIST when fetching secrets from Hashicorp Vault.',
+		},
 	},
 
 	deployment: {


### PR DESCRIPTION
## Summary
Hashicorp Vault prefers a `LIST` HTTP method to be used when fetching secrets but not all environments will allow custom http methods through WAFs. This PR adds `N8N_EXTERNAL_SECRETS_PREFER_GET` which when set to `true` will use GET instead of LIST to fetch secrets.


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))