### PR TITLE
fix: Adjust set up template button styles (no-changelog)

### DIFF
--- a/cypress/composables/setup-workflow-credentials-button.ts
+++ b/cypress/composables/setup-workflow-credentials-button.ts
@@ -2,4 +2,4 @@
  * Getters
  */
 
-export const getSetupWorkflowCredentialsButton = () => cy.get(`button:contains("Set up Template")`);
+export const getSetupWorkflowCredentialsButton = () => cy.get(`button:contains("Set up template")`);

--- a/packages/editor-ui/src/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue
+++ b/packages/editor-ui/src/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue
@@ -65,6 +65,8 @@ onBeforeUnmount(() => {
 		v-if="showButton"
 		:label="i18n.baseText('nodeView.setupTemplate')"
 		size="large"
+		icon="box-open"
+		type="secondary"
 		@click="handleClick()"
 	/>
 </template>

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1095,7 +1095,7 @@
 	"nodeView.zoomOut": "Zoom Out",
 	"nodeView.zoomToFit": "Zoom to Fit",
 	"nodeView.replaceMe": "Replace Me",
-	"nodeView.setupTemplate": "Set up Template",
+	"nodeView.setupTemplate": "Set up template",
 	"contextMenu.node": "node | nodes",
 	"contextMenu.sticky": "sticky note | sticky notes",
 	"contextMenu.selectAll": "Select all",


### PR DESCRIPTION
## Summary

- Add icon
- Change to secondary
- Fix text

**Before**:

![image](https://github.com/n8n-io/n8n/assets/10324676/d8fdab58-a5f0-46b4-8931-163ac2571f2f)


**After**:

![image](https://github.com/n8n-io/n8n/assets/10324676/5bf3cc36-36f6-4904-aa4e-f188fa03bca0)



## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 