### PR TITLE
fix(core): Account for immediate confirmation request during test webhook creation

### DIFF
--- a/packages/cli/test/unit/TestWebhooks.test.ts
+++ b/packages/cli/test/unit/TestWebhooks.test.ts
@@ -8,7 +8,7 @@ import * as WebhookHelpers from '@/WebhookHelpers';
 import type * as express from 'express';
 
 import type { IWorkflowDb, WebhookRequest } from '@/Interfaces';
-import type { IWebhookData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import type { IWebhookData, IWorkflowExecuteAdditionalData, Workflow } from 'n8n-workflow';
 import type {
 	TestWebhookRegistrationsService,
 	TestWebhookRegistration,
@@ -50,11 +50,18 @@ describe('TestWebhooks', () => {
 			mock<IWorkflowExecuteAdditionalData>(),
 		];
 
-		test('if webhook is needed, should return true and activate webhook', async () => {
+		test('if webhook is needed, should register then create webhook and return true', async () => {
+			const workflow = mock<Workflow>();
+
+			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(workflow);
 			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook]);
 
 			const needsWebhook = await testWebhooks.needsWebhook(...args);
 
+			const [registerOrder] = registrations.register.mock.invocationCallOrder;
+			const [createOrder] = workflow.createWebhookIfNotExists.mock.invocationCallOrder;
+
+			expect(registerOrder).toBeLessThan(createOrder);
 			expect(needsWebhook).toBe(true);
 		});
 


### PR DESCRIPTION
Some third-party services send a confirmation request immediately on webhook creation - but by the time the confirmation request reaches the server, the test webhook not yet cached, so the confirmation request receives a 404. This PR ensures we register the test webhook _before_ creation at the third-party service. 

Tested in-memory and with Redis.

To test manually, log in to Asana using `nodeqa` in the vault and create a PAT, run `pnpm start:tunnel`, create an Asana credential, create an Asana trigger (resource is e.g. the numeric ID for a task in the URL), and create a test webhook. Creation should succeed, and user-prompted events should be received.

Report: https://n8nio.slack.com/archives/C04B1GZ4T0U/p1705210902129699