### PR TITLE
fix(core): Prevent issues with missing or mismatching encryption key

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -259,6 +259,13 @@ export class Worker extends BaseCommand {
 
 	constructor(argv: string[], cmdConfig: IConfig) {
 		super(argv, cmdConfig);
+
+		if (!process.env.N8N_ENCRYPTION_KEY) {
+			throw new ApplicationError(
+				'Missing environment variable "N8N_ENCRYPTION_KEY" on worker. Please specify the encryption key when starting a worker. For more information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key',
+			);
+		}
+
 		this.setInstanceType('worker');
 		this.setInstanceQueueModeId();
 	}

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -262,7 +262,7 @@ export class Worker extends BaseCommand {
 
 		if (!process.env.N8N_ENCRYPTION_KEY) {
 			throw new ApplicationError(
-				'Missing environment variable "N8N_ENCRYPTION_KEY" on worker. Please specify the encryption key when starting a worker. For more information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key',
+				'Missing encryption key. Worker started without the required N8N_ENCRYPTION_KEY env var. More information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key',
 			);
 		}
 

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -14,7 +14,7 @@ if (inE2ETests) {
 	process.env.N8N_AI_ENABLED = 'true';
 } else if (inTest) {
 	process.env.N8N_LOG_LEVEL = 'silent';
-	process.env.N8N_ENCRYPTION_KEY = 'test-encryption-key';
+	process.env.N8N_ENCRYPTION_KEY = 'test_key';
 	process.env.N8N_PUBLIC_API_DISABLED = 'true';
 	process.env.SKIP_STATISTICS_EVENTS = 'true';
 } else {

--- a/packages/cli/test/setup-test-folder.ts
+++ b/packages/cli/test/setup-test-folder.ts
@@ -11,6 +11,6 @@ process.env.N8N_USER_FOLDER = testDir;
 
 writeFileSync(
 	join(testDir, '.n8n/config'),
-	JSON.stringify({ encryptionKey: 'testkey', instanceId: '123' }),
+	JSON.stringify({ encryptionKey: 'test_key', instanceId: '123' }),
 	'utf-8',
 );

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -41,9 +41,9 @@ export class Credentials extends ICredentials {
 			throw new ApplicationError('No data is set so nothing can be returned.');
 		}
 
-		const decryptedData = this.cipher.decrypt(this.data);
-
 		try {
+			const decryptedData = this.cipher.decrypt(this.data);
+
 			return jsonParse(decryptedData);
 		} catch (e) {
 			throw new ApplicationError(

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -75,12 +75,12 @@ export class InstanceSettings {
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 
-			console.log('[file] encryptionKey', encryptionKey);
-			console.log('[env] N8N_ENCRYPTION_KEY', process.env.N8N_ENCRYPTION_KEY);
+			// console.log('[file] encryptionKey', encryptionKey);
+			// console.log('[env] N8N_ENCRYPTION_KEY', process.env.N8N_ENCRYPTION_KEY);
 
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
-					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY. If specifying this environment variable, please make sure it matches the value in the settings file.`,
+					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY}. If specifying this environment variable, please make sure it matches the value in the settings file.`,
 				);
 			}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -77,7 +77,7 @@ export class InstanceSettings {
 
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
-					`The encryption key ${encryptionKey} in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY} environment variable. Please make sure it matches the value in the settings file, or do not specify it.`,
+					`Mismatching encryption keys. The encryption key in the settings file ${this.settingsFile} does not match the N8N_ENCRYPTION_KEY env var. Please make sure both keys match, or do not specify N8N_ENCRYPTION_KEY so that n8n will use the key in the settings file, or autogenerate one if missing. More information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key`,
 				);
 			}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -77,7 +77,7 @@ export class InstanceSettings {
 
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
-					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY} environment variable. Please make sure it matches the value in the settings file, or do not specify it.`,
+					`The encryption key ${encryptionKey} in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY} environment variable. Please make sure it matches the value in the settings file, or do not specify it.`,
 				);
 			}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -75,11 +75,7 @@ export class InstanceSettings {
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 
-			if (
-				!inTest &&
-				process.env.N8N_ENCRYPTION_KEY &&
-				encryptionKey !== process.env.N8N_ENCRYPTION_KEY
-			) {
+			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
 					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY}. If specifying this environment variable, please make sure it matches the value in the settings file.`,
 				);

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -75,10 +75,11 @@ export class InstanceSettings {
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 
-			// console.log('[file] encryptionKey', encryptionKey);
-			// console.log('[env] N8N_ENCRYPTION_KEY', process.env.N8N_ENCRYPTION_KEY);
-
-			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
+			if (
+				!inTest &&
+				process.env.N8N_ENCRYPTION_KEY &&
+				encryptionKey !== process.env.N8N_ENCRYPTION_KEY
+			) {
 				throw new ApplicationError(
 					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY}. If specifying this environment variable, please make sure it matches the value in the settings file.`,
 				);

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -77,7 +77,7 @@ export class InstanceSettings {
 
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
-					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY}. If specifying this environment variable, please make sure it matches the value in the settings file.`,
+					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY ${process.env.N8N_ENCRYPTION_KEY} environment variable. Please make sure it matches the value in the settings file, or do not specify it.`,
 				);
 			}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -77,7 +77,7 @@ export class InstanceSettings {
 
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
-					`Mismatching encryption keys. The encryption key in the settings file ${this.settingsFile} does not match the N8N_ENCRYPTION_KEY env var. Please make sure both keys match, or do not specify N8N_ENCRYPTION_KEY so that n8n will use the key in the settings file, or autogenerate one if missing. More information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key`,
+					`Mismatching encryption keys. The encryption key in the settings file ${this.settingsFile} does not match the N8N_ENCRYPTION_KEY env var. Please make sure both keys match. More information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key`,
 				);
 			}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -14,6 +14,8 @@ interface WritableSettings {
 
 type Settings = ReadOnlySettings & WritableSettings;
 
+const inTest = process.env.NODE_ENV === 'test';
+
 @Service()
 export class InstanceSettings {
 	private readonly userHome = this.getUserHome();
@@ -69,7 +71,7 @@ export class InstanceSettings {
 				errorMessage: `Error parsing n8n-config file "${this.settingsFile}". It does not seem to be valid JSON.`,
 			});
 
-			console.info(`User settings loaded from: ${this.settingsFile}`);
+			if (!inTest) console.info(`User settings loaded from: ${this.settingsFile}`);
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 
@@ -90,7 +92,7 @@ export class InstanceSettings {
 
 		this.save(settings);
 
-		if (!process.env.N8N_ENCRYPTION_KEY) {
+		if (!inTest && !process.env.N8N_ENCRYPTION_KEY) {
 			console.info(`No encryption key found - Auto-generated and saved to: ${this.settingsFile}`);
 		}
 

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -75,6 +75,9 @@ export class InstanceSettings {
 
 			const { encryptionKey, tunnelSubdomain } = settings;
 
+			console.log('[file] encryptionKey', encryptionKey);
+			console.log('[env] N8N_ENCRYPTION_KEY', process.env.N8N_ENCRYPTION_KEY);
+
 			if (process.env.N8N_ENCRYPTION_KEY && encryptionKey !== process.env.N8N_ENCRYPTION_KEY) {
 				throw new ApplicationError(
 					`The encryption key in the settings file ${this.settingsFile} does not match the one in the N8N_ENCRYPTION_KEY. If specifying this environment variable, please make sure it matches the value in the settings file.`,

--- a/packages/core/test/InstanceSettings.test.ts
+++ b/packages/core/test/InstanceSettings.test.ts
@@ -24,6 +24,12 @@ describe('InstanceSettings', () => {
 			readSpy.mockReturnValue('{"encryptionKey":"test_key"');
 			expect(() => new InstanceSettings()).toThrowError();
 		});
+
+		it('should throw if the env and file keys do not match', () => {
+			readSpy.mockReturnValue(JSON.stringify({ encryptionKey: 'key_1' }));
+			process.env.N8N_ENCRYPTION_KEY = 'key_2';
+			expect(() => new InstanceSettings()).toThrowError();
+		});
 	});
 
 	describe('If the settings file does not exist', () => {

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -1259,38 +1259,22 @@ export class HttpRequestV3 implements INodeType {
 				genericCredentialType = this.getNodeParameter('genericAuthType', 0) as string;
 
 				if (genericCredentialType === 'httpBasicAuth') {
-					try {
-						httpBasicAuth = await this.getCredentials('httpBasicAuth', itemIndex);
-					} catch {}
+					httpBasicAuth = await this.getCredentials('httpBasicAuth', itemIndex);
 				} else if (genericCredentialType === 'httpDigestAuth') {
-					try {
-						httpDigestAuth = await this.getCredentials('httpDigestAuth', itemIndex);
-					} catch {}
+					httpDigestAuth = await this.getCredentials('httpDigestAuth', itemIndex);
 				} else if (genericCredentialType === 'httpHeaderAuth') {
-					try {
-						httpHeaderAuth = await this.getCredentials('httpHeaderAuth', itemIndex);
-					} catch {}
+					httpHeaderAuth = await this.getCredentials('httpHeaderAuth', itemIndex);
 				} else if (genericCredentialType === 'httpQueryAuth') {
-					try {
-						httpQueryAuth = await this.getCredentials('httpQueryAuth', itemIndex);
-					} catch {}
+					httpQueryAuth = await this.getCredentials('httpQueryAuth', itemIndex);
 				} else if (genericCredentialType === 'httpCustomAuth') {
-					try {
-						httpCustomAuth = await this.getCredentials('httpCustomAuth', itemIndex);
-					} catch {}
+					httpCustomAuth = await this.getCredentials('httpCustomAuth', itemIndex);
 				} else if (genericCredentialType === 'oAuth1Api') {
-					try {
-						oAuth1Api = await this.getCredentials('oAuth1Api', itemIndex);
-					} catch {}
+					oAuth1Api = await this.getCredentials('oAuth1Api', itemIndex);
 				} else if (genericCredentialType === 'oAuth2Api') {
-					try {
-						oAuth2Api = await this.getCredentials('oAuth2Api', itemIndex);
-					} catch {}
+					oAuth2Api = await this.getCredentials('oAuth2Api', itemIndex);
 				}
 			} else if (authentication === 'predefinedCredentialType') {
-				try {
-					nodeCredentialType = this.getNodeParameter('nodeCredentialType', 0) as string;
-				} catch {}
+				nodeCredentialType = this.getNodeParameter('nodeCredentialType', 0) as string;
 			}
 
 			const requestMethod = this.getNodeParameter('method', itemIndex) as string;


### PR DESCRIPTION
- [x] If `N8N_ENCRYPTION_KEY` does not match `configFile.encryptionKey`, fail to init main
- [x] If `N8N_ENCRYPTION_KEY` is missing on worker, fail to init worker
- [x] If credential decryption fails when attempting to edit a credential, surface [better error message](https://share.cleanshot.com/4DRcwv68)
- [x] If HTTPRN execution fails due to cred decryption error, [block execution](https://share.cleanshot.com/mH8H3Kcg)
- [x] Tests

Story: https://linear.app/n8n/issue/PAY-1184