### PR TITLE
fix(editor): Update wording when an instance owner or admin is viewing a credential they do not own

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -420,7 +420,7 @@
 	"credentialEdit.oAuthButton.signInWithGoogle": "Sign in with Google",
 	"credentialEdit.credentialSharing.info.owner": "Sharing a credential allows people to use it in their workflows. They cannot access credential details.",
 	"credentialEdit.credentialSharing.info.reader": "You can view this credential because you have permission to read and share (and rename or delete it too).{notShared}",
-	"credentialEdit.credentialSharing.info.notShared": "To use it in a workflow you need to share it with yourself.",
+	"credentialEdit.credentialSharing.info.notShared": "You can share it with yourself or other users to use it in a workflow.",
 	"credentialEdit.credentialSharing.info.sharee": "Only {credentialOwnerName} can change who this credential is shared with",
 	"credentialEdit.credentialSharing.info.sharee.fallback": "the owner",
 	"credentialEdit.credentialSharing.select.placeholder": "Add users...",


### PR DESCRIPTION

## Summary
Now that instance admins and owners can share on credentials, we need to tweak the wording so it's clear what they can do in the UI and the access they have.

### Acceptance Criteria

When an instance owner/admin views a credential they do not own, we should show the following text `You can view this credential because you have permission to read and share (and rename or delete it too).`

When an instance owner/admin views a credential they do not own and has NOT been shared with them, we should show the following text `You can view this credential because you have permission to read and share (and rename or delete it too). You can share it with yourself or other users to use it in a workflow.`