### PR TITLE
fix(core): Prevent NodeErrors from being wrapped multiple times

### DIFF
--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -45,6 +45,8 @@ export abstract class NodeError extends ExecutionBaseError {
 		}
 
 		this.node = node;
+
+		if (error instanceof NodeError) return error;
 	}
 
 	/**

--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -35,18 +35,16 @@ const COMMON_ERRORS: IDataObject = {
  * a value recursively inside an error object.
  */
 export abstract class NodeError extends ExecutionBaseError {
-	node: INode;
-
-	constructor(node: INode, error: Error | JsonObject) {
-		if (error instanceof Error) {
-			super(error.message, { cause: error });
-		} else {
-			super('', { errorResponse: error });
-		}
-
-		this.node = node;
-
+	constructor(
+		readonly node: INode,
+		error: Error | JsonObject,
+	) {
 		if (error instanceof NodeError) return error;
+
+		const isError = error instanceof Error;
+		const message = isError ? error.message : '';
+		const options = isError ? { cause: error } : { errorResponse: error };
+		super(message, options);
 	}
 
 	/**

--- a/packages/workflow/test/errors/node.error.test.ts
+++ b/packages/workflow/test/errors/node.error.test.ts
@@ -1,0 +1,16 @@
+import { mock } from 'jest-mock-extended';
+import type { INode } from '@/Interfaces';
+import { NodeApiError } from '@/errors/node-api.error';
+import { NodeOperationError } from '@/errors/node-operation.error';
+
+describe('NodeError', () => {
+	const node = mock<INode>();
+
+	it('should prevent errors from being re-wrapped', () => {
+		const apiError = new NodeApiError(node, mock({ message: 'Some error happened', code: 500 }));
+		const opsError = new NodeOperationError(node, mock());
+
+		expect(new NodeOperationError(node, apiError)).toEqual(apiError);
+		expect(new NodeOperationError(node, opsError)).toEqual(opsError);
+	});
+});


### PR DESCRIPTION
This change will prevent nodes code from creating `NodeOperationError` wrapping other instances of `NodeError`, hopefully reducing the number of layers in error chains. 

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included