### PR TITLE
feat(API): Add Get Method for Single Credential to the PublicAPI

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.handler.ts
@@ -21,6 +21,7 @@ import {
 } from './credentials.service';
 import { Container } from 'typedi';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import { date } from 'express-openapi-validator/dist/framework/base.serdes';
 
 export = {
 	createCredential: [
@@ -80,7 +81,7 @@ export = {
 				data: decodedData,
 				type: credential.type,
 				shared: credential.shared,
-				lastUpdate: credential.updatedAt,
+				updatedAt: credential.updatedAt,
 				nodeAccess: credential.nodesAccess,
 			});
 		},

--- a/packages/cli/src/PublicApi/v1/handlers/credentials/spec/paths/credentials.id.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/credentials/spec/paths/credentials.id.yml
@@ -1,3 +1,28 @@
+get:
+  x-eov-operation-id: getCredential
+  x-eov-operation-handler: v1/handlers/credentials/credentials.handler
+  tags:
+    - Credential
+  summary: Retrieves a credential by ID
+  description: Retrieves a credential by ID. You must be the owner of the credentials.
+  parameters:
+    - name: id
+      in: path
+      description: The credential ID that needs to be retrieved
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/credential.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:
   x-eov-operation-id: deleteCredential
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler

--- a/packages/cli/src/PublicApi/v1/handlers/credentials/spec/schemas/credentialList.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/credentials/spec/schemas/credentialList.yml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './credential.yml'
+  nextCursor:
+    type: string
+    description: Paginate through credentials by setting the cursor parameter to a nextCursor attribute returned by a previous request. Default value fetches the first "page" of the collection.
+    nullable: true
+    example: MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDA
+

--- a/packages/cli/src/PublicApi/v1/shared/spec/schemas/_index.yml
+++ b/packages/cli/src/PublicApi/v1/shared/spec/schemas/_index.yml
@@ -20,6 +20,8 @@ Credential:
   $ref: './../../../handlers/credentials/spec/schemas/credential.yml'
 CredentialType:
   $ref: './../../../handlers/credentials/spec/schemas/credentialType.yml'
+CredentialList:
+  $ref: './../../../handlers/credentials/spec/schemas/credentialList.yml'
 Audit:
   $ref: './../../../handlers/audit/spec/schemas/audit.yml'
 Pull:

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -209,7 +209,12 @@ export declare namespace CredentialRequest {
 
 	type Delete = Get;
 
-	type GetAll = AuthenticatedRequest<{}, {}, {}, { filter: string }>;
+	type GetAll = AuthenticatedRequest<
+		{},
+		{},
+		{},
+		{ limit?: number; offset?: number; cursor?: string }
+	>;
 
 	type Update = AuthenticatedRequest<{ id: string }, {}, CredentialProperties>;
 


### PR DESCRIPTION
## Summary
Add Get Method for Single Credential to the PublicAPI so that a user has the ability to programatically retrieve existing credentials

## Related tickets and issues
N/A

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated] Swagger updated via yml changes
- [x] Tests included.
         