### PR TITLE
fix: Store workflow settings when saving an execution

### DIFF
--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -226,10 +226,10 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		const { data, workflowData, ...rest } = execution;
 		const { identifiers: inserted } = await this.insert(rest);
 		const { id: executionId } = inserted[0] as { id: string };
-		const { connections, nodes, name } = workflowData ?? {};
+		const { connections, nodes, name, settings } = workflowData ?? {};
 		await this.executionDataRepository.insert({
 			executionId,
-			workflowData: { connections, nodes, name, id: workflowData?.id },
+			workflowData: { connections, nodes, name, settings, id: workflowData?.id },
 			data: stringify(data),
 		});
 		return String(executionId);

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -20,7 +20,7 @@ describe('ExecutionRepository', () => {
 	describe('createNewExecution', () => {
 		it('should save execution data', async () => {
 			const executionRepo = Container.get(ExecutionRepository);
-			const workflow = await createWorkflow();
+			const workflow = await createWorkflow({ settings: { executionOrder: 'v1' } });
 			const executionId = await executionRepo.createNewExecution({
 				workflowId: workflow.id,
 				data: {
@@ -48,6 +48,7 @@ describe('ExecutionRepository', () => {
 				connections: workflow.connections,
 				nodes: workflow.nodes,
 				name: workflow.name,
+				settings: workflow.settings,
 			});
 			expect(executionData?.data).toEqual('[{"resultData":"1"},{}]');
 		});


### PR DESCRIPTION
## Summary
In a recent change, we stopped storing the workflow settings of a workflow when creating a new execution. This led to n8n not following the workflow settings during runtime.



## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8281
https://linear.app/n8n/issue/N8N-7157/workflow-executionorder-v1-is-not-working-as-expected-in-n8n-version


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.