### PR TITLE
fix(editor): Open native context menu when editing Sticky

### DIFF
--- a/packages/editor-ui/src/components/Sticky.vue
+++ b/packages/editor-ui/src/components/Sticky.vue
@@ -328,8 +328,10 @@ export default defineComponent({
 			}
 		},
 		onContextMenu(e: MouseEvent): void {
-			if (this.node) {
+			if (this.node && !this.isActive) {
 				this.contextMenu.open(e, { source: 'node-right-click', node: this.node });
+			} else {
+				e.stopPropagation();
 			}
 		},
 	},


### PR DESCRIPTION
## Summary

Right click a sticky
- when not editing it should open n8n's context menu
- when editing it should open the native context menu

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1060/canvas-context-menu-shows-when-editing-sticky-note

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 