### PR TITLE
feat(core): Add N8N_GRACEFUL_SHUTDOWN_TIMEOUT env var

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -42,11 +42,8 @@ export abstract class BaseCommand extends Command {
 
 	/**
 	 * How long to wait for graceful shutdown before force killing the process.
-	 * Subclasses can override this value.
 	 */
-	protected gracefulShutdownTimeoutInS: number = config.get(
-		'generic.gracefulShutdownTimeoutInS',
-	) as number;
+	protected gracefulShutdownTimeoutInS: number = config.getEnv('generic.gracefulShutdownTimeout');
 
 	async init(): Promise<void> {
 		await initErrorHandling();

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -44,7 +44,9 @@ export abstract class BaseCommand extends Command {
 	 * How long to wait for graceful shutdown before force killing the process.
 	 * Subclasses can override this value.
 	 */
-	protected gracefulShutdownTimeoutInS: number = 30;
+	protected gracefulShutdownTimeoutInS: number = config.get(
+		'generic.gracefulShutdownTimeoutInS',
+	) as number;
 
 	async init(): Promise<void> {
 		await initErrorHandling();

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -264,7 +264,13 @@ export class Worker extends BaseCommand {
 	}
 
 	async init() {
-		this.gracefulShutdownTimeoutInS = config.getEnv('queue.bull.gracefulShutdownTimeout');
+		const configuredShutdownTimeout = config.getEnv('queue.bull.gracefulShutdownTimeout');
+		if (configuredShutdownTimeout) {
+			this.gracefulShutdownTimeoutInS = configuredShutdownTimeout;
+			this.logger.warn(
+				'QUEUE_WORKER_TIMEOUT has been deprecated. Rename it to N8N_GRACEFUL_SHUTDOWN_TIMEOUT.',
+			);
+		}
 		await this.initCrashJournal();
 
 		this.logger.debug('Starting n8n worker...');

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -439,7 +439,7 @@ export const schema = {
 				env: 'QUEUE_RECOVERY_INTERVAL',
 			},
 			gracefulShutdownTimeout: {
-				doc: 'How long should n8n wait for running executions before exiting worker process (seconds)',
+				doc: '[DEPRECATED] (Use N8N_GRACEFUL_SHUTDOWN_TIMEOUT instead) How long should n8n wait for running executions before exiting worker process (seconds)',
 				format: Number,
 				default: 30,
 				env: 'QUEUE_WORKER_TIMEOUT',
@@ -496,6 +496,13 @@ export const schema = {
 			format: ['stable', 'beta', 'nightly', 'dev'] as const,
 			default: 'dev',
 			env: 'N8N_RELEASE_TYPE',
+		},
+
+		gracefulShutdownTimeoutInS: {
+			doc: 'How long should n8n process wait for components to shut down before exiting the process (seconds)',
+			format: Number,
+			default: 30,
+			env: 'N8N_GRACEFUL_SHUTDOWN_TIMEOUT',
 		},
 	},
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -498,7 +498,7 @@ export const schema = {
 			env: 'N8N_RELEASE_TYPE',
 		},
 
-		gracefulShutdownTimeoutInS: {
+		gracefulShutdownTimeout: {
 			doc: 'How long should n8n process wait for components to shut down before exiting the process (seconds)',
 			format: Number,
 			default: 30,


### PR DESCRIPTION
## Summary

Add generic N8N_GRACEFUL_SHUTDOWN_TIMEOUT which controls how long n8n process will wait for graceful exit before exitting forcefully. This variables replaces the QUEUE_WORKER_TIMEOUT variable that was used for worker process.

DEPRECATED: QUEUE_WORKER_TIMEOUT deprected

QUEUE_WORKER_TIMEOUT environment variable has been replaced with N8N_GRACEFUL_SHUTDOWN_TIMEOUT.


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1614/unify-graceful-shutdown-timeout


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 