### PR TITLE
fix: Properly output saml validation errors

### DIFF
--- a/packages/cli/src/sso/saml/samlValidator.ts
+++ b/packages/cli/src/sso/saml/samlValidator.ts
@@ -88,7 +88,13 @@ export async function validateMetadata(metadata: string): Promise<boolean> {
 			return true;
 		} else {
 			logger.warn('SAML Validate Metadata: Invalid metadata');
-			logger.warn(validationResult ? validationResult.errors.join('\n') : '');
+			logger.warn(
+				validationResult
+					? validationResult.errors
+							.map((error) => `${error.message} - ${error.rawMessage}`)
+							.join('\n')
+					: '',
+			);
 		}
 	} catch (error) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/cli/src/sso/saml/samlValidator.ts
+++ b/packages/cli/src/sso/saml/samlValidator.ts
@@ -124,7 +124,13 @@ export async function validateResponse(response: string): Promise<boolean> {
 			return true;
 		} else {
 			logger.warn('SAML Validate Response: Failed');
-			logger.warn(validationResult ? validationResult.errors.join('\n') : '');
+			logger.warn(
+				validationResult
+					? validationResult.errors
+							.map((error) => `${error.message} - ${error.rawMessage}`)
+							.join('\n')
+					: '',
+			);
 		}
 	} catch (error) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
## Summary
Errors were being displayed as `[object Object]` in the logs



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1217/saml-authentication-failed


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.