### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ From the terminal, run:
 
 This command will download everything that is needed to start n8n. You can then access n8n and start building workflows by opening [http://localhost:5678](http://localhost:5678).
 
+## Self Host
+
+You can also deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=n8n):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=n8n)
+
 ## n8n cloud
 
 Sign-up for an [n8n cloud](https://www.n8n.io/cloud/) account.


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment users receive a link which can then be CNAME-ed to any domain.

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.