### PR TITLE
feat: Redirect users without feature flag from template cred setup (no-changelog)

### DIFF
--- a/cypress/composables/featureFlags.ts
+++ b/cypress/composables/featureFlags.ts
@@ -1,0 +1,12 @@
+export const overrideFeatureFlag = (name: string, value: boolean | string) => {
+	cy.window().then((win) => {
+		// If feature flags hasn't been initialized yet, we store the override
+		// in local storage and it gets loaded when the feature flags are
+		// initialized.
+		win.localStorage.setItem('N8N_EXPERIMENT_OVERRIDES', JSON.stringify({ [name]: value }));
+
+		if (win.featureFlags) {
+			win.featureFlags.override(name, value);
+		}
+	});
+};

--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -38,6 +38,7 @@ describe('Template credentials setup', () => {
 
 	it('can be opened from template workflow page', () => {
 		templateWorkflowPage.actions.visit(testTemplate.id);
+		templateCredentialsSetupPage.enableTemplateCredentialSetupFeatureFlag();
 		templateWorkflowPage.getters.useTemplateButton().should('be.visible');
 		templateCredentialsSetupPage.enableTemplateCredentialSetupFeatureFlag();
 		templateWorkflowPage.actions.clickUseThisWorkflowButton();
@@ -51,14 +52,6 @@ describe('Template credentials setup', () => {
 		visitTemplateCollectionPage(testData.ecommerceStarterPack);
 		templateCredentialsSetupPage.enableTemplateCredentialSetupFeatureFlag();
 		clickUseWorkflowButtonByTitle('Promote new Shopify products on Twitter and Telegram');
-
-		templateCredentialsSetupPage.getters
-			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)
-			.should('be.visible');
-	});
-
-	it('can be opened with a direct url', () => {
-		templateCredentialsSetupPage.visitTemplateCredentialSetupPage(testTemplate.id);
 
 		templateCredentialsSetupPage.getters
 			.title(`Set up 'Promote new Shopify products on Twitter and Telegram' template`)

--- a/cypress/pages/template-credential-setup.ts
+++ b/cypress/pages/template-credential-setup.ts
@@ -1,5 +1,6 @@
 import { CredentialsModal, MessageBox } from './modals';
 import * as formStep from '../composables/setup-template-form-step';
+import { overrideFeatureFlag } from '../composables/featureFlags';
 
 export type TemplateTestData = {
 	id: number;
@@ -28,15 +29,14 @@ export const getters = {
 };
 
 export const enableTemplateCredentialSetupFeatureFlag = () => {
-	cy.window().then((win) => {
-		win.featureFlags.override('017_template_credential_setup_v2', true);
-	});
+	overrideFeatureFlag('017_template_credential_setup_v2', true);
 };
 
 export const visitTemplateCredentialSetupPage = (templateId: number) => {
-	cy.visit(`/templates/${templateId}/setup`);
-	formStep.getFormStep().eq(0).should('be.visible');
+	cy.visit(`templates/${templateId}/setup`);
 	enableTemplateCredentialSetupFeatureFlag();
+
+	formStep.getFormStep().eq(0).should('be.visible');
 };
 
 /**

--- a/cypress/pages/template-workflow.ts
+++ b/cypress/pages/template-workflow.ts
@@ -5,7 +5,7 @@ export class TemplateWorkflowPage extends BasePage {
 
 	getters = {
 		useTemplateButton: () => cy.get('[data-test-id="use-template-button"]'),
-		description: () => cy.get('[data-test-id="template-description"]')
+		description: () => cy.get('[data-test-id="template-description"]'),
 	};
 
 	actions = {
@@ -17,7 +17,15 @@ export class TemplateWorkflowPage extends BasePage {
 			this.getters.useTemplateButton().click();
 		},
 
-		openTemplate: (template: {workflow: {id: number, name: string, description: string, user: {username: string}, image: {id: number, url: string}[] }}) => {
+		openTemplate: (template: {
+			workflow: {
+				id: number;
+				name: string;
+				description: string;
+				user: { username: string };
+				image: { id: number; url: string }[];
+			};
+		}) => {
 			cy.intercept('GET', `https://api.n8n.io/api/templates/workflows/${template.workflow.id}`, {
 				statusCode: 200,
 				body: template,

--- a/packages/editor-ui/src/utils/templates/__tests__/templateActions.test.ts
+++ b/packages/editor-ui/src/utils/templates/__tests__/templateActions.test.ts
@@ -67,6 +67,7 @@ describe('templateActions', () => {
 					templateId,
 					templatesStore,
 					router,
+					source: 'workflow',
 				});
 			});
 
@@ -75,18 +76,6 @@ describe('templateActions', () => {
 					name: VIEWS.TEMPLATE_IMPORT,
 					params: { id: templateId },
 				});
-			});
-
-			it("should track 'User inserted workflow template'", async () => {
-				expect(telemetry.track).toHaveBeenCalledWith(
-					'User inserted workflow template',
-					{
-						source: 'workflow',
-						template_id: templateId,
-						wf_template_repo_session_id: '',
-					},
-					{ withPostHog: true },
-				);
 			});
 		});
 
@@ -111,6 +100,7 @@ describe('templateActions', () => {
 					templateId,
 					templatesStore,
 					router,
+					source: 'workflow',
 				});
 			});
 
@@ -144,6 +134,7 @@ describe('templateActions', () => {
 					templateId,
 					templatesStore,
 					router,
+					source: 'workflow',
 				});
 			});
 

--- a/packages/editor-ui/src/utils/templates/templateActions.ts
+++ b/packages/editor-ui/src/utils/templates/templateActions.ts
@@ -98,9 +98,8 @@ async function openTemplateWorkflowOnNodeView(opts: {
 	templatesStore: TemplatesStore;
 	router: Router;
 	inNewBrowserTab?: boolean;
-	telemetry: Telemetry;
 }) {
-	const { externalHooks, templateId, templatesStore, telemetry, inNewBrowserTab, router } = opts;
+	const { externalHooks, templateId, templatesStore, inNewBrowserTab, router } = opts;
 	const routeLocation: RouteLocationRaw = {
 		name: VIEWS.TEMPLATE_IMPORT,
 		params: { id: templateId },
@@ -111,9 +110,6 @@ async function openTemplateWorkflowOnNodeView(opts: {
 		wf_template_repo_session_id: templatesStore.currentSessionId,
 	};
 
-	telemetry.track('User inserted workflow template', telemetryPayload, {
-		withPostHog: true,
-	});
 	await externalHooks.run('templatesWorkflowView.openWorkflow', telemetryPayload);
 
 	if (inNewBrowserTab) {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1305,6 +1305,18 @@ export default defineComponent({
 				return;
 			}
 
+			this.$telemetry.track(
+				'User inserted workflow template',
+				{
+					source: 'workflow',
+					template_id: templateId,
+					wf_template_repo_session_id: this.templatesStore.previousSessionId,
+				},
+				{
+					withPostHog: true,
+				},
+			);
+
 			this.blankRedirect = true;
 			await this.$router.replace({ name: VIEWS.NEW_WORKFLOW, query: { templateId } });
 

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, onBeforeMount, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useSetupTemplateStore } from './setupTemplate.store';
 import N8nHeading from 'n8n-design-system/components/N8nHeading';
@@ -19,15 +19,6 @@ const posthogStore = usePostHog();
 // Router
 const route = useRoute();
 const router = useRouter();
-
-const currentTemplateId = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id;
-
-if (!posthogStore.isFeatureEnabled(TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT)) {
-	void router.replace({
-		name: VIEWS.TEMPLATE_IMPORT,
-		params: { id: currentTemplateId },
-	});
-}
 
 //#region Computed
 
@@ -87,6 +78,15 @@ const skipIfTemplateHasNoCreds = async () => {
 //#region Lifecycle hooks
 
 setupTemplateStore.setTemplateId(templateId.value);
+
+onBeforeMount(async () => {
+	if (!posthogStore.isFeatureEnabled(TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT)) {
+		void router.replace({
+			name: VIEWS.TEMPLATE_IMPORT,
+			params: { id: templateId.value },
+		});
+	}
+});
 
 onMounted(async () => {
 	await setupTemplateStore.init();

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue
@@ -7,18 +7,27 @@ import N8nLink from 'n8n-design-system/components/N8nLink';
 import AppsRequiringCredsNotice from './AppsRequiringCredsNotice.vue';
 import SetupTemplateFormStep from './SetupTemplateFormStep.vue';
 import TemplatesView from '../TemplatesView.vue';
-import { VIEWS } from '@/constants';
+import { TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT, VIEWS } from '@/constants';
 import { useI18n } from '@/composables/useI18n';
-import { useTelemetry } from '@/composables/useTelemetry';
+import { usePostHog } from '@/stores/posthog.store';
 
 // Store
 const setupTemplateStore = useSetupTemplateStore();
 const i18n = useI18n();
-const telemetry = useTelemetry();
+const posthogStore = usePostHog();
 
 // Router
 const route = useRoute();
 const router = useRouter();
+
+const currentTemplateId = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id;
+
+if (!posthogStore.isFeatureEnabled(TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT)) {
+	void router.replace({
+		name: VIEWS.TEMPLATE_IMPORT,
+		params: { id: currentTemplateId },
+	});
+}
 
 //#region Computed
 

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -153,16 +153,6 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 			wf_template_repo_session_id: templatesStore.currentSessionId,
 		});
 
-		telemetry.track(
-			'User inserted workflow template',
-			{
-				source: 'workflow',
-				template_id: templateId.value,
-				wf_template_repo_session_id: templatesStore.currentSessionId,
-			},
-			{ withPostHog: true },
-		);
-
 		telemetry.track('User closed cred setup', {
 			completed: false,
 			creds_filled: 0,


### PR DESCRIPTION
## Summary

- Move 'User inserted workflow template' telemetry event to NodeView
    This way the event gets fired in all scenarios and we don't have to remember to add it everywhere.
- Redirect users without feature flag from template cred setup to NodeView


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 