### PR TITLE
fix(core): Parse any readable stream response instead of only IncomingMessage

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2855,10 +2855,7 @@ const getRequestHelperFunctions = (
 
 				let contentBody: Exclude<IN8nHttpResponse, Buffer>;
 
-				if (
-					newResponse.body?.constructor.name === 'IncomingMessage' &&
-					paginationOptions.binaryResult !== true
-				) {
+				if (newResponse.body instanceof Readable && paginationOptions.binaryResult !== true) {
 					const data = await this.helpers
 						.binaryToBuffer(newResponse.body as Buffer | Readable)
 						.then((body) => body.toString());
@@ -2954,10 +2951,7 @@ const getRequestHelperFunctions = (
 						// configured to stop on 404 response codes. For that reason we have to throw here
 						// now an error manually if the response code is not a success one.
 						let data = tempResponseData.body;
-						if (
-							data?.constructor.name === 'IncomingMessage' &&
-							paginationOptions.binaryResult !== true
-						) {
+						if (data instanceof Readable && paginationOptions.binaryResult !== true) {
 							data = await this.helpers
 								.binaryToBuffer(tempResponseData.body as Buffer | Readable)
 								.then((body) => body.toString());


### PR DESCRIPTION
## Summary

The code was expecting an `IncomingMessage` instance, but it seems it now gets a `BrotliDecompress` object from axios. Both extend `Readable` so, by checking for a Readable stream the issue is fixed.

~~Probably introduced after upgrading axios.~~

## Related tickets and issues
https://github.com/n8n-io/n8n/pull/7745
https://linear.app/n8n/issue/NODE-1058/pagination-failing-in-http-request-in-some-cases


## Review / Merge checklist
- [x] PR title and summary are descriptive