### PR TITLE
fix(FTP Node): FTP connection failed due to missing password credential in node

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -469,6 +469,7 @@ export class Ftp implements INodeType {
 							host: credentials.host as string,
 							port: credentials.port as number,
 							username: credentials.username as string,
+							password: credentials.password as string,
 							privateKey: formatPrivateKey(credentials.privateKey as string),
 							passphrase: credentials.passphrase as string | undefined,
 						});
@@ -520,6 +521,7 @@ export class Ftp implements INodeType {
 						host: credentials.host as string,
 						port: credentials.port as number,
 						username: credentials.username as string,
+						password: credentials.password as string,
 						privateKey: formatPrivateKey(credentials.privateKey as string),
 						passphrase: credentials.passphrase as string | undefined,
 					});

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -469,7 +469,7 @@ export class Ftp implements INodeType {
 							host: credentials.host as string,
 							port: credentials.port as number,
 							username: credentials.username as string,
-							password: credentials.password as string,
+							password: (credentials.password as string) || undefined,
 							privateKey: formatPrivateKey(credentials.privateKey as string),
 							passphrase: credentials.passphrase as string | undefined,
 						});
@@ -521,7 +521,7 @@ export class Ftp implements INodeType {
 						host: credentials.host as string,
 						port: credentials.port as number,
 						username: credentials.username as string,
-						password: credentials.password as string,
+						password: (credentials.password as string) || undefined,
 						privateKey: formatPrivateKey(credentials.privateKey as string),
 						passphrase: credentials.passphrase as string | undefined,
 					});


### PR DESCRIPTION
## Summary
The credentials have been defined in the setup, but the password data was not passed to the connect method. As a result, the node throws the following exception.

> Error: connect->getConnection: All configured authentication methods failed
    at fmtError (/Users/mehmetvacitbaydarman/Desktop/FiWork/Azure/Fi.N8n/node_modules/.pnpm/ssh2-sftp-client@7.2.3/node_modules/ssh2-sftp-client/src/utils.js:55:18)
    at SftpClient.connect (/Users/mehmetvacitbaydarman/Desktop/FiWork/Azure/Fi.N8n/node_modules/.pnpm/ssh2-sftp-client@7.2.3/node_modules/ssh2-sftp-client/src/index.js:218:13)
    at Object.execute (/Users/mehmetvacitbaydarman/Desktop/FiWork/Azure/Fi.N8n/packages/nodes-base/nodes/Ftp/Ftp.node.ts:519:6)
    at Workflow.runNode (/Users/mehmetvacitbaydarman/Desktop/FiWork/Azure/Fi.N8n/packages/workflow/src/Workflow.ts:1307:8)
    at /Users/mehmetvacitbaydarman/Desktop/FiWork/Azure/Fi.N8n/packages/core/src/WorkflowExecute.ts:1061:29



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 