### PR TITLE
refactor(core): Break dependency cycle in internal hooks (no-changelog)

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -21,7 +21,6 @@ import type {
 import { Telemetry } from '@/telemetry';
 import type { AuthProviderType } from '@db/entities/AuthIdentity';
 import { eventBus } from './eventbus';
-import { EventsService } from '@/services/events.service';
 import type { User } from '@db/entities/User';
 import { N8N_VERSION } from '@/constants';
 import { NodeTypes } from './NodeTypes';
@@ -50,19 +49,11 @@ function userToPayload(user: User): {
 @Service()
 export class InternalHooks {
 	constructor(
-		private telemetry: Telemetry,
-		private nodeTypes: NodeTypes,
-		private roleService: RoleService,
-		eventsService: EventsService,
+		private readonly telemetry: Telemetry,
+		private readonly nodeTypes: NodeTypes,
+		private readonly roleService: RoleService,
 		private readonly instanceSettings: InstanceSettings,
-	) {
-		eventsService.on('telemetry.onFirstProductionWorkflowSuccess', async (metrics) =>
-			this.onFirstProductionWorkflowSuccess(metrics),
-		);
-		eventsService.on('telemetry.onFirstWorkflowDataLoad', async (metrics) =>
-			this.onFirstWorkflowDataLoad(metrics),
-		);
-	}
+	) {}
 
 	async init() {
 		await this.telemetry.init();

--- a/packages/cli/test/unit/services/user.service.test.ts
+++ b/packages/cli/test/unit/services/user.service.test.ts
@@ -8,12 +8,14 @@ import { UserService } from '@/services/user.service';
 import { mockInstance } from '../../shared/mocking';
 import { RoleService } from '@/services/role.service';
 import { v4 as uuid } from 'uuid';
+import { Telemetry } from '@/telemetry';
 
 describe('UserService', () => {
 	config.set('userManagement.jwtSecret', 'random-secret');
 
 	mockInstance(Logger);
 	mockInstance(RoleService);
+	mockInstance(Telemetry);
 
 	const userRepository = mockInstance(UserRepository);
 	const userService = Container.get(UserService);


### PR DESCRIPTION
Before:

```
InternalHooks -> EventsService -> UserService -> InternalHooks
```

After:

```
EventsService -> InternalHooks
EventsService -> UserService -> InternalHooks
```
