### PR TITLE
fix(editor): Fix operation change failing in certain conditions

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -490,4 +490,19 @@ describe('NDV', () => {
 		ndv.getters.nodeVersion().should('have.text', 'Function node version 1 (Deprecated)');
 		ndv.actions.close();
 	});
+	it('Should handle mismatched option attributes', () => {
+		workflowPage.actions.addInitialNodeToCanvas('LDAP', { keepNdvOpen: true, action: 'Create a new entry' });
+		// Add some attributes in Create operation
+		cy.getByTestId('parameter-item').contains('Add Attributes').click();
+		ndv.actions.changeNodeOperation('Update');
+		// Attributes should be empty after operation change
+		cy.getByTestId('parameter-item').contains('Currently no items exist').should('exist');
+	});
+	it('Should keep RLC values after operation change', () => {
+		const TEST_DOC_ID = '1111';
+		workflowPage.actions.addInitialNodeToCanvas('Google Sheets', { keepNdvOpen: true, action: 'Append row in sheet' });
+		ndv.actions.setRLCValue('documentId', TEST_DOC_ID);
+		ndv.actions.changeNodeOperation('Update Row');
+		ndv.getters.resourceLocatorInput('documentId').find('input').should('have.value', TEST_DOC_ID);
+	});
 });

--- a/cypress/pages/ndv.ts
+++ b/cypress/pages/ndv.ts
@@ -246,9 +246,13 @@ export class NDV extends BasePage {
 			});
 			this.actions.validateExpressionPreview(fieldName, `node doesn't exist`);
 		},
-
 		openSettings: () => {
 			this.getters.nodeSettingsTab().click();
+		},
+		changeNodeOperation: (operation: string) => {
+			this.getters.parameterInput('operation').click();
+			cy.get('.el-select-dropdown__item').contains(new RegExp(`^${operation}$`)).click({ force: true });
+			this.getters.parameterInput('operation').find('input').should('have.value', operation);
 		},
 	};
 }


### PR DESCRIPTION
## Summary
This PR handles the case when there are multiple parameters with the same name but different `options` and `displayOptions`. In this case, if one of such fields is set, changing the dependent parameter value so the other should be shown causes an error in case their options are not compatible (this [check](https://github.com/n8n-io/n8n/blob/7806a65229878a473f5526bad0b94614e8bfa8aa/packages/workflow/src/NodeHelpers.ts#L786)).

#### Example:
LDAP node has two `options` properties with the same name:
1. `attributes` with predefined options (`add`, `replace`, `delete`). Shown when **Update** operation is selected
2. `attributes` with a collection of `attribute` objects. Shows for the **Create** operation

Setting one of these parameter values and switching operation so the other is shown breaks the app.
This PR checks if there is a value saved for such parameter and removes it before calling `getNodeParameters` in `valueChanged` handler.

## Related tickets and issues
Fixes ADO-1589

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 