### PR TITLE
fix(Invoice Ninja Node): Fix issue with custom invoice numbers not working with v5

### DIFF
--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -863,7 +863,12 @@ export class InvoiceNinja implements INodeType {
 							body.invoice_date = additionalFields.quouteDate as string;
 						}
 						if (additionalFields.quoteNumber) {
-							body.invoice_number = additionalFields.quoteNumber as string;
+							if (apiVersion === 'v4') {
+								body.invoice_number = additionalFields.quoteNumber as string;
+							} else if (apiVersion === 'v5') {
+								// eslint-disable-next-line id-denylist
+								body.number = additionalFields.quoteNumber as string;
+							}
 						}
 						if (additionalFields.invoiceStatus) {
 							body.invoice_status_id = additionalFields.invoiceStatus as number;

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -418,7 +418,12 @@ export class InvoiceNinja implements INodeType {
 							body.invoice_date = additionalFields.invoiceDate as string;
 						}
 						if (additionalFields.invoiceNumber) {
-							body.invoice_number = additionalFields.invoiceNumber as string;
+							if (apiVersion === 'v4') {
+								body.invoice_number = additionalFields.invoiceNumber as string;
+							} else if (apiVersion === 'v5') {
+								// eslint-disable-next-line id-denylist
+								body.number = additionalFields.invoiceNumber as string;
+							}
 						}
 						if (additionalFields.invoiceStatus) {
 							body.invoice_status_id = additionalFields.invoiceStatus as number;

--- a/packages/nodes-base/nodes/InvoiceNinja/QuoteInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/QuoteInterface.ts
@@ -23,6 +23,8 @@ export interface IQuote {
 	invoice_items?: IItem[];
 	line_items?: IItem[];
 	invoice_number?: string;
+	// eslint-disable-next-line id-denylist
+	number?: string;
 	invoice_status_id?: number;
 	is_amount_discount?: boolean;
 	is_quote?: boolean;

--- a/packages/nodes-base/nodes/InvoiceNinja/invoiceInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/invoiceInterface.ts
@@ -23,6 +23,8 @@ export interface IInvoice {
 	invoice_items?: IItem[];
 	line_items?: IItem[];
 	invoice_number?: string;
+	// eslint-disable-next-line id-denylist
+	number?: string;
 	invoice_status_id?: number;
 	is_amount_discount?: boolean;
 	paid?: number;


### PR DESCRIPTION
## Summary
The v5 API expects the invoice number to under the `number` property rather than `invoice_number`, At some point this month I am going to bring in the big PR that fixes all of the v5 issues.

## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8191