### PR TITLE
fix(MySQL Node): Only escape table names when needed

### DIFF
--- a/packages/nodes-base/nodes/MySql/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v2/utils.test.ts
@@ -7,6 +7,7 @@ import {
 	addWhereClauses,
 	addSortRules,
 	replaceEmptyStringsByNulls,
+	escapeSqlIdentifier,
 } from '../../v2/helpers/utils';
 
 const mySqlMockNode: INode = {
@@ -146,5 +147,31 @@ describe('Test MySql V2, replaceEmptyStringsByNulls', () => {
 		const replacedData = replaceEmptyStringsByNulls(data);
 		expect(replacedData).toBeDefined();
 		expect(replacedData).toEqual([{ json: { id: 1, name: '' } }]);
+	});
+});
+
+describe('Test MySql V2, escapeSqlIdentifier', () => {
+	it('should escape fully qualified identifier', () => {
+		const input = 'db_name.tbl_name.col_name';
+		const escapedIdentifier = escapeSqlIdentifier(input);
+		expect(escapedIdentifier).toEqual('`db_name`.`tbl_name`.`col_name`');
+	});
+
+	it('should escape table name only', () => {
+		const input = 'tbl_name';
+		const escapedIdentifier = escapeSqlIdentifier(input);
+		expect(escapedIdentifier).toEqual('`tbl_name`');
+	});
+
+	it('should escape fully qualified identifier with backticks', () => {
+		const input = '`db_name`.`tbl_name`.`col_name`';
+		const escapedIdentifier = escapeSqlIdentifier(input);
+		expect(escapedIdentifier).toEqual('`db_name`.`tbl_name`.`col_name`');
+	});
+
+	it('should escape identifier with dots', () => {
+		const input = '`db_name`.`some.dotted.tbl_name`';
+		const escapedIdentifier = escapeSqlIdentifier(input);
+		expect(escapedIdentifier).toEqual('`db_name`.`some.dotted.tbl_name`');
 	});
 });

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/deleteTable.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/deleteTable.operation.ts
@@ -13,7 +13,7 @@ import type {
 	WhereClause,
 } from '../../helpers/interfaces';
 
