### PR TITLE
refactor(core): Move `typeorm` operators from various sources into repositories (no-changelog)

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -31,7 +31,6 @@ import type { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import type { WorkflowExecute } from 'n8n-core';
 
 import type PCancelable from 'p-cancelable';
-import type { FindOperator } from 'typeorm';
 
 import type { ChildProcess } from 'child_process';
 
@@ -605,8 +604,6 @@ export interface IWorkflowExecuteProcess {
 export interface IWorkflowStatisticsDataLoaded {
 	dataLoaded: boolean;
 }
-
-export type WhereClause = Record<string, { [key: string]: string | FindOperator<unknown> }>;
 
 // ----------------------------------
 //          community nodes

--- a/packages/cli/src/UserManagement/UserManagementHelper.ts
+++ b/packages/cli/src/UserManagement/UserManagementHelper.ts
@@ -1,9 +1,4 @@
-import { In } from 'typeorm';
 import { Container } from 'typedi';
-import type { Scope } from '@n8n/permissions';
-
-import type { WhereClause } from '@/Interfaces';
-import type { User } from '@db/entities/User';
 import { License } from '@/License';
 
 export function isSharingEnabled(): boolean {
@@ -28,33 +23,4 @@ export function rightDiff<T1, T2>(
 		}
 		return acc;
 	}, []);
-}
-
-/**
- * Build a `where` clause for a TypeORM entity search,
- * checking for member access if the user is not an owner.
- */
-export function whereClause({
-	user,
-	entityType,
-	globalScope,
-	entityId = '',
-	roles = [],
-}: {
-	user: User;
-	entityType: 'workflow' | 'credentials';
-	globalScope: Scope;
-	entityId?: string;
-	roles?: string[];
-}): WhereClause {
-	const where: WhereClause = entityId ? { [entityType]: { id: entityId } } : {};
-
-	if (!user.hasGlobalScope(globalScope)) {
-		where.user = { id: user.id };
-		if (roles?.length) {
-			where.role = { name: In(roles) };
-		}
-	}
-
-	return where;
 }

