### PR TITLE
fix(Venafi TLS Protect Cloud Node): Remove parameter `Application Server Type`

### DIFF
--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateRequestDescription.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/CertificateRequestDescription.ts
@@ -87,24 +87,6 @@ export const certificateRequestFields: INodeProperties[] = [
 		default: false,
 	},
 	{
-		displayName: 'Application Server Type Name or ID',
-		name: 'applicationServerTypeId',
-		type: 'options',
-		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
-		typeOptions: {
-			loadOptionsMethod: 'getApplicationServerTypes',
-		},
-		displayOptions: {
-			show: {
-				operation: ['create'],
-				resource: ['certificateRequest'],
-				generateCsr: [true],
-			},
-		},
-		default: '',
-	},
-	{
 		displayName: 'Common Name',
 		name: 'commonName',
 		required: true,

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
@@ -88,23 +88,6 @@ export class VenafiTlsProtectCloud implements INodeType {
 				}
 				return returnData;
 			},
-			async getApplicationServerTypes(
-				this: ILoadOptionsFunctions,
-			): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const { applicationServerTypes } = await venafiApiRequest.call(
-					this,
-					'GET',
-					'/outagedetection/v1/applicationservertypes',
-				);
-				for (const applicationServerType of applicationServerTypes) {
-					returnData.push({
-						name: applicationServerType.platformName,
-						value: applicationServerType.id,
-					});
-				}
-				return returnData;
-			},
 			async getCertificateIssuingTemplates(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
@@ -157,10 +140,6 @@ export class VenafiTlsProtectCloud implements INodeType {
 						};
 
 						if (generateCsr) {
-							const applicationServerTypeId = this.getNodeParameter(
-								'applicationServerTypeId',
-								i,
-							) as string;
 							const commonName = this.getNodeParameter('commonName', i) as string;
 							const additionalFields = this.getNodeParameter('additionalFields', i);
 
@@ -169,7 +148,6 @@ export class VenafiTlsProtectCloud implements INodeType {
 							const subjectAltNamesByType: ISubjectAltNamesByType = {};
 
 							body.isVaaSGenerated = true;
-							body.applicationServerTypeId = applicationServerTypeId;
 
 							csrAttributes.commonName = commonName;
 


### PR DESCRIPTION
## Summary
Parameter was removed from the API. 

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))