### PR TITLE
test(core): Fix cleanup in test teardown script (no-changelog)

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -14,7 +14,6 @@ if (inE2ETests) {
 	process.env.N8N_AI_ENABLED = 'true';
 } else if (inTest) {
 	process.env.N8N_LOG_LEVEL = 'silent';
-	process.env.N8N_ENCRYPTION_KEY = 'test_key';
 	process.env.N8N_PUBLIC_API_DISABLED = 'true';
 	process.env.SKIP_STATISTICS_EVENTS = 'true';
 } else {

--- a/packages/cli/test/setup-test-folder.ts
+++ b/packages/cli/test/setup-test-folder.ts
@@ -2,6 +2,8 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
 
+process.env.N8N_ENCRYPTION_KEY = 'test_key';
+
 const baseDir = join(tmpdir(), 'n8n-tests/');
 mkdirSync(baseDir, { recursive: true });
 


### PR DESCRIPTION
The test teardown script uses the real user dir instead of the temp user dir, which causes an encryption key mismatch error. This PR ensures we always the temp user dir whenever `NODE_ENV=test`, so that the env key and config file key match.