### PR TITLE
fix(core): Report when waitTill is invalid and handle it 

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -59,6 +59,16 @@ export class WaitTracker {
 		for (const execution of executions) {
 			const executionId = execution.id;
 			if (this.waitingExecutions[executionId] === undefined) {
+				if (!(execution.waitTill instanceof Date)) {
+					ErrorReporter.error('Wait Till is not a date object', {
+						extra: {
+							variableType: typeof execution.waitTill,
+						},
+					});
+					if (typeof execution.waitTill === 'string') {
+						execution.waitTill = new Date(execution.waitTill);
+					}
+				}
 				const triggerTime = execution.waitTill!.getTime() - new Date().getTime();
 				this.waitingExecutions[executionId] = {
 					executionId,

--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -60,6 +60,11 @@ export class WaitTracker {
 			const executionId = execution.id;
 			if (this.waitingExecutions[executionId] === undefined) {
 				if (!(execution.waitTill instanceof Date)) {
+					// n8n expects waitTill to be a date object
+					// but for some reason it's not being converted
+					// we are handling this like this since it seems to address the issue
+					// for some users, as reported by Jon when using a custom image.
+					// Once we figure out why this it not a Date object, we can remove this.
 					ErrorReporter.error('Wait Till is not a date object', {
 						extra: {
 							variableType: typeof execution.waitTill,


### PR DESCRIPTION
## Summary
Executions sometimes fail to resume with the issue `execution.waitTill.getTime is not a function`. Since we cannot reproduce it locally, this attempts to patch it temporarily until we identify the source.



## Related tickets and issues
https://n8nio.sentry.io/issues/4703277858/?project=4503924908883968
https://community.n8n.io/t/wait-does-not-work-after-65-seconds/34776
https://github.com/n8n-io/n8n/issues/6624
https://github.com/n8n-io/n8n/issues/8136
https://linear.app/n8n/issue/PAY-1173/bug-waiting-executions-failing-to-resume




## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.