### PR TITLE
fix(NocoDB Node): Download attachments

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -16,6 +16,7 @@ interface IAttachment {
 	title: string;
 	mimetype: string;
 	size: number;
+	signedUrl?: string;
 }
 
 /**
@@ -42,12 +43,15 @@ export async function apiRequest(
 
 	query = query || {};
 
+	if (!uri) {
+		uri = baseUrl.endsWith('/') ? `${baseUrl.slice(0, -1)}${endpoint}` : `${baseUrl}${endpoint}`;
+	}
+
 	const options: OptionsWithUri = {
 		method,
 		body,
 		qs: query,
-		uri:
-			uri || baseUrl.endsWith('/') ? `${baseUrl.slice(0, -1)}${endpoint}` : `${baseUrl}${endpoint}`,
+		uri,
 		json: true,
 	};
 
@@ -109,11 +113,14 @@ export async function downloadRecordAttachments(
 		const element: INodeExecutionData = { json: {}, binary: {} };
 		element.json = record as unknown as IDataObject;
 		for (const fieldName of fieldNames) {
+			let attachments = record[fieldName] as IAttachment[];
+			if (typeof attachments === 'string') {
+				attachments = jsonParse<IAttachment[]>(record[fieldName] as string);
+			}
 			if (record[fieldName]) {
-				for (const [index, attachment] of jsonParse<IAttachment[]>(
-					record[fieldName] as string,
-				).entries()) {
-					const file: Buffer = await apiRequest.call(this, 'GET', '', {}, {}, attachment.url, {
+				for (const [index, attachment] of attachments.entries()) {
+					const attachmentUrl = attachment.signedUrl || attachment.url;
+					const file: Buffer = await apiRequest.call(this, 'GET', '', {}, {}, attachmentUrl, {
 						json: false,
 						encoding: null,
 					});


### PR DESCRIPTION
## Summary
PR fixes Get Many fails to execute when Download Attachments is set to true
![image](https://github.com/n8n-io/n8n/assets/88898367/7f3ab8c7-e07e-4f31-bf6e-f2e28e6a685a)


## Related tickets and issues
https://community.n8n.io/t/nocodb-unable-to-download-file/33333
https://linear.app/n8n/issue/NODE-960/nocodb-row-get-many-fails-to-execute-when-download-attachments-is-set