### PR TITLE
fix: Add template id to workflows created from templates (no-changelog)

### DIFF
--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -86,7 +86,7 @@ describe('Template credentials setup', () => {
 		workflowPage.getters.canvasNodes().should('have.length', 3);
 	});
 
-	it.only('can create credentials and workflow from the template', () => {
+	it('can create credentials and workflow from the template', () => {
 		templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
 
 		// Continue button should be disabled if no credentials are created

--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -86,7 +86,7 @@ describe('Template credentials setup', () => {
 		workflowPage.getters.canvasNodes().should('have.length', 3);
 	});
 
-	it('can create credentials and workflow from the template', () => {
+	it.only('can create credentials and workflow from the template', () => {
 		templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
 
 		// Continue button should be disabled if no credentials are created
@@ -106,6 +106,22 @@ describe('Template credentials setup', () => {
 		cy.wait('@createWorkflow');
 
 		workflowPage.getters.canvasNodes().should('have.length', 3);
+
+		// Focus the canvas so the copy to clipboard works
+		workflowPage.getters.canvasNodes().eq(0).realClick();
+		workflowPage.actions.selectAll();
+		workflowPage.actions.hitCopy();
+
+		cy.grantBrowserPermissions('clipboardReadWrite', 'clipboardSanitizedWrite');
+		// Check workflow JSON by copying it to clipboard
+		cy.readClipboard().then((workflowJSON) => {
+			const workflow = JSON.parse(workflowJSON);
+
+			expect(workflow.meta).to.haveOwnProperty('templateId', testTemplate.id.toString());
+			workflow.nodes.forEach((node: any) => {
+				expect(Object.keys(node.credentials ?? {})).to.have.lengthOf(1);
+			});
+		});
 	});
 
 	it('should work with a template that has no credentials (ADO-1603)', () => {

--- a/packages/editor-ui/src/utils/templates/templateActions.ts
+++ b/packages/editor-ui/src/utils/templates/templateActions.ts
@@ -37,7 +37,10 @@ export async function createWorkflowFromTemplate(opts: {
 		nodes,
 		connections,
 		active: false,
-		// Ignored: pinData, settings, tags, versionId, meta
+		meta: {
+			templateId: template.id.toString(),
+		},
+		// Ignored: pinData, settings, tags, versionId
 	};
 
 	const createdWorkflow = await workflowsStore.createNewWorkflow(workflowToCreate);


### PR DESCRIPTION
## Summary

In #8088 template ID was added to workflow metadata, but it was missing from workflows that were created using the template credential setup. This fixes that.

## Related tickets and issues

https://linear.app/n8n/issue/ADO-1639/bug-connect-wf-with-template


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 