### PR TITLE
fix: Make params panel double width for all SQL nodes

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -36,6 +36,7 @@ export class MicrosoftSql implements INodeType {
 		},
 		inputs: ['main'],
 		outputs: ['main'],
+		parameterPane: 'wide',
 		credentials: [
 			{
 				name: 'microsoftSql',

--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -13,6 +13,7 @@ export class MySql extends VersionedNodeType {
 			group: ['input'],
 			defaultVersion: 2.2,
 			description: 'Get, add and update data in MySQL',
+			parameterPane: 'wide',
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -13,6 +13,7 @@ export class Postgres extends VersionedNodeType {
 			group: ['input'],
 			defaultVersion: 2.3,
 			description: 'Get, add and update data in Postgres',
+			parameterPane: 'wide',
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -24,6 +24,7 @@ export class QuestDb implements INodeType {
 		},
 		inputs: ['main'],
 		outputs: ['main'],
+		parameterPane: 'wide',
 		credentials: [
 			{
 				name: 'questDb',

--- a/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
+++ b/packages/nodes-base/nodes/Snowflake/Snowflake.node.ts
@@ -24,6 +24,7 @@ export class Snowflake implements INodeType {
 		},
 		inputs: ['main'],
 		outputs: ['main'],
+		parameterPane: 'wide',
 		credentials: [
 			{
 				name: 'snowflake',

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -22,6 +22,7 @@ export class TimescaleDb implements INodeType {
 		},
 		inputs: ['main'],
 		outputs: ['main'],
+		parameterPane: 'wide',
 		credentials: [
 			{
 				name: 'timescaleDb',


### PR DESCRIPTION
## Summary

Make params panel double width for all SQL nodes

<img width="1445" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/422e7c6c-90c9-4cf0-832b-fab7679275d3">


## Related tickets and issues
https://linear.app/n8n/issue/NODE-986/make-all-sql-nodes-have-a-double-width-params-pane

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 