### PR TITLE
chore: Upgrade isbot to next major version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -139,7 +139,7 @@
     "infisical-node": "1.3.0",
     "inquirer": "7.3.3",
     "ioredis": "5.2.4",
-    "isbot": "3.6.13",
+    "isbot": "4.1.2",
     "json-diff": "1.0.6",
     "jsonschema": "1.4.1",
     "jsonwebtoken": "9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -139,7 +139,6 @@
     "infisical-node": "1.3.0",
     "inquirer": "7.3.3",
     "ioredis": "5.2.4",
-    "isbot": "4.2.0",
     "json-diff": "1.0.6",
     "jsonschema": "1.4.1",
     "jsonwebtoken": "9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -139,7 +139,7 @@
     "infisical-node": "1.3.0",
     "inquirer": "7.3.3",
     "ioredis": "5.2.4",
-    "isbot": "4.1.2",
+    "isbot": "4.2.0",
     "json-diff": "1.0.6",
     "jsonschema": "1.4.1",
     "jsonwebtoken": "9.0.0",

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -3,7 +3,6 @@ import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import express from 'express';
 import compression from 'compression';
-import { createIsbotFromList } from 'isbot';
 
 import config from '@/config';
 import { N8N_VERSION, inDevelopment, inTest } from '@/constants';
@@ -213,10 +212,9 @@ export abstract class AbstractServer {
 		}
 
 		// Block bots from scanning the application
-		const checkIfBot = createIsbotFromList(['bot']);
 		this.app.use((req, res, next) => {
 			const userAgent = req.headers['user-agent'];
-			if (userAgent && checkIfBot(userAgent)) {
+			if (userAgent && /bot/i.test(userAgent)) {
 				this.logger.info(`Blocked ${req.method} ${req.url} for "${userAgent}"`);
 				res.status(204).end();
 			} else next();

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import express from 'express';
 import compression from 'compression';
-import isbot from 'isbot';
+import { createIsbotFromList } from 'isbot';
 
 import config from '@/config';
 import { N8N_VERSION, inDevelopment, inTest } from '@/constants';
@@ -213,7 +213,7 @@ export abstract class AbstractServer {
 		}
 
 		// Block bots from scanning the application
-		const checkIfBot = isbot.spawn(['bot']);
+		const checkIfBot = createIsbotFromList(['bot']);
 		this.app.use((req, res, next) => {
 			const userAgent = req.headers['user-agent'];
 			if (userAgent && checkIfBot(userAgent)) {

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -214,7 +214,7 @@ export abstract class AbstractServer {
 		// Block bots from scanning the application
 		this.app.use((req, res, next) => {
 			const userAgent = req.headers['user-agent'];
-			if (userAgent && /bot/i.test(userAgent)) {
+			if (/bot/i.test(userAgent)) {
 				this.logger.info(`Blocked ${req.method} ${req.url} for "${userAgent}"`);
 				res.status(204).end();
 			} else next();

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -15,7 +15,7 @@ import { BINARY_ENCODING, NodeOperationError, Node } from 'n8n-workflow';
 
 import { v4 as uuid } from 'uuid';
 import basicAuth from 'basic-auth';
-import isbot from 'isbot';
+import { isbot } from 'isbot';
 import { file as tmpFile } from 'tmp-promise';
 
 import {

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -849,7 +849,7 @@
     "iconv-lite": "0.6.3",
     "ics": "2.40.0",
     "imap-simple": "4.3.0",
-    "isbot": "4.1.2",
+    "isbot": "4.2.0",
     "iso-639-1": "2.1.15",
     "js-nacl": "1.4.0",
     "jsonwebtoken": "9.0.0",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -849,7 +849,7 @@
     "iconv-lite": "0.6.3",
     "ics": "2.40.0",
     "imap-simple": "4.3.0",
-    "isbot": "4.2.0",
+    "isbot": "4.3.0",
     "iso-639-1": "2.1.15",
     "js-nacl": "1.4.0",
     "jsonwebtoken": "9.0.0",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -849,7 +849,7 @@
     "iconv-lite": "0.6.3",
     "ics": "2.40.0",
     "imap-simple": "4.3.0",
-    "isbot": "3.6.13",
+    "isbot": "4.1.2",
     "iso-639-1": "2.1.15",
     "js-nacl": "1.4.0",
     "jsonwebtoken": "9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17480,8 +17480,8 @@ packages:
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  /isbot@4.1.2:
-    resolution: {integrity: sha512-0zMFnUxzYc7+v7c+8E9HthL7of0afZPlqJ8yN3FwjpjPCDVBdm87oYkRHrsMR521GXHXcW/sBvG1fBDnxlKcFw==}
+  /isbot@4.2.0:
+    resolution: {integrity: sha512-yVfLv4iS22wXWMWv2KtapKUZ3etRJ0nkaC5u6o5y6dID+rQuKX/NpF2iVcGGORkrYlhA3CS5aEZGKwtdelMkHw==}
     engines: {node: '>=18'}
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17477,8 +17477,8 @@ packages:
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  /isbot@4.2.0:
-    resolution: {integrity: sha512-yVfLv4iS22wXWMWv2KtapKUZ3etRJ0nkaC5u6o5y6dID+rQuKX/NpF2iVcGGORkrYlhA3CS5aEZGKwtdelMkHw==}
+  /isbot@4.3.0:
+    resolution: {integrity: sha512-cohu4X66cXP120xwF+UubL+BQzOQLN1O0DOPOmkci6elgZ7o6XIn8B3FARk59RL0aX3cGTq8Ta7MVOWpay3rbw==}
     engines: {node: '>=18'}
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1251,8 +1251,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       isbot:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.0
+        version: 4.3.0
       iso-639-1:
         specifier: 2.1.15
         version: 2.1.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,8 +472,8 @@ importers:
         specifier: 5.2.4
         version: 5.2.4
       isbot:
-        specifier: 3.6.13
-        version: 3.6.13
+        specifier: 4.1.2
+        version: 4.1.2
       json-diff:
         specifier: 1.0.6
         version: 1.0.6
@@ -1254,8 +1254,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       isbot:
-        specifier: 3.6.13
-        version: 3.6.13
+        specifier: 4.1.2
+        version: 4.1.2
       iso-639-1:
         specifier: 2.1.15
         version: 2.1.15
@@ -17480,9 +17480,9 @@ packages:
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  /isbot@3.6.13:
-    resolution: {integrity: sha512-uoP4uK5Dc2CrabmK+Gue1jTL+scHiCc1c9rblRpJwG8CPxjLIv8jmGyyGRGkbPOweayhkskdZsEQXG6p+QCQrg==}
-    engines: {node: '>=12'}
+  /isbot@4.1.2:
+    resolution: {integrity: sha512-0zMFnUxzYc7+v7c+8E9HthL7of0afZPlqJ8yN3FwjpjPCDVBdm87oYkRHrsMR521GXHXcW/sBvG1fBDnxlKcFw==}
+    engines: {node: '>=18'}
     dev: false
 
   /isexe@2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1251,8 +1251,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       isbot:
-        specifier: 4.1.2
-        version: 4.1.2
+        specifier: 4.2.0
+        version: 4.2.0
       iso-639-1:
         specifier: 2.1.15
         version: 2.1.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,9 +471,6 @@ importers:
       ioredis:
         specifier: 5.2.4
         version: 5.2.4
-      isbot:
-        specifier: 4.1.2
-        version: 4.1.2
       json-diff:
         specifier: 1.0.6
         version: 1.0.6


### PR DESCRIPTION
## Summary

### n8n-nodes-base

#### Upgrade isbot dependency

[isbot](https://github.com/omrilotan/isbot/blob/main/CHANGELOG.md#400) version 4 is meant to improve performance by building the regular expression in build time instead of runtime. It comes with updates to the bot recognition pattern and future support. It is also Typescript.

The basic use migration involves a change to named import:

```diff
- import isbot from "isbot"
+ import { isbot } from "isbot"
```

```diff
- import isbot from "isbot"
- const instance = isbot.spawn(["bot"]);

+ import { createIsbotFromList } from "isbot";
+ const instance = createIsbotFromList(["bot"]);
```

### n8n (cli)

#### Remove isbot dependency

isbot offers a comprehensive yet efficient bot pattern. If the use case was only to match the "bot" substring - it is simpler to match the substring and continue


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] **N/A** [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] **N/A** Tests included.