### PR TITLE
fix: Set '@typescript-eslint/return-await' rule to 'always' for node code (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -252,15 +252,15 @@ export class Agent implements INodeType {
 		const agentType = this.getNodeParameter('agent', 0, '') as string;
 
 		if (agentType === 'conversationalAgent') {
-			return conversationalAgentExecute.call(this);
+			return await conversationalAgentExecute.call(this);
 		} else if (agentType === 'openAiFunctionsAgent') {
-			return openAiFunctionsAgentExecute.call(this);
+			return await openAiFunctionsAgentExecute.call(this);
 		} else if (agentType === 'reActAgent') {
-			return reActAgentAgentExecute.call(this);
+			return await reActAgentAgentExecute.call(this);
 		} else if (agentType === 'sqlAgent') {
-			return sqlAgentAgentExecute.call(this);
+			return await sqlAgentAgentExecute.call(this);
 		} else if (agentType === 'planAndExecuteAgent') {
-			return planAndExecuteAgentExecute.call(this);
+			return await planAndExecuteAgentExecute.call(this);
 		}
 
 		throw new NodeOperationError(this.getNode(), `The agent type "${agentType}" is not supported`);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -102,5 +102,5 @@ export async function conversationalAgentExecute(
 		returnData.push({ json: response });
 	}
 
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
@@ -101,5 +101,5 @@ export async function openAiFunctionsAgentExecute(
 		returnData.push({ json: response });
 	}
 
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
@@ -76,5 +76,5 @@ export async function planAndExecuteAgentExecute(
 		returnData.push({ json: response });
 	}
 
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -94,5 +94,5 @@ export async function reActAgentAgentExecute(
 		returnData.push({ json: response });
 	}
 
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
@@ -101,5 +101,5 @@ export async function sqlAgentAgentExecute(
 		returnData.push({ json: response });
 	}
 
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -380,6 +380,6 @@ export class OpenAiAssistant implements INodeType {
 			returnData.push({ json: response });
 		}
 
-		return this.prepareOutputData(returnData);
+		return await this.prepareOutputData(returnData);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -166,7 +166,7 @@ async function getChain(
 
 	// If there are no output parsers, create a simple LLM chain and execute the query
 	if (!outputParsers.length) {
-		return createSimpleLLMChain(context, llm, query, chatTemplate);
+		return await createSimpleLLMChain(context, llm, query, chatTemplate);
 	}
 
 	// If there's only one output parser, use it; otherwise, create a combined output parser

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -126,6 +126,6 @@ export class ChainRetrievalQa implements INodeType {
 			const response = await chain.call({ query });
 			returnData.push({ json: { response } });
 		}
-		return this.prepareOutputData(returnData);
+		return await this.prepareOutputData(returnData);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
@@ -258,6 +258,6 @@ export class ChainSummarizationV1 implements INodeType {
 			returnData.push({ json: { response } });
 		}
 
-		return this.prepareOutputData(returnData);
+		return await this.prepareOutputData(returnData);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -415,6 +415,6 @@ export class ChainSummarizationV2 implements INodeType {
 			}
 		}
 
-		return this.prepareOutputData(returnData);
+		return await this.prepareOutputData(returnData);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
@@ -98,7 +98,7 @@ export class MemoryChatRetriever implements INodeType {
 		const messages = await memory?.chatHistory.getMessages();
 
 		if (simplifyOutput && messages) {
-			return this.prepareOutputData(simplifyMessages(messages));
+			return await this.prepareOutputData(simplifyMessages(messages));
 		}
 
 		const serializedMessages =
@@ -107,6 +107,6 @@ export class MemoryChatRetriever implements INodeType {
 				return { json: serializedMessage as unknown as IDataObject };
 			}) ?? [];
 
-		return this.prepareOutputData(serializedMessages);
+		return await this.prepareOutputData(serializedMessages);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryManager/MemoryManager.node.ts
@@ -324,6 +324,6 @@ export class MemoryManager implements INodeType {
 			result.push(...executionData);
 		}
 
-		return this.prepareOutputData(result);
+		return await this.prepareOutputData(result);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -163,7 +163,7 @@ export class ToolCode implements INodeType {
 
 		const runFunction = async (query: string): Promise<string> => {
 			const sandbox = getSandbox(query, itemIndex);
-			return sandbox.runCode() as Promise<string>;
+			return await (sandbox.runCode() as Promise<string>);
 		};
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -46,7 +46,7 @@ export const VectorStoreInMemory = createVectorStoreNode({
 		const memoryKey = context.getNodeParameter('memoryKey', itemIndex) as string;
 		const vectorStoreSingleton = MemoryVectorStoreManager.getInstance(embeddings);
 
-		return vectorStoreSingleton.getVectorStore(`${workflowId}__${memoryKey}`);
+		return await vectorStoreSingleton.getVectorStore(`${workflowId}__${memoryKey}`);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		const memoryKey = context.getNodeParameter('memoryKey', itemIndex) as string;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemoryInsert/VectorStoreInMemoryInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemoryInsert/VectorStoreInMemoryInsert.node.ts
@@ -108,6 +108,6 @@ export class VectorStoreInMemoryInsert implements INodeType {
 			clearStore,
 		);
 
-		return this.prepareOutputData(serializedDocuments);
+		return await this.prepareOutputData(serializedDocuments);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -97,7 +97,7 @@ export const VectorStorePinecone = createVectorStoreNode({
 			filter,
 		};
 
-		return PineconeStore.fromExistingIndex(embeddings, config);
+		return await PineconeStore.fromExistingIndex(embeddings, config);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
@@ -134,6 +134,6 @@ export class VectorStorePineconeInsert implements INodeType {
 			pineconeIndex,
 		});
 
-		return this.prepareOutputData(serializedDocuments);
+		return await this.prepareOutputData(serializedDocuments);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -59,7 +59,7 @@ export const VectorStoreQdrant = createVectorStoreNode({
 			collectionName: collection,
 		};
 
-		return QdrantVectorStore.fromExistingCollection(embeddings, config);
+		return await QdrantVectorStore.fromExistingCollection(embeddings, config);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		const collectionName = context.getNodeParameter('qdrantCollection', itemIndex, '', {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -76,7 +76,7 @@ export const VectorStoreSupabase = createVectorStoreNode({
 		const credentials = await context.getCredentials('supabaseApi');
 		const client = createClient(credentials.host as string, credentials.serviceRole as string);
 
-		return SupabaseVectorStore.fromExistingIndex(embeddings, {
+		return await SupabaseVectorStore.fromExistingIndex(embeddings, {
 			client,
 			tableName,
 			queryName: options.queryName ?? 'match_documents',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabaseInsert/VectorStoreSupabaseInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabaseInsert/VectorStoreSupabaseInsert.node.ts
@@ -122,6 +122,6 @@ export class VectorStoreSupabaseInsert implements INodeType {
 			queryName,
 		});
 
-		return this.prepareOutputData(serializedDocuments);
+		return await this.prepareOutputData(serializedDocuments);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
@@ -139,6 +139,6 @@ export class VectorStoreZepInsert implements INodeType {
 
 		await ZepVectorStore.fromDocuments(processedDocuments, embeddings, zepConfig);
 
-		return this.prepareOutputData(serializedDocuments);
+		return await this.prepareOutputData(serializedDocuments);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -239,7 +239,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					resultData.push(...serializedDocs);
 				}
 
-				return this.prepareOutputData(resultData);
+				return await this.prepareOutputData(resultData);
 			}
 
 			if (mode === 'insert') {
@@ -267,7 +267,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					}
 				}
 
-				return this.prepareOutputData(resultData);
+				return await this.prepareOutputData(resultData);
 			}
 
 			throw new NodeOperationError(

--- a/packages/@n8n_io/eslint-config/node.js
+++ b/packages/@n8n_io/eslint-config/node.js
@@ -8,4 +8,11 @@ module.exports = {
 		es6: true,
 		node: true,
 	},
+
+	rules: {
+		/**
+		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md
+		 */
+		'@typescript-eslint/return-await': ['error', 'always'],
+	},
 };

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -208,7 +208,7 @@ export abstract class AbstractServer {
 			// TODO UM: check if this needs validation with user management.
 			this.app.delete(
 				`/${this.restEndpoint}/test-webhook/:id`,
-				send(async (req) => testWebhooks.cancelWebhook(req.params.id)),
+				send(async (req) => await testWebhooks.cancelWebhook(req.params.id)),
 			);
 		}
 

--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -178,7 +178,7 @@ export class ActiveExecutions {
 			this.activeExecutions[executionId].workflowExecution!.cancel();
 		}
 
-		return this.getPostExecutePromise(executionId);
+		return await this.getPostExecutePromise(executionId);
 	}
 
 	/**
@@ -197,7 +197,7 @@ export class ActiveExecutions {
 
 		this.activeExecutions[executionId].postExecutePromises.push(waitPromise);
 
-		return waitPromise.promise();
+		return await waitPromise.promise();
 	}
 
 	/**

--- a/packages/cli/src/ActiveWebhooks.ts
+++ b/packages/cli/src/ActiveWebhooks.ts
@@ -30,7 +30,7 @@ export class ActiveWebhooks implements IWebhookManager {
 	) {}
 
 	async getWebhookMethods(path: string) {
-		return this.webhookService.getWebhookMethods(path);
+		return await this.webhookService.getWebhookMethods(path);
 	}
 
 	async findAccessControlOptions(path: string, httpMethod: IHttpRequestMethods) {
@@ -120,7 +120,7 @@ export class ActiveWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
-		return new Promise((resolve, reject) => {
+		return await new Promise((resolve, reject) => {
 			const executionMode = 'webhook';
 			void WebhookHelpers.executeWebhook(
 				workflow,

--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -89,7 +89,7 @@ export class ActiveWorkflowRunner {
 	}
 
 	async getAllWorkflowActivationErrors() {
-		return this.activationErrorsService.getAll();
+		return await this.activationErrorsService.getAll();
 	}
 
 	/**
@@ -305,7 +305,7 @@ export class ActiveWorkflowRunner {
 		};
 
 		const workflowRunner = new WorkflowRunner();
-		return workflowRunner.run(runData, true, undefined, undefined, responsePromise);
+		return await workflowRunner.run(runData, true, undefined, undefined, responsePromise);
 	}
 
 	/**

--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -121,7 +121,10 @@ export class CredentialsHelper extends ICredentialsHelper {
 			if (typeof credentialType.authenticate === 'function') {
 				// Special authentication function is defined
 
-				return credentialType.authenticate(credentials, requestOptions as IHttpRequestOptions);
+				return await credentialType.authenticate(
+					credentials,
+					requestOptions as IHttpRequestOptions,
+				);
 			}
 
 			if (typeof credentialType.authenticate === 'object') {

--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -54,7 +54,7 @@ if (!inTest) {
 }
 
 export async function transaction<T>(fn: (entityManager: EntityManager) => Promise<T>): Promise<T> {
-	return connection.transaction(fn);
+	return await connection.transaction(fn);
 }
 
 export function getConnectionOptions(dbType: DatabaseType): ConnectionOptions {

--- a/packages/cli/src/ExternalSecrets/ExternalSecrets.controller.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecrets.controller.ee.ts
@@ -13,7 +13,7 @@ export class ExternalSecretsController {
 	@Get('/providers')
 	@RequireGlobalScope('externalSecretsProvider:list')
 	async getProviders() {
-		return this.secretsService.getProviders();
+		return await this.secretsService.getProviders();
 	}
 
 	@Get('/providers/:provider')

--- a/packages/cli/src/ExternalSecrets/ExternalSecrets.service.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecrets.service.ee.ts
@@ -134,7 +134,7 @@ export class ExternalSecretsService {
 		}
 		const { settings } = providerAndSettings;
 		const newData = this.unredact(data, settings.settings);
-		return Container.get(ExternalSecretsManager).testProviderSettings(providerName, newData);
+		return await Container.get(ExternalSecretsManager).testProviderSettings(providerName, newData);
 	}
 
 	async updateProvider(providerName: string) {
@@ -143,6 +143,6 @@ export class ExternalSecretsService {
 		if (!providerAndSettings) {
 			throw new ExternalSecretsProviderNotFoundError(providerName);
 		}
-		return Container.get(ExternalSecretsManager).updateProvider(providerName);
+		return await Container.get(ExternalSecretsManager).updateProvider(providerName);
 	}
 }

--- a/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
+++ b/packages/cli/src/ExternalSecrets/ExternalSecretsManager.ee.ts
@@ -48,10 +48,13 @@ export class ExternalSecretsManager {
 					this.initialized = true;
 					resolve();
 					this.initializingPromise = undefined;
-					this.updateInterval = setInterval(async () => this.updateSecrets(), updateIntervalTime());
+					this.updateInterval = setInterval(
+						async () => await this.updateSecrets(),
+						updateIntervalTime(),
+					);
 				});
 			}
-			return this.initializingPromise;
+			return await this.initializingPromise;
 		}
 	}
 
@@ -107,8 +110,8 @@ export class ExternalSecretsManager {
 		}
 		const providers: Array<SecretsProvider | null> = (
 			await Promise.allSettled(
-				Object.entries(settings).map(async ([name, providerSettings]) =>
-					this.initProvider(name, providerSettings),
+				Object.entries(settings).map(
+					async ([name, providerSettings]) => await this.initProvider(name, providerSettings),
 				),
 			)
 		).map((i) => (i.status === 'rejected' ? null : i.value));

--- a/packages/cli/src/ExternalSecrets/providers/vault.ts
+++ b/packages/cli/src/ExternalSecrets/providers/vault.ts
@@ -436,7 +436,7 @@ export class VaultProvider extends SecretsProvider {
 				await Promise.allSettled(
 					listResp.data.data.keys.map(async (key): Promise<[string, IDataObject] | null> => {
 						if (key.endsWith('/')) {
-							return this.getKVSecrets(mountPath, kvVersion, path + key);
+							return await this.getKVSecrets(mountPath, kvVersion, path + key);
 						}
 						let secretPath = mountPath;
 						if (kvVersion === '2') {

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -56,11 +56,13 @@ export class InternalHooks {
 		eventsService: EventsService,
 		private readonly instanceSettings: InstanceSettings,
 	) {
-		eventsService.on('telemetry.onFirstProductionWorkflowSuccess', async (metrics) =>
-			this.onFirstProductionWorkflowSuccess(metrics),
+		eventsService.on(
+			'telemetry.onFirstProductionWorkflowSuccess',
+			async (metrics) => await this.onFirstProductionWorkflowSuccess(metrics),
 		);
-		eventsService.on('telemetry.onFirstWorkflowDataLoad', async (metrics) =>
-			this.onFirstWorkflowDataLoad(metrics),
+		eventsService.on(
+			'telemetry.onFirstWorkflowDataLoad',
+			async (metrics) => await this.onFirstWorkflowDataLoad(metrics),
 		);
 	}
 
@@ -88,7 +90,7 @@ export class InternalHooks {
 			license_tenant_id: diagnosticInfo.licenseTenantId,
 		};
 
-		return Promise.all([
+		return await Promise.all([
 			this.telemetry.identify(info),
 			this.telemetry.track('Instance started', {
 				...info,
@@ -98,7 +100,7 @@ export class InternalHooks {
 	}
 
 	async onFrontendSettingsAPI(sessionId?: string): Promise<void> {
-		return this.telemetry.track('Session started', { session_id: sessionId });
+		return await this.telemetry.track('Session started', { session_id: sessionId });
 	}
 
 	async onPersonalizationSurveySubmitted(
@@ -111,7 +113,7 @@ export class InternalHooks {
 			personalizationSurveyData[snakeCase(camelCaseKey)] = answers[camelCaseKey];
 		});
 
-		return this.telemetry.track(
+		return await this.telemetry.track(
 			'User responded to personalization questions',
 			personalizationSurveyData,
 		);
@@ -459,7 +461,7 @@ export class InternalHooks {
 			user_id_list: userList,
 		};
 
-		return this.telemetry.track('User updated workflow sharing', properties);
+		return await this.telemetry.track('User updated workflow sharing', properties);
 	}
 
 	async onN8nStop(): Promise<void> {
@@ -469,7 +471,7 @@ export class InternalHooks {
 			}, 3000);
 		});
 
-		return Promise.race([timeoutPromise, this.telemetry.trackN8nStop()]);
+		return await Promise.race([timeoutPromise, this.telemetry.trackN8nStop()]);
 	}
 
 	async onUserDeletion(userDeletionData: {
@@ -554,42 +556,42 @@ export class InternalHooks {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved user', userRetrievedData);
+		return await this.telemetry.track('User retrieved user', userRetrievedData);
 	}
 
 	async onUserRetrievedAllUsers(userRetrievedData: {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved all users', userRetrievedData);
+		return await this.telemetry.track('User retrieved all users', userRetrievedData);
 	}
 
 	async onUserRetrievedExecution(userRetrievedData: {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved execution', userRetrievedData);
+		return await this.telemetry.track('User retrieved execution', userRetrievedData);
 	}
 
 	async onUserRetrievedAllExecutions(userRetrievedData: {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved all executions', userRetrievedData);
+		return await this.telemetry.track('User retrieved all executions', userRetrievedData);
 	}
 
 	async onUserRetrievedWorkflow(userRetrievedData: {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved workflow', userRetrievedData);
+		return await this.telemetry.track('User retrieved workflow', userRetrievedData);
 	}
 
 	async onUserRetrievedAllWorkflows(userRetrievedData: {
 		user_id: string;
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User retrieved all workflows', userRetrievedData);
+		return await this.telemetry.track('User retrieved all workflows', userRetrievedData);
 	}
 
 	async onUserUpdate(userUpdateData: { user: User; fields_changed: string[] }): Promise<void> {
@@ -649,7 +651,7 @@ export class InternalHooks {
 		message_type: 'Reset password' | 'New user invite' | 'Resend invite';
 		public_api: boolean;
 	}): Promise<void> {
-		return this.telemetry.track(
+		return await this.telemetry.track(
 			'Instance sent transactional email to user',
 			userTransactionalEmailData,
 		);
@@ -661,7 +663,7 @@ export class InternalHooks {
 		method: string;
 		api_version: string;
 	}): Promise<void> {
-		return this.telemetry.track('User invoked API', userInvokedApiData);
+		return await this.telemetry.track('User invoked API', userInvokedApiData);
 	}
 
 	async onApiKeyDeleted(apiKeyDeletedData: { user: User; public_api: boolean }): Promise<void> {
@@ -709,7 +711,7 @@ export class InternalHooks {
 	}
 
 	async onInstanceOwnerSetup(instanceOwnerSetupData: { user_id: string }): Promise<void> {
-		return this.telemetry.track('Owner finished instance setup', instanceOwnerSetupData);
+		return await this.telemetry.track('Owner finished instance setup', instanceOwnerSetupData);
 	}
 
 	async onUserSignup(
@@ -963,7 +965,7 @@ export class InternalHooks {
 		users_synced: number;
 		error: string;
 	}): Promise<void> {
-		return this.telemetry.track('Ldap general sync finished', data);
+		return await this.telemetry.track('Ldap general sync finished', data);
 	}
 
 	async onUserUpdatedLdapSettings(data: {
@@ -980,15 +982,15 @@ export class InternalHooks {
 		loginLabel: string;
 		loginEnabled: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('Ldap general sync finished', data);
+		return await this.telemetry.track('Ldap general sync finished', data);
 	}
 
 	async onLdapLoginSyncFailed(data: { error: string }): Promise<void> {
-		return this.telemetry.track('Ldap login sync failed', data);
+		return await this.telemetry.track('Ldap login sync failed', data);
 	}
 
 	async userLoginFailedDueToLdapDisabled(data: { user_id: string }): Promise<void> {
-		return this.telemetry.track('User login failed since ldap disabled', data);
+		return await this.telemetry.track('User login failed since ldap disabled', data);
 	}
 
 	/*
@@ -998,7 +1000,7 @@ export class InternalHooks {
 		user_id: string;
 		workflow_id: string;
 	}): Promise<void> {
-		return this.telemetry.track('Workflow first prod success', data);
+		return await this.telemetry.track('Workflow first prod success', data);
 	}
 
 	async onFirstWorkflowDataLoad(data: {
@@ -1009,7 +1011,7 @@ export class InternalHooks {
 		credential_type?: string;
 		credential_id?: string;
 	}): Promise<void> {
-		return this.telemetry.track('Workflow first data fetched', data);
+		return await this.telemetry.track('Workflow first data fetched', data);
 	}
 
 	/**
@@ -1023,11 +1025,11 @@ export class InternalHooks {
 	 * Audit
 	 */
 	async onAuditGeneratedViaCli() {
-		return this.telemetry.track('Instance generated security audit via CLI command');
+		return await this.telemetry.track('Instance generated security audit via CLI command');
 	}
 
 	async onVariableCreated(createData: { variable_type: string }): Promise<void> {
-		return this.telemetry.track('User created variable', createData);
+		return await this.telemetry.track('User created variable', createData);
 	}
 
 	async onSourceControlSettingsUpdated(data: {
@@ -1036,7 +1038,7 @@ export class InternalHooks {
 		repo_type: 'github' | 'gitlab' | 'other';
 		connected: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User updated source control settings', data);
+		return await this.telemetry.track('User updated source control settings', data);
 	}
 
 	async onSourceControlUserStartedPullUI(data: {
@@ -1044,11 +1046,11 @@ export class InternalHooks {
 		workflow_conflicts: number;
 		cred_conflicts: number;
 	}): Promise<void> {
-		return this.telemetry.track('User started pull via UI', data);
+		return await this.telemetry.track('User started pull via UI', data);
 	}
 
 	async onSourceControlUserFinishedPullUI(data: { workflow_updates: number }): Promise<void> {
-		return this.telemetry.track('User finished pull via UI', {
+		return await this.telemetry.track('User finished pull via UI', {
 			workflow_updates: data.workflow_updates,
 		});
 	}
@@ -1057,7 +1059,7 @@ export class InternalHooks {
 		workflow_updates: number;
 		forced: boolean;
 	}): Promise<void> {
-		return this.telemetry.track('User pulled via API', data);
+		return await this.telemetry.track('User pulled via API', data);
 	}
 
 	async onSourceControlUserStartedPushUI(data: {
@@ -1067,7 +1069,7 @@ export class InternalHooks {
 		creds_eligible_with_conflicts: number;
 		variables_eligible: number;
 	}): Promise<void> {
-		return this.telemetry.track('User started push via UI', data);
+		return await this.telemetry.track('User started push via UI', data);
 	}
 
 	async onSourceControlUserFinishedPushUI(data: {
@@ -1076,7 +1078,7 @@ export class InternalHooks {
 		creds_pushed: number;
 		variables_pushed: number;
 	}): Promise<void> {
-		return this.telemetry.track('User finished push via UI', data);
+		return await this.telemetry.track('User finished push via UI', data);
 	}
 
 	async onExternalSecretsProviderSettingsSaved(saveData: {
@@ -1086,6 +1088,6 @@ export class InternalHooks {
 		is_new: boolean;
 		error_message?: string | undefined;
 	}): Promise<void> {
-		return this.telemetry.track('User updated external secrets settings', saveData);
+		return await this.telemetry.track('User updated external secrets settings', saveData);
 	}
 }

--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -51,7 +51,7 @@ export const randomPassword = (): string => {
  * Return the user role to be assigned to LDAP users
  */
 export const getLdapUserRole = async (): Promise<Role> => {
-	return Container.get(RoleService).findGlobalMemberRole();
+	return await Container.get(RoleService).findGlobalMemberRole();
 };
 
 /**
@@ -101,7 +101,7 @@ export const escapeFilter = (filter: string): string => {
 export const getAuthIdentityByLdapId = async (
 	idAttributeValue: string,
 ): Promise<AuthIdentity | null> => {
-	return Container.get(AuthIdentityRepository).findOne({
+	return await Container.get(AuthIdentityRepository).findOne({
 		relations: ['user', 'user.globalRole'],
 		where: {
 			providerId: idAttributeValue,
@@ -111,7 +111,7 @@ export const getAuthIdentityByLdapId = async (
 };
 
 export const getUserByEmail = async (email: string): Promise<User | null> => {
-	return Container.get(UserRepository).findOne({
+	return await Container.get(UserRepository).findOne({
 		where: { email },
 		relations: ['globalRole'],
 	});
@@ -190,10 +190,10 @@ export const processUsers = async (
 	toDisableUsers: string[],
 ): Promise<void> => {
 	await Db.transaction(async (transactionManager) => {
-		return Promise.all([
+		return await Promise.all([
 			...toCreateUsers.map(async ([ldapId, user]) => {
 				const authIdentity = AuthIdentity.create(await transactionManager.save(user), ldapId);
-				return transactionManager.save(authIdentity);
+				return await transactionManager.save(authIdentity);
 			}),
 			...toUpdateUsers.map(async ([ldapId, user]) => {
 				const authIdentity = await transactionManager.findOneBy(AuthIdentity, {
@@ -240,7 +240,7 @@ export const getLdapSynchronizations = async (
 	perPage: number,
 ): Promise<AuthProviderSyncHistory[]> => {
 	const _page = Math.abs(page);
-	return Container.get(AuthProviderSyncHistoryRepository).find({
+	return await Container.get(AuthProviderSyncHistoryRepository).find({
 		where: { providerType: 'ldap' },
 		order: { id: 'DESC' },
 		take: perPage,
@@ -267,7 +267,7 @@ export const getMappingAttributes = (ldapConfig: LdapConfig): string[] => {
 };
 
 export const createLdapAuthIdentity = async (user: User, ldapId: string) => {
-	return Container.get(AuthIdentityRepository).save(AuthIdentity.create(user, ldapId));
+	return await Container.get(AuthIdentityRepository).save(AuthIdentity.create(user, ldapId));
 };
 
 export const createLdapUserOnLocalDb = async (role: Role, data: Partial<User>, ldapId: string) => {
@@ -288,5 +288,5 @@ export const updateLdapUserOnLocalDb = async (identity: AuthIdentity, data: Part
 };
 
 export const deleteAllLdapIdentities = async () => {
-	return Container.get(AuthIdentityRepository).delete({ providerType: 'ldap' });
+	return await Container.get(AuthIdentityRepository).delete({ providerType: 'ldap' });
 };

--- a/packages/cli/src/Ldap/ldap.controller.ts
+++ b/packages/cli/src/Ldap/ldap.controller.ts
@@ -19,7 +19,7 @@ export class LdapController {
 	@Get('/config')
 	@RequireGlobalScope('ldap:manage')
 	async getConfig() {
-		return this.ldapService.loadConfig();
+		return await this.ldapService.loadConfig();
 	}
 
 	@Post('/test-connection')
@@ -55,7 +55,7 @@ export class LdapController {
 	@RequireGlobalScope('ldap:sync')
 	async getLdapSync(req: LdapConfiguration.GetSync) {
 		const { page = '0', perPage = '20' } = req.query;
-		return getLdapSynchronizations(parseInt(page, 10), parseInt(perPage, 10));
+		return await getLdapSynchronizations(parseInt(page, 10), parseInt(perPage, 10));
 	}
 
 	@Post('/sync')

--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -59,13 +59,13 @@ export class License {
 		const offlineMode = !isMainInstance;
 		const autoRenewOffset = config.getEnv('license.autoRenewOffset');
 		const saveCertStr = isMainInstance
-			? async (value: TLicenseBlock) => this.saveCertStr(value)
+			? async (value: TLicenseBlock) => await this.saveCertStr(value)
 			: async () => {};
 		const onFeatureChange = isMainInstance
-			? async (features: TFeatures) => this.onFeatureChange(features)
+			? async (features: TFeatures) => await this.onFeatureChange(features)
 			: async () => {};
 		const collectUsageMetrics = isMainInstance
-			? async () => this.collectUsageMetrics()
+			? async () => await this.collectUsageMetrics()
 			: async () => [];
 
 		try {
@@ -78,7 +78,7 @@ export class License {
 				autoRenewOffset,
 				offlineMode,
 				logger: this.logger,
-				loadCertStr: async () => this.loadCertStr(),
+				loadCertStr: async () => await this.loadCertStr(),
 				saveCertStr,
 				deviceFingerprint: () => this.instanceSettings.instanceId,
 				collectUsageMetrics,

--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -182,7 +182,7 @@ export class LoadNodesAndCredentials {
 			'node_modules',
 			packageName,
 		);
-		return this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
+		return await this.runDirectoryLoader(PackageDirectoryLoader, finalNodeUnpackedPath);
 	}
 
 	async unloadPackage(packageName: string) {

--- a/packages/cli/src/Mfa/helpers.ts
+++ b/packages/cli/src/Mfa/helpers.ts
@@ -8,7 +8,7 @@ export const isMfaFeatureEnabled = () => config.get(MFA_FEATURE_ENABLED);
 const isMfaFeatureDisabled = () => !isMfaFeatureEnabled();
 
 const getUsersWithMfaEnabled = async () =>
-	Container.get(UserRepository).count({ where: { mfaEnabled: true } });
+	await Container.get(UserRepository).count({ where: { mfaEnabled: true } });
 
 export const handleMfaDisable = async () => {
 	if (isMfaFeatureDisabled()) {

--- a/packages/cli/src/Mfa/mfa.service.ts
+++ b/packages/cli/src/Mfa/mfa.service.ts
@@ -25,7 +25,7 @@ export class MfaService {
 			secret,
 			recoveryCodes,
 		);
-		return this.userRepository.update(userId, {
+		return await this.userRepository.update(userId, {
 			mfaSecret: encryptedSecret,
 			mfaRecoveryCodes: encryptedRecoveryCodes,
 		});

--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -144,7 +144,7 @@ export const loadPublicApiVersions = async (
 	const apiRouters = await Promise.all(
 		versions.map(async (version) => {
 			const openApiPath = path.join(__dirname, version, 'openapi.yml');
-			return createApiRouter(version, openApiPath, __dirname, publicApiEndpoint);
+			return await createApiRouter(version, openApiPath, __dirname, publicApiEndpoint);
 		}),
 	);
 

--- a/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.service.ts
@@ -14,7 +14,7 @@ import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 
 export async function getCredentials(credentialId: string): Promise<ICredentialsDb | null> {
-	return Container.get(CredentialsRepository).findOneBy({ id: credentialId });
+	return await Container.get(CredentialsRepository).findOneBy({ id: credentialId });
 }
 
 export async function getSharedCredentials(
@@ -22,7 +22,7 @@ export async function getSharedCredentials(
 	credentialId: string,
 	relations?: string[],
 ): Promise<SharedCredentials | null> {
-	return Container.get(SharedCredentialsRepository).findOne({
+	return await Container.get(SharedCredentialsRepository).findOne({
 		where: {
 			userId,
 			credentialsId: credentialId,
@@ -64,7 +64,7 @@ export async function saveCredential(
 
 	await Container.get(ExternalHooks).run('credentials.create', [encryptedData]);
 
-	return Db.transaction(async (transactionManager) => {
+	return await Db.transaction(async (transactionManager) => {
 		const savedCredential = await transactionManager.save<CredentialsEntity>(credential);
 
 		savedCredential.data = credential.data;
@@ -85,7 +85,7 @@ export async function saveCredential(
 
 export async function removeCredential(credentials: CredentialsEntity): Promise<ICredentialsDb> {
 	await Container.get(ExternalHooks).run('credentials.delete', [credentials.id]);
-	return Container.get(CredentialsRepository).remove(credentials);
+	return await Container.get(CredentialsRepository).remove(credentials);
 }
 
 export async function encryptCredential(credential: CredentialsEntity): Promise<ICredentialsDb> {

--- a/packages/cli/src/PublicApi/v1/handlers/users/users.service.ee.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/users/users.service.ee.ts
@@ -15,7 +15,7 @@ export async function getUser(data: {
 	withIdentifier: string;
 	includeRole?: boolean;
 }): Promise<User | null> {
-	return Container.get(UserRepository).findOne({
+	return await Container.get(UserRepository).findOne({
 		where: {
 			...(uuidValidate(data.withIdentifier) && { id: data.withIdentifier }),
 			...(!uuidValidate(data.withIdentifier) && { email: data.withIdentifier }),

--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.service.ts
@@ -25,7 +25,7 @@ export async function getSharedWorkflow(
 	user: User,
 	workflowId?: string | undefined,
 ): Promise<SharedWorkflow | null> {
-	return Container.get(SharedWorkflowRepository).findOne({
+	return await Container.get(SharedWorkflowRepository).findOne({
 		where: {
 			...(!['owner', 'admin'].includes(user.globalRole.name) && { userId: user.id }),
 			...(workflowId && { workflowId }),
@@ -35,7 +35,7 @@ export async function getSharedWorkflow(
 }
 
 export async function getWorkflowById(id: string): Promise<WorkflowEntity | null> {
-	return Container.get(WorkflowRepository).findOne({
+	return await Container.get(WorkflowRepository).findOne({
 		where: { id },
 	});
 }
@@ -45,7 +45,7 @@ export async function createWorkflow(
 	user: User,
 	role: Role,
 ): Promise<WorkflowEntity> {
-	return Db.transaction(async (transactionManager) => {
+	return await Db.transaction(async (transactionManager) => {
 		const newWorkflow = new WorkflowEntity();
 		Object.assign(newWorkflow, workflow);
 		const savedWorkflow = await transactionManager.save<WorkflowEntity>(newWorkflow);
@@ -70,18 +70,18 @@ export async function setWorkflowAsActive(workflow: WorkflowEntity) {
 }
 
 export async function setWorkflowAsInactive(workflow: WorkflowEntity) {
-	return Container.get(WorkflowRepository).update(workflow.id, {
+	return await Container.get(WorkflowRepository).update(workflow.id, {
 		active: false,
 		updatedAt: new Date(),
 	});
 }
 
 export async function deleteWorkflow(workflow: WorkflowEntity): Promise<WorkflowEntity> {
-	return Container.get(WorkflowRepository).remove(workflow);
+	return await Container.get(WorkflowRepository).remove(workflow);
 }
 
 export async function updateWorkflow(workflowId: string, updateData: WorkflowEntity) {
-	return Container.get(WorkflowRepository).update(workflowId, updateData);
+	return await Container.get(WorkflowRepository).update(workflowId, updateData);
 }
 
 export function parseTagNames(tags: string): string[] {

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -74,27 +74,27 @@ export class Queue {
 	}
 
 	async add(jobData: JobData, jobOptions: object): Promise<Job> {
-		return this.jobQueue.add(jobData, jobOptions);
+		return await this.jobQueue.add(jobData, jobOptions);
 	}
 
 	async getJob(jobId: JobId): Promise<Job | null> {
-		return this.jobQueue.getJob(jobId);
+		return await this.jobQueue.getJob(jobId);
 	}
 
 	async getJobs(jobTypes: Bull.JobStatus[]): Promise<Job[]> {
-		return this.jobQueue.getJobs(jobTypes);
+		return await this.jobQueue.getJobs(jobTypes);
 	}
 
 	async process(concurrency: number, fn: Bull.ProcessCallbackFunction<JobData>): Promise<void> {
-		return this.jobQueue.process(concurrency, fn);
+		return await this.jobQueue.process(concurrency, fn);
 	}
 
 	async ping(): Promise<string> {
-		return this.jobQueue.client.ping();
+		return await this.jobQueue.client.ping();
 	}
 
 	async pause(isLocal?: boolean): Promise<void> {
-		return this.jobQueue.pause(isLocal);
+		return await this.jobQueue.pause(isLocal);
 	}
 
 	getBullObjectInstance(): JobQueue {

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -209,8 +209,9 @@ export class Server extends AbstractServer {
 				order: { createdAt: 'ASC' },
 				where: {},
 			})
-			.then(async (workflow) =>
-				Container.get(InternalHooks).onServerStarted(diagnosticInfo, workflow?.createdAt),
+			.then(
+				async (workflow) =>
+					await Container.get(InternalHooks).onServerStarted(diagnosticInfo, workflow?.createdAt),
 			);
 
 		Container.get(CollaborationService);

--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -101,7 +101,7 @@ export class TestWebhooks implements IWebhookManager {
 			throw new NotFoundError('Could not find node to process webhook.');
 		}
 
-		return new Promise(async (resolve, reject) => {
+		return await new Promise(async (resolve, reject) => {
 			try {
 				const executionMode = 'manual';
 				const executionId = await WebhookHelpers.executeWebhook(
@@ -229,7 +229,10 @@ export class TestWebhooks implements IWebhookManager {
 			return false; // no webhooks found to start a workflow
 		}
 
-		const timeout = setTimeout(async () => this.cancelWebhook(workflow.id), TEST_WEBHOOK_TIMEOUT);
+		const timeout = setTimeout(
+			async () => await this.cancelWebhook(workflow.id),
+			TEST_WEBHOOK_TIMEOUT,
+		);
 
 		for (const webhook of webhooks) {
 			const key = this.registrations.toKey(webhook);

--- a/packages/cli/src/UserManagement/email/UserManagementMailer.ts
+++ b/packages/cli/src/UserManagement/email/UserManagementMailer.ts
@@ -53,7 +53,7 @@ export class UserManagementMailer {
 	async verifyConnection(): Promise<void> {
 		if (!this.mailer) throw new ApplicationError('No mailer configured.');
 
-		return this.mailer.verifyConnection();
+		return await this.mailer.verifyConnection();
 	}
 
 	async invite(inviteEmailData: InviteEmailData): Promise<SendEmailResult> {

--- a/packages/cli/src/WaitingWebhooks.ts
+++ b/packages/cli/src/WaitingWebhooks.ts
@@ -122,7 +122,7 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		const runExecutionData = execution.data;
 
-		return new Promise((resolve, reject) => {
+		return await new Promise((resolve, reject) => {
 			const executionMode = 'webhook';
 			void WebhookHelpers.executeWebhook(
 				workflow,

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -417,14 +417,15 @@ export class WorkflowRunner {
 					fullRunData.status = this.activeExecutions.getStatus(executionId);
 					this.activeExecutions.remove(executionId, fullRunData);
 				})
-				.catch(async (error) =>
-					this.processError(
-						error,
-						new Date(),
-						data.executionMode,
-						executionId,
-						additionalData.hooks,
-					),
+				.catch(
+					async (error) =>
+						await this.processError(
+							error,
+							new Date(),
+							data.executionMode,
+							executionId,
+							additionalData.hooks,
+						),
 				);
 		} catch (error) {
 			await this.processError(

--- a/packages/cli/src/WorkflowRunnerProcess.ts
+++ b/packages/cli/src/WorkflowRunnerProcess.ts
@@ -276,7 +276,7 @@ class WorkflowRunnerProcess {
 				this.data.executionMode,
 				this.data.executionData,
 			);
-			return this.workflowExecute.processRunExecutionData(this.workflow);
+			return await this.workflowExecute.processRunExecutionData(this.workflow);
 		}
 		if (
 			this.data.runData === undefined ||
@@ -289,7 +289,7 @@ class WorkflowRunnerProcess {
 
 			// Can execute without webhook so go on
 			this.workflowExecute = new WorkflowExecute(additionalData, this.data.executionMode);
-			return this.workflowExecute.run(
+			return await this.workflowExecute.run(
 				this.workflow,
 				startNode,
 				this.data.destinationNode,
@@ -298,7 +298,7 @@ class WorkflowRunnerProcess {
 		}
 		// Execute only the nodes between start and destination nodes
 		this.workflowExecute = new WorkflowExecute(additionalData, this.data.executionMode);
-		return this.workflowExecute.runPartialWorkflow(
+		return await this.workflowExecute.runPartialWorkflow(
 			this.workflow,
 			this.data.runData,
 			this.data.startNodes,
@@ -383,7 +383,7 @@ class WorkflowRunnerProcess {
  * @param {*} data The data
  */
 async function sendToParentProcess(type: string, data: any): Promise<void> {
-	return new Promise((resolve, reject) => {
+	return await new Promise((resolve, reject) => {
 		process.send!(
 			{
 				type,

--- a/packages/cli/src/auth/jwt.ts
+++ b/packages/cli/src/auth/jwt.ts
@@ -80,7 +80,7 @@ export async function resolveJwt(token: string): Promise<User> {
 	const jwtPayload: JwtPayload = Container.get(JwtService).verify(token, {
 		algorithms: ['HS256'],
 	});
-	return resolveJwtContent(jwtPayload);
+	return await resolveJwtContent(jwtPayload);
 }
 
 export async function issueCookie(res: Response, user: User): Promise<void> {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -59,8 +59,8 @@ export abstract class BaseCommand extends Command {
 		this.nodeTypes = Container.get(NodeTypes);
 		await Container.get(LoadNodesAndCredentials).init();
 
-		await Db.init().catch(async (error: Error) =>
-			this.exitWithCrash('There was an error initializing DB', error),
+		await Db.init().catch(
+			async (error: Error) => await this.exitWithCrash('There was an error initializing DB', error),
 		);
 
 		// This needs to happen after DB.init() or otherwise DB Connection is not
@@ -71,8 +71,9 @@ export abstract class BaseCommand extends Command {
 
 		await this.server?.init();
 
-		await Db.migrate().catch(async (error: Error) =>
-			this.exitWithCrash('There was an error running database migrations', error),
+		await Db.migrate().catch(
+			async (error: Error) =>
+				await this.exitWithCrash('There was an error running database migrations', error),
 		);
 
 		const dbType = config.getEnv('database.type');

--- a/packages/cli/src/commands/executeBatch.ts
+++ b/packages/cli/src/commands/executeBatch.ts
@@ -120,7 +120,7 @@ export class ExecuteBatch extends BaseCommand {
 		const activeExecutionsInstance = Container.get(ActiveExecutions);
 		const stopPromises = activeExecutionsInstance
 			.getActiveExecutions()
-			.map(async (execution) => activeExecutionsInstance.stopExecution(execution.id));
+			.map(async (execution) => await activeExecutionsInstance.stopExecution(execution.id));
 
 		await Promise.allSettled(stopPromises);
 
@@ -410,7 +410,7 @@ export class ExecuteBatch extends BaseCommand {
 			this.initializeLogs();
 		}
 
-		return new Promise(async (res) => {
+		return await new Promise(async (res) => {
 			const promisesArray = [];
 			for (let i = 0; i < ExecuteBatch.concurrency; i++) {
 				const promise = new Promise(async (resolve) => {
@@ -623,7 +623,7 @@ export class ExecuteBatch extends BaseCommand {
 			}
 		});
 
-		return new Promise(async (resolve) => {
+		return await new Promise(async (resolve) => {
 			let gotCancel = false;
 
 			// Timeouts execution after 5 minutes.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -174,7 +174,7 @@ export class Start extends BaseCommand {
 					);
 				}
 				streams.push(createWriteStream(destFile, 'utf-8'));
-				return pipeline(streams);
+				return await pipeline(streams);
 			}
 		};
 

--- a/packages/cli/src/commands/user-management/reset.ts
+++ b/packages/cli/src/commands/user-management/reset.ts
@@ -71,7 +71,7 @@ export class Reset extends BaseCommand {
 
 		await Container.get(UserRepository).save(user);
 
-		return Container.get(UserRepository).findOneByOrFail({ globalRoleId: globalRole.id });
+		return await Container.get(UserRepository).findOneByOrFail({ globalRoleId: globalRole.id });
 	}
 
 	async catch(error: Error): Promise<void> {

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -345,8 +345,9 @@ export class Worker extends BaseCommand {
 		Worker.jobQueue = Container.get(Queue);
 		await Worker.jobQueue.init();
 		this.logger.debug('Queue singleton ready');
-		void Worker.jobQueue.process(flags.concurrency, async (job) =>
-			this.runJob(job, this.nodeTypes),
+		void Worker.jobQueue.process(
+			flags.concurrency,
+			async (job) => await this.runJob(job, this.nodeTypes),
 		);
 
 		Worker.jobQueue.getBullObjectInstance().on('global:progress', (jobId: JobId, progress) => {

--- a/packages/cli/src/controllers/activeWorkflows.controller.ts
+++ b/packages/cli/src/controllers/activeWorkflows.controller.ts
@@ -9,7 +9,7 @@ export class ActiveWorkflowsController {
 
 	@Get('/')
 	async getActiveWorkflows(req: ActiveWorkflowRequest.GetAllActive) {
-		return this.activeWorkflowsService.getAllActiveIdsFor(req.user);
+		return await this.activeWorkflowsService.getAllActiveIdsFor(req.user);
 	}
 
 	@Get('/error/:id')
@@ -18,6 +18,6 @@ export class ActiveWorkflowsController {
 			user,
 			params: { id: workflowId },
 		} = req;
-		return this.activeWorkflowsService.getActivationError(workflowId, user);
+		return await this.activeWorkflowsService.getActivationError(workflowId, user);
 	}
 }

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -102,7 +102,7 @@ export class AuthController {
 				authenticationMethod: usedAuthenticationMethod,
 			});
 
-			return this.userService.toPublic(user, { posthog: this.postHog, withScopes: true });
+			return await this.userService.toPublic(user, { posthog: this.postHog, withScopes: true });
 		}
 		void this.internalHooks.onUserLoginFailed({
 			user: email,
@@ -150,7 +150,7 @@ export class AuthController {
 		}
 
 		await issueCookie(res, user);
-		return this.userService.toPublic(user, { posthog: this.postHog, withScopes: true });
+		return await this.userService.toPublic(user, { posthog: this.postHog, withScopes: true });
 	}
 
 	/**

--- a/packages/cli/src/controllers/dynamicNodeParameters.controller.ts
+++ b/packages/cli/src/controllers/dynamicNodeParameters.controller.ts
@@ -57,7 +57,7 @@ export class DynamicNodeParametersController {
 		const additionalData = await getBase(req.user.id, currentNodeParameters);
 
 		if (methodName) {
-			return this.service.getOptionsViaMethodName(
+			return await this.service.getOptionsViaMethodName(
 				methodName,
 				path,
 				additionalData,
@@ -68,7 +68,7 @@ export class DynamicNodeParametersController {
 		}
 
 		if (loadOptions) {
-			return this.service.getOptionsViaLoadOptions(
+			return await this.service.getOptionsViaLoadOptions(
 				jsonParse(loadOptions),
 				additionalData,
 				nodeTypeAndVersion,
@@ -87,7 +87,7 @@ export class DynamicNodeParametersController {
 		const { path, methodName, filter, paginationToken } = req.query;
 		const { credentials, currentNodeParameters, nodeTypeAndVersion } = req.params;
 		const additionalData = await getBase(req.user.id, currentNodeParameters);
-		return this.service.getResourceLocatorResults(
+		return await this.service.getResourceLocatorResults(
 			methodName,
 			path,
 			additionalData,
@@ -106,7 +106,7 @@ export class DynamicNodeParametersController {
 		const { path, methodName } = req.query;
 		const { credentials, currentNodeParameters, nodeTypeAndVersion } = req.params;
 		const additionalData = await getBase(req.user.id, currentNodeParameters);
-		return this.service.getResourceMappingFields(
+		return await this.service.getResourceMappingFields(
 			methodName,
 			path,
 			additionalData,

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -177,6 +177,9 @@ export class InvitationController {
 		await this.externalHooks.run('user.profile.update', [invitee.email, publicInvitee]);
 		await this.externalHooks.run('user.password.update', [invitee.email, invitee.password]);
 
-		return this.userService.toPublic(updatedUser, { posthog: this.postHog, withScopes: true });
+		return await this.userService.toPublic(updatedUser, {
+			posthog: this.postHog,
+			withScopes: true,
+		});
 	}
 }

--- a/packages/cli/src/controllers/nodeTypes.controller.ts
+++ b/packages/cli/src/controllers/nodeTypes.controller.ts
@@ -50,8 +50,8 @@ export class NodeTypesController {
 
 		const nodeTypes: INodeTypeDescription[] = [];
 
-		const promises = nodeInfos.map(async ({ name, version }) =>
-			populateTranslation(name, version, nodeTypes),
+		const promises = nodeInfos.map(
+			async ({ name, version }) => await populateTranslation(name, version, nodeTypes),
 		);
 
 		await Promise.all(promises);

--- a/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
+++ b/packages/cli/src/controllers/oauth/abstractOAuth.controller.ts
@@ -61,14 +61,14 @@ export abstract class AbstractOAuthController {
 	}
 
 	protected async getAdditionalData(user: User) {
-		return WorkflowExecuteAdditionalData.getBase(user.id);
+		return await WorkflowExecuteAdditionalData.getBase(user.id);
 	}
 
 	protected async getDecryptedData(
 		credential: ICredentialsDb,
 		additionalData: IWorkflowExecuteAdditionalData,
 	) {
-		return this.credentialsHelper.getDecrypted(
+		return await this.credentialsHelper.getDecrypted(
 			additionalData,
 			credential,
 			credential.type,
@@ -105,6 +105,6 @@ export abstract class AbstractOAuthController {
 
 	/** Get a credential without user check */
 	protected async getCredentialWithoutUser(credentialId: string): Promise<ICredentialsDb | null> {
-		return this.credentialsRepository.findOneBy({ id: credentialId });
+		return await this.credentialsRepository.findOneBy({ id: credentialId });
 	}
 }

--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -20,20 +20,20 @@ export class OrchestrationController {
 	async getWorkersStatus(req: OrchestrationRequest.Get) {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
 		const id = req.params.id;
-		return this.singleMainSetup.getWorkerStatus(id);
+		return await this.singleMainSetup.getWorkerStatus(id);
 	}
 
 	@RequireGlobalScope('orchestration:read')
 	@Post('/worker/status')
 	async getWorkersStatusAll() {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
-		return this.singleMainSetup.getWorkerStatus();
+		return await this.singleMainSetup.getWorkerStatus();
 	}
 
 	@RequireGlobalScope('orchestration:list')
 	@Post('/worker/ids')
 	async getWorkerIdsAll() {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
-		return this.singleMainSetup.getWorkerIds();
+		return await this.singleMainSetup.getWorkerIds();
 	}
 }

--- a/packages/cli/src/controllers/owner.controller.ts
+++ b/packages/cli/src/controllers/owner.controller.ts
@@ -104,7 +104,7 @@ export class OwnerController {
 
 		void this.internalHooks.onInstanceOwnerSetup({ user_id: userId });
 
-		return this.userService.toPublic(owner, { posthog: this.postHog, withScopes: true });
+		return await this.userService.toPublic(owner, { posthog: this.postHog, withScopes: true });
 	}
 
 	@Post('/dismiss-banner')

--- a/packages/cli/src/controllers/tags.controller.ts
+++ b/packages/cli/src/controllers/tags.controller.ts
@@ -32,7 +32,7 @@ export class TagsController {
 	@Get('/')
 	@RequireGlobalScope('tag:list')
 	async getAll(req: TagsRequest.GetAll) {
-		return this.tagService.getAll({ withUsageCount: req.query.withUsageCount === 'true' });
+		return await this.tagService.getAll({ withUsageCount: req.query.withUsageCount === 'true' });
 	}
 
 	@Post('/')
@@ -40,7 +40,7 @@ export class TagsController {
 	async createTag(req: TagsRequest.Create) {
 		const tag = this.tagService.toEntity({ name: req.body.name });
 
-		return this.tagService.save(tag, 'create');
+		return await this.tagService.save(tag, 'create');
 	}
 
 	@Patch('/:id(\\w+)')
@@ -48,7 +48,7 @@ export class TagsController {
 	async updateTag(req: TagsRequest.Update) {
 		const newTag = this.tagService.toEntity({ id: req.params.id, name: req.body.name.trim() });
 
-		return this.tagService.save(newTag, 'update');
+		return await this.tagService.save(newTag, 'update');
 	}
 
 	@Delete('/:id(\\w+)')

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -102,8 +102,9 @@ export class UsersController {
 		const users = await this.userRepository.find(findManyOptions);
 
 		const publicUsers: Array<Partial<PublicUser>> = await Promise.all(
-			users.map(async (u) =>
-				this.userService.toPublic(u, { withInviteUrl: true, inviterId: req.user.id }),
+			users.map(
+				async (u) =>
+					await this.userService.toPublic(u, { withInviteUrl: true, inviterId: req.user.id }),
 			),
 		);
 

--- a/packages/cli/src/controllers/workflowStatistics.controller.ts
+++ b/packages/cli/src/controllers/workflowStatistics.controller.ts
@@ -49,12 +49,12 @@ export class WorkflowStatisticsController {
 
 	@Get('/:id/counts/')
 	async getCounts(req: ExecutionRequest.Get): Promise<WorkflowStatisticsData<number>> {
-		return this.getData(req.params.id, 'count', 0);
+		return await this.getData(req.params.id, 'count', 0);
 	}
 
 	@Get('/:id/times/')
 	async getTimes(req: ExecutionRequest.Get): Promise<WorkflowStatisticsData<Date | null>> {
-		return this.getData(req.params.id, 'latestEvent', null);
+		return await this.getData(req.params.id, 'latestEvent', null);
 	}
 
 	@Get('/:id/data-loaded/')

--- a/packages/cli/src/credentials/credentials.controller.ee.ts
+++ b/packages/cli/src/credentials/credentials.controller.ee.ts
@@ -102,7 +102,7 @@ EECredentialsController.post(
 			mergedCredentials.data = EECredentials.unredact(mergedCredentials.data, decryptedData);
 		}
 
-		return EECredentials.test(req.user, mergedCredentials);
+		return await EECredentials.test(req.user, mergedCredentials);
 	}),
 );
 

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -27,7 +27,7 @@ credentialsController.get(
 	'/',
 	listQueryMiddleware,
 	ResponseHelper.send(async (req: ListQuery.Request) => {
-		return CredentialsService.getMany(req.user, { listQueryOptions: req.listQueryOptions });
+		return await CredentialsService.getMany(req.user, { listQueryOptions: req.listQueryOptions });
 	}),
 );
 
@@ -105,7 +105,7 @@ credentialsController.post(
 			mergedCredentials.data = CredentialsService.unredact(mergedCredentials.data, decryptedData);
 		}
 
-		return CredentialsService.test(req.user, mergedCredentials);
+		return await CredentialsService.test(req.user, mergedCredentials);
 	}),
 );
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -43,7 +43,7 @@ export class EECredentialsService extends CredentialsService {
 			where.userId = user.id;
 		}
 
-		return Container.get(SharedCredentialsRepository).findOne({
+		return await Container.get(SharedCredentialsRepository).findOne({
 			where,
 			relations,
 		});
@@ -79,6 +79,6 @@ export class EECredentialsService extends CredentialsService {
 				}),
 			);
 
-		return transaction.save(newSharedCredentials);
+		return await transaction.save(newSharedCredentials);
 	}
 }

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -35,7 +35,7 @@ export type CredentialsGetSharedOptions =
 
 export class CredentialsService {
 	static async get(where: FindOptionsWhere<ICredentialsDb>, options?: { relations: string[] }) {
-		return Container.get(CredentialsRepository).findOne({
+		return await Container.get(CredentialsRepository).findOne({
 			relations: options?.relations,
 			where,
 		});
@@ -94,7 +94,7 @@ export class CredentialsService {
 			}
 		}
 
-		return Container.get(SharedCredentialsRepository).findOne({ where, relations });
+		return await Container.get(SharedCredentialsRepository).findOne({ where, relations });
 	}
 
 	static async prepareCreateData(
@@ -180,7 +180,7 @@ export class CredentialsService {
 
 		// We sadly get nothing back from "update". Neither if it updated a record
 		// nor the new value. So query now the updated entry.
-		return Container.get(CredentialsRepository).findOneBy({ id: credentialId });
+		return await Container.get(CredentialsRepository).findOneBy({ id: credentialId });
 	}
 
 	static async save(
@@ -231,7 +231,7 @@ export class CredentialsService {
 		credentials: ICredentialsDecrypted,
 	): Promise<INodeCredentialTestResult> {
 		const helper = Container.get(CredentialsHelper);
-		return helper.testCredentials(user, credentials.type, credentials);
+		return await helper.testCredentials(user, credentials.type, credentials);
 	}
 
 	// Take data and replace all sensitive values with a sentinel value.

--- a/packages/cli/src/databases/dsl/Indices.ts
+++ b/packages/cli/src/databases/dsl/Indices.ts
@@ -40,7 +40,7 @@ export class CreateIndex extends IndexOperation {
 
 	async execute(queryRunner: QueryRunner) {
 		const { columnNames, isUnique } = this;
-		return queryRunner.createIndex(
+		return await queryRunner.createIndex(
 			this.fullTableName,
 			new TableIndex({ name: this.customIndexName ?? this.fullIndexName, columnNames, isUnique }),
 		);
@@ -49,6 +49,9 @@ export class CreateIndex extends IndexOperation {
 
 export class DropIndex extends IndexOperation {
 	async execute(queryRunner: QueryRunner) {
-		return queryRunner.dropIndex(this.fullTableName, this.customIndexName ?? this.fullIndexName);
+		return await queryRunner.dropIndex(
+			this.fullTableName,
+			this.customIndexName ?? this.fullIndexName,
+		);
 	}
 }

--- a/packages/cli/src/databases/dsl/Table.ts
+++ b/packages/cli/src/databases/dsl/Table.ts
@@ -62,7 +62,7 @@ export class CreateTable extends TableOperation {
 	async execute(queryRunner: QueryRunner) {
 		const { driver } = queryRunner.connection;
 		const { columns, tableName: name, prefix, indices, foreignKeys } = this;
-		return queryRunner.createTable(
+		return await queryRunner.createTable(
 			new Table({
 				name: `${prefix}${name}`,
 				columns: columns.map((c) => c.toOptions(driver)),
@@ -78,7 +78,7 @@ export class CreateTable extends TableOperation {
 export class DropTable extends TableOperation {
 	async execute(queryRunner: QueryRunner) {
 		const { tableName: name, prefix } = this;
-		return queryRunner.dropTable(`${prefix}${name}`, true);
+		return await queryRunner.dropTable(`${prefix}${name}`, true);
 	}
 }
 
@@ -95,7 +95,7 @@ export class AddColumns extends TableOperation {
 	async execute(queryRunner: QueryRunner) {
 		const { driver } = queryRunner.connection;
 		const { tableName, prefix, columns } = this;
-		return queryRunner.addColumns(
+		return await queryRunner.addColumns(
 			`${prefix}${tableName}`,
 			columns.map((c) => new TableColumn(c.toOptions(driver))),
 		);
@@ -114,7 +114,7 @@ export class DropColumns extends TableOperation {
 
 	async execute(queryRunner: QueryRunner) {
 		const { tableName, prefix, columnNames } = this;
-		return queryRunner.dropColumns(`${prefix}${tableName}`, columnNames);
+		return await queryRunner.dropColumns(`${prefix}${tableName}`, columnNames);
 	}
 }
 
@@ -136,7 +136,7 @@ class ModifyNotNull extends TableOperation {
 		const oldColumn = table.findColumnByName(columnName)!;
 		const newColumn = oldColumn.clone();
 		newColumn.isNullable = isNullable;
-		return queryRunner.changeColumn(table, oldColumn, newColumn);
+		return await queryRunner.changeColumn(table, oldColumn, newColumn);
 	}
 }
 

--- a/packages/cli/src/databases/migrations/common/1620821879465-UniqueWorkflowNames.ts
+++ b/packages/cli/src/databases/migrations/common/1620821879465-UniqueWorkflowNames.ts
@@ -20,7 +20,7 @@ export class UniqueWorkflowNames1620821879465 implements ReversibleMigration {
 				await Promise.all(
 					duplicates.map(async (workflow, index) => {
 						if (index === 0) return;
-						return runQuery(`UPDATE ${tableName} SET name = :name WHERE id = :id`, {
+						return await runQuery(`UPDATE ${tableName} SET name = :name WHERE id = :id`, {
 							name: `${workflow.name} ${index + 1}`,
 							id: workflow.id,
 						});

--- a/packages/cli/src/databases/migrations/common/1659888469333-AddJsonKeyPinData.ts
+++ b/packages/cli/src/databases/migrations/common/1659888469333-AddJsonKeyPinData.ts
@@ -26,11 +26,12 @@ export class AddJsonKeyPinData1659888469333 implements IrreversibleMigration {
 		const selectQuery = `SELECT id, ${columnName} FROM ${tableName} WHERE ${columnName} IS NOT NULL`;
 		await runInBatches<Workflow>(selectQuery, async (workflows) => {
 			await Promise.all(
-				this.makeUpdateParams(workflows).map(async (workflow) =>
-					runQuery(`UPDATE ${tableName} SET ${columnName} = :pinData WHERE id = :id;`, {
-						pinData: workflow.pinData,
-						id: workflow.id,
-					}),
+				this.makeUpdateParams(workflows).map(
+					async (workflow) =>
+						await runQuery(`UPDATE ${tableName} SET ${columnName} = :pinData WHERE id = :id;`, {
+							pinData: workflow.pinData,
+							id: workflow.id,
+						}),
 				),
 			);
 		});

--- a/packages/cli/src/databases/migrations/common/1671726148419-RemoveWorkflowDataLoadedFlag.ts
+++ b/packages/cli/src/databases/migrations/common/1671726148419-RemoveWorkflowDataLoadedFlag.ts
@@ -18,13 +18,13 @@ export class RemoveWorkflowDataLoadedFlag1671726148419 implements ReversibleMigr
 		await Promise.all(
 			workflowIds.map(
 				async ({ id, dataLoaded }) =>
-					dataLoaded &&
-					runQuery(
-						`INSERT INTO ${statisticsTableName}
+					await (dataLoaded &&
+						runQuery(
+							`INSERT INTO ${statisticsTableName}
 						(${escape.columnName('workflowId')}, name, count, ${escape.columnName('latestEvent')})
 						VALUES (:id, :name, 1, ${now})`,
-						{ id, name: StatisticsNames.dataLoaded },
-					),
+							{ id, name: StatisticsNames.dataLoaded },
+						)),
 			),
 		);
 
@@ -47,10 +47,11 @@ export class RemoveWorkflowDataLoadedFlag1671726148419 implements ReversibleMigr
 		);
 
 		await Promise.all(
-			workflowsIds.map(async ({ workflowId }) =>
-				runQuery(`UPDATE ${workflowTableName} SET ${columnName} = true WHERE id = :id`, {
-					id: workflowId,
-				}),
+			workflowsIds.map(
+				async ({ workflowId }) =>
+					await runQuery(`UPDATE ${workflowTableName} SET ${columnName} = true WHERE id = :id`, {
+						id: workflowId,
+					}),
 			),
 		);
 

--- a/packages/cli/src/databases/migrations/common/1675940580449-PurgeInvalidWorkflowConnections.ts
+++ b/packages/cli/src/databases/migrations/common/1675940580449-PurgeInvalidWorkflowConnections.ts
@@ -47,10 +47,13 @@ export class PurgeInvalidWorkflowConnections1675940580449 implements Irreversibl
 				});
 
 				// Update database with new connections
-				return runQuery(`UPDATE ${workflowsTable} SET connections = :connections WHERE id = :id`, {
-					connections: JSON.stringify(connections),
-					id: workflow.id,
-				});
+				return await runQuery(
+					`UPDATE ${workflowsTable} SET connections = :connections WHERE id = :id`,
+					{
+						connections: JSON.stringify(connections),
+						id: workflow.id,
+					},
+				);
 			}),
 		);
 	}

--- a/packages/cli/src/databases/migrations/postgresdb/1681134145996-AddUserActivatedProperty.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/1681134145996-AddUserActivatedProperty.ts
@@ -18,15 +18,15 @@ export class AddUserActivatedProperty1681134145996 implements ReversibleMigratio
 						AND r.scope = 'workflow'`,
 		)) as UserSettings[];
 
-		const updatedUsers = activatedUsers.map(async (user) =>
-			queryRunner.query(
+		const updatedUserPromises = activatedUsers.map(async (user) => {
+			await queryRunner.query(
 				`UPDATE "${tablePrefix}user" SET settings = '${JSON.stringify(
 					user.settings,
 				)}' WHERE id = '${user.id}' `,
-			),
-		);
+			);
+		});
 
-		await Promise.all(updatedUsers);
+		await Promise.all(updatedUserPromises);
 
 		if (!activatedUsers.length) {
 			await queryRunner.query(

--- a/packages/cli/src/databases/migrations/sqlite/1681134145996-AddUserActivatedProperty.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1681134145996-AddUserActivatedProperty.ts
@@ -18,14 +18,14 @@ export class AddUserActivatedProperty1681134145996 implements ReversibleMigratio
 						AND r.scope = "workflow"`,
 		)) as UserSettings[];
 
-		const updatedUsers = activatedUsers.map(async (user) =>
-			queryRunner.query(
+		const updatedUserPromises = activatedUsers.map(async (user) => {
+			await queryRunner.query(
 				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 				`UPDATE ${tablePrefix}user SET settings = '${user.settings}' WHERE id = '${user.id}' `,
-			),
-		);
+			);
+		});
 
-		await Promise.all(updatedUsers);
+		await Promise.all(updatedUserPromises);
 
 		if (!activatedUsers.length) {
 			await queryRunner.query(

--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -20,11 +20,11 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			credentialsId: credentialId,
 			userId: Not(In(userIds)),
 		};
-		return transaction.delete(SharedCredentials, conditions);
+		return await transaction.delete(SharedCredentials, conditions);
 	}
 
 	async findStartingWith(credentialName: string) {
-		return this.find({
+		return await this.find({
 			select: ['name'],
 			where: { name: Like(`${credentialName}%`) },
 		});
@@ -37,7 +37,7 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			findManyOptions.where = { ...findManyOptions.where, id: In(credentialIds) };
 		}
 
-		return this.find(findManyOptions);
+		return await this.find(findManyOptions);
 	}
 
 	private toFindManyOptions(listQueryOptions?: ListQuery.Options) {
@@ -84,6 +84,6 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			findManyOptions.relations = ['shared', 'shared.user', 'shared.role'];
 		}
 
-		return this.find(findManyOptions);
+		return await this.find(findManyOptions);
 	}
 }

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -251,7 +251,10 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	 * Permanently remove a single execution and its binary data.
 	 */
 	async hardDelete(ids: { workflowId: string; executionId: string }) {
-		return Promise.all([this.delete(ids.executionId), this.binaryDataService.deleteMany([ids])]);
+		return await Promise.all([
+			this.delete(ids.executionId),
+			this.binaryDataService.deleteMany([ids]),
+		]);
 	}
 
 	async updateStatus(executionId: string, status: ExecutionStatus) {
@@ -438,7 +441,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async getIdsSince(date: Date) {
-		return this.find({
+		return await this.find({
 			select: ['id'],
 			where: {
 				startedAt: MoreThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(date)),
@@ -474,7 +477,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 		const [timeBasedWhere, countBasedWhere] = toPrune;
 
-		return this.createQueryBuilder()
+		return await this.createQueryBuilder()
 			.update(ExecutionEntity)
 			.set({ deletedAt: new Date() })
 			.where({
@@ -516,7 +519,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async deleteByIds(executionIds: string[]) {
-		return this.delete({ id: In(executionIds) });
+		return await this.delete({ id: In(executionIds) });
 	}
 
 	async getWaitingExecutions() {
@@ -534,7 +537,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			where.waitTill = LessThanOrEqual(DateUtils.mixedDateToUtcDatetimeString(waitTill));
 		}
 
-		return this.findMultipleExecutions({
+		return await this.findMultipleExecutions({
 			select: ['id', 'waitTill'],
 			where,
 			order: {
@@ -606,7 +609,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			where = { ...where, workflowId: In(params.workflowIds) };
 		}
 
-		return this.findMultipleExecutions(
+		return await this.findMultipleExecutions(
 			{
 				select: [
 					'id',
@@ -636,7 +639,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		workflowIds: string[],
 		includeData?: boolean,
 	): Promise<IExecutionBase | undefined> {
-		return this.findSingleExecution(id, {
+		return await this.findSingleExecution(id, {
 			where: {
 				workflowId: In(workflowIds),
 			},
@@ -646,7 +649,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async findIfShared(executionId: string, sharedWorkflowIds: string[]) {
-		return this.findSingleExecution(executionId, {
+		return await this.findSingleExecution(executionId, {
 			where: {
 				workflowId: In(sharedWorkflowIds),
 			},

--- a/packages/cli/src/databases/repositories/executionData.repository.ts
+++ b/packages/cli/src/databases/repositories/executionData.repository.ts
@@ -9,7 +9,7 @@ export class ExecutionDataRepository extends Repository<ExecutionData> {
 	}
 
 	async findByExecutionIds(executionIds: string[]) {
-		return this.find({
+		return await this.find({
 			select: ['workflowData'],
 			where: {
 				executionId: In(executionIds),

--- a/packages/cli/src/databases/repositories/installedPackages.repository.ts
+++ b/packages/cli/src/databases/repositories/installedPackages.repository.ts
@@ -41,7 +41,7 @@ export class InstalledPackagesRepository extends Repository<InstalledPackages> {
 
 				installedPackage.installedNodes.push(installedNode);
 
-				return manager.save(installedNode);
+				return await manager.save(installedNode);
 			});
 		});
 

--- a/packages/cli/src/databases/repositories/role.repository.ts
+++ b/packages/cli/src/databases/repositories/role.repository.ts
@@ -11,7 +11,7 @@ export class RoleRepository extends Repository<Role> {
 	}
 
 	async findRole(scope: RoleScopes, name: RoleNames) {
-		return this.findOne({ where: { scope, name } });
+		return await this.findOne({ where: { scope, name } });
 	}
 
 	/**
@@ -34,7 +34,7 @@ export class RoleRepository extends Repository<Role> {
 	}
 
 	async getIdsInScopeWorkflowByNames(roleNames: RoleNames[]) {
-		return this.find({
+		return await this.find({
 			select: ['id'],
 			where: { name: In(roleNames), scope: 'workflow' },
 		}).then((role) => role.map(({ id }) => id));

--- a/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedCredentials.repository.ts
@@ -25,7 +25,7 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 	}
 
 	async findByCredentialIds(credentialIds: string[]) {
-		return this.find({
+		return await this.find({
 			relations: ['credentials', 'role', 'user'],
 			where: {
 				credentialsId: In(credentialIds),
@@ -34,7 +34,7 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 	}
 
 	async makeOwnerOfAllCredentials(user: User, role: Role) {
-		return this.update({ userId: Not(user.id), roleId: role.id }, { user });
+		return await this.update({ userId: Not(user.id), roleId: role.id }, { user });
 	}
 
 	/**
@@ -58,11 +58,11 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 		// If credential sharing is not enabled, get only credentials owned by this user
 		if (roleId) where.roleId = roleId;
 
-		return this.find({ where });
+		return await this.find({ where });
 	}
 
 	async deleteByIds(transaction: EntityManager, sharedCredentialsIds: string[], user?: User) {
-		return transaction.delete(SharedCredentials, {
+		return await transaction.delete(SharedCredentials, {
 			user,
 			credentialsId: In(sharedCredentialsIds),
 		});

--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -20,7 +20,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 		if (!user.hasGlobalScope('workflow:read')) {
 			where.userId = user.id;
 		}
-		return this.exist({ where });
+		return await this.exist({ where });
 	}
 
 	async getSharedWorkflowIds(workflowIds: string[]) {
@@ -34,7 +34,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 	}
 
 	async findByWorkflowIds(workflowIds: string[]) {
-		return this.find({
+		return await this.find({
 			relations: ['role', 'user'],
 			where: {
 				role: {
@@ -68,11 +68,11 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 
 		if (extraRelations) relations.push(...extraRelations);
 
-		return this.findOne({ relations, where });
+		return await this.findOne({ relations, where });
 	}
 
 	async makeOwnerOfAllWorkflows(user: User, role: Role) {
-		return this.update({ userId: Not(user.id), roleId: role.id }, { user });
+		return await this.update({ userId: Not(user.id), roleId: role.id }, { user });
 	}
 
 	async getSharing(
@@ -90,7 +90,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			where.userId = user.id;
 		}
 
-		return this.findOne({ where, relations });
+		return await this.findOne({ where, relations });
 	}
 
 	async getSharedWorkflows(
@@ -100,7 +100,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			workflowIds?: string[];
 		},
 	): Promise<SharedWorkflow[]> {
-		return this.find({
+		return await this.find({
 			where: {
 				...(!['owner', 'admin'].includes(user.globalRole.name) && { userId: user.id }),
 				...(options.workflowIds && { workflowId: In(options.workflowIds) }),
@@ -123,11 +123,11 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			return acc;
 		}, []);
 
-		return transaction.save(newSharedWorkflows);
+		return await transaction.save(newSharedWorkflows);
 	}
 
 	async findWithFields(workflowIds: string[], { fields }: { fields: string[] }) {
-		return this.find({
+		return await this.find({
 			where: {
 				workflowId: In(workflowIds),
 			},
@@ -136,7 +136,7 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 	}
 
 	async deleteByIds(transaction: EntityManager, sharedWorkflowIds: string[], user?: User) {
-		return transaction.delete(SharedWorkflow, {
+		return await transaction.delete(SharedWorkflow, {
 			user,
 			workflowId: In(sharedWorkflowIds),
 		});

--- a/packages/cli/src/databases/repositories/tag.repository.ts
+++ b/packages/cli/src/databases/repositories/tag.repository.ts
@@ -12,7 +12,7 @@ export class TagRepository extends Repository<TagEntity> {
 	}
 
 	async findMany(tagIds: string[]) {
-		return this.find({
+		return await this.find({
 			select: ['id', 'name'],
 			where: { id: In(tagIds) },
 		});

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -11,7 +11,7 @@ export class UserRepository extends Repository<User> {
 	}
 
 	async findManybyIds(userIds: string[]) {
-		return this.find({
+		return await this.find({
 			where: { id: In(userIds) },
 			relations: ['globalRole'],
 		});
@@ -22,11 +22,11 @@ export class UserRepository extends Repository<User> {
 	}
 
 	async getByIds(transaction: EntityManager, ids: string[]) {
-		return transaction.find(User, { where: { id: In(ids) } });
+		return await transaction.find(User, { where: { id: In(ids) } });
 	}
 
 	async findManyByEmail(emails: string[]) {
-		return this.find({
+		return await this.find({
 			where: { email: In(emails) },
 			relations: ['globalRole'],
 			select: ['email', 'password', 'id'],
@@ -34,11 +34,11 @@ export class UserRepository extends Repository<User> {
 	}
 
 	async deleteMany(userIds: string[]) {
-		return this.delete({ id: In(userIds) });
+		return await this.delete({ id: In(userIds) });
 	}
 
 	async findNonShellUser(email: string) {
-		return this.findOne({
+		return await this.findOne({
 			where: {
 				email,
 				password: Not(IsNull()),

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -26,14 +26,14 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	}
 
 	async get(where: FindOptionsWhere<WorkflowEntity>, options?: { relations: string[] }) {
-		return this.findOne({
+		return await this.findOne({
 			where,
 			relations: options?.relations,
 		});
 	}
 
 	async getAllActive() {
-		return this.find({
+		return await this.find({
 			where: { active: true },
 			relations: ['shared', 'shared.user', 'shared.user.globalRole', 'shared.role'],
 		});
@@ -48,7 +48,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	}
 
 	async findById(workflowId: string) {
-		return this.findOne({
+		return await this.findOne({
 			where: { id: workflowId },
 			relations: ['shared', 'shared.user', 'shared.user.globalRole', 'shared.role'],
 		});
@@ -61,7 +61,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 		if (fields?.length) options.select = fields as FindOptionsSelect<WorkflowEntity>;
 
-		return this.find(options);
+		return await this.find(options);
 	}
 
 	async getActiveTriggerCount() {
@@ -88,7 +88,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		workflowId: string,
 		userIds: string[],
 	): Promise<DeleteResult> {
-		return transaction.delete(SharedWorkflow, {
+		return await transaction.delete(SharedWorkflow, {
 			workflowId,
 			userId: Not(In(userIds)),
 		});
@@ -96,7 +96,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 
 	async updateWorkflowTriggerCount(id: string, triggerCount: number): Promise<UpdateResult> {
 		const qb = this.createQueryBuilder('workflow');
-		return qb
+		return await qb
 			.update()
 			.set({
 				triggerCount,
@@ -185,35 +185,35 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	}
 
 	async findStartingWith(workflowName: string): Promise<Array<{ name: string }>> {
-		return this.find({
+		return await this.find({
 			select: ['name'],
 			where: { name: Like(`${workflowName}%`) },
 		});
 	}
 
 	async findIn(workflowIds: string[]) {
-		return this.find({
+		return await this.find({
 			select: ['id', 'name'],
 			where: { id: In(workflowIds) },
 		});
 	}
 
 	async findWebhookBasedActiveWorkflows() {
-		return this.createQueryBuilder('workflow')
+		return await (this.createQueryBuilder('workflow')
 			.select('DISTINCT workflow.id, workflow.name')
 			.innerJoin(WebhookEntity, 'webhook_entity', 'workflow.id = webhook_entity.workflowId')
-			.execute() as Promise<Array<{ id: string; name: string }>>;
+			.execute() as Promise<Array<{ id: string; name: string }>>);
 	}
 
 	async updateActiveState(workflowId: string, newState: boolean) {
-		return this.update({ id: workflowId }, { active: newState });
+		return await this.update({ id: workflowId }, { active: newState });
 	}
 
 	async deactivateAll() {
-		return this.update({ active: true }, { active: false });
+		return await this.update({ active: true }, { active: false });
 	}
 
 	async findByActiveState(activeState: boolean) {
-		return this.findBy({ active: activeState });
+		return await this.findBy({ active: activeState });
 	}
 }

--- a/packages/cli/src/databases/repositories/workflowHistory.repository.ts
+++ b/packages/cli/src/databases/repositories/workflowHistory.repository.ts
@@ -9,6 +9,6 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 	}
 
 	async deleteEarlierThan(date: Date) {
-		return this.delete({ createdAt: LessThan(date) });
+		return await this.delete({ createdAt: LessThan(date) });
 	}
 }

--- a/packages/cli/src/databases/utils/migrationHelpers.ts
+++ b/packages/cli/src/databases/utils/migrationHelpers.ts
@@ -118,9 +118,9 @@ const createContext = (queryRunner: QueryRunner, migration: Migration): Migratio
 				namedParameters,
 				{},
 			);
-			return queryRunner.query(query, parameters) as Promise<T>;
+			return await (queryRunner.query(query, parameters) as Promise<T>);
 		} else {
-			return queryRunner.query(sql) as Promise<T>;
+			return await (queryRunner.query(sql) as Promise<T>);
 		}
 	},
 	runInBatches: async <T>(

--- a/packages/cli/src/decorators/registerController.ts
+++ b/packages/cli/src/decorators/registerController.ts
@@ -121,7 +121,8 @@ export const registerController = (app: Application, controllerClass: Class<obje
 				const authRole = authRoles?.[handlerName] ?? authRoles?.['*'];
 				const features = licenseFeatures?.[handlerName] ?? licenseFeatures?.['*'];
 				const scopes = requiredScopes?.[handlerName] ?? requiredScopes?.['*'];
-				const handler = async (req: Request, res: Response) => controller[handlerName](req, res);
+				const handler = async (req: Request, res: Response) =>
+					await controller[handlerName](req, res);
 				router[method](
 					path,
 					...(authRole ? [createAuthMiddleware(authRole)] : []),

--- a/packages/cli/src/environments/sourceControl/sourceControl.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControl.service.ee.ts
@@ -171,7 +171,7 @@ export class SourceControlService {
 			await this.initGitService();
 		}
 		await this.gitService.fetch();
-		return this.gitService.getBranches();
+		return await this.gitService.getBranches();
 	}
 
 	async setBranch(branch: string): Promise<{ branches: string[]; currentBranch: string }> {
@@ -182,7 +182,7 @@ export class SourceControlService {
 			branchName: branch,
 			connected: branch?.length > 0,
 		});
-		return this.gitService.setBranch(branch);
+		return await this.gitService.setBranch(branch);
 	}
 
 	// will reset the branch to the remote branch and pull

--- a/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
@@ -95,7 +95,7 @@ export class SourceControlExportService {
 					owner: owners[e.id],
 				};
 				this.logger.debug(`Writing workflow ${e.id} to ${fileName}`);
-				return fsWriteFile(fileName, JSON.stringify(sanitizedWorkflow, null, 2));
+				return await fsWriteFile(fileName, JSON.stringify(sanitizedWorkflow, null, 2));
 			}),
 		);
 	}
@@ -253,7 +253,7 @@ export class SourceControlExportService {
 						nodesAccess: sharedCredential.credentials.nodesAccess,
 					};
 					this.logger.debug(`Writing credential ${sharedCredential.credentials.id} to ${fileName}`);
-					return fsWriteFile(fileName, JSON.stringify(sanitizedCredential, null, 2));
+					return await fsWriteFile(fileName, JSON.stringify(sanitizedCredential, null, 2));
 				}),
 			);
 			return {

--- a/packages/cli/src/environments/sourceControl/sourceControlGit.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlGit.service.ee.ts
@@ -232,7 +232,7 @@ export class SourceControlGitService {
 		}
 		await this.git.checkout(branch);
 		await this.git.branch([`--set-upstream-to=${SOURCE_CONTROL_ORIGIN}/${branch}`, branch]);
-		return this.getBranches();
+		return await this.getBranches();
 	}
 
 	async getCurrentBranch(): Promise<{ current: string; remote: string }> {
@@ -253,7 +253,7 @@ export class SourceControlGitService {
 		const currentBranch = await this.getCurrentBranch();
 		if (currentBranch.remote) {
 			const target = currentBranch.remote;
-			return this.git.diffSummary(['...' + target, '--ignore-all-space']);
+			return await this.git.diffSummary(['...' + target, '--ignore-all-space']);
 		}
 		return;
 	}
@@ -265,7 +265,7 @@ export class SourceControlGitService {
 		const currentBranch = await this.getCurrentBranch();
 		if (currentBranch.remote) {
 			const target = currentBranch.current;
-			return this.git.diffSummary([target, '--ignore-all-space']);
+			return await this.git.diffSummary([target, '--ignore-all-space']);
 		}
 		return;
 	}
@@ -274,7 +274,7 @@ export class SourceControlGitService {
 		if (!this.git) {
 			throw new ApplicationError('Git is not initialized (fetch)');
 		}
-		return this.git.fetch();
+		return await this.git.fetch();
 	}
 
 	async pull(options: { ffOnly: boolean } = { ffOnly: true }): Promise<PullResult> {
@@ -286,7 +286,7 @@ export class SourceControlGitService {
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			Object.assign(params, { '--ff-only': true });
 		}
-		return this.git.pull(params);
+		return await this.git.pull(params);
 	}
 
 	async push(
@@ -300,9 +300,9 @@ export class SourceControlGitService {
 			throw new ApplicationError('Git is not initialized ({)');
 		}
 		if (force) {
-			return this.git.push(SOURCE_CONTROL_ORIGIN, branch, ['-f']);
+			return await this.git.push(SOURCE_CONTROL_ORIGIN, branch, ['-f']);
 		}
-		return this.git.push(SOURCE_CONTROL_ORIGIN, branch);
+		return await this.git.push(SOURCE_CONTROL_ORIGIN, branch);
 	}
 
 	async stage(files: Set<string>, deletedFiles?: Set<string>): Promise<string> {
@@ -316,7 +316,7 @@ export class SourceControlGitService {
 				this.logger.debug(`Git rm: ${(error as Error).message}`);
 			}
 		}
-		return this.git.add(Array.from(files));
+		return await this.git.add(Array.from(files));
 	}
 
 	async resetBranch(
@@ -326,9 +326,9 @@ export class SourceControlGitService {
 			throw new ApplicationError('Git is not initialized (Promise)');
 		}
 		if (options?.hard) {
-			return this.git.raw(['reset', '--hard', options.target]);
+			return await this.git.raw(['reset', '--hard', options.target]);
 		}
-		return this.git.raw(['reset', options.target]);
+		return await this.git.raw(['reset', options.target]);
 		// built-in reset method does not work
 		// return this.git.reset();
 	}
@@ -337,7 +337,7 @@ export class SourceControlGitService {
 		if (!this.git) {
 			throw new ApplicationError('Git is not initialized (commit)');
 		}
-		return this.git.commit(message);
+		return await this.git.commit(message);
 	}
 
 	async status(): Promise<StatusResult> {

--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -186,7 +186,7 @@ export class SourceControlImportService {
 	}
 
 	public async getLocalVariablesFromDb(): Promise<Variables[]> {
-		return this.variablesService.getAllCached();
+		return await this.variablesService.getAllCached();
 	}
 
 	public async getRemoteTagsAndMappingsFromFile(): Promise<{

--- a/packages/cli/src/environments/variables/variables.controller.ee.ts
+++ b/packages/cli/src/environments/variables/variables.controller.ee.ts
@@ -23,7 +23,7 @@ export class VariablesController {
 	@Get('/')
 	@RequireGlobalScope('variable:list')
 	async getVariables() {
-		return this.variablesService.getAllCached();
+		return await this.variablesService.getAllCached();
 	}
 
 	@Post('/')

--- a/packages/cli/src/environments/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments/variables/variables.service.ee.ts
@@ -18,7 +18,7 @@ export class VariablesService {
 	async getAllCached(): Promise<Variables[]> {
 		const variables = await this.cacheService.get('variables', {
 			async refreshFn() {
-				return Container.get(VariablesService).findAll();
+				return await Container.get(VariablesService).findAll();
 			},
 		});
 		return (variables as Array<Partial<Variables>>).map((v) => this.variablesRepository.create(v));
@@ -49,7 +49,7 @@ export class VariablesService {
 	}
 
 	async findAll(): Promise<Variables[]> {
-		return this.variablesRepository.find();
+		return await this.variablesRepository.find();
 	}
 
 	validateVariable(variable: Omit<Variables, 'id'>): void {

--- a/packages/cli/src/eventbus/MessageEventBusDestination/MessageEventBusDestination.ee.ts
+++ b/packages/cli/src/eventbus/MessageEventBusDestination/MessageEventBusDestination.ee.ts
@@ -99,7 +99,7 @@ export abstract class MessageEventBusDestination implements MessageEventBusDesti
 	}
 
 	async deleteFromDb() {
-		return MessageEventBusDestination.deleteFromDb(this.getId());
+		return await MessageEventBusDestination.deleteFromDb(this.getId());
 	}
 
 	static async deleteFromDb(id: string) {

--- a/packages/cli/src/eventbus/eventBus.controller.ee.ts
+++ b/packages/cli/src/eventbus/eventBus.controller.ee.ts
@@ -61,9 +61,9 @@ export class EventBusControllerEE {
 	@RequireGlobalScope('eventBusDestination:list')
 	async getDestination(req: express.Request): Promise<MessageEventBusDestinationOptions[]> {
 		if (isWithIdString(req.query)) {
-			return eventBus.findDestination(req.query.id);
+			return await eventBus.findDestination(req.query.id);
 		} else {
-			return eventBus.findDestination();
+			return await eventBus.findDestination();
 		}
 	}
 
@@ -115,7 +115,7 @@ export class EventBusControllerEE {
 	@RequireGlobalScope('eventBusDestination:test')
 	async sendTestMessage(req: express.Request): Promise<boolean> {
 		if (isWithIdString(req.query)) {
-			return eventBus.testDestination(req.query.id);
+			return await eventBus.testDestination(req.query.id);
 		}
 		return false;
 	}
@@ -124,7 +124,7 @@ export class EventBusControllerEE {
 	@RequireGlobalScope('eventBusDestination:delete')
 	async deleteDestination(req: AuthenticatedRequest) {
 		if (isWithIdString(req.query)) {
-			return eventBus.removeDestination(req.query.id);
+			return await eventBus.removeDestination(req.query.id);
 		} else {
 			throw new BadRequestError('Query is missing id');
 		}

--- a/packages/cli/src/eventbus/eventBus.controller.ts
+++ b/packages/cli/src/eventbus/eventBus.controller.ts
@@ -45,17 +45,17 @@ export class EventBusController {
 		if (isWithQueryString(req.query)) {
 			switch (req.query.query as EventMessageReturnMode) {
 				case 'sent':
-					return eventBus.getEventsSent();
+					return await eventBus.getEventsSent();
 				case 'unsent':
-					return eventBus.getEventsUnsent();
+					return await eventBus.getEventsUnsent();
 				case 'unfinished':
-					return eventBus.getUnfinishedExecutions();
+					return await eventBus.getUnfinishedExecutions();
 				case 'all':
 				default:
-					return eventBus.getEventsAll();
+					return await eventBus.getEventsAll();
 			}
 		} else {
-			return eventBus.getEventsAll();
+			return await eventBus.getEventsAll();
 		}
 	}
 
@@ -63,7 +63,7 @@ export class EventBusController {
 	@RequireGlobalScope('eventBusEvent:list')
 	async getFailedEvents(req: express.Request): Promise<FailedEventSummary[]> {
 		const amount = parseInt(req.query?.amount as string) ?? 5;
-		return eventBus.getEventsFailed(amount);
+		return await eventBus.getEventsFailed(amount);
 	}
 
 	@Get('/execution/:id')
@@ -74,7 +74,7 @@ export class EventBusController {
 			if (req.query?.logHistory) {
 				logHistory = parseInt(req.query.logHistory as string, 10);
 			}
-			return eventBus.getEventsByExecutionId(req.params.id, logHistory);
+			return await eventBus.getEventsByExecutionId(req.params.id, logHistory);
 		}
 		return;
 	}
@@ -88,7 +88,7 @@ export class EventBusController {
 			const applyToDb = req.query.applyToDb !== undefined ? !!req.query.applyToDb : true;
 			const messages = await eventBus.getEventsByExecutionId(id, logHistory);
 			if (messages.length > 0) {
-				return recoverExecutionDataFromEventLogMessages(id, messages, applyToDb);
+				return await recoverExecutionDataFromEventLogMessages(id, messages, applyToDb);
 			}
 		}
 		return;

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -9,23 +9,23 @@ import { isSharingEnabled } from '@/UserManagement/UserManagementHelper';
 export class ExecutionsController {
 	@Get('/')
 	async getExecutionsList(req: ExecutionRequest.GetAll) {
-		return ExecutionsService.getExecutionsList(req);
+		return await ExecutionsService.getExecutionsList(req);
 	}
 
 	@Get('/:id')
 	async getExecution(req: ExecutionRequest.Get) {
 		return isSharingEnabled()
-			? EnterpriseExecutionsService.getExecution(req)
-			: ExecutionsService.getExecution(req);
+			? await EnterpriseExecutionsService.getExecution(req)
+			: await ExecutionsService.getExecution(req);
 	}
 
 	@Post('/:id/retry')
 	async retryExecution(req: ExecutionRequest.Retry) {
-		return ExecutionsService.retryExecution(req);
+		return await ExecutionsService.retryExecution(req);
 	}
 
 	@Post('/delete')
 	async deleteExecutions(req: ExecutionRequest.Delete) {
-		return ExecutionsService.deleteExecutions(req);
+		return await ExecutionsService.deleteExecutions(req);
 	}
 }

--- a/packages/cli/src/executions/executions.service.ee.ts
+++ b/packages/cli/src/executions/executions.service.ee.ts
@@ -14,7 +14,7 @@ export class EnterpriseExecutionsService extends ExecutionsService {
 	 */
 	static async getWorkflowIdsForUser(user: User): Promise<string[]> {
 		// Get all workflows
-		return Container.get(WorkflowSharingService).getSharedWorkflowIds(user);
+		return await Container.get(WorkflowSharingService).getSharedWorkflowIds(user);
 	}
 
 	static async getExecution(

--- a/packages/cli/src/executions/executions.service.ts
+++ b/packages/cli/src/executions/executions.service.ts
@@ -78,7 +78,7 @@ export class ExecutionsService {
 	 */
 	static async getWorkflowIdsForUser(user: User): Promise<string[]> {
 		// Get all workflows using owner role
-		return Container.get(WorkflowSharingService).getSharedWorkflowIds(user, ['owner']);
+		return await Container.get(WorkflowSharingService).getSharedWorkflowIds(user, ['owner']);
 	}
 
 	static async getExecutionsList(req: ExecutionRequest.GetAll): Promise<IExecutionsListResponse> {
@@ -342,7 +342,7 @@ export class ExecutionsService {
 			}
 		}
 
-		return Container.get(ExecutionRepository).deleteExecutionsByFilter(
+		return await Container.get(ExecutionRepository).deleteExecutionsByFilter(
 			requestFilters,
 			sharedWorkflowIds,
 			{

--- a/packages/cli/src/license/license.controller.ts
+++ b/packages/cli/src/license/license.controller.ts
@@ -9,7 +9,7 @@ export class LicenseController {
 
 	@Get('/')
 	async getLicenseData() {
-		return this.licenseService.getLicenseData();
+		return await this.licenseService.getLicenseData();
 	}
 
 	@Post('/activate')
@@ -17,14 +17,14 @@ export class LicenseController {
 	async activateLicense(req: LicenseRequest.Activate) {
 		const { activationKey } = req.body;
 		await this.licenseService.activateLicense(activationKey);
-		return this.getTokenAndData();
+		return await this.getTokenAndData();
 	}
 
 	@Post('/renew')
 	@RequireGlobalScope('license:manage')
 	async renewLicense() {
 		await this.licenseService.renewLicense();
-		return this.getTokenAndData();
+		return await this.getTokenAndData();
 	}
 
 	private async getTokenAndData() {

--- a/packages/cli/src/middlewares/listQuery/dtos/credentials.filter.dto.ts
+++ b/packages/cli/src/middlewares/listQuery/dtos/credentials.filter.dto.ts
@@ -14,6 +14,6 @@ export class CredentialsFilter extends BaseFilter {
 	type?: string;
 
 	static async fromString(rawFilter: string) {
-		return this.toFilter(rawFilter, CredentialsFilter);
+		return await this.toFilter(rawFilter, CredentialsFilter);
 	}
 }

--- a/packages/cli/src/middlewares/listQuery/dtos/user.filter.dto.ts
+++ b/packages/cli/src/middlewares/listQuery/dtos/user.filter.dto.ts
@@ -24,6 +24,6 @@ export class UserFilter extends BaseFilter {
 	isOwner?: boolean;
 
 	static async fromString(rawFilter: string) {
-		return this.toFilter(rawFilter, UserFilter);
+		return await this.toFilter(rawFilter, UserFilter);
 	}
 }

--- a/packages/cli/src/middlewares/listQuery/dtos/workflow.filter.dto.ts
+++ b/packages/cli/src/middlewares/listQuery/dtos/workflow.filter.dto.ts
@@ -21,6 +21,6 @@ export class WorkflowFilter extends BaseFilter {
 	tags?: string[];
 
 	static async fromString(rawFilter: string) {
-		return this.toFilter(rawFilter, WorkflowFilter);
+		return await this.toFilter(rawFilter, WorkflowFilter);
 	}
 }

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -49,7 +49,7 @@ export class PostHogClient {
 
 		// cannot use local evaluation because that requires PostHog personal api key with org-wide
 		// https://github.com/PostHog/posthog/issues/4849
-		return this.postHog.getAllFlags(fullId, {
+		return await this.postHog.getAllFlags(fullId, {
 			personProperties: {
 				created_at_timestamp: user.createdAt.getTime().toString(),
 			},

--- a/packages/cli/src/security-audit/SecurityAudit.service.ts
+++ b/packages/cli/src/security-audit/SecurityAudit.service.ts
@@ -30,7 +30,7 @@ export class SecurityAuditService {
 			select: ['id', 'name', 'active', 'nodes', 'connections'],
 		});
 
-		const promises = categories.map(async (c) => this.reporters[c].report(workflows));
+		const promises = categories.map(async (c) => await this.reporters[c].report(workflows));
 
 		const reports = (await Promise.all(promises)).filter((r): r is Risk.Report => r !== null);
 

--- a/packages/cli/src/security-audit/risk-reporters/CredentialsRiskReporter.ts
+++ b/packages/cli/src/security-audit/risk-reporters/CredentialsRiskReporter.ts
@@ -119,7 +119,7 @@ export class CredentialsRiskReporter implements RiskReporter {
 
 		const executionIds = await this.executionRepository.getIdsSince(date);
 
-		return this.executionDataRepository.findByExecutionIds(executionIds);
+		return await this.executionDataRepository.findByExecutionIds(executionIds);
 	}
 
 	/**

--- a/packages/cli/src/services/activeWorkflows.service.ts
+++ b/packages/cli/src/services/activeWorkflows.service.ts
@@ -47,6 +47,6 @@ export class ActiveWorkflowsService {
 			throw new BadRequestError(`Workflow with ID "${workflowId}" could not be found.`);
 		}
 
-		return this.activationErrorsService.get(workflowId);
+		return await this.activationErrorsService.get(workflowId);
 	}
 }

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -332,7 +332,7 @@ export class CacheService extends EventEmitter {
 
 		if (keys.length === 0) return;
 
-		return this.cache.store.mdel(...keys);
+		return await this.cache.store.mdel(...keys);
 	}
 
 	/**

--- a/packages/cli/src/services/cache/redis.cache-manager.ts
+++ b/packages/cli/src/services/cache/redis.cache-manager.ts
@@ -88,7 +88,7 @@ function builder(
 				);
 		},
 		mget: async (...args) =>
-			redisCache
+			await redisCache
 				.mget(args)
 				.then((results) =>
 					results.map((result) =>
@@ -101,8 +101,8 @@ function builder(
 		async del(key) {
 			await redisCache.del(key);
 		},
-		ttl: async (key) => redisCache.pttl(key),
-		keys: async (pattern = '*') => keys(pattern),
+		ttl: async (key) => await redisCache.pttl(key),
+		keys: async (pattern = '*') => await keys(pattern),
 		reset,
 		isCacheable,
 		get client() {
@@ -137,7 +137,7 @@ function builder(
 			await redisCache.hset(key, fieldValueRecord);
 		},
 		async hkeys(key: string) {
-			return redisCache.hkeys(key);
+			return await redisCache.hkeys(key);
 		},
 		async hvals<T>(key: string): Promise<T[]> {
 			const values = await redisCache.hvals(key);
@@ -147,7 +147,7 @@ function builder(
 			return (await redisCache.hexists(key, field)) === 1;
 		},
 		async hdel(key: string, field: string) {
-			return redisCache.hdel(key, field);
+			return await redisCache.hdel(key, field);
 		},
 	} as RedisStore;
 }
@@ -156,7 +156,7 @@ export function redisStoreUsingClient(redisCache: Redis | Cluster, options?: Con
 	const reset = async () => {
 		await redisCache.flushdb();
 	};
-	const keys = async (pattern: string) => redisCache.keys(pattern);
+	const keys = async (pattern: string) => await redisCache.keys(pattern);
 
 	return builder(redisCache, reset, keys, options);
 }

--- a/packages/cli/src/services/communityPackages.service.ts
+++ b/packages/cli/src/services/communityPackages.service.ts
@@ -59,22 +59,22 @@ export class CommunityPackagesService {
 	}
 
 	async findInstalledPackage(packageName: string) {
-		return this.installedPackageRepository.findOne({
+		return await this.installedPackageRepository.findOne({
 			where: { packageName },
 			relations: ['installedNodes'],
 		});
 	}
 
 	async isPackageInstalled(packageName: string) {
-		return this.installedPackageRepository.exist({ where: { packageName } });
+		return await this.installedPackageRepository.exist({ where: { packageName } });
 	}
 
 	async getAllInstalledPackages() {
-		return this.installedPackageRepository.find({ relations: ['installedNodes'] });
+		return await this.installedPackageRepository.find({ relations: ['installedNodes'] });
 	}
 
 	async removePackageFromDatabase(packageName: InstalledPackages) {
-		return this.installedPackageRepository.remove(packageName);
+		return await this.installedPackageRepository.remove(packageName);
 	}
 
 	async persistInstalledPackage(packageLoader: PackageDirectoryLoader) {
@@ -297,14 +297,14 @@ export class CommunityPackagesService {
 	}
 
 	async installNpmModule(packageName: string, version?: string): Promise<InstalledPackages> {
-		return this.installOrUpdateNpmModule(packageName, { version });
+		return await this.installOrUpdateNpmModule(packageName, { version });
 	}
 
 	async updateNpmModule(
 		packageName: string,
 		installedPackage: InstalledPackages,
 	): Promise<InstalledPackages> {
-		return this.installOrUpdateNpmModule(packageName, { installedPackage });
+		return await this.installOrUpdateNpmModule(packageName, { installedPackage });
 	}
 
 	async removeNpmModule(packageName: string, installedPackage: InstalledPackages): Promise<void> {

--- a/packages/cli/src/services/events.service.ts
+++ b/packages/cli/src/services/events.service.ts
@@ -17,9 +17,13 @@ export class EventsService extends EventEmitter {
 		super({ captureRejections: true });
 		if ('SKIP_STATISTICS_EVENTS' in process.env) return;
 
-		this.on('nodeFetchedData', async (workflowId, node) => this.nodeFetchedData(workflowId, node));
-		this.on('workflowExecutionCompleted', async (workflowData, runData) =>
-			this.workflowExecutionCompleted(workflowData, runData),
+		this.on(
+			'nodeFetchedData',
+			async (workflowId, node) => await this.nodeFetchedData(workflowId, node),
+		);
+		this.on(
+			'workflowExecutionCompleted',
+			async (workflowData, runData) => await this.workflowExecutionCompleted(workflowData, runData),
 		);
 	}
 

--- a/packages/cli/src/services/executionMetadata.service.ts
+++ b/packages/cli/src/services/executionMetadata.service.ts
@@ -19,6 +19,6 @@ export class ExecutionMetadataService {
 			});
 		}
 
-		return this.executionMetadataRepository.save(metadataRows);
+		return await this.executionMetadataRepository.save(metadataRows);
 	}
 }

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -49,7 +49,7 @@ export class FrontendService {
 		private readonly urlService: UrlService,
 		private readonly internalHooks: InternalHooks,
 	) {
-		loadNodesAndCredentials.addPostProcessor(async () => this.generateTypes());
+		loadNodesAndCredentials.addPostProcessor(async () => await this.generateTypes());
 		void this.generateTypes();
 
 		this.initSettings();

--- a/packages/cli/src/services/naming.service.ts
+++ b/packages/cli/src/services/naming.service.ts
@@ -10,11 +10,11 @@ export class NamingService {
 	) {}
 
 	async getUniqueWorkflowName(requestedName: string) {
-		return this.getUniqueName(requestedName, 'workflow');
+		return await this.getUniqueName(requestedName, 'workflow');
 	}
 
 	async getUniqueCredentialName(requestedName: string) {
-		return this.getUniqueName(requestedName, 'credential');
+		return await this.getUniqueName(requestedName, 'credential');
 	}
 
 	private async getUniqueName(requestedName: string, entity: 'workflow' | 'credential') {

--- a/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
+++ b/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
@@ -137,6 +137,6 @@ export class MultiMainSetup extends SingleMainSetup {
 	}
 
 	async fetchLeaderKey() {
-		return this.redisPublisher.get(this.leaderKey);
+		return await this.redisPublisher.get(this.leaderKey);
 	}
 }

--- a/packages/cli/src/services/orchestration/webhook/handleCommandMessageWebhook.ts
+++ b/packages/cli/src/services/orchestration/webhook/handleCommandMessageWebhook.ts
@@ -2,5 +2,5 @@ import { handleCommandMessageMain } from '../main/handleCommandMessageMain';
 
 export async function handleCommandMessageWebhook(messageString: string) {
 	// currently webhooks handle commands the same way as the main instance
-	return handleCommandMessageMain(messageString);
+	return await handleCommandMessageMain(messageString);
 }

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -74,7 +74,7 @@ export class OwnershipService {
 	async getInstanceOwner() {
 		const globalOwnerRole = await this.roleService.findGlobalOwnerRole();
 
-		return this.userRepository.findOneOrFail({
+		return await this.userRepository.findOneOrFail({
 			where: { globalRoleId: globalOwnerRole.id },
 			relations: ['globalRole'],
 		});

--- a/packages/cli/src/services/password.utility.ts
+++ b/packages/cli/src/services/password.utility.ts
@@ -12,11 +12,11 @@ export class PasswordUtility {
 		const SALT_ROUNDS = 10;
 		const salt = genSaltSync(SALT_ROUNDS);
 
-		return hash(plaintext, salt);
+		return await hash(plaintext, salt);
 	}
 
 	async compare(plaintext: string, hashed: string) {
-		return compare(plaintext, hashed);
+		return await compare(plaintext, hashed);
 	}
 
 	validate(plaintext?: string) {

--- a/packages/cli/src/services/pruning.service.ts
+++ b/packages/cli/src/services/pruning.service.ts
@@ -74,7 +74,7 @@ export class PruningService {
 		const when = [rateMs / TIME.MINUTE, 'min'].join(' ');
 
 		this.softDeletionInterval = setInterval(
-			async () => this.softDeleteOnPruningCycle(),
+			async () => await this.softDeleteOnPruningCycle(),
 			this.rates.softDeletion,
 		);
 

--- a/packages/cli/src/services/redis/RedisServicePubSubPublisher.ts
+++ b/packages/cli/src/services/redis/RedisServicePubSubPublisher.ts
@@ -57,7 +57,7 @@ export class RedisServicePubSubPublisher extends RedisServiceBaseSender {
 	async get(key: string) {
 		if (!this.redisClient) await this.init();
 
-		return this.redisClient?.get(key);
+		return await this.redisClient?.get(key);
 	}
 
 	async clear(key: string) {

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -66,35 +66,35 @@ export class RoleService {
 	}
 
 	async findGlobalOwnerRole() {
-		return this.findCached('global', 'owner');
+		return await this.findCached('global', 'owner');
 	}
 
 	async findGlobalMemberRole() {
-		return this.findCached('global', 'member');
+		return await this.findCached('global', 'member');
 	}
 
 	async findGlobalAdminRole() {
-		return this.findCached('global', 'admin');
+		return await this.findCached('global', 'admin');
 	}
 
 	async findWorkflowOwnerRole() {
-		return this.findCached('workflow', 'owner');
+		return await this.findCached('workflow', 'owner');
 	}
 
 	async findWorkflowEditorRole() {
-		return this.findCached('workflow', 'editor');
+		return await this.findCached('workflow', 'editor');
 	}
 
 	async findCredentialOwnerRole() {
-		return this.findCached('credential', 'owner');
+		return await this.findCached('credential', 'owner');
 	}
 
 	async findCredentialUserRole() {
-		return this.findCached('credential', 'user');
+		return await this.findCached('credential', 'user');
 	}
 
 	async findRoleByUserAndWorkflow(userId: string, workflowId: string) {
-		return this.sharedWorkflowRepository
+		return await this.sharedWorkflowRepository
 			.findOne({
 				where: { workflowId, userId },
 				relations: ['role'],

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -31,7 +31,7 @@ export class TagService {
 
 		await this.externalHooks.run(`tag.after${action}`, [tag]);
 
-		return savedTag;
+		return await savedTag;
 	}
 
 	async delete(id: string) {
@@ -41,7 +41,7 @@ export class TagService {
 
 		await this.externalHooks.run('tag.afterDelete', [id]);
 
-		return deleteResult;
+		return await deleteResult;
 	}
 
 	async getAll<T extends { withUsageCount: boolean }>(options?: T): Promise<GetAllResult<T>> {
@@ -59,9 +59,9 @@ export class TagService {
 			}) as GetAllResult<T>;
 		}
 
-		return this.tagRepository.find({
+		return await (this.tagRepository.find({
 			select: ['id', 'name', 'createdAt', 'updatedAt'],
-		}) as Promise<GetAllResult<T>>;
+		}) as Promise<GetAllResult<T>>);
 	}
 
 	/**

--- a/packages/cli/src/services/test-webhook-registrations.service.ts
+++ b/packages/cli/src/services/test-webhook-registrations.service.ts
@@ -46,7 +46,7 @@ export class TestWebhookRegistrationsService {
 	}
 
 	async get(key: string) {
-		return this.cacheService.getHashValue<TestWebhookRegistration>(this.cacheKey, key);
+		return await this.cacheService.getHashValue<TestWebhookRegistration>(this.cacheKey, key);
 	}
 
 	async getAllKeys() {

--- a/packages/cli/src/services/webhook.service.ts
+++ b/packages/cli/src/services/webhook.service.ts
@@ -43,7 +43,7 @@ export class WebhookService {
 	 * Find a matching webhook with zero dynamic path segments, e.g. `<uuid>` or `user/profile`.
 	 */
 	private async findStaticWebhook(method: Method, path: string) {
-		return this.webhookRepository.findOneBy({ webhookPath: path, method });
+		return await this.webhookRepository.findOneBy({ webhookPath: path, method });
 	}
 
 	/**
@@ -87,13 +87,13 @@ export class WebhookService {
 	}
 
 	async findWebhook(method: Method, path: string) {
-		return this.findCached(method, path);
+		return await this.findCached(method, path);
 	}
 
 	async storeWebhook(webhook: WebhookEntity) {
 		void this.cacheService.set(webhook.cacheKey, webhook);
 
-		return this.webhookRepository.insert(webhook);
+		return await this.webhookRepository.insert(webhook);
 	}
 
 	createWebhook(data: Partial<WebhookEntity>) {
@@ -103,17 +103,17 @@ export class WebhookService {
 	async deleteWorkflowWebhooks(workflowId: string) {
 		const webhooks = await this.webhookRepository.findBy({ workflowId });
 
-		return this.deleteWebhooks(webhooks);
+		return await this.deleteWebhooks(webhooks);
 	}
 
 	private async deleteWebhooks(webhooks: WebhookEntity[]) {
 		void this.cacheService.deleteMany(webhooks.map((w) => w.cacheKey));
 
-		return this.webhookRepository.remove(webhooks);
+		return await this.webhookRepository.remove(webhooks);
 	}
 
 	async getWebhookMethods(path: string) {
-		return this.webhookRepository
+		return await this.webhookRepository
 			.find({ select: ['method'], where: { webhookPath: path } })
 			.then((rows) => rows.map((r) => r.method));
 	}

--- a/packages/cli/src/shutdown/Shutdown.service.ts
+++ b/packages/cli/src/shutdown/Shutdown.service.ts
@@ -85,7 +85,7 @@ export class ShutdownService {
 		const handlers = Object.values(this.handlersByPriority).reverse();
 		for (const handlerGroup of handlers) {
 			await Promise.allSettled(
-				handlerGroup.map(async (handler) => this.shutdownComponent(handler)),
+				handlerGroup.map(async (handler) => await this.shutdownComponent(handler)),
 			);
 		}
 	}

--- a/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
+++ b/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
@@ -107,7 +107,7 @@ export class SamlController {
 	@NoAuthRequired()
 	@Get(SamlUrls.acs, { middlewares: [samlLicensedMiddleware] })
 	async acsGet(req: SamlConfiguration.AcsRequest, res: express.Response) {
-		return this.acsHandler(req, res, 'redirect');
+		return await this.acsHandler(req, res, 'redirect');
 	}
 
 	/**
@@ -117,7 +117,7 @@ export class SamlController {
 	@NoAuthRequired()
 	@Post(SamlUrls.acs, { middlewares: [samlLicensedMiddleware] })
 	async acsPost(req: SamlConfiguration.AcsRequest, res: express.Response) {
-		return this.acsHandler(req, res, 'post');
+		return await this.acsHandler(req, res, 'post');
 	}
 
 	/**
@@ -198,7 +198,7 @@ export class SamlController {
 		} catch {
 			// ignore
 		}
-		return this.handleInitSSO(res, redirectUrl);
+		return await this.handleInitSSO(res, redirectUrl);
 	}
 
 	/**
@@ -209,7 +209,7 @@ export class SamlController {
 	@Get(SamlUrls.configTest, { middlewares: [samlLicensedMiddleware] })
 	@RequireGlobalScope('saml:manage')
 	async configTestGet(req: AuthenticatedRequest, res: express.Response) {
-		return this.handleInitSSO(res, getServiceProviderConfigTestReturnUrl());
+		return await this.handleInitSSO(res, getServiceProviderConfigTestReturnUrl());
 	}
 
 	private async handleInitSSO(res: express.Response, relayState?: string) {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -97,7 +97,7 @@ export class Telemetry {
 					...this.executionCountsBuffer[workflowId],
 				});
 
-				return promise;
+				return await promise;
 			});
 
 		this.executionCountsBuffer = {};
@@ -117,7 +117,7 @@ export class Telemetry {
 			read_only_instance: sourceControlPreferences.branchReadOnly,
 		};
 		allPromises.push(this.track('pulse', pulsePacket));
-		return Promise.all(allPromises);
+		return await Promise.all(allPromises);
 	}
 
 	async trackWorkflowExecution(properties: IExecutionTrackProperties): Promise<void> {
@@ -155,7 +155,7 @@ export class Telemetry {
 	async trackN8nStop(): Promise<void> {
 		clearInterval(this.pulseIntervalReference);
 		void this.track('User instance stopped');
-		return new Promise<void>(async (resolve) => {
+		return await new Promise<void>(async (resolve) => {
 			await this.postHog.stop();
 
 			if (this.rudderStack) {
@@ -170,7 +170,7 @@ export class Telemetry {
 		[key: string]: string | number | boolean | object | undefined | null;
 	}): Promise<void> {
 		const { instanceId } = this.instanceSettings;
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			if (this.rudderStack) {
 				this.rudderStack.identify(
 					{
@@ -191,7 +191,7 @@ export class Telemetry {
 		{ withPostHog } = { withPostHog: false }, // whether to additionally track with PostHog
 	): Promise<void> {
 		const { instanceId } = this.instanceSettings;
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			if (this.rudderStack) {
 				const { user_id } = properties;
 				const updatedProperties: ITelemetryTrackProperties = {

--- a/packages/cli/src/workflows/workflowHistory/workflowHistory.service.ee.ts
+++ b/packages/cli/src/workflows/workflowHistory/workflowHistory.service.ee.ts
@@ -19,7 +19,7 @@ export class WorkflowHistoryService {
 	) {}
 
 	private async getSharedWorkflow(user: User, workflowId: string): Promise<SharedWorkflow | null> {
-		return this.sharedWorkflowRepository.findOne({
+		return await this.sharedWorkflowRepository.findOne({
 			where: {
 				...(!user.hasGlobalScope('workflow:read') && { userId: user.id }),
 				workflowId,
@@ -37,7 +37,7 @@ export class WorkflowHistoryService {
 		if (!sharedWorkflow) {
 			throw new SharedWorkflowNotFoundError('');
 		}
-		return this.workflowHistoryRepository.find({
+		return await this.workflowHistoryRepository.find({
 			where: {
 				workflowId: sharedWorkflow.workflowId,
 			},

--- a/packages/cli/src/workflows/workflowHistory/workflowHistoryManager.ee.ts
+++ b/packages/cli/src/workflows/workflowHistory/workflowHistoryManager.ee.ts
@@ -15,7 +15,7 @@ export class WorkflowHistoryManager {
 			clearInterval(this.pruneTimer);
 		}
 
-		this.pruneTimer = setInterval(async () => this.prune(), WORKFLOW_HISTORY_PRUNE_INTERVAL);
+		this.pruneTimer = setInterval(async () => await this.prune(), WORKFLOW_HISTORY_PRUNE_INTERVAL);
 	}
 
 	shutdown() {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -329,7 +329,7 @@ export class WorkflowsController {
 			}
 		}
 
-		return this.workflowExecutionService.executeManually(
+		return await this.workflowExecutionService.executeManually(
 			req.body,
 			req.user,
 			GenericHelpers.getSessionId(req),

--- a/packages/cli/test/integration/ExternalSecrets/externalSecrets.api.test.ts
+++ b/packages/cli/test/integration/ExternalSecrets/externalSecrets.api.test.ts
@@ -35,7 +35,7 @@ const testServer = setupTestServer({
 const connectedDate = '2023-08-01T12:32:29.000Z';
 
 async function setExternalSecretsSettings(settings: ExternalSecretsSettings) {
-	return Container.get(SettingsRepository).saveEncryptedSecretsProviderSettings(
+	return await Container.get(SettingsRepository).saveEncryptedSecretsProviderSettings(
 		Container.get(Cipher).encrypt(settings),
 	);
 }
@@ -45,7 +45,7 @@ async function getExternalSecretsSettings(): Promise<ExternalSecretsSettings | n
 	if (encSettings === null) {
 		return null;
 	}
-	return jsonParse(Container.get(Cipher).decrypt(encSettings));
+	return await jsonParse(Container.get(Cipher).decrypt(encSettings));
 }
 
 const resetManager = async () => {

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -14,7 +14,7 @@ let owner: User;
 
 const saveExecution = async ({ belongingTo }: { belongingTo: User }) => {
 	const workflow = await createWorkflow({}, belongingTo);
-	return createSuccessfulExecution(workflow);
+	return await createSuccessfulExecution(workflow);
 };
 
 beforeEach(async () => {

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -93,7 +93,7 @@ const createLdapConfig = async (attributes: Partial<LdapConfig> = {}): Promise<L
 		}),
 		loadOnStartup: true,
 	});
-	return jsonParse(ldapConfig);
+	return await jsonParse(ldapConfig);
 };
 
 test('Member role should not be able to access ldap routes', async () => {

--- a/packages/cli/test/integration/pruning.service.test.ts
+++ b/packages/cli/test/integration/pruning.service.test.ts
@@ -47,7 +47,7 @@ describe('softDeleteOnPruningCycle()', () => {
 	});
 
 	async function findAllExecutions() {
-		return Container.get(ExecutionRepository).find({
+		return await Container.get(ExecutionRepository).find({
 			order: { id: 'asc' },
 			withDeleted: true,
 		});

--- a/packages/cli/test/integration/security-audit/DatabaseRiskReporter.test.ts
+++ b/packages/cli/test/integration/security-audit/DatabaseRiskReporter.test.ts
@@ -55,7 +55,7 @@ test('should report expressions in queries', async () => {
 			],
 		};
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);
@@ -110,7 +110,7 @@ test('should report expressions in query params', async () => {
 			],
 		};
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);
@@ -162,7 +162,7 @@ test('should report unused query params', async () => {
 			],
 		};
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);

--- a/packages/cli/test/integration/security-audit/FilesystemRiskReporter.test.ts
+++ b/packages/cli/test/integration/security-audit/FilesystemRiskReporter.test.ts
@@ -47,7 +47,7 @@ test('should report filesystem interaction nodes', async () => {
 			],
 		});
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);

--- a/packages/cli/test/integration/security-audit/InstanceRiskReporter.test.ts
+++ b/packages/cli/test/integration/security-audit/InstanceRiskReporter.test.ts
@@ -102,7 +102,7 @@ test('should not report webhooks having basic or header auth', async () => {
 			],
 		};
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);
@@ -165,7 +165,7 @@ test('should not report webhooks validated by direct children', async () => {
 			},
 		};
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);

--- a/packages/cli/test/integration/security-audit/NodesRiskReporter.test.ts
+++ b/packages/cli/test/integration/security-audit/NodesRiskReporter.test.ts
@@ -58,7 +58,7 @@ test('should report risky official nodes', async () => {
 			],
 		});
 
-		return Container.get(WorkflowRepository).save(details);
+		return await Container.get(WorkflowRepository).save(details);
 	});
 
 	await Promise.all(promises);

--- a/packages/cli/test/integration/security-audit/utils.ts
+++ b/packages/cli/test/integration/security-audit/utils.ts
@@ -53,7 +53,7 @@ export async function saveManualTriggerWorkflow() {
 		],
 	};
 
-	return Container.get(WorkflowRepository).save(details);
+	return await Container.get(WorkflowRepository).save(details);
 }
 
 export const MOCK_09990_N8N_VERSION = {

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -55,17 +55,17 @@ export async function shareCredentialWithUsers(credential: CredentialsEntity, us
 			roleId: role?.id,
 		}),
 	);
-	return Container.get(SharedCredentialsRepository).save(newSharedCredentials);
+	return await Container.get(SharedCredentialsRepository).save(newSharedCredentials);
 }
 
 export function affixRoleToSaveCredential(role: Role) {
 	return async (credentialPayload: CredentialPayload, { user }: { user: User }) =>
-		saveCredential(credentialPayload, { user, role });
+		await saveCredential(credentialPayload, { user, role });
 }
 
 export async function getAllCredentials() {
-	return Container.get(CredentialsRepository).find();
+	return await Container.get(CredentialsRepository).find();
 }
 
 export const getCredentialById = async (id: string) =>
-	Container.get(CredentialsRepository).findOneBy({ id });
+	await Container.get(CredentialsRepository).findOneBy({ id });

--- a/packages/cli/test/integration/shared/db/executions.ts
+++ b/packages/cli/test/integration/shared/db/executions.ts
@@ -10,8 +10,8 @@ export async function createManyExecutions(
 	workflow: WorkflowEntity,
 	callback: (workflow: WorkflowEntity) => Promise<ExecutionEntity>,
 ) {
-	const executionsRequests = [...Array(amount)].map(async (_) => callback(workflow));
-	return Promise.all(executionsRequests);
+	const executionsRequests = [...Array(amount)].map(async (_) => await callback(workflow));
+	return await Promise.all(executionsRequests);
 }
 
 /**
@@ -47,23 +47,29 @@ export async function createExecution(
  * Store a successful execution in the DB and assign it to a workflow.
  */
 export async function createSuccessfulExecution(workflow: WorkflowEntity) {
-	return createExecution({ finished: true, status: 'success' }, workflow);
+	return await createExecution({ finished: true, status: 'success' }, workflow);
 }
 
 /**
  * Store an error execution in the DB and assign it to a workflow.
  */
 export async function createErrorExecution(workflow: WorkflowEntity) {
-	return createExecution({ finished: false, stoppedAt: new Date(), status: 'failed' }, workflow);
+	return await createExecution(
+		{ finished: false, stoppedAt: new Date(), status: 'failed' },
+		workflow,
+	);
 }
 
 /**
  * Store a waiting execution in the DB and assign it to a workflow.
  */
 export async function createWaitingExecution(workflow: WorkflowEntity) {
-	return createExecution({ finished: false, waitTill: new Date(), status: 'waiting' }, workflow);
+	return await createExecution(
+		{ finished: false, waitTill: new Date(), status: 'waiting' },
+		workflow,
+	);
 }
 
 export async function getAllExecutions() {
-	return Container.get(ExecutionRepository).find();
+	return await Container.get(ExecutionRepository).find();
 }

--- a/packages/cli/test/integration/shared/db/roles.ts
+++ b/packages/cli/test/integration/shared/db/roles.ts
@@ -2,31 +2,31 @@ import Container from 'typedi';
 import { RoleService } from '@/services/role.service';
 
 export async function getGlobalOwnerRole() {
-	return Container.get(RoleService).findGlobalOwnerRole();
+	return await Container.get(RoleService).findGlobalOwnerRole();
 }
 
 export async function getGlobalMemberRole() {
-	return Container.get(RoleService).findGlobalMemberRole();
+	return await Container.get(RoleService).findGlobalMemberRole();
 }
 
 export async function getGlobalAdminRole() {
-	return Container.get(RoleService).findGlobalAdminRole();
+	return await Container.get(RoleService).findGlobalAdminRole();
 }
 
 export async function getWorkflowOwnerRole() {
-	return Container.get(RoleService).findWorkflowOwnerRole();
+	return await Container.get(RoleService).findWorkflowOwnerRole();
 }
 
 export async function getWorkflowEditorRole() {
-	return Container.get(RoleService).findWorkflowEditorRole();
+	return await Container.get(RoleService).findWorkflowEditorRole();
 }
 
 export async function getCredentialOwnerRole() {
-	return Container.get(RoleService).findCredentialOwnerRole();
+	return await Container.get(RoleService).findCredentialOwnerRole();
 }
 
 export async function getAllRoles() {
-	return Promise.all([
+	return await Promise.all([
 		getGlobalOwnerRole(),
 		getGlobalMemberRole(),
 		getWorkflowOwnerRole(),

--- a/packages/cli/test/integration/shared/db/users.ts
+++ b/packages/cli/test/integration/shared/db/users.ts
@@ -27,7 +27,7 @@ export async function createUser(attributes: Partial<User> = {}): Promise<User> 
 	});
 	user.computeIsOwner();
 
-	return Container.get(UserRepository).save(user);
+	return await Container.get(UserRepository).save(user);
 }
 
 export async function createLdapUser(attributes: Partial<User>, ldapId: string): Promise<User> {
@@ -70,15 +70,15 @@ export async function createUserWithMfaEnabled(
 }
 
 export async function createOwner() {
-	return createUser({ globalRole: await getGlobalOwnerRole() });
+	return await createUser({ globalRole: await getGlobalOwnerRole() });
 }
 
 export async function createMember() {
-	return createUser({ globalRole: await getGlobalMemberRole() });
+	return await createUser({ globalRole: await getGlobalMemberRole() });
 }
 
 export async function createAdmin() {
-	return createUser({ globalRole: await getGlobalAdminRole() });
+	return await createUser({ globalRole: await getGlobalAdminRole() });
 }
 
 export async function createUserShell(globalRole: Role): Promise<User> {
@@ -92,7 +92,7 @@ export async function createUserShell(globalRole: Role): Promise<User> {
 		shell.email = randomEmail();
 	}
 
-	return Container.get(UserRepository).save(shell);
+	return await Container.get(UserRepository).save(shell);
 }
 
 /**
@@ -120,27 +120,27 @@ export async function createManyUsers(
 		),
 	);
 
-	return Container.get(UserRepository).save(users);
+	return await Container.get(UserRepository).save(users);
 }
 
 export async function addApiKey(user: User): Promise<User> {
 	user.apiKey = randomApiKey();
-	return Container.get(UserRepository).save(user);
+	return await Container.get(UserRepository).save(user);
 }
 
 export const getAllUsers = async () =>
-	Container.get(UserRepository).find({
+	await Container.get(UserRepository).find({
 		relations: ['globalRole', 'authIdentities'],
 	});
 
 export const getUserById = async (id: string) =>
-	Container.get(UserRepository).findOneOrFail({
+	await Container.get(UserRepository).findOneOrFail({
 		where: { id },
 		relations: ['globalRole', 'authIdentities'],
 	});
 
 export const getLdapIdentities = async () =>
-	Container.get(AuthIdentityRepository).find({
+	await Container.get(AuthIdentityRepository).find({
 		where: { providerType: 'ldap' },
 		relations: ['user'],
 	});

--- a/packages/cli/test/integration/shared/db/workflowHistory.ts
+++ b/packages/cli/test/integration/shared/db/workflowHistory.ts
@@ -7,7 +7,7 @@ export async function createWorkflowHistoryItem(
 	workflowId: string,
 	data?: Partial<WorkflowHistory>,
 ) {
-	return Container.get(WorkflowHistoryRepository).save({
+	return await Container.get(WorkflowHistoryRepository).save({
 		authors: 'John Smith',
 		connections: {},
 		nodes: [
@@ -32,12 +32,13 @@ export async function createManyWorkflowHistoryItems(
 	time?: Date,
 ) {
 	const baseTime = (time ?? new Date()).valueOf();
-	return Promise.all(
-		[...Array(count)].map(async (_, i) =>
-			createWorkflowHistoryItem(workflowId, {
-				createdAt: new Date(baseTime + i),
-				updatedAt: new Date(baseTime + i),
-			}),
+	return await Promise.all(
+		[...Array(count)].map(
+			async (_, i) =>
+				await createWorkflowHistoryItem(workflowId, {
+					createdAt: new Date(baseTime + i),
+					updatedAt: new Date(baseTime + i),
+				}),
 		),
 	);
 }

--- a/packages/cli/test/integration/shared/db/workflows.ts
+++ b/packages/cli/test/integration/shared/db/workflows.ts
@@ -11,8 +11,10 @@ export async function createManyWorkflows(
 	attributes: Partial<WorkflowEntity> = {},
 	user?: User,
 ) {
-	const workflowRequests = [...Array(amount)].map(async (_) => createWorkflow(attributes, user));
-	return Promise.all(workflowRequests);
+	const workflowRequests = [...Array(amount)].map(
+		async (_) => await createWorkflow(attributes, user),
+	);
+	return await Promise.all(workflowRequests);
 }
 
 /**
@@ -60,11 +62,11 @@ export async function shareWorkflowWithUsers(workflow: WorkflowEntity, users: Us
 		workflow,
 		role,
 	}));
-	return Container.get(SharedWorkflowRepository).save(sharedWorkflows);
+	return await Container.get(SharedWorkflowRepository).save(sharedWorkflows);
 }
 
 export async function getWorkflowSharing(workflow: WorkflowEntity) {
-	return Container.get(SharedWorkflowRepository).findBy({
+	return await Container.get(SharedWorkflowRepository).findBy({
 		workflowId: workflow.id,
 	});
 }
@@ -115,8 +117,8 @@ export async function createWorkflowWithTrigger(
 }
 
 export async function getAllWorkflows() {
-	return Container.get(WorkflowRepository).find();
+	return await Container.get(WorkflowRepository).find();
 }
 
 export const getWorkflowById = async (id: string) =>
-	Container.get(WorkflowRepository).findOneBy({ id });
+	await Container.get(WorkflowRepository).findOneBy({ id });

--- a/packages/cli/test/integration/shared/utils/testServer.ts
+++ b/packages/cli/test/integration/shared/utils/testServer.ts
@@ -38,7 +38,7 @@ function prefix(pathSegment: string) {
 
 		url.pathname = pathSegment + url.pathname;
 		request.url = url.toString();
-		return request;
+		return await request;
 	};
 }
 

--- a/packages/cli/test/integration/variables.test.ts
+++ b/packages/cli/test/integration/variables.test.ts
@@ -26,7 +26,7 @@ async function createVariable(key: string, value: string) {
 }
 
 async function getVariableByKey(key: string) {
-	return Container.get(VariablesRepository).findOne({
+	return await Container.get(VariablesRepository).findOne({
 		where: {
 			key,
 		},
@@ -34,7 +34,7 @@ async function getVariableByKey(key: string) {
 }
 
 async function getVariableById(id: string) {
-	return Container.get(VariablesRepository).findOne({
+	return await Container.get(VariablesRepository).findOne({
 		where: {
 			id,
 		},

--- a/packages/cli/test/integration/workflowHistory.api.test.ts
+++ b/packages/cli/test/integration/workflowHistory.api.test.ts
@@ -60,8 +60,9 @@ describe('GET /workflow-history/:workflowId', () => {
 		const versions = await Promise.all(
 			new Array(10)
 				.fill(undefined)
-				.map(async (_, i) =>
-					createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
+				.map(
+					async (_, i) =>
+						await createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
 				),
 		);
 
@@ -84,13 +85,14 @@ describe('GET /workflow-history/:workflowId', () => {
 		const versions = await Promise.all(
 			new Array(10)
 				.fill(undefined)
-				.map(async (_, i) =>
-					createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
+				.map(
+					async (_, i) =>
+						await createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
 				),
 		);
 
 		const versions2 = await Promise.all(
-			new Array(10).fill(undefined).map(async (_) => createWorkflowHistoryItem(workflow2.id)),
+			new Array(10).fill(undefined).map(async (_) => await createWorkflowHistoryItem(workflow2.id)),
 		);
 
 		const last = versions.sort((a, b) => b.createdAt.valueOf() - a.createdAt.valueOf())[0]! as any;
@@ -111,8 +113,9 @@ describe('GET /workflow-history/:workflowId', () => {
 		const versions = await Promise.all(
 			new Array(10)
 				.fill(undefined)
-				.map(async (_, i) =>
-					createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
+				.map(
+					async (_, i) =>
+						await createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
 				),
 		);
 
@@ -134,8 +137,9 @@ describe('GET /workflow-history/:workflowId', () => {
 		const versions = await Promise.all(
 			new Array(10)
 				.fill(undefined)
-				.map(async (_, i) =>
-					createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
+				.map(
+					async (_, i) =>
+						await createWorkflowHistoryItem(workflow.id, { createdAt: new Date(Date.now() + i) }),
 				),
 		);
 

--- a/packages/cli/test/integration/workflowHistoryManager.test.ts
+++ b/packages/cli/test/integration/workflowHistoryManager.test.ts
@@ -102,7 +102,7 @@ describe('Workflow History Manager', () => {
 	const createWorkflowHistory = async (ageInDays = 2) => {
 		const workflow = await createWorkflow();
 		const time = DateTime.now().minus({ days: ageInDays }).toJSDate();
-		return createManyWorkflowHistoryItems(workflow.id, 10, time);
+		return await createManyWorkflowHistoryItems(workflow.id, 10, time);
 	};
 
 	const pruneAndAssertCount = async (finalCount = 10, initialCount = 10) => {

--- a/packages/cli/test/teardown.ts
+++ b/packages/cli/test/teardown.ts
@@ -17,7 +17,9 @@ export default async () => {
 		.filter(({ Database: dbName }) => dbName.startsWith(testDbPrefix))
 		.map(({ Database: dbName }) => dbName);
 
-	const promises = databases.map(async (dbName) => connection.query(`DROP DATABASE ${dbName};`));
+	const promises = databases.map(
+		async (dbName) => await connection.query(`DROP DATABASE ${dbName};`),
+	);
 	await Promise.all(promises);
 	await connection.destroy();
 };

--- a/packages/cli/test/unit/ExternalSecrets/ExternalSecretsManager.test.ts
+++ b/packages/cli/test/unit/ExternalSecrets/ExternalSecretsManager.test.ts
@@ -67,7 +67,7 @@ describe('External Secrets Manager', () => {
 		mockProvidersInstance.setProviders({
 			dummy: ErrorProvider,
 		});
-		expect(async () => manager!.init()).not.toThrow();
+		expect(async () => await manager!.init()).not.toThrow();
 	});
 
 	test('should not throw errors during shutdown', async () => {

--- a/packages/cli/test/unit/Helpers.ts
+++ b/packages/cli/test/unit/Helpers.ts
@@ -5,7 +5,7 @@ import type { INodeTypeData } from 'n8n-workflow';
  * the macrotask queue and so called at the next iteration of the event loop
  * after all promises in the microtask queue have settled first.
  */
-export const flushPromises = async () => new Promise(setImmediate);
+export const flushPromises = async () => await new Promise(setImmediate);
 
 export function mockNodeTypesData(
 	nodeNames: string[],

--- a/packages/cli/test/unit/PermissionChecker.test.ts
+++ b/packages/cli/test/unit/PermissionChecker.test.ts
@@ -123,7 +123,7 @@ describe('check()', () => {
 			],
 		});
 
-		expect(async () => permissionChecker.check(workflow, userId)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflow, userId)).not.toThrow();
 	});
 
 	test('should allow if requesting user is instance owner', async () => {
@@ -153,7 +153,7 @@ describe('check()', () => {
 			],
 		});
 
-		expect(async () => permissionChecker.check(workflow, owner.id)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflow, owner.id)).not.toThrow();
 	});
 
 	test('should allow if workflow creds are valid subset', async () => {
@@ -200,7 +200,7 @@ describe('check()', () => {
 			],
 		});
 
-		expect(async () => permissionChecker.check(workflow, owner.id)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflow, owner.id)).not.toThrow();
 	});
 
 	test('should deny if workflow creds are not valid subset', async () => {

--- a/packages/cli/test/unit/UserManagementMailer.test.ts
+++ b/packages/cli/test/unit/UserManagementMailer.test.ts
@@ -22,7 +22,7 @@ describe('UserManagementMailer', () => {
 		test('not be called when SMTP not set up', async () => {
 			const userManagementMailer = new UserManagementMailer();
 			// NodeMailer.verifyConnection gets called only explicitly
-			await expect(async () => userManagementMailer.verifyConnection()).rejects.toThrow();
+			await expect(async () => await userManagementMailer.verifyConnection()).rejects.toThrow();
 
 			expect(NodeMailer.prototype.verifyConnection).toHaveBeenCalledTimes(0);
 		});
@@ -34,7 +34,7 @@ describe('UserManagementMailer', () => {
 
 			const userManagementMailer = new UserManagementMailer();
 			// NodeMailer.verifyConnection gets called only explicitly
-			expect(async () => userManagementMailer.verifyConnection()).not.toThrow();
+			expect(async () => await userManagementMailer.verifyConnection()).not.toThrow();
 		});
 	});
 });

--- a/packages/cli/test/unit/services/communityPackages.service.test.ts
+++ b/packages/cli/test/unit/services/communityPackages.service.test.ts
@@ -173,7 +173,7 @@ describe('CommunityPackagesService', () => {
 
 			mocked(exec).mockImplementation(erroringExecMock);
 
-			const call = async () => communityPackagesService.executeNpmCommand('ls');
+			const call = async () => await communityPackagesService.executeNpmCommand('ls');
 
 			await expect(call).rejects.toThrowError(RESPONSE_ERROR_MESSAGES.PACKAGE_NOT_FOUND);
 

--- a/packages/cli/test/unit/shutdown/Shutdown.service.test.ts
+++ b/packages/cli/test/unit/shutdown/Shutdown.service.test.ts
@@ -104,7 +104,7 @@ describe('ShutdownService', () => {
 		});
 
 		it('should throw error if app is not shutting down', async () => {
-			await expect(async () => shutdownService.waitForShutdown()).rejects.toThrow(
+			await expect(async () => await shutdownService.waitForShutdown()).rejects.toThrow(
 				'App is not shutting down',
 			);
 		});

--- a/packages/core/src/ActiveWorkflows.ts
+++ b/packages/core/src/ActiveWorkflows.ts
@@ -209,8 +209,8 @@ export class ActiveWorkflows {
 
 		const w = this.activeWorkflows[workflowId];
 
-		w.triggerResponses?.forEach(async (r) => this.close(r, workflowId, 'trigger'));
-		w.pollResponses?.forEach(async (r) => this.close(r, workflowId, 'poller'));
+		w.triggerResponses?.forEach(async (r) => await this.close(r, workflowId, 'trigger'));
+		w.pollResponses?.forEach(async (r) => await this.close(r, workflowId, 'poller'));
 
 		delete this.activeWorkflows[workflowId];
 
@@ -221,8 +221,8 @@ export class ActiveWorkflows {
 		for (const workflowId of Object.keys(this.activeWorkflows)) {
 			const w = this.activeWorkflows[workflowId];
 
-			w.triggerResponses?.forEach(async (r) => this.close(r, workflowId, 'trigger'));
-			w.pollResponses?.forEach(async (r) => this.close(r, workflowId, 'poller'));
+			w.triggerResponses?.forEach(async (r) => await this.close(r, workflowId, 'trigger'));
+			w.pollResponses?.forEach(async (r) => await this.close(r, workflowId, 'poller'));
 		}
 	}
 

--- a/packages/core/src/BinaryData/FileSystem.manager.ts
+++ b/packages/core/src/BinaryData/FileSystem.manager.ts
@@ -61,13 +61,13 @@ export class FileSystemManager implements BinaryData.Manager {
 			throw new FileNotFoundError(filePath);
 		}
 
-		return fs.readFile(filePath);
+		return await fs.readFile(filePath);
 	}
 
 	async getMetadata(fileId: string): Promise<BinaryData.Metadata> {
 		const filePath = this.resolvePath(`${fileId}.metadata`);
 
-		return jsonParse(await fs.readFile(filePath, { encoding: 'utf-8' }));
+		return await jsonParse(await fs.readFile(filePath, { encoding: 'utf-8' }));
 	}
 
 	async deleteMany(ids: BinaryData.IdsForDeletion) {

--- a/packages/core/src/BinaryData/ObjectStore.manager.ts
+++ b/packages/core/src/BinaryData/ObjectStore.manager.ts
@@ -34,11 +34,11 @@ export class ObjectStoreManager implements BinaryData.Manager {
 	}
 
 	async getAsBuffer(fileId: string) {
-		return this.objectStoreService.get(fileId, { mode: 'buffer' });
+		return await this.objectStoreService.get(fileId, { mode: 'buffer' });
 	}
 
 	async getAsStream(fileId: string) {
-		return this.objectStoreService.get(fileId, { mode: 'stream' });
+		return await this.objectStoreService.get(fileId, { mode: 'stream' });
 	}
 
 	async getMetadata(fileId: string): Promise<BinaryData.Metadata> {
@@ -102,6 +102,6 @@ export class ObjectStoreManager implements BinaryData.Manager {
 	}
 
 	private async toBuffer(bufferOrStream: Buffer | Readable) {
-		return toBuffer(bufferOrStream);
+		return await toBuffer(bufferOrStream);
 	}
 }

--- a/packages/core/src/BinaryData/utils.ts
+++ b/packages/core/src/BinaryData/utils.ts
@@ -34,7 +34,7 @@ export async function doesNotExist(dir: string) {
 
 export async function toBuffer(body: Buffer | Readable) {
 	if (Buffer.isBuffer(body)) return body;
-	return new Promise<Buffer>((resolve, reject) => {
+	return await new Promise<Buffer>((resolve, reject) => {
 		body
 			.once('error', (cause) => {
 				if ('code' in cause && cause.code === 'Z_DATA_ERROR')

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -754,7 +754,7 @@ export async function proxyRequestToAxios(
 			}
 		};
 	} else {
-		requestFn = async () => axios(axiosConfig);
+		requestFn = async () => await axios(axiosConfig);
 	}
 
 	try {
@@ -969,14 +969,14 @@ export function getBinaryPath(binaryDataId: string): string {
  * Returns binary file metadata
  */
 export async function getBinaryMetadata(binaryDataId: string): Promise<BinaryData.Metadata> {
-	return Container.get(BinaryDataService).getMetadata(binaryDataId);
+	return await Container.get(BinaryDataService).getMetadata(binaryDataId);
 }
 
 /**
  * Returns binary file stream for piping
  */
 export async function getBinaryStream(binaryDataId: string, chunkSize?: number): Promise<Readable> {
-	return Container.get(BinaryDataService).getAsStream(binaryDataId, chunkSize);
+	return await Container.get(BinaryDataService).getAsStream(binaryDataId, chunkSize);
 }
 
 export function assertBinaryData(
@@ -1024,7 +1024,7 @@ export async function getBinaryDataBuffer(
 	inputIndex: number,
 ): Promise<Buffer> {
 	const binaryData = inputData.main[inputIndex]![itemIndex]!.binary![propertyName]!;
-	return Container.get(BinaryDataService).getAsBuffer(binaryData);
+	return await Container.get(BinaryDataService).getAsBuffer(binaryData);
 }
 
 /**
@@ -1041,7 +1041,7 @@ export async function setBinaryDataBuffer(
 	workflowId: string,
 	executionId: string,
 ): Promise<IBinaryData> {
-	return Container.get(BinaryDataService).store(
+	return await Container.get(BinaryDataService).store(
 		workflowId,
 		executionId,
 		bufferOrStream,
@@ -1100,7 +1100,7 @@ export async function copyBinaryFile(
 		returnData.fileName = path.parse(filePath).base;
 	}
 
-	return Container.get(BinaryDataService).copyBinaryFile(
+	return await Container.get(BinaryDataService).copyBinaryFile(
 		workflowId,
 		executionId,
 		returnData,
@@ -1197,7 +1197,7 @@ async function prepareBinaryData(
 		}
 	}
 
-	return setBinaryDataBuffer(returnData, binaryData, workflowId, executionId);
+	return await setBinaryDataBuffer(returnData, binaryData, workflowId, executionId);
 }
 
 /**
@@ -1289,7 +1289,7 @@ export async function requestOAuth2(
 		});
 	}
 	if (isN8nRequest) {
-		return this.helpers.httpRequest(newRequestOptions).catch(async (error: AxiosError) => {
+		return await this.helpers.httpRequest(newRequestOptions).catch(async (error: AxiosError) => {
 			if (error.response?.status === 401) {
 				Logger.debug(
 					`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Should revalidate.`,
@@ -1346,7 +1346,7 @@ export async function requestOAuth2(
 					});
 				}
 
-				return this.helpers.httpRequest(refreshedRequestOption);
+				return await this.helpers.httpRequest(refreshedRequestOption);
 			}
 			throw error;
 		});
@@ -1356,7 +1356,7 @@ export async function requestOAuth2(
 			? 401
 			: oAuth2Options?.tokenExpiredStatusCode;
 
-	return this.helpers
+	return await this.helpers
 		.request(newRequestOptions)
 		.then((response) => {
 			const requestOptions = newRequestOptions as any;
@@ -1433,7 +1433,7 @@ export async function requestOAuth2(
 					});
 				}
 
-				return this.helpers.request(newRequestOptions);
+				return await this.helpers.request(newRequestOptions);
 			}
 
 			// Unknown error so simply throw it
@@ -1506,10 +1506,10 @@ export async function requestOAuth1(
 		oauth.authorize(requestOptions as unknown as clientOAuth1.RequestOptions, token),
 	);
 	if (isN8nRequest) {
-		return this.helpers.httpRequest(requestOptions as IHttpRequestOptions);
+		return await this.helpers.httpRequest(requestOptions as IHttpRequestOptions);
 	}
 
-	return this.helpers.request(requestOptions).catch(async (error: IResponseError) => {
+	return await this.helpers.request(requestOptions).catch(async (error: IResponseError) => {
 		// Unknown error so simply throw it
 		throw error;
 	});
@@ -2984,7 +2984,7 @@ const getRequestHelperFunctions = (
 			requestOptions,
 			additionalCredentialOptions,
 		): Promise<any> {
-			return httpRequestWithAuthentication.call(
+			return await httpRequestWithAuthentication.call(
 				this,
 				credentialsType,
 				requestOptions,
@@ -2996,7 +2996,7 @@ const getRequestHelperFunctions = (
 		},
 
 		request: async (uriOrObject, options) =>
-			proxyRequestToAxios(workflow, additionalData, node, uriOrObject, options),
+			await proxyRequestToAxios(workflow, additionalData, node, uriOrObject, options),
 
 		async requestWithAuthentication(
 			this,
@@ -3004,7 +3004,7 @@ const getRequestHelperFunctions = (
 			requestOptions,
 			additionalCredentialOptions,
 		): Promise<any> {
-			return requestWithAuthentication.call(
+			return await requestWithAuthentication.call(
 				this,
 				credentialsType,
 				requestOptions,
@@ -3020,7 +3020,7 @@ const getRequestHelperFunctions = (
 			credentialsType: string,
 			requestOptions: OptionsWithUrl | RequestPromiseOptions,
 		): Promise<any> {
-			return requestOAuth1.call(this, credentialsType, requestOptions);
+			return await requestOAuth1.call(this, credentialsType, requestOptions);
 		},
 
 		async requestOAuth2(
@@ -3029,7 +3029,7 @@ const getRequestHelperFunctions = (
 			requestOptions: OptionsWithUri | RequestPromiseOptions,
 			oAuth2Options?: IOAuth2Options,
 		): Promise<any> {
-			return requestOAuth2.call(
+			return await requestOAuth2.call(
 				this,
 				credentialsType,
 				requestOptions,
@@ -3139,7 +3139,7 @@ const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunctions =>
 				level: 'warning',
 			});
 		}
-		return fsWriteFile(filePath, content, { encoding: 'binary', flag });
+		return await fsWriteFile(filePath, content, { encoding: 'binary', flag });
 	},
 });
 
@@ -3148,7 +3148,7 @@ const getNodeHelperFunctions = (
 	workflowId: string,
 ): NodeHelperFunctions => ({
 	copyBinaryFile: async (filePath, fileName, mimeType) =>
-		copyBinaryFile(workflowId, executionId!, filePath, fileName, mimeType),
+		await copyBinaryFile(workflowId, executionId!, filePath, fileName, mimeType),
 });
 
 const getBinaryHelperFunctions = (
@@ -3159,11 +3159,11 @@ const getBinaryHelperFunctions = (
 	getBinaryStream,
 	getBinaryMetadata,
 	binaryToBuffer: async (body: Buffer | Readable) =>
-		Container.get(BinaryDataService).toBuffer(body),
+		await Container.get(BinaryDataService).toBuffer(body),
 	prepareBinaryData: async (binaryData, filePath, mimeType) =>
-		prepareBinaryData(binaryData, executionId!, workflowId, filePath, mimeType),
+		await prepareBinaryData(binaryData, executionId!, workflowId, filePath, mimeType),
 	setBinaryDataBuffer: async (data, binaryData) =>
-		setBinaryDataBuffer(data, binaryData, workflowId, executionId!),
+		await setBinaryDataBuffer(data, binaryData, workflowId, executionId!),
 	copyBinaryFile: async () => {
 		throw new ApplicationError('`copyBinaryFile` has been removed. Please upgrade this node.');
 	},
@@ -3213,7 +3213,8 @@ export function getExecutePollFunctions(
 			},
 			getMode: () => mode,
 			getActivationMode: () => activation,
-			getCredentials: async (type) => getCredentials(workflow, node, type, additionalData, mode),
+			getCredentials: async (type) =>
+				await getCredentials(workflow, node, type, additionalData, mode),
 			getNodeParameter: (
 				parameterName: string,
 				fallbackValue?: any,
@@ -3275,7 +3276,8 @@ export function getExecuteTriggerFunctions(
 			},
 			getMode: () => mode,
 			getActivationMode: () => activation,
-			getCredentials: async (type) => getCredentials(workflow, node, type, additionalData, mode),
+			getCredentials: async (type) =>
+				await getCredentials(workflow, node, type, additionalData, mode),
 			getNodeParameter: (
 				parameterName: string,
 				fallbackValue?: any,
@@ -3333,7 +3335,7 @@ export function getExecuteFunctions(
 			...executionCancellationFunctions(abortSignal),
 			getMode: () => mode,
 			getCredentials: async (type, itemIndex) =>
-				getCredentials(
+				await getCredentials(
 					workflow,
 					node,
 					type,
@@ -3365,19 +3367,20 @@ export function getExecuteFunctions(
 				workflowInfo: IExecuteWorkflowInfo,
 				inputData?: INodeExecutionData[],
 			): Promise<any> {
-				return additionalData
+				return await additionalData
 					.executeWorkflow(workflowInfo, additionalData, {
 						parentWorkflowId: workflow.id?.toString(),
 						inputData,
 						parentWorkflowSettings: workflow.settings,
 						node,
 					})
-					.then(async (result) =>
-						Container.get(BinaryDataService).duplicateBinaryData(
-							workflow.id,
-							additionalData.executionId!,
-							result,
-						),
+					.then(
+						async (result) =>
+							await Container.get(BinaryDataService).duplicateBinaryData(
+								workflow.id,
+								additionalData.executionId!,
+								result,
+							),
 					);
 			},
 			getContext(type: ContextType): IContextObject {
@@ -3390,7 +3393,7 @@ export function getExecuteFunctions(
 				// TODO: Not implemented yet, and maybe also not needed
 				inputIndex?: number,
 			): Promise<unknown> {
-				return getInputConnectionData.call(
+				return await getInputConnectionData.call(
 					this,
 					workflow,
 					runExecutionData,
@@ -3482,7 +3485,7 @@ export function getExecuteFunctions(
 				return dataProxy.getDataProxy();
 			},
 			binaryToBuffer: async (body: Buffer | Readable) =>
-				Container.get(BinaryDataService).toBuffer(body),
+				await Container.get(BinaryDataService).toBuffer(body),
 			async putExecutionToWait(waitTill: Date): Promise<void> {
 				runExecutionData.waitTill = toUtcDate(waitTill, getTimezone(workflow));
 				if (additionalData.setExecutionStatus) {
@@ -3581,7 +3584,7 @@ export function getExecuteFunctions(
 				assertBinaryData: (itemIndex, propertyName) =>
 					assertBinaryData(inputData, node, itemIndex, propertyName, 0),
 				getBinaryDataBuffer: async (itemIndex, propertyName) =>
-					getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
+					await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
 
 				returnJsonArray,
 				normalizeItems,
@@ -3632,7 +3635,7 @@ export function getExecuteSingleFunctions(
 				return NodeHelpers.getContext(runExecutionData, type, node);
 			},
 			getCredentials: async (type) =>
-				getCredentials(
+				await getCredentials(
 					workflow,
 					node,
 					type,
@@ -3726,7 +3729,7 @@ export function getExecuteSingleFunctions(
 				assertBinaryData: (propertyName, inputIndex = 0) =>
 					assertBinaryData(inputData, node, itemIndex, propertyName, inputIndex),
 				getBinaryDataBuffer: async (propertyName, inputIndex = 0) =>
-					getBinaryDataBuffer(inputData, itemIndex, propertyName, inputIndex),
+					await getBinaryDataBuffer(inputData, itemIndex, propertyName, inputIndex),
 			},
 		};
 	})(workflow, runExecutionData, connectionInputData, inputData, node, itemIndex);
@@ -3736,7 +3739,7 @@ export function getCredentialTestFunctions(): ICredentialTestFunctions {
 	return {
 		helpers: {
 			request: async (uriOrObject: string | object, options?: object) => {
-				return proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
+				return await proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
 			},
 		},
 	};
@@ -3755,7 +3758,7 @@ export function getLoadOptionsFunctions(
 		return {
 			...getCommonWorkflowFunctions(workflow, node, additionalData),
 			getCredentials: async (type) =>
-				getCredentials(workflow, node, type, additionalData, 'internal'),
+				await getCredentials(workflow, node, type, additionalData, 'internal'),
 			getCurrentNodeParameter: (
 				parameterPath: string,
 				options?: IGetNodeParameterOptions,
@@ -3832,7 +3835,8 @@ export function getExecuteHookFunctions(
 	return ((workflow: Workflow, node: INode) => {
 		return {
 			...getCommonWorkflowFunctions(workflow, node, additionalData),
-			getCredentials: async (type) => getCredentials(workflow, node, type, additionalData, mode),
+			getCredentials: async (type) =>
+				await getCredentials(workflow, node, type, additionalData, mode),
 			getMode: () => mode,
 			getActivationMode: () => activation,
 			getNodeParameter: (
@@ -3904,7 +3908,8 @@ export function getExecuteWebhookFunctions(
 				}
 				return additionalData.httpRequest.body;
 			},
-			getCredentials: async (type) => getCredentials(workflow, node, type, additionalData, mode),
+			getCredentials: async (type) =>
+				await getCredentials(workflow, node, type, additionalData, mode),
 			getHeaderData(): IncomingHttpHeaders {
 				if (additionalData.httpRequest === undefined) {
 					throw new ApplicationError('Request is missing');
@@ -3937,7 +3942,7 @@ export function getExecuteWebhookFunctions(
 				};
 				const runIndex = 0;
 
-				return getInputConnectionData.call(
+				return await getInputConnectionData.call(
 					this,
 					workflow,
 					runExecutionData,

--- a/packages/core/src/ObjectStore/ObjectStore.service.ee.ts
+++ b/packages/core/src/ObjectStore/ObjectStore.service.ee.ts
@@ -65,7 +65,7 @@ export class ObjectStoreService {
 	async checkConnection() {
 		if (this.isReady) return;
 
-		return this.request('HEAD', this.host, this.bucket.name);
+		return await this.request('HEAD', this.host, this.bucket.name);
 	}
 
 	/**
@@ -74,7 +74,7 @@ export class ObjectStoreService {
 	 * @doc https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
 	 */
 	async put(filename: string, buffer: Buffer, metadata: BinaryData.PreWriteMetadata = {}) {
-		if (this.isReadOnly) return this.blockWrite(filename);
+		if (this.isReadOnly) return await this.blockWrite(filename);
 
 		const headers: Record<string, string | number> = {
 			'Content-Length': buffer.length,
@@ -86,7 +86,7 @@ export class ObjectStoreService {
 
 		const path = `/${this.bucket.name}/${filename}`;
 
-		return this.request('PUT', this.host, path, { headers, body: buffer });
+		return await this.request('PUT', this.host, path, { headers, body: buffer });
 	}
 
 	/**
@@ -131,7 +131,7 @@ export class ObjectStoreService {
 	async deleteOne(fileId: string) {
 		const path = `${this.bucket.name}/${fileId}`;
 
-		return this.request('DELETE', this.host, path);
+		return await this.request('DELETE', this.host, path);
 	}
 
 	/**
@@ -156,7 +156,7 @@ export class ObjectStoreService {
 
 		const path = `${this.bucket.name}/?delete`;
 
-		return this.request('POST', this.host, path, { headers, body });
+		return await this.request('POST', this.host, path, { headers, body });
 	}
 
 	/**

--- a/packages/core/src/ObjectStore/utils.ts
+++ b/packages/core/src/ObjectStore/utils.ts
@@ -7,12 +7,12 @@ export function isStream(maybeStream: unknown): maybeStream is Stream {
 }
 
 export async function parseXml<T>(xml: string): Promise<T> {
-	return parseStringPromise(xml, {
+	return await (parseStringPromise(xml, {
 		explicitArray: false,
 		ignoreAttrs: true,
 		tagNameProcessors: [firstCharLowerCase],
 		valueProcessors: [parseNumbers, parseBooleans],
-	}) as Promise<T>;
+	}) as Promise<T>);
 }
 
 export function writeBlockedMessage(filename: string) {

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -308,7 +308,7 @@ export class WorkflowExecute {
 			return;
 		}
 
-		return this.additionalData.hooks.executeHookFunctions(hookName, parameters);
+		return await this.additionalData.hooks.executeHookFunctions(hookName, parameters);
 	}
 
 	moveNodeMetadata(): void {
@@ -1657,14 +1657,19 @@ export class WorkflowExecute {
 			})()
 				.then(async () => {
 					if (this.status === 'canceled' && executionError === undefined) {
-						return this.processSuccessExecution(
+						return await this.processSuccessExecution(
 							startedAt,
 							workflow,
 							new WorkflowOperationError('Workflow has been canceled or timed out!'),
 							closeFunction,
 						);
 					}
-					return this.processSuccessExecution(startedAt, workflow, executionError, closeFunction);
+					return await this.processSuccessExecution(
+						startedAt,
+						workflow,
+						executionError,
+						closeFunction,
+					);
 				})
 				.catch(async (error) => {
 					const fullRunData = this.getFullRunData(startedAt);
@@ -1708,7 +1713,7 @@ export class WorkflowExecute {
 					return fullRunData;
 				});
 
-			return returnPromise.then(resolve);
+			return await returnPromise.then(resolve);
 		});
 	}
 

--- a/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ActionNetwork/GenericFunctions.ts
@@ -38,7 +38,7 @@ export async function actionNetworkApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'actionNetworkApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'actionNetworkApi', options);
 }
 
 /**
@@ -218,7 +218,7 @@ export const adjustEventPayload = adjustLocation;
 // ----------------------------------------
 
 async function loadResource(this: ILoadOptionsFunctions, resource: string) {
-	return handleListing.call(this, 'GET', `/${resource}`, {}, {}, { returnAll: true });
+	return await handleListing.call(this, 'GET', `/${resource}`, {}, {}, { returnAll: true });
 }
 
 export const resourceLoaders = {

--- a/packages/nodes-base/nodes/Airtable/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/v1/GenericFunctions.ts
@@ -59,7 +59,7 @@ export async function apiRequest(
 		delete options.body;
 	}
 	const authenticationMethod = this.getNodeParameter('authentication', 0) as string;
-	return this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
+	return await this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
 }
 
 /**

--- a/packages/nodes-base/nodes/Airtable/v2/AirtableV2.node.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/AirtableV2.node.ts
@@ -26,6 +26,6 @@ export class AirtableV2 implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
@@ -46,7 +46,7 @@ export async function apiRequest(
 	}
 
 	const authenticationMethod = this.getNodeParameter('authentication', 0) as string;
-	return this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
+	return await this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
 }
 
 /**

--- a/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/ApiTemplateIo.node.ts
@@ -350,11 +350,11 @@ export class ApiTemplateIo implements INodeType {
 	methods = {
 		loadOptions: {
 			async getImageTemplates(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return loadResource.call(this, 'image');
+				return await loadResource.call(this, 'image');
 			},
 
 			async getPdfTemplates(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return loadResource.call(this, 'pdf');
+				return await loadResource.call(this, 'pdf');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ApiTemplateIo/GenericFunctions.ts
@@ -74,7 +74,7 @@ export function validateJSON(json: string | object | undefined): any {
 }
 
 export async function downloadImage(this: IExecuteFunctions, url: string) {
-	return this.helpers.request({
+	return await this.helpers.request({
 		uri: url,
 		method: 'GET',
 		json: false,

--- a/packages/nodes-base/nodes/Asana/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Asana/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function asanaApiRequest(
 	};
 
 	const credentialType = authenticationMethod === 'accessToken' ? 'asanaApi' : 'asanaOAuth2Api';
-	return this.helpers.requestWithAuthentication.call(this, credentialType, options);
+	return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 }
 
 export async function asanaApiRequestAllItems(

--- a/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/GenericFunctions.ts
@@ -29,7 +29,7 @@ export async function awsApiRequest(
 		headers,
 		region: credentials?.region as string,
 	} as IHttpRequestOptions;
-	return this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
+	return await this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
 }
 
 export async function awsApiRequestREST(

--- a/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/GenericFunctions.ts
@@ -41,7 +41,7 @@ export async function awsApiRequest(
 	if (Object.keys(option).length !== 0) {
 		Object.assign(requestOptions, option);
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
+	return await this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
 }
 
 export async function awsApiRequestREST(

--- a/packages/nodes-base/nodes/Aws/S3/V1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V1/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function awsApiRequest(
 	if (Object.keys(option).length !== 0) {
 		Object.assign(requestOptions, option);
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
+	return await this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
 }
 
 export async function awsApiRequestREST(

--- a/packages/nodes-base/nodes/Aws/S3/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/GenericFunctions.ts
@@ -37,7 +37,7 @@ export async function awsApiRequest(
 	if (Object.keys(option).length !== 0) {
 		Object.assign(requestOptions, option);
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
+	return await this.helpers.requestWithAuthentication.call(this, 'aws', requestOptions);
 }
 
 export async function awsApiRequestREST(

--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -174,7 +174,7 @@ export async function validateCredentials(
 
 	const response = await this.helpers.request(options);
 
-	return new Promise((resolve, reject) => {
+	return await new Promise((resolve, reject) => {
 		parseString(response as string, { explicitArray: false }, (err, data) => {
 			if (err) {
 				return reject(err);

--- a/packages/nodes-base/nodes/BambooHr/v1/methods/credentialTest.ts
+++ b/packages/nodes-base/nodes/BambooHr/v1/methods/credentialTest.ts
@@ -26,7 +26,7 @@ async function validateCredentials(
 		url: `https://api.bamboohr.com/api/gateway.php/${subdomain}/v1/employees/directory`,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }
 
 export async function bambooHrApiCredentialTest(

--- a/packages/nodes-base/nodes/Bannerbear/Bannerbear.node.ts
+++ b/packages/nodes-base/nodes/Bannerbear/Bannerbear.node.ts
@@ -144,7 +144,7 @@ export class Bannerbear implements INodeType {
 
 						const promise = async (uid: string) => {
 							let data: IDataObject = {};
-							return new Promise((resolve, reject) => {
+							return await new Promise((resolve, reject) => {
 								const timeout = setInterval(async () => {
 									data = await bannerbearApiRequest.call(this, 'GET', `/images/${uid}`);
 

--- a/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Baserow/GenericFunctions.ts
@@ -146,7 +146,7 @@ export class TableFieldMapper {
 		jwtToken: string,
 	): Promise<LoadedResource[]> {
 		const endpoint = `/api/database/fields/table/${table}/`;
-		return baserowApiRequest.call(this, 'GET', endpoint, jwtToken);
+		return await baserowApiRequest.call(this, 'GET', endpoint, jwtToken);
 	}
 
 	createMappings(tableFields: LoadedResource[]) {

--- a/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
+++ b/packages/nodes-base/nodes/Beeminder/Beeminder.node.functions.ts
@@ -16,7 +16,7 @@ export async function createDatapoint(
 
 	const endpoint = `/users/${credentials.user}/goals/${data.goalName}/datapoints.json`;
 
-	return beeminderApiRequest.call(this, 'POST', endpoint, data);
+	return await beeminderApiRequest.call(this, 'POST', endpoint, data);
 }
 
 export async function getAllDatapoints(
@@ -28,10 +28,10 @@ export async function getAllDatapoints(
 	const endpoint = `/users/${credentials.user}/goals/${data.goalName}/datapoints.json`;
 
 	if (data.count !== undefined) {
-		return beeminderApiRequest.call(this, 'GET', endpoint, {}, data);
+		return await beeminderApiRequest.call(this, 'GET', endpoint, {}, data);
 	}
 
-	return beeminderApiRequestAllItems.call(this, 'GET', endpoint, {}, data);
+	return await beeminderApiRequestAllItems.call(this, 'GET', endpoint, {}, data);
 }
 
 export async function updateDatapoint(
@@ -42,7 +42,7 @@ export async function updateDatapoint(
 
 	const endpoint = `/users/${credentials.user}/goals/${data.goalName}/datapoints/${data.datapointId}.json`;
 
-	return beeminderApiRequest.call(this, 'PUT', endpoint, data);
+	return await beeminderApiRequest.call(this, 'PUT', endpoint, data);
 }
 
 export async function deleteDatapoint(
@@ -53,5 +53,5 @@ export async function deleteDatapoint(
 
 	const endpoint = `/users/${credentials.user}/goals/${data.goalName}/datapoints/${data.datapointId}.json`;
 
-	return beeminderApiRequest.call(this, 'DELETE', endpoint);
+	return await beeminderApiRequest.call(this, 'DELETE', endpoint);
 }

--- a/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function beeminderApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'beeminderApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'beeminderApi', options);
 }
 
 export async function beeminderApiRequestAllItems(

--- a/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
+++ b/packages/nodes-base/nodes/Bitwarden/Bitwarden.node.ts
@@ -94,11 +94,11 @@ export class Bitwarden implements INodeType {
 	methods = {
 		loadOptions: {
 			async getGroups(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'groups');
+				return await loadResource.call(this, 'groups');
 			},
 
 			async getCollections(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'collections');
+				return await loadResource.call(this, 'collections');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/Brevo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Brevo/GenericFunctions.ts
@@ -325,7 +325,7 @@ export namespace BrevoWebhookApi {
 			options,
 		)) as string;
 
-		return jsonParse(webhooks);
+		return await jsonParse(webhooks);
 	};
 
 	export const createWebHook = async (
@@ -355,7 +355,7 @@ export namespace BrevoWebhookApi {
 			options,
 		);
 
-		return jsonParse(webhookId as string);
+		return await jsonParse(webhookId as string);
 	};
 
 	export const deleteWebhook = async (ref: IHookFunctions, webhookId: string) => {
@@ -371,6 +371,6 @@ export namespace BrevoWebhookApi {
 			body,
 		};
 
-		return ref.helpers.requestWithAuthentication.call(ref, credentialsName, options);
+		return await ref.helpers.requestWithAuthentication.call(ref, credentialsName, options);
 	};
 }

--- a/packages/nodes-base/nodes/Calendly/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Calendly/GenericFunctions.ts
@@ -57,7 +57,7 @@ export async function calendlyApiRequest(
 		delete options.qs;
 	}
 	options = Object.assign({}, options, option);
-	return this.helpers.requestWithAuthentication.call(this, 'calendlyApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'calendlyApi', options);
 }
 
 export async function validateCredentials(
@@ -89,5 +89,5 @@ export async function validateCredentials(
 			uri: 'https://calendly.com/api/v1/users/me',
 		});
 	}
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
@@ -30,7 +30,7 @@ export async function clockifyApiRequest(
 		json: true,
 		useQuerystring: true,
 	};
-	return this.helpers.requestWithAuthentication.call(this, 'clockifyApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'clockifyApi', options);
 }
 
 export async function clockifyApiRequestAllItems(

--- a/packages/nodes-base/nodes/Cockpit/CollectionFunctions.ts
+++ b/packages/nodes-base/nodes/Cockpit/CollectionFunctions.ts
@@ -20,7 +20,7 @@ export async function createCollectionEntry(
 		};
 	}
 
-	return cockpitApiRequest.call(this, 'post', `/collections/save/${resourceName}`, body);
+	return await cockpitApiRequest.call(this, 'post', `/collections/save/${resourceName}`, body);
 }
 
 export async function getAllCollectionEntries(
@@ -76,11 +76,11 @@ export async function getAllCollectionEntries(
 		body.lang = options.language as string;
 	}
 
-	return cockpitApiRequest.call(this, 'post', `/collections/get/${resourceName}`, body);
+	return await cockpitApiRequest.call(this, 'post', `/collections/get/${resourceName}`, body);
 }
 
 export async function getAllCollectionNames(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 ): Promise<string[]> {
-	return cockpitApiRequest.call(this, 'GET', '/collections/listCollections', {});
+	return await cockpitApiRequest.call(this, 'GET', '/collections/listCollections', {});
 }

--- a/packages/nodes-base/nodes/Cockpit/FormFunctions.ts
+++ b/packages/nodes-base/nodes/Cockpit/FormFunctions.ts
@@ -11,5 +11,5 @@ export async function submitForm(
 		form,
 	};
 
-	return cockpitApiRequest.call(this, 'post', `/forms/submit/${resourceName}`, body);
+	return await cockpitApiRequest.call(this, 'post', `/forms/submit/${resourceName}`, body);
 }

--- a/packages/nodes-base/nodes/Cockpit/SingletonFunctions.ts
+++ b/packages/nodes-base/nodes/Cockpit/SingletonFunctions.ts
@@ -5,11 +5,11 @@ export async function getSingleton(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	resourceName: string,
 ): Promise<any> {
-	return cockpitApiRequest.call(this, 'get', `/singletons/get/${resourceName}`);
+	return await cockpitApiRequest.call(this, 'get', `/singletons/get/${resourceName}`);
 }
 
 export async function getAllSingletonNames(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 ): Promise<string[]> {
-	return cockpitApiRequest.call(this, 'GET', '/singletons/listSingletons', {});
+	return await cockpitApiRequest.call(this, 'GET', '/singletons/listSingletons', {});
 }

--- a/packages/nodes-base/nodes/Code/PythonSandbox.ts
+++ b/packages/nodes-base/nodes/Code/PythonSandbox.ts
@@ -40,7 +40,7 @@ export class PythonSandbox extends Sandbox {
 	}
 
 	async runCode(): Promise<unknown> {
-		return this.runCodeInPython<unknown>();
+		return await this.runCodeInPython<unknown>();
 	}
 
 	async runCodeAllItems() {

--- a/packages/nodes-base/nodes/Copper/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Copper/GenericFunctions.ts
@@ -184,7 +184,7 @@ export async function handleListing(
 	const option = { resolveWithFullResponse: true };
 
 	if (returnAll) {
-		return copperApiRequestAllItems.call(this, method, endpoint, body, qs, uri, option);
+		return await copperApiRequestAllItems.call(this, method, endpoint, body, qs, uri, option);
 	}
 
 	const limit = this.getNodeParameter('limit', 0);

--- a/packages/nodes-base/nodes/Cortex/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Cortex/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function cortexApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'cortexApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'cortexApi', options);
 }
 
 export function getEntityLabel(entity: IDataObject): string {

--- a/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/CustomerIo/GenericFunctions.ts
@@ -43,7 +43,7 @@ export async function customerIoApiRequest(
 		options.url = `https://beta-api.customer.io/v1/api${endpoint}`;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'customerIoApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'customerIoApi', options);
 }
 
 export function eventExists(currentEvents: string[], webhookEvents: IDataObject) {

--- a/packages/nodes-base/nodes/Dhl/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dhl/GenericFunctions.ts
@@ -67,5 +67,5 @@ export async function validateCredentials(
 		json: true,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
@@ -61,6 +61,6 @@ describe('Test DiscordV2, channel => create', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
@@ -57,6 +57,6 @@ describe('Test DiscordV2, channel => deleteChannel', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
@@ -107,6 +107,6 @@ describe('Test DiscordV2, channel => get', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
@@ -136,6 +136,6 @@ describe('Test DiscordV2, channel => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
@@ -64,6 +64,6 @@ describe('Test DiscordV2, channel => update', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
@@ -85,6 +85,6 @@ describe('Test DiscordV2, member => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
@@ -49,6 +49,6 @@ describe('Test DiscordV2, member => roleAdd', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
@@ -57,6 +57,6 @@ describe('Test DiscordV2, member => roleRemove', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
@@ -49,6 +49,6 @@ describe('Test DiscordV2, message => deleteMessage', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
@@ -68,6 +68,6 @@ describe('Test DiscordV2, message => get', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
@@ -93,6 +93,6 @@ describe('Test DiscordV2, message => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
@@ -49,6 +49,6 @@ describe('Test DiscordV2, message => react', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
@@ -102,6 +102,6 @@ describe('Test DiscordV2, message => send', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
@@ -99,6 +99,6 @@ describe('Test DiscordV2, webhook => sendLegacy', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Discord/v2/DiscordV2.node.ts
+++ b/packages/nodes-base/nodes/Discord/v2/DiscordV2.node.ts
@@ -30,6 +30,6 @@ export class DiscordV2 implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Dropbox/GenericFunctions.ts
@@ -85,7 +85,7 @@ export async function dropboxpiRequestAllItems(
 }
 
 export async function getRootDirectory(this: IHookFunctions | IExecuteFunctions) {
-	return dropboxApiRequest.call(
+	return await dropboxApiRequest.call(
 		this,
 		'POST',
 		'https://api.dropboxapi.com/2/users/get_current_account',

--- a/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
+++ b/packages/nodes-base/nodes/Dropcontact/Dropcontact.node.ts
@@ -294,7 +294,7 @@ export class Dropcontact implements INodeType {
 				if (!simplify) {
 					const waitTime = this.getNodeParameter('options.waitTime', 0, 45) as number;
 
-					const delay = async (ms: any) => new Promise((res) => setTimeout(res, ms * 1000));
+					const delay = async (ms: any) => await new Promise((res) => setTimeout(res, ms * 1000));
 					await delay(waitTime);
 					responseData = await dropcontactApiRequest.call(
 						this,

--- a/packages/nodes-base/nodes/Dropcontact/GenericFunction.ts
+++ b/packages/nodes-base/nodes/Dropcontact/GenericFunction.ts
@@ -34,7 +34,7 @@ export async function dropcontactApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'dropcontactApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'dropcontactApi', options);
 }
 
 export function mapPairedItemsFrom<T>(iterable: Iterable<T> | ArrayLike<T>): IPairedItemData[] {

--- a/packages/nodes-base/nodes/Elastic/ElasticSecurity/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Elastic/ElasticSecurity/GenericFunctions.ts
@@ -97,7 +97,7 @@ export async function handleListing(
 	const returnAll = this.getNodeParameter('returnAll', 0);
 
 	if (returnAll) {
-		return elasticSecurityApiRequestAllItems.call(this, method, endpoint, body, qs);
+		return await elasticSecurityApiRequestAllItems.call(this, method, endpoint, body, qs);
 	}
 
 	const responseData = await elasticSecurityApiRequestAllItems.call(

--- a/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
@@ -332,7 +332,7 @@ export class EmailReadImapV1 implements INodeType {
 					.getPartData(message, attachmentPart)
 					.then(async (partData) => {
 						// Return it in the format n8n expects
-						return this.helpers.prepareBinaryData(
+						return await this.helpers.prepareBinaryData(
 							partData as Buffer,
 							attachmentPart.disposition.params.filename as string,
 						);
@@ -341,7 +341,7 @@ export class EmailReadImapV1 implements INodeType {
 				attachmentPromises.push(attachmentPromise);
 			}
 
-			return Promise.all(attachmentPromises);
+			return await Promise.all(attachmentPromises);
 		};
 
 		// Returns all the new unseen messages
@@ -588,7 +588,7 @@ export class EmailReadImapV1 implements INodeType {
 
 			// Connect to the IMAP server and open the mailbox
 			// that we get informed whenever a new email arrives
-			return imapConnect(config).then(async (conn) => {
+			return await imapConnect(config).then(async (conn) => {
 				conn.on('error', async (error) => {
 					const errorCode = error.code.toUpperCase();
 					if (['ECONNRESET', 'EPIPE'].includes(errorCode as string)) {

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -359,13 +359,13 @@ export class EmailReadImapV2 implements INodeType {
 								?.filename as string,
 						);
 						// Return it in the format n8n expects
-						return this.helpers.prepareBinaryData(partData as Buffer, fileName);
+						return await this.helpers.prepareBinaryData(partData as Buffer, fileName);
 					});
 
 				attachmentPromises.push(attachmentPromise);
 			}
 
-			return Promise.all(attachmentPromises);
+			return await Promise.all(attachmentPromises);
 		};
 
 		// Returns all the new unseen messages
@@ -618,7 +618,7 @@ export class EmailReadImapV2 implements INodeType {
 
 			// Connect to the IMAP server and open the mailbox
 			// that we get informed whenever a new email arrives
-			return imapConnect(config).then(async (conn) => {
+			return await imapConnect(config).then(async (conn) => {
 				conn.on('close', async (_hadError: boolean) => {
 					if (isCurrentlyReconnecting) {
 						this.logger.debug('Email Read Imap: Connected closed for forced reconnecting');

--- a/packages/nodes-base/nodes/Emelia/Emelia.node.ts
+++ b/packages/nodes-base/nodes/Emelia/Emelia.node.ts
@@ -68,11 +68,11 @@ export class Emelia implements INodeType {
 
 		loadOptions: {
 			async getCampaigns(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'campaign');
+				return await loadResource.call(this, 'campaign');
 			},
 
 			async getContactLists(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'contactList');
+				return await loadResource.call(this, 'contactList');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/ExecuteCommand/ExecuteCommand.node.ts
+++ b/packages/nodes-base/nodes/ExecuteCommand/ExecuteCommand.node.ts
@@ -26,7 +26,7 @@ async function execPromise(command: string): Promise<IExecReturnData> {
 		stdout: '',
 	};
 
-	return new Promise((resolve, _reject) => {
+	return await new Promise((resolve, _reject) => {
 		exec(command, { cwd: process.cwd() }, (error, stdout, stderr) => {
 			returnData.stdout = stdout.trim();
 			returnData.stderr = stderr.trim();

--- a/packages/nodes-base/nodes/FacebookLeadAds/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FacebookLeadAds/GenericFunctions.ts
@@ -123,7 +123,7 @@ export async function appWebhookSubscriptionCreate(
 	appId: string,
 	subscription: CreateFacebookAppWebhookSubscription,
 ) {
-	return facebookAppApiRequest.call(this, 'POST', `/${appId}/subscriptions`, {
+	return await facebookAppApiRequest.call(this, 'POST', `/${appId}/subscriptions`, {
 		type: 'form',
 		payload: { ...subscription },
 	});
@@ -134,7 +134,7 @@ export async function appWebhookSubscriptionDelete(
 	appId: string,
 	object: string,
 ) {
-	return facebookAppApiRequest.call(this, 'DELETE', `/${appId}/subscriptions`, {
+	return await facebookAppApiRequest.call(this, 'DELETE', `/${appId}/subscriptions`, {
 		type: 'form',
 		payload: { object },
 	});
@@ -159,7 +159,7 @@ export async function facebookEntityDetail(
 	entityId: string,
 	fields = 'id,name,access_token',
 ): Promise<any> {
-	return facebookApiRequest.call(this, 'GET', `/${entityId}`, {}, { fields });
+	return await facebookApiRequest.call(this, 'GET', `/${entityId}`, {}, { fields });
 }
 
 export async function facebookPageApiRequest(
@@ -197,7 +197,7 @@ export async function installAppOnPage(
 	pageId: string,
 	fields: string,
 ) {
-	return facebookPageApiRequest.call(
+	return await facebookPageApiRequest.call(
 		this,
 		'POST',
 		`/${pageId}/subscribed_apps`,

--- a/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
+++ b/packages/nodes-base/nodes/FileMaker/FileMaker.node.ts
@@ -600,7 +600,7 @@ export class FileMaker implements INodeType {
 			// Get all the available topics to display them to user so that they can
 			// select them easily
 			async getLayouts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return layoutsApiRequest.call(this);
+				return await layoutsApiRequest.call(this);
 			},
 			async getResponseLayouts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -93,6 +93,6 @@ export class FormTriggerV1 implements INodeType {
 	}
 
 	async webhook(this: IWebhookFunctions) {
-		return formWebhook(this);
+		return await formWebhook(this);
 	}
 }

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -97,6 +97,6 @@ export class FormTriggerV2 implements INodeType {
 	}
 
 	async webhook(this: IWebhookFunctions) {
-		return formWebhook(this);
+		return await formWebhook(this);
 	}
 }

--- a/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Freshservice/GenericFunctions.ts
@@ -106,7 +106,7 @@ export async function handleListing(
 	const returnAll = this.getNodeParameter('returnAll', 0);
 
 	if (returnAll) {
-		return freshserviceApiRequestAllItems.call(this, method, endpoint, body, qs);
+		return await freshserviceApiRequestAllItems.call(this, method, endpoint, body, qs);
 	}
 
 	const responseData = await freshserviceApiRequestAllItems.call(this, method, endpoint, body, qs);

--- a/packages/nodes-base/nodes/FreshworksCrm/FreshworksCrm.node.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/FreshworksCrm.node.ts
@@ -139,15 +139,15 @@ export class FreshworksCrm implements INodeType {
 			},
 
 			async getBusinessTypes(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'business_types');
+				return await loadResource.call(this, 'business_types');
 			},
 
 			async getCampaigns(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'campaigns');
+				return await loadResource.call(this, 'campaigns');
 			},
 
 			async getContactStatuses(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'contact_statuses');
+				return await loadResource.call(this, 'contact_statuses');
 			},
 
 			async getContactViews(this: ILoadOptionsFunctions) {
@@ -169,27 +169,27 @@ export class FreshworksCrm implements INodeType {
 			},
 
 			async getDealPaymentStatuses(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_payment_statuses');
+				return await loadResource.call(this, 'deal_payment_statuses');
 			},
 
 			async getDealPipelines(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_pipelines');
+				return await loadResource.call(this, 'deal_pipelines');
 			},
 
 			async getDealProducts(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_products');
+				return await loadResource.call(this, 'deal_products');
 			},
 
 			async getDealReasons(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_reasons');
+				return await loadResource.call(this, 'deal_reasons');
 			},
 
 			async getDealStages(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_stages');
+				return await loadResource.call(this, 'deal_stages');
 			},
 
 			async getDealTypes(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'deal_types');
+				return await loadResource.call(this, 'deal_types');
 			},
 
 			async getDealViews(this: ILoadOptionsFunctions) {
@@ -199,23 +199,23 @@ export class FreshworksCrm implements INodeType {
 			},
 
 			async getIndustryTypes(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'industry_types');
+				return await loadResource.call(this, 'industry_types');
 			},
 
 			async getLifecycleStages(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'lifecycle_stages');
+				return await loadResource.call(this, 'lifecycle_stages');
 			},
 
 			async getOutcomes(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'sales_activity_outcomes');
+				return await loadResource.call(this, 'sales_activity_outcomes');
 			},
 
 			async getSalesActivityTypes(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'sales_activity_types');
+				return await loadResource.call(this, 'sales_activity_types');
 			},
 
 			async getTerritories(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'territories');
+				return await loadResource.call(this, 'territories');
 			},
 
 			async getUsers(this: ILoadOptionsFunctions) {

--- a/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FreshworksCrm/GenericFunctions.ts
@@ -110,7 +110,7 @@ export async function handleListing(
 	const returnAll = this.getNodeParameter('returnAll', 0);
 
 	if (returnAll) {
-		return freshworksCrmApiRequestAllItems.call(this, method, endpoint, body, qs);
+		return await freshworksCrmApiRequestAllItems.call(this, method, endpoint, body, qs);
 	}
 
 	const responseData = await freshworksCrmApiRequestAllItems.call(this, method, endpoint, body, qs);

--- a/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Ghost/GenericFunctions.ts
@@ -40,7 +40,7 @@ export async function ghostApiRequest(
 		json: true,
 	};
 
-	return this.helpers.requestWithAuthentication.call(this, credentialType, options);
+	return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 }
 
 export async function ghostApiRequestAllItems(

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -139,7 +139,7 @@ export async function handleGetAll(
 		qs.limit = this.getNodeParameter('limit', 0);
 	}
 
-	return goToWebinarApiRequestAllItems.call(this, 'GET', endpoint, qs, body, resource);
+	return await goToWebinarApiRequestAllItems.call(this, 'GET', endpoint, qs, body, resource);
 }
 
 export async function loadWebinars(this: ILoadOptionsFunctions) {

--- a/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GoToWebinar.node.ts
@@ -110,13 +110,13 @@ export class GoToWebinar implements INodeType {
 	methods = {
 		loadOptions: {
 			async getWebinars(this: ILoadOptionsFunctions) {
-				return loadWebinars.call(this);
+				return await loadWebinars.call(this);
 			},
 			async getAnswers(this: ILoadOptionsFunctions) {
-				return loadAnswers.call(this);
+				return await loadAnswers.call(this);
 			},
 			async getWebinarSessions(this: ILoadOptionsFunctions) {
-				return loadWebinarSessions.call(this);
+				return await loadWebinarSessions.call(this);
 			},
 			// Get all the timezones to display them to user so that they can
 			// select them easily
@@ -135,12 +135,12 @@ export class GoToWebinar implements INodeType {
 			async getRegistranSimpleQuestions(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return loadRegistranSimpleQuestions.call(this);
+				return await loadRegistranSimpleQuestions.call(this);
 			},
 			async getRegistranMultiChoiceQuestions(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return loadRegistranMultiChoiceQuestions.call(this);
+				return await loadRegistranMultiChoiceQuestions.call(this);
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/Google/Analytics/v2/GoogleAnalyticsV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v2/GoogleAnalyticsV2.node.ts
@@ -22,6 +22,6 @@ export class GoogleAnalyticsV2 implements INodeType {
 	methods = { loadOptions, listSearch };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
@@ -71,6 +71,6 @@ describe('Test Google BigQuery V2, executeQuery', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
@@ -78,6 +78,6 @@ describe('Test Google BigQuery V2, insert auto map', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
@@ -75,6 +75,6 @@ describe('Test Google BigQuery V2, insert define manually', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Google/BigQuery/v2/GoogleBigQueryV2.node.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/GoogleBigQueryV2.node.ts
@@ -23,6 +23,6 @@ export class GoogleBigQueryV2 implements INodeType {
 	methods = { loadOptions, listSearch };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Google/Drive/v2/GoogleDriveV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/GoogleDriveV2.node.ts
@@ -22,6 +22,6 @@ export class GoogleDriveV2 implements INodeType {
 	methods = { listSearch };
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -103,5 +103,5 @@ export async function getGoogleAccessToken(
 		json: true,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -638,7 +638,7 @@ export async function replyToEmail(
 		threadId,
 	};
 
-	return googleApiRequest.call(this, 'POST', '/gmail/v1/users/me/messages/send', body, qs);
+	return await googleApiRequest.call(this, 'POST', '/gmail/v1/users/me/messages/send', body, qs);
 }
 
 export async function simplifyOutput(

--- a/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v1/GoogleSheet.ts
@@ -281,7 +281,7 @@ export class GoogleSheet {
 			keyRowIndex,
 			usePathForKeyRow,
 		);
-		return this.appendData(range, data, valueInputMode);
+		return await this.appendData(range, data, valueInputMode);
 	}
 
 	getColumnWithOffset(startColumn: string, offset: number): string {
@@ -456,7 +456,7 @@ export class GoogleSheet {
 			}
 		}
 
-		return this.batchUpdate(updateData, valueInputMode);
+		return await this.batchUpdate(updateData, valueInputMode);
 	}
 
 	/**

--- a/packages/nodes-base/nodes/Google/Sheet/v2/GoogleSheetsV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/GoogleSheetsV2.node.ts
@@ -26,6 +26,6 @@ export class GoogleSheetsV2 implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -401,7 +401,7 @@ export class GoogleSheet {
 			columnNamesList,
 			useAppend ? null : '',
 		);
-		return this.appendData(range, data, valueInputMode, lastRow, useAppend);
+		return await this.appendData(range, data, valueInputMode, lastRow, useAppend);
 	}
 
 	getColumnWithOffset(startColumn: string, offset: number): string {

--- a/packages/nodes-base/nodes/HighLevel/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HighLevel/GenericFunctions.ts
@@ -152,7 +152,7 @@ export async function highLevelApiRequest(
 		delete options.qs;
 	}
 	options = Object.assign({}, options, option);
-	return this.helpers.requestWithAuthentication.call(this, 'highLevelApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'highLevelApi', options);
 }
 
 export async function opportunityUpdatePreSendAction(

--- a/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
+++ b/packages/nodes-base/nodes/HomeAssistant/HomeAssistant.node.ts
@@ -158,18 +158,18 @@ export class HomeAssistant implements INodeType {
 
 		loadOptions: {
 			async getAllEntities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getHomeAssistantEntities.call(this);
+				return await getHomeAssistantEntities.call(this);
 			},
 			async getCameraEntities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getHomeAssistantEntities.call(this, 'camera');
+				return await getHomeAssistantEntities.call(this, 'camera');
 			},
 			async getDomains(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getHomeAssistantServices.call(this);
+				return await getHomeAssistantServices.call(this);
 			},
 			async getDomainServices(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const currentDomain = this.getCurrentNodeParameter('domain') as string;
 				if (currentDomain) {
-					return getHomeAssistantServices.call(this, currentDomain);
+					return await getHomeAssistantServices.call(this, currentDomain);
 				} else {
 					return [];
 				}

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -145,8 +145,8 @@ export async function reduceAsync<T, R>(
 	reducer: (acc: Awaited<Promise<R>>, cur: T) => Promise<R>,
 	init: Promise<R> = Promise.resolve({} as R),
 ): Promise<R> {
-	return arr.reduce(async (promiseAcc, item) => {
-		return reducer(await promiseAcc, item);
+	return await arr.reduce(async (promiseAcc, item) => {
+		return await reducer(await promiseAcc, item);
 	}, init);
 }
 
@@ -157,12 +157,12 @@ export const prepareRequestBody = async (
 	defaultReducer: BodyParametersReducer,
 ) => {
 	if (bodyType === 'json' && version >= 4) {
-		return parameters.reduce(async (acc, entry) => {
+		return await parameters.reduce(async (acc, entry) => {
 			const result = await acc;
 			set(result, entry.name, entry.value);
 			return result;
 		}, Promise.resolve({}));
 	} else {
-		return reduceAsync(parameters, defaultReducer);
+		return await reduceAsync(parameters, defaultReducer);
 	}
 };

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
@@ -40,6 +40,6 @@ describe('Test Binary Data Download', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -169,6 +169,6 @@ describe('Test HTTP Request Node', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
@@ -2015,5 +2015,5 @@ export async function validateCredentials(
 		options.headers = { Authorization: `Bearer ${appToken}` };
 	}
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
@@ -2004,5 +2004,5 @@ export async function validateCredentials(
 		options.headers = { Authorization: `Bearer ${appToken}` };
 	}
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/ItemLists/V1/ItemListsV1.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/V1/ItemListsV1.node.ts
@@ -1384,7 +1384,7 @@ return 0;`,
 				}
 				return [newItems];
 			} else if (operation === 'summarize') {
-				return summarize.execute.call(this, items);
+				return await summarize.execute.call(this, items);
 			} else {
 				throw new NodeOperationError(this.getNode(), `Operation '${operation}' is not recognized`);
 			}

--- a/packages/nodes-base/nodes/ItemLists/V2/ItemListsV2.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/V2/ItemListsV2.node.ts
@@ -1431,7 +1431,7 @@ return 0;`,
 				}
 				return [newItems];
 			} else if (operation === 'summarize') {
-				return summarize.execute.call(this, items);
+				return await summarize.execute.call(this, items);
 			} else {
 				throw new NodeOperationError(this.getNode(), `Operation '${operation}' is not recognized`);
 			}

--- a/packages/nodes-base/nodes/ItemLists/V3/ItemListsV3.node.ts
+++ b/packages/nodes-base/nodes/ItemLists/V3/ItemListsV3.node.ts
@@ -19,6 +19,6 @@ export class ItemListsV3 implements INodeType {
 	}
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -356,7 +356,7 @@ export class Jira implements INodeType {
 			// Get all the users to display them to user so that they can
 			// select them easily
 			async getUsers(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getUsers.call(this);
+				return await getUsers.call(this);
 			},
 
 			// Get all the groups to display them to user so that they can

--- a/packages/nodes-base/nodes/KoBoToolbox/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/KoBoToolbox/GenericFunctions.ts
@@ -84,7 +84,7 @@ export async function koBoToolboxRawRequest(
 		option.url = (credentials.URL as string) + option.url;
 	}
 
-	return this.helpers.httpRequestWithAuthentication.call(this, 'koBoToolboxApi', option);
+	return await this.helpers.httpRequestWithAuthentication.call(this, 'koBoToolboxApi', option);
 }
 
 function parseGeoPoint(geoPoint: string): null | number[] {

--- a/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Lemlist/GenericFunctions.ts
@@ -41,7 +41,7 @@ export async function lemlistApiRequest(
 		Object.assign(options, option);
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'lemlistApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'lemlistApi', options);
 }
 
 /**

--- a/packages/nodes-base/nodes/Linear/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Linear/GenericFunctions.ts
@@ -92,7 +92,7 @@ export async function validateCredentials(
 		json: true,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }
 
 //@ts-ignore

--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -241,7 +241,7 @@ export class LocalFileTrigger implements INodeType {
 		}
 
 		async function closeFunction() {
-			return watcher.close();
+			return await watcher.close();
 		}
 
 		return {

--- a/packages/nodes-base/nodes/Magento/Magento2.node.ts
+++ b/packages/nodes-base/nodes/Magento/Magento2.node.ts
@@ -277,10 +277,10 @@ export class Magento2 implements INodeType {
 			async getFilterableCustomerAttributes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getProductAttributes.call(this, (attribute) => attribute.is_filterable);
+				return await getProductAttributes.call(this, (attribute) => attribute.is_filterable);
 			},
 			async getProductAttributes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getProductAttributes.call(this);
+				return await getProductAttributes.call(this);
 			},
 			// async getProductAttributesFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 			// 	return getProductAttributes.call(this, undefined, { name: '*', value: '*', description: 'All properties' });
@@ -288,12 +288,15 @@ export class Magento2 implements INodeType {
 			async getFilterableProductAttributes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getProductAttributes.call(this, (attribute) => attribute.is_searchable === '1');
+				return await getProductAttributes.call(
+					this,
+					(attribute) => attribute.is_searchable === '1',
+				);
 			},
 			async getSortableProductAttributes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getProductAttributes.call(this, (attribute) => attribute.used_for_sort_by);
+				return await getProductAttributes.call(this, (attribute) => attribute.used_for_sort_by);
 			},
 			async getOrderAttributes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				return getOrderFields()

--- a/packages/nodes-base/nodes/Mailchimp/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailchimp/GenericFunctions.ts
@@ -23,7 +23,7 @@ async function getMetadata(
 		url: credentials.metadataUrl as string,
 		json: true,
 	};
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }
 
 export async function mailchimpApiRequest(

--- a/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailjet/GenericFunctions.ts
@@ -50,7 +50,7 @@ export async function mailjetApiRequest(
 		delete options.body;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, credentialType, options);
+	return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 }
 
 export async function mailjetApiRequestAllItems(

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -64,7 +64,7 @@ export async function handleMatrixCall(
 ): Promise<any> {
 	if (resource === 'account') {
 		if (operation === 'me') {
-			return matrixApiRequest.call(this, 'GET', '/account/whoami');
+			return await matrixApiRequest.call(this, 'GET', '/account/whoami');
 		}
 	} else if (resource === 'room') {
 		if (operation === 'create') {
@@ -78,20 +78,20 @@ export async function handleMatrixCall(
 			if (roomAlias) {
 				body.room_alias_name = roomAlias;
 			}
-			return matrixApiRequest.call(this, 'POST', '/createRoom', body);
+			return await matrixApiRequest.call(this, 'POST', '/createRoom', body);
 		} else if (operation === 'join') {
 			const roomIdOrAlias = this.getNodeParameter('roomIdOrAlias', index) as string;
-			return matrixApiRequest.call(this, 'POST', `/rooms/${roomIdOrAlias}/join`);
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomIdOrAlias}/join`);
 		} else if (operation === 'leave') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
-			return matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/leave`);
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/leave`);
 		} else if (operation === 'invite') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const userId = this.getNodeParameter('userId', index) as string;
 			const body: IDataObject = {
 				user_id: userId,
 			};
-			return matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/invite`, body);
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/invite`, body);
 		} else if (operation === 'kick') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const userId = this.getNodeParameter('userId', index) as string;
@@ -100,7 +100,7 @@ export async function handleMatrixCall(
 				user_id: userId,
 				reason,
 			};
-			return matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/kick`, body);
+			return await matrixApiRequest.call(this, 'POST', `/rooms/${roomId}/kick`, body);
 		}
 	} else if (resource === 'message') {
 		if (operation === 'create') {
@@ -119,7 +119,7 @@ export async function handleMatrixCall(
 				body.body = fallbackText;
 			}
 			const messageId = uuid();
-			return matrixApiRequest.call(
+			return await matrixApiRequest.call(
 				this,
 				'PUT',
 				`/rooms/${roomId}/send/m.room.message/${messageId}`,
@@ -181,7 +181,7 @@ export async function handleMatrixCall(
 		if (operation === 'get') {
 			const roomId = this.getNodeParameter('roomId', index) as string;
 			const eventId = this.getNodeParameter('eventId', index) as string;
-			return matrixApiRequest.call(this, 'GET', `/rooms/${roomId}/event/${eventId}`);
+			return await matrixApiRequest.call(this, 'GET', `/rooms/${roomId}/event/${eventId}`);
 		}
 	} else if (resource === 'media') {
 		if (operation === 'upload') {
@@ -225,7 +225,7 @@ export async function handleMatrixCall(
 				url: uploadRequestResult.content_uri,
 			};
 			const messageId = uuid();
-			return matrixApiRequest.call(
+			return await matrixApiRequest.call(
 				this,
 				'PUT',
 				`/rooms/${roomId}/send/m.room.message/${messageId}`,

--- a/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts
@@ -22,6 +22,6 @@ export class MattermostV1 implements INodeType {
 	methods = { loadOptions };
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Mattermost/v1/transport/index.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/transport/index.ts
@@ -32,7 +32,7 @@ export async function apiRequest(
 		skipSslCertificateValidation: credentials.allowUnauthorizedCerts as boolean,
 	};
 
-	return this.helpers.httpRequestWithAuthentication.call(this, 'mattermostApi', options);
+	return await this.helpers.httpRequestWithAuthentication.call(this, 'mattermostApi', options);
 }
 
 export async function apiRequestAllItems(

--- a/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Dynamics/MicrosoftDynamicsCrm.node.ts
@@ -62,49 +62,49 @@ export class MicrosoftDynamicsCrm implements INodeType {
 	methods = {
 		loadOptions: {
 			async getAccountCategories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'accountcategorycode');
+				return await getPicklistOptions.call(this, 'account', 'accountcategorycode');
 			},
 			async getAccountRatingCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'accountratingcode');
+				return await getPicklistOptions.call(this, 'account', 'accountratingcode');
 			},
 			async getAddressTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'address1_addresstypecode');
+				return await getPicklistOptions.call(this, 'account', 'address1_addresstypecode');
 			},
 			async getBusinessTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'businesstypecode');
+				return await getPicklistOptions.call(this, 'account', 'businesstypecode');
 			},
 			async getCustomerSizeCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'customersizecode');
+				return await getPicklistOptions.call(this, 'account', 'customersizecode');
 			},
 			async getCustomerTypeCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'customertypecode');
+				return await getPicklistOptions.call(this, 'account', 'customertypecode');
 			},
 			async getIndustryCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'industrycode');
+				return await getPicklistOptions.call(this, 'account', 'industrycode');
 			},
 			async getPaymentTermsCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'paymenttermscode');
+				return await getPicklistOptions.call(this, 'account', 'paymenttermscode');
 			},
 			async getPreferredAppointmentDayCodes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'preferredappointmentdaycode');
+				return await getPicklistOptions.call(this, 'account', 'preferredappointmentdaycode');
 			},
 			async getPreferredAppointmentTimeCodes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'preferredappointmenttimecode');
+				return await getPicklistOptions.call(this, 'account', 'preferredappointmenttimecode');
 			},
 			async getPreferredContactMethodCodes(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'preferredcontactmethodcode');
+				return await getPicklistOptions.call(this, 'account', 'preferredcontactmethodcode');
 			},
 			async getShippingMethodCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'shippingmethodcode');
+				return await getPicklistOptions.call(this, 'account', 'shippingmethodcode');
 			},
 			async getTerritoryCodes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return getPicklistOptions.call(this, 'account', 'territorycode');
+				return await getPicklistOptions.call(this, 'account', 'territorycode');
 			},
 			async getAccountFields(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const fields = await getEntityFields.call(this, 'account');

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
@@ -65,6 +65,6 @@ describe('Test MicrosoftExcelV2, table => addTable', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
@@ -86,6 +86,6 @@ describe('Test MicrosoftExcelV2, table => append', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
@@ -61,6 +61,6 @@ describe('Test MicrosoftExcelV2, table => convertToRange', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
@@ -52,6 +52,6 @@ describe('Test MicrosoftExcelV2, table => deleteTable', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
@@ -66,6 +66,6 @@ describe('Test MicrosoftExcelV2, table => getColumns', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
@@ -90,6 +90,6 @@ describe('Test MicrosoftExcelV2, table => getRows', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
@@ -107,6 +107,6 @@ describe('Test MicrosoftExcelV2, table => lookup', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
@@ -82,6 +82,6 @@ describe('Test MicrosoftExcelV2, workbook => addWorksheet', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
@@ -52,6 +52,6 @@ describe('Test MicrosoftExcelV2, workbook => deleteWorkbook', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
@@ -67,6 +67,6 @@ describe('Test MicrosoftExcelV2, workbook => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
@@ -49,6 +49,6 @@ describe('Test MicrosoftExcelV2, worksheet => append', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
@@ -61,6 +61,6 @@ describe('Test MicrosoftExcelV2, worksheet => clear', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
@@ -60,6 +60,6 @@ describe('Test MicrosoftExcelV2, worksheet => deleteWorksheet', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
@@ -69,6 +69,6 @@ describe('Test MicrosoftExcelV2, worksheet => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
@@ -46,6 +46,6 @@ describe('Test MicrosoftExcelV2, worksheet => readRows', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
@@ -59,6 +59,6 @@ describe('Test MicrosoftExcelV2, worksheet => update', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
@@ -61,6 +61,6 @@ describe('Test MicrosoftExcelV2, worksheet => upsert', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/MicrosoftExcelV2.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/MicrosoftExcelV2.node.ts
@@ -22,6 +22,6 @@ export class MicrosoftExcelV2 implements INodeType {
 	methods = { listSearch, loadOptions };
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
@@ -73,6 +73,6 @@ describe('Test MicrosoftOutlookV2, calendar => create', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
@@ -52,6 +52,6 @@ describe('Test MicrosoftOutlookV2, calendar => delete', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
@@ -74,6 +74,6 @@ describe('Test MicrosoftOutlookV2, calendar => get', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
@@ -93,6 +93,6 @@ describe('Test MicrosoftOutlookV2, calendar => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
@@ -73,6 +73,6 @@ describe('Test MicrosoftOutlookV2, calendar => update', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
@@ -102,6 +102,6 @@ describe('Test MicrosoftOutlookV2, contact => create', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
@@ -113,6 +113,6 @@ describe('Test MicrosoftOutlookV2, contact => update', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
@@ -142,6 +142,6 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
@@ -57,6 +57,6 @@ describe('Test MicrosoftOutlookV2, draft => send', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
@@ -150,6 +150,6 @@ describe('Test MicrosoftOutlookV2, contact => event', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
@@ -65,6 +65,6 @@ describe('Test MicrosoftOutlookV2, contact => folder', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
@@ -60,6 +60,6 @@ describe('Test MicrosoftOutlookV2, folderMessage => getAll', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
@@ -56,6 +56,6 @@ describe('Test MicrosoftOutlookV2, message => move', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
@@ -123,6 +123,6 @@ describe('Test MicrosoftOutlookV2, message => reply', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
@@ -62,6 +62,6 @@ describe('Test MicrosoftOutlookV2, message => send', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/GenericFunctions.ts
@@ -229,7 +229,7 @@ export async function binaryToAttachments(
 	items: INodeExecutionData[],
 	i: number,
 ) {
-	return Promise.all(
+	return await Promise.all(
 		attachments.map(async (attachment) => {
 			const binaryPropertyName = attachment.binaryPropertyName as string;
 			const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/MicrosoftOutlookV2.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/MicrosoftOutlookV2.node.ts
@@ -22,6 +22,6 @@ export class MicrosoftOutlookV2 implements INodeType {
 	methods = { loadOptions, listSearch };
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/methods/listSearch.ts
@@ -50,7 +50,7 @@ export async function searchContacts(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return search.call(this, '/contacts', 'displayName', filter, paginationToken);
+	return await search.call(this, '/contacts', 'displayName', filter, paginationToken);
 }
 
 export async function searchCalendars(
@@ -58,7 +58,7 @@ export async function searchCalendars(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return search.call(this, '/calendars', 'name', filter, paginationToken);
+	return await search.call(this, '/calendars', 'name', filter, paginationToken);
 }
 
 export async function searchDrafts(

--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -67,10 +67,10 @@ export async function executeQueryQueue(
 	tables: ITables,
 	buildQueryQueue: (data: OperationInputData) => Array<Promise<object>>,
 ): Promise<any[]> {
-	return Promise.all(
+	return await Promise.all(
 		Object.keys(tables).map(async (table) => {
 			const columnsResults = Object.keys(tables[table]).map(async (columnString) => {
-				return Promise.all(
+				return await Promise.all(
 					buildQueryQueue({
 						table,
 						columnString,
@@ -78,7 +78,7 @@ export async function executeQueryQueue(
 					}),
 				);
 			});
-			return Promise.all(columnsResults);
+			return await Promise.all(columnsResults);
 		}),
 	);
 }
@@ -121,7 +121,7 @@ const escapeTableName = (table: string) => {
 };
 
 export async function insertOperation(tables: ITables, pool: mssql.ConnectionPool) {
-	return executeQueryQueue(
+	return await executeQueryQueue(
 		tables,
 		({ table, columnString, items }: OperationInputData): Array<Promise<object>> => {
 			return chunk(items, 1000).map(async (insertValues) => {
@@ -141,14 +141,14 @@ export async function insertOperation(tables: ITables, pool: mssql.ConnectionPoo
 					columnString,
 				)}) VALUES ${valuesPlaceholder.join(', ')};`;
 
-				return request.query(query);
+				return await request.query(query);
 			});
 		},
 	);
 }
 
 export async function updateOperation(tables: ITables, pool: mssql.ConnectionPool) {
-	return executeQueryQueue(
+	return await executeQueryQueue(
 		tables,
 		({ table, columnString, items }: OperationInputData): Array<Promise<object>> => {
 			return items.map(async (item) => {
@@ -168,7 +168,7 @@ export async function updateOperation(tables: ITables, pool: mssql.ConnectionPoo
 					', ',
 				)} WHERE ${condition};`;
 
-				return request.query(query);
+				return await request.query(query);
 			});
 		},
 	);
@@ -197,11 +197,11 @@ export async function deleteOperation(tables: ITables, pool: mssql.ConnectionPoo
 						table,
 					)} WHERE [${deleteKey}] IN (${valuesPlaceholder.join(', ')});`;
 
-					return request.query(query);
+					return await request.query(query);
 				});
-				return Promise.all(queryQueue);
+				return await Promise.all(queryQueue);
 			});
-			return Promise.all(deleteKeyResults);
+			return await Promise.all(deleteKeyResults);
 		}),
 	);
 

--- a/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
@@ -55,6 +55,6 @@ describe('Test MySqlV1, executeQuery', () => {
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/MySql/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MySql/v1/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function createConnection(
 		}
 	}
 
-	return mysql2.createConnection(baseCredentials);
+	return await mysql2.createConnection(baseCredentials);
 }
 
 export async function searchTables(

--- a/packages/nodes-base/nodes/MySql/v1/MySqlV1.node.ts
+++ b/packages/nodes-base/nodes/MySql/v1/MySqlV1.node.ts
@@ -316,7 +316,7 @@ export class MySqlV1 implements INodeType {
 						);
 					}
 
-					return connection.query(rawQuery);
+					return await connection.query(rawQuery);
 				});
 
 				returnItems = ((await Promise.all(queryQueue)) as mysql2.OkPacket[][]).reduce(
@@ -398,8 +398,9 @@ export class MySqlV1 implements INodeType {
 				const updateSQL = `UPDATE ${table} SET ${columns
 					.map((column) => `${column} = ?`)
 					.join(',')} WHERE ${updateKey} = ?;`;
-				const queryQueue = updateItems.map(async (item) =>
-					connection.query(updateSQL, Object.values(item).concat(item[updateKey])),
+				const queryQueue = updateItems.map(
+					async (item) =>
+						await connection.query(updateSQL, Object.values(item).concat(item[updateKey])),
 				);
 				const queryResult = await Promise.all(queryQueue);
 				returnItems = this.helpers.returnJsonArray(

--- a/packages/nodes-base/nodes/MySql/v2/MySqlV2.node.ts
+++ b/packages/nodes-base/nodes/MySql/v2/MySqlV2.node.ts
@@ -25,6 +25,6 @@ export class MySqlV2 implements INodeType {
 	methods = { listSearch, loadOptions, credentialTest };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/MySql/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/MySql/v2/transport/index.ts
@@ -133,6 +133,6 @@ export async function createPool(
 				.connect(tunnelConfig);
 		});
 
-		return poolSetup;
+		return await poolSetup;
 	}
 }

--- a/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
@@ -31,6 +31,6 @@ describe('Test N8n Node, expect base_url to be received from credentials', () =>
 	};
 
 	for (const testData of tests) {
-		test(testData.description, async () => testNode(testData, nodeTypes));
+		test(testData.description, async () => await testNode(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -63,7 +63,7 @@ export async function apiRequest(
 		delete options.body;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
+	return await this.helpers.requestWithAuthentication.call(this, authenticationMethod, options);
 }
 
 /**

--- a/packages/nodes-base/nodes/Postgres/v1/genericFunctions.ts
+++ b/packages/nodes-base/nodes/Postgres/v1/genericFunctions.ts
@@ -120,7 +120,7 @@ export async function pgQuery(
 	if (mode === 'multiple') {
 		return (await db.multi(pgp.helpers.concat(allQueries))).flat(1);
 	} else if (mode === 'transaction') {
-		return db.tx(async (t) => {
+		return await db.tx(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < allQueries.length; i++) {
 				try {
@@ -141,7 +141,7 @@ export async function pgQuery(
 			return result;
 		});
 	} else if (mode === 'independently') {
-		return db.task(async (t) => {
+		return await db.task(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < allQueries.length; i++) {
 				try {
@@ -215,7 +215,7 @@ export async function pgQueryV2(
 			})
 			.flat();
 	} else if (mode === 'transaction') {
-		return db.tx(async (t) => {
+		return await db.tx(async (t) => {
 			const result: INodeExecutionData[] = [];
 			for (let i = 0; i < allQueries.length; i++) {
 				try {
@@ -239,7 +239,7 @@ export async function pgQueryV2(
 			return result;
 		});
 	} else if (mode === 'independently') {
-		return db.task(async (t) => {
+		return await db.task(async (t) => {
 			const result: INodeExecutionData[] = [];
 			for (let i = 0; i < allQueries.length; i++) {
 				try {
@@ -308,9 +308,9 @@ export async function pgInsert(
 	if (mode === 'multiple') {
 		const query =
 			pgp.helpers.insert(getItemsCopy(items, columnNames, guardedColumns), cs) + returning;
-		return db.any(query);
+		return await db.any(query);
 	} else if (mode === 'transaction') {
-		return db.tx(async (t) => {
+		return await db.tx(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < items.length; i++) {
 				const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -329,7 +329,7 @@ export async function pgInsert(
 			return result;
 		});
 	} else if (mode === 'independently') {
-		return db.task(async (t) => {
+		return await db.task(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < items.length; i++) {
 				const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -407,7 +407,7 @@ export async function pgInsertV2(
 			})
 			.flat();
 	} else if (mode === 'transaction') {
-		return db.tx(async (t) => {
+		return await db.tx(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < items.length; i++) {
 				const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -432,7 +432,7 @@ export async function pgInsertV2(
 			return result;
 		});
 	} else if (mode === 'independently') {
-		return db.task(async (t) => {
+		return await db.task(async (t) => {
 			const result: IDataObject[] = [];
 			for (let i = 0; i < items.length; i++) {
 				const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -532,14 +532,14 @@ export async function pgUpdate(
 				})
 				.join(' AND ') +
 			returning;
-		return db.any(query);
+		return await db.any(query);
 	} else {
 		const where =
 			' WHERE ' +
 			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 			updateKeys.map((entry) => pgp.as.name(entry.name) + ' = ${' + entry.prop + '}').join(' AND ');
 		if (mode === 'transaction') {
-			return db.tx(async (t) => {
+			return await db.tx(async (t) => {
 				const result: IDataObject[] = [];
 				for (let i = 0; i < items.length; i++) {
 					const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -565,7 +565,7 @@ export async function pgUpdate(
 				return result;
 			});
 		} else if (mode === 'independently') {
-			return db.task(async (t) => {
+			return await db.task(async (t) => {
 				const result: IDataObject[] = [];
 				for (let i = 0; i < items.length; i++) {
 					const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -667,7 +667,7 @@ export async function pgUpdateV2(
 			// eslint-disable-next-line n8n-local-rules/no-interpolation-in-regular-string
 			updateKeys.map((entry) => pgp.as.name(entry.name) + ' = ${' + entry.prop + '}').join(' AND ');
 		if (mode === 'transaction') {
-			return db.tx(async (t) => {
+			return await db.tx(async (t) => {
 				const result: IDataObject[] = [];
 				for (let i = 0; i < items.length; i++) {
 					const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);
@@ -695,7 +695,7 @@ export async function pgUpdateV2(
 				return result;
 			});
 		} else if (mode === 'independently') {
-			return db.task(async (t) => {
+			return await db.task(async (t) => {
 				const result: IDataObject[] = [];
 				for (let i = 0; i < items.length; i++) {
 					const itemCopy = getItemCopy(items[i], columnNames, guardedColumns);

--- a/packages/nodes-base/nodes/Postgres/v2/PostgresV2.node.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/PostgresV2.node.ts
@@ -23,6 +23,6 @@ export class PostgresV2 implements INodeType {
 	methods = { credentialTest, listSearch, loadOptions, resourceMapping };
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/deleteTable.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/deleteTable.operation.ts
@@ -158,5 +158,5 @@ export async function execute(
 		queries.push(queryWithValues);
 	}
 
-	return runQueries(queries, items, nodeOptions);
+	return await runQueries(queries, items, nodeOptions);
 }

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -107,5 +107,5 @@ export async function execute(
 		queries.push({ query, values });
 	}
 
-	return runQueries(queries, items, nodeOptions);
+	return await runQueries(queries, items, nodeOptions);
 }

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -232,5 +232,5 @@ export async function execute(
 		queries.push({ query, values });
 	}
 
-	return runQueries(queries, items, nodeOptions);
+	return await runQueries(queries, items, nodeOptions);
 }

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/select.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/select.operation.ts
@@ -133,5 +133,5 @@ export async function execute(
 		queries.push(queryWithValues);
 	}
 
-	return runQueries(queries, items, nodeOptions);
+	return await runQueries(queries, items, nodeOptions);
 }

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -304,5 +304,5 @@ export async function execute(
 		queries.push({ query, values });
 	}
 
-	return runQueries(queries, items, nodeOptions);
+	return await runQueries(queries, items, nodeOptions);
 }

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -169,7 +169,7 @@ export async function handleListing(
 	}
 
 	if (returnAll) {
-		return quickBooksApiRequestAllItems.call(this, 'GET', endpoint, qs, {}, resource);
+		return await quickBooksApiRequestAllItems.call(this, 'GET', endpoint, qs, {}, resource);
 	} else {
 		const limit = this.getNodeParameter('limit', i);
 		qs.query += ` MAXRESULTS ${limit}`;

--- a/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
+++ b/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
@@ -145,39 +145,39 @@ export class QuickBooks implements INodeType {
 	methods = {
 		loadOptions: {
 			async getCustomers(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'customer');
+				return await loadResource.call(this, 'customer');
 			},
 
 			async getCustomFields(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'preferences');
+				return await loadResource.call(this, 'preferences');
 			},
 
 			async getDepartments(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'department');
+				return await loadResource.call(this, 'department');
 			},
 
 			async getItems(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'item');
+				return await loadResource.call(this, 'item');
 			},
 
 			async getMemos(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'CreditMemo');
+				return await loadResource.call(this, 'CreditMemo');
 			},
 
 			async getPurchases(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'purchase');
+				return await loadResource.call(this, 'purchase');
 			},
 
 			async getTaxCodeRefs(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'TaxCode');
+				return await loadResource.call(this, 'TaxCode');
 			},
 
 			async getTerms(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'Term');
+				return await loadResource.call(this, 'Term');
 			},
 
 			async getVendors(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'vendor');
+				return await loadResource.call(this, 'vendor');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -36,7 +36,7 @@ export async function rabbitmqConnect(
 		}
 	}
 
-	return new Promise(async (resolve, reject) => {
+	return await new Promise(async (resolve, reject) => {
 		try {
 			const connection = await amqplib.connect(credentialData, optsData);
 
@@ -73,7 +73,7 @@ export async function rabbitmqConnectQueue(
 ): Promise<amqplib.Channel> {
 	const channel = await rabbitmqConnect.call(this, options);
 
-	return new Promise(async (resolve, reject) => {
+	return await new Promise(async (resolve, reject) => {
 		try {
 			await channel.assertQueue(queue, options);
 
@@ -104,7 +104,7 @@ export async function rabbitmqConnectExchange(
 ): Promise<amqplib.Channel> {
 	const channel = await rabbitmqConnect.call(this, options);
 
-	return new Promise(async (resolve, reject) => {
+	return await new Promise(async (resolve, reject) => {
 		try {
 			await channel.assertExchange(exchange, type, options);
 			resolve(channel);

--- a/packages/nodes-base/nodes/Redis/utils.ts
+++ b/packages/nodes-base/nodes/Redis/utils.ts
@@ -94,13 +94,13 @@ export async function getValue(client: RedisClientType, keyName: string, type?: 
 	}
 
 	if (type === 'string') {
-		return client.get(keyName);
+		return await client.get(keyName);
 	} else if (type === 'hash') {
-		return client.hGetAll(keyName);
+		return await client.hGetAll(keyName);
 	} else if (type === 'list') {
-		return client.lRange(keyName, 0, -1);
+		return await client.lRange(keyName, 0, -1);
 	} else if (type === 'sets') {
-		return client.sMembers(keyName);
+		return await client.sMembers(keyName);
 	}
 }
 

--- a/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
@@ -23,7 +23,7 @@ export async function rocketchatApiRequest(
 	if (Object.keys(options.body as IDataObject).length === 0) {
 		delete options.body;
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'rocketchatApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'rocketchatApi', options);
 }
 
 export function validateJSON(json: string | undefined): any {

--- a/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
@@ -21,6 +21,6 @@ describe('Test HTTP Request Node', () => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 });

--- a/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
+++ b/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
@@ -67,10 +67,10 @@ export class RundeckApi {
 			query.filter = filter;
 		}
 
-		return this.request('POST', `/api/14/job/${jobId}/run`, body, query);
+		return await this.request('POST', `/api/14/job/${jobId}/run`, body, query);
 	}
 
 	async getJobMetadata(jobId: string): Promise<IDataObject> {
-		return this.request('GET', `/api/18/job/${jobId}/info`, {}, {});
+		return await this.request('GET', `/api/18/job/${jobId}/info`, {}, {});
 	}
 }

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -79,7 +79,7 @@ async function getAccessToken(
 		json: true,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }
 
 export async function salesforceApiRequest(

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -459,7 +459,7 @@ export class ScheduleTrigger implements INodeType {
 				try {
 					const cronJob = new CronJob(
 						cronExpression,
-						async () => executeTrigger({ activated: false } as IRecurencyRule),
+						async () => await executeTrigger({ activated: false } as IRecurencyRule),
 						undefined,
 						true,
 						timezone,
@@ -476,7 +476,7 @@ export class ScheduleTrigger implements INodeType {
 				const seconds = interval[i].secondsInterval as number;
 				intervalValue *= seconds;
 				const intervalObj = setInterval(
-					async () => executeTrigger({ activated: false } as IRecurencyRule),
+					async () => await executeTrigger({ activated: false } as IRecurencyRule),
 					intervalValue,
 				) as NodeJS.Timeout;
 				intervalArr.push(intervalObj);
@@ -486,7 +486,7 @@ export class ScheduleTrigger implements INodeType {
 				const minutes = interval[i].minutesInterval as number;
 				intervalValue *= 60 * minutes;
 				const intervalObj = setInterval(
-					async () => executeTrigger({ activated: false } as IRecurencyRule),
+					async () => await executeTrigger({ activated: false } as IRecurencyRule),
 					intervalValue,
 				) as NodeJS.Timeout;
 				intervalArr.push(intervalObj);
@@ -500,7 +500,7 @@ export class ScheduleTrigger implements INodeType {
 				if (hour === 1) {
 					const cronJob = new CronJob(
 						cronExpression,
-						async () => executeTrigger({ activated: false } as IRecurencyRule),
+						async () => await executeTrigger({ activated: false } as IRecurencyRule),
 						undefined,
 						true,
 						timezone,
@@ -510,7 +510,7 @@ export class ScheduleTrigger implements INodeType {
 					const cronJob = new CronJob(
 						cronExpression,
 						async () =>
-							executeTrigger({
+							await executeTrigger({
 								activated: true,
 								index: i,
 								intervalSize: hour,
@@ -533,7 +533,7 @@ export class ScheduleTrigger implements INodeType {
 				if (day === 1) {
 					const cronJob = new CronJob(
 						cronExpression,
-						async () => executeTrigger({ activated: false } as IRecurencyRule),
+						async () => await executeTrigger({ activated: false } as IRecurencyRule),
 						undefined,
 						true,
 						timezone,
@@ -543,7 +543,7 @@ export class ScheduleTrigger implements INodeType {
 					const cronJob = new CronJob(
 						cronExpression,
 						async () =>
-							executeTrigger({
+							await executeTrigger({
 								activated: true,
 								index: i,
 								intervalSize: day,
@@ -568,7 +568,7 @@ export class ScheduleTrigger implements INodeType {
 				if (week === 1) {
 					const cronJob = new CronJob(
 						cronExpression,
-						async () => executeTrigger({ activated: false } as IRecurencyRule),
+						async () => await executeTrigger({ activated: false } as IRecurencyRule),
 						undefined,
 						true,
 						timezone,
@@ -578,7 +578,7 @@ export class ScheduleTrigger implements INodeType {
 					const cronJob = new CronJob(
 						cronExpression,
 						async () =>
-							executeTrigger({
+							await executeTrigger({
 								activated: true,
 								index: i,
 								intervalSize: week,
@@ -602,7 +602,7 @@ export class ScheduleTrigger implements INodeType {
 				if (month === 1) {
 					const cronJob = new CronJob(
 						cronExpression,
-						async () => executeTrigger({ activated: false } as IRecurencyRule),
+						async () => await executeTrigger({ activated: false } as IRecurencyRule),
 						undefined,
 						true,
 						timezone,
@@ -612,7 +612,7 @@ export class ScheduleTrigger implements INodeType {
 					const cronJob = new CronJob(
 						cronExpression,
 						async () =>
-							executeTrigger({
+							await executeTrigger({
 								activated: true,
 								index: i,
 								intervalSize: month,

--- a/packages/nodes-base/nodes/Segment/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Segment/GenericFunctions.ts
@@ -29,5 +29,5 @@ export async function segmentApiRequest(
 	if (!Object.keys(body as IDataObject).length) {
 		delete options.body;
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'segmentApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'segmentApi', options);
 }

--- a/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SendGrid/GenericFunctions.ts
@@ -34,7 +34,7 @@ export async function sendGridApiRequest(
 		Object.assign(options, option);
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'sendGridApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'sendGridApi', options);
 }
 
 export async function sendGridApiRequestAllItems(

--- a/packages/nodes-base/nodes/Shopify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Shopify/GenericFunctions.ts
@@ -78,7 +78,7 @@ export async function shopifyApiRequest(
 		}
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, credentialType, options, {
+	return await this.helpers.requestWithAuthentication.call(this, credentialType, options, {
 		oauth2: oAuth2Options,
 	});
 }

--- a/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
@@ -1,13 +1,13 @@
 import type snowflake from 'snowflake-sdk';
 
 export async function connect(conn: snowflake.Connection) {
-	return new Promise<void>((resolve, reject) => {
+	return await new Promise<void>((resolve, reject) => {
 		conn.connect((error) => (error ? reject(error) : resolve()));
 	});
 }
 
 export async function destroy(conn: snowflake.Connection) {
-	return new Promise<void>((resolve, reject) => {
+	return await new Promise<void>((resolve, reject) => {
 		conn.destroy((error) => (error ? reject(error) : resolve()));
 	});
 }
@@ -17,7 +17,7 @@ export async function execute(
 	sqlText: string,
 	binds: snowflake.InsertBinds,
 ) {
-	return new Promise<any[] | undefined>((resolve, reject) => {
+	return await new Promise<any[] | undefined>((resolve, reject) => {
 		conn.execute({
 			sqlText,
 			binds,

--- a/packages/nodes-base/nodes/Splunk/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Splunk/GenericFunctions.ts
@@ -90,7 +90,7 @@ export function formatSearch(responseData: SplunkSearchResponse) {
 // ----------------------------------------
 
 export async function parseXml(xml: string) {
-	return new Promise((resolve, reject) => {
+	return await new Promise((resolve, reject) => {
 		parseString(xml, { explicitArray: false }, (error, result) => {
 			error ? reject(error) : resolve(result);
 		});

--- a/packages/nodes-base/nodes/Strapi/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strapi/GenericFunctions.ts
@@ -87,7 +87,7 @@ export async function getToken(
 		uri: credentials.apiVersion === 'v4' ? `${url}/api/auth/local` : `${url}/auth/local`,
 		json: true,
 	};
-	return this.helpers.request(options) as Promise<{ jwt: string }>;
+	return await (this.helpers.request(options) as Promise<{ jwt: string }>);
 }
 
 export async function strapiApiRequestAllItems(

--- a/packages/nodes-base/nodes/Stripe/Stripe.node.ts
+++ b/packages/nodes-base/nodes/Stripe/Stripe.node.ts
@@ -113,7 +113,7 @@ export class Stripe implements INodeType {
 	methods = {
 		loadOptions: {
 			async getCustomers(this: ILoadOptionsFunctions) {
-				return loadResource.call(this, 'customer');
+				return await loadResource.call(this, 'customer');
 			},
 			async getCurrencies(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];

--- a/packages/nodes-base/nodes/Stripe/helpers.ts
+++ b/packages/nodes-base/nodes/Stripe/helpers.ts
@@ -32,7 +32,7 @@ export async function stripeApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'stripeApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'stripeApi', options);
 }
 
 /**

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -312,7 +312,7 @@ export async function validateCredentials(
 		json: true,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }
 
 export function mapPairedItemsFrom<T>(iterable: Iterable<T> | ArrayLike<T>): IPairedItemData[] {

--- a/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
+++ b/packages/nodes-base/nodes/SurveyMonkey/SurveyMonkeyTrigger.node.ts
@@ -491,7 +491,7 @@ export class SurveyMonkeyTrigger implements INodeType {
 			return {};
 		}
 
-		return new Promise((resolve, _reject) => {
+		return await new Promise((resolve, _reject) => {
 			const data: Buffer[] = [];
 
 			req.on('data', (chunk) => {

--- a/packages/nodes-base/nodes/SyncroMSP/v1/SyncroMspV1.node.ts
+++ b/packages/nodes-base/nodes/SyncroMSP/v1/SyncroMspV1.node.ts
@@ -51,6 +51,6 @@ export class SyncroMspV1 implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/SyncroMSP/v1/transport/index.ts
+++ b/packages/nodes-base/nodes/SyncroMSP/v1/transport/index.ts
@@ -79,5 +79,5 @@ export async function validateCredentials(
 		url: `https://${subdomain}.syncromsp.com/api/v1//me`,
 	};
 
-	return this.helpers.request(options);
+	return await this.helpers.request(options);
 }

--- a/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Taiga/GenericFunctions.ts
@@ -132,7 +132,7 @@ export async function handleListing(
 	const returnAll = this.getNodeParameter('returnAll', i);
 
 	if (returnAll) {
-		return taigaApiRequestAllItems.call(this, method, endpoint, body, qs);
+		return await taigaApiRequestAllItems.call(this, method, endpoint, body, qs);
 	} else {
 		qs.limit = this.getNodeParameter('limit', i);
 		responseData = await taigaApiRequestAllItems.call(this, method, endpoint, body, qs);
@@ -151,5 +151,5 @@ export function throwOnEmptyUpdate(this: IExecuteFunctions, resource: Resource) 
 }
 
 export async function getVersionForUpdate(this: IExecuteFunctions, endpoint: string) {
-	return taigaApiRequest.call(this, 'GET', endpoint).then((response) => response.version);
+	return await taigaApiRequest.call(this, 'GET', endpoint).then((response) => response.version);
 }

--- a/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/TheHive/GenericFunctions.ts
@@ -42,7 +42,7 @@ export async function theHiveApiRequest(
 	if (Object.keys(query).length === 0) {
 		delete options.qs;
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'theHiveApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'theHiveApi', options);
 }
 
 // Helpers functions

--- a/packages/nodes-base/nodes/TheHiveProject/TheHiveProject.node.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/TheHiveProject.node.ts
@@ -10,6 +10,6 @@ export class TheHiveProject implements INodeType {
 	methods = { loadOptions, listSearch, resourceMapping };
 
 	async execute(this: IExecuteFunctions) {
-		return router.call(this);
+		return await router.call(this);
 	}
 }

--- a/packages/nodes-base/nodes/TheHiveProject/actions/router.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/router.ts
@@ -76,5 +76,5 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			throw error;
 		}
 	}
-	return this.prepareOutputData(returnData);
+	return await this.prepareOutputData(returnData);
 }

--- a/packages/nodes-base/nodes/TheHiveProject/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/methods/listSearch.ts
@@ -62,7 +62,15 @@ export async function caseSearch(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return listResource.call(this, 'listCase', 'title', 'title', 'cases', filter, paginationToken);
+	return await listResource.call(
+		this,
+		'listCase',
+		'title',
+		'title',
+		'cases',
+		filter,
+		paginationToken,
+	);
 }
 
 export async function commentSearch(
@@ -70,7 +78,7 @@ export async function commentSearch(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return listResource.call(
+	return await listResource.call(
 		this,
 		'listComment',
 		'message',
@@ -86,7 +94,15 @@ export async function alertSearch(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return listResource.call(this, 'listAlert', 'title', 'title', 'alerts', filter, paginationToken);
+	return await listResource.call(
+		this,
+		'listAlert',
+		'title',
+		'title',
+		'alerts',
+		filter,
+		paginationToken,
+	);
 }
 
 export async function taskSearch(
@@ -94,7 +110,15 @@ export async function taskSearch(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return listResource.call(this, 'listTask', 'title', 'title', undefined, filter, paginationToken);
+	return await listResource.call(
+		this,
+		'listTask',
+		'title',
+		'title',
+		undefined,
+		filter,
+		paginationToken,
+	);
 }
 
 export async function pageSearch(
@@ -171,7 +195,7 @@ export async function logSearch(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	return listResource.call(
+	return await listResource.call(
 		this,
 		'listLog',
 		'message',

--- a/packages/nodes-base/nodes/TheHiveProject/transport/requestApi.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/transport/requestApi.ts
@@ -38,5 +38,5 @@ export async function theHiveApiRequest(
 	if (Object.keys(query).length === 0) {
 		delete options.qs;
 	}
-	return this.helpers.requestWithAuthentication.call(this, 'theHiveProjectApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'theHiveProjectApi', options);
 }

--- a/packages/nodes-base/nodes/Todoist/v1/Service.ts
+++ b/packages/nodes-base/nodes/Todoist/v1/Service.ts
@@ -18,7 +18,7 @@ export class TodoistService implements Service {
 		operation: OperationType,
 		itemIndex: number,
 	): Promise<TodoistResponse> {
-		return this.handlers[operation].handleOperation(ctx, itemIndex);
+		return await this.handlers[operation].handleOperation(ctx, itemIndex);
 	}
 
 	private handlers = {

--- a/packages/nodes-base/nodes/Todoist/v2/Service.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/Service.ts
@@ -18,7 +18,7 @@ export class TodoistService implements Service {
 		operation: OperationType,
 		itemIndex: number,
 	): Promise<TodoistResponse> {
-		return this.handlers[operation].handleOperation(ctx, itemIndex);
+		return await this.handlers[operation].handleOperation(ctx, itemIndex);
 	}
 
 	private handlers = {

--- a/packages/nodes-base/nodes/Trello/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Trello/GenericFunctions.ts
@@ -28,7 +28,7 @@ export async function apiRequest(
 		json: true,
 	};
 
-	return this.helpers.requestWithAuthentication.call(this, 'trelloApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'trelloApi', options);
 }
 
 export async function apiRequestAllItems(

--- a/packages/nodes-base/nodes/Twake/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twake/GenericFunctions.ts
@@ -29,5 +29,5 @@ export async function twakeApiRequest(
 	// 	options.uri = `${credentials!.hostUrl}/api/v1${resource}`;
 	// }
 
-	return this.helpers.requestWithAuthentication.call(this, 'twakeCloudApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'twakeCloudApi', options);
 }

--- a/packages/nodes-base/nodes/Twilio/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twilio/GenericFunctions.ts
@@ -33,7 +33,7 @@ export async function twilioApiRequest(
 		json: true,
 	};
 
-	return this.helpers.requestWithAuthentication.call(this, 'twilioApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'twilioApi', options);
 }
 
 const XML_CHAR_MAP: { [key: string]: string } = {

--- a/packages/nodes-base/nodes/UrlScanIo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UrlScanIo/GenericFunctions.ts
@@ -25,7 +25,7 @@ export async function urlScanIoApiRequest(
 		delete options.qs;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'urlScanIoApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'urlScanIoApi', options);
 }
 
 export async function handleListing(

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
@@ -121,7 +121,7 @@ export async function encryptPassphrase(
 	let encryptedKeyStorePass = '';
 
 	const promise = async () => {
-		return new Promise((resolve, reject) => {
+		return await new Promise((resolve, reject) => {
 			nacl_factory.instantiate((nacl: any) => {
 				try {
 					const passphraseUTF8 = nacl.encode_utf8(passphrase) as string;
@@ -142,5 +142,5 @@ export async function encryptPassphrase(
 			});
 		});
 	};
-	return promise();
+	return await promise();
 }

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -392,15 +392,15 @@ export class Wait extends Webhook {
 
 	async webhook(context: IWebhookFunctions) {
 		const resume = context.getNodeParameter('resume', 0) as string;
-		if (resume === 'form') return formWebhook(context);
-		return super.webhook(context);
+		if (resume === 'form') return await formWebhook(context);
+		return await super.webhook(context);
 	}
 
 	async execute(context: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const resume = context.getNodeParameter('resume', 0) as string;
 
 		if (['webhook', 'form'].includes(resume)) {
-			return this.configureAndPutToWait(context);
+			return await this.configureAndPutToWait(context);
 		}
 
 		let waitTill: Date;
@@ -433,14 +433,14 @@ export class Wait extends Webhook {
 		if (waitValue < 65000) {
 			// If wait time is shorter than 65 seconds leave execution active because
 			// we just check the database every 60 seconds.
-			return new Promise((resolve) => {
+			return await new Promise((resolve) => {
 				const timer = setTimeout(() => resolve([context.getInputData()]), waitValue);
 				context.onExecutionCancellation(() => clearTimeout(timer));
 			});
 		}
 
 		// If longer than 65 seconds put execution to wait
-		return this.putToWait(context, waitTill);
+		return await this.putToWait(context, waitTill);
 	}
 
 	private async configureAndPutToWait(context: IExecuteFunctions) {
@@ -471,7 +471,7 @@ export class Wait extends Webhook {
 			}
 		}
 
-		return this.putToWait(context, waitTill);
+		return await this.putToWait(context, waitTill);
 	}
 
 	private async putToWait(context: IExecuteFunctions, waitTill: Date) {

--- a/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
@@ -47,7 +47,7 @@ export async function webflowApiRequest(
 	if (Object.keys(options.body as IDataObject).length === 0) {
 		delete options.body;
 	}
-	return this.helpers.requestWithAuthentication.call(this, credentialsType, options);
+	return await this.helpers.requestWithAuthentication.call(this, credentialsType, options);
 }
 
 export async function webflowApiRequestAllItems(

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -119,11 +119,11 @@ export class Webhook extends Node {
 		}
 
 		if (options.binaryData) {
-			return this.handleBinaryData(context);
+			return await this.handleBinaryData(context);
 		}
 
 		if (req.contentType === 'multipart/form-data') {
-			return this.handleFormData(context);
+			return await this.handleFormData(context);
 		}
 
 		const nodeVersion = context.getNode().typeVersion;

--- a/packages/nodes-base/nodes/Wekan/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wekan/GenericFunctions.ts
@@ -29,5 +29,5 @@ export async function apiRequest(
 		json: true,
 	};
 
-	return this.helpers.requestWithAuthentication.call(this, 'wekanApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'wekanApi', options);
 }

--- a/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/WooCommerce/GenericFunctions.ts
@@ -39,7 +39,7 @@ export async function woocommerceApiRequest(
 		delete options.form;
 	}
 	options = Object.assign({}, options, option);
-	return this.helpers.requestWithAuthentication.call(this, 'wooCommerceApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'wooCommerceApi', options);
 }
 
 export async function woocommerceApiRequestAllItems(

--- a/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
@@ -33,5 +33,5 @@ export async function wufooApiRequest(
 		delete options.body;
 	}
 
-	return this.helpers.requestWithAuthentication.call(this, 'wufooApi', options);
+	return await this.helpers.requestWithAuthentication.call(this, 'wufooApi', options);
 }

--- a/packages/nodes-base/nodes/Zendesk/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zendesk/GenericFunctions.ts
@@ -53,7 +53,7 @@ export async function zendeskApiRequest(
 
 	const credentialType = authenticationMethod === 'apiToken' ? 'zendeskApi' : 'zendeskOAuth2Api';
 
-	return this.helpers.requestWithAuthentication.call(this, credentialType, options);
+	return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 }
 
 /**

--- a/packages/nodes-base/nodes/Zoho/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zoho/GenericFunctions.ts
@@ -125,7 +125,7 @@ export async function handleListing(
 	const returnAll = this.getNodeParameter('returnAll', 0);
 
 	if (returnAll) {
-		return zohoApiRequestAllItems.call(this, method, endpoint, body, qs);
+		return await zohoApiRequestAllItems.call(this, method, endpoint, body, qs);
 	}
 
 	const responseData = await zohoApiRequestAllItems.call(this, method, endpoint, body, qs);

--- a/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
+++ b/packages/nodes-base/nodes/Zoho/ZohoCrm.node.ts
@@ -212,93 +212,93 @@ export class ZohoCrm implements INodeType {
 			// standard fields - called from `makeGetAllFields`
 
 			async getAccountFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'account');
+				return await getFields.call(this, 'account');
 			},
 
 			async getContactFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'contact');
+				return await getFields.call(this, 'contact');
 			},
 
 			async getDealFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'deal');
+				return await getFields.call(this, 'deal');
 			},
 
 			async getInvoiceFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'invoice');
+				return await getFields.call(this, 'invoice');
 			},
 
 			async getLeadFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'lead');
+				return await getFields.call(this, 'lead');
 			},
 
 			async getProductFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'product');
+				return await getFields.call(this, 'product');
 			},
 
 			async getPurchaseOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'purchase_order');
+				return await getFields.call(this, 'purchase_order');
 			},
 
 			async getVendorOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'vendor');
+				return await getFields.call(this, 'vendor');
 			},
 
 			async getQuoteFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'quote');
+				return await getFields.call(this, 'quote');
 			},
 
 			async getSalesOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'sales_order');
+				return await getFields.call(this, 'sales_order');
 			},
 
 			async getVendorFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'vendor');
+				return await getFields.call(this, 'vendor');
 			},
 
 			// custom fields
 
 			async getCustomAccountFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'account', { onlyCustom: true });
+				return await getFields.call(this, 'account', { onlyCustom: true });
 			},
 
 			async getCustomContactFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'contact', { onlyCustom: true });
+				return await getFields.call(this, 'contact', { onlyCustom: true });
 			},
 
 			async getCustomDealFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'deal', { onlyCustom: true });
+				return await getFields.call(this, 'deal', { onlyCustom: true });
 			},
 
 			async getCustomInvoiceFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'invoice', { onlyCustom: true });
+				return await getFields.call(this, 'invoice', { onlyCustom: true });
 			},
 
 			async getCustomLeadFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'lead', { onlyCustom: true });
+				return await getFields.call(this, 'lead', { onlyCustom: true });
 			},
 
 			async getCustomProductFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'product', { onlyCustom: true });
+				return await getFields.call(this, 'product', { onlyCustom: true });
 			},
 
 			async getCustomPurchaseOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'purchase_order', { onlyCustom: true });
+				return await getFields.call(this, 'purchase_order', { onlyCustom: true });
 			},
 
 			async getCustomVendorOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'vendor', { onlyCustom: true });
+				return await getFields.call(this, 'vendor', { onlyCustom: true });
 			},
 
 			async getCustomQuoteFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'quote', { onlyCustom: true });
+				return await getFields.call(this, 'quote', { onlyCustom: true });
 			},
 
 			async getCustomSalesOrderFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'sales_order', { onlyCustom: true });
+				return await getFields.call(this, 'sales_order', { onlyCustom: true });
 			},
 
 			async getCustomVendorFields(this: ILoadOptionsFunctions) {
-				return getFields.call(this, 'vendor', { onlyCustom: true });
+				return await getFields.call(this, 'vendor', { onlyCustom: true });
 			},
 
 			// ----------------------------------------
@@ -306,23 +306,23 @@ export class ZohoCrm implements INodeType {
 			// ----------------------------------------
 
 			async getAccountType(this: ILoadOptionsFunctions) {
-				return getPicklistOptions.call(this, 'account', 'Account_Type');
+				return await getPicklistOptions.call(this, 'account', 'Account_Type');
 			},
 
 			async getDealStage(this: ILoadOptionsFunctions) {
-				return getPicklistOptions.call(this, 'deal', 'Stage');
+				return await getPicklistOptions.call(this, 'deal', 'Stage');
 			},
 
 			async getPurchaseOrderStatus(this: ILoadOptionsFunctions) {
-				return getPicklistOptions.call(this, 'purchaseOrder', 'Status');
+				return await getPicklistOptions.call(this, 'purchaseOrder', 'Status');
 			},
 
 			async getSalesOrderStatus(this: ILoadOptionsFunctions) {
-				return getPicklistOptions.call(this, 'salesOrder', 'Status');
+				return await getPicklistOptions.call(this, 'salesOrder', 'Status');
 			},
 
 			async getQuoteStage(this: ILoadOptionsFunctions) {
-				return getPicklistOptions.call(this, 'quote', 'Quote_Stage');
+				return await getPicklistOptions.call(this, 'quote', 'Quote_Stage');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/Zoom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Zoom/GenericFunctions.ts
@@ -49,7 +49,7 @@ export async function zoomApiRequest(
 }
 
 async function wait() {
-	return new Promise((resolve, _reject) => {
+	return await new Promise((resolve, _reject) => {
 		setTimeout(() => {
 			resolve(true);
 		}, 1000);

--- a/packages/nodes-base/test/nodes/Helpers.ts
+++ b/packages/nodes-base/test/nodes/Helpers.ts
@@ -104,7 +104,7 @@ export class CredentialsHelper extends ICredentialsHelper {
 	): Promise<IHttpRequestOptions> {
 		const credentialType = this.credentialTypes.getByName(typeName);
 		if (typeof credentialType.authenticate === 'function') {
-			return credentialType.authenticate(credentials, requestParams);
+			return await credentialType.authenticate(credentials, requestParams);
 		}
 		return requestParams;
 	}
@@ -390,7 +390,7 @@ export const testWorkflows = (workflows: string[]) => {
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {
-		test(testData.description, async () => equalityTest(testData, nodeTypes));
+		test(testData.description, async () => await equalityTest(testData, nodeTypes));
 	}
 };
 

--- a/packages/workflow/.eslintrc.js
+++ b/packages/workflow/.eslintrc.js
@@ -16,5 +16,9 @@ module.exports = {
 		'@typescript-eslint/no-redundant-type-constituents': 'warn',
 		'@typescript-eslint/prefer-nullish-coalescing': 'warn',
 		'@typescript-eslint/prefer-optional-chain': 'warn',
+		/**
+		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md
+		 */
+		'@typescript-eslint/return-await': ['error', 'always'],
 	},
 };

--- a/packages/workflow/src/DeferredPromise.ts
+++ b/packages/workflow/src/DeferredPromise.ts
@@ -6,9 +6,9 @@ export interface IDeferredPromise<T> {
 }
 
 export async function createDeferredPromise<T = void>(): Promise<IDeferredPromise<T>> {
-	return new Promise<IDeferredPromise<T>>((resolveCreate) => {
+	return await new Promise<IDeferredPromise<T>>((resolveCreate) => {
 		const promise = new Promise<T>((resolve, reject) => {
-			resolveCreate({ promise: async () => promise, resolve, reject });
+			resolveCreate({ promise: async () => await promise, resolve, reject });
 		});
 	});
 }

--- a/packages/workflow/src/RoutingNode.ts
+++ b/packages/workflow/src/RoutingNode.ts
@@ -284,7 +284,7 @@ export class RoutingNode {
 		runIndex: number,
 	): Promise<INodeExecutionData[]> {
 		if (typeof action === 'function') {
-			return action.call(executeSingleFunctions, inputData, responseData);
+			return await action.call(executeSingleFunctions, inputData, responseData);
 		}
 		if (action.type === 'rootProperty') {
 			try {
@@ -534,19 +534,20 @@ export class RoutingNode {
 		const executePaginationFunctions = {
 			...executeSingleFunctions,
 			makeRoutingRequest: async (requestOptions: DeclarativeRestApiSettings.ResultOptions) => {
-				return this.rawRoutingRequest(
+				return await this.rawRoutingRequest(
 					executeSingleFunctions,
 					requestOptions,
 					credentialType,
 					credentialsDecrypted,
-				).then(async (data) =>
-					this.postProcessResponseData(
-						executeSingleFunctions,
-						data,
-						requestData,
-						itemIndex,
-						runIndex,
-					),
+				).then(
+					async (data) =>
+						await this.postProcessResponseData(
+							executeSingleFunctions,
+							data,
+							requestData,
+							itemIndex,
+							runIndex,
+						),
 				);
 			},
 		};
@@ -649,14 +650,15 @@ export class RoutingNode {
 							requestData,
 							credentialType,
 							credentialsDecrypted,
-						).then(async (data) =>
-							this.postProcessResponseData(
-								executeSingleFunctions,
-								data,
-								requestData,
-								itemIndex,
-								runIndex,
-							),
+						).then(
+							async (data) =>
+								await this.postProcessResponseData(
+									executeSingleFunctions,
+									data,
+									requestData,
+									itemIndex,
+									runIndex,
+								),
 						);
 
 						(requestData.options[optionsType] as IDataObject)[properties.offsetParameter] =
@@ -694,14 +696,15 @@ export class RoutingNode {
 				requestData,
 				credentialType,
 				credentialsDecrypted,
-			).then(async (data) =>
-				this.postProcessResponseData(
-					executeSingleFunctions,
-					data,
-					requestData,
-					itemIndex,
-					runIndex,
-				),
+			).then(
+				async (data) =>
+					await this.postProcessResponseData(
+						executeSingleFunctions,
+						data,
+						requestData,
+						itemIndex,
+						runIndex,
+					),
 			);
 		}
 		return responseData;

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -1058,7 +1058,7 @@ export class Workflow {
 			webhookData,
 		);
 
-		return webhookFn.call(thisArgs);
+		return await webhookFn.call(thisArgs);
 	}
 
 	/**
@@ -1143,7 +1143,7 @@ export class Workflow {
 			return triggerResponse;
 		}
 		// In all other modes simply start the trigger
-		return nodeType.trigger.call(triggerFunctions);
+		return await nodeType.trigger.call(triggerFunctions);
 	}
 
 	/**
@@ -1172,7 +1172,7 @@ export class Workflow {
 			});
 		}
 
-		return nodeType.poll.call(pollFunctions);
+		return await nodeType.poll.call(pollFunctions);
 	}
 
 	/**
@@ -1208,7 +1208,9 @@ export class Workflow {
 			webhookData,
 			closeFunctions,
 		);
-		return nodeType instanceof Node ? nodeType.webhook(context) : nodeType.webhook.call(context);
+		return nodeType instanceof Node
+			? await nodeType.webhook(context)
+			: await nodeType.webhook.call(context);
 	}
 
 	/**
@@ -1322,7 +1324,7 @@ export class Workflow {
 					: await nodeType.execute.call(context);
 
 			const closeFunctionsResults = await Promise.allSettled(
-				closeFunctions.map(async (fn) => fn()),
+				closeFunctions.map(async (fn) => await fn()),
 			);
 
 			const closingErrors = closeFunctionsResults

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -107,7 +107,7 @@ export const jsonStringify = (obj: unknown, options: JSONStringifyOptions = {}):
 };
 
 export const sleep = async (ms: number): Promise<void> =>
-	new Promise((resolve) => {
+	await new Promise((resolve) => {
 		setTimeout(resolve, ms);
 	});
 

--- a/packages/workflow/test/Helpers.ts
+++ b/packages/workflow/test/Helpers.ts
@@ -189,7 +189,7 @@ export function getExecuteFunctions(
 				workflowInfo: IExecuteWorkflowInfo,
 				inputData?: INodeExecutionData[],
 			): Promise<any> {
-				return additionalData.executeWorkflow(workflowInfo, additionalData, { inputData });
+				return await additionalData.executeWorkflow(workflowInfo, additionalData, { inputData });
 			},
 			getContext(type: string): IContextObject {
 				return NodeHelpers.getContext(runExecutionData, type, node);


### PR DESCRIPTION
## Summary

Returning a promise from function without awaiting it causes the function to be dropped from the stacktrace. This makes debugging harder. So this PR changes TS ESLint rule '@typescript-eslint/return-await' from its default value to 'always', so it is required to await any promises returned from async functions.

More details here:
https://github.com/goldbergyoni/nodebestpractices#-212-always-await-promises-before-returning-to-avoid-a-partial-stacktrace https://eslint.org/docs/latest/rules/no-return-await


## Related tickets and issues

https://n8nio.slack.com/archives/C03MZF137FV/p1705496007084329


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 