### PR TITLE
feat: Add new versions of AI nodes with new chat trigger defaults

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -144,7 +144,7 @@ export class Agent implements INodeType {
 		name: 'agent',
 		icon: 'fa:robot',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description: 'Generates an action plan and executes it. Can use external tools.',
 		subtitle:
 			"={{ {	conversationalAgent: 'Conversational Agent', openAiFunctionsAgent: 'OpenAI Functions Agent', reactAgent: 'ReAct Agent', sqlAgent: 'SQL Agent' }[$parameter.agent] }}",

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/description.ts
@@ -29,6 +29,19 @@ export const conversationalAgentProperties: INodeProperties[] = [
 		default: '={{ $json.chat_input }}',
 	},
 	{
+		displayName: 'Text',
+		name: 'text',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				agent: ['conversationalAgent'],
+				'@version': [1.2],
+			},
+		},
+		default: '={{ $json.chatInput }}',
+	},
+	{
 		displayName: 'Options',
 		name: 'options',
 		type: 'collection',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/description.ts
@@ -29,6 +29,19 @@ export const openAiFunctionsAgentProperties: INodeProperties[] = [
 		default: '={{ $json.chat_input }}',
 	},
 	{
+		displayName: 'Text',
+		name: 'text',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				agent: ['openAiFunctionsAgent'],
+				'@version': [1.2],
+			},
+		},
+		default: '={{ $json.chatInput }}',
+	},
+	{
 		displayName: 'Options',
 		name: 'options',
 		type: 'collection',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/description.ts
@@ -29,6 +29,19 @@ export const planAndExecuteAgentProperties: INodeProperties[] = [
 		default: '={{ $json.chat_input }}',
 	},
 	{
+		displayName: 'Text',
+		name: 'text',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				agent: ['planAndExecuteAgent'],
+				'@version': [1.2],
+			},
+		},
+		default: '={{ $json.chatInput } }',
+	},
+	{
 		displayName: 'Options',
 		name: 'options',
 		type: 'collection',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/description.ts
@@ -29,6 +29,19 @@ export const reActAgentAgentProperties: INodeProperties[] = [
 		default: '={{ $json.chat_input }}',
 	},
 	{
+		displayName: 'Text',
+		name: 'text',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				agent: ['reActAgent'],
+				'@version': [1.2],
+			},
+		},
+		default: '={{ $json.chatInput }}',
+	},
+	{
 		displayName: 'Options',
 		name: 'options',
 		type: 'collection',

--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -224,6 +224,23 @@ export class OpenAiAssistant implements INodeType {
 				type: 'string',
 				required: true,
 				default: '={{ $json.chat_input }}',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Text',
+				name: 'text',
+				type: 'string',
+				required: true,
+				default: '={{ $json.chatInput }}',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 			{
 				displayName: 'OpenAI Tools',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -217,7 +217,7 @@ export class ChainLlm implements INodeType {
 		name: 'chainLlm',
 		icon: 'fa:link',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'A simple chain to prompt a large language model',
 		defaults: {
 			name: 'Basic LLM Chain',
@@ -263,6 +263,18 @@ export class ChainLlm implements INodeType {
 				displayOptions: {
 					show: {
 						'@version': [1.1, 1.2],
+					},
+				},
+			},
+			{
+				displayName: 'Prompt',
+				name: 'prompt',
+				type: 'string',
+				required: true,
+				default: '={{ $json.chatInput }}',
+				displayOptions: {
+					show: {
+						'@version': [1.3],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -18,7 +18,7 @@ export class ChainRetrievalQa implements INodeType {
 		name: 'chainRetrievalQa',
 		icon: 'fa:link',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description: 'Answer questions about retrieved documents',
 		defaults: {
 			name: 'Question and Answer Chain',
@@ -79,6 +79,18 @@ export class ChainRetrievalQa implements INodeType {
 				displayOptions: {
 					show: {
 						'@version': [1.1],
+					},
+				},
+			},
+			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				required: true,
+				default: '={{ $json.chatInput }}',
+				displayOptions: {
+					show: {
+						'@version': [1.2],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -70,7 +70,7 @@ export class MemoryBufferWindow implements INodeType {
 		name: 'memoryBufferWindow',
 		icon: 'fa:database',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Stores in n8n memory, so no credentials required',
 		defaults: {
 			name: 'Window Buffer Memory',
@@ -101,6 +101,23 @@ export class MemoryBufferWindow implements INodeType {
 				type: 'string',
 				default: 'chat_history',
 				description: 'The key to use to store the memory in the workflow data',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Session ID',
+				name: 'sessionKey',
+				type: 'string',
+				default: '={{ $json.sessionId }}',
+				description: 'The key to use to store the memory',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 			{
 				displayName: 'Context Window Length',

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
@@ -17,7 +17,7 @@ export class MemoryMotorhead implements INodeType {
 		name: 'memoryMotorhead',
 		icon: 'fa:file-export',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Use Motorhead Memory',
 		defaults: {
 			name: 'Motorhead',
@@ -54,6 +54,23 @@ export class MemoryMotorhead implements INodeType {
 				type: 'string',
 				required: true,
 				default: '',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Session ID',
+				name: 'sessionId',
+				type: 'string',
+				default: '={{ $json.sessionId }}',
+				description: 'The key to use to store the memory',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 		],
 	};

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
@@ -21,7 +21,7 @@ export class MemoryRedisChat implements INodeType {
 		name: 'memoryRedisChat',
 		icon: 'file:redis.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Stores the chat history in Redis.',
 		defaults: {
 			name: 'Redis Chat Memory',
@@ -58,6 +58,23 @@ export class MemoryRedisChat implements INodeType {
 				type: 'string',
 				default: 'chat_history',
 				description: 'The key to use to store the memory in the workflow data',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Session ID',
+				name: 'sessionKey',
+				type: 'string',
+				default: '={{ $json.sessionId }}',
+				description: 'The key to use to store the memory',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 			{
 				displayName: 'Session Time To Live',

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
@@ -12,7 +12,7 @@ export class MemoryXata implements INodeType {
 		name: 'memoryXata',
 		icon: 'file:xata.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Use Xata Memory',
 		defaults: {
 			name: 'Xata',
@@ -51,6 +51,23 @@ export class MemoryXata implements INodeType {
 				type: 'string',
 				required: true,
 				default: '',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Session ID',
+				name: 'sessionId',
+				type: 'string',
+				default: '={{ $json.sessionId }}',
+				description: 'The key to use to store the memory',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 		],
 	};

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryZep/MemoryZep.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryZep/MemoryZep.node.ts
@@ -17,7 +17,7 @@ export class MemoryZep implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:zep.png',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Use Zep Memory',
 		defaults: {
 			name: 'Zep',
@@ -54,6 +54,23 @@ export class MemoryZep implements INodeType {
 				type: 'string',
 				required: true,
 				default: '',
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
+			},
+			{
+				displayName: 'Session ID',
+				name: 'sessionId',
+				type: 'string',
+				default: '={{ $json.sessionId }}',
+				description: 'The key to use to store the memory',
+				displayOptions: {
+					show: {
+						'@version': [1.1],
+					},
+				},
 			},
 		],
 	};

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -24,6 +24,19 @@ export class ChatTrigger implements INodeType {
 		defaults: {
 			name: 'Chat Trigger',
 		},
+		codex: {
+			categories: ['Core Nodes'],
+			resources: {
+				primaryDocumentation: [
+					{
+						url: 'https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/',
+					},
+				],
+			},
+			subcategories: {
+				'Core Nodes': ['Other Trigger Nodes'],
+			},
+		},
 		// TODO: This will be reworked, so we also have to update then here
 		supportsCORS: true,
 		maxNodes: 1,

--- a/packages/editor-ui/src/__tests__/defaults.ts
+++ b/packages/editor-ui/src/__tests__/defaults.ts
@@ -1,7 +1,7 @@
 import type { INodeTypeData, INodeTypeDescription } from 'n8n-workflow';
 import {
 	AGENT_NODE_TYPE,
-	MANUAL_CHAT_TRIGGER_NODE_TYPE,
+	CHAT_TRIGGER_NODE_TYPE,
 	MANUAL_TRIGGER_NODE_TYPE,
 } from '@/constants';
 import nodeTypesJson from '../../../nodes-base/dist/types/nodes.json';
@@ -20,10 +20,10 @@ export const testingNodeTypes: INodeTypeData = {
 			description: findNodeWithName(MANUAL_TRIGGER_NODE_TYPE),
 		},
 	},
-	[MANUAL_CHAT_TRIGGER_NODE_TYPE]: {
+	[CHAT_TRIGGER_NODE_TYPE]: {
 		sourcePath: '',
 		type: {
-			description: findNodeWithName(MANUAL_CHAT_TRIGGER_NODE_TYPE),
+			description: findNodeWithName(CHAT_TRIGGER_NODE_TYPE),
 		},
 	},
 	[AGENT_NODE_TYPE]: {

--- a/packages/editor-ui/src/__tests__/defaults.ts
+++ b/packages/editor-ui/src/__tests__/defaults.ts
@@ -1,9 +1,5 @@
 import type { INodeTypeData, INodeTypeDescription } from 'n8n-workflow';
-import {
-	AGENT_NODE_TYPE,
-	CHAT_TRIGGER_NODE_TYPE,
-	MANUAL_TRIGGER_NODE_TYPE,
-} from '@/constants';
+import { AGENT_NODE_TYPE, CHAT_TRIGGER_NODE_TYPE, MANUAL_TRIGGER_NODE_TYPE } from '@/constants';
 import nodeTypesJson from '../../../nodes-base/dist/types/nodes.json';
 import aiNodeTypesJson from '../../../@n8n/nodes-langchain/dist/types/nodes.json';
 

--- a/packages/editor-ui/src/components/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat.vue
@@ -408,6 +408,9 @@ export default defineComponent({
 			if (triggerNode.type === MANUAL_CHAT_TRIGGER_NODE_TYPE && triggerNode.typeVersion < 1.1) {
 				inputKey = 'input';
 			}
+			if (triggerNode.type === CHAT_TRIGGER_NODE_TYPE) {
+				inputKey = 'chatInput';
+			}
 
 			const usersStore = useUsersStore();
 			const currentUser = usersStore.currentUser ?? ({} as IUser);
@@ -424,6 +427,7 @@ export default defineComponent({
 									// TODO: I changed it temporary to "chat_history" from "sessionId" to be
 									//       identical. Probably should be renamed again.
 									chat_history: `test-${currentUser.id || 'unknown'}`,
+									sessionId: `test-${currentUser.id || 'unknown'}`,
 									action: 'sendMessage',
 									[inputKey]: message,
 								},

--- a/packages/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/editor-ui/src/composables/useNodeHelpers.ts
@@ -545,7 +545,7 @@ export function useNodeHelpers() {
 		}
 
 		// TODO: Is this problematic?
-		let data: ITaskDataConnections | undefined = taskData.data!;
+		let data: ITaskDataConnections | undefined = taskData.data;
 		if (paneType === 'input' && taskData.inputOverride) {
 			data = taskData.inputOverride!;
 		}

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -199,8 +199,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 		isNodeInOutgoingNodeConnections() {
 			return (firstNode: string, secondNode: string): boolean => {
 				const firstNodeConnections = this.outgoingConnectionsByNodeName(firstNode);
-				if (!firstNodeConnections || !firstNodeConnections.main || !firstNodeConnections.main[0])
-					return false;
+				if (!firstNodeConnections?.main?.[0]) return false;
 				const connections = firstNodeConnections.main[0];
 				if (connections.some((node) => node.node === secondNode)) return true;
 				return connections.some((node) =>


### PR DESCRIPTION
- Add a new version of `text` and `prompt` parameters for entities that assume use of chat trigger to corresponding default(`={{ $json.chatInput }}`, )
- Add a new version of `sessionId` for memory nodes to use the new `$json.sessionId` property
- Use `chatInput` as input key when starting wf with debug chat, also added `sessionId` while keeping `chat_history` for compatibility sake