### PR TITLE
refactor(editor): Remove tracking for SAML test success (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/SettingsSso.vue
+++ b/packages/editor-ui/src/views/SettingsSso.vue
@@ -82,8 +82,6 @@ const getSamlConfig = async () => {
 	ssoSettingsSaved.value = !!config?.metadata;
 };
 
-let testSucceeded = false;
-
 const onSave = async () => {
 	try {
 		const config =
@@ -110,7 +108,6 @@ const onSave = async () => {
 		telemetry.track('User updated single sign on settings', {
 			instance_id: rootStore.instanceId,
 			identity_provider: ipsType.value === 'url' ? 'metadata' : 'xml',
-			is_valid: testSucceeded,
 			is_active: ssoStore.isSamlLoginEnabled,
 		});
 	} catch (error) {
@@ -128,10 +125,8 @@ const onTest = async () => {
 		if (typeof window !== 'undefined') {
 			window.open(url, '_blank');
 		}
-		testSucceeded = true;
 	} catch (error) {
 		toast.showError(error, 'error');
-		testSucceeded = false;
 	}
 };
 


### PR DESCRIPTION
Follow-up to: https://github.com/n8n-io/n8n/pull/8102

It turns out that SAML test success cannot be tracked on the FE. We might track on the BE, but after further discussion with Product, we do not really need to track this property, so this PR simply removes it.