### PR TITLE
ci: Fix duplicate key in pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11138,7 +11138,7 @@ packages:
     dependencies:
       js-beautify: 1.14.9
       vue: 3.3.4
-      vue-component-type-helpers: 1.8.25
+      vue-component-type-helpers: 1.8.27
     dev: true
 
   /@vue/tsconfig@0.5.1:
@@ -25713,10 +25713,6 @@ packages:
       chart.js: 4.4.0
       vue: 3.3.4
     dev: false
-
-  /vue-component-type-helpers@1.8.25:
-    resolution: {integrity: sha512-NCA6sekiJIMnMs4DdORxATXD+/NRkQpS32UC+I1KQJUasx+Z7MZUb3Y+MsKsFmX+PgyTYSteb73JW77AibaCCw==}
-    dev: true
 
   /vue-component-type-helpers@1.8.27:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}


### PR DESCRIPTION
Remove duplicate `vue-component-type-helpers` key from pnpm-lock.yaml to fix [failing build](https://github.com/n8n-io/n8n/actions/runs/7394510516/job/20118003420). This is caused due to incorrect merge of the lock file. The `11cda41214100a1a3e65309434ab8be3ccef1898` lock file has two different version like this:

```yaml
  /vue-component-type-helpers@1.8.25:
    resolution: {integrity: sha512-NCA6sekiJIMnMs4DdORxATXD+/NRkQpS32UC+I1KQJUasx+Z7MZUb3Y+MsKsFmX+PgyTYSteb73JW77AibaCCw==}
    dev: true

  /vue-component-type-helpers@1.8.27:
    resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
    dev: true
```

But after merging(step that happens during git checkout step in CI) `2881e63c050b2f198f34c0f00833abc7ee8dddec` it becomes:
```yaml
  /vue-component-type-helpers@1.8.27:
    resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
    dev: true

  /vue-component-type-helpers@1.8.27:
    resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
    dev: true
```
Resulting in `Ignoring broken lockfile at ...: The lockfile at "n8n/pnpm-lock.yaml" is broken: duplicated mapping key (25680:3)` error.