### PR TITLE
docs(Discord Node): Better OAuth description (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Discord/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Discord/v2/actions/versionDescription.ts
@@ -61,7 +61,7 @@ export const versionDescription: INodeTypeDescription = {
 				{
 					name: 'OAuth2',
 					value: 'oAuth2',
-					description: 'Manage messages, channels, and members on a server',
+					description: "Same features as 'Bot Token' with easier Bot installation",
 				},
 				{
 					name: 'Webhook',


### PR DESCRIPTION
## Summary
Just tweaked the OUath connection description to explain users what is the difference with the Bot connection.



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1056/discord-node-copy-tweak-to-better-explain-why-to-use-oauth



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 