### PR TITLE
fix(Redis Trigger Node): Activating a workflow with a Redis trigger fails

### DIFF
--- a/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
+++ b/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
@@ -118,7 +118,7 @@ export class RedisTrigger implements INodeType {
 		};
 
 		if (this.getMode() === 'trigger') {
-			await manualTriggerFunction();
+			void manualTriggerFunction();
 		}
 
 		async function closeFunction() {


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

We were awaiting for the promise to resolve before returning. Because the trigger method does not return until the first message is received or the connection errors, the requests that actives the workflows did not respond making the activation button irresponsive.  

Without the change:

https://www.loom.com/share/769b26d5d4ee407e999344fab3905eae

With the change:

https://www.loom.com/share/d1691ee1941248bc97f2ed97b0c129a3

## Related tickets and issues
https://linear.app/n8n/issue/ADO-895/activating-a-workflow-with-a-redis-trigger-fails


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.