### PR TITLE
fix(API): Fix manual chat trigger execution

### DIFF
--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -6,6 +6,7 @@ import {
 	type IHttpRequestMethods,
 	WebhookPathTakenError,
 	Workflow,
+IRunData,
 } from 'n8n-workflow';
 import type {
 	IResponseCallbackData,
@@ -189,6 +190,7 @@ export class TestWebhooks implements IWebhookManager {
 		userId: string,
 		workflowEntity: IWorkflowDb,
 		additionalData: IWorkflowExecuteAdditionalData,
+		runData?: IRunData,
 		sessionId?: string,
 		destinationNode?: string,
 	) {
@@ -212,6 +214,10 @@ export class TestWebhooks implements IWebhookManager {
 		for (const webhook of webhooks) {
 			const key = this.registrations.toKey(webhook);
 			const registration = await this.registrations.get(key);
+
+			if (runData && webhook.node in runData) {
+				return false;
+			}
 
 			if (registration && !webhook.webhookId) {
 				throw new WebhookPathTakenError(webhook.node);

--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -1,12 +1,11 @@
 import type express from 'express';
 import { Service } from 'typedi';
-import {
-	type IWebhookData,
-	type IWorkflowExecuteAdditionalData,
-	type IHttpRequestMethods,
-	WebhookPathTakenError,
-	Workflow,
-IRunData,
+import { WebhookPathTakenError, Workflow } from 'n8n-workflow';
+import type {
+	IWebhookData,
+	IWorkflowExecuteAdditionalData,
+	IHttpRequestMethods,
+	IRunData,
 } from 'n8n-workflow';
 import type {
 	IResponseCallbackData,

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -320,6 +320,7 @@ export class WorkflowService {
 				user.id,
 				workflowData,
 				additionalData,
+				runData,
 				sessionId,
 				destinationNode,
 			);


### PR DESCRIPTION
## Summary

Due to wrongly resolved [merge conflict](https://github.com/n8n-io/n8n/pull/7409/commits/e857ba930fc76d9213d00ce8c957a48683a9a761), the `needsWebhook` function incorrectly returns `true` for manual chat trigger execution. To fix this, we need to pass the runData and check if webhook runData is already set.