### PR TITLE
fix(editor): Unify canvas button positioning

### DIFF
--- a/packages/editor-ui/src/components/CanvasControls.vue
+++ b/packages/editor-ui/src/components/CanvasControls.vue
@@ -93,8 +93,8 @@ onBeforeUnmount(() => {
 .zoomMenu {
 	position: absolute;
 	width: 210px;
-	bottom: var(--spacing-2xl);
-	left: 35px;
+	bottom: var(--spacing-l);
+	left: var(--spacing-l);
 	line-height: 25px;
 	color: #444;
 	padding-right: 5px;

--- a/packages/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreation.vue
@@ -173,8 +173,8 @@ function nodeTypeSelected(nodeTypes: string[]) {
 .nodeCreatorButton {
 	position: absolute;
 	text-align: center;
-	top: var(--spacing-s);
-	right: var(--spacing-s);
+	top: var(--spacing-l);
+	right: var(--spacing-l);
 	pointer-events: all !important;
 
 	button {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4995,7 +4995,7 @@ export default defineComponent({
 	align-items: center;
 	left: 50%;
 	transform: translateX(-50%);
-	bottom: var(--spacing-2xl);
+	bottom: var(--spacing-l);
 	width: auto;
 
 	@media (max-width: $breakpoint-2xs) {
@@ -5199,7 +5199,7 @@ export default defineComponent({
 
 .setupCredentialsButtonWrapper {
 	position: absolute;
-	left: 35px;
-	top: var(--spacing-s);
+	left: var(--spacing-l);
+	top: var(--spacing-l);
 }
 </style>


### PR DESCRIPTION

## Summary

Unify the margin different canvas buttons have relative to the edge of the canvas.

**Before**:

![image](https://github.com/n8n-io/n8n/assets/10324676/c947c67c-f3a0-4720-a6b3-e93da4b0d7a8)


**After**:

![image](https://github.com/n8n-io/n8n/assets/10324676/ac968a18-4780-4b82-b89e-6bbb507b90f1)


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 