### PR TITLE
fix(core): Adjust `packageName` tagging for Sentry errors (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/application.error.ts
+++ b/packages/workflow/src/errors/application.error.ts
@@ -26,7 +26,13 @@ export class ApplicationError extends Error {
 		this.extra = extra;
 
 		try {
-			const filePath = callsites()[2].getFileName() ?? '';
+			const filePath = callsites()[1].getFileName() ?? '';
+
+			if (filePath.includes('/dist/errors/')) {
+				this.packageName = 'unknown';
+				return;
+			}
+
 			const match = /packages\/([^\/]+)\//.exec(filePath)?.[1];
 
 			if (match) this.tags.packageName = match;


### PR DESCRIPTION
At [#7958](https://github.com/n8n-io/n8n/pull/7958) we added a `packageName` tag to errors reported to Sentry, to identify errors from `nodes-base` so that the nodes team can start tackling them. But for some errors this tag is missing or incorrect. This is because `callsites()[2]` is pointing to the constructor of the `ApplicationError` (which lives in `workflow`) instead of the place of instantiation of the error. 

This PR adjusts the `callsites()` index to point to the place of instantiation. Also, assuming this index may not always be correctly pointing to this place, we set `unknown` to detect any errors where we know indexed access to `callsites()` to be incorrect. We might need to refine the callsite identification in future if we notice `unknown` tags coming up.

To test, set a breakpoint on `match` in `ApplicationError` and throw an `ApplicationError` in a BE package. The error's `match` should be correct.