### PR TITLE
fix(Set Node): Field not excluded if dot notation disabled and field was set by using drag-and-drop from ui

### DIFF
--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -35,15 +35,28 @@ const configureFieldHelper = (dotNotation?: boolean) => {
 			},
 		};
 	} else {
+		const sanitazeKey = (item: IDataObject, key: string) => {
+			if (item[key] !== undefined) {
+				return key;
+			}
+
+			if (key.startsWith("['") && key.endsWith("']")) {
+				key = key.slice(2, -2);
+				if (item[key] !== undefined) {
+					return key;
+				}
+			}
+			return key;
+		};
 		return {
 			set: (item: IDataObject, key: string, value: IDataObject) => {
-				item[key] = value;
+				item[sanitazeKey(item, key)] = value;
 			},
 			get: (item: IDataObject, key: string) => {
-				return item[key];
+				return item[sanitazeKey(item, key)];
 			},
 			unset: (item: IDataObject, key: string) => {
-				delete item[key];
+				delete item[sanitazeKey(item, key)];
 			},
 		};
 	}


### PR DESCRIPTION
## Summary
Sanitize fields when dot notation disabled
![image](https://github.com/n8n-io/n8n/assets/88898367/5056bc8d-279e-4bc2-8689-4858fc25474d)

## Related tickets and issues
https://community.n8n.io/t/edit-fields-set-new-set-node-cannot-delete-field-with-space-or-non-latin-character-when-support-dot-notation-is-off/31989
https://linear.app/n8n/issue/NODE-883/set-edit-fields-node-spaces-in-field-names-break-fields-to-exclude