### PR TITLE
refactor(core): Move more `typeorm` operators to `UserRepository` (no-changelog)

### DIFF
--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -24,6 +24,7 @@ import { InternalServerError } from '@/errors/response-errors/internal-server.er
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { UnauthorizedError } from '@/errors/response-errors/unauthorized.error';
 import { ApplicationError } from 'n8n-workflow';
+import { UserRepository } from '@/databases/repositories/user.repository';
 
 @RestController()
 export class AuthController {
@@ -33,6 +34,7 @@ export class AuthController {
 		private readonly mfaService: MfaService,
 		private readonly userService: UserService,
 		private readonly license: License,
+		private readonly userRepository: UserRepository,
 		private readonly postHog?: PostHogClient,
 	) {}
 
@@ -185,7 +187,7 @@ export class AuthController {
 			}
 		}
 
-		const users = await this.userService.findManybyIds([inviterId, inviteeId]);
+		const users = await this.userRepository.findManybyIds([inviterId, inviteeId]);
 
 		if (users.length !== 2) {
 			this.logger.debug(

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -1,5 +1,4 @@
 import validator from 'validator';
-import { In } from 'typeorm';
 import { Authorized, Get, Post, RestController } from '@/decorators';
 import { issueCookie, resolveJwt } from '@/auth/jwt';
 import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
@@ -186,10 +185,8 @@ export class AuthController {
 			}
 		}
 
-		const users = await this.userService.findMany({
-			where: { id: In([inviterId, inviteeId]) },
-			relations: ['globalRole'],
-		});
+		const users = await this.userService.findManybyIds([inviterId, inviteeId]);
+
 		if (users.length !== 2) {
 			this.logger.debug(
 				'Request to resolve signup token failed because the ID of the inviter and/or the ID of the invitee were not found in database',

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -1,4 +1,3 @@
-import { In } from 'typeorm';
 import { Response } from 'express';
 
 import config from '@/config';
@@ -18,6 +17,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { UnauthorizedError } from '@/errors/response-errors/unauthorized.error';
 import { InternalHooks } from '@/InternalHooks';
 import { ExternalHooks } from '@/ExternalHooks';
+import { UserRepository } from '@/databases/repositories/user.repository';
 
 @Authorized()
 @RestController('/invitations')
@@ -29,6 +29,7 @@ export class InvitationController {
 		private readonly userService: UserService,
 		private readonly license: License,
 		private readonly passwordUtility: PasswordUtility,
+		private readonly userRepository: UserRepository,
 		private readonly postHog: PostHogClient,
 	) {}
 
@@ -135,10 +136,7 @@ export class InvitationController {
 
 		const validPassword = this.passwordUtility.validate(password);
 
-		const users = await this.userService.findMany({
-			where: { id: In([inviterId, inviteeId]) },
-			relations: ['globalRole'],
-		});
+		const users = await this.userRepository.findManybyIds([inviterId, inviteeId]);
 
 		if (users.length !== 2) {
 			this.logger.debug(

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -1,10 +1,17 @@
 import { Service } from 'typedi';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { User } from '../entities/User';
 
 @Service()
 export class UserRepository extends Repository<User> {
 	constructor(dataSource: DataSource) {
 		super(User, dataSource.manager);
+	}
+
+	async findManybyIds(userIds: string[]) {
+		return this.find({
+			where: { id: In(userIds) },
+			relations: ['globalRole'],
+		});
 	}
 }

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -9,9 +9,6 @@ export class UserRepository extends Repository<User> {
 	}
 
 	async findManybyIds(userIds: string[]) {
-		return this.find({
-			where: { id: In(userIds) },
-			relations: ['globalRole'],
-		});
+		return this.find({ where: { id: In(userIds) } });
 	}
 }

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -9,6 +9,9 @@ export class UserRepository extends Repository<User> {
 	}
 
 	async findManybyIds(userIds: string[]) {
-		return this.find({ where: { id: In(userIds) } });
+		return this.find({
+			where: { id: In(userIds) },
+			relations: ['globalRole'],
+		});
 	}
 }

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -41,6 +41,13 @@ export class UserService {
 		return this.userRepository.find(options);
 	}
 
+	async findManybyIds(userIds: string[]) {
+		return this.findMany({
+			where: { id: In(userIds) },
+			relations: ['globalRole'],
+		});
+	}
+
 	async findOneBy(options: FindOptionsWhere<User>) {
 		return this.userRepository.findOneBy(options);
 	}

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -41,13 +41,6 @@ export class UserService {
 		return this.userRepository.find(options);
 	}
 
-	async findManybyIds(userIds: string[]) {
-		return this.findMany({
-			where: { id: In(userIds) },
-			relations: ['globalRole'],
-		});
-	}
-
 	async findOneBy(options: FindOptionsWhere<User>) {
 		return this.userRepository.findOneBy(options);
 	}


### PR DESCRIPTION
Follow-up to: #8163