### PR TITLE
feat(core): Custom session timeout and refresh configuration

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -667,7 +667,8 @@ export interface ILicensePostResponse extends ILicenseReadResponse {
 
 export interface JwtToken {
 	token: string;
-	expiresIn: number;
+	// TODO: is it ok to rename this?
+	expiresInSeconds: number;
 }
 
 export interface JwtPayload {

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -667,7 +667,6 @@ export interface ILicensePostResponse extends ILicenseReadResponse {
 
 export interface JwtToken {
 	token: string;
-	// TODO: is it ok to rename this?
 	expiresInSeconds: number;
 }
 

--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -667,7 +667,8 @@ export interface ILicensePostResponse extends ILicenseReadResponse {
 
 export interface JwtToken {
 	token: string;
-	expiresInSeconds: number;
+	/** The amount of seconds after which the JWT will expire. **/
+	expiresIn: number;
 }
 
 export interface JwtPayload {

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -88,7 +88,7 @@ export async function resolveJwt(token: string): Promise<User> {
 export async function issueCookie(res: Response, user: User): Promise<void> {
 	const userData = issueJWT(user);
 	res.cookie(AUTH_COOKIE_NAME, userData.token, {
-		maxAge: userData.expiresInSeconds,
+		maxAge: userData.expiresInSeconds * Time.seconds.toMilliseconds,
 		httpOnly: true,
 		sameSite: 'lax',
 	});

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -44,7 +44,7 @@ export function issueJWT(user: User): JwtToken {
 
 	return {
 		token: signedToken,
-		expiresInSeconds,
+		expiresIn: expiresInSeconds,
 	};
 }
 
@@ -88,7 +88,7 @@ export async function resolveJwt(token: string): Promise<User> {
 export async function issueCookie(res: Response, user: User): Promise<void> {
 	const userData = issueJWT(user);
 	res.cookie(AUTH_COOKIE_NAME, userData.token, {
-		maxAge: userData.expiresInSeconds * Time.seconds.toMilliseconds,
+		maxAge: userData.expiresIn * Time.seconds.toMilliseconds,
 		httpOnly: true,
 		sameSite: 'lax',
 	});

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -1,6 +1,6 @@
 import type { Response } from 'express';
 import { createHash } from 'crypto';
-import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES, Time } from '@/constants';
 import type { JwtPayload, JwtToken } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import config from '@/config';
@@ -14,8 +14,9 @@ import { ApplicationError } from 'n8n-workflow';
 
 export function issueJWT(user: User): JwtToken {
 	const { id, email, password } = user;
-	const expiresInHours = config.get('userManagement.jwtSessionDurationHours');
-	const expiresInSeconds = expiresInHours * 60 * 60;
+	const expiresInHours = config.getEnv('userManagement.jwtSessionDurationHours');
+	const expiresInSeconds = expiresInHours * Time.hours.toSeconds;
+
 	const isWithinUsersLimit = Container.get(License).isWithinUsersLimit();
 
 	const payload: JwtPayload = {

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -62,9 +62,21 @@ if (!inE2ETests && !inTest) {
 	});
 }
 
+// Validate Configuration
 config.validate({
 	allowed: 'strict',
 });
+const userManagement = config.get('userManagement');
+if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHours) {
+	// Can't use the logger here, because it depends on the config.
+	// I could validate it in `Start.init()`, but that feels like the wrong seperation of concerns
+	// I could also do it in `refreshExpiringCookie`, but that would then print the message on every request.
+	console.warn(
+		'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS needs to smaller than N8N_USER_MANAGEMENT_JWT_DURATION_HOURS. Setting N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS to 0 for now.',
+	);
+
+	config.set('userManagement.jwtRefreshTimeoutHours', 0);
+}
 
 setGlobalState({
 	defaultTimezone: config.getEnv('generic.timezone'),

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -68,9 +68,6 @@ config.validate({
 });
 const userManagement = config.get('userManagement');
 if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHours) {
-	// Can't use the logger here, because it depends on the config.
-	// I could validate it in `Start.init()`, but that feels like the wrong seperation of concerns
-	// I could also do it in `refreshExpiringCookie`, but that would then print the message on every request.
 	console.warn(
 		'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS needs to smaller than N8N_USER_MANAGEMENT_JWT_DURATION_HOURS. Setting N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS to 0 for now.',
 	);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -762,7 +762,6 @@ export const schema = {
 			default: '',
 			env: 'N8N_USER_MANAGEMENT_JWT_SECRET',
 		},
-		// TODO: Is it ok to add units here?
 		jwtSessionDurationHours: {
 			doc: 'Set a specific expiration date for the JWTs in hours.',
 			format: Number,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -762,11 +762,12 @@ export const schema = {
 			default: '',
 			env: 'N8N_USER_MANAGEMENT_JWT_SECRET',
 		},
-		jwtDuration: {
-			doc: 'Set a specific JWT secret (optional - n8n can generate one)', // Generated @ start.ts
+		// TODO: Is it ok to add units here?
+		jwtSessionDurationHours: {
+			doc: 'Set a specific expiration date for the JWTs.',
 			format: Number,
 			default: 168,
-			env: 'N8N_USER_MANAGEMENT_JWT_DURATION',
+			env: 'N8N_USER_MANAGEMENT_JWT_DURATION_HOURS',
 		},
 		isInstanceOwnerSetUp: {
 			// n8n loads this setting from DB on startup

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -768,6 +768,12 @@ export const schema = {
 			default: 168,
 			env: 'N8N_USER_MANAGEMENT_JWT_DURATION_HOURS',
 		},
+		jwtRefreshTimeoutHours: {
+			doc: '',
+			format: Number,
+			default: 0,
+			env: 'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS',
+		},
 		isInstanceOwnerSetUp: {
 			// n8n loads this setting from DB on startup
 			doc: "Whether the instance owner's account has been set up",

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -769,7 +769,7 @@ export const schema = {
 			env: 'N8N_USER_MANAGEMENT_JWT_DURATION_HOURS',
 		},
 		jwtRefreshTimeoutHours: {
-			doc: '',
+			doc: 'How long before the JWT expires to automatically refresh it. 0 means 25% of N8N_USER_MANAGEMENT_JWT_DURATION_HOURS. -1 means it will never refresh, which forces users to login again after the defined period in N8N_USER_MANAGEMENT_JWT_DURATION_HOURS.',
 			format: Number,
 			default: 0,
 			env: 'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS',

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -764,7 +764,7 @@ export const schema = {
 		},
 		// TODO: Is it ok to add units here?
 		jwtSessionDurationHours: {
-			doc: 'Set a specific expiration date for the JWTs.',
+			doc: 'Set a specific expiration date for the JWTs in hours.',
 			format: Number,
 			default: 168,
 			env: 'N8N_USER_MANAGEMENT_JWT_DURATION_HOURS',

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -119,6 +119,9 @@ export const TIME = {
  * Eventually this will superseed `TIME` above
  */
 export const Time = {
+	seconds: {
+		toMilliseconds: 1000,
+	},
 	minutes: {
 		toMilliseconds: 60 * 1000,
 	},

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -103,6 +103,7 @@ export const UM_FIX_INSTRUCTION =
 
 /**
  * Units of time in milliseconds
+ * @deprecated Please use constants.Time instead.
  */
 export const TIME = {
 	SECOND: 1000,
@@ -110,6 +111,25 @@ export const TIME = {
 	HOUR: 60 * 60 * 1000,
 	DAY: 24 * 60 * 60 * 1000,
 } as const;
+
+/**
+ * Convert time from any unit to any other unit
+ *
+ * Please amend conversions as necessary.
+ * Eventually this will superseed `TIME` above
+ */
+export const Time = {
+	minutes: {
+		toMilliseconds: 60 * 1000,
+	},
+	hours: {
+		toMilliseconds: 60 * 60 * 1000,
+		toSeconds: 60 * 60,
+	},
+	days: {
+		toSeconds: 24 * 60 * 60,
+	},
+};
 
 export const MIN_PASSWORD_CHAR_LENGTH = 8;
 

--- a/packages/cli/src/middlewares/auth.ts
+++ b/packages/cli/src/middlewares/auth.ts
@@ -60,7 +60,6 @@ export const refreshExpiringCookie = (async (req: AuthenticatedRequest, res, nex
 	if (cookieAuth && req.user && jwtRefreshTimeoutHours !== -1) {
 		const cookieContents = jwt.decode(cookieAuth) as JwtPayload & { exp: number };
 		if (cookieContents.exp * 1000 - Date.now() < jwtRefreshTimeoutMilliSeconds) {
-			// if cookie expires in < 3 days, renew it.
 			await issueCookie(res, req.user);
 		}
 	}

--- a/packages/cli/src/middlewares/auth.ts
+++ b/packages/cli/src/middlewares/auth.ts
@@ -11,6 +11,7 @@ import { issueCookie, resolveJwtContent } from '@/auth/jwt';
 import { canSkipAuth } from '@/decorators/registerController';
 import { Logger } from '@/Logger';
 import { JwtService } from '@/services/jwt.service';
+import config from '@/config';
 
 const jwtFromRequest = (req: Request) => {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -42,10 +43,23 @@ const userManagementJwtAuth = (): RequestHandler => {
  * middleware to refresh cookie before it expires
  */
 export const refreshExpiringCookie = (async (req: AuthenticatedRequest, res, next) => {
+	const jwtRefreshTimeoutHours = config.get('userManagement.jwtRefreshTimeoutHours');
+
+	let jwtRefreshTimeoutMilliSeconds: number;
+
+	if (jwtRefreshTimeoutHours === 0) {
+		const jwtSessionDurationHours = config.get('userManagement.jwtSessionDurationHours');
+
+		jwtRefreshTimeoutMilliSeconds = Math.floor(jwtSessionDurationHours * 0.25 * 60 * 60 * 1000);
+	} else {
+		jwtRefreshTimeoutMilliSeconds = Math.floor(jwtRefreshTimeoutHours * 60 * 60 * 1000);
+	}
+
 	const cookieAuth = jwtFromRequest(req);
-	if (cookieAuth && req.user) {
+
+	if (cookieAuth && req.user && jwtRefreshTimeoutHours !== -1) {
 		const cookieContents = jwt.decode(cookieAuth) as JwtPayload & { exp: number };
-		if (cookieContents.exp * 1000 - Date.now() < 259200000) {
+		if (cookieContents.exp * 1000 - Date.now() < jwtRefreshTimeoutMilliSeconds) {
 			// if cookie expires in < 3 days, renew it.
 			await issueCookie(res, req.user);
 		}

--- a/packages/cli/src/middlewares/auth.ts
+++ b/packages/cli/src/middlewares/auth.ts
@@ -41,7 +41,7 @@ const userManagementJwtAuth = (): RequestHandler => {
 /**
  * middleware to refresh cookie before it expires
  */
-const refreshExpiringCookie: RequestHandler = async (req: AuthenticatedRequest, res, next) => {
+export const refreshExpiringCookie = (async (req: AuthenticatedRequest, res, next) => {
 	const cookieAuth = jwtFromRequest(req);
 	if (cookieAuth && req.user) {
 		const cookieContents = jwt.decode(cookieAuth) as JwtPayload & { exp: number };
@@ -51,7 +51,7 @@ const refreshExpiringCookie: RequestHandler = async (req: AuthenticatedRequest, 
 		}
 	}
 	next();
-};
+}) satisfies RequestHandler;
 
 const passportMiddleware = passport.authenticate('jwt', { session: false }) as RequestHandler;
 

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -1,0 +1,45 @@
+import { Container } from 'typedi';
+import { v4 as uuid } from 'uuid';
+
+import { JwtService } from '@/services/jwt.service';
+import { License } from '@/License';
+import { User } from '@db/entities/User';
+import { issueJWT } from '@/auth/jwt';
+
+import { mockInstance } from '../../shared/mocking';
+
+// TODO: is the the right level of testing?
+// Should I mock more or less?
+// Should I write an integration test that checks that a user is actually logged out?
+describe('jwt', () => {
+	const jwtService = Container.get(JwtService);
+
+	describe('issueJWT', () => {
+		beforeEach(() => {
+			// TODO: Why do I need to mock the License but not for example the JwtService 🤷
+			mockInstance(License);
+		});
+
+		it('should default to expire in 168 hours', () => {
+			const defaultInSeconds = 7 * 24 * 60 * 60;
+			const defaultInMS = defaultInSeconds * 1000;
+			// TODO: is this the right way to create a mock user?
+			const mockUser = Object.assign(new User(), {
+				id: uuid(),
+				password: 'passwordHash',
+				mfaEnabled: false,
+				mfaSecret: 'test',
+				mfaRecoveryCodes: ['test'],
+				updatedAt: new Date(),
+				authIdentities: [],
+			});
+			const { token, expiresIn } = issueJWT(mockUser);
+
+			expect(expiresIn).toBe(defaultInMS);
+			const decodedToken = jwtService.verify(token);
+			expect(decodedToken.exp).toBeDefined();
+			expect(decodedToken.iat).toBeDefined();
+			expect(decodedToken.exp! - decodedToken.iat!).toBe(defaultInSeconds);
+		});
+	});
+});

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -1,6 +1,7 @@
 import { Container } from 'typedi';
 import { v4 as uuid } from 'uuid';
 
+import config from '@/config';
 import { JwtService } from '@/services/jwt.service';
 import { License } from '@/License';
 import { User } from '@db/entities/User';
@@ -11,10 +12,10 @@ import { mockInstance } from '../../shared/mocking';
 // TODO: is the the right level of testing?
 // Should I mock more or less?
 // Should I write an integration test that checks that a user is actually logged out?
-describe('jwt', () => {
+describe('jwt.issueJWT', () => {
 	const jwtService = Container.get(JwtService);
 
-	describe('issueJWT', () => {
+	describe('when not setting userManagement.jwtSessionDuration', () => {
 		beforeEach(() => {
 			// TODO: Why do I need to mock the License but not for example the JwtService 🤷
 			mockInstance(License);
@@ -22,7 +23,6 @@ describe('jwt', () => {
 
 		it('should default to expire in 168 hours', () => {
 			const defaultInSeconds = 7 * 24 * 60 * 60;
-			const defaultInMS = defaultInSeconds * 1000;
 			// TODO: is this the right way to create a mock user?
 			const mockUser = Object.assign(new User(), {
 				id: uuid(),
@@ -33,13 +33,47 @@ describe('jwt', () => {
 				updatedAt: new Date(),
 				authIdentities: [],
 			});
-			const { token, expiresIn } = issueJWT(mockUser);
+			const { token, expiresInSeconds } = issueJWT(mockUser);
 
-			expect(expiresIn).toBe(defaultInMS);
+			expect(expiresInSeconds).toBe(defaultInSeconds);
 			const decodedToken = jwtService.verify(token);
 			expect(decodedToken.exp).toBeDefined();
 			expect(decodedToken.iat).toBeDefined();
 			expect(decodedToken.exp! - decodedToken.iat!).toBe(defaultInSeconds);
+		});
+	});
+
+	describe('when setting userManagement.jwtSessionDuration', () => {
+		let oldDuration: number;
+		let testDuration = 1;
+
+		beforeEach(() => {
+			mockInstance(License);
+			oldDuration = config.get('userManagement.jwtSessionDurationHours');
+			config.set('userManagement.jwtSessionDurationHours', testDuration);
+		});
+
+		afterEach(() => {
+			config.set('userManagement.jwtSessionDuration', oldDuration);
+		});
+
+		it('should apply it to tokens', () => {
+			const mockUser = Object.assign(new User(), {
+				id: uuid(),
+				password: 'passwordHash',
+				mfaEnabled: false,
+				mfaSecret: 'test',
+				mfaRecoveryCodes: ['test'],
+				updatedAt: new Date(),
+				authIdentities: [],
+			});
+			const { token, expiresInSeconds } = issueJWT(mockUser);
+
+			expect(expiresInSeconds).toBe(testDuration * 60 * 60);
+			const decodedToken = jwtService.verify(token);
+			expect(decodedToken.exp).toBeDefined();
+			expect(decodedToken.iat).toBeDefined();
+			expect(decodedToken.exp! - decodedToken.iat!).toBe(testDuration * 60 * 60);
 		});
 	});
 });

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -17,7 +17,7 @@ describe('jwt.issueJWT', () => {
 	const jwtService = Container.get(JwtService);
 
 	describe('when not setting userManagement.jwtSessionDuration', () => {
-		it('should default to expire in 168 hours', () => {
+		it('should default to expire in 7 days', () => {
 			const defaultInSeconds = 7 * Time.days.toSeconds;
 			const mockUser = mock<User>({ password: 'passwordHash' });
 			const { token, expiresInSeconds } = issueJWT(mockUser);

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -20,9 +20,9 @@ describe('jwt.issueJWT', () => {
 		it('should default to expire in 7 days', () => {
 			const defaultInSeconds = 7 * Time.days.toSeconds;
 			const mockUser = mock<User>({ password: 'passwordHash' });
-			const { token, expiresInSeconds } = issueJWT(mockUser);
+			const { token, expiresIn } = issueJWT(mockUser);
 
-			expect(expiresInSeconds).toBe(defaultInSeconds);
+			expect(expiresIn).toBe(defaultInSeconds);
 			const decodedToken = jwtService.verify(token);
 			if (decodedToken.exp === undefined || decodedToken.iat === undefined) {
 				fail('Expected exp and iat to be defined');
@@ -48,9 +48,9 @@ describe('jwt.issueJWT', () => {
 
 		it('should apply it to tokens', () => {
 			const mockUser = mock<User>({ password: 'passwordHash' });
-			const { token, expiresInSeconds } = issueJWT(mockUser);
+			const { token, expiresIn } = issueJWT(mockUser);
 
-			expect(expiresInSeconds).toBe(testDurationSeconds);
+			expect(expiresIn).toBe(testDurationSeconds);
 			const decodedToken = jwtService.verify(token);
 			if (decodedToken.exp === undefined || decodedToken.iat === undefined) {
 				fail('Expected exp and iat to be defined on decodedToken');

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -33,12 +33,12 @@ describe('jwt.issueJWT', () => {
 	});
 
 	describe('when setting userManagement.jwtSessionDuration', () => {
-		let oldDuration: number;
-		let testDurationHours = 1;
+		const oldDuration = config.get('userManagement.jwtSessionDurationHours');
+		const testDurationHours = 1;
+		const testDurationSeconds = testDurationHours * Time.hours.toSeconds;
 
 		beforeEach(() => {
 			mockInstance(License);
-			oldDuration = config.get('userManagement.jwtSessionDurationHours');
 			config.set('userManagement.jwtSessionDurationHours', testDurationHours);
 		});
 
@@ -50,12 +50,12 @@ describe('jwt.issueJWT', () => {
 			const mockUser = mock<User>({ password: 'passwordHash' });
 			const { token, expiresInSeconds } = issueJWT(mockUser);
 
-			expect(expiresInSeconds).toBe(testDurationHours * Time.hours.toSeconds);
+			expect(expiresInSeconds).toBe(testDurationSeconds);
 			const decodedToken = jwtService.verify(token);
 			if (decodedToken.exp === undefined || decodedToken.iat === undefined) {
 				fail('Expected exp and iat to be defined on decodedToken');
 			}
-			expect(decodedToken.exp - decodedToken.iat).toBe(testDurationHours * Time.hours.toSeconds);
+			expect(decodedToken.exp - decodedToken.iat).toBe(testDurationSeconds);
 		});
 	});
 });

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -9,6 +9,10 @@ import { issueJWT } from '@/auth/jwt';
 
 import { mockInstance } from '../../shared/mocking';
 
+// TODO: Why do I need to mock the License but not for example the JwtService 🤷
+// A: because of the server not being initialized
+mockInstance(License);
+
 // TODO: is the the right level of testing?
 // Should I mock more or less?
 // Should I write an integration test that checks that a user is actually logged out?
@@ -16,11 +20,6 @@ describe('jwt.issueJWT', () => {
 	const jwtService = Container.get(JwtService);
 
 	describe('when not setting userManagement.jwtSessionDuration', () => {
-		beforeEach(() => {
-			// TODO: Why do I need to mock the License but not for example the JwtService 🤷
-			mockInstance(License);
-		});
-
 		it('should default to expire in 168 hours', () => {
 			const defaultInSeconds = 7 * 24 * 60 * 60;
 			// TODO: is this the right way to create a mock user?

--- a/packages/cli/test/unit/auth/jwt.test.ts
+++ b/packages/cli/test/unit/auth/jwt.test.ts
@@ -1,55 +1,45 @@
 import { Container } from 'typedi';
-import { v4 as uuid } from 'uuid';
+import { mock } from 'jest-mock-extended';
 
 import config from '@/config';
 import { JwtService } from '@/services/jwt.service';
 import { License } from '@/License';
-import { User } from '@db/entities/User';
+import { Time } from '@/constants';
 import { issueJWT } from '@/auth/jwt';
 
 import { mockInstance } from '../../shared/mocking';
 
-// TODO: Why do I need to mock the License but not for example the JwtService 🤷
-// A: because of the server not being initialized
+import type { User } from '@db/entities/User';
+
 mockInstance(License);
 
-// TODO: is the the right level of testing?
-// Should I mock more or less?
-// Should I write an integration test that checks that a user is actually logged out?
 describe('jwt.issueJWT', () => {
 	const jwtService = Container.get(JwtService);
 
 	describe('when not setting userManagement.jwtSessionDuration', () => {
 		it('should default to expire in 168 hours', () => {
-			const defaultInSeconds = 7 * 24 * 60 * 60;
-			// TODO: is this the right way to create a mock user?
-			const mockUser = Object.assign(new User(), {
-				id: uuid(),
-				password: 'passwordHash',
-				mfaEnabled: false,
-				mfaSecret: 'test',
-				mfaRecoveryCodes: ['test'],
-				updatedAt: new Date(),
-				authIdentities: [],
-			});
+			const defaultInSeconds = 7 * Time.days.toSeconds;
+			const mockUser = mock<User>({ password: 'passwordHash' });
 			const { token, expiresInSeconds } = issueJWT(mockUser);
 
 			expect(expiresInSeconds).toBe(defaultInSeconds);
 			const decodedToken = jwtService.verify(token);
-			expect(decodedToken.exp).toBeDefined();
-			expect(decodedToken.iat).toBeDefined();
-			expect(decodedToken.exp! - decodedToken.iat!).toBe(defaultInSeconds);
+			if (decodedToken.exp === undefined || decodedToken.iat === undefined) {
+				fail('Expected exp and iat to be defined');
+			}
+
+			expect(decodedToken.exp - decodedToken.iat).toBe(defaultInSeconds);
 		});
 	});
 
 	describe('when setting userManagement.jwtSessionDuration', () => {
 		let oldDuration: number;
-		let testDuration = 1;
+		let testDurationHours = 1;
 
 		beforeEach(() => {
 			mockInstance(License);
 			oldDuration = config.get('userManagement.jwtSessionDurationHours');
-			config.set('userManagement.jwtSessionDurationHours', testDuration);
+			config.set('userManagement.jwtSessionDurationHours', testDurationHours);
 		});
 
 		afterEach(() => {
@@ -57,22 +47,15 @@ describe('jwt.issueJWT', () => {
 		});
 
 		it('should apply it to tokens', () => {
-			const mockUser = Object.assign(new User(), {
-				id: uuid(),
-				password: 'passwordHash',
-				mfaEnabled: false,
-				mfaSecret: 'test',
-				mfaRecoveryCodes: ['test'],
-				updatedAt: new Date(),
-				authIdentities: [],
-			});
+			const mockUser = mock<User>({ password: 'passwordHash' });
 			const { token, expiresInSeconds } = issueJWT(mockUser);
 
-			expect(expiresInSeconds).toBe(testDuration * 60 * 60);
+			expect(expiresInSeconds).toBe(testDurationHours * Time.hours.toSeconds);
 			const decodedToken = jwtService.verify(token);
-			expect(decodedToken.exp).toBeDefined();
-			expect(decodedToken.iat).toBeDefined();
-			expect(decodedToken.exp! - decodedToken.iat!).toBe(testDuration * 60 * 60);
+			if (decodedToken.exp === undefined || decodedToken.iat === undefined) {
+				fail('Expected exp and iat to be defined on decodedToken');
+			}
+			expect(decodedToken.exp - decodedToken.iat).toBe(testDurationHours * Time.hours.toSeconds);
 		});
 	});
 });

--- a/packages/cli/test/unit/config/index.test.ts
+++ b/packages/cli/test/unit/config/index.test.ts
@@ -1,0 +1,9 @@
+describe('userManagement.jwtRefreshTimeoutHours', () => {
+	it("resets jwtRefreshTimeoutHours to 0 if it's greater than or equal to jwtSessionDurationHours", async () => {
+		process.env.N8N_USER_MANAGEMENT_JWT_DURATION_HOURS = '1';
+		process.env.N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS = '1';
+		const { default: config } = await import('@/config');
+
+		expect(config.getEnv('userManagement.jwtRefreshTimeoutHours')).toBe(0);
+	});
+});

--- a/packages/cli/test/unit/middleware/auth.test.ts
+++ b/packages/cli/test/unit/middleware/auth.test.ts
@@ -17,7 +17,8 @@ mockInstance(License);
 jest.useFakeTimers();
 
 describe('refreshExpiringCookie', () => {
-	const oldDuration: number = config.get('userManagement.jwtSessionDurationHours');
+	const oldDuration = config.getEnv('userManagement.jwtSessionDurationHours');
+	const oldTimeout = config.getEnv('userManagement.jwtRefreshTimeoutHours');
 	let mockUser: User;
 
 	beforeEach(() => {
@@ -26,7 +27,7 @@ describe('refreshExpiringCookie', () => {
 
 	afterEach(() => {
 		config.set('userManagement.jwtSessionDuration', oldDuration);
-		config.set('userManagement.jwtRefreshTimeoutHours', 0);
+		config.set('userManagement.jwtRefreshTimeoutHours', oldTimeout);
 	});
 
 	it('does not do anything if the user is not authorized', async () => {

--- a/packages/cli/test/unit/middleware/auth.test.ts
+++ b/packages/cli/test/unit/middleware/auth.test.ts
@@ -41,7 +41,6 @@ describe('refreshExpiringCookie', () => {
 		expect(res.cookie).not.toHaveBeenCalled();
 	});
 
-	// TODO: structure tests
 	describe('with N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=-1', () => {
 		it('does not refresh the cookie, ever', async () => {
 			config.set('userManagement.jwtSessionDurationHours', 1);

--- a/packages/cli/test/unit/middleware/auth.test.ts
+++ b/packages/cli/test/unit/middleware/auth.test.ts
@@ -1,0 +1,71 @@
+import { v4 as uuid } from 'uuid';
+
+import config from '@/config';
+import { AUTH_COOKIE_NAME } from '@/constants';
+import { License } from '@/License';
+import { User } from '@/databases/entities/User';
+import { issueJWT } from '@/auth/jwt';
+import { refreshExpiringCookie } from '@/middlewares';
+
+import { mockInstance } from '../../shared/mocking';
+
+import type { AuthenticatedRequest } from '@/requests';
+import type { Response } from 'express';
+
+mockInstance(License);
+
+describe('refreshExpiringCookie', () => {
+	const oldDuration: number = config.get('userManagement.jwtSessionDurationHours');
+	let mockUser: User;
+
+	beforeEach(() => {
+		mockUser = Object.assign(new User(), {
+			id: uuid(),
+			password: 'passwordHash',
+			mfaEnabled: false,
+			mfaSecret: 'test',
+			mfaRecoveryCodes: ['test'],
+			updatedAt: new Date(),
+			authIdentities: [],
+		});
+	});
+
+	afterEach(() => {
+		config.set('userManagement.jwtSessionDuration', oldDuration);
+	});
+
+	it('does not do anything if the user is not authorized', async () => {
+		const req = {} as AuthenticatedRequest;
+		const res = { cookie: jest.fn() } as unknown as Response;
+		const next = jest.fn();
+
+		await refreshExpiringCookie(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(res.cookie).not.toHaveBeenCalled();
+	});
+
+	it('does not do anything if the cookie is still valid', async () => {
+		config.set('userManagement.jwtSessionDurationHours', 73);
+		const { token } = issueJWT(mockUser);
+
+		const req = { cookies: { [AUTH_COOKIE_NAME]: token }, user: mockUser } as AuthenticatedRequest;
+		const res = { cookie: jest.fn() } as unknown as Response;
+		const next = jest.fn();
+		await refreshExpiringCookie(req, res, next);
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(res.cookie).not.toHaveBeenCalled();
+	});
+
+	it('refreshes the cookie if it has less than 3 days to live', async () => {
+		config.set('userManagement.jwtSessionDurationHours', 71);
+		const { token } = issueJWT(mockUser);
+		const req = { cookies: { [AUTH_COOKIE_NAME]: token }, user: mockUser } as AuthenticatedRequest;
+		const res = { cookie: jest.fn() } as unknown as Response;
+		const next = jest.fn();
+
+		await refreshExpiringCookie(req, res, next);
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(res.cookie).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cli/test/unit/middleware/auth.test.ts
+++ b/packages/cli/test/unit/middleware/auth.test.ts
@@ -108,6 +108,7 @@ describe('refreshExpiringCookie', () => {
 	});
 
 	describe('with N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=50', () => {
+		const jwtSessionDurationHours = 51;
 		let token: string;
 		let req: AuthenticatedRequest;
 		let res: Response;
@@ -115,7 +116,7 @@ describe('refreshExpiringCookie', () => {
 
 		// ARRANGE
 		beforeEach(() => {
-			config.set('userManagement.jwtSessionDurationHours', 51);
+			config.set('userManagement.jwtSessionDurationHours', jwtSessionDurationHours);
 			config.set('userManagement.jwtRefreshTimeoutHours', 50);
 
 			token = issueJWT(mockUser).token;
@@ -151,6 +152,11 @@ describe('refreshExpiringCookie', () => {
 			// ASSERT
 			expect(next).toHaveBeenCalledTimes(1);
 			expect(res.cookie).toHaveBeenCalledTimes(1);
+			expect(res.cookie).toHaveBeenCalledWith(AUTH_COOKIE_NAME, expect.any(String), {
+				httpOnly: true,
+				maxAge: jwtSessionDurationHours * Time.hours.toMilliseconds,
+				sameSite: 'lax',
+			});
 		});
 	});
 });

--- a/packages/cli/test/unit/middleware/auth.test.ts
+++ b/packages/cli/test/unit/middleware/auth.test.ts
@@ -1,42 +1,37 @@
-import { v4 as uuid } from 'uuid';
+import { mock } from 'jest-mock-extended';
 
 import config from '@/config';
-import { AUTH_COOKIE_NAME } from '@/constants';
+import { AUTH_COOKIE_NAME, Time } from '@/constants';
 import { License } from '@/License';
-import { User } from '@/databases/entities/User';
 import { issueJWT } from '@/auth/jwt';
 import { refreshExpiringCookie } from '@/middlewares';
 
 import { mockInstance } from '../../shared/mocking';
 
 import type { AuthenticatedRequest } from '@/requests';
-import type { Response } from 'express';
+import type { NextFunction, Response } from 'express';
+import type { User } from '@/databases/entities/User';
 
 mockInstance(License);
+
+jest.useFakeTimers();
 
 describe('refreshExpiringCookie', () => {
 	const oldDuration: number = config.get('userManagement.jwtSessionDurationHours');
 	let mockUser: User;
 
 	beforeEach(() => {
-		mockUser = Object.assign(new User(), {
-			id: uuid(),
-			password: 'passwordHash',
-			mfaEnabled: false,
-			mfaSecret: 'test',
-			mfaRecoveryCodes: ['test'],
-			updatedAt: new Date(),
-			authIdentities: [],
-		});
+		mockUser = mock<User>({ password: 'passwordHash' });
 	});
 
 	afterEach(() => {
 		config.set('userManagement.jwtSessionDuration', oldDuration);
+		config.set('userManagement.jwtRefreshTimeoutHours', 0);
 	});
 
 	it('does not do anything if the user is not authorized', async () => {
-		const req = {} as AuthenticatedRequest;
-		const res = { cookie: jest.fn() } as unknown as Response;
+		const req = mock<AuthenticatedRequest>();
+		const res = mock<Response>({ cookie: jest.fn() });
 		const next = jest.fn();
 
 		await refreshExpiringCookie(req, res, next);
@@ -45,27 +40,117 @@ describe('refreshExpiringCookie', () => {
 		expect(res.cookie).not.toHaveBeenCalled();
 	});
 
-	it('does not do anything if the cookie is still valid', async () => {
-		config.set('userManagement.jwtSessionDurationHours', 73);
-		const { token } = issueJWT(mockUser);
+	// TODO: structure tests
+	describe('with N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=-1', () => {
+		it('does not refresh the cookie, ever', async () => {
+			config.set('userManagement.jwtSessionDurationHours', 1);
+			config.set('userManagement.jwtRefreshTimeoutHours', -1);
+			const { token } = issueJWT(mockUser);
 
-		const req = { cookies: { [AUTH_COOKIE_NAME]: token }, user: mockUser } as AuthenticatedRequest;
-		const res = { cookie: jest.fn() } as unknown as Response;
-		const next = jest.fn();
-		await refreshExpiringCookie(req, res, next);
-		expect(next).toHaveBeenCalledTimes(1);
-		expect(res.cookie).not.toHaveBeenCalled();
+			jest.advanceTimersByTime(1000 * 60 * 55); /* 55 minutes */
+
+			const req = mock<AuthenticatedRequest>({
+				cookies: { [AUTH_COOKIE_NAME]: token },
+				user: mockUser,
+			});
+			const res = mock<Response>({ cookie: jest.fn() });
+			const next = jest.fn();
+			await refreshExpiringCookie(req, res, next);
+
+			expect(next).toHaveBeenCalledTimes(1);
+			expect(res.cookie).not.toHaveBeenCalled();
+		});
 	});
 
-	it('refreshes the cookie if it has less than 3 days to live', async () => {
-		config.set('userManagement.jwtSessionDurationHours', 71);
-		const { token } = issueJWT(mockUser);
-		const req = { cookies: { [AUTH_COOKIE_NAME]: token }, user: mockUser } as AuthenticatedRequest;
-		const res = { cookie: jest.fn() } as unknown as Response;
-		const next = jest.fn();
+	describe('with N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=0', () => {
+		let token: string;
+		let req: AuthenticatedRequest;
+		let res: Response;
+		let next: NextFunction;
 
-		await refreshExpiringCookie(req, res, next);
-		expect(next).toHaveBeenCalledTimes(1);
-		expect(res.cookie).toHaveBeenCalledTimes(1);
+		beforeEach(() => {
+			// ARRANGE
+			config.set('userManagement.jwtSessionDurationHours', 1);
+			config.set('userManagement.jwtRefreshTimeoutHours', 0);
+			token = issueJWT(mockUser).token;
+
+			req = mock<AuthenticatedRequest>({
+				cookies: { [AUTH_COOKIE_NAME]: token },
+				user: mockUser,
+			});
+			res = mock<Response>({ cookie: jest.fn() });
+			next = jest.fn();
+		});
+
+		it('does not refresh the cookie when more than 1/4th of time is left', async () => {
+			// ARRANGE
+			jest.advanceTimersByTime(44 * Time.minutes.toMilliseconds); /* 44 minutes */
+
+			// ACT
+			await refreshExpiringCookie(req, res, next);
+
+			// ASSERT
+			expect(next).toHaveBeenCalledTimes(1);
+			expect(res.cookie).not.toHaveBeenCalled();
+		});
+
+		it('refreshes the cookie when 1/4th of time is left', async () => {
+			// ARRANGE
+			jest.advanceTimersByTime(46 * Time.minutes.toMilliseconds); /* 46 minutes */
+
+			// ACT
+			await refreshExpiringCookie(req, res, next);
+
+			// ASSERT
+			expect(next).toHaveBeenCalledTimes(1);
+			expect(res.cookie).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('with N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=50', () => {
+		let token: string;
+		let req: AuthenticatedRequest;
+		let res: Response;
+		let next: NextFunction;
+
+		// ARRANGE
+		beforeEach(() => {
+			config.set('userManagement.jwtSessionDurationHours', 51);
+			config.set('userManagement.jwtRefreshTimeoutHours', 50);
+
+			token = issueJWT(mockUser).token;
+			req = mock<AuthenticatedRequest>({
+				cookies: { [AUTH_COOKIE_NAME]: token },
+				user: mockUser,
+			});
+			res = mock<Response>({ cookie: jest.fn() });
+			next = jest.fn();
+		});
+
+		it('does not do anything if the cookie is still valid', async () => {
+			// ARRANGE
+			// cookie has 50.5 hours to live: 51 - 0.5
+			jest.advanceTimersByTime(30 * Time.minutes.toMilliseconds);
+
+			// ACT
+			await refreshExpiringCookie(req, res, next);
+
+			// ASSERT
+			expect(next).toHaveBeenCalledTimes(1);
+			expect(res.cookie).not.toHaveBeenCalled();
+		});
+
+		it('refreshes the cookie if it has less than 50 hours to live', async () => {
+			// ARRANGE
+			// cookie has 49.5 hours to live: 51 - 1.5
+			jest.advanceTimersByTime(1.5 * Time.hours.toMilliseconds);
+
+			// ACT
+			await refreshExpiringCookie(req, res, next);
+
+			// ASSERT
+			expect(next).toHaveBeenCalledTimes(1);
+			expect(res.cookie).toHaveBeenCalledTimes(1);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
This allows configuring the session timeout and refresh via environment variables.

You can test it by starting n8n like this:

```sh
env N8N_USER_MANAGEMENT_JWT_DURATION_HOURS=0.005 N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=-1 pnpm dev
```

0.005 hours is 18 seconds and -1 means that the auto refresh of the cookie/JWT is disabled.
So you can log in, navigate around. Wait 18 seconds. Refresh and see that you're logged out.

If you want to test the auto refresh you can do this:
```sh
env N8N_USER_MANAGEMENT_JWT_DURATION_HOURS=0.005 N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS=0.0025 pnpm dev
```

This will make the session last for 18 seconds and when less than 9 seconds are remaining it will issue a new cookie/JWT.

---

Reviewing this commit by commit can be easier. I mostly added tests before making changes, to make sure I don't break old behaviour.

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1182/custom-session-timeout-configuration
https://linear.app/n8n/issue/DOC-734/add-custom-session-timeout-setting-to-environment-variables-page
https://github.com/n8n-io/n8n-docs/pull/1849


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
