### PR TITLE
fix(core): Support workers view in multi-main mode

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -232,6 +232,12 @@ export class Start extends BaseCommand {
 
 		await Container.get(OrchestrationHandlerMainService).init();
 
+		/**
+		 * @tech_debt This is temporarily necessary so that worker view is accessible
+		 * in multi-main mode.
+		 */
+		await Container.get(SingleMainSetup).init();
+
 		const multiMainSetup = Container.get(MultiMainSetup);
 
 		await multiMainSetup.init();


### PR DESCRIPTION
Worker view methods live in `SingleMainSetup`, which is not initialized in multi-main mode, causing workers view to load forever on multi-main mode. Ideally, worker view methods should be located in `OrchestrationService`, but that turned out to be a non-trivial refactor, so that will need to wait until we simplify the [orchestration hierarchy](https://excalidraw.com/#json=qzPEHGlHge6pBYWICzL-s,WhFR1pTXnMZQA41yXYYSkw).

To solve the immediate issue, this PR initializes `SingleMainSetup` in multi-main mode so that workers view is accessible in multi-main mode. This is a temporary solution until we can improve orchestration code.

### Testing

Run a main instance in multi-main mode:

```
EXECUTIONS_MODE=queue N8N_CONFIG_FILES=<path> N8N_MULTI_MAIN_SETUP_ENABLED=true N8N_LICENSE_TENANT_ID=<id> N8N_LICENSE_ACTIVATION_KEY=<key> N8N_LOG_LEVEL=debug pnpm start
```

Run a worker:

```
N8N_CONFIG_FILES=$N8N_CONFIG_FILES_DIR/dockerized-postgres.json EXECUTIONS_MODE=queue N8N_LICENSE_TENANT_ID=<id> N8N_LICENSE_ACTIVATION_KEY=<key> N8N_ENCRYPTION_KEY=<encr_key> N8N_LOG_LEVEL=debug pnpm worker
```

And access `/settings/workers` → Worker specs should be visible.