### PR TITLE
fix(editor): Add read only mode to filter component

### DIFF
--- a/packages/editor-ui/src/components/FilterConditions/Condition.vue
+++ b/packages/editor-ui/src/components/FilterConditions/Condition.vue
@@ -32,6 +32,7 @@ interface Props {
 	issues?: string[];
 	fixedLeftValue?: boolean;
 	canRemove?: boolean;
+	readOnly?: boolean;
 	index?: number;
 }
 
@@ -39,6 +40,7 @@ const props = withDefaults(defineProps<Props>(), {
 	issues: () => [],
 	canRemove: true,
 	fixedLeftValue: false,
+	readOnly: false,
 });
 
 const emit = defineEmits<{
@@ -190,7 +192,7 @@ const onBlur = (): void => {
 		data-test-id="filter-condition"
 	>
 		<n8n-icon-button
-			v-if="canRemove"
+			v-if="canRemove && !readOnly"
 			type="tertiary"
 			text
 			size="mini"
@@ -227,6 +229,7 @@ const onBlur = (): void => {
 						:value="condition.leftValue"
 						:path="`${path}.left`"
 						:class="[$style.input, $style.inputLeft]"
+						:is-read-only="readOnly"
 						data-test-id="filter-condition-left"
 						@update="onLeftValueChange"
 						@blur="onBlur"
@@ -234,6 +237,7 @@ const onBlur = (): void => {
 					<OperatorSelect
 						:class="$style.select"
 						:selected="`${operator.type}:${operator.operation}`"
+						:read-only="readOnly"
 						@operatorChange="onOperatorChange"
 					></OperatorSelect>
 					<ParameterInputFull
@@ -248,6 +252,7 @@ const onBlur = (): void => {
 						:value="condition.rightValue"
 						:path="`${path}.right`"
 						:class="[$style.input, $style.inputRight]"
+						:is-read-only="readOnly"
 						data-test-id="filter-condition-right"
 						@update="onRightValueChange"
 						@blur="onBlur"

--- a/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
+++ b/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
@@ -29,9 +29,10 @@ interface Props {
 	value: FilterValue;
 	path: string;
 	node: INode | null;
+	readOnly?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), { readOnly: false });
 
 const emit = defineEmits<{
 	(event: 'valueChanged', value: { name: string; node: string; value: FilterValue }): void;
@@ -145,7 +146,7 @@ function getIssues(index: number): string[] {
 				<div v-for="(condition, index) of state.paramValue.conditions" :key="condition.id">
 					<CombinatorSelect
 						v-if="index !== 0"
-						:read-only="index !== 1"
+						:read-only="index !== 1 || readOnly"
 						:options="allowedCombinators"
 						:selected="state.paramValue.combinator"
 						:class="$style.combinator"
@@ -157,6 +158,7 @@ function getIssues(index: number): string[] {
 						:index="index"
 						:options="state.paramValue.options"
 						:fixed-left-value="!!parameter.typeOptions?.filter?.leftValue"
+						:read-only="readOnly"
 						:can-remove="index !== 0 || state.paramValue.conditions.length > 1"
 						:path="`${path}.${index}`"
 						:issues="getIssues(index)"
@@ -166,7 +168,7 @@ function getIssues(index: number): string[] {
 					></Condition>
 				</div>
 			</div>
-			<div v-if="!singleCondition" :class="$style.addConditionWrapper">
+			<div v-if="!singleCondition && !readOnly" :class="$style.addConditionWrapper">
 				<n8n-button
 					type="tertiary"
 					block

--- a/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
+++ b/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
@@ -6,9 +6,10 @@ import type { FilterOperator } from './types';
 
 interface Props {
 	selected: string;
+	readOnly?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), { readOnly: false });
 
 const selected = ref(props.selected);
 const menuOpen = ref(false);
@@ -57,6 +58,7 @@ function onGroupSelect(group: string) {
 		data-test-id="filter-operator-select"
 		size="small"
 		:model-value="selected"
+		:disabled="readOnly"
 		@update:modelValue="onOperatorChange"
 		@visible-change="onSelectVisibleChange"
 		@mouseenter="shouldRenderItems = true"

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -102,6 +102,7 @@
 				:value="nodeHelpers.getParameterValue(nodeValues, parameter.name, path)"
 				:path="getPath(parameter.name)"
 				:node="node"
+				:read-only="isReadOnly"
 				@valueChanged="valueChanged"
 			/>
 			<div


### PR DESCRIPTION
## Summary

Make sure fields in the filter component are not editable in read only mode (for example in executions view)

<img width="588" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/ac7858af-0d05-4e1c-927d-083584e48345">

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1044/bug-can-editdelete-if-conditions-in-executions-view

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 