### PR TITLE
refactor(core): Continue moving `typeorm` operators to repositories (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/role.repository.ts
+++ b/packages/cli/src/databases/repositories/role.repository.ts
@@ -39,4 +39,8 @@ export class RoleRepository extends Repository<Role> {
 			where: { name: In(roleNames), scope: 'workflow' },
 		}).then((role) => role.map(({ id }) => id));
 	}
+
+	async findByName(roleName: RoleNames) {
+		return this.find({ where: { name: roleName } });
+	}
 }

--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -141,4 +141,16 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			workflowId: In(sharedWorkflowIds),
 		});
 	}
+
+	async findWorkflowIdsByUser(user: User, { roles }: { roles?: Role[] } = {}) {
+		const where: FindOptionsWhere<SharedWorkflow> = {};
+
+		if (!user.hasGlobalScope('workflow:read')) where.userId = user.id;
+
+		if (roles) where.role = In(roles.map((r) => r.id));
+
+		const sharings = await this.find({ select: ['workflowId'], where });
+
+		return sharings.map((s) => s.workflowId);
+	}
 }

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -54,12 +54,12 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		});
 	}
 
-	async findByIds(workflowIds: string[], { fields }: { fields?: string[] } = {}) {
+	async findByIds(workflowIds: string[], { select }: { select?: string[] } = {}) {
 		const options: FindManyOptions<WorkflowEntity> = {
 			where: { id: In(workflowIds) },
 		};
 
-		if (fields?.length) options.select = fields as FindOptionsSelect<WorkflowEntity>;
+		if (select?.length) options.select = select as FindOptionsSelect<WorkflowEntity>;
 
 		return this.find(options);
 	}

--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -226,7 +226,7 @@ export class SourceControlImportService {
 		const workflowRunner = this.activeWorkflowRunner;
 		const candidateIds = candidates.map((c) => c.id);
 		const existingWorkflows = await Container.get(WorkflowRepository).findByIds(candidateIds, {
-			fields: ['id', 'name', 'versionId', 'active'],
+			select: ['id', 'name', 'versionId', 'active'],
 		});
 		const allSharedWorkflows = await Container.get(SharedWorkflowRepository).findWithFields(
 			candidateIds,

--- a/packages/cli/src/executions/executions.service.ee.ts
+++ b/packages/cli/src/executions/executions.service.ee.ts
@@ -1,5 +1,4 @@
 import type { User } from '@db/entities/User';
-import { getSharedWorkflowIds } from '@/WorkflowHelpers';
 import { ExecutionsService } from './executions.service';
 import type { ExecutionRequest } from '@/requests';
 import type { IExecutionResponse, IExecutionFlattedResponse } from '@/Interfaces';
@@ -7,6 +6,7 @@ import { EnterpriseWorkflowService } from '../workflows/workflow.service.ee';
 import type { WorkflowWithSharingsAndCredentials } from '@/workflows/workflows.types';
 import Container from 'typedi';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 
 export class EEExecutionsService extends ExecutionsService {
 	/**
@@ -14,7 +14,7 @@ export class EEExecutionsService extends ExecutionsService {
 	 */
 	static async getWorkflowIdsForUser(user: User): Promise<string[]> {
 		// Get all workflows
-		return getSharedWorkflowIds(user);
+		return Container.get(SharedWorkflowRepository).findWorkflowIdsByUser(user);
 	}
 
 	static async getExecution(

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -142,9 +142,12 @@ export class WorkflowsController {
 	@Get('/', { middlewares: listQueryMiddleware })
 	async getAll(req: ListQuery.Request, res: express.Response) {
 		try {
-			const roles: Role[] = isSharingEnabled()
-				? []
-				: await Container.get(RoleRepository).findByName('owner');
+			const roles: Role[] = [];
+
+			if (!isSharingEnabled()) {
+				const role = await Container.get(RoleRepository).findRole('workflow', 'owner');
+				if (role) roles.push(role);
+			}
 
 			const sharedWorkflowIds = await Container.get(SharedWorkflowRepository).findWorkflowIdsByUser(
 				req.user,

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -32,12 +32,13 @@ import { NamingService } from '@/services/naming.service';
 import { TagRepository } from '@/databases/repositories/tag.repository';
 import { EnterpriseWorkflowService } from './workflow.service.ee';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import type { RoleNames } from '@/databases/entities/Role';
+import type { Role } from '@/databases/entities/Role';
 import { UnauthorizedError } from '@/errors/response-errors/unauthorized.error';
 import { CredentialsService } from '../credentials/credentials.service';
 import { UserRepository } from '@/databases/repositories/user.repository';
 import { Authorized, Delete, Get, Patch, Post, Put, RestController } from '@/decorators';
 import { WorkflowRequest } from './workflow.request';
+import { RoleRepository } from '@/databases/repositories/role.repository';
 
 @Service()
 @Authorized()
@@ -141,8 +142,14 @@ export class WorkflowsController {
 	@Get('/', { middlewares: listQueryMiddleware })
 	async getAll(req: ListQuery.Request, res: express.Response) {
 		try {
-			const roles: RoleNames[] = isSharingEnabled() ? [] : ['owner'];
-			const sharedWorkflowIds = await WorkflowHelpers.getSharedWorkflowIds(req.user, roles);
+			const roles: Role[] = isSharingEnabled()
+				? []
+				: await Container.get(RoleRepository).findByName('owner');
+
+			const sharedWorkflowIds = await Container.get(SharedWorkflowRepository).findWorkflowIdsByUser(
+				req.user,
+				{ roles },
+			);
 
 			const { workflows: data, count } = await Container.get(WorkflowService).getMany(
 				sharedWorkflowIds,


### PR DESCRIPTION
Subset of #8243 to narrow down what is breaking e2e tests there.

e2e: https://github.com/n8n-io/n8n/actions/runs/7503649510