### PR TITLE
ci: Disable `import/no-extraneous-dependencies` in frontend tests (no-changelog)

### DIFF
--- a/packages/@n8n/chat/.eslintrc.cjs
+++ b/packages/@n8n/chat/.eslintrc.cjs
@@ -15,7 +15,6 @@ module.exports = {
 		'id-denylist': 'warn',
 		'import/extensions': 'warn',
 		'import/no-default-export': 'warn',
-		'import/no-extraneous-dependencies': 'warn',
 		'import/order': 'off',
 		'import/no-cycle': 'warn',
 		'import/no-duplicates': 'warn',

--- a/packages/@n8n/nodes-langchain/.eslintrc.js
+++ b/packages/@n8n/nodes-langchain/.eslintrc.js
@@ -17,7 +17,6 @@ module.exports = {
 		'import/extensions': 'warn',
 		'import/order': 'warn',
 		'prefer-spread': 'warn',
-		'import/no-extraneous-dependencies': 'warn',
 
 		'@typescript-eslint/naming-convention': ['error', { selector: 'memberLike', format: null }],
 		'@typescript-eslint/no-explicit-any': 'warn', //812 warnings, better to fix in separate PR

--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -473,7 +473,7 @@ const config = (module.exports = {
 			},
 		},
 		{
-			files: ['test/**/*.ts', 'src/__tests__/*.ts'],
+			files: ['test/**/*.ts', '**/__tests__/*.ts'],
 			rules: {
 				'n8n-local-rules/no-plain-errors': 'off',
 				'n8n-local-rules/no-skipped-tests':

--- a/packages/@n8n_io/eslint-config/frontend.js
+++ b/packages/@n8n_io/eslint-config/frontend.js
@@ -21,6 +21,12 @@ module.exports = {
 				'n8n-local-rules/dangerously-use-html-string-missing': 'error',
 			},
 		},
+		{
+			files: ['**/*.test.ts', '**/test/**/*.ts', '**/__tests__/**/*.ts'],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
 	],
 
 	rules: {
@@ -53,6 +59,7 @@ module.exports = {
 		],
 		'vue/prop-name-casing': ['error', 'camelCase'],
 		'vue/attribute-hyphenation': ['error', 'always'],
+		'import/no-extraneous-dependencies': 'warn',
 
 		// TODO: fix these
 		'@typescript-eslint/no-unsafe-call': 'off',

--- a/packages/editor-ui/.eslintrc.js
+++ b/packages/editor-ui/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
 		'id-denylist': 'warn',
 		'import/extensions': 'warn',
 		'import/no-default-export': 'warn',
-		'import/no-extraneous-dependencies': 'warn',
 		'import/order': 'off',
 		'import/no-cycle': 'warn',
 		'import/no-duplicates': 'warn',


### PR DESCRIPTION
supersedes #8180