-import { addWhereClauses } from '../../helpers/utils';
+import { addWhereClauses, escapeSqlIdentifier } from '../../helpers/utils';
 
 import {
 	optionsCollection,
@@ -98,11 +98,11 @@ export async function execute(
 		let values: QueryValues = [];
 
 		if (deleteCommand === 'drop') {
-			query = `DROP TABLE IF EXISTS \`${table}\``;
+			query = `DROP TABLE IF EXISTS ${escapeSqlIdentifier(table)}`;
 		}
 
 		if (deleteCommand === 'truncate') {
-			query = `TRUNCATE TABLE \`${table}\``;
+			query = `TRUNCATE TABLE ${escapeSqlIdentifier(table)}`;
 		}
 
 		if (deleteCommand === 'delete') {
@@ -114,7 +114,7 @@ export async function execute(
 			[query, values] = addWhereClauses(
 				this.getNode(),
 				i,
-				`DELETE FROM \`${table}\``,
+				`DELETE FROM ${escapeSqlIdentifier(table)}`,
 				whereClauses,
 				values,
 				combineConditions,

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/insert.operation.ts
@@ -14,7 +14,7 @@ import type {
 
 import { AUTO_MAP, BATCH_MODE, DATA_MODE } from '../../helpers/interfaces';
 
-import { replaceEmptyStringsByNulls } from '../../helpers/utils';
+import { escapeSqlIdentifier, replaceEmptyStringsByNulls } from '../../helpers/utils';
 
 import { optionsCollection } from '../common.descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
@@ -171,11 +171,13 @@ export async function execute(
 			];
 		}
 
-		const escapedColumns = columns.map((column) => `\`${column}\``).join(', ');
+		const escapedColumns = columns.map(escapeSqlIdentifier).join(', ');
 		const placeholder = `(${columns.map(() => '?').join(',')})`;
 		const replacements = items.map(() => placeholder).join(',');
 
-		const query = `INSERT ${priority} ${ignore} INTO \`${table}\` (${escapedColumns}) VALUES ${replacements}`;
+		const query = `INSERT ${priority} ${ignore} INTO ${escapeSqlIdentifier(
+			table,
+		)} (${escapedColumns}) VALUES ${replacements}`;
 
 		const values = insertItems.reduce(
 			(acc: IDataObject[], item) => acc.concat(Object.values(item) as IDataObject[]),
@@ -214,10 +216,12 @@ export async function execute(
 				columns = Object.keys(insertItem);
 			}
 
-			const escapedColumns = columns.map((column) => `\`${column}\``).join(', ');
+			const escapedColumns = columns.map(escapeSqlIdentifier).join(', ');
 			const placeholder = `(${columns.map(() => '?').join(',')})`;
 
-			const query = `INSERT ${priority} ${ignore} INTO \`${table}\` (${escapedColumns}) VALUES ${placeholder};`;
+			const query = `INSERT ${priority} ${ignore} INTO ${escapeSqlIdentifier(
+				table,
+			)} (${escapedColumns}) VALUES ${placeholder};`;
 
 			const values = Object.values(insertItem) as QueryValues;
 

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/select.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/select.operation.ts
@@ -13,7 +13,7 @@ import type {
 	WhereClause,
 } from '../../helpers/interfaces';
 
-import { addSortRules, addWhereClauses } from '../../helpers/utils';
+import { addSortRules, addWhereClauses, escapeSqlIdentifier } from '../../helpers/utils';
 
 import {
 	optionsCollection,
@@ -91,10 +91,10 @@ export async function execute(
 		const SELECT = selectDistinct ? 'SELECT DISTINCT' : 'SELECT';
 
 		if (outputColumns.includes('*')) {
-			query = `${SELECT} * FROM \`${table}\``;
+			query = `${SELECT} * FROM ${escapeSqlIdentifier(table)}`;
 		} else {
-			const escapedColumns = outputColumns.map((column) => `\`${column}\``).join(', ');
-			query = `${SELECT} ${escapedColumns} FROM \`${table}\``;
+			const escapedColumns = outputColumns.map(escapeSqlIdentifier).join(', ');
+			query = `${SELECT} ${escapedColumns} FROM ${escapeSqlIdentifier(table)}`;
 		}
 
 		let values: QueryValues = [];

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/update.operation.ts
@@ -8,7 +8,7 @@ import type {
 import type { QueryRunner, QueryValues, QueryWithValues } from '../../helpers/interfaces';
 import { AUTO_MAP, DATA_MODE } from '../../helpers/interfaces';
 
-import { replaceEmptyStringsByNulls } from '../../helpers/utils';
+import { escapeSqlIdentifier, replaceEmptyStringsByNulls } from '../../helpers/utils';
 
 import { optionsCollection } from '../common.descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
@@ -182,14 +182,16 @@ export async function execute(
 		const updates: string[] = [];
 
 		for (const column of updateColumns) {
-			updates.push(`\`${column}\` = ?`);
+			updates.push(`${escapeSqlIdentifier(column)} = ?`);
 			values.push(item[column] as string);
 		}
 
-		const condition = `\`${columnToMatchOn}\` = ?`;
+		const condition = `${escapeSqlIdentifier(columnToMatchOn)} = ?`;
 		values.push(valueToMatchOn);
 
-		const query = `UPDATE \`${table}\` SET ${updates.join(', ')} WHERE ${condition}`;
+		const query = `UPDATE ${escapeSqlIdentifier(table)} SET ${updates.join(
+			', ',
+		)} WHERE ${condition}`;
 
 		queries.push({ query, values });
 	}

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/upsert.operation.ts
@@ -8,7 +8,7 @@ import type {
 import type { QueryRunner, QueryValues, QueryWithValues } from '../../helpers/interfaces';
 import { AUTO_MAP, DATA_MODE } from '../../helpers/interfaces';
 
-import { replaceEmptyStringsByNulls } from '../../helpers/utils';
+import { escapeSqlIdentifier, replaceEmptyStringsByNulls } from '../../helpers/utils';
 
 import { optionsCollection } from '../common.descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
@@ -177,10 +177,12 @@ export async function execute(
 		const onConflict = 'ON DUPLICATE KEY UPDATE';
 
 		const columns = Object.keys(item);
-		const escapedColumns = columns.map((column) => `\`${column}\``).join(', ');
+		const escapedColumns = columns.map(escapeSqlIdentifier).join(', ');
 		const placeholder = `${columns.map(() => '?').join(',')}`;
 
-		const insertQuery = `INSERT INTO \`${table}\`(${escapedColumns}) VALUES(${placeholder})`;
+		const insertQuery = `INSERT INTO ${escapeSqlIdentifier(
+			table,
+		)}(${escapedColumns}) VALUES(${placeholder})`;
 
 		const values = Object.values(item) as QueryValues;
 
@@ -189,7 +191,7 @@ export async function execute(
 		const updates: string[] = [];
 
 		for (const column of updateColumns) {
-			updates.push(`\`${column}\` = ?`);
+			updates.push(`${escapeSqlIdentifier(column)} = ?`);
 			values.push(item[column] as string);
 		}
 

--- a/packages/nodes-base/nodes/MySql/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/MySql/v2/methods/loadOptions.ts
@@ -1,6 +1,7 @@
 import type { IDataObject, ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
 import { Client } from 'ssh2';
 import { createPool } from '../transport';
+import { escapeSqlIdentifier } from '../helpers/utils';
 
 export async function getColumns(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const credentials = await this.getCredentials('mySql');
@@ -22,7 +23,9 @@ export async function getColumns(this: ILoadOptionsFunctions): Promise<INodeProp
 
 		const columns = (
 			await connection.query(
-				`SHOW COLUMNS FROM \`${table}\` FROM \`${credentials.database as string}\``,
+				`SHOW COLUMNS FROM ${escapeSqlIdentifier(table)} FROM ${escapeSqlIdentifier(
+					credentials.database as string,
+				)}`,
 			)
 		)[0] as IDataObject[];
 


### PR DESCRIPTION
## Summary

Only escape table names when needed in the MySQL node. Also adds support for fully qualified identifiers like

```sql
`db_name`.`tbl_name`
`tbl_name`
tbl_name
.tbl_name
```
<img width="1354" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/7bd55fc9-d6b2-4d31-89a4-11df330c80af">

See reproduction steps in linear.

## Related tickets and issues
https://linear.app/n8n/issue/NODE-964/mysql-n8n-rejects-valid-identifiers-on-insert
https://community.n8n.io/t/mysql-node-insert-operation-unable-to-address-the-table-in-a-db/33399


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 