### PR TITLE
fix(core): Use relative imports for dynamic imports in SecurityAuditService

### DIFF
--- a/packages/cli/src/security-audit/SecurityAudit.service.ts
+++ b/packages/cli/src/security-audit/SecurityAudit.service.ts
@@ -52,7 +52,7 @@ export class SecurityAuditService {
 			const className = category.charAt(0).toUpperCase() + category.slice(1) + 'RiskReporter';
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			const RiskReporterModule = await import(`@/security-audit/risk-reporters/${className}`);
+			const RiskReporterModule = await import(`./risk-reporters/${className}`);
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const RiskReporterClass = RiskReporterModule[className] as { new (): RiskReporter };


### PR DESCRIPTION
`tsc-alias` doesn't seem to replace imports when using template strings

## Related tickets and issues
#8085


## Review / Merge checklist
- [x] PR title and summary are descriptive.