### PR TITLE
fix: Small ui fixes to workflow cred setup modal (no-changelog)

### DIFF
--- a/cypress/composables/modals/workflow-credential-setup-modal.ts
+++ b/cypress/composables/modals/workflow-credential-setup-modal.ts
@@ -4,9 +4,10 @@
 
 export const getWorkflowCredentialsModal = () => cy.getByTestId('setup-workflow-credentials-modal');
 
+export const getContinueButton = () => cy.getByTestId('continue-button');
+
 /**
  * Actions
  */
 
-export const closeModal = () =>
-	getWorkflowCredentialsModal().find("button[aria-label='Close this dialog']").click();
+export const closeModalFromContinueButton = () => getContinueButton().click();

--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -43,7 +43,7 @@ describe('Template credentials setup', () => {
 		templateWorkflowPage.actions.clickUseThisWorkflowButton();
 
 		templateCredentialsSetupPage.getters
-			.title(`Setup 'Promote new Shopify products on Twitter and Telegram' template`)
+			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)
 			.should('be.visible');
 	});
 
@@ -53,7 +53,7 @@ describe('Template credentials setup', () => {
 		clickUseWorkflowButtonByTitle('Promote new Shopify products on Twitter and Telegram');
 
 		templateCredentialsSetupPage.getters
-			.title(`Setup 'Promote new Shopify products on Twitter and Telegram' template`)
+			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)
 			.should('be.visible');
 	});
 
@@ -61,7 +61,7 @@ describe('Template credentials setup', () => {
 		templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
 
 		templateCredentialsSetupPage.getters
-			.title(`Setup 'Promote new Shopify products on Twitter and Telegram' template`)
+			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)
 			.should('be.visible');
 	});
 
@@ -69,7 +69,7 @@ describe('Template credentials setup', () => {
 		templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
 
 		templateCredentialsSetupPage.getters
-			.title(`Setup 'Promote new Shopify products on Twitter and Telegram' template`)
+			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)
 			.should('be.visible');
 
 		templateCredentialsSetupPage.getters
@@ -195,7 +195,8 @@ describe('Template credentials setup', () => {
 			templateCredentialsSetupPage.fillInDummyCredentialsForAppWithConfirm('X (Formerly Twitter)');
 			templateCredentialsSetupPage.fillInDummyCredentialsForApp('Telegram');
 
-			setupCredsModal.closeModal();
+			setupCredsModal.closeModalFromContinueButton();
+			setupCredsModal.getWorkflowCredentialsModal().should('not.exist');
 
 			// Focus the canvas so the copy to clipboard works
 			workflowPage.getters.canvasNodes().eq(0).realClick();

--- a/packages/editor-ui/src/components/SetupWorkflowCredentialsModal/SetupWorkflowCredentialsModal.vue
+++ b/packages/editor-ui/src/components/SetupWorkflowCredentialsModal/SetupWorkflowCredentialsModal.vue
@@ -8,10 +8,12 @@ import SetupTemplateFormStep from '@/views/SetupWorkflowFromTemplateView/SetupTe
 import { onMounted, onUnmounted } from 'vue';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useUIStore } from '@/stores/ui.store';
 
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const workflowStore = useWorkflowsStore();
+const uiStore = useUIStore();
 
 const props = defineProps<{
 	modalName: string;
@@ -45,7 +47,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-	<Modal width="900px" max-height="90%" :name="props.modalName">
+	<Modal width="700px" max-height="90%" :name="props.modalName">
 		<template #header>
 			<N8nHeading tag="h2" size="xlarge">
 				{{ i18n.baseText('setupCredentialsModal.title') }}
@@ -74,6 +76,18 @@ onUnmounted(() => {
 				</div>
 			</div>
 		</template>
+
+		<template #footer>
+			<div :class="$style.footer">
+				<n8n-button
+					size="large"
+					:label="i18n.baseText('templateSetup.continue.button')"
+					:disabled="numFilledCredentials === 0"
+					data-test-id="continue-button"
+					@click="uiStore.closeModal(props.modalName)"
+				/>
+			</div>
+		</template>
 	</Modal>
 </template>
 
@@ -84,7 +98,6 @@ onUnmounted(() => {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	max-width: 768px;
 }
 
 .notice {
@@ -101,5 +114,10 @@ onUnmounted(() => {
 .appCredential:not(:last-of-type) {
 	padding-bottom: var(--spacing-2xl);
 	border-bottom: 1px solid var(--color-foreground-light);
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
 }
 </style>

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2365,11 +2365,11 @@
 	"filter.condition.resolvedFalse": "This condition is false for the first input item",
 	"filter.condition.placeholderLeft": "value1",
 	"filter.condition.placeholderRight": "value2",
-	"templateSetup.title": "Setup '{name}' template",
+	"templateSetup.title": "Set up '{name}' template",
 	"templateSetup.instructions": "You need {0} account to setup this template",
 	"templateSetup.skip": "Skip",
 	"templateSetup.continue.button": "Continue",
 	"templateSetup.credential.description": "The credential you select will be used in the {0} node of the workflow template. | The credential you select will be used in the {0} nodes of the workflow template.",
 	"templateSetup.continue.button.fillRemaining": "Fill remaining credentials to continue",
-	"setupCredentialsModal.title": "Setup credentials"
+	"setupCredentialsModal.title": "Set up credentials"
 }


### PR DESCRIPTION

## Summary

- Change title from Setup to Set up
- Add Continue button
- Make modal narrower with smaller margin

**Before**:

![image](https://github.com/n8n-io/n8n/assets/10324676/3bdec662-213c-4453-8c96-77ad4f734363)


**After**:

![image](https://github.com/n8n-io/n8n/assets/10324676/1c06abd0-eb6c-4101-99fc-d6068ec8d91d)


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 