--- a/packages/cli/src/WorkflowHelpers.ts
+++ b/packages/cli/src/WorkflowHelpers.ts
@@ -418,7 +418,7 @@ export async function replaceInvalidCredentials(workflow: WorkflowEntity): Promi
 
 /**
  * Get the IDs of the workflows that have been shared with the user.
- * Returns all IDs if user has the 'workflow:read' scope (see `whereClause`)
+ * Returns all IDs if user has the 'workflow:read' scope.
  */
 export async function getSharedWorkflowIds(user: User, roles?: RoleNames[]): Promise<string[]> {
 	const where: FindOptionsWhere<SharedWorkflow> = {};

--- a/packages/cli/src/commands/user-management/reset.ts
+++ b/packages/cli/src/commands/user-management/reset.ts
@@ -1,5 +1,4 @@
 import { Container } from 'typedi';
-import { Not } from 'typeorm';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import { User } from '@db/entities/User';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
@@ -25,20 +24,16 @@ export class Reset extends BaseCommand {
 	async run(): Promise<void> {
 		const owner = await this.getInstanceOwner();
 
-		const ownerWorkflowRole = await Container.get(RoleService).findWorkflowOwnerRole();
-		const ownerCredentialRole = await Container.get(RoleService).findCredentialOwnerRole();
+		const workflowOwnerRole = await Container.get(RoleService).findWorkflowOwnerRole();
+		const credentialOwnerRole = await Container.get(RoleService).findCredentialOwnerRole();
 
-		await Container.get(SharedWorkflowRepository).update(
-			{ userId: Not(owner.id), roleId: ownerWorkflowRole.id },
-			{ user: owner },
+		await Container.get(SharedWorkflowRepository).makeOwnerOfAllWorkflows(owner, workflowOwnerRole);
+		await Container.get(SharedCredentialsRepository).makeOwnerOfAllCredentials(
+			owner,
+			credentialOwnerRole,
 		);
 
-		await Container.get(SharedCredentialsRepository).update(
-			{ userId: Not(owner.id), roleId: ownerCredentialRole.id },
-			{ user: owner },
-		);
-
-		await Container.get(UserRepository).delete({ id: Not(owner.id) });
+		await Container.get(UserRepository).deleteAllExcept(owner);
 		await Container.get(UserRepository).save(Object.assign(owner, defaultUserProps));
 
 		const danglingCredentials: CredentialsEntity[] = await Container.get(CredentialsRepository)
@@ -50,7 +45,7 @@ export class Reset extends BaseCommand {
 			Container.get(SharedCredentialsRepository).create({
 				credentials,
 				user: owner,
-				role: ownerCredentialRole,
+				role: credentialOwnerRole,
 			}),
 		);
 		await Container.get(SharedCredentialsRepository).save(newSharedCredentials);

--- a/packages/cli/src/controllers/debug.controller.ts
+++ b/packages/cli/src/controllers/debug.controller.ts
@@ -2,7 +2,6 @@ import { Get, RestController } from '@/decorators';
 import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import { MultiMainSetup } from '@/services/orchestration/main/MultiMainSetup.ee';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import { In } from 'typeorm';
 import { WebhookEntity } from '@/databases/entities/WebhookEntity';
 
 @RestController('/debug')
@@ -17,10 +16,9 @@ export class DebugController {
 	async getMultiMainSetupDetails() {
 		const leaderKey = await this.multiMainSetup.fetchLeaderKey();
 
-		const triggersAndPollers = await this.workflowRepository.find({
-			select: ['id', 'name'],
-			where: { id: In(this.activeWorkflowRunner.allActiveInMemory()) },
-		});
+		const triggersAndPollers = await this.workflowRepository.findIn(
+			this.activeWorkflowRunner.allActiveInMemory(),
+		);
 
 		const webhooks = (await this.workflowRepository
 			.createQueryBuilder('workflow')

--- a/packages/cli/src/controllers/debug.controller.ts
+++ b/packages/cli/src/controllers/debug.controller.ts
@@ -2,7 +2,6 @@ import { Get, RestController } from '@/decorators';
 import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 import { MultiMainSetup } from '@/services/orchestration/main/MultiMainSetup.ee';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import { WebhookEntity } from '@/databases/entities/WebhookEntity';
 
 @RestController('/debug')
 export class DebugController {
@@ -20,11 +19,7 @@ export class DebugController {
 			this.activeWorkflowRunner.allActiveInMemory(),
 		);
 
-		const webhooks = (await this.workflowRepository
-			.createQueryBuilder('workflow')
-			.select('DISTINCT workflow.id, workflow.name')
-			.innerJoin(WebhookEntity, 'webhook_entity', 'workflow.id = webhook_entity.workflowId')
-			.execute()) as Array<{ id: string; name: string }>;
+		const webhooks = await this.workflowRepository.findWebhookBasedActiveWorkflows();
 
 		const activationErrors = await this.activeWorkflowRunner.getAllWorkflowActivationErrors();
 

--- a/packages/cli/src/controllers/workflowStatistics.controller.ts
+++ b/packages/cli/src/controllers/workflowStatistics.controller.ts
@@ -5,7 +5,6 @@ import { StatisticsNames } from '@db/entities/WorkflowStatistics';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { WorkflowStatisticsRepository } from '@db/repositories/workflowStatistics.repository';
 import { ExecutionRequest } from '@/requests';
-import { whereClause } from '@/UserManagement/UserManagementHelper';
 import type { IWorkflowStatisticsDataLoaded } from '@/Interfaces';
 import { Logger } from '@/Logger';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -33,17 +32,10 @@ export class WorkflowStatisticsController {
 	async hasWorkflowAccess(req: ExecutionRequest.Get, res: Response, next: NextFunction) {
 		const { user } = req;
 		const workflowId = req.params.id;
-		const allowed = await this.sharedWorkflowRepository.exist({
-			relations: ['workflow'],
-			where: whereClause({
-				user,
-				globalScope: 'workflow:read',
-				entityType: 'workflow',
-				entityId: workflowId,
-			}),
-		});
 
-		if (allowed) {
+		const hasAccess = await this.sharedWorkflowRepository.hasAccess(workflowId, user);
+
+		if (hasAccess) {
 			next();
 		} else {
 			this.logger.verbose('User attempted to read a workflow without permissions', {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -8,8 +8,7 @@ import type {
 } from 'n8n-workflow';
 import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
 import { Container } from 'typedi';
-import type { FindManyOptions, FindOptionsWhere } from 'typeorm';
-import { In, Like } from 'typeorm';
+import type { FindOptionsWhere } from 'typeorm';
 
 import type { Scope } from '@n8n/permissions';
 
@@ -42,95 +41,33 @@ export class CredentialsService {
 		});
 	}
 
-	private static toFindManyOptions(listQueryOptions?: ListQuery.Options) {
-		const findManyOptions: FindManyOptions<CredentialsEntity> = {};
-
-		type Select = Array<keyof CredentialsEntity>;
-
-		const defaultRelations = ['shared', 'shared.role', 'shared.user'];
-		const defaultSelect: Select = ['id', 'name', 'type', 'nodesAccess', 'createdAt', 'updatedAt'];
-
-		if (!listQueryOptions) return { select: defaultSelect, relations: defaultRelations };
-
-		const { filter, select, take, skip } = listQueryOptions;
-
-		if (typeof filter?.name === 'string' && filter?.name !== '') {
-			filter.name = Like(`%${filter.name}%`);
-		}
-
-		if (typeof filter?.type === 'string' && filter?.type !== '') {
-			filter.type = Like(`%${filter.type}%`);
-		}
-
-		if (filter) findManyOptions.where = filter;
-		if (select) findManyOptions.select = select;
-		if (take) findManyOptions.take = take;
-		if (skip) findManyOptions.skip = skip;
-
-		if (take && select && !select?.id) {
-			findManyOptions.select = { ...findManyOptions.select, id: true }; // pagination requires id
-		}
-
-		if (!findManyOptions.select) {
-			findManyOptions.select = defaultSelect;
-			findManyOptions.relations = defaultRelations;
-		}
-
-		return findManyOptions;
-	}
-
 	static async getMany(
 		user: User,
 		options: { listQueryOptions?: ListQuery.Options; onlyOwn?: boolean } = {},
 	) {
-		const findManyOptions = this.toFindManyOptions(options.listQueryOptions);
-
 		const returnAll = user.hasGlobalScope('credential:list') && !options.onlyOwn;
 		const isDefaultSelect = !options.listQueryOptions?.select;
 
 		if (returnAll) {
-			const credentials = await Container.get(CredentialsRepository).find(findManyOptions);
+			const credentials = await Container.get(CredentialsRepository).findMany(
+				options.listQueryOptions,
+			);
 
 			return isDefaultSelect
 				? credentials.map((c) => Container.get(OwnershipService).addOwnedByAndSharedWith(c))
 				: credentials;
 		}
 
-		const ids = await this.getAccessibleCredentials(user.id);
+		const ids = await Container.get(SharedCredentialsRepository).getAccessibleCredentials(user.id);
 
-		const credentials = await Container.get(CredentialsRepository).find({
-			...findManyOptions,
-			where: { ...findManyOptions.where, id: In(ids) }, // only accessible credentials
-		});
+		const credentials = await Container.get(CredentialsRepository).findMany(
+			options.listQueryOptions,
+			ids, // only accessible credentials
+		);
 
 		return isDefaultSelect
 			? credentials.map((c) => Container.get(OwnershipService).addOwnedByAndSharedWith(c))
 			: credentials;
-	}
-
-	/**
-	 * Get the IDs of all credentials owned by or shared with a user.
-	 */
-	private static async getAccessibleCredentials(userId: string) {
-		const sharings = await Container.get(SharedCredentialsRepository).find({
-			relations: ['role'],
-			where: {
-				userId,
-				role: { name: In(['owner', 'user']), scope: 'credential' },
-			},
-		});
-
-		return sharings.map((s) => s.credentialsId);
-	}
-
-	static async getManyByIds(ids: string[], { withSharings } = { withSharings: false }) {
-		const options: FindManyOptions<CredentialsEntity> = { where: { id: In(ids) } };
-
-		if (withSharings) {
-			options.relations = ['shared', 'shared.user', 'shared.role'];
-		}
-
-		return Container.get(CredentialsRepository).find(options);
 	}
 
 	/**

--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -1,16 +1,9 @@
 import { Service } from 'typedi';
-import {
-	DataSource,
-	In,
-	Not,
-	Repository,
-	type DeleteResult,
-	type EntityManager,
-	type FindOptionsWhere,
-	Like,
-} from 'typeorm';
+import { DataSource, In, Not, Repository, Like } from 'typeorm';
+import type { FindManyOptions, DeleteResult, EntityManager, FindOptionsWhere } from 'typeorm';
 import { CredentialsEntity } from '../entities/CredentialsEntity';
 import { SharedCredentials } from '../entities/SharedCredentials';
+import type { ListQuery } from '@/requests';
 
 @Service()
 export class CredentialsRepository extends Repository<CredentialsEntity> {
@@ -35,5 +28,62 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			select: ['name'],
 			where: { name: Like(`${credentialName}%`) },
 		});
+	}
+
+	async findMany(listQueryOptions?: ListQuery.Options, credentialIds?: string[]) {
+		const findManyOptions = this.toFindManyOptions(listQueryOptions);
+
+		if (credentialIds) {
+			findManyOptions.where = { ...findManyOptions.where, id: In(credentialIds) };
+		}
+
+		return this.find(findManyOptions);
+	}
+
+	private toFindManyOptions(listQueryOptions?: ListQuery.Options) {
+		const findManyOptions: FindManyOptions<CredentialsEntity> = {};
+
+		type Select = Array<keyof CredentialsEntity>;
+
+		const defaultRelations = ['shared', 'shared.role', 'shared.user'];
+		const defaultSelect: Select = ['id', 'name', 'type', 'nodesAccess', 'createdAt', 'updatedAt'];
+
+		if (!listQueryOptions) return { select: defaultSelect, relations: defaultRelations };
+
+		const { filter, select, take, skip } = listQueryOptions;
+
+		if (typeof filter?.name === 'string' && filter?.name !== '') {
+			filter.name = Like(`%${filter.name}%`);
+		}
+
+		if (typeof filter?.type === 'string' && filter?.type !== '') {
+			filter.type = Like(`%${filter.type}%`);
+		}
+
+		if (filter) findManyOptions.where = filter;
+		if (select) findManyOptions.select = select;
+		if (take) findManyOptions.take = take;
+		if (skip) findManyOptions.skip = skip;
+
+		if (take && select && !select?.id) {
+			findManyOptions.select = { ...findManyOptions.select, id: true }; // pagination requires id
+		}
+
+		if (!findManyOptions.select) {
+			findManyOptions.select = defaultSelect;
+			findManyOptions.relations = defaultRelations;
+		}
+
+		return findManyOptions;
+	}
+
+	async getManyByIds(ids: string[], { withSharings } = { withSharings: false }) {
+		const findManyOptions: FindManyOptions<CredentialsEntity> = { where: { id: In(ids) } };
+
+		if (withSharings) {
+			findManyOptions.relations = ['shared', 'shared.user', 'shared.role'];
+		}
+
+		return this.find(findManyOptions);
 	}
 }

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -187,17 +187,17 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			where?: FindOptionsWhere<ExecutionEntity>;
 		},
 	): Promise<IExecutionFlattedDb | IExecutionResponse | IExecutionBase | undefined> {
-		const whereClause: FindOneOptions<ExecutionEntity> = {
+		const findOptions: FindOneOptions<ExecutionEntity> = {
 			where: {
 				id,
 				...options?.where,
 			},
 		};
 		if (options?.includeData) {
-			whereClause.relations = ['executionData'];
+			findOptions.relations = ['executionData'];
 		}
 
-		const execution = await this.findOne(whereClause);
+		const execution = await this.findOne(findOptions);
 
 		if (!execution) {
 			return undefined;

--- a/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
@@ -35,4 +35,19 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 	async makeOwnerOfAllCredentials(user: User, role: Role) {
 		return this.update({ userId: Not(user.id), roleId: role.id }, { user });
 	}
+
+	/**
+	 * Get the IDs of all credentials owned by or shared with a user.
+	 */
+	async getAccessibleCredentials(userId: string) {
+		const sharings = await this.find({
+			relations: ['role'],
+			where: {
+				userId,
+				role: { name: In(['owner', 'user']), scope: 'credential' },
+			},
+		});
+
+		return sharings.map((s) => s.credentialsId);
+	}
 }

--- a/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
@@ -1,7 +1,8 @@
 import { Service } from 'typedi';
-import { DataSource, In, Repository } from 'typeorm';
+import { DataSource, In, Not, Repository } from 'typeorm';
 import { SharedCredentials } from '../entities/SharedCredentials';
 import type { User } from '../entities/User';
+import type { Role } from '../entities/Role';
 
 @Service()
 export class SharedCredentialsRepository extends Repository<SharedCredentials> {
@@ -29,5 +30,9 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 				credentialsId: In(credentialIds),
 			},
 		});
+	}
+
+	async makeOwnerOfAllCredentials(user: User, role: Role) {
+		return this.update({ userId: Not(user.id), roleId: role.id }, { user });
 	}
 }

--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -1,8 +1,9 @@
 import { Service } from 'typedi';
-import { DataSource, type FindOptionsWhere, Repository, In } from 'typeorm';
+import { DataSource, type FindOptionsWhere, Repository, In, Not } from 'typeorm';
 import { SharedWorkflow } from '../entities/SharedWorkflow';
 import { type User } from '../entities/User';
 import type { Scope } from '@n8n/permissions';
+import type { Role } from '../entities/Role';
 
 @Service()
 export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
@@ -66,5 +67,9 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 		if (extraRelations) relations.push(...extraRelations);
 
 		return this.findOne({ relations, where });
+	}
+
+	async makeOwnerOfAllWorkflows(user: User, role: Role) {
+		return this.update({ userId: Not(user.id), roleId: role.id }, { user });
 	}
 }

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from 'typedi';
-import { DataSource, In, Repository } from 'typeorm';
+import { DataSource, In, Not, Repository } from 'typeorm';
 import { User } from '../entities/User';
 
 @Service()
@@ -13,5 +13,9 @@ export class UserRepository extends Repository<User> {
 			where: { id: In(userIds) },
 			relations: ['globalRole'],
 		});
+	}
+
+	async deleteAllExcept(user: User) {
+		await this.delete({ id: Not(user.id) });
 	}
 }

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -183,4 +183,11 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			where: { name: Like(`${workflowName}%`) },
 		});
 	}
