### PR TITLE
refactor(core): Move `typeorm` operators from workflow controllers to `TagRepository` (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/tag.repository.ts
+++ b/packages/cli/src/databases/repositories/tag.repository.ts
@@ -1,10 +1,17 @@
 import { Service } from 'typedi';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { TagEntity } from '../entities/TagEntity';
 
 @Service()
 export class TagRepository extends Repository<TagEntity> {
 	constructor(dataSource: DataSource) {
 		super(TagEntity, dataSource.manager);
+	}
+
+	async findMany(tagIds: string[]) {
+		return this.find({
+			select: ['id', 'name'],
+			where: { id: In(tagIds) },
+		});
 	}
 }

--- a/packages/cli/src/workflows/workflows.controller.ee.ts
+++ b/packages/cli/src/workflows/workflows.controller.ee.ts
@@ -14,7 +14,6 @@ import { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import { CredentialsService } from '../credentials/credentials.service';
 import type { IExecutionPushResponse } from '@/Interfaces';
 import * as GenericHelpers from '@/GenericHelpers';
-import { In } from 'typeorm';
 import { Container } from 'typedi';
 import { InternalHooks } from '@/InternalHooks';
 import { RoleService } from '@/services/role.service';
@@ -29,6 +28,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { WorkflowService } from './workflow.service';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { TagRepository } from '@/databases/repositories/tag.repository';
 
 export const EEWorkflowController = express.Router();
 
@@ -169,12 +169,7 @@ EEWorkflowController.post(
 		const { tags: tagIds } = req.body;
 
 		if (tagIds?.length && !config.getEnv('workflowTagsDisabled')) {
-			newWorkflow.tags = await Container.get(TagService).findMany({
-				select: ['id', 'name'],
-				where: {
-					id: In(tagIds),
-				},
-			});
+			newWorkflow.tags = await Container.get(TagRepository).findMany(tagIds);
 		}
 
 		await WorkflowHelpers.replaceInvalidCredentials(newWorkflow);

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -17,7 +17,6 @@ import { isBelowOnboardingThreshold } from '@/WorkflowHelpers';
 import { EEWorkflowController } from './workflows.controller.ee';
 import { WorkflowService } from './workflow.service';
 import { whereClause } from '@/UserManagement/UserManagementHelper';
-import { In } from 'typeorm';
 import { Container } from 'typedi';
 import { InternalHooks } from '@/InternalHooks';
 import { RoleService } from '@/services/role.service';
@@ -31,6 +30,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NamingService } from '@/services/naming.service';
+import { TagRepository } from '@/databases/repositories/tag.repository';
 
 export const workflowsController = express.Router();
 workflowsController.use('/', EEWorkflowController);
@@ -56,12 +56,7 @@ workflowsController.post(
 		const { tags: tagIds } = req.body;
 
 		if (tagIds?.length && !config.getEnv('workflowTagsDisabled')) {
-			newWorkflow.tags = await Container.get(TagService).findMany({
-				select: ['id', 'name'],
-				where: {
-					id: In(tagIds),
-				},
-			});
+			newWorkflow.tags = await Container.get(TagRepository).findMany(tagIds);
 		}
 
 		await WorkflowHelpers.replaceInvalidCredentials(newWorkflow);


### PR DESCRIPTION
Moving persistence logic to repositories to reduce circular dependencies.