### PR TITLE
fix: Fix issue with API key being required for the Qdrant Node

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/QdrantApi.credentials.ts
@@ -18,7 +18,7 @@ export class QdrantApi implements ICredentialType {
 			name: 'apiKey',
 			type: 'string',
 			typeOptions: { password: true },
-			required: true,
+			required: false,
 			default: '',
 		},
 		{


### PR DESCRIPTION
## Summary
This PR makes the API key value in the Qdrant credentials optional, since local Qdrant deployments may not have it configured.