+
+	async findIn(workflowIds: string[]) {
+		return this.find({
+			select: ['id', 'name'],
+			where: { id: In(workflowIds) },
+		});
+	}
 }

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -17,6 +17,7 @@ import { isStringArray } from '@/utils';
 import config from '@/config';
 import { WorkflowEntity } from '../entities/WorkflowEntity';
 import { SharedWorkflow } from '../entities/SharedWorkflow';
+import { WebhookEntity } from '../entities/WebhookEntity';
 
 @Service()
 export class WorkflowRepository extends Repository<WorkflowEntity> {
@@ -189,5 +190,12 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			select: ['id', 'name'],
 			where: { id: In(workflowIds) },
 		});
+	}
+
+	async findWebhookBasedActiveWorkflows() {
+		return this.createQueryBuilder('workflow')
+			.select('DISTINCT workflow.id, workflow.name')
+			.innerJoin(WebhookEntity, 'webhook_entity', 'workflow.id = webhook_entity.workflowId')
+			.execute() as Promise<Array<{ id: string; name: string }>>;
 	}
 }

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -12,12 +12,13 @@ import type {
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ApplicationError, NodeOperationError } from 'n8n-workflow';
 import { RoleService } from '@/services/role.service';
-import { Service } from 'typedi';
+import Container, { Service } from 'typedi';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
 
 @Service()
 export class EnterpriseWorkflowService {
@@ -111,7 +112,7 @@ export class EnterpriseWorkflowService {
 				credentialIdsUsedByWorkflow.add(credential.id);
 			});
 		});
-		const workflowCredentials = await CredentialsService.getManyByIds(
+		const workflowCredentials = await Container.get(CredentialsRepository).getManyByIds(
 			Array.from(credentialIdsUsedByWorkflow),
 			{ withSharings: true },
 		);

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -12,7 +12,7 @@ import type {
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ApplicationError, NodeOperationError } from 'n8n-workflow';
 import { RoleService } from '@/services/role.service';
-import Container, { Service } from 'typedi';
+import { Service } from 'typedi';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -28,6 +28,7 @@ export class EnterpriseWorkflowService {
 		private readonly roleService: RoleService,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly workflowRepository: WorkflowRepository,
+		private readonly credentialsRepository: CredentialsRepository,
 	) {}
 
 	async isOwned(
@@ -112,7 +113,7 @@ export class EnterpriseWorkflowService {
 				credentialIdsUsedByWorkflow.add(credential.id);
 			});
 		});
-		const workflowCredentials = await Container.get(CredentialsRepository).getManyByIds(
+		const workflowCredentials = await this.credentialsRepository.getManyByIds(
 			Array.from(credentialIdsUsedByWorkflow),
 			{ withSharings: true },
 		);

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -20,7 +20,6 @@ import { NodeTypes } from '@/NodeTypes';
 import { WorkflowRunner } from '@/WorkflowRunner';
 import * as WorkflowExecuteAdditionalData from '@/WorkflowExecuteAdditionalData';
 import { TestWebhooks } from '@/TestWebhooks';
-import { whereClause } from '@/UserManagement/UserManagementHelper';
 import { InternalHooks } from '@/InternalHooks';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
 import { OwnershipService } from '@/services/ownership.service';
@@ -137,16 +136,12 @@ export class WorkflowService {
 		forceSave?: boolean,
 		roles?: string[],
 	): Promise<WorkflowEntity> {
-		const shared = await this.sharedWorkflowRepository.findOne({
-			relations: ['workflow', 'role'],
-			where: whereClause({
-				user,
-				globalScope: 'workflow:update',
-				entityType: 'workflow',
-				entityId: workflowId,
-				roles,
-			}),
-		});
+		const shared = await this.sharedWorkflowRepository.findSharing(
+			workflowId,
+			user,
+			'workflow:update',
+			{ roles },
+		);
 
 		if (!shared) {
 			this.logger.verbose('User attempted to update a workflow without permissions', {
@@ -403,16 +398,12 @@ export class WorkflowService {
 	async delete(user: User, workflowId: string): Promise<WorkflowEntity | undefined> {
 		await this.externalHooks.run('workflow.delete', [workflowId]);
 
-		const sharedWorkflow = await this.sharedWorkflowRepository.findOne({
-			relations: ['workflow', 'role'],
-			where: whereClause({
-				user,
-				globalScope: 'workflow:delete',
-				entityType: 'workflow',
-				entityId: workflowId,
-				roles: ['owner'],
-			}),
-		});
+		const sharedWorkflow = await this.sharedWorkflowRepository.findSharing(
+			workflowId,
+			user,
+			'workflow:delete',
+			{ roles: ['owner'] },
+		);
 
 		if (!sharedWorkflow) {
 			return;

--- a/packages/cli/test/integration/debug.controller.test.ts
+++ b/packages/cli/test/integration/debug.controller.test.ts
@@ -31,19 +31,11 @@ describe('DebugController', () => {
 			const instanceId = 'main-71JdWtq306epIFki';
 			const leaderKey = 'some-leader-key';
 
-			const createQueryBuilder = {
-				select: () => createQueryBuilder,
-				innerJoin: () => createQueryBuilder,
-				execute: () => webhooks,
-			};
-
 			workflowRepository.findIn.mockResolvedValue(triggersAndPollers);
+			workflowRepository.findWebhookBasedActiveWorkflows.mockResolvedValue(webhooks);
 			activeWorkflowRunner.allActiveInMemory.mockReturnValue([workflowId]);
 			activeWorkflowRunner.getAllWorkflowActivationErrors.mockResolvedValue(activationErrors);
 
-			jest
-				.spyOn(workflowRepository, 'createQueryBuilder')
-				.mockImplementation(() => createQueryBuilder);
 			jest.spyOn(MultiMainSetup.prototype, 'instanceId', 'get').mockReturnValue(instanceId);
 			jest.spyOn(MultiMainSetup.prototype, 'fetchLeaderKey').mockResolvedValue(leaderKey);
 			jest.spyOn(MultiMainSetup.prototype, 'isLeader', 'get').mockReturnValue(true);

--- a/packages/cli/test/integration/debug.controller.test.ts
+++ b/packages/cli/test/integration/debug.controller.test.ts
@@ -37,7 +37,7 @@ describe('DebugController', () => {
 				execute: () => webhooks,
 			};
 
-			workflowRepository.find.mockResolvedValue(triggersAndPollers);
+			workflowRepository.findIn.mockResolvedValue(triggersAndPollers);
 			activeWorkflowRunner.allActiveInMemory.mockReturnValue([workflowId]);
 			activeWorkflowRunner.getAllWorkflowActivationErrors.mockResolvedValue(activationErrors);
 


### PR DESCRIPTION
Follow-up to: #8165