### PR TITLE
fix: Change setup credentials modal title (no-changelog)

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2371,5 +2371,5 @@
 	"templateSetup.continue.button": "Continue",
 	"templateSetup.credential.description": "The credential you select will be used in the {0} node of the workflow template. | The credential you select will be used in the {0} nodes of the workflow template.",
 	"templateSetup.continue.button.fillRemaining": "Fill remaining credentials to continue",
-	"setupCredentialsModal.title": "Set up credentials"
+	"setupCredentialsModal.title": "Set up template"
 }


### PR DESCRIPTION
## Summary

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/11c97639-d086-47b9-91fe-03bd18e852e7)


After:

![image](https://github.com/n8n-io/n8n/assets/10324676/8febda59-88f0-480d-a133-63bae3ef1896)



## Related tickets and issues

https://linear.app/n8n/issue/ADO-1463/feature-enable-users-to-close-and-re-open-the-setup


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 