### PR TITLE
fix(Github Trigger Node): Enforce SSL validation by default

### DIFF
--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -434,6 +434,14 @@ export class GithubTrigger implements INodeType {
 				default: [],
 				description: 'The events to listen to',
 			},
+			{
+				displayName: 'Insecure SSL',
+				name: 'insecureSSL',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether the SSL certificate of the n8n host be verified by GitHub when delivering payloads',
+			},
 		],
 	};
 
@@ -465,7 +473,7 @@ export class GithubTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 				// If it did not error then the webhook exists
@@ -488,14 +496,14 @@ export class GithubTrigger implements INodeType {
 				const events = this.getNodeParameter('events', []);
 
 				const endpoint = `/repos/${owner}/${repository}/hooks`;
+				const insecureSSL = this.getNodeParameter('insecureSSL') as boolean;
 
 				const body = {
 					name: 'web',
 					config: {
 						url: webhookUrl,
 						content_type: 'json',
-						// secret: '...later...',
-						insecure_ssl: '1', // '0' -> not allow inscure ssl | '1' -> allow insercure SSL
+						insecure_ssl: insecureSSL ? '1' : '0',
 					},
 					events,
 					active: true,

--- a/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
+++ b/packages/nodes-base/nodes/Github/GithubTrigger.node.ts
@@ -435,12 +435,21 @@ export class GithubTrigger implements INodeType {
 				description: 'The events to listen to',
 			},
 			{
-				displayName: 'Insecure SSL',
-				name: 'insecureSSL',
-				type: 'boolean',
-				default: false,
-				description:
-					'Whether the SSL certificate of the n8n host be verified by GitHub when delivering payloads',
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				placeholder: 'Add Option',
+				default: {},
+				options: [
+					{
+						displayName: 'Insecure SSL',
+						name: 'insecureSSL',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether the SSL certificate of the n8n host be verified by GitHub when delivering payloads',
+					},
+				],
 			},
 		],
 	};
@@ -496,14 +505,14 @@ export class GithubTrigger implements INodeType {
 				const events = this.getNodeParameter('events', []);
 
 				const endpoint = `/repos/${owner}/${repository}/hooks`;
-				const insecureSSL = this.getNodeParameter('insecureSSL') as boolean;
+				const options = this.getNodeParameter('options') as { insecureSSL: boolean };
 
 				const body = {
 					name: 'web',
 					config: {
 						url: webhookUrl,
 						content_type: 'json',
-						insecure_ssl: insecureSSL ? '1' : '0',
+						insecure_ssl: options.insecureSSL ? '1' : '0',
 					},
 					events,
 					active: true,


### PR DESCRIPTION
Github webhooks in n8n currently do not validate n8n host's SSL certificate, and that can be security issue.  
This PR adds and option to allow disable the certificate validation during the webhook creation, but the option is `false` by default.


## Related tickets and issues
Fixes #8263

## Review / Merge checklist
- [x] PR title and summary are descriptive