### PR TITLE
docs: Add notice to TheHive triggers to highlight manual steps

### DIFF
--- a/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
+++ b/packages/nodes-base/nodes/TheHive/TheHiveTrigger.node.ts
@@ -29,7 +29,16 @@ export class TheHiveTrigger implements INodeType {
 				path: 'webhook',
 			},
 		],
-		properties: [...eventsDescription],
+		properties: [
+			{
+				displayName:
+					'You must set up the webhook in TheHive — instructions <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger/#configure-a-webhook-in-thehive" target="_blank">here</a>',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+			...eventsDescription,
+		],
 	};
 
 	webhookMethods = {

--- a/packages/nodes-base/nodes/TheHiveProject/TheHiveProjectTrigger.node.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/TheHiveProjectTrigger.node.ts
@@ -32,6 +32,13 @@ export class TheHiveProjectTrigger implements INodeType {
 		],
 		properties: [
 			{
+				displayName:
+					'You must set up the webhook in TheHive — instructions <a href="https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger/#configure-a-webhook-in-thehive" target="_blank">here</a>',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Events',
 				name: 'events',
 				type: 'multiOptions',


### PR DESCRIPTION
## Summary
The Hive and The Hive 5 triggers require manual configuration, This PR adds a notice to the triggers with a link to the docs page.

TheHive5 Trigger
![image](https://github.com/n8n-io/n8n/assets/4688521/1c7f3dd0-f825-4095-8578-cec02723e2e4)

TheHive Trigger
![image](https://github.com/n8n-io/n8n/assets/4688521/ebf2b1de-93c6-4d4f-b3c3-aa34cd43922b)
