### PR TITLE
ci: Add lint rule `no-dynamic-import-template` (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -402,7 +402,7 @@ module.exports = {
 			type: 'error',
 			docs: {
 				description:
-					'Disallow non-relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve them.',
+					'Disallow non-relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve aliased paths in this scenario.',
 				recommended: true,
 			},
 		},
@@ -416,7 +416,7 @@ module.exports = {
 					context.report({
 						node,
 						message:
-							'Use relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve them.',
+							'Use relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve aliased paths in this scenario.',
 					});
 				},
 			};

--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -396,6 +396,32 @@ module.exports = {
 			};
 		},
 	},
+
+	'no-dynamic-import-template': {
+		meta: {
+			type: 'error',
+			docs: {
+				description:
+					'Disallow non-relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve them.',
+				recommended: true,
+			},
+		},
+		create: function (context) {
+			return {
+				'AwaitExpression > ImportExpression TemplateLiteral'(node) {
+					const templateValue = node.quasis[0].value.cooked;
+
+					if (!templateValue?.startsWith('@/')) return;
+
+					context.report({
+						node,
+						message:
+							'Use relative imports in template string argument to `await import()`, because `tsc-alias` as of 1.8.7 is unable to resolve them.',
+					});
+				},
+			};
+		},
+	},
 };
 
 const isJsonParseCall = (node) =>

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
 	],
 
 	rules: {
+		'n8n-local-rules/no-dynamic-import-template': 'error',
+
 		// TODO: Remove this
 		'import/no-cycle': 'warn',
 		'import/order': 'off',


### PR DESCRIPTION
Follow-up to: https://github.com/n8n-io/n8n/pull/8086

`tsc-alias` as of 1.8.7 is unable to resolve template strings in dynamic imports. Since the module name mapper in Jest is able to, this issue is hard to detect, hence the new lint rule `no-dynamic-import-template`. This is for now specific to `@/` in the `cli` package - we can generalize later if needed. Ideally we should contribute a fix upstream when we have more time.

<img width="940" alt="Capture 2023-12-19 at 12 39 55@2x" src="https://github.com/n8n-io/n8n/assets/44588767/78d4a277-ccff-455c-8610-d1bba39d93f2">