### PR TITLE
fix(editor): Vertically center workflow preview loading state

### DIFF
--- a/packages/editor-ui/src/components/WorkflowPreview.vue
+++ b/packages/editor-ui/src/components/WorkflowPreview.vue
@@ -249,6 +249,10 @@ watch(
 
 .imageLoader {
 	width: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: 100%;
 }
 
 .executionPreview {


### PR DESCRIPTION
## Summary

Title self explanatory

before:

<img width="1198" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/26c29cad-b376-40fd-9881-343f5e722d58">

now:

<img width="1211" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/9f2d4020-6bf8-481a-b69f-eddb57cfaaae">



## Related tickets and issues
[ado-1645-fix-center-loading-preview-loading-state
](https://linear.app/n8n/issue/ADO-1645/fix-center-loading-preview-loading-state)

## Review / Merge checklist
- [ x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
