### PR TITLE
fix(core): Fix issue that pinnedData is not used with Test-Webhooks

### DIFF
--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -3,6 +3,7 @@ import {
 	MANUAL_TRIGGER_NODE_NAME,
 	PIPEDRIVE_NODE_NAME,
 	EDIT_FIELDS_SET_NODE_NAME,
+	BACKEND_BASE_URL,
 } from '../constants';
 import { WorkflowPage, NDV } from '../pages';
 
@@ -149,6 +150,21 @@ describe('Data pinning', () => {
 		const output = '[Object: {"json": {"http": 123}, "pairedItem": {"item": 0}}]';
 
 		cy.get('div').contains(output).should('be.visible');
+	});
+
+	it('should use pin data in manual executions that are started by a webhook', () => {
+		cy.createFixtureWorkflow('Test_workflow_webhook_with_pin_data.json', 'Test');
+
+		workflowPage.actions.executeWorkflow();
+
+		cy.request('GET', `${BACKEND_BASE_URL}/webhook-test/b0d79ddb-df2d-49b1-8555-9fa2b482608f`).then((response) => {
+			expect(response.status).to.eq(200);
+		});
+
+		workflowPage.actions.openNode('End');
+
+		ndv.getters.outputTableRow(1).should('exist')
+		ndv.getters.outputTableRow(1).should('have.text', 'pin-overwritten');
 	});
 });
 

--- a/cypress/fixtures/Test_workflow_webhook_with_pin_data.json
+++ b/cypress/fixtures/Test_workflow_webhook_with_pin_data.json
@@ -1,0 +1,151 @@
+{
+    "name": "PinData Test",
+    "nodes": [
+      {
+        "parameters": {},
+        "id": "0a60e507-7f34-41c0-a0f9-697d852033b6",
+        "name": "When clicking \"Execute Workflow\"",
+        "type": "n8n-nodes-base.manualTrigger",
+        "typeVersion": 1,
+        "position": [
+          780,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "path": "b0d79ddb-df2d-49b1-8555-9fa2b482608f",
+          "responseMode": "lastNode",
+          "options": {}
+        },
+        "id": "66425ce3-450d-4aa6-a53b-a701ab89c2de",
+        "name": "Webhook",
+        "type": "n8n-nodes-base.webhook",
+        "typeVersion": 1.1,
+        "position": [
+          780,
+          540
+        ],
+        "webhookId": "b0d79ddb-df2d-49b1-8555-9fa2b482608f"
+      },
+      {
+        "parameters": {
+          "fields": {
+            "values": [
+              {
+                "name": "nodeData",
+                "stringValue": "init"
+              }
+            ]
+          },
+          "include": "none",
+          "options": {}
+        },
+        "id": "3211b3c5-49e9-4694-8f86-7a5783bc653a",
+        "name": "Init Data",
+        "type": "n8n-nodes-base.set",
+        "typeVersion": 3.2,
+        "position": [
+          1000,
+          320
+        ]
+      },
+      {
+        "parameters": {
+          "fields": {
+            "values": [
+              {
+                "name": "nodeData",
+                "stringValue": "pin"
+              }
+            ]
+          },
+          "options": {}
+        },
+        "id": "97b31120-4720-4632-9d35-356f345119f7",
+        "name": "Pin Data",
+        "type": "n8n-nodes-base.set",
+        "typeVersion": 3.2,
+        "position": [
+          1240,
+          320
+        ]
+      },
+      {
+        "parameters": {},
+        "id": "1ee7be4f-7006-43bf-bb0c-29db3058a399",
+        "name": "End",
+        "type": "n8n-nodes-base.noOp",
+        "typeVersion": 1,
+        "position": [
+          1460,
+          320
+        ]
+      }
+    ],
+    "pinData": {
+      "Pin Data": [
+        {
+          "json": {
+            "nodeData": "pin-overwritten"
+          }
+        }
+      ]
+    },
+    "connections": {
+      "When clicking \"Execute Workflow\"": {
+        "main": [
+          [
+            {
+              "node": "Init Data",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Webhook": {
+        "main": [
+          [
+            {
+              "node": "Init Data",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Init Data": {
+        "main": [
+          [
+            {
+              "node": "Pin Data",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Pin Data": {
+        "main": [
+          [
+            {
+              "node": "End",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "active": false,
+    "settings": {
+      "executionOrder": "v1"
+    },
+    "versionId": "ded8577a-3ed2-4611-842c-a7922ec58b98",
+    "id": "weofVLZo0ssmPDrV",
+    "meta": {
+      "instanceId": "021d3c82ba2d3bc090cbf4fc81c9312668bcc34297e022bb3438c5c88a43a5ff"
+    },
+    "tags": []
+  }

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -519,11 +519,16 @@ export async function executeWebhook(
 			Object.assign(runExecutionData, runExecutionDataMerge);
 		}
 
+		if (workflowData.pinData) {
+			runExecutionData.resultData.pinData = workflowData.pinData;
+		}
+
 		const runData: IWorkflowExecutionDataProcess = {
 			executionMode,
 			executionData: runExecutionData,
 			sessionId,
 			workflowData,
+			pinData: workflowData.pinData,
 			userId: user.id,
 		};
 

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -293,6 +293,7 @@ export class WorkflowRunner {
 			nodeTypes,
 			staticData: data.workflowData.staticData,
 			settings: workflowSettings,
+			pinData: data.pinData || data.workflowData.pinData,
 		});
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
 			data.userId,


### PR DESCRIPTION
## Summary
When a workflow gets started via a Test-Webhook the pinned data does get ignored and the nodes executed anyway.



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 