### PR TITLE
fix(core): Prevent axios from force setting a form-urlencoded content-type

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -162,6 +162,13 @@ axios.defaults.paramsSerializer = (params) => {
 	}
 	return stringify(params, { arrayFormat: 'indices' });
 };
+axios.interceptors.request.use((config) => {
+	// If no content-type is set by us, prevent axios from force-setting the content-type to `application/x-www-form-urlencoded`
+	if (config.data === undefined) {
+		config.headers.setContentType(false, false);
+	}
+	return config;
+});
 
 const pushFormDataValue = (form: FormData, key: string, value: any) => {
 	if (value?.hasOwnProperty('value') && value.hasOwnProperty('options')) {


### PR DESCRIPTION
[Since v1 axios is force-setting a content-type of `application/x-www-form-urlencoded` on POST/PUT/PATCH requests, even if they have no payload](https://github.com/axios/axios/blob/v1.x/lib/core/dispatchRequest.js#L45-L47).
This is causing nodes that do not support form-urlencoded bodies to fail.
By setting the content-type to `false` (if a content-type wasn't already set), we force axios to not overwrite this header.

[Workflows tests](https://github.com/n8n-io/n8n/actions/runs/7288103743/job/19860060607)

## Review / Merge checklist
- [x] PR title and summary are descriptive.