### PR TITLE
ci: Add support for optionally including ARM64 support in custom images (no-changelog)

### DIFF
--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -35,6 +35,11 @@ on:
         description: 'URL to call after Docker Image got built successfully.'
         required: false
         default: ''
+      include-arm64:
+        description: 'Include ARM64 support'
+        type: boolean
+        required: true
+        default: false
 
 jobs:
   build:
@@ -76,7 +81,7 @@ jobs:
           build-args: |
             N8N_RELEASE_TYPE=nightly
           file: ./docker/images/n8n-custom/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ github.event.inputs.include-arm64 == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           provenance: false
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ github.event.inputs.tag || 'nightly' }}


### PR DESCRIPTION
This change adds a checkbox in the dispatch dialog, which when enabled, also includes ARM64 support.
![image](https://github.com/n8n-io/n8n/assets/196144/05202938-d9f2-4dd2-896a-91046b8caebf)
