### PR TITLE
fix(editor): Prevent storing pairedItem data inside of pinData

### DIFF
--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -694,7 +694,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			}
 
 			const storedPinData = payload.data.map((item) =>
-				isJsonKeyObject(item) ? item : { json: item },
+				isJsonKeyObject(item) ? { json: item.json } : { json: item },
 			);
 
 			this.workflow = {


### PR DESCRIPTION
## Summary
When pinning data after an execution, the pairedItem data gets stored in the pinData field. This creates problems during executions.

Before:
<img width="1141" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/e555d00a-6ff2-4601-8072-3194a0c5e1c2">

After: 
<img width="1140" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/d97e9d90-28f5-4dcc-b63e-62497c646994">


## Related tickets and issues
https://linear.app/n8n/issue/PAY-812/wrong-error-shown-when-paireditem-fails-because-of-incorrect-pinned


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 