### PR TITLE
refactor: Make execution IDs mandatory in BE

### DIFF
--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -49,6 +49,7 @@ export class ActiveExecutions {
 				startedAt: new Date(),
 				workflowData: executionData.workflowData,
 				status: executionStatus,
+				workflowId: executionData.workflowData.id,
 			};
 
 			if (executionData.retryOf !== undefined) {

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -147,7 +147,6 @@ export interface IExecutionResponse extends IExecutionBase {
 	data: IRunExecutionData;
 	retryOf?: string;
 	retrySuccessId?: string;
-	waitTill?: Date | null;
 	workflowData: IWorkflowBase | WorkflowWithSharingsAndCredentials;
 }
 
@@ -161,9 +160,7 @@ export interface IExecutionFlatted extends IExecutionBase {
 export interface IExecutionFlattedDb extends IExecutionBase {
 	id: string;
 	data: string;
-	waitTill?: Date | null;
 	workflowData: Omit<IWorkflowBase, 'pinData'>;
-	status: ExecutionStatus;
 }
 
 export interface IExecutionFlattedResponse extends IExecutionFlatted {

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -81,7 +81,6 @@ export type ITagWithCountDb = Pick<TagEntity, 'id' | 'name' | 'createdAt' | 'upd
 
 // Almost identical to editor-ui.Interfaces.ts
 export interface IWorkflowDb extends IWorkflowBase {
-	id: string;
 	tags?: TagEntity[];
 }
 
@@ -124,13 +123,13 @@ export interface IExecutionBase {
 	retryOf?: string; // If it is a retry, the id of the execution it is a retry of.
 	retrySuccessId?: string; // If it failed and a retry did succeed. The id of the successful retry.
 	status: ExecutionStatus;
+	waitTill?: Date | null;
 }
 
 // Data in regular format with references
 export interface IExecutionDb extends IExecutionBase {
 	data: IRunExecutionData;
-	waitTill?: Date | null;
-	workflowData?: IWorkflowBase;
+	workflowData: IWorkflowBase;
 }
 
 /**

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -118,7 +118,7 @@ export interface IExecutionBase {
 	mode: WorkflowExecuteMode;
 	startedAt: Date;
 	stoppedAt?: Date; // empty value means execution is still running
-	workflowId?: string; // To be able to filter executions easily //
+	workflowId: string;
 	finished: boolean;
 	retryOf?: string; // If it is a retry, the id of the execution it is a retry of.
 	retrySuccessId?: string; // If it failed and a retry did succeed. The id of the successful retry.

--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -33,7 +33,7 @@ export = {
 			}
 
 			await Container.get(ExecutionRepository).hardDelete({
-				workflowId: execution.workflowId as string,
+				workflowId: execution.workflowId,
 				executionId: execution.id,
 			});
 

--- a/packages/cli/src/ResponseHelper.ts
+++ b/packages/cli/src/ResponseHelper.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { Request, Response } from 'express';
-import { parse, stringify } from 'flatted';
 import picocolors from 'picocolors';
 import {
 	ErrorReporterProxy as ErrorReporter,
@@ -8,13 +7,7 @@ import {
 	NodeApiError,
 } from 'n8n-workflow';
 import { Readable } from 'node:stream';
-import type {
-	IExecutionDb,
-	IExecutionFlatted,
-	IExecutionFlattedDb,
-	IExecutionResponse,
-	IWorkflowDb,
-} from '@/Interfaces';
+
 import { inDevelopment } from '@/constants';
 import { ResponseError } from './errors/response-errors/abstract/response.error';
 

--- a/packages/cli/src/ResponseHelper.ts
+++ b/packages/cli/src/ResponseHelper.ts
@@ -173,68 +173,6 @@ export function send<T, R extends Request, S extends Response>(
 	};
 }
 
-/**
- * Flattens the Execution data.
- * As it contains a lot of references which normally would be saved as duplicate data
- * with regular JSON.stringify it gets flattened which keeps the references in place.
- *
- * @param {IExecutionDb} fullExecutionData The data to flatten
- */
-// TODO: Remove this functions since it's purpose should be fulfilled by the execution repository
-export function flattenExecutionData(fullExecutionData: IExecutionDb): IExecutionFlatted {
-	// Flatten the data
-	const returnData: IExecutionFlatted = {
-		data: stringify(fullExecutionData.data),
-		mode: fullExecutionData.mode,
-		// @ts-ignore
-		waitTill: fullExecutionData.waitTill,
-		startedAt: fullExecutionData.startedAt,
-		stoppedAt: fullExecutionData.stoppedAt,
-		finished: fullExecutionData.finished ? fullExecutionData.finished : false,
-		workflowId: fullExecutionData.workflowId,
-
-		workflowData: fullExecutionData.workflowData!,
-		status: fullExecutionData.status,
-	};
-
-	if (fullExecutionData.id !== undefined) {
-		returnData.id = fullExecutionData.id;
-	}
-
-	if (fullExecutionData.retryOf !== undefined) {
-		returnData.retryOf = fullExecutionData.retryOf.toString();
-	}
-
-	if (fullExecutionData.retrySuccessId !== undefined) {
-		returnData.retrySuccessId = fullExecutionData.retrySuccessId.toString();
-	}
-
-	return returnData;
-}
-
-/**
- * Unflattens the Execution data.
- *
- * @param {IExecutionFlattedDb} fullExecutionData The data to unflatten
- */
-// TODO: Remove this functions since it's purpose should be fulfilled by the execution repository
-export function unflattenExecutionData(fullExecutionData: IExecutionFlattedDb): IExecutionResponse {
-	const returnData: IExecutionResponse = {
-		id: fullExecutionData.id,
-		workflowData: fullExecutionData.workflowData as IWorkflowDb,
-		data: parse(fullExecutionData.data),
-		mode: fullExecutionData.mode,
-		waitTill: fullExecutionData.waitTill ? fullExecutionData.waitTill : undefined,
-		startedAt: fullExecutionData.startedAt,
-		stoppedAt: fullExecutionData.stoppedAt,
-		finished: fullExecutionData.finished ? fullExecutionData.finished : false,
-		workflowId: fullExecutionData.workflowId,
-		status: fullExecutionData.status,
-	};
-
-	return returnData;
-}
-
 export const flattenObject = (obj: { [x: string]: any }, prefix = '') =>
 	Object.keys(obj).reduce((acc, k) => {
 		const pre = prefix.length ? prefix + '.' : '';

--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -151,7 +151,6 @@ export class WaitTracker {
 			const workflowRunner = new WorkflowRunner();
 			await workflowRunner.run(data, false, false, executionId);
 		})().catch((error: Error) => {
-			console.log('got an error', error.message, error.stack);
 			ErrorReporter.error(error);
 			this.logger.error(
 				`There was a problem starting the waiting execution with id "${executionId}": "${error.message}"`,

--- a/packages/cli/src/WaitingWebhooks.ts
+++ b/packages/cli/src/WaitingWebhooks.ts
@@ -78,7 +78,7 @@ export class WaitingWebhooks implements IWebhookManager {
 		const { workflowData } = execution;
 
 		const workflow = new Workflow({
-			id: workflowData.id!,
+			id: workflowData.id,
 			name: workflowData.name,
 			nodes: workflowData.nodes,
 			connections: workflowData.connections,
@@ -90,7 +90,7 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		let workflowOwner;
 		try {
-			workflowOwner = await this.ownershipService.getWorkflowOwnerCached(workflowData.id!);
+			workflowOwner = await this.ownershipService.getWorkflowOwnerCached(workflowData.id);
 		} catch (error) {
 			throw new NotFoundError('Could not find workflow');
 		}

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -420,7 +420,7 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 						// Workflow is saved so update in database
 						try {
 							await Container.get(WorkflowStaticDataService).saveStaticDataById(
-								this.workflowData.id as string,
+								this.workflowData.id,
 								newStaticData,
 							);
 						} catch (e) {
@@ -464,7 +464,7 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 								this.retryOf,
 							);
 							await Container.get(ExecutionRepository).hardDelete({
-								workflowId: this.workflowData.id as string,
+								workflowId: this.workflowData.id,
 								executionId: this.executionId,
 							});
 
@@ -483,7 +483,7 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 
 					await updateExistingExecution({
 						executionId: this.executionId,
-						workflowId: this.workflowData.id as string,
+						workflowId: this.workflowData.id,
 						executionData: fullExecutionData,
 					});
 
@@ -566,7 +566,7 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 						// Workflow is saved so update in database
 						try {
 							await Container.get(WorkflowStaticDataService).saveStaticDataById(
-								this.workflowData.id as string,
+								this.workflowData.id,
 								newStaticData,
 							);
 						} catch (e) {
@@ -601,7 +601,7 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 
 					await updateExistingExecution({
 						executionId: this.executionId,
-						workflowId: this.workflowData.id as string,
+						workflowId: this.workflowData.id,
 						executionData: fullExecutionData,
 					});
 				} catch (error) {
@@ -702,7 +702,7 @@ export async function getRunData(
 
 export async function getWorkflowData(
 	workflowInfo: IExecuteWorkflowInfo,
-	parentWorkflowId?: string,
+	parentWorkflowId: string,
 	parentWorkflowSettings?: IWorkflowSettings,
 ): Promise<IWorkflowBase> {
 	if (workflowInfo.id === undefined && workflowInfo.code === undefined) {
@@ -748,7 +748,7 @@ async function executeWorkflow(
 	additionalData: IWorkflowExecuteAdditionalData,
 	options: {
 		node?: INode;
-		parentWorkflowId?: string;
+		parentWorkflowId: string;
 		inputData?: INodeExecutionData[];
 		parentExecutionId?: string;
 		loadedWorkflowData?: IWorkflowBase;
@@ -769,7 +769,7 @@ async function executeWorkflow(
 
 	const workflowName = workflowData ? workflowData.name : undefined;
 	const workflow = new Workflow({
-		id: workflowData.id?.toString(),
+		id: workflowData.id,
 		name: workflowName,
 		nodes: workflowData.nodes,
 		connections: workflowData.connections,
@@ -788,10 +788,7 @@ async function executeWorkflow(
 	if (options.parentExecutionId !== undefined) {
 		executionId = options.parentExecutionId;
 	} else {
-		executionId =
-			options.parentExecutionId !== undefined
-				? options.parentExecutionId
-				: await activeExecutions.add(runData);
+		executionId = options.parentExecutionId ?? (await activeExecutions.add(runData));
 	}
 
 	void internalHooks.onWorkflowBeforeExecute(executionId || '', runData);
@@ -801,7 +798,7 @@ async function executeWorkflow(
 		await PermissionChecker.check(workflow, additionalData.userId);
 		await PermissionChecker.checkSubworkflowExecutePolicy(
 			workflow,
-			options.parentWorkflowId!,
+			options.parentWorkflowId,
 			options.node,
 		);
 
@@ -1082,7 +1079,7 @@ export function getWorkflowHooksWorkerMain(
 
 			if (shouldNotSave) {
 				await Container.get(ExecutionRepository).hardDelete({
-					workflowId: this.workflowData.id as string,
+					workflowId: this.workflowData.id,
 					executionId: this.executionId,
 				});
 			}

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -876,6 +876,7 @@ async function executeWorkflow(
 			stoppedAt: fullRunData.stoppedAt,
 			status: fullRunData.status,
 			workflowData,
+			workflowId: workflowData.id,
 		};
 		if (workflowData.id) {
 			fullExecutionData.workflowId = workflowData.id;

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -197,16 +197,16 @@ class WorkflowRunnerProcess {
 		additionalData.executeWorkflow = async (
 			workflowInfo: IExecuteWorkflowInfo,
 			additionalData: IWorkflowExecuteAdditionalData,
-			options?: {
-				parentWorkflowId?: string;
+			options: {
+				parentWorkflowId: string;
 				inputData?: INodeExecutionData[];
 				parentWorkflowSettings?: IWorkflowSettings;
 			},
 		): Promise<Array<INodeExecutionData[] | null> | IRun> => {
 			const workflowData = await WorkflowExecuteAdditionalData.getWorkflowData(
 				workflowInfo,
-				options?.parentWorkflowId,
-				options?.parentWorkflowSettings,
+				options.parentWorkflowId,
+				options.parentWorkflowSettings,
 			);
 			const runData = await WorkflowExecuteAdditionalData.getRunData(
 				workflowData,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -30,6 +30,7 @@ import { UrlService } from '@/services/url.service';
 import { SettingsRepository } from '@db/repositories/settings.repository';
 import { ExecutionRepository } from '@db/repositories/execution.repository';
 import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { WaitTracker } from '@/WaitTracker';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
@@ -98,6 +99,8 @@ export class Start extends BaseCommand {
 		try {
 			// Stop with trying to activate workflows that could not be activated
 			this.activeWorkflowRunner.removeAllQueuedWorkflowActivations();
+
+			Container.get(WaitTracker).shutdown();
 
 			await this.externalHooks?.run('n8n.stop', []);
 

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -122,7 +122,7 @@ export class Worker extends BaseCommand {
 				{ extra: { executionId } },
 			);
 		}
-		const workflowId = fullExecutionData.workflowData.id!; // @tech_debt Ensure this is not optional
+		const workflowId = fullExecutionData.workflowData.id;
 
 		this.logger.info(
 			`Start job: ${job.id} (Workflow ID: ${workflowId} | Execution: ${executionId})`,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -762,6 +762,12 @@ export const schema = {
 			default: '',
 			env: 'N8N_USER_MANAGEMENT_JWT_SECRET',
 		},
+		jwtDuration: {
+			doc: 'Set a specific JWT secret (optional - n8n can generate one)', // Generated @ start.ts
+			format: Number,
+			default: 168,
+			env: 'N8N_USER_MANAGEMENT_JWT_DURATION',
+		},
 		isInstanceOwnerSetUp: {
 			// n8n loads this setting from DB on startup
 			doc: "Whether the instance owner's account has been set up",

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -229,7 +229,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		const { connections, nodes, name, settings } = workflowData ?? {};
 		await this.executionDataRepository.insert({
 			executionId,
-			workflowData: { connections, nodes, name, settings, id: workflowData?.id },
+			workflowData: { connections, nodes, name, settings, id: workflowData.id },
 			data: stringify(data),
 		});
 		return String(executionId);

--- a/packages/cli/src/executionLifecycleHooks/shared/sharedHookFunctions.ts
+++ b/packages/cli/src/executionLifecycleHooks/shared/sharedHookFunctions.ts
@@ -54,6 +54,7 @@ export function prepareExecutionDataForDbUpdate(parameters: {
 		workflowData: pristineWorkflowData,
 		waitTill: runData.waitTill,
 		status: workflowStatusFinal,
+		workflowId: pristineWorkflowData.id,
 	};
 
 	if (retryOf !== undefined) {

--- a/packages/cli/src/executions/executions.service.ts
+++ b/packages/cli/src/executions/executions.service.ts
@@ -281,7 +281,7 @@ export class ExecutionsService {
 		if (req.body.loadWorkflow) {
 			// Loads the currently saved workflow to execute instead of the
 			// one saved at the time of the execution.
-			const workflowId = execution.workflowData.id as string;
+			const workflowId = execution.workflowData.id;
 			const workflowData = (await Container.get(WorkflowRepository).findOneBy({
 				id: workflowId,
 			})) as IWorkflowBase;
@@ -296,7 +296,7 @@ export class ExecutionsService {
 			data.workflowData = workflowData;
 			const nodeTypes = Container.get(NodeTypes);
 			const workflowInstance = new Workflow({
-				id: workflowData.id as string,
+				id: workflowData.id,
 				name: workflowData.name,
 				nodes: workflowData.nodes,
 				connections: workflowData.connections,

--- a/packages/cli/test/unit/WaitTracker.test.ts
+++ b/packages/cli/test/unit/WaitTracker.test.ts
@@ -1,114 +1,83 @@
 import { WaitTracker } from '@/WaitTracker';
 import { mock } from 'jest-mock-extended';
-import { mockInstance } from '../shared/mocking';
-import { OwnershipService } from '@/services/ownership.service';
-import { User } from '@/databases/entities/User';
-import { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { IExecutionResponse } from '@/Interfaces';
-import { Logger } from '@/Logger';
-import Container from 'typedi';
-import { Push } from '@/push';
-import { ActiveExecutions } from '@/ActiveExecutions';
 
 jest.useFakeTimers();
 
-Container.set(Logger, mockInstance(Logger));
-Container.set(Push, mockInstance(Push));
-Container.set(ActiveExecutions, mockInstance(ActiveExecutions));
-
-const workflowOwner = new User();
-workflowOwner.id = '123';
-
-let executionsToReturn: IExecutionResponse[] = [];
-let executionToReturn: IExecutionResponse | undefined;
-
-let startExecutionSpy: jest.SpyInstance;
-
-const executionRepositoryFindSingleExecutionMock = jest.fn(async () => executionToReturn);
-const executionRepositoryGetWaitingExecutionsMock = jest.fn(async () => executionsToReturn);
-const executionRepositoryUpdateExistingExecutionMock = jest.fn();
-
-const ownershipServiceGetWorkflowOwnerCachedMock = jest.fn(async () => {
-	console.log('potato');
-	return workflowOwner;
-});
-
-const fakeExecution: IExecutionResponse = {
-	id: '123',
-	data: { resultData: { runData: {} } },
-	workflowData: {
-		id: '456',
-		name: 'Test workflow',
-		active: true,
-		createdAt: new Date(),
-		updatedAt: new Date(),
-		nodes: [],
-		connections: {},
-	},
-	mode: 'trigger',
-	startedAt: new Date(),
-	finished: false,
-	status: 'new',
-	waitTill: new Date(new Date().getTime() + 1000),
-};
-
 describe('WaitTracker', () => {
-	let waitTracker: WaitTracker;
+	const executionRepository = mock<ExecutionRepository>();
 
-	beforeEach(() => {
-		waitTracker = new WaitTracker(
-			mock(),
-			mockInstance(ExecutionRepository, {
-				// @ts-expect-error
-				// We won't be implementing all overrides here
-				findSingleExecution: executionRepositoryFindSingleExecutionMock,
-				getWaitingExecutions: executionRepositoryGetWaitingExecutionsMock,
-				updateExistingExecution: executionRepositoryUpdateExistingExecutionMock,
-			}),
-			mockInstance(OwnershipService),
-		);
-		startExecutionSpy = jest.spyOn(waitTracker, 'startExecution');
+	const execution = mock<IExecutionResponse>({
+		id: '123',
+		waitTill: new Date(Date.now() + 1000),
 	});
 
 	afterEach(() => {
-		waitTracker.shutdown();
+		jest.clearAllMocks();
 	});
 
-	describe('getWaitingExecutions', () => {
-		it('Should reach out to the database when constructed', async () => {
-			expect(executionRepositoryGetWaitingExecutionsMock).toHaveBeenCalledTimes(1);
+	describe('constructor()', () => {
+		it('should query DB for waiting executions', async () => {
+			executionRepository.getWaitingExecutions.mockResolvedValue([execution]);
+
+			new WaitTracker(mock(), executionRepository, mock());
+
+			expect(executionRepository.getWaitingExecutions).toHaveBeenCalledTimes(1);
 		});
 
-		it('Should do nothing when there are no executions to start', async () => {
-			await waitTracker.getWaitingExecutions();
+		it('if no executions to start, should do nothing', () => {
+			executionRepository.getWaitingExecutions.mockResolvedValue([]);
 
-			expect(executionRepositoryFindSingleExecutionMock).not.toHaveBeenCalled();
+			new WaitTracker(mock(), executionRepository, mock());
+
+			expect(executionRepository.findSingleExecution).not.toHaveBeenCalled();
 		});
 
-		it('Should not call start execution when there is an execution to start but not enough time pass', async () => {
-			executionsToReturn = [fakeExecution];
+		describe('if execution to start', () => {
+			it('if not enough time passed, should not start execution', async () => {
+				executionRepository.getWaitingExecutions.mockResolvedValue([execution]);
+				const waitTracker = new WaitTracker(mock(), executionRepository, mock());
 
-			await waitTracker.getWaitingExecutions();
-			jest.advanceTimersByTime(100);
-			expect(startExecutionSpy).not.toHaveBeenCalled();
-		});
+				executionRepository.getWaitingExecutions.mockResolvedValue([execution]);
+				await waitTracker.getWaitingExecutions();
 
-		it('Should call start execution when there is an execution to start and enough time elapsed', async () => {
-			executionsToReturn = [fakeExecution];
+				const startExecutionSpy = jest.spyOn(waitTracker, 'startExecution');
 
-			await waitTracker.getWaitingExecutions();
-			jest.advanceTimersByTime(20000);
-			expect(startExecutionSpy).toHaveBeenCalledWith('123');
+				jest.advanceTimersByTime(100);
+
+				expect(startExecutionSpy).not.toHaveBeenCalled();
+			});
+
+			it('if enough time passed, should start execution', async () => {
+				executionRepository.getWaitingExecutions.mockResolvedValue([]);
+				const waitTracker = new WaitTracker(mock(), executionRepository, mock());
+
+				executionRepository.getWaitingExecutions.mockResolvedValue([execution]);
+				await waitTracker.getWaitingExecutions();
+
+				const startExecutionSpy = jest.spyOn(waitTracker, 'startExecution');
+
+				jest.advanceTimersByTime(2_000);
+
+				expect(startExecutionSpy).toHaveBeenCalledWith(execution.id);
+			});
 		});
 	});
 
-	describe('startExecution', () => {
-		it('Should fetch execution when called', async () => {
-			executionRepositoryFindSingleExecutionMock.mockClear();
-			executionRepositoryFindSingleExecutionMock.mockResolvedValue(fakeExecution);
-			waitTracker.startExecution('123');
+	describe('startExecution()', () => {
+		it('should query for execution to start', async () => {
+			executionRepository.getWaitingExecutions.mockResolvedValue([]);
+			const waitTracker = new WaitTracker(mock(), executionRepository, mock());
+
+			executionRepository.findSingleExecution.mockResolvedValue(execution);
+			waitTracker.startExecution(execution.id);
 			jest.advanceTimersByTime(5);
-			expect(executionRepositoryFindSingleExecutionMock).toHaveBeenCalled();
+
+			expect(executionRepository.findSingleExecution).toHaveBeenCalledWith(execution.id, {
+				includeData: true,
+				unflattenData: true,
+			});
 		});
 	});
 });

--- a/packages/cli/test/unit/WaitTracker.test.ts
+++ b/packages/cli/test/unit/WaitTracker.test.ts
@@ -1,0 +1,114 @@
+import { WaitTracker } from '@/WaitTracker';
+import { mock } from 'jest-mock-extended';
+import { mockInstance } from '../shared/mocking';
+import { OwnershipService } from '@/services/ownership.service';
+import { User } from '@/databases/entities/User';
+import { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import type { IExecutionResponse } from '@/Interfaces';
+import { Logger } from '@/Logger';
+import Container from 'typedi';
+import { Push } from '@/push';
+import { ActiveExecutions } from '@/ActiveExecutions';
+
+jest.useFakeTimers();
+
+Container.set(Logger, mockInstance(Logger));
+Container.set(Push, mockInstance(Push));
+Container.set(ActiveExecutions, mockInstance(ActiveExecutions));
+
+const workflowOwner = new User();
+workflowOwner.id = '123';
+
+let executionsToReturn: IExecutionResponse[] = [];
+let executionToReturn: IExecutionResponse | undefined;
+
+let startExecutionSpy: jest.SpyInstance;
+
+const executionRepositoryFindSingleExecutionMock = jest.fn(async () => executionToReturn);
+const executionRepositoryGetWaitingExecutionsMock = jest.fn(async () => executionsToReturn);
+const executionRepositoryUpdateExistingExecutionMock = jest.fn();
+
+const ownershipServiceGetWorkflowOwnerCachedMock = jest.fn(async () => {
+	console.log('potato');
+	return workflowOwner;
+});
+
+const fakeExecution: IExecutionResponse = {
+	id: '123',
+	data: { resultData: { runData: {} } },
+	workflowData: {
+		id: '456',
+		name: 'Test workflow',
+		active: true,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		nodes: [],
+		connections: {},
+	},
+	mode: 'trigger',
+	startedAt: new Date(),
+	finished: false,
+	status: 'new',
+	waitTill: new Date(new Date().getTime() + 1000),
+};
+
+describe('WaitTracker', () => {
+	let waitTracker: WaitTracker;
+
+	beforeEach(() => {
+		waitTracker = new WaitTracker(
+			mock(),
+			mockInstance(ExecutionRepository, {
+				// @ts-expect-error
+				// We won't be implementing all overrides here
+				findSingleExecution: executionRepositoryFindSingleExecutionMock,
+				getWaitingExecutions: executionRepositoryGetWaitingExecutionsMock,
+				updateExistingExecution: executionRepositoryUpdateExistingExecutionMock,
+			}),
+			mockInstance(OwnershipService),
+		);
+		startExecutionSpy = jest.spyOn(waitTracker, 'startExecution');
+	});
+
+	afterEach(() => {
+		waitTracker.shutdown();
+	});
+
+	describe('getWaitingExecutions', () => {
+		it('Should reach out to the database when constructed', async () => {
+			expect(executionRepositoryGetWaitingExecutionsMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('Should do nothing when there are no executions to start', async () => {
+			await waitTracker.getWaitingExecutions();
+
+			expect(executionRepositoryFindSingleExecutionMock).not.toHaveBeenCalled();
+		});
+
+		it('Should not call start execution when there is an execution to start but not enough time pass', async () => {
+			executionsToReturn = [fakeExecution];
+
+			await waitTracker.getWaitingExecutions();
+			jest.advanceTimersByTime(100);
+			expect(startExecutionSpy).not.toHaveBeenCalled();
+		});
+
+		it('Should call start execution when there is an execution to start and enough time elapsed', async () => {
+			executionsToReturn = [fakeExecution];
+
+			await waitTracker.getWaitingExecutions();
+			jest.advanceTimersByTime(20000);
+			expect(startExecutionSpy).toHaveBeenCalledWith('123');
+		});
+	});
+
+	describe('startExecution', () => {
+		it('Should fetch execution when called', async () => {
+			executionRepositoryFindSingleExecutionMock.mockClear();
+			executionRepositoryFindSingleExecutionMock.mockResolvedValue(fakeExecution);
+			waitTracker.startExecution('123');
+			jest.advanceTimersByTime(5);
+			expect(executionRepositoryFindSingleExecutionMock).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1884,7 +1884,7 @@ export interface IWaitingForExecutionSource {
 }
 
 export interface IWorkflowBase {
-	id?: string;
+	id: string;
 	name: string;
 	active: boolean;
 	createdAt: Date;
@@ -1921,7 +1921,7 @@ export interface IWorkflowExecuteAdditionalData {
 		additionalData: IWorkflowExecuteAdditionalData,
 		options: {
 			node?: INode;
-			parentWorkflowId?: string;
+			parentWorkflowId: string;
 			inputData?: INodeExecutionData[];
 			parentExecutionId?: string;
 			loadedWorkflowData?: IWorkflowBase;


### PR DESCRIPTION
## Summary
This PR attempts to assert that workflow and execution ID are always present in the backend.
This covers:

- Creation of new executions (should always contain `workflowData.id` with valid value



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1147/ensure-all-workflows-have-ids



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.