### PR TITLE
Feat/UInclude sort field in pipedrive get all persons

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
+++ b/packages/nodes-base/nodes/Pipedrive/Pipedrive.node.ts
@@ -3502,6 +3502,14 @@ export class Pipedrive implements INodeType {
 						description:
 							'If supplied, only persons whose name starts with the specified letter will be returned',
 					},
+					{
+						displayName: 'Sort',
+						name: 'sort',
+						type: 'string',
+						default: '',
+						description:
+							'The field names and sorting mode separated by a comma (field_name_1 ASC, field_name_2 DESC). Only first-level field keys are supported (no nested keys).',
+					},
 				],
 			},
 
@@ -4786,6 +4794,10 @@ export class Pipedrive implements INodeType {
 
 						if (additionalFields.firstChar) {
 							qs.first_char = additionalFields.firstChar as string;
+						}
+
+						if (additionalFields.sort) {
+							qs.sort = additionalFields.sort as string;
 						}
 
 						endpoint = '/persons';


### PR DESCRIPTION
## Summary
Include sort field in Pipedrive get all persons node

![image](https://github.com/n8n-io/n8n/assets/102531532/e1ab6676-14f0-44d3-b7b6-02e9da9d2259)
