### PR TITLE
fix(Schedule Trigger Node): Use the correct `moment` import

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -1,5 +1,5 @@
 import type { IDataObject } from 'n8n-workflow';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import type { IRecurencyRule } from './SchedulerInterface';
 
 export function recurencyCheck(

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -8,7 +8,7 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 
 import { CronJob } from 'cron';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import type { IRecurencyRule } from './SchedulerInterface';
 import { convertToUnixFormat, recurencyCheck } from './GenericFunctions';
 


### PR DESCRIPTION
Any node that uses `moment.tz` should import from `moment-timezone` instead of `moment`.

This fixes #8184

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included