### PR TITLE
feat: Rename template cred setup feature flag (no-changelog)

### DIFF
--- a/cypress/pages/template-credential-setup.ts
+++ b/cypress/pages/template-credential-setup.ts
@@ -29,7 +29,7 @@ export const getters = {
 
 export const enableTemplateCredentialSetupFeatureFlag = () => {
 	cy.window().then((win) => {
-		win.featureFlags.override('016_template_credential_setup', true);
+		win.featureFlags.override('017_template_credential_setup_v2', true);
 	});
 };
 

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -625,7 +625,7 @@ export const ASK_AI_EXPERIMENT = {
 	gpt4: 'gpt4',
 };
 
-export const TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT = '016_template_credential_setup';
+export const TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT = '017_template_credential_setup_v2';
 
 export const EXPERIMENTS_TO_TRACK = [ASK_AI_EXPERIMENT.name, TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT];
 


### PR DESCRIPTION
## Summary

Rename the feature flag used for template credential setup, so we can ensure all users who have that flag enabled have specific set of features on their n8n version.


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 