### PR TITLE
fix(Microsoft SQL Node): Fix "Maximum call stack size exceeded" error on too many rows

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -248,7 +248,6 @@ export class MicrosoftSql implements INodeType {
 		const pool = configurePool(credentials);
 		await pool.connect();
 
-		const returnItems: INodeExecutionData[] = [];
 		let responseData: IDataObject | IDataObject[] = [];
 
 		const items = this.getInputData();
@@ -327,12 +326,11 @@ export class MicrosoftSql implements INodeType {
 
 		const itemData = generatePairedItemData(items.length);
 
-		const executionData = this.helpers.constructExecutionMetaData(
+		const returnItems = this.helpers.constructExecutionMetaData(
 			this.helpers.returnJsonArray(responseData),
 			{ itemData },
 		);
 
-		returnItems.push(...executionData);
 		return [returnItems];
 	}
 }


### PR DESCRIPTION
Array de-structuring combined with `.push(` on an array of 120k items is always going push the stack beyond it's max size. This is why why we should avoid this pattern whenever possible.

We've already had to fix this exact same issue for the Google Sheets Node in #7384

## Related tickets and issues
Fixes #8333


## Review / Merge checklist
- [x] PR title and summary are descriptive