### PR TITLE
ci: Update the validate-n8n-pull-request-title action (no-changelog)

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Validate PR title
         id: validate_pr_title
-        uses: n8n-io/validate-n8n-pull-request-title@v1.1
+        uses: n8n-io/validate-n8n-pull-request-title@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Use the updated version of the PR title validating action to allow Langchain nodes as well. 

[Changes in the action](https://github.com/n8n-io/validate-n8n-pull-request-title/compare/v1.1...v1.3).

## Review / Merge checklist
- [x] PR title and summary are descriptive