### PR TITLE
refactor(core): Move `typeorm` operators from `SourceControlExportService` to repositories (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from 'typedi';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { SharedCredentials } from '../entities/SharedCredentials';
 import type { User } from '../entities/User';
 
@@ -20,5 +20,14 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 		});
 		if (!sharedCredential) return null;
 		return sharedCredential.credentials;
+	}
+
+	async findByCredentialIds(credentialIds: string[]) {
+		return this.find({
+			relations: ['credentials', 'role', 'user'],
+			where: {
+				credentialsId: In(credentialIds),
+			},
+		});
 	}
 }

--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -28,4 +28,17 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 		});
 		return sharedWorkflows.map((sharing) => sharing.workflowId);
 	}
+
+	async findByWorkflowIds(workflowIds: string[]) {
+		return this.find({
+			relations: ['role', 'user'],
+			where: {
+				role: {
+					name: 'owner',
+					scope: 'workflow',
+				},
+				workflowId: In(workflowIds),
+			},
+		});
+	}
 }

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -53,6 +53,10 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		});
 	}
 
+	async findByIds(workflowIds: string[]) {
+		return this.find({ where: { id: In(workflowIds) } });
+	}
+
 	async getActiveTriggerCount() {
 		const totalTriggerCount = await this.sum('triggerCount', {
 			active: true,

--- a/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
@@ -21,7 +21,6 @@ import {
 	stringContainsExpression,
 } from './sourceControlHelper.ee';
 import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
-import { In } from 'typeorm';
 import type { SourceControlledFile } from './types/sourceControlledFile';
 import { VariablesService } from '../variables/variables.service.ee';
 import { TagRepository } from '@db/repositories/tag.repository';
@@ -105,21 +104,9 @@ export class SourceControlExportService {
 		try {
 			sourceControlFoldersExistCheck([this.workflowExportFolder]);
 			const workflowIds = candidates.map((e) => e.id);
-			const sharedWorkflows = await Container.get(SharedWorkflowRepository).find({
-				relations: ['role', 'user'],
-				where: {
-					role: {
-						name: 'owner',
-						scope: 'workflow',
-					},
-					workflowId: In(workflowIds),
-				},
-			});
-			const workflows = await Container.get(WorkflowRepository).find({
-				where: {
-					id: In(workflowIds),
-				},
-			});
+			const sharedWorkflows =
+				await Container.get(SharedWorkflowRepository).findByWorkflowIds(workflowIds);
+			const workflows = await Container.get(WorkflowRepository).findByIds(workflowIds);
 
 			// determine owner of each workflow to be exported
 			const owners: Record<string, string> = {};
@@ -241,12 +228,9 @@ export class SourceControlExportService {
 		try {
 			sourceControlFoldersExistCheck([this.credentialExportFolder]);
 			const credentialIds = candidates.map((e) => e.id);
-			const credentialsToBeExported = await Container.get(SharedCredentialsRepository).find({
-				relations: ['credentials', 'role', 'user'],
-				where: {
-					credentialsId: In(credentialIds),
-				},
-			});
+			const credentialsToBeExported = await Container.get(
+				SharedCredentialsRepository,
+			).findByCredentialIds(credentialIds);
 			let missingIds: string[] = [];
 			if (credentialsToBeExported.length !== credentialIds.length) {
 				const foundCredentialIds = credentialsToBeExported.map((e) => e.credentialsId);


### PR DESCRIPTION
Follow-up to: #8165