### PR TITLE
fix(GitHub Node): Fix issue that File->Get did not run once per item

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -2204,6 +2204,7 @@ export class Github implements INodeType {
 						const newItem: INodeExecutionData = {
 							json: items[i].json,
 							binary: {},
+							pairedItem: items[i].pairedItem,
 						};
 
 						if (items[i].binary !== undefined) {
@@ -2218,9 +2219,8 @@ export class Github implements INodeType {
 							path as string,
 						);
 
-						items[i] = newItem;
-
-						return [items];
+						returnData.push(newItem);
+						continue;
 					}
 				}
 


### PR DESCRIPTION
## Summary
The Operation File -> Get is implemented wrong. Instead of downloading a file for each of the items it only downloads the file of the first one and then stops.


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1027/fix-issue-that-github-node-file-get



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 