### PR TITLE
fix: Adjust cred setup telemetry (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -153,6 +153,16 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 			wf_template_repo_session_id: templatesStore.currentSessionId,
 		});
 
+		telemetry.track(
+			'User inserted workflow template',
+			{
+				source: 'workflow',
+				template_id: templateId.value,
+				wf_template_repo_session_id: templatesStore.currentSessionId,
+			},
+			{ withPostHog: true },
+		);
+
 		telemetry.track('User closed cred setup', {
 			completed: false,
 			creds_filled: 0,
@@ -196,14 +206,20 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 				workflow_id: createdWorkflow.id,
 			});
 
-			const telemetryPayload = {
-				source: 'workflow',
-				template_id: template.value.id,
-				wf_template_repo_session_id: templatesStore.currentSessionId,
-			};
+			telemetry.track(
+				'User inserted workflow template',
+				{
+					source: 'workflow',
+					template_id: templateId.value,
+					wf_template_repo_session_id: templatesStore.currentSessionId,
+				},
+				{ withPostHog: true },
+			);
 
-			telemetry.track('User inserted workflow template', telemetryPayload, {
-				withPostHog: true,
+			telemetry.track('User saved new workflow from template', {
+				template_id: templateId.value,
+				workflow_id: createdWorkflow.id,
+				wf_template_repo_session_id: templatesStore.currentSessionId,
 			});
 
 			// Replace the URL so back button doesn't come back to this setup view


### PR DESCRIPTION

## Summary

- Fire 'User inserted workflow template' on skip
- Fire 'User saved new workflow from template' on continue


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 