### PR TITLE
feat(core): Add user.profile.beforeUpdate hook

### DIFF
--- a/packages/cli/src/ResponseHelper.ts
+++ b/packages/cli/src/ResponseHelper.ts
@@ -51,6 +51,28 @@ export function sendSuccessResponse(
 	}
 }
 
+/**
+ * Checks if the given error is a ResponseError. It can be either an
+ * instance of ResponseError or an error which has the same properties.
+ * The latter case is for external hooks.
+ */
+function isResponseError(error: Error): error is ResponseError {
+	if (error instanceof ResponseError) {
+		return true;
+	}
+
+	if (error instanceof Error) {
+		return (
+			'httpStatusCode' in error &&
+			typeof error.httpStatusCode === 'number' &&
+			'errorCode' in error &&
+			typeof error.errorCode === 'number'
+		);
+	}
+
+	return false;
+}
+
 interface ErrorResponse {
 	code: number;
 	message: string;
@@ -66,7 +88,7 @@ export function sendErrorResponse(res: Response, error: Error) {
 		message: error.message ?? 'Unknown error',
 	};
 
-	if (error instanceof ResponseError) {
+	if (isResponseError(error)) {
 		if (inDevelopment) {
 			console.error(picocolors.red(error.httpStatusCode), error.message);
 		}

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -75,6 +75,8 @@ export class MeController {
 			}
 		}
 
+		await this.externalHooks.run('user.profile.beforeUpdate', [userId, currentEmail, payload]);
+
 		await this.userService.update(userId, payload);
 		const user = await this.userService.findOneOrFail({ where: { id: userId } });
 


### PR DESCRIPTION
## Summary

Add `user.profile.beforeUpdate` hook so we can prevent user email change if it overlaps with other users email.


## Related tickets and issues

https://github.com/n8n-io/n8n-cloud/pull/903

https://linear.app/n8n/issue/ADO-1248/feature-prevent-users-from-updating-email-if-it-already-exists-in


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 