### PR TITLE
fix(editor): Tweaking button sizes in execution preview

### DIFF
--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionPreview.vue
@@ -80,7 +80,7 @@
 			</div>
 			<div>
 				<n8n-button
-					size="large"
+					size="medium"
 					:type="debugButtonData.type"
 					:class="{
 						[$style.debugLink]: true,
@@ -111,7 +111,7 @@
 				>
 					<span class="retry-button">
 						<n8n-icon-button
-							size="large"
+							size="medium"
 							type="tertiary"
 							:title="$locale.baseText('executionsList.retryExecution')"
 							icon="redo"
@@ -133,7 +133,7 @@
 				<n8n-icon-button
 					:title="$locale.baseText('executionDetails.deleteExecution')"
 					icon="trash"
-					size="large"
+					size="medium"
 					type="tertiary"
 					data-test-id="execution-preview-delete-button"
 					@click="onDeleteExecution"


### PR DESCRIPTION
## Summary
Changed the size of the buttons on the execution preview in the executions history.
n00b contributor, please point out errors I'm making!

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1176/improve-hierarchy-of-workflow-executions-view


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 