### PR TITLE
feat(editor): Gracefully ignore invalid payloads in postMessage handler

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4347,7 +4347,7 @@ export default defineComponent({
 			}
 		},
 		async onPostMessageReceived(message: MessageEvent) {
-			if (!message?.data?.includes?.('"command"')) {
+			if (!message || typeof message.data !== 'string' || !message.data?.includes?.('"command"')) {
 				return;
 			}
 			try {


### PR DESCRIPTION
It's possible for browser extensions to send `message` events to an n8n window.
This change improves the already existing check to ignore invalid messages.

## Related tickets and issues
Fixes https://community.n8n.io/t/errors-in-the-browser-console-on-n8n-1-version/33910

## Review / Merge checklist
- [x] PR title and summary are descriptive.