### PR TITLE
fix(core): Avoid wrapping `ExecutionBaseError` to prevent misreporting to Sentry (no-changelog)

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -1805,7 +1805,7 @@ export async function requestWithAuthentication(
 			}
 			throw error;
 		} catch (error) {
-			if (error instanceof NodeOperationError) throw error;
+			if (error instanceof ExecutionBaseError) throw error;
 
 			throw new NodeApiError(this.getNode(), error);
 		}

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -1805,6 +1805,8 @@ export async function requestWithAuthentication(
 			}
 			throw error;
 		} catch (error) {
+			if (error instanceof NodeOperationError) throw error;
+
 			throw new NodeApiError(this.getNode(), error);
 		}
 	}


### PR DESCRIPTION
`requestWithAuthentication` has calls that may throw `NodeOperationError` but we are wrapping those errors in `NodeApiError`, which is causing those errors to be reported to Sentry even when they are level `warning`.

Ref: https://n8nio.sentry.io/issues/4833348705