### PR TITLE
fix: Disable `@typescript-eslint/no-use-before-define` rule (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/frontend.js
+++ b/packages/@n8n_io/eslint-config/frontend.js
@@ -36,6 +36,7 @@ module.exports = {
 		'vue/v-slot-style': 'error',
 		'vue/no-unused-components': 'error',
 		'vue/multi-word-component-names': 'off',
+		'@typescript-eslint/no-use-before-define': 'off',
 		'@typescript-eslint/no-explicit-any': 'error',
 		'vue/component-name-in-template-casing': [
 			'error',

--- a/packages/editor-ui/.eslintrc.js
+++ b/packages/editor-ui/.eslintrc.js
@@ -33,7 +33,6 @@ module.exports = {
 		'@typescript-eslint/no-unnecessary-type-assertion': 'warn',
 		'@typescript-eslint/no-unused-expressions': 'warn',
 		'@typescript-eslint/no-unused-vars': 'warn',
-		'@typescript-eslint/no-use-before-define': 'warn',
 		'@typescript-eslint/no-var-requires': 'warn',
 		'@typescript-eslint/prefer-nullish-coalescing': 'warn',
 		'@typescript-eslint/prefer-optional-chain': 'warn',


### PR DESCRIPTION
## Summary
Disabling this rule as discussed in the Front End engineering meeting.


## Related tickets and issues
https://linear.app/n8n/issue/PAY-1193/disable-eslint-rule-for-using-function-before-definition-on-the-front

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 