### PR TITLE
fix:  Stop showing fake door templates when user clicks on "use template" (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/SuggestedTemplates/SuggestedTemplatesPreviewModal.vue
+++ b/packages/editor-ui/src/components/SuggestedTemplates/SuggestedTemplatesPreviewModal.vue
@@ -44,8 +44,6 @@ function showConfirmationMessage(event: PointerEvent) {
 				withPostHog: true,
 			},
 		);
-		localStorage.setItem(SUGGESTED_TEMPLATES_FLAG, 'false');
-		uiStore.deleteSuggestedTemplates();
 	}
 }
 
@@ -55,9 +53,12 @@ function openCanvas() {
 			title: i18n.baseText('suggestedTemplates.notification.comingSoon.title'),
 			message: i18n.baseText('suggestedTemplates.notification.comingSoon.message'),
 			type: 'info',
+			duration: 10000,
 			onClick: showConfirmationMessage,
 		},
 	]);
+	localStorage.setItem(SUGGESTED_TEMPLATES_FLAG, 'false');
+	uiStore.deleteSuggestedTemplates();
 	uiStore.closeModal(SUGGESTED_TEMPLATES_PREVIEW_MODAL_KEY);
 	uiStore.nodeViewInitialized = false;
 	void router.push({ name: VIEWS.NEW_WORKFLOW });


### PR DESCRIPTION
## Summary

We stop showing the fake-door templates when the user clicks on "notify me when it's is available" (this notification is shown when the user clicks on "use template"). This PR changes this behavior and stop showing the fakedoor templates when the user clicks on "use template". Additionally, also increases the  "template coming soon" notification time from 4.5 seconds to 10 seconds.

<img width="395" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/2e643b1f-dd52-46f0-951f-29e630241f73">
