### PR TITLE
refactor(core): Move `typeorm` operators from `EnterpriseWorkflowService` to `WorkflowRepository` (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -1,7 +1,17 @@
 import { Service } from 'typedi';
-import { DataSource, Repository, type UpdateResult, type FindOptionsWhere } from 'typeorm';
+import {
+	DataSource,
+	Repository,
+	type UpdateResult,
+	type FindOptionsWhere,
+	type DeleteResult,
+	type EntityManager,
+	In,
+	Not,
+} from 'typeorm';
 import config from '@/config';
 import { WorkflowEntity } from '../entities/WorkflowEntity';
+import { SharedWorkflow } from '../entities/SharedWorkflow';
 
 @Service()
 export class WorkflowRepository extends Repository<WorkflowEntity> {
@@ -35,6 +45,29 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			active: true,
 		});
 		return totalTriggerCount ?? 0;
+	}
+
+	async getSharings(
+		transaction: EntityManager,
+		workflowId: string,
+		relations = ['shared'],
+	): Promise<SharedWorkflow[]> {
+		const workflow = await transaction.findOne(WorkflowEntity, {
+			where: { id: workflowId },
+			relations,
+		});
+		return workflow?.shared ?? [];
+	}
+
+	async pruneSharings(
+		transaction: EntityManager,
+		workflowId: string,
+		userIds: string[],
+	): Promise<DeleteResult> {
+		return transaction.delete(SharedWorkflow, {
+			workflowId,
+			userId: Not(In(userIds)),
+		});
 	}
 
 	async updateWorkflowTriggerCount(id: string, triggerCount: number): Promise<UpdateResult> {

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -1,9 +1,8 @@
-import type { DeleteResult, EntityManager } from 'typeorm';
-import { In, Not } from 'typeorm';
+import type { EntityManager } from 'typeorm';
 import * as WorkflowHelpers from '@/WorkflowHelpers';
-import { SharedWorkflow } from '@db/entities/SharedWorkflow';
+import type { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import type { User } from '@db/entities/User';
-import { WorkflowEntity } from '@db/entities/WorkflowEntity';
+import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import { UserService } from '@/services/user.service';
 import { WorkflowService } from './workflow.service';
 import type {
@@ -46,29 +45,6 @@ export class EnterpriseWorkflowService {
 		const { workflow } = sharing;
 
 		return { ownsWorkflow: true, workflow };
-	}
-
-	async getSharings(
-		transaction: EntityManager,
-		workflowId: string,
-		relations = ['shared'],
-	): Promise<SharedWorkflow[]> {
-		const workflow = await transaction.findOne(WorkflowEntity, {
-			where: { id: workflowId },
-			relations,
-		});
-		return workflow?.shared ?? [];
-	}
-
-	async pruneSharings(
-		transaction: EntityManager,
-		workflowId: string,
-		userIds: string[],
-	): Promise<DeleteResult> {
-		return transaction.delete(SharedWorkflow, {
-			workflowId,
-			userId: Not(In(userIds)),
-		});
 	}
 
 	async share(

--- a/packages/cli/src/workflows/workflows.controller.ee.ts
+++ b/packages/cli/src/workflows/workflows.controller.ee.ts
@@ -81,7 +81,7 @@ EEWorkflowController.put(
 		}
 
 		const ownerIds = (
-			await Container.get(EnterpriseWorkflowService).getSharings(
+			await Container.get(WorkflowRepository).getSharings(
 				Db.getConnection().createEntityManager(),
 				workflowId,
 				['shared', 'shared.role'],
@@ -93,12 +93,12 @@ EEWorkflowController.put(
 		let newShareeIds: string[] = [];
 		await Db.transaction(async (trx) => {
 			// remove all sharings that are not supposed to exist anymore
-			await Container.get(EnterpriseWorkflowService).pruneSharings(trx, workflowId, [
+			await Container.get(WorkflowRepository).pruneSharings(trx, workflowId, [
 				...ownerIds,
 				...shareWithIds,
 			]);
 
-			const sharings = await Container.get(EnterpriseWorkflowService).getSharings(trx, workflowId);
+			const sharings = await Container.get(WorkflowRepository).getSharings(trx, workflowId);
 
 			// extract the new sharings that need to be added
 			newShareeIds = rightDiff(


### PR DESCRIPTION
Moving persistence logic to repositories to reduce circular dependencies.