### PR TITLE
feat(Wordpress Node): Add option to ignore error when using self signed certificates

### DIFF
--- a/packages/nodes-base/credentials/WordpressApi.credentials.ts
+++ b/packages/nodes-base/credentials/WordpressApi.credentials.ts
@@ -35,6 +35,13 @@ export class WordpressApi implements ICredentialType {
 			default: '',
 			placeholder: 'https://example.com',
 		},
+		{
+			displayName: 'Ignore SSL Issues',
+			name: 'allowUnauthorizedCerts',
+			type: 'boolean',
+			description: 'Whether to connect even if SSL certificate validation is not possible',
+			default: false,
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -52,6 +59,7 @@ export class WordpressApi implements ICredentialType {
 			baseURL: '={{$credentials?.url}}/wp-json/wp/v2',
 			url: '/users',
 			method: 'GET',
+			skipSslCertificateValidation: '={{$credentials.allowUnauthorizedCerts}}',
 		},
 	};
 }

--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -30,6 +30,7 @@ export async function wordpressApiRequest(
 		qs,
 		body,
 		uri: uri || `${credentials.url}/wp-json/wp/v2${resource}`,
+		rejectUnauthorized: !credentials.allowUnauthorizedCerts,
 		json: true,
 	};
 	options = Object.assign({}, options, option);


### PR DESCRIPTION
## Summary
Adds option to ignore SSL issues to the Wordpress node, This is useful when using a self signed certificate in a local setup.


## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8151