### PR TITLE
fix(core): Remove circular dependency in WorkflowService and ActiveWorkflowRunner

### DIFF
--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
-import { Container, Service } from 'typedi';
+import { Service } from 'typedi';
 import { ActiveWorkflows, NodeExecuteFunctions } from 'n8n-core';
 
 import type {
@@ -95,6 +94,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		private readonly multiMainSetup: MultiMainSetup,
 		private readonly activationErrorsService: ActivationErrorsService,
 		private readonly executionService: ExecutionsService,
+		private readonly workflowStaticDataService: WorkflowStaticDataService,
 	) {}
 
 	async init() {
@@ -219,7 +219,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 						return reject(error);
 					}
 					// Save static data if it changed
-					await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+					await this.workflowStaticDataService.saveStaticData(workflow);
 					resolve(data);
 				},
 			);
@@ -415,7 +415,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		}
 		await this.webhookService.populateCache();
 
-		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+		await this.workflowStaticDataService.saveStaticData(workflow);
 	}
 
 	/**
@@ -454,7 +454,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 			await workflow.deleteWebhook(webhookData, NodeExecuteFunctions, mode, 'update');
 		}
 
-		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+		await this.workflowStaticDataService.saveStaticData(workflow);
 
 		await this.webhookService.deleteWorkflowWebhooks(workflowId);
 	}
@@ -527,7 +527,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 				donePromise?: IDeferredPromise<IRun | undefined>,
 			): void => {
 				this.logger.debug(`Received event to trigger execution for workflow "${workflow.name}"`);
-				void Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+				void this.workflowStaticDataService.saveStaticData(workflow);
 				const executePromise = this.runWorkflow(
 					workflowData,
 					node,
@@ -584,7 +584,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 				donePromise?: IDeferredPromise<IRun | undefined>,
 			): void => {
 				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
-				void Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+				void this.workflowStaticDataService.saveStaticData(workflow);
 
 				const executePromise = this.runWorkflow(
 					workflowData,
@@ -829,7 +829,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 
 		// If for example webhooks get created it sometimes has to save the
 		// id of them in the static data. So make sure that data gets persisted.
-		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
+		await this.workflowStaticDataService.saveStaticData(workflow);
 	}
 
 	/**

--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -59,7 +59,6 @@ import { NodeTypes } from '@/NodeTypes';
 import { WorkflowRunner } from '@/WorkflowRunner';
 import { ExternalHooks } from '@/ExternalHooks';
 import { whereClause } from './UserManagement/UserManagementHelper';
-import { WorkflowService } from './workflows/workflow.service';
 import { WebhookNotFoundError } from './errors/response-errors/webhook-not-found.error';
 import { In } from 'typeorm';
 import { WebhookService } from './services/webhook.service';
@@ -70,6 +69,7 @@ import { MultiMainSetup } from '@/services/orchestration/main/MultiMainSetup.ee'
 import { ActivationErrorsService } from '@/ActivationErrors.service';
 import type { Scope } from '@n8n/permissions';
 import { NotFoundError } from './errors/response-errors/not-found.error';
+import { WorkflowStaticDataService } from '@/workflows/workflowStaticData.service';
 
 @Service()
 export class ActiveWorkflowRunner implements IWebhookManager {
@@ -214,10 +214,12 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 				undefined,
 				request,
 				response,
-				(error: Error | null, data: object) => {
+				async (error: Error | null, data: object) => {
 					if (error !== null) {
 						return reject(error);
 					}
+					// Save static data if it changed
+					await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 					resolve(data);
 				},
 			);
@@ -413,7 +415,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 		}
 		await this.webhookService.populateCache();
 
-		await Container.get(WorkflowService).saveStaticData(workflow);
+		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 	}
 
 	/**
@@ -452,7 +454,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 			await workflow.deleteWebhook(webhookData, NodeExecuteFunctions, mode, 'update');
 		}
 
-		await Container.get(WorkflowService).saveStaticData(workflow);
+		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 
 		await this.webhookService.deleteWorkflowWebhooks(workflowId);
 	}
@@ -525,7 +527,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 				donePromise?: IDeferredPromise<IRun | undefined>,
 			): void => {
 				this.logger.debug(`Received event to trigger execution for workflow "${workflow.name}"`);
-				void Container.get(WorkflowService).saveStaticData(workflow);
+				void Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 				const executePromise = this.runWorkflow(
 					workflowData,
 					node,
@@ -582,7 +584,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 				donePromise?: IDeferredPromise<IRun | undefined>,
 			): void => {
 				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
-				void Container.get(WorkflowService).saveStaticData(workflow);
+				void Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 
 				const executePromise = this.runWorkflow(
 					workflowData,
@@ -817,7 +819,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 			await this.activationErrorsService.unset(workflowId);
 
 			const triggerCount = this.countTriggers(workflow, additionalData);
-			await Container.get(WorkflowService).updateWorkflowTriggerCount(workflow.id, triggerCount);
+			await this.workflowRepository.updateWorkflowTriggerCount(workflow.id, triggerCount);
 		} catch (e) {
 			const error = e instanceof Error ? e : new Error(`${e}`);
 			await this.activationErrorsService.set(workflowId, error.message);
@@ -827,7 +829,7 @@ export class ActiveWorkflowRunner implements IWebhookManager {
 
 		// If for example webhooks get created it sometimes has to save the
 		// id of them in the static data. So make sure that data gets persisted.
-		await Container.get(WorkflowService).saveStaticData(workflow);
+		await Container.get(WorkflowStaticDataService).saveStaticData(workflow);
 	}
 
 	/**

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -60,7 +60,6 @@ import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import { EventsService } from '@/services/events.service';
 import { OwnershipService } from './services/ownership.service';
 import { parseBody } from './middlewares';
-import { WorkflowService } from './workflows/workflow.service';
 import { Logger } from './Logger';
 import { NotFoundError } from './errors/response-errors/not-found.error';
 import { InternalServerError } from './errors/response-errors/internal-server.error';
@@ -385,9 +384,6 @@ export async function executeWebhook(
 				workflowData: [[{ json: {} }]],
 			};
 		}
-
-		// Save static data if it changed
-		await Container.get(WorkflowService).saveStaticData(workflow);
 
 		const additionalKeys: IWorkflowDataProxyAdditionalKeys = {
 			$executionId: executionId,

--- a/packages/cli/src/executions/executions.service.ee.ts
+++ b/packages/cli/src/executions/executions.service.ee.ts
@@ -6,7 +6,7 @@ import type { IExecutionResponse, IExecutionFlattedResponse } from '@/Interfaces
 import { EnterpriseWorkflowService } from '../workflows/workflow.service.ee';
 import type { WorkflowWithSharingsAndCredentials } from '@/workflows/workflows.types';
 import Container from 'typedi';
-import { WorkflowService } from '@/workflows/workflow.service';
+import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
 
 export class EEExecutionsService extends ExecutionsService {
 	/**
@@ -26,7 +26,7 @@ export class EEExecutionsService extends ExecutionsService {
 
 		const relations = ['shared', 'shared.user', 'shared.role'];
 
-		const workflow = (await Container.get(WorkflowService).get(
+		const workflow = (await Container.get(WorkflowRepository).get(
 			{ id: execution.workflowId },
 			{ relations },
 		)) as WorkflowWithSharingsAndCredentials;

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -18,6 +18,7 @@ import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
 
 @Service()
 export class EnterpriseWorkflowService {
@@ -26,6 +27,7 @@ export class EnterpriseWorkflowService {
 		private readonly userService: UserService,
 		private readonly roleService: RoleService,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
+		private readonly workflowRepository: WorkflowRepository,
 	) {}
 
 	async isOwned(
@@ -182,7 +184,7 @@ export class EnterpriseWorkflowService {
 	}
 
 	async preventTampering(workflow: WorkflowEntity, workflowId: string, user: User) {
-		const previousVersion = await this.workflowService.get({ id: workflowId });
+		const previousVersion = await this.workflowRepository.get({ id: workflowId });
 
 		if (!previousVersion) {
 			throw new NotFoundError('Workflow not found');

--- a/packages/cli/src/workflows/workflowStaticData.service.ts
+++ b/packages/cli/src/workflows/workflowStaticData.service.ts
@@ -1,0 +1,41 @@
+import { Service } from 'typedi';
+import { type IDataObject, type Workflow, ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
+import { Logger } from '@/Logger';
+import { WorkflowRepository } from '@db/repositories/workflow.repository';
+import { isWorkflowIdValid } from '@/utils';
+
+@Service()
+export class WorkflowStaticDataService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly workflowRepository: WorkflowRepository,
+	) {}
+
+	/** Saves the static data if it changed */
+	async saveStaticData(workflow: Workflow): Promise<void> {
+		if (workflow.staticData.__dataChanged === true) {
+			// Static data of workflow changed and so has to be saved
+			if (isWorkflowIdValid(workflow.id)) {
+				// Workflow is saved so update in database
+				try {
+					await this.saveStaticDataById(workflow.id, workflow.staticData);
+					workflow.staticData.__dataChanged = false;
+				} catch (error) {
+					ErrorReporter.error(error);
+					this.logger.error(
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+						`There was a problem saving the workflow with id "${workflow.id}" to save changed Data: "${error.message}"`,
+						{ workflowId: workflow.id },
+					);
+				}
+			}
+		}
+	}
+
+	/** Saves the given static data on workflow */
+	async saveStaticDataById(workflowId: string, newStaticData: IDataObject): Promise<void> {
+		await this.workflowRepository.update(workflowId, {
+			staticData: newStaticData,
+		});
+	}
+}

--- a/packages/cli/src/workflows/workflows.controller.ee.ts
+++ b/packages/cli/src/workflows/workflows.controller.ee.ts
@@ -28,6 +28,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { WorkflowService } from './workflow.service';
+import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
 
 export const EEWorkflowController = express.Router();
 
@@ -129,7 +130,7 @@ EEWorkflowController.get(
 			relations.push('tags');
 		}
 
-		const workflow = await Container.get(WorkflowService).get({ id: workflowId }, { relations });
+		const workflow = await Container.get(WorkflowRepository).get({ id: workflowId }, { relations });
 
 		if (!workflow) {
 			throw new NotFoundError(`Workflow with ID "${workflowId}" does not exist`);


### PR DESCRIPTION
## Summary
A circular dependency between `WorkflowService` and `ActiveWorkflowRunner` is sometimes causing `this.activeWorkflowRunner` to be `undefined` in  `WorkflowService`.
Breaking this circular dependency should hopefully fix this issue.

## Related tickets and issues
#8122


## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included