### PR TITLE
test: Add e2e tests for cred setup on workflow editor (no-changelog)

### DIFF
--- a/cypress/composables/modals/workflow-credential-setup-modal.ts
+++ b/cypress/composables/modals/workflow-credential-setup-modal.ts
@@ -1,0 +1,12 @@
+/**
+ * Getters
+ */
+
+export const getWorkflowCredentialsModal = () => cy.getByTestId('setup-workflow-credentials-modal');
+
+/**
+ * Actions
+ */
+
+export const closeModal = () =>
+	getWorkflowCredentialsModal().find("button[aria-label='Close this dialog']").click();

--- a/cypress/composables/setup-template-form-step.ts
+++ b/cypress/composables/setup-template-form-step.ts
@@ -1,0 +1,14 @@
+/**
+ * Getters
+ */
+
+export const getFormStep = () => cy.getByTestId('setup-credentials-form-step');
+
+export const getStepHeading = ($el: JQuery<HTMLElement>) =>
+	cy.wrap($el).findChildByTestId('credential-step-heading');
+
+export const getStepDescription = ($el: JQuery<HTMLElement>) =>
+	cy.wrap($el).findChildByTestId('credential-step-description');
+
+export const getCreateAppCredentialsButton = (appName: string) =>
+	cy.get(`button:contains("Create new ${appName} credential")`);

--- a/cypress/composables/setup-workflow-credentials-button.ts
+++ b/cypress/composables/setup-workflow-credentials-button.ts
@@ -1,0 +1,5 @@
+/**
+ * Getters
+ */
+
+export const getSetupWorkflowCredentialsButton = () => cy.get(`button:contains("Set up Template")`);

--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -159,6 +159,10 @@ describe('Template credentials setup', () => {
 			templateCredentialsSetupPage.getters.skipLink().click();
 
 			getSetupWorkflowCredentialsButton().should('be.visible');
+
+			// We need to save the workflow or otherwise a browser native popup
+			// will block cypress from continuing
+			workflowPage.actions.saveWorkflowOnButtonClick();
 		});
 
 		it('should allow credential setup from workflow editor if user fills in credentials partially during template setup', () => {
@@ -197,6 +201,10 @@ describe('Template credentials setup', () => {
 					expect(Object.keys(node.credentials ?? {})).to.have.lengthOf(1);
 				});
 			});
+
+			// We need to save the workflow or otherwise a browser native popup
+			// will block cypress from continuing
+			workflowPage.actions.saveWorkflowOnButtonClick();
 		});
 	});
 });

--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -6,6 +6,9 @@ import {
 import * as templateCredentialsSetupPage from '../pages/template-credential-setup';
 import { TemplateWorkflowPage } from '../pages/template-workflow';
 import { WorkflowPage } from '../pages/workflow';
+import * as formStep from '../composables/setup-template-form-step';
+import { getSetupWorkflowCredentialsButton } from '../composables/setup-workflow-credentials-button';
+import * as setupCredsModal from '../composables/modals/workflow-credential-setup-modal';
 
 const templateWorkflowPage = new TemplateWorkflowPage();
 const workflowPage = new WorkflowPage();
@@ -69,13 +72,9 @@ describe('Template credentials setup', () => {
 			'The credential you select will be used in the Telegram node of the workflow template.',
 		];
 
-		templateCredentialsSetupPage.getters.appCredentialSteps().each(($el, index) => {
-			templateCredentialsSetupPage.getters
-				.stepHeading($el)
-				.should('have.text', expectedAppNames[index]);
-			templateCredentialsSetupPage.getters
-				.stepDescription($el)
-				.should('have.text', expectedAppDescriptions[index]);
+		formStep.getFormStep().each(($el, index) => {
+			formStep.getStepHeading($el).should('have.text', expectedAppNames[index]);
+			formStep.getStepDescription($el).should('have.text', expectedAppDescriptions[index]);
 		});
 	});
 
@@ -100,10 +99,7 @@ describe('Template credentials setup', () => {
 		templateCredentialsSetupPage.fillInDummyCredentialsForAppWithConfirm('X (Formerly Twitter)');
 		templateCredentialsSetupPage.fillInDummyCredentialsForApp('Telegram');
 
-		cy.intercept('POST', '/rest/workflows').as('createWorkflow');
-		templateCredentialsSetupPage.getters.continueButton().should('be.enabled');
-		templateCredentialsSetupPage.getters.continueButton().click();
-		cy.wait('@createWorkflow');
+		templateCredentialsSetupPage.finishCredentialSetup();
 
 		workflowPage.getters.canvasNodes().should('have.length', 3);
 
@@ -137,13 +133,9 @@ describe('Template credentials setup', () => {
 			'The credential you select will be used in the Nextcloud node of the workflow template.',
 		];
 
-		templateCredentialsSetupPage.getters.appCredentialSteps().each(($el, index) => {
-			templateCredentialsSetupPage.getters
-				.stepHeading($el)
-				.should('have.text', expectedAppNames[index]);
-			templateCredentialsSetupPage.getters
-				.stepDescription($el)
-				.should('have.text', expectedAppDescriptions[index]);
+		formStep.getFormStep().each(($el, index) => {
+			formStep.getStepHeading($el).should('have.text', expectedAppNames[index]);
+			formStep.getStepDescription($el).should('have.text', expectedAppDescriptions[index]);
 		});
 
 		templateCredentialsSetupPage.getters.continueButton().should('be.disabled');
@@ -151,11 +143,60 @@ describe('Template credentials setup', () => {
 		templateCredentialsSetupPage.fillInDummyCredentialsForApp('Email (IMAP)');
 		templateCredentialsSetupPage.fillInDummyCredentialsForApp('Nextcloud');
 
-		cy.intercept('POST', '/rest/workflows').as('createWorkflow');
-		templateCredentialsSetupPage.getters.continueButton().should('be.enabled');
-		templateCredentialsSetupPage.getters.continueButton().click();
-		cy.wait('@createWorkflow');
+		templateCredentialsSetupPage.finishCredentialSetup();
 
 		workflowPage.getters.canvasNodes().should('have.length', 3);
+	});
+
+	describe('Credential setup from workflow editor', () => {
+		beforeEach(() => {
+			cy.resetDatabase();
+			cy.signinAsOwner();
+		});
+
+		it('should allow credential setup from workflow editor if user skips it during template setup', () => {
+			templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
+			templateCredentialsSetupPage.getters.skipLink().click();
+
+			getSetupWorkflowCredentialsButton().should('be.visible');
+		});
+
+		it('should allow credential setup from workflow editor if user fills in credentials partially during template setup', () => {
+			templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
+			templateCredentialsSetupPage.fillInDummyCredentialsForApp('Shopify');
+
+			templateCredentialsSetupPage.finishCredentialSetup();
+
+			getSetupWorkflowCredentialsButton().should('be.visible');
+		});
+
+		it('should fill credentials from workflow editor', () => {
+			templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
+			templateCredentialsSetupPage.getters.skipLink().click();
+
+			getSetupWorkflowCredentialsButton().click();
+			setupCredsModal.getWorkflowCredentialsModal().should('be.visible');
+
+			templateCredentialsSetupPage.fillInDummyCredentialsForApp('Shopify');
+			templateCredentialsSetupPage.fillInDummyCredentialsForAppWithConfirm('X (Formerly Twitter)');
+			templateCredentialsSetupPage.fillInDummyCredentialsForApp('Telegram');
+
+			setupCredsModal.closeModal();
+
+			// Focus the canvas so the copy to clipboard works
+			workflowPage.getters.canvasNodes().eq(0).realClick();
+			workflowPage.actions.selectAll();
+			workflowPage.actions.hitCopy();
+
+			cy.grantBrowserPermissions('clipboardReadWrite', 'clipboardSanitizedWrite');
+			// Check workflow JSON by copying it to clipboard
+			cy.readClipboard().then((workflowJSON) => {
+				const workflow = JSON.parse(workflowJSON);
+
+				workflow.nodes.forEach((node: any) => {
+					expect(Object.keys(node.credentials ?? {})).to.have.lengthOf(1);
+				});
+			});
+		});
 	});
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,12 @@
 import 'cypress-real-events';
 import { WorkflowPage } from '../pages';
-import { BACKEND_BASE_URL, INSTANCE_MEMBERS, INSTANCE_OWNER, N8N_AUTH_COOKIE } from '../constants';
+import {
+	BACKEND_BASE_URL,
+	INSTANCE_ADMIN,
+	INSTANCE_MEMBERS,
+	INSTANCE_OWNER,
+	N8N_AUTH_COOKIE,
+} from '../constants';
 
 Cypress.Commands.add('getByTestId', (selector, ...args) => {
 	return cy.get(`[data-test-id="${selector}"]`, ...args);
@@ -49,6 +55,10 @@ Cypress.Commands.add('signin', ({ email, password }) => {
 			failOnStatusCode: false,
 		}),
 	);
+});
+
+Cypress.Commands.add('signinAsOwner', () => {
+	cy.signin({ email: INSTANCE_OWNER.email, password: INSTANCE_OWNER.password });
 });
 
 Cypress.Commands.add('signout', () => {
@@ -181,5 +191,13 @@ Cypress.Commands.add('shouldNotHaveConsoleErrors', () => {
 	cy.window().then((win) => {
 		const spy = cy.spy(win.console, 'error');
 		cy.wrap(spy).should('not.have.been.called');
+	});
+});
+
+Cypress.Commands.add('resetDatabase', () => {
+	cy.request('POST', `${BACKEND_BASE_URL}/rest/e2e/reset`, {
+		owner: INSTANCE_OWNER,
+		members: INSTANCE_MEMBERS,
+		admin: INSTANCE_ADMIN,
 	});
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,12 +1,8 @@
-import { BACKEND_BASE_URL, INSTANCE_ADMIN, INSTANCE_MEMBERS, INSTANCE_OWNER } from '../constants';
+import { INSTANCE_OWNER } from '../constants';
 import './commands';
 
 before(() => {
-	cy.request('POST', `${BACKEND_BASE_URL}/rest/e2e/reset`, {
-		owner: INSTANCE_OWNER,
-		members: INSTANCE_MEMBERS,
-		admin: INSTANCE_ADMIN,
-	});
+	cy.resetDatabase();
 
 	Cypress.on('uncaught:exception', (err) => {
 		return !err.message.includes('ResizeObserver');

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -23,6 +23,7 @@ declare global {
 			findChildByTestId(childTestId: string): Chainable<JQuery<HTMLElement>>;
 			createFixtureWorkflow(fixtureKey: string, workflowName: string): void;
 			signin(payload: SigninPayload): void;
+			signinAsOwner(): void;
 			signout(): void;
 			interceptREST(method: string, url: string): Chainable<Interception>;
 			enableFeature(feature: string): void;
@@ -48,6 +49,7 @@ declare global {
 					};
 				}
 			>;
+			resetDatabase(): void;
 		}
 	}
 }

--- a/packages/editor-ui/src/components/Modals.vue
+++ b/packages/editor-ui/src/components/Modals.vue
@@ -166,7 +166,7 @@
 		<ModalRoot :name="SETUP_CREDENTIALS_MODAL_KEY">
 			<template #default="{ modalName, data }">
 				<SetupWorkflowCredentialsModal
-					data-test-id="suggested-templates-preview-modal"
+					data-test-id="setup-workflow-credentials-modal"
 					:modal-name="modalName"
 					:data="data"
 				/>


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/n8n-io/n8n/pull/8240

Adds e2e tests for the template credential setup in workflow editor


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 