### PR TITLE
docs: Improve documentation for the toTitleCase function

### DIFF
--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -408,7 +408,7 @@ toSnakeCase.doc = {
 toTitleCase.doc = {
 	name: 'toTitleCase',
 	description:
-		'Formats a string to title case. Example: "This Is a Title". Will not change already uppercaes letters to prevent losing information from acronyms and trademarks such as iPhone or FAANG.',
+		'Formats a string to title case. Example: "This Is a Title". Will not change already uppercase letters to prevent losing information from acronyms and trademarks such as iPhone or FAANG.',
 	returnType: 'string',
 	docURL:
 		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-toTitleCase',

--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -407,7 +407,8 @@ toSnakeCase.doc = {
 
 toTitleCase.doc = {
 	name: 'toTitleCase',
-	description: 'Formats a string to title case. Example: "This Is a Title".',
+	description:
+		'Formats a string to title case. Example: "This Is a Title". Will not change already uppercaes letters to prevent losing information from acronyms and trademarks such as iPhone or FAANG.',
 	returnType: 'string',
 	docURL:
 		'https://docs.n8n.io/code/builtin/data-transformation-functions/strings/#string-toTitleCase',


### PR DESCRIPTION
## Summary
Update description of `toTitleCase` to better explain what it does.


## Related tickets and issues
https://linear.app/n8n/issue/PAY-857/expressions-totitlecase-fails-to-lowercase-the-non-leading-letters


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.