### PR TITLE
fix(Ollama Model Node): Use a simpler credentials test

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Validate PR title
         id: validate_pr_title
-        uses: n8n-io/validate-n8n-pull-request-title@v1.1
+        uses: n8n-io/validate-n8n-pull-request-title@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/OllamaApi.credentials.ts
@@ -20,15 +20,8 @@ export class OllamaApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: '={{ $credentials.baseUrl }}',
-			url: '/api/generate',
-			method: 'POST',
-			headers: {
-				'anthropic-version': '2023-06-01',
-			},
-			body: {
-				model: 'llama2',
-				prompt: 'Hello',
-			},
+			url: '/',
+			method: 'GET',
 		},
 	};
 }


### PR DESCRIPTION
## Summary
There are two issues with the current credentials test
1. It assumes that anyone using Ollama has `llama2:latest` downloaded
2. It uses a more expensive inference operation just to determine if the service is reachable.

## Review / Merge checklist
- [x] PR title and summary are descriptive