### PR TITLE
fix(core): Prevent invalid compressed responses from making executions stuck forever

### DIFF
--- a/packages/core/src/BinaryData/utils.ts
+++ b/packages/core/src/BinaryData/utils.ts
@@ -33,8 +33,14 @@ export async function doesNotExist(dir: string) {
 }
 
 export async function toBuffer(body: Buffer | Readable) {
-	return new Promise<Buffer>((resolve) => {
-		if (Buffer.isBuffer(body)) resolve(body);
-		else body.pipe(concatStream(resolve));
+	if (Buffer.isBuffer(body)) return body;
+	return new Promise<Buffer>((resolve, reject) => {
+		body
+			.once('error', (cause) => {
+				if ('code' in cause && cause.code === 'Z_DATA_ERROR')
+					reject(new Error('Failed to decompress response', { cause }));
+				else reject(cause);
+			})
+			.pipe(concatStream(resolve));
 	});
 }

--- a/packages/core/test/BinaryData/utils.test.ts
+++ b/packages/core/test/BinaryData/utils.test.ts
@@ -1,0 +1,31 @@
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import { toBuffer } from '@/BinaryData/utils';
+
+describe('BinaryData/utils', () => {
+	describe('toBuffer', () => {
+		it('should handle buffer objects', async () => {
+			const body = Buffer.from('test');
+			expect((await toBuffer(body)).toString()).toEqual('test');
+		});
+
+		it('should handle valid uncompressed Readable streams', async () => {
+			const body = Readable.from(Buffer.from('test'));
+			expect((await toBuffer(body)).toString()).toEqual('test');
+		});
+
+		it('should handle valid compressed Readable streams', async () => {
+			const gunzip = createGunzip();
+			const body = Readable.from(
+				Buffer.from('1f8b08000000000000032b492d2e01000c7e7fd804000000', 'hex'),
+			).pipe(gunzip);
+			expect((await toBuffer(body)).toString()).toEqual('test');
+		});
+
+		it('should throw on invalid compressed Readable streams', async () => {
+			const gunzip = createGunzip();
+			const body = Readable.from(Buffer.from('0001f8b080000000000000000', 'hex')).pipe(gunzip);
+			await expect(toBuffer(body)).rejects.toThrow(new Error('Failed to decompress response'));
+		});
+	});
+});


### PR DESCRIPTION
## Summary
When a service responds with compressed data that is partial, invalid, or contains trailing garbage, it can cause an execution to get stuck forever. 
This PR detects this scenario and throws an explicit error in this case.

## Related tickets and issues
NODE-1000

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included