### PR TITLE
ci(core): Improve circular dependency reporting in typedi (no-changelog)

### DIFF
--- a/patches/typedi@0.10.0.patch
+++ b/patches/typedi@0.10.0.patch
@@ -1,20 +1,14 @@
 diff --git a/cjs/container-instance.class.js b/cjs/container-instance.class.js
-index e473b1e652aa0b6e7462f7ba93fcef2812483b20..1e406113d68c401ee170c997afb53e5f71edeee2 100644
+index e473b1e652aa0b6e7462f7ba93fcef2812483b20..9e57857e5584373b88a9fad3fbb37bbcc56b554a 100644
 --- a/cjs/container-instance.class.js
 +++ b/cjs/container-instance.class.js
-@@ -209,6 +209,7 @@ class ContainerInstance {
-             // this allows us to support javascript where we don't have decorators and emitted metadata about dependencies
-             // need to be injected, and user can use provided container to get instances he needs
-             params.push(this);
-+            if (process.env.NODE_ENV === 'production') Object.freeze(constructableTargetType.prototype);
-             value = new constructableTargetType(...params);
-             // TODO: Calling this here, leads to infinite loop, because @Inject decorator registerds a handler
-             // TODO: which calls Container.get, which will check if the requested type has a value set and if not
-@@ -234,6 +235,7 @@ class ContainerInstance {
+@@ -234,6 +234,9 @@ class ContainerInstance {
       */
      initializeParams(target, paramTypes) {
          return paramTypes.map((paramType, index) => {
-+            if (paramType === undefined) throw new ReferenceError('Cannot inject an `undefined` dependency. Possibly a circular dependency detected');
++            if (paramType === undefined) {
++                throw new ReferenceError(`Circular dependency: Target${target.name}. Index: ${index} `);
++            }
              const paramHandler = container_class_1.Container.handlers.find(handler => {
                  /**
                   * @Inject()-ed values are stored as parameter handlers and they reference their target

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ patchedDependencies:
     hash: kzcwsjcayy5m6iezu7r4tdimjq
     path: patches/pyodide@0.23.4.patch
   typedi@0.10.0:
-    hash: 62r6bc2crgimafeyruodhqlgo4
+    hash: sk6omkefrosihg7lmqbzh7vfxe
     path: patches/typedi@0.10.0.patch
 
 importers:
@@ -686,7 +686,7 @@ importers:
         version: 1.1.1
       typedi:
         specifier: 0.10.0
-        version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
+        version: 0.10.0(patch_hash=sk6omkefrosihg7lmqbzh7vfxe)
       typeorm:
         specifier: 0.3.17
         version: 0.3.17(ioredis@5.2.4)(mysql2@2.3.3)(pg@8.8.0)(sqlite3@5.1.6)
@@ -861,7 +861,7 @@ importers:
         version: 6.11.0
       typedi:
         specifier: 0.10.0
-        version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
+        version: 0.10.0(patch_hash=sk6omkefrosihg7lmqbzh7vfxe)
       uuid:
         specifier: 8.3.2
         version: 8.3.2
@@ -1257,7 +1257,7 @@ importers:
         version: 3.0.3
       typedi:
         specifier: ^0.10.0
-        version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
+        version: 0.10.0(patch_hash=sk6omkefrosihg7lmqbzh7vfxe)
     devDependencies:
       '@oclif/dev-cli':
         specifier: ^1.22.2
@@ -1444,7 +1444,7 @@ importers:
         version: 3.0.3
       typedi:
         specifier: 0.10.0
-        version: 0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4)
+        version: 0.10.0(patch_hash=sk6omkefrosihg7lmqbzh7vfxe)
       uuid:
         specifier: 8.3.2
         version: 8.3.2
@@ -24350,7 +24350,7 @@ packages:
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typedi@0.10.0(patch_hash=62r6bc2crgimafeyruodhqlgo4):
+  /typedi@0.10.0(patch_hash=sk6omkefrosihg7lmqbzh7vfxe):
     resolution: {integrity: sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==}
     dev: false
     patched: true


### PR DESCRIPTION
## Summary
While backend development, this change explicitly logs the location and index of a circular dependency, which helps getting rid of the circular dependency.

