### PR TITLE
fix(Supabase Node): Pagination for get all rows

### DIFF
--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -310,12 +310,18 @@ export class Supabase implements INodeType {
 						qs.limit = this.getNodeParameter('limit', 0);
 					}
 
-					let rows;
+					let rows: IDataObject[] = [];
 
 					try {
-						rows = await supabaseApiRequest.call(this, 'GET', endpoint, {}, qs);
+						let responseLength = 0;
+						do {
+							const newRows = await supabaseApiRequest.call(this, 'GET', endpoint, {}, qs);
+							responseLength = newRows.length;
+							rows = rows.concat(newRows);
+							qs.offset = rows.length;
+						} while (responseLength >= 1000);
 						const executionData = this.helpers.constructExecutionMetaData(
-							this.helpers.returnJsonArray(rows as IDataObject[]),
+							this.helpers.returnJsonArray(rows),
 							{ itemData: { item: i } },
 						);
 						returnData.push(...executionData);


### PR DESCRIPTION
## Summary
Get Many will now return all rows from table

## Related tickets and issues
https://community.n8n.io/t/bug-supabase-get-rows-is-limited-to-1-000/32226
https://linear.app/n8n/issue/NODE-894/supabase-using-row-get-many-with-return-all-only-returns-first-1000