### PR TITLE
refactor(core): Move `typeorm` operators from `WorkflowService` to `WorkflowRepository` (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -1,7 +1,18 @@
 import { Service } from 'typedi';
-import { DataSource, Repository, type UpdateResult, type FindOptionsWhere } from 'typeorm';
+import {
+	DataSource,
+	Repository,
+	In,
+	Like,
+	type UpdateResult,
+	type FindOptionsWhere,
+	type FindOptionsSelect,
+	type FindManyOptions,
+} from 'typeorm';
 import config from '@/config';
 import { WorkflowEntity } from '../entities/WorkflowEntity';
+import type { ListQuery } from '@/requests';
+import { isStringArray } from '@/utils';
 
 @Service()
 export class WorkflowRepository extends Repository<WorkflowEntity> {
@@ -52,5 +63,78 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			})
 			.where('id = :id', { id })
 			.execute();
+	}
+
+	async getMany(sharedWorkflowIds: string[], options?: ListQuery.Options) {
+		if (sharedWorkflowIds.length === 0) return { workflows: [], count: 0 };
+
+		const where: FindOptionsWhere<WorkflowEntity> = {
+			...options?.filter,
+			id: In(sharedWorkflowIds),
+		};
+
+		const reqTags = options?.filter?.tags;
+
+		if (isStringArray(reqTags)) {
+			where.tags = reqTags.map((tag) => ({ name: tag }));
+		}
+
+		type Select = FindOptionsSelect<WorkflowEntity> & { ownedBy?: true };
+
+		const select: Select = options?.select
+			? { ...options.select } // copy to enable field removal without affecting original
+			: {
+					name: true,
+					active: true,
+					createdAt: true,
+					updatedAt: true,
+					versionId: true,
+					shared: { userId: true, roleId: true },
+			  };
+
+		delete select?.ownedBy; // remove non-entity field, handled after query
+
+		const relations: string[] = [];
+
+		const areTagsEnabled = !config.getEnv('workflowTagsDisabled');
+		const isDefaultSelect = options?.select === undefined;
+		const areTagsRequested = isDefaultSelect || options?.select?.tags === true;
+		const isOwnedByIncluded = isDefaultSelect || options?.select?.ownedBy === true;
+
+		if (areTagsEnabled && areTagsRequested) {
+			relations.push('tags');
+			select.tags = { id: true, name: true };
+		}
+
+		if (isOwnedByIncluded) relations.push('shared', 'shared.role', 'shared.user');
+
+		if (typeof where.name === 'string' && where.name !== '') {
+			where.name = Like(`%${where.name}%`);
+		}
+
+		const findManyOptions: FindManyOptions<WorkflowEntity> = {
+			select: { ...select, id: true },
+			where,
+		};
+
+		if (isDefaultSelect || options?.select?.updatedAt === true) {
+			findManyOptions.order = { updatedAt: 'ASC' };
+		}
+
+		if (relations.length > 0) {
+			findManyOptions.relations = relations;
+		}
+
+		if (options?.take) {
+			findManyOptions.skip = options.skip;
+			findManyOptions.take = options.take;
+		}
+
+		const [workflows, count] = (await this.findAndCount(findManyOptions)) as [
+			ListQuery.Workflow.Plain[] | ListQuery.Workflow.WithSharing[],
+			number,
+		];
+
+		return { workflows, count };
 	}
 }


### PR DESCRIPTION
Moving persistence logic to repositories to reduce circular dependencies.