### PR TITLE
fix: Set '@typescript-eslint/return-await' rule to 'always' for FE (no-changelog)

### DIFF
--- a/packages/@n8n/chat/src/__tests__/utils/fetch.ts
+++ b/packages/@n8n/chat/src/__tests__/utils/fetch.ts
@@ -3,7 +3,7 @@ import type { LoadPreviousSessionResponse, SendMessageResponse } from '@n8n/chat
 export function createFetchResponse<T>(data: T) {
 	return async () =>
 		({
-			json: async () => new Promise<T>((resolve) => resolve(data)),
+			json: async () => await new Promise<T>((resolve) => resolve(data)),
 		}) as Response;
 }
 

--- a/packages/@n8n/chat/src/api/generic.ts
+++ b/packages/@n8n/chat/src/api/generic.ts
@@ -16,7 +16,7 @@ export async function authenticatedFetch<T>(...args: Parameters<typeof fetch>): 
 		},
 	});
 
-	return (await response.json()) as Promise<T>;
+	return await ((await response.json()) as Promise<T>);
 }
 
 export async function get<T>(url: string, query: object = {}, options: RequestInit = {}) {
@@ -27,11 +27,11 @@ export async function get<T>(url: string, query: object = {}, options: RequestIn
 		).toString()}`;
 	}
 
-	return authenticatedFetch<T>(resolvedUrl, { ...options, method: 'GET' });
+	return await authenticatedFetch<T>(resolvedUrl, { ...options, method: 'GET' });
 }
 
 export async function post<T>(url: string, body: object = {}, options: RequestInit = {}) {
-	return authenticatedFetch<T>(url, {
+	return await authenticatedFetch<T>(url, {
 		...options,
 		method: 'POST',
 		body: JSON.stringify(body),
@@ -39,7 +39,7 @@ export async function post<T>(url: string, body: object = {}, options: RequestIn
 }
 
 export async function put<T>(url: string, body: object = {}, options: RequestInit = {}) {
-	return authenticatedFetch<T>(url, {
+	return await authenticatedFetch<T>(url, {
 		...options,
 		method: 'PUT',
 		body: JSON.stringify(body),
@@ -47,7 +47,7 @@ export async function put<T>(url: string, body: object = {}, options: RequestIni
 }
 
 export async function patch<T>(url: string, body: object = {}, options: RequestInit = {}) {
-	return authenticatedFetch<T>(url, {
+	return await authenticatedFetch<T>(url, {
 		...options,
 		method: 'PATCH',
 		body: JSON.stringify(body),
@@ -55,7 +55,7 @@ export async function patch<T>(url: string, body: object = {}, options: RequestI
 }
 
 export async function del<T>(url: string, body: object = {}, options: RequestInit = {}) {
-	return authenticatedFetch<T>(url, {
+	return await authenticatedFetch<T>(url, {
 		...options,
 		method: 'DELETE',
 		body: JSON.stringify(body),

--- a/packages/@n8n/chat/src/api/generic.ts
+++ b/packages/@n8n/chat/src/api/generic.ts
@@ -16,7 +16,7 @@ export async function authenticatedFetch<T>(...args: Parameters<typeof fetch>): 
 		},
 	});
 
-	return await ((await response.json()) as Promise<T>);
+	return (await response.json()) as T;
 }
 
 export async function get<T>(url: string, query: object = {}, options: RequestInit = {}) {

--- a/packages/@n8n/chat/src/api/message.ts
+++ b/packages/@n8n/chat/src/api/message.ts
@@ -7,7 +7,7 @@ import type {
 
 export async function loadPreviousSession(sessionId: string, options: ChatOptions) {
 	const method = options.webhookConfig?.method === 'POST' ? post : get;
-	return method<LoadPreviousSessionResponse>(
+	return await method<LoadPreviousSessionResponse>(
 		`${options.webhookUrl}`,
 		{
 			action: 'loadPreviousSession',
@@ -22,7 +22,7 @@ export async function loadPreviousSession(sessionId: string, options: ChatOption
 
 export async function sendMessage(message: string, sessionId: string, options: ChatOptions) {
 	const method = options.webhookConfig?.method === 'POST' ? post : get;
-	return method<SendMessageResponse>(
+	return await method<SendMessageResponse>(
 		`${options.webhookUrl}`,
 		{
 			action: 'sendMessage',

--- a/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
+++ b/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
@@ -42,7 +42,7 @@ describe('CredentialsFlow', () => {
 					refresh_token: config.refreshToken,
 					scope: requestedScope,
 				});
-			return new Promise<{ headers: Headers; body: unknown }>((resolve) => {
+			return await new Promise<{ headers: Headers; body: unknown }>((resolve) => {
 				nockScope.once('request', (req) => {
 					resolve({
 						headers: req.headers,

--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -336,6 +336,11 @@ const config = (module.exports = {
 			},
 		],
 
+		/**
+		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md
+		 */
+		'@typescript-eslint/return-await': ['error', 'always'],
+
 		// ----------------------------------
 		//       eslint-plugin-import
 		// ----------------------------------

--- a/packages/@n8n_io/eslint-config/node.js
+++ b/packages/@n8n_io/eslint-config/node.js
@@ -8,11 +8,4 @@ module.exports = {
 		es6: true,
 		node: true,
 	},
-
-	rules: {
-		/**
-		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md
-		 */
-		'@typescript-eslint/return-await': ['error', 'always'],
-	},
 };

--- a/packages/editor-ui/src/__tests__/utils.ts
+++ b/packages/editor-ui/src/__tests__/utils.ts
@@ -5,7 +5,7 @@ export const retry = async (
 	assertion: () => ReturnType<typeof expect>,
 	{ interval = 20, timeout = 1000 } = {},
 ) => {
-	return new Promise((resolve, reject) => {
+	return await new Promise((resolve, reject) => {
 		const startTime = Date.now();
 
 		const tryAgain = () => {
@@ -22,7 +22,7 @@ export const retry = async (
 	});
 };
 
-export const waitAllPromises = async () => new Promise((resolve) => setTimeout(resolve));
+export const waitAllPromises = async () => await new Promise((resolve) => setTimeout(resolve));
 
 export const SETTINGS_STORE_DEFAULT_STATE: ISettingsState = {
 	settings: {

--- a/packages/editor-ui/src/api/ai.ts
+++ b/packages/editor-ui/src/api/ai.ts
@@ -21,7 +21,7 @@ export async function generateCodeForPrompt(
 		n8nVersion: string;
 	},
 ): Promise<{ code: string }> {
-	return makeRestApiRequest(ctx, 'POST', '/ask-ai', {
+	return await makeRestApiRequest(ctx, 'POST', '/ask-ai', {
 		question,
 		context,
 		model,

--- a/packages/editor-ui/src/api/api-keys.ts
+++ b/packages/editor-ui/src/api/api-keys.ts
@@ -2,13 +2,13 @@ import type { IRestApiContext } from '@/Interface';
 import { makeRestApiRequest } from '@/utils/apiUtils';
 
 export async function getApiKey(context: IRestApiContext): Promise<{ apiKey: string | null }> {
-	return makeRestApiRequest(context, 'GET', '/me/api-key');
+	return await makeRestApiRequest(context, 'GET', '/me/api-key');
 }
 
 export async function createApiKey(context: IRestApiContext): Promise<{ apiKey: string | null }> {
-	return makeRestApiRequest(context, 'POST', '/me/api-key');
+	return await makeRestApiRequest(context, 'POST', '/me/api-key');
 }
 
 export async function deleteApiKey(context: IRestApiContext): Promise<{ success: boolean }> {
-	return makeRestApiRequest(context, 'DELETE', '/me/api-key');
+	return await makeRestApiRequest(context, 'DELETE', '/me/api-key');
 }

--- a/packages/editor-ui/src/api/cloudPlans.ts
+++ b/packages/editor-ui/src/api/cloudPlans.ts
@@ -2,27 +2,27 @@ import type { Cloud, IRestApiContext, InstanceUsage, LeadEnrichmentTemplates } f
 import { get, post } from '@/utils/apiUtils';
 
 export async function getCurrentPlan(context: IRestApiContext): Promise<Cloud.PlanData> {
-	return get(context.baseUrl, '/admin/cloud-plan');
+	return await get(context.baseUrl, '/admin/cloud-plan');
 }
 
 export async function getCurrentUsage(context: IRestApiContext): Promise<InstanceUsage> {
-	return get(context.baseUrl, '/cloud/limits');
+	return await get(context.baseUrl, '/cloud/limits');
 }
 
 export async function getCloudUserInfo(context: IRestApiContext): Promise<Cloud.UserAccount> {
-	return get(context.baseUrl, '/cloud/proxy/user/me');
+	return await get(context.baseUrl, '/cloud/proxy/user/me');
 }
 
 export async function confirmEmail(context: IRestApiContext): Promise<Cloud.UserAccount> {
-	return post(context.baseUrl, '/cloud/proxy/user/resend-confirmation-email');
+	return await post(context.baseUrl, '/cloud/proxy/user/resend-confirmation-email');
 }
 
 export async function getAdminPanelLoginCode(context: IRestApiContext): Promise<{ code: string }> {
-	return get(context.baseUrl, '/cloud/proxy/login/code');
+	return await get(context.baseUrl, '/cloud/proxy/login/code');
 }
 
 export async function fetchSuggestedTemplates(
 	context: IRestApiContext,
 ): Promise<LeadEnrichmentTemplates> {
-	return get(context.baseUrl, '/cloud/proxy/templates');
+	return await get(context.baseUrl, '/cloud/proxy/templates');
 }

--- a/packages/editor-ui/src/api/communityNodes.ts
+++ b/packages/editor-ui/src/api/communityNodes.ts
@@ -13,16 +13,16 @@ export async function installNewPackage(
 	context: IRestApiContext,
 	name: string,
 ): Promise<PublicInstalledPackage> {
-	return post(context.baseUrl, '/community-packages', { name });
+	return await post(context.baseUrl, '/community-packages', { name });
 }
 
 export async function uninstallPackage(context: IRestApiContext, name: string): Promise<void> {
-	return makeRestApiRequest(context, 'DELETE', '/community-packages', { name });
+	return await makeRestApiRequest(context, 'DELETE', '/community-packages', { name });
 }
 
 export async function updatePackage(
 	context: IRestApiContext,
 	name: string,
 ): Promise<PublicInstalledPackage> {
-	return makeRestApiRequest(context, 'PATCH', '/community-packages', { name });
+	return await makeRestApiRequest(context, 'PATCH', '/community-packages', { name });
 }

--- a/packages/editor-ui/src/api/credentials.ee.ts
+++ b/packages/editor-ui/src/api/credentials.ee.ts
@@ -7,7 +7,7 @@ export async function setCredentialSharedWith(
 	id: string,
 	data: IShareCredentialsPayload,
 ): Promise<ICredentialsResponse> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'PUT',
 		`/credentials/${id}/share`,

--- a/packages/editor-ui/src/api/credentials.ts
+++ b/packages/editor-ui/src/api/credentials.ts
@@ -22,22 +22,22 @@ export async function getCredentialsNewName(
 	context: IRestApiContext,
 	name?: string,
 ): Promise<{ name: string }> {
-	return makeRestApiRequest(context, 'GET', '/credentials/new', name ? { name } : {});
+	return await makeRestApiRequest(context, 'GET', '/credentials/new', name ? { name } : {});
 }
 
 export async function getAllCredentials(context: IRestApiContext): Promise<ICredentialsResponse[]> {
-	return makeRestApiRequest(context, 'GET', '/credentials');
+	return await makeRestApiRequest(context, 'GET', '/credentials');
 }
 
 export async function createNewCredential(
 	context: IRestApiContext,
 	data: ICredentialsDecrypted,
 ): Promise<ICredentialsResponse> {
-	return makeRestApiRequest(context, 'POST', '/credentials', data as unknown as IDataObject);
+	return await makeRestApiRequest(context, 'POST', '/credentials', data as unknown as IDataObject);
 }
 
 export async function deleteCredential(context: IRestApiContext, id: string): Promise<boolean> {
-	return makeRestApiRequest(context, 'DELETE', `/credentials/${id}`);
+	return await makeRestApiRequest(context, 'DELETE', `/credentials/${id}`);
 }
 
 export async function updateCredential(
@@ -45,14 +45,19 @@ export async function updateCredential(
 	id: string,
 	data: ICredentialsDecrypted,
 ): Promise<ICredentialsResponse> {
-	return makeRestApiRequest(context, 'PATCH', `/credentials/${id}`, data as unknown as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'PATCH',
+		`/credentials/${id}`,
+		data as unknown as IDataObject,
+	);
 }
 
 export async function getCredentialData(
 	context: IRestApiContext,
 	id: string,
 ): Promise<ICredentialsDecryptedResponse | ICredentialsResponse | undefined> {
-	return makeRestApiRequest(context, 'GET', `/credentials/${id}`, {
+	return await makeRestApiRequest(context, 'GET', `/credentials/${id}`, {
 		includeData: true,
 	});
 }
@@ -62,7 +67,7 @@ export async function oAuth1CredentialAuthorize(
 	context: IRestApiContext,
 	data: ICredentialsResponse,
 ): Promise<string> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'GET',
 		'/oauth1-credential/auth',
@@ -75,7 +80,7 @@ export async function oAuth2CredentialAuthorize(
 	context: IRestApiContext,
 	data: ICredentialsResponse,
 ): Promise<string> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'GET',
 		'/oauth2-credential/auth',
@@ -87,5 +92,10 @@ export async function testCredential(
 	context: IRestApiContext,
 	data: INodeCredentialTestRequest,
 ): Promise<INodeCredentialTestResult> {
-	return makeRestApiRequest(context, 'POST', '/credentials/test', data as unknown as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'POST',
+		'/credentials/test',
+		data as unknown as IDataObject,
+	);
 }

--- a/packages/editor-ui/src/api/curlHelper.ts
+++ b/packages/editor-ui/src/api/curlHelper.ts
@@ -5,5 +5,5 @@ export async function getCurlToJson(
 	context: IRestApiContext,
 	curlCommand: string,
 ): Promise<CurlToJSONResponse> {
-	return makeRestApiRequest(context, 'POST', '/curl-to-json', { curlCommand });
+	return await makeRestApiRequest(context, 'POST', '/curl-to-json', { curlCommand });
 }

--- a/packages/editor-ui/src/api/environments.ee.ts
+++ b/packages/editor-ui/src/api/environments.ee.ts
@@ -3,33 +3,38 @@ import { makeRestApiRequest } from '@/utils/apiUtils';
 import type { IDataObject } from 'n8n-workflow';
 
 export async function getVariables(context: IRestApiContext): Promise<EnvironmentVariable[]> {
-	return makeRestApiRequest(context, 'GET', '/variables');
+	return await makeRestApiRequest(context, 'GET', '/variables');
 }
 
 export async function getVariable(
 	context: IRestApiContext,
 	{ id }: { id: EnvironmentVariable['id'] },
 ): Promise<EnvironmentVariable> {
-	return makeRestApiRequest(context, 'GET', `/variables/${id}`);
+	return await makeRestApiRequest(context, 'GET', `/variables/${id}`);
 }
 
 export async function createVariable(
 	context: IRestApiContext,
 	data: Omit<EnvironmentVariable, 'id'>,
 ) {
-	return makeRestApiRequest(context, 'POST', '/variables', data as unknown as IDataObject);
+	return await makeRestApiRequest(context, 'POST', '/variables', data as unknown as IDataObject);
 }
 
 export async function updateVariable(
 	context: IRestApiContext,
 	{ id, ...data }: EnvironmentVariable,
 ) {
-	return makeRestApiRequest(context, 'PATCH', `/variables/${id}`, data as unknown as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'PATCH',
+		`/variables/${id}`,
+		data as unknown as IDataObject,
+	);
 }
 
 export async function deleteVariable(
 	context: IRestApiContext,
 	{ id }: { id: EnvironmentVariable['id'] },
 ) {
-	return makeRestApiRequest(context, 'DELETE', `/variables/${id}`);
+	return await makeRestApiRequest(context, 'DELETE', `/variables/${id}`);
 }

--- a/packages/editor-ui/src/api/eventbus.ee.ts
+++ b/packages/editor-ui/src/api/eventbus.ee.ts
@@ -12,12 +12,12 @@ export async function saveDestinationToDb(
 			...destination,
 			subscribedEvents,
 		};
-		return makeRestApiRequest(context, 'POST', '/eventbus/destination', data);
+		return await makeRestApiRequest(context, 'POST', '/eventbus/destination', data);
 	}
 }
 
 export async function deleteDestinationFromDb(context: IRestApiContext, destinationId: string) {
-	return makeRestApiRequest(context, 'DELETE', `/eventbus/destination?id=${destinationId}`);
+	return await makeRestApiRequest(context, 'DELETE', `/eventbus/destination?id=${destinationId}`);
 }
 
 export async function sendTestMessageToDestination(
@@ -28,27 +28,27 @@ export async function sendTestMessageToDestination(
 		const data: IDataObject = {
 			...destination,
 		};
-		return makeRestApiRequest(context, 'GET', '/eventbus/testmessage', data);
+		return await makeRestApiRequest(context, 'GET', '/eventbus/testmessage', data);
 	}
 }
 
 export async function getEventNamesFromBackend(context: IRestApiContext): Promise<string[]> {
-	return makeRestApiRequest(context, 'GET', '/eventbus/eventnames');
+	return await makeRestApiRequest(context, 'GET', '/eventbus/eventnames');
 }
 
 export async function getDestinationsFromBackend(
 	context: IRestApiContext,
 ): Promise<MessageEventBusDestinationOptions[]> {
-	return makeRestApiRequest(context, 'GET', '/eventbus/destination');
+	return await makeRestApiRequest(context, 'GET', '/eventbus/destination');
 }
 
 export async function getExecutionEvents(context: IRestApiContext, executionId: string) {
-	return makeRestApiRequest(context, 'GET', `/eventbus/execution/${executionId}`);
+	return await makeRestApiRequest(context, 'GET', `/eventbus/execution/${executionId}`);
 }
 
 export async function recoverExecutionDataFromEvents(
 	context: IRestApiContext,
 	executionId: string,
 ) {
-	return makeRestApiRequest(context, 'GET', `/eventbus/execution-recover/${executionId}`);
+	return await makeRestApiRequest(context, 'GET', `/eventbus/execution-recover/${executionId}`);
 }

--- a/packages/editor-ui/src/api/externalSecrets.ee.ts
+++ b/packages/editor-ui/src/api/externalSecrets.ee.ts
@@ -8,20 +8,20 @@ import { makeRestApiRequest } from '@/utils/apiUtils';
 export const getExternalSecrets = async (
 	context: IRestApiContext,
 ): Promise<Record<string, string[]>> => {
-	return makeRestApiRequest(context, 'GET', '/external-secrets/secrets');
+	return await makeRestApiRequest(context, 'GET', '/external-secrets/secrets');
 };
 
 export const getExternalSecretsProviders = async (
 	context: IRestApiContext,
 ): Promise<ExternalSecretsProvider[]> => {
-	return makeRestApiRequest(context, 'GET', '/external-secrets/providers');
+	return await makeRestApiRequest(context, 'GET', '/external-secrets/providers');
 };
 
 export const getExternalSecretsProvider = async (
 	context: IRestApiContext,
 	id: string,
 ): Promise<ExternalSecretsProviderWithProperties> => {
-	return makeRestApiRequest(context, 'GET', `/external-secrets/providers/${id}`);
+	return await makeRestApiRequest(context, 'GET', `/external-secrets/providers/${id}`);
 };
 
 export const testExternalSecretsProviderConnection = async (
@@ -29,7 +29,7 @@ export const testExternalSecretsProviderConnection = async (
 	id: string,
 	data: ExternalSecretsProvider['data'],
 ): Promise<{ testState: ExternalSecretsProvider['state'] }> => {
-	return makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/test`, data);
+	return await makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/test`, data);
 };
 
 export const updateProvider = async (
@@ -37,14 +37,14 @@ export const updateProvider = async (
 	id: string,
 	data: ExternalSecretsProvider['data'],
 ): Promise<boolean> => {
-	return makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}`, data);
+	return await makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}`, data);
 };
 
 export const reloadProvider = async (
 	context: IRestApiContext,
 	id: string,
 ): Promise<{ updated: boolean }> => {
-	return makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/update`);
+	return await makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/update`);
 };
 
 export const connectProvider = async (
@@ -52,7 +52,7 @@ export const connectProvider = async (
 	id: string,
 	connected: boolean,
 ): Promise<boolean> => {
-	return makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/connect`, {
+	return await makeRestApiRequest(context, 'POST', `/external-secrets/providers/${id}/connect`, {
 		connected,
 	});
 };

--- a/packages/editor-ui/src/api/invitation.ts
+++ b/packages/editor-ui/src/api/invitation.ts
@@ -19,12 +19,12 @@ export async function inviteUsers(
 	context: IRestApiContext,
 	params: Array<{ email: string; role: InvitableRoleName }>,
 ) {
-	return makeRestApiRequest<IInviteResponse[]>(context, 'POST', '/invitations', params);
+	return await makeRestApiRequest<IInviteResponse[]>(context, 'POST', '/invitations', params);
 }
 
 export async function acceptInvitation(context: IRestApiContext, params: AcceptInvitationParams) {
 	const { inviteeId, ...props } = params;
-	return makeRestApiRequest<CurrentUserResponse>(
+	return await makeRestApiRequest<CurrentUserResponse>(
 		context,
 		'POST',
 		`/invitations/${params.inviteeId}/accept`,

--- a/packages/editor-ui/src/api/ldap.ts
+++ b/packages/editor-ui/src/api/ldap.ts
@@ -3,27 +3,32 @@ import { makeRestApiRequest } from '@/utils/apiUtils';
 import type { IDataObject } from 'n8n-workflow';
 
 export async function getLdapConfig(context: IRestApiContext): Promise<ILdapConfig> {
-	return makeRestApiRequest(context, 'GET', '/ldap/config');
+	return await makeRestApiRequest(context, 'GET', '/ldap/config');
 }
 
 export async function testLdapConnection(context: IRestApiContext): Promise<{}> {
-	return makeRestApiRequest(context, 'POST', '/ldap/test-connection');
+	return await makeRestApiRequest(context, 'POST', '/ldap/test-connection');
 }
 
 export async function updateLdapConfig(
 	context: IRestApiContext,
 	adConfig: ILdapConfig,
 ): Promise<ILdapConfig> {
-	return makeRestApiRequest(context, 'PUT', '/ldap/config', adConfig as unknown as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'PUT',
+		'/ldap/config',
+		adConfig as unknown as IDataObject,
+	);
 }
 
 export async function runLdapSync(context: IRestApiContext, data: IDataObject): Promise<{}> {
-	return makeRestApiRequest(context, 'POST', '/ldap/sync', data as unknown as IDataObject);
+	return await makeRestApiRequest(context, 'POST', '/ldap/sync', data as unknown as IDataObject);
 }
 
 export async function getLdapSynchronizations(
 	context: IRestApiContext,
 	pagination: { page: number },
 ): Promise<ILdapSyncData[]> {
-	return makeRestApiRequest(context, 'GET', '/ldap/sync', pagination);
+	return await makeRestApiRequest(context, 'GET', '/ldap/sync', pagination);
 }

--- a/packages/editor-ui/src/api/mfa.ts
+++ b/packages/editor-ui/src/api/mfa.ts
@@ -4,20 +4,20 @@ import { makeRestApiRequest } from '@/utils/apiUtils';
 export async function getMfaQR(
 	context: IRestApiContext,
 ): Promise<{ qrCode: string; secret: string; recoveryCodes: string[] }> {
-	return makeRestApiRequest(context, 'GET', '/mfa/qr');
+	return await makeRestApiRequest(context, 'GET', '/mfa/qr');
 }
 
 export async function enableMfa(context: IRestApiContext, data: { token: string }): Promise<void> {
-	return makeRestApiRequest(context, 'POST', '/mfa/enable', data);
+	return await makeRestApiRequest(context, 'POST', '/mfa/enable', data);
 }
 
 export async function verifyMfaToken(
 	context: IRestApiContext,
 	data: { token: string },
 ): Promise<void> {
-	return makeRestApiRequest(context, 'POST', '/mfa/verify', data);
+	return await makeRestApiRequest(context, 'POST', '/mfa/verify', data);
 }
 
 export async function disableMfa(context: IRestApiContext): Promise<void> {
-	return makeRestApiRequest(context, 'DELETE', '/mfa/disable');
+	return await makeRestApiRequest(context, 'DELETE', '/mfa/disable');
 }

--- a/packages/editor-ui/src/api/nodeTypes.ts
+++ b/packages/editor-ui/src/api/nodeTypes.ts
@@ -17,28 +17,28 @@ export async function getNodeTypes(baseUrl: string) {
 export async function getNodeTranslationHeaders(
 	context: IRestApiContext,
 ): Promise<INodeTranslationHeaders | undefined> {
-	return makeRestApiRequest(context, 'GET', '/node-translation-headers');
+	return await makeRestApiRequest(context, 'GET', '/node-translation-headers');
 }
 
 export async function getNodesInformation(
 	context: IRestApiContext,
 	nodeInfos: INodeTypeNameVersion[],
 ): Promise<INodeTypeDescription[]> {
-	return makeRestApiRequest(context, 'POST', '/node-types', { nodeInfos });
+	return await makeRestApiRequest(context, 'POST', '/node-types', { nodeInfos });
 }
 
 export async function getNodeParameterOptions(
 	context: IRestApiContext,
 	sendData: DynamicNodeParameters.OptionsRequest,
 ): Promise<INodePropertyOptions[]> {
-	return makeRestApiRequest(context, 'GET', '/dynamic-node-parameters/options', sendData);
+	return await makeRestApiRequest(context, 'GET', '/dynamic-node-parameters/options', sendData);
 }
 
 export async function getResourceLocatorResults(
 	context: IRestApiContext,
 	sendData: DynamicNodeParameters.ResourceLocatorResultsRequest,
 ): Promise<INodeListSearchResult> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'GET',
 		'/dynamic-node-parameters/resource-locator-results',
@@ -50,7 +50,7 @@ export async function getResourceMapperFields(
 	context: IRestApiContext,
 	sendData: DynamicNodeParameters.ResourceMapperFieldsRequest,
 ): Promise<ResourceMapperFields> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'GET',
 		'/dynamic-node-parameters/resource-mapper-fields',

--- a/packages/editor-ui/src/api/settings.ts
+++ b/packages/editor-ui/src/api/settings.ts
@@ -9,11 +9,11 @@ import { N8N_IO_BASE_URL, NPM_COMMUNITY_NODE_SEARCH_API_URL } from '@/constants'
 import type { IN8nUISettings } from 'n8n-workflow';
 
 export async function getSettings(context: IRestApiContext): Promise<IN8nUISettings> {
-	return makeRestApiRequest(context, 'GET', '/settings');
+	return await makeRestApiRequest(context, 'GET', '/settings');
 }
 
 export async function getPromptsData(instanceId: string, userId: string): Promise<IN8nPrompts> {
-	return get(
+	return await get(
 		N8N_IO_BASE_URL,
 		'/prompts',
 		{},
@@ -26,7 +26,7 @@ export async function submitContactInfo(
 	userId: string,
 	email: string,
 ): Promise<IN8nPromptResponse> {
-	return post(
+	return await post(
 		N8N_IO_BASE_URL,
 		'/prompt',
 		{ email },
@@ -39,7 +39,7 @@ export async function submitValueSurvey(
 	userId: string,
 	params: IN8nValueSurveyData,
 ): Promise<IN8nPromptResponse> {
-	return post(N8N_IO_BASE_URL, '/value-survey', params, {
+	return await post(N8N_IO_BASE_URL, '/value-survey', params, {
 		'n8n-instance-id': instanceId,
 		'n8n-user-id': userId,
 	});

--- a/packages/editor-ui/src/api/sourceControl.ts
+++ b/packages/editor-ui/src/api/sourceControl.ts
@@ -17,26 +17,26 @@ const createPreferencesRequestFn =
 		context: IRestApiContext,
 		preferences: Partial<SourceControlPreferences>,
 	): Promise<SourceControlPreferences> =>
-		makeRestApiRequest(context, method, `${sourceControlApiRoot}/preferences`, preferences);
+		await makeRestApiRequest(context, method, `${sourceControlApiRoot}/preferences`, preferences);
 
 export const pushWorkfolder = async (
 	context: IRestApiContext,
 	data: IDataObject,
 ): Promise<void> => {
-	return makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/push-workfolder`, data);
+	return await makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/push-workfolder`, data);
 };
 
 export const pullWorkfolder = async (
 	context: IRestApiContext,
 	data: IDataObject,
 ): Promise<void> => {
-	return makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/pull-workfolder`, data);
+	return await makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/pull-workfolder`, data);
 };
 
 export const getBranches = async (
 	context: IRestApiContext,
 ): Promise<{ branches: string[]; currentBranch: string }> => {
-	return makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/get-branches`);
+	return await makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/get-branches`);
 };
 
 export const savePreferences = createPreferencesRequestFn('POST');
@@ -45,11 +45,11 @@ export const updatePreferences = createPreferencesRequestFn('PATCH');
 export const getPreferences = async (
 	context: IRestApiContext,
 ): Promise<SourceControlPreferences> => {
-	return makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/preferences`);
+	return await makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/preferences`);
 };
 
 export const getStatus = async (context: IRestApiContext): Promise<SourceControlStatus> => {
-	return makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/status`);
+	return await makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/status`);
 };
 
 export const getAggregatedStatus = async (
@@ -60,14 +60,14 @@ export const getAggregatedStatus = async (
 		verbose: boolean;
 	} = { direction: 'push', preferLocalVersion: true, verbose: false },
 ): Promise<SourceControlAggregatedFile[]> => {
-	return makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/get-status`, options);
+	return await makeRestApiRequest(context, 'GET', `${sourceControlApiRoot}/get-status`, options);
 };
 
 export const disconnect = async (
 	context: IRestApiContext,
 	keepKeyPair: boolean,
 ): Promise<string> => {
-	return makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/disconnect`, {
+	return await makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/disconnect`, {
 		keepKeyPair,
 	});
 };
@@ -76,7 +76,7 @@ export const generateKeyPair = async (
 	context: IRestApiContext,
 	keyGeneratorType?: TupleToUnion<SshKeyTypes>,
 ): Promise<string> => {
-	return makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/generate-key-pair`, {
+	return await makeRestApiRequest(context, 'POST', `${sourceControlApiRoot}/generate-key-pair`, {
 		keyGeneratorType,
 	});
 };

--- a/packages/editor-ui/src/api/sso.ts
+++ b/packages/editor-ui/src/api/sso.ts
@@ -7,33 +7,33 @@ import type {
 } from '@/Interface';
 
 export const initSSO = async (context: IRestApiContext): Promise<string> => {
-	return makeRestApiRequest(context, 'GET', '/sso/saml/initsso');
+	return await makeRestApiRequest(context, 'GET', '/sso/saml/initsso');
 };
 
 export const getSamlMetadata = async (context: IRestApiContext): Promise<SamlPreferences> => {
-	return makeRestApiRequest(context, 'GET', '/sso/saml/metadata');
+	return await makeRestApiRequest(context, 'GET', '/sso/saml/metadata');
 };
 
 export const getSamlConfig = async (
 	context: IRestApiContext,
 ): Promise<SamlPreferences & SamlPreferencesExtractedData> => {
-	return makeRestApiRequest(context, 'GET', '/sso/saml/config');
+	return await makeRestApiRequest(context, 'GET', '/sso/saml/config');
 };
 
 export const saveSamlConfig = async (
 	context: IRestApiContext,
 	data: SamlPreferences,
 ): Promise<SamlPreferences | undefined> => {
-	return makeRestApiRequest(context, 'POST', '/sso/saml/config', data);
+	return await makeRestApiRequest(context, 'POST', '/sso/saml/config', data);
 };
 
 export const toggleSamlConfig = async (
 	context: IRestApiContext,
 	data: SamlPreferencesLoginEnabled,
 ): Promise<void> => {
-	return makeRestApiRequest(context, 'POST', '/sso/saml/config/toggle', data);
+	return await makeRestApiRequest(context, 'POST', '/sso/saml/config/toggle', data);
 };
 
 export const testSamlConfig = async (context: IRestApiContext): Promise<string> => {
-	return makeRestApiRequest(context, 'GET', '/sso/saml/config/test');
+	return await makeRestApiRequest(context, 'GET', '/sso/saml/config/test');
 };

--- a/packages/editor-ui/src/api/tags.ts
+++ b/packages/editor-ui/src/api/tags.ts
@@ -2,11 +2,11 @@ import type { IRestApiContext, ITag } from '@/Interface';
 import { makeRestApiRequest } from '@/utils/apiUtils';
 
 export async function getTags(context: IRestApiContext, withUsageCount = false): Promise<ITag[]> {
-	return makeRestApiRequest(context, 'GET', '/tags', { withUsageCount });
+	return await makeRestApiRequest(context, 'GET', '/tags', { withUsageCount });
 }
 
 export async function createTag(context: IRestApiContext, params: { name: string }): Promise<ITag> {
-	return makeRestApiRequest(context, 'POST', '/tags', params);
+	return await makeRestApiRequest(context, 'POST', '/tags', params);
 }
 
 export async function updateTag(
@@ -14,9 +14,9 @@ export async function updateTag(
 	id: string,
 	params: { name: string },
 ): Promise<ITag> {
-	return makeRestApiRequest(context, 'PATCH', `/tags/${id}`, params);
+	return await makeRestApiRequest(context, 'PATCH', `/tags/${id}`, params);
 }
 
 export async function deleteTag(context: IRestApiContext, id: string): Promise<boolean> {
-	return makeRestApiRequest(context, 'DELETE', `/tags/${id}`);
+	return await makeRestApiRequest(context, 'DELETE', `/tags/${id}`);
 }

--- a/packages/editor-ui/src/api/templates.ts
+++ b/packages/editor-ui/src/api/templates.ts
@@ -16,14 +16,14 @@ function stringifyArray(arr: number[]) {
 }
 
 export async function testHealthEndpoint(apiEndpoint: string) {
-	return get(apiEndpoint, '/health');
+	return await get(apiEndpoint, '/health');
 }
 
 export async function getCategories(
 	apiEndpoint: string,
 	headers?: IDataObject,
 ): Promise<{ categories: ITemplatesCategory[] }> {
-	return get(apiEndpoint, '/templates/categories', undefined, headers);
+	return await get(apiEndpoint, '/templates/categories', undefined, headers);
 }
 
 export async function getCollections(
@@ -31,7 +31,7 @@ export async function getCollections(
 	query: ITemplatesQuery,
 	headers?: IDataObject,
 ): Promise<{ collections: ITemplatesCollection[] }> {
-	return get(
+	return await get(
 		apiEndpoint,
 		'/templates/collections',
 		{ category: stringifyArray(query.categories || []), search: query.search },
@@ -48,7 +48,7 @@ export async function getWorkflows(
 	workflows: ITemplatesWorkflow[];
 	filters: TemplateSearchFacet[];
 }> {
-	return get(
+	return await get(
 		apiEndpoint,
 		'/templates/search',
 		{
@@ -66,7 +66,7 @@ export async function getCollectionById(
 	collectionId: string,
 	headers?: IDataObject,
 ): Promise<{ collection: ITemplatesCollectionResponse }> {
-	return get(apiEndpoint, `/templates/collections/${collectionId}`, undefined, headers);
+	return await get(apiEndpoint, `/templates/collections/${collectionId}`, undefined, headers);
 }
 
 export async function getTemplateById(
@@ -74,7 +74,7 @@ export async function getTemplateById(
 	templateId: string,
 	headers?: IDataObject,
 ): Promise<{ workflow: ITemplatesWorkflowResponse }> {
-	return get(apiEndpoint, `/templates/workflows/${templateId}`, undefined, headers);
+	return await get(apiEndpoint, `/templates/workflows/${templateId}`, undefined, headers);
 }
 
 export async function getWorkflowTemplate(
@@ -82,5 +82,5 @@ export async function getWorkflowTemplate(
 	templateId: string,
 	headers?: IDataObject,
 ): Promise<IWorkflowTemplate> {
-	return get(apiEndpoint, `/workflows/templates/${templateId}`, undefined, headers);
+	return await get(apiEndpoint, `/workflows/templates/${templateId}`, undefined, headers);
 }

--- a/packages/editor-ui/src/api/ui.ts
+++ b/packages/editor-ui/src/api/ui.ts
@@ -6,5 +6,7 @@ export async function dismissBannerPermanently(
 	context: IRestApiContext,
 	data: { bannerName: BannerName; dismissedBanners: string[] },
 ): Promise<void> {
-	return makeRestApiRequest(context, 'POST', '/owner/dismiss-banner', { banner: data.bannerName });
+	return await makeRestApiRequest(context, 'POST', '/owner/dismiss-banner', {
+		banner: data.bannerName,
+	});
 }

--- a/packages/editor-ui/src/api/usage.ts
+++ b/packages/editor-ui/src/api/usage.ts
@@ -2,18 +2,18 @@ import { makeRestApiRequest, request } from '@/utils/apiUtils';
 import type { IRestApiContext, UsageState } from '@/Interface';
 
 export const getLicense = async (context: IRestApiContext): Promise<UsageState['data']> => {
-	return makeRestApiRequest(context, 'GET', '/license');
+	return await makeRestApiRequest(context, 'GET', '/license');
 };
 
 export const activateLicenseKey = async (
 	context: IRestApiContext,
 	data: { activationKey: string },
 ): Promise<UsageState['data']> => {
-	return makeRestApiRequest(context, 'POST', '/license/activate', data);
+	return await makeRestApiRequest(context, 'POST', '/license/activate', data);
 };
 
 export const renewLicense = async (context: IRestApiContext): Promise<UsageState['data']> => {
-	return makeRestApiRequest(context, 'POST', '/license/renew');
+	return await makeRestApiRequest(context, 'POST', '/license/renew');
 };
 
 export const requestLicenseTrial = async (data: {
@@ -23,7 +23,7 @@ export const requestLicenseTrial = async (data: {
 	email: string;
 	instanceUrl: string;
 }): Promise<UsageState['data']> => {
-	return request({
+	return await request({
 		method: 'POST',
 		baseURL: 'https://enterprise.n8n.io',
 		endpoint: '/enterprise-trial',

--- a/packages/editor-ui/src/api/users.ts
+++ b/packages/editor-ui/src/api/users.ts
@@ -11,14 +11,14 @@ import { makeRestApiRequest } from '@/utils/apiUtils';
 export async function loginCurrentUser(
 	context: IRestApiContext,
 ): Promise<CurrentUserResponse | null> {
-	return makeRestApiRequest(context, 'GET', '/login');
+	return await makeRestApiRequest(context, 'GET', '/login');
 }
 
 export async function login(
 	context: IRestApiContext,
 	params: { email: string; password: string; mfaToken?: string; mfaRecoveryToken?: string },
 ): Promise<CurrentUserResponse> {
-	return makeRestApiRequest(context, 'POST', '/login', params);
+	return await makeRestApiRequest(context, 'POST', '/login', params);
 }
 
 export async function logout(context: IRestApiContext): Promise<void> {
@@ -29,14 +29,19 @@ export async function setupOwner(
 	context: IRestApiContext,
 	params: { firstName: string; lastName: string; email: string; password: string },
 ): Promise<CurrentUserResponse> {
-	return makeRestApiRequest(context, 'POST', '/owner/setup', params as unknown as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'POST',
+		'/owner/setup',
+		params as unknown as IDataObject,
+	);
 }
 
 export async function validateSignupToken(
 	context: IRestApiContext,
 	params: { inviterId: string; inviteeId: string },
 ): Promise<{ inviter: { firstName: string; lastName: string } }> {
-	return makeRestApiRequest(context, 'GET', '/resolve-signup-token', params);
+	return await makeRestApiRequest(context, 'GET', '/resolve-signup-token', params);
 }
 
 export async function signup(
@@ -50,7 +55,7 @@ export async function signup(
 	},
 ): Promise<CurrentUserResponse> {
 	const { inviteeId, ...props } = params;
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'POST',
 		`/users/${params.inviteeId}`,
@@ -88,14 +93,14 @@ export async function updateCurrentUser(
 		email: string;
 	},
 ): Promise<IUserResponse> {
-	return makeRestApiRequest(context, 'PATCH', '/me', params as unknown as IDataObject);
+	return await makeRestApiRequest(context, 'PATCH', '/me', params as unknown as IDataObject);
 }
 
 export async function updateCurrentUserSettings(
 	context: IRestApiContext,
 	settings: IUserResponse['settings'],
 ): Promise<IUserResponse['settings']> {
-	return makeRestApiRequest(context, 'PATCH', '/me/settings', settings as IDataObject);
+	return await makeRestApiRequest(context, 'PATCH', '/me/settings', settings as IDataObject);
 }
 
 export async function updateOtherUserSettings(
@@ -103,14 +108,19 @@ export async function updateOtherUserSettings(
 	userId: string,
 	settings: IUserResponse['settings'],
 ): Promise<IUserResponse['settings']> {
-	return makeRestApiRequest(context, 'PATCH', `/users/${userId}/settings`, settings as IDataObject);
+	return await makeRestApiRequest(
+		context,
+		'PATCH',
+		`/users/${userId}/settings`,
+		settings as IDataObject,
+	);
 }
 
 export async function updateCurrentUserPassword(
 	context: IRestApiContext,
 	params: { newPassword: string; currentPassword: string },
 ): Promise<void> {
-	return makeRestApiRequest(context, 'PATCH', '/me/password', params);
+	return await makeRestApiRequest(context, 'PATCH', '/me/password', params);
 }
 
 export async function deleteUser(
@@ -121,21 +131,21 @@ export async function deleteUser(
 }
 
 export async function getUsers(context: IRestApiContext): Promise<IUserResponse[]> {
-	return makeRestApiRequest(context, 'GET', '/users');
+	return await makeRestApiRequest(context, 'GET', '/users');
 }
 
 export async function getInviteLink(
 	context: IRestApiContext,
 	{ id }: { id: string },
 ): Promise<{ link: string }> {
-	return makeRestApiRequest(context, 'GET', `/users/${id}/invite-link`);
+	return await makeRestApiRequest(context, 'GET', `/users/${id}/invite-link`);
 }
 
 export async function getPasswordResetLink(
 	context: IRestApiContext,
 	{ id }: { id: string },
 ): Promise<{ link: string }> {
-	return makeRestApiRequest(context, 'GET', `/users/${id}/password-reset-link`);
+	return await makeRestApiRequest(context, 'GET', `/users/${id}/password-reset-link`);
 }
 
 export async function submitPersonalizationSurvey(
@@ -154,5 +164,5 @@ export async function updateGlobalRole(
 	context: IRestApiContext,
 	{ id, newRoleName }: UpdateGlobalRolePayload,
 ): Promise<IUserResponse> {
-	return makeRestApiRequest(context, 'PATCH', `/users/${id}/role`, { newRoleName });
+	return await makeRestApiRequest(context, 'PATCH', `/users/${id}/role`, { newRoleName });
 }

--- a/packages/editor-ui/src/api/versions.ts
+++ b/packages/editor-ui/src/api/versions.ts
@@ -8,5 +8,5 @@ export async function getNextVersions(
 	instanceId: string,
 ): Promise<IVersion[]> {
 	const headers = { [INSTANCE_ID_HEADER as string]: instanceId };
-	return get(endpoint, version, {}, headers);
+	return await get(endpoint, version, {}, headers);
 }

--- a/packages/editor-ui/src/api/workflow-webhooks.ts
+++ b/packages/editor-ui/src/api/workflow-webhooks.ts
@@ -9,7 +9,7 @@ export async function fetchNextOnboardingPrompt(
 	instanceId: string,
 	currentUser: IUser,
 ): Promise<IOnboardingCallPrompt> {
-	return get(N8N_API_BASE_URL, ONBOARDING_PROMPTS_ENDPOINT, {
+	return await get(N8N_API_BASE_URL, ONBOARDING_PROMPTS_ENDPOINT, {
 		instance_id: instanceId,
 		user_id: `${instanceId}#${currentUser.id}`,
 		is_owner: currentUser.isOwner,
@@ -40,7 +40,7 @@ export async function submitEmailOnSignup(
 	email: string | undefined,
 	agree: boolean,
 ): Promise<string> {
-	return post(N8N_API_BASE_URL, CONTACT_EMAIL_SUBMISSION_ENDPOINT, {
+	return await post(N8N_API_BASE_URL, CONTACT_EMAIL_SUBMISSION_ENDPOINT, {
 		instance_id: instanceId,
 		user_id: `${instanceId}#${currentUser.id}`,
 		email,

--- a/packages/editor-ui/src/api/workflows.ee.ts
+++ b/packages/editor-ui/src/api/workflows.ee.ts
@@ -7,7 +7,7 @@ export async function setWorkflowSharedWith(
 	id: string,
 	data: IShareWorkflowsPayload,
 ): Promise<IWorkflowsShareResponse> {
-	return makeRestApiRequest(
+	return await makeRestApiRequest(
 		context,
 		'PUT',
 		`/workflows/${id}/share`,

--- a/packages/editor-ui/src/api/workflows.ts
+++ b/packages/editor-ui/src/api/workflows.ts
@@ -14,21 +14,21 @@ export async function getNewWorkflow(context: IRestApiContext, name?: string) {
 export async function getWorkflow(context: IRestApiContext, id: string, filter?: object) {
 	const sendData = filter ? { filter } : undefined;
 
-	return makeRestApiRequest(context, 'GET', `/workflows/${id}`, sendData);
+	return await makeRestApiRequest(context, 'GET', `/workflows/${id}`, sendData);
 }
 
 export async function getWorkflows(context: IRestApiContext, filter?: object) {
 	const sendData = filter ? { filter } : undefined;
 
-	return makeRestApiRequest(context, 'GET', '/workflows', sendData);
+	return await makeRestApiRequest(context, 'GET', '/workflows', sendData);
 }
 
 export async function getActiveWorkflows(context: IRestApiContext) {
-	return makeRestApiRequest(context, 'GET', '/active-workflows');
+	return await makeRestApiRequest(context, 'GET', '/active-workflows');
 }
 
 export async function getCurrentExecutions(context: IRestApiContext, filter: IDataObject) {
-	return makeRestApiRequest(context, 'GET', '/executions-current', { filter });
+	return await makeRestApiRequest(context, 'GET', '/executions-current', { filter });
 }
 
 export async function getExecutions(
@@ -36,9 +36,9 @@ export async function getExecutions(
 	filter?: ExecutionFilters,
 	options?: ExecutionOptions,
 ): Promise<{ count: number; results: IExecutionsCurrentSummaryExtended[]; estimated: boolean }> {
-	return makeRestApiRequest(context, 'GET', '/executions', { filter, ...options });
+	return await makeRestApiRequest(context, 'GET', '/executions', { filter, ...options });
 }
 
 export async function getExecutionData(context: IRestApiContext, executionId: string) {
-	return makeRestApiRequest(context, 'GET', `/executions/${executionId}`);
+	return await makeRestApiRequest(context, 'GET', `/executions/${executionId}`);
 }

--- a/packages/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/editor-ui/src/components/CollectionParameter.vue
@@ -65,7 +65,9 @@ import { get } from 'lodash-es';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useI18n } from '@/composables/useI18n';
-const ParameterInputList = defineAsyncComponent(async () => import('./ParameterInputList.vue'));
+const ParameterInputList = defineAsyncComponent(
+	async () => await import('./ParameterInputList.vue'),
+);
 
 const selectedOption = ref<string | undefined>(undefined);
 export interface Props {

--- a/packages/editor-ui/src/components/FixedCollectionParameter.vue
+++ b/packages/editor-ui/src/components/FixedCollectionParameter.vue
@@ -136,7 +136,9 @@ import { deepCopy, isINodePropertyCollectionList } from 'n8n-workflow';
 
 import { get } from 'lodash-es';
 
-const ParameterInputList = defineAsyncComponent(async () => import('./ParameterInputList.vue'));
+const ParameterInputList = defineAsyncComponent(
+	async () => await import('./ParameterInputList.vue'),
+);
 
 export default defineComponent({
 	name: 'FixedCollectionParameter',

--- a/packages/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreation.vue
@@ -19,7 +19,7 @@ type Props = {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const NodeCreator = defineAsyncComponent(
-	async () => import('@/components/Node/NodeCreator/NodeCreator.vue'),
+	async () => await import('@/components/Node/NodeCreator/NodeCreator.vue'),
 );
 
 const props = withDefaults(defineProps<Props>(), {

--- a/packages/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/composables/useKeyboardNavigation.ts
@@ -32,7 +32,7 @@ export const useKeyboardNavigation = defineStore('nodeCreatorKeyboardNavigation'
 		return element?.getAttribute(KEYBOARD_ID_ATTR) || undefined;
 	}
 	async function refreshSelectableItems(): Promise<void> {
-		return new Promise((resolve) => {
+		return await new Promise((resolve) => {
 			// Wait for DOM to update
 			cleanupSelectableItems();
 			setTimeout(() => {

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -172,9 +172,11 @@ import { get, set } from 'lodash-es';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 
 const FixedCollectionParameter = defineAsyncComponent(
-	async () => import('./FixedCollectionParameter.vue'),
+	async () => await import('./FixedCollectionParameter.vue'),
 );
-const CollectionParameter = defineAsyncComponent(async () => import('./CollectionParameter.vue'));
+const CollectionParameter = defineAsyncComponent(
+	async () => await import('./CollectionParameter.vue'),
+);
 
 export default defineComponent({
 	name: 'ParameterInputList',

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -622,11 +622,17 @@ import { isObject } from 'lodash-es';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 
-const RunDataTable = defineAsyncComponent(async () => import('@/components/RunDataTable.vue'));
-const RunDataJson = defineAsyncComponent(async () => import('@/components/RunDataJson.vue'));
-const RunDataSchema = defineAsyncComponent(async () => import('@/components/RunDataSchema.vue'));
-const RunDataHtml = defineAsyncComponent(async () => import('@/components/RunDataHtml.vue'));
-const RunDataSearch = defineAsyncComponent(async () => import('@/components/RunDataSearch.vue'));
+const RunDataTable = defineAsyncComponent(
+	async () => await import('@/components/RunDataTable.vue'),
+);
+const RunDataJson = defineAsyncComponent(async () => await import('@/components/RunDataJson.vue'));
+const RunDataSchema = defineAsyncComponent(
+	async () => await import('@/components/RunDataSchema.vue'),
+);
+const RunDataHtml = defineAsyncComponent(async () => await import('@/components/RunDataHtml.vue'));
+const RunDataSearch = defineAsyncComponent(
+	async () => await import('@/components/RunDataSearch.vue'),
+);
 
 export type EnterEditModeArgs = {
 	origin: 'editIconButton' | 'insertTestDataLink';
@@ -1399,7 +1405,7 @@ export default defineComponent({
 				return;
 			} else {
 				const bufferString = 'data:' + mimeType + ';base64,' + data;
-				const blob = await fetch(bufferString).then(async (d) => d.blob());
+				const blob = await fetch(bufferString).then(async (d) => await d.blob());
 				saveAs(blob, fileName);
 			}
 		},

--- a/packages/editor-ui/src/components/RunDataJson.vue
+++ b/packages/editor-ui/src/components/RunDataJson.vue
@@ -94,7 +94,7 @@ import { useExternalHooks } from '@/composables/useExternalHooks';
 import TextWithHighlights from './TextWithHighlights.vue';
 
 const RunDataJsonActions = defineAsyncComponent(
-	async () => import('@/components/RunDataJsonActions.vue'),
+	async () => await import('@/components/RunDataJsonActions.vue'),
 );
 
 export default defineComponent({

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -106,7 +106,7 @@ export default defineComponent({
 	},
 	methods: {
 		async activeChanged(newActiveState: boolean) {
-			return this.updateWorkflowActivation(this.workflowId, newActiveState);
+			return await this.updateWorkflowActivation(this.workflowId, newActiveState);
 		},
 		async displayActivationError() {
 			let errorMessage: string;

--- a/packages/editor-ui/src/components/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat.vue
@@ -150,7 +150,9 @@ import { useExternalHooks } from '@/composables/useExternalHooks';
 // eslint-disable-next-line import/no-unresolved
 import MessageTyping from '@n8n/chat/components/MessageTyping.vue';
 
-const RunDataAi = defineAsyncComponent(async () => import('@/components/RunDataAi/RunDataAi.vue'));
+const RunDataAi = defineAsyncComponent(
+	async () => await import('@/components/RunDataAi/RunDataAi.vue'),
+);
 
 interface ChatMessage {
 	text: string;

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -272,7 +272,7 @@ export default defineComponent({
 			this.loading = true;
 
 			const saveWorkflowPromise = async () => {
-				return new Promise<string>((resolve) => {
+				return await new Promise<string>((resolve) => {
 					if (this.workflow.id === PLACEHOLDER_EMPTY_WORKFLOW_ID) {
 						nodeViewEventBus.emit('saveWorkflow', () => {
 							resolve(this.workflow.id);
@@ -439,7 +439,7 @@ export default defineComponent({
 				);
 
 				if (shouldSave === MODAL_CONFIRM) {
-					return this.onSave();
+					return await this.onSave();
 				}
 			}
 

--- a/packages/editor-ui/src/composables/useHistoryHelper.ts
+++ b/packages/editor-ui/src/composables/useHistoryHelper.ts
@@ -26,7 +26,7 @@ export function useHistoryHelper(activeRoute: Route) {
 	const { isCtrlKeyPressed } = useDeviceSupport();
 
 	const undo = async () =>
-		callDebounced(
+		await callDebounced(
 			async () => {
 				const command = historyStore.popUndoableToUndo();
 				if (!command) {
@@ -55,7 +55,7 @@ export function useHistoryHelper(activeRoute: Route) {
 		);
 
 	const redo = async () =>
-		callDebounced(
+		await callDebounced(
 			async () => {
 				const command = historyStore.popUndoableToRedo();
 				if (!command) {

--- a/packages/editor-ui/src/composables/useMessage.ts
+++ b/packages/editor-ui/src/composables/useMessage.ts
@@ -21,9 +21,11 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.alert(message, configOrTitle, resolvedConfig).catch(handleCancelOrClose);
+			return await MessageBox.alert(message, configOrTitle, resolvedConfig).catch(
+				handleCancelOrClose,
+			);
 		}
-		return MessageBox.alert(message, resolvedConfig).catch(handleCancelOrClose);
+		return await MessageBox.alert(message, resolvedConfig).catch(handleCancelOrClose);
 	}
 
 	async function confirm(
@@ -41,13 +43,13 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.confirm(message, configOrTitle, resolvedConfig).catch(
+			return await (MessageBox.confirm(message, configOrTitle, resolvedConfig).catch(
 				handleCancelOrClose,
-			) as unknown as Promise<MessageBoxConfirmResult>;
+			) as unknown as Promise<MessageBoxConfirmResult>);
 		}
-		return MessageBox.confirm(message, resolvedConfig).catch(
+		return await (MessageBox.confirm(message, resolvedConfig).catch(
 			handleCancelOrClose,
-		) as unknown as Promise<MessageBoxConfirmResult>;
+		) as unknown as Promise<MessageBoxConfirmResult>);
 	}
 
 	async function prompt(
@@ -62,9 +64,11 @@ export function useMessage() {
 		};
 
 		if (typeof configOrTitle === 'string') {
-			return MessageBox.prompt(message, configOrTitle, resolvedConfig).catch(handleCancelOrClose);
+			return await MessageBox.prompt(message, configOrTitle, resolvedConfig).catch(
+				handleCancelOrClose,
+			);
 		}
-		return MessageBox.prompt(message, resolvedConfig).catch(handleCancelOrClose);
+		return await MessageBox.prompt(message, resolvedConfig).catch(handleCancelOrClose);
 	}
 
 	return {

--- a/packages/editor-ui/src/mixins/workflowActivate.ts
+++ b/packages/editor-ui/src/mixins/workflowActivate.ts
@@ -33,7 +33,7 @@ export const workflowActivate = defineComponent({
 	methods: {
 		async activateCurrentWorkflow(telemetrySource?: string) {
 			const workflowId = this.workflowsStore.workflowId;
-			return this.updateWorkflowActivation(workflowId, true, telemetrySource);
+			return await this.updateWorkflowActivation(workflowId, true, telemetrySource);
 		},
 		async updateWorkflowActivation(
 			workflowId: string | undefined,

--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -904,7 +904,7 @@ export const workflowHelpers = defineComponent({
 			const currentWorkflow = id || this.$route.params.name;
 
 			if (!currentWorkflow || ['new', PLACEHOLDER_EMPTY_WORKFLOW_ID].includes(currentWorkflow)) {
-				return this.saveAsNewWorkflow({ name, tags }, redirect);
+				return await this.saveAsNewWorkflow({ name, tags }, redirect);
 			}
 
 			// Workflow exists already so update it
@@ -983,7 +983,7 @@ export const workflowHelpers = defineComponent({
 					);
 
 					if (overwrite === MODAL_CONFIRM) {
-						return this.saveCurrentWorkflow({ id, name, tags }, redirect, true);
+						return await this.saveCurrentWorkflow({ id, name, tags }, redirect, true);
 					}
 
 					return false;

--- a/packages/editor-ui/src/models/history.ts
+++ b/packages/editor-ui/src/models/history.ts
@@ -75,7 +75,7 @@ export class MoveNodeCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('nodeMove', {
 				nodeName: this.nodeName,
 				position: this.oldPosition,
@@ -102,7 +102,7 @@ export class AddNodeCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('revertAddNode', { node: this.node });
 			resolve();
 		});
@@ -126,7 +126,7 @@ export class RemoveNodeCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('revertRemoveNode', { node: this.node });
 			resolve();
 		});
@@ -156,7 +156,7 @@ export class AddConnectionCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('revertAddConnection', { connection: this.connectionData });
 			resolve();
 		});
@@ -186,7 +186,7 @@ export class RemoveConnectionCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			setTimeout(() => {
 				historyBus.emit('revertRemoveConnection', { connection: this.connectionData });
 				resolve();
@@ -220,7 +220,7 @@ export class EnableNodeToggleCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('enableNodeToggle', {
 				nodeName: this.nodeName,
 				isDisabled: this.oldState,
@@ -254,7 +254,7 @@ export class RenameNodeCommand extends Command {
 	}
 
 	async revert(): Promise<void> {
-		return new Promise<void>((resolve) => {
+		return await new Promise<void>((resolve) => {
 			historyBus.emit('revertRenameNode', {
 				currentName: this.currentName,
 				newName: this.newName,

--- a/packages/editor-ui/src/plugins/i18n/index.ts
+++ b/packages/editor-ui/src/plugins/i18n/index.ts
@@ -559,11 +559,11 @@ export async function loadLanguage(language?: string) {
 	if (!language) return;
 
 	if (i18nInstance.global.locale === language) {
-		return setLanguage(language);
+		return await setLanguage(language);
 	}
 
 	if (loadedLanguages.includes(language)) {
-		return setLanguage(language);
+		return await setLanguage(language);
 	}
 
 	const { numberFormats, ...rest } = (await import(`./locales/${language}.json`)).default;
@@ -576,7 +576,7 @@ export async function loadLanguage(language?: string) {
 
 	loadedLanguages.push(language);
 
-	return setLanguage(language);
+	return await setLanguage(language);
 }
 
 /**

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -19,46 +19,49 @@ import { middleware } from '@/rbac/middleware';
 import type { RouteConfig, RouterMiddleware } from '@/types/router';
 import { initializeCore } from '@/init';
 
-const ChangePasswordView = async () => import('./views/ChangePasswordView.vue');
-const ErrorView = async () => import('./views/ErrorView.vue');
-const ForgotMyPasswordView = async () => import('./views/ForgotMyPasswordView.vue');
-const MainHeader = async () => import('@/components/MainHeader/MainHeader.vue');
-const MainSidebar = async () => import('@/components/MainSidebar.vue');
-const NodeView = async () => import('@/views/NodeView.vue');
-const WorkflowExecutionsList = async () => import('@/components/ExecutionsView/ExecutionsList.vue');
+const ChangePasswordView = async () => await import('./views/ChangePasswordView.vue');
+const ErrorView = async () => await import('./views/ErrorView.vue');
+const ForgotMyPasswordView = async () => await import('./views/ForgotMyPasswordView.vue');
+const MainHeader = async () => await import('@/components/MainHeader/MainHeader.vue');
+const MainSidebar = async () => await import('@/components/MainSidebar.vue');
+const NodeView = async () => await import('@/views/NodeView.vue');
+const WorkflowExecutionsList = async () =>
+	await import('@/components/ExecutionsView/ExecutionsList.vue');
 const ExecutionsLandingPage = async () =>
-	import('@/components/ExecutionsView/ExecutionsLandingPage.vue');
-const ExecutionPreview = async () => import('@/components/ExecutionsView/ExecutionPreview.vue');
-const SettingsView = async () => import('./views/SettingsView.vue');
-const SettingsLdapView = async () => import('./views/SettingsLdapView.vue');
-const SettingsPersonalView = async () => import('./views/SettingsPersonalView.vue');
-const SettingsUsersView = async () => import('./views/SettingsUsersView.vue');
-const SettingsCommunityNodesView = async () => import('./views/SettingsCommunityNodesView.vue');
-const SettingsApiView = async () => import('./views/SettingsApiView.vue');
-const SettingsLogStreamingView = async () => import('./views/SettingsLogStreamingView.vue');
-const SettingsFakeDoorView = async () => import('./views/SettingsFakeDoorView.vue');
-const SetupView = async () => import('./views/SetupView.vue');
-const SigninView = async () => import('./views/SigninView.vue');
-const SignupView = async () => import('./views/SignupView.vue');
-const TemplatesCollectionView = async () => import('@/views/TemplatesCollectionView.vue');
-const TemplatesWorkflowView = async () => import('@/views/TemplatesWorkflowView.vue');
+	await import('@/components/ExecutionsView/ExecutionsLandingPage.vue');
+const ExecutionPreview = async () =>
+	await import('@/components/ExecutionsView/ExecutionPreview.vue');
+const SettingsView = async () => await import('./views/SettingsView.vue');
+const SettingsLdapView = async () => await import('./views/SettingsLdapView.vue');
+const SettingsPersonalView = async () => await import('./views/SettingsPersonalView.vue');
+const SettingsUsersView = async () => await import('./views/SettingsUsersView.vue');
+const SettingsCommunityNodesView = async () =>
+	await import('./views/SettingsCommunityNodesView.vue');
+const SettingsApiView = async () => await import('./views/SettingsApiView.vue');
+const SettingsLogStreamingView = async () => await import('./views/SettingsLogStreamingView.vue');
+const SettingsFakeDoorView = async () => await import('./views/SettingsFakeDoorView.vue');
+const SetupView = async () => await import('./views/SetupView.vue');
+const SigninView = async () => await import('./views/SigninView.vue');
+const SignupView = async () => await import('./views/SignupView.vue');
+const TemplatesCollectionView = async () => await import('@/views/TemplatesCollectionView.vue');
+const TemplatesWorkflowView = async () => await import('@/views/TemplatesWorkflowView.vue');
 const SetupWorkflowFromTemplateView = async () =>
-	import('@/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue');
-const TemplatesSearchView = async () => import('@/views/TemplatesSearchView.vue');
-const CredentialsView = async () => import('@/views/CredentialsView.vue');
-const ExecutionsView = async () => import('@/views/ExecutionsView.vue');
-const WorkflowsView = async () => import('@/views/WorkflowsView.vue');
-const VariablesView = async () => import('@/views/VariablesView.vue');
-const SettingsUsageAndPlan = async () => import('./views/SettingsUsageAndPlan.vue');
-const SettingsSso = async () => import('./views/SettingsSso.vue');
-const SignoutView = async () => import('@/views/SignoutView.vue');
-const SamlOnboarding = async () => import('@/views/SamlOnboarding.vue');
-const SettingsSourceControl = async () => import('./views/SettingsSourceControl.vue');
-const SettingsExternalSecrets = async () => import('./views/SettingsExternalSecrets.vue');
-const SettingsAuditLogs = async () => import('./views/SettingsAuditLogs.vue');
-const WorkerView = async () => import('./views/WorkerView.vue');
-const WorkflowHistory = async () => import('@/views/WorkflowHistory.vue');
-const WorkflowOnboardingView = async () => import('@/views/WorkflowOnboardingView.vue');
+	await import('@/views/SetupWorkflowFromTemplateView/SetupWorkflowFromTemplateView.vue');
+const TemplatesSearchView = async () => await import('@/views/TemplatesSearchView.vue');
+const CredentialsView = async () => await import('@/views/CredentialsView.vue');
+const ExecutionsView = async () => await import('@/views/ExecutionsView.vue');
+const WorkflowsView = async () => await import('@/views/WorkflowsView.vue');
+const VariablesView = async () => await import('@/views/VariablesView.vue');
+const SettingsUsageAndPlan = async () => await import('./views/SettingsUsageAndPlan.vue');
+const SettingsSso = async () => await import('./views/SettingsSso.vue');
+const SignoutView = async () => await import('@/views/SignoutView.vue');
+const SamlOnboarding = async () => await import('@/views/SamlOnboarding.vue');
+const SettingsSourceControl = async () => await import('./views/SettingsSourceControl.vue');
+const SettingsExternalSecrets = async () => await import('./views/SettingsExternalSecrets.vue');
+const SettingsAuditLogs = async () => await import('./views/SettingsAuditLogs.vue');
+const WorkerView = async () => await import('./views/WorkerView.vue');
+const WorkflowHistory = async () => await import('@/views/WorkflowHistory.vue');
+const WorkflowOnboardingView = async () => await import('@/views/WorkflowOnboardingView.vue');
 
 function getTemplatesRedirect(defaultRedirect: VIEWS[keyof VIEWS]) {
 	const settingsStore = useSettingsStore();

--- a/packages/editor-ui/src/stores/cloudPlan.store.ts
+++ b/packages/editor-ui/src/stores/cloudPlan.store.ts
@@ -79,7 +79,7 @@ export const useCloudPlanStore = defineStore(STORES.CLOUD_PLAN, () => {
 	};
 
 	const getAutoLoginCode = async (): Promise<{ code: string }> => {
-		return getAdminPanelLoginCode(rootStore.getRestApiContext);
+		return await getAdminPanelLoginCode(rootStore.getRestApiContext);
 	};
 
 	const getOwnerCurrentPlan = async () => {

--- a/packages/editor-ui/src/stores/credentials.store.ts
+++ b/packages/editor-ui/src/stores/credentials.store.ts
@@ -257,7 +257,7 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, {
 			id: string;
 		}): Promise<ICredentialsResponse | ICredentialsDecryptedResponse | undefined> {
 			const rootStore = useRootStore();
-			return getCredentialData(rootStore.getRestApiContext, id);
+			return await getCredentialData(rootStore.getRestApiContext, id);
 		},
 		async createNewCredential(data: ICredentialsDecrypted): Promise<ICredentialsResponse> {
 			const rootStore = useRootStore();
@@ -320,15 +320,15 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, {
 		},
 		async oAuth2Authorize(data: ICredentialsResponse): Promise<string> {
 			const rootStore = useRootStore();
-			return oAuth2CredentialAuthorize(rootStore.getRestApiContext, data);
+			return await oAuth2CredentialAuthorize(rootStore.getRestApiContext, data);
 		},
 		async oAuth1Authorize(data: ICredentialsResponse): Promise<string> {
 			const rootStore = useRootStore();
-			return oAuth1CredentialAuthorize(rootStore.getRestApiContext, data);
+			return await oAuth1CredentialAuthorize(rootStore.getRestApiContext, data);
 		},
 		async testCredential(data: ICredentialsDecrypted): Promise<INodeCredentialTestResult> {
 			const rootStore = useRootStore();
-			return testCredential(rootStore.getRestApiContext, { credentials: data });
+			return await testCredential(rootStore.getRestApiContext, { credentials: data });
 		},
 		async getNewCredentialName(params: { credentialTypeName: string }): Promise<string> {
 			try {
@@ -392,9 +392,14 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, {
 
 		async getCredentialTranslation(credentialType: string): Promise<object> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/credential-translation', {
-				credentialType,
-			});
+			return await makeRestApiRequest(
+				rootStore.getRestApiContext,
+				'GET',
+				'/credential-translation',
+				{
+					credentialType,
+				},
+			);
 		},
 	},
 });

--- a/packages/editor-ui/src/stores/externalSecrets.ee.store.ts
+++ b/packages/editor-ui/src/stores/externalSecrets.ee.store.ts
@@ -90,7 +90,7 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	}
 
 	async function testProviderConnection(id: string, data: ExternalSecretsProvider['data']) {
-		return externalSecretsApi.testExternalSecretsProviderConnection(
+		return await externalSecretsApi.testExternalSecretsProviderConnection(
 			rootStore.getRestApiContext,
 			id,
 			data,

--- a/packages/editor-ui/src/stores/logStreaming.store.ts
+++ b/packages/editor-ui/src/stores/logStreaming.store.ts
@@ -212,11 +212,11 @@ export const useLogStreamingStore = defineStore('logStreaming', {
 		},
 		async fetchEventNames(): Promise<string[]> {
 			const rootStore = useRootStore();
-			return getEventNamesFromBackend(rootStore.getRestApiContext);
+			return await getEventNamesFromBackend(rootStore.getRestApiContext);
 		},
 		async fetchDestinations(): Promise<MessageEventBusDestinationOptions[]> {
 			const rootStore = useRootStore();
-			return getDestinationsFromBackend(rootStore.getRestApiContext);
+			return await getDestinationsFromBackend(rootStore.getRestApiContext);
 		},
 		async deleteDestination(destinationId: string) {
 			const rootStore = useRootStore();

--- a/packages/editor-ui/src/stores/nodeTypes.store.ts
+++ b/packages/editor-ui/src/stores/nodeTypes.store.ts
@@ -275,13 +275,13 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, {
 			sendData: DynamicNodeParameters.OptionsRequest,
 		): Promise<INodePropertyOptions[]> {
 			const rootStore = useRootStore();
-			return getNodeParameterOptions(rootStore.getRestApiContext, sendData);
+			return await getNodeParameterOptions(rootStore.getRestApiContext, sendData);
 		},
 		async getResourceLocatorResults(
 			sendData: DynamicNodeParameters.ResourceLocatorResultsRequest,
 		): Promise<INodeListSearchResult> {
 			const rootStore = useRootStore();
-			return getResourceLocatorResults(rootStore.getRestApiContext, sendData);
+			return await getResourceLocatorResults(rootStore.getRestApiContext, sendData);
 		},
 		async getResourceMapperFields(
 			sendData: DynamicNodeParameters.ResourceMapperFieldsRequest,

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -363,23 +363,23 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 		},
 		async getLdapConfig() {
 			const rootStore = useRootStore();
-			return getLdapConfig(rootStore.getRestApiContext);
+			return await getLdapConfig(rootStore.getRestApiContext);
 		},
 		async getLdapSynchronizations(pagination: { page: number }) {
 			const rootStore = useRootStore();
-			return getLdapSynchronizations(rootStore.getRestApiContext, pagination);
+			return await getLdapSynchronizations(rootStore.getRestApiContext, pagination);
 		},
 		async testLdapConnection() {
 			const rootStore = useRootStore();
-			return testLdapConnection(rootStore.getRestApiContext);
+			return await testLdapConnection(rootStore.getRestApiContext);
 		},
 		async updateLdapConfig(ldapConfig: ILdapConfig) {
 			const rootStore = useRootStore();
-			return updateLdapConfig(rootStore.getRestApiContext, ldapConfig);
+			return await updateLdapConfig(rootStore.getRestApiContext, ldapConfig);
 		},
 		async runLdapSync(data: IDataObject) {
 			const rootStore = useRootStore();
-			return runLdapSync(rootStore.getRestApiContext, data);
+			return await runLdapSync(rootStore.getRestApiContext, data);
 		},
 		setSaveDataErrorExecution(newValue: string) {
 			this.saveDataErrorExecution = newValue;
@@ -392,7 +392,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 		},
 		async getTimezones(): Promise<IDataObject> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/options/timezones');
+			return await makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/options/timezones');
 		},
 	},
 });

--- a/packages/editor-ui/src/stores/sourceControl.store.ts
+++ b/packages/editor-ui/src/stores/sourceControl.store.ts
@@ -60,7 +60,7 @@ export const useSourceControlStore = defineStore('sourceControl', () => {
 	};
 
 	const pullWorkfolder = async (force: boolean) => {
-		return vcApi.pullWorkfolder(rootStore.getRestApiContext, { force });
+		return await vcApi.pullWorkfolder(rootStore.getRestApiContext, { force });
 	};
 
 	const setPreferences = (data: Partial<SourceControlPreferences>) => {
@@ -103,11 +103,11 @@ export const useSourceControlStore = defineStore('sourceControl', () => {
 	};
 
 	const getStatus = async () => {
-		return vcApi.getStatus(rootStore.getRestApiContext);
+		return await vcApi.getStatus(rootStore.getRestApiContext);
 	};
 
 	const getAggregatedStatus = async () => {
-		return vcApi.getAggregatedStatus(rootStore.getRestApiContext);
+		return await vcApi.getAggregatedStatus(rootStore.getRestApiContext);
 	};
 
 	return {

--- a/packages/editor-ui/src/stores/sso.store.ts
+++ b/packages/editor-ui/src/stores/sso.store.ts
@@ -53,23 +53,23 @@ export const useSSOStore = defineStore('sso', () => {
 			isDefaultAuthenticationSaml.value,
 	);
 
-	const getSSORedirectUrl = async () => ssoApi.initSSO(rootStore.getRestApiContext);
+	const getSSORedirectUrl = async () => await ssoApi.initSSO(rootStore.getRestApiContext);
 
 	const toggleLoginEnabled = async (enabled: boolean) =>
-		ssoApi.toggleSamlConfig(rootStore.getRestApiContext, { loginEnabled: enabled });
+		await ssoApi.toggleSamlConfig(rootStore.getRestApiContext, { loginEnabled: enabled });
 
-	const getSamlMetadata = async () => ssoApi.getSamlMetadata(rootStore.getRestApiContext);
+	const getSamlMetadata = async () => await ssoApi.getSamlMetadata(rootStore.getRestApiContext);
 	const getSamlConfig = async () => {
 		const samlConfig = await ssoApi.getSamlConfig(rootStore.getRestApiContext);
 		state.samlConfig = samlConfig;
 		return samlConfig;
 	};
 	const saveSamlConfig = async (config: SamlPreferences) =>
-		ssoApi.saveSamlConfig(rootStore.getRestApiContext, config);
-	const testSamlConfig = async () => ssoApi.testSamlConfig(rootStore.getRestApiContext);
+		await ssoApi.saveSamlConfig(rootStore.getRestApiContext, config);
+	const testSamlConfig = async () => await ssoApi.testSamlConfig(rootStore.getRestApiContext);
 
 	const updateUser = async (params: { firstName: string; lastName: string }) =>
-		updateCurrentUser(rootStore.getRestApiContext, {
+		await updateCurrentUser(rootStore.getRestApiContext, {
 			id: usersStore.currentUser!.id,
 			email: usersStore.currentUser!.email!,
 			...params,

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -341,7 +341,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 			const settingsStore = useSettingsStore();
 			const apiEndpoint: string = settingsStore.templatesHost;
 			const versionCli: string = settingsStore.versionCli;
-			return getWorkflowTemplate(apiEndpoint, templateId, { 'n8n-version': versionCli });
+			return await getWorkflowTemplate(apiEndpoint, templateId, { 'n8n-version': versionCli });
 		},
 
 		async getFixedWorkflowTemplate(templateId: string): Promise<IWorkflowTemplate | undefined> {

--- a/packages/editor-ui/src/stores/ui.store.ts
+++ b/packages/editor-ui/src/stores/ui.store.ts
@@ -473,21 +473,21 @@ export const useUIStore = defineStore(STORES.UI, {
 			const instanceId = rootStore.instanceId;
 			// TODO: current USER
 			const currentUser = {} as IUser;
-			return fetchNextOnboardingPrompt(instanceId, currentUser);
+			return await fetchNextOnboardingPrompt(instanceId, currentUser);
 		},
 		async applyForOnboardingCall(email: string): Promise<string> {
 			const rootStore = useRootStore();
 			const instanceId = rootStore.instanceId;
 			// TODO: current USER
 			const currentUser = {} as IUser;
-			return applyForOnboardingCall(instanceId, currentUser, email);
+			return await applyForOnboardingCall(instanceId, currentUser, email);
 		},
 		async submitContactEmail(email: string, agree: boolean): Promise<string> {
 			const rootStore = useRootStore();
 			const instanceId = rootStore.instanceId;
 			// TODO: current USER
 			const currentUser = {} as IUser;
-			return submitEmailOnSignup(instanceId, currentUser, email || currentUser.email, agree);
+			return await submitEmailOnSignup(instanceId, currentUser, email || currentUser.email, agree);
 		},
 		openCommunityPackageUninstallConfirmModal(packageName: string) {
 			this.setActiveId(COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, packageName);
@@ -549,7 +549,7 @@ export const useUIStore = defineStore(STORES.UI, {
 		},
 		async getCurlToJson(curlCommand: string): Promise<CurlToJSONResponse> {
 			const rootStore = useRootStore();
-			return getCurlToJson(rootStore.getRestApiContext, curlCommand);
+			return await getCurlToJson(rootStore.getRestApiContext, curlCommand);
 		},
 		async goToUpgrade(
 			source: CloudUpdateLinkSourceType,

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -215,7 +215,7 @@ export const useUsersStore = defineStore(STORES.USERS, {
 			inviterId: string;
 		}): Promise<{ inviter: { firstName: string; lastName: string } }> {
 			const rootStore = useRootStore();
-			return validateSignupToken(rootStore.getRestApiContext, params);
+			return await validateSignupToken(rootStore.getRestApiContext, params);
 		},
 		async acceptInvitation(params: {
 			inviteeId: string;
@@ -326,7 +326,7 @@ export const useUsersStore = defineStore(STORES.USERS, {
 		},
 		async getUserPasswordResetLink(params: { id: string }): Promise<{ link: string }> {
 			const rootStore = useRootStore();
-			return getPasswordResetLink(rootStore.getRestApiContext, params);
+			return await getPasswordResetLink(rootStore.getRestApiContext, params);
 		},
 		async submitPersonalizationSurvey(results: IPersonalizationLatestVersion): Promise<void> {
 			const rootStore = useRootStore();
@@ -344,11 +344,11 @@ export const useUsersStore = defineStore(STORES.USERS, {
 		},
 		async getMfaQR(): Promise<{ qrCode: string; secret: string; recoveryCodes: string[] }> {
 			const rootStore = useRootStore();
-			return getMfaQR(rootStore.getRestApiContext);
+			return await getMfaQR(rootStore.getRestApiContext);
 		},
 		async verifyMfaToken(data: { token: string }): Promise<void> {
 			const rootStore = useRootStore();
-			return verifyMfaToken(rootStore.getRestApiContext, data);
+			return await verifyMfaToken(rootStore.getRestApiContext, data);
 		},
 		async enableMfa(data: { token: string }) {
 			const rootStore = useRootStore();

--- a/packages/editor-ui/src/stores/workflowHistory.store.ts
+++ b/packages/editor-ui/src/stores/workflowHistory.store.ts
@@ -30,13 +30,13 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 		workflowId: string,
 		queryParams: WorkflowHistoryRequestParams,
 	): Promise<WorkflowHistory[]> =>
-		whApi.getWorkflowHistory(rootStore.getRestApiContext, workflowId, queryParams);
+		await whApi.getWorkflowHistory(rootStore.getRestApiContext, workflowId, queryParams);
 
 	const getWorkflowVersion = async (
 		workflowId: string,
 		versionId: string,
 	): Promise<WorkflowVersion> =>
-		whApi.getWorkflowVersion(rootStore.getRestApiContext, workflowId, versionId);
+		await whApi.getWorkflowVersion(rootStore.getRestApiContext, workflowId, versionId);
 
 	const downloadVersion = async (
 		workflowId: string,
@@ -74,7 +74,7 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 			connections,
 			name: newWorkflow.name,
 		};
-		return workflowsStore.createNewWorkflow(newWorkflowData);
+		return await workflowsStore.createNewWorkflow(newWorkflowData);
 	};
 
 	const restoreWorkflow = async (
@@ -90,13 +90,15 @@ export const useWorkflowHistoryStore = defineStore('workflowHistory', () => {
 			updateData.active = false;
 		}
 
-		return workflowsStore.updateWorkflow(workflowId, updateData, true).catch(async (error) => {
-			if (error.httpStatusCode === 400 && error.message.includes('can not be activated')) {
-				return workflowsStore.fetchWorkflow(workflowId);
-			} else {
-				throw new Error(error);
-			}
-		});
+		return await workflowsStore
+			.updateWorkflow(workflowId, updateData, true)
+			.catch(async (error) => {
+				if (error.httpStatusCode === 400 && error.message.includes('can not be activated')) {
+					return await workflowsStore.fetchWorkflow(workflowId);
+				} else {
+					throw new Error(error);
+				}
+			});
 	};
 
 	return {

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -366,14 +366,14 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 		// Returns a workflow from a given URL
 		async getWorkflowFromUrl(url: string): Promise<IWorkflowDb> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/workflows/from-url', {
+			return await makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/workflows/from-url', {
 				url,
 			});
 		},
 
 		async getActivationError(id: string): Promise<string | undefined> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'GET',
 				`/active-workflows/error/${id}`,
@@ -1237,7 +1237,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				};
 			}
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'POST',
 				`/executions/${id}/retry`,
@@ -1248,7 +1248,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 		// Deletes executions
 		async deleteExecutions(sendData: IExecutionDeleteFilter): Promise<void> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'POST',
 				'/executions/delete',
@@ -1273,7 +1273,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				};
 			}
 			const rootStore = useRootStore();
-			return makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/executions', sendData);
+			return await makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/executions', sendData);
 		},
 
 		async getCurrentExecutions(filter: IDataObject): Promise<IExecutionsCurrentSummaryExtended[]> {
@@ -1284,7 +1284,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				};
 			}
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'GET',
 				'/executions-current',
@@ -1308,7 +1308,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			sendData.active = false;
 
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'POST',
 				'/workflows',
@@ -1323,7 +1323,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			forceSave = false,
 		): Promise<IWorkflowDb> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'PATCH',
 				`/workflows/${id}${forceSave ? '?forceSave=true' : ''}`,
@@ -1333,7 +1333,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 
 		async runWorkflow(startRunData: IStartRunData): Promise<IExecutionPushResponse> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'POST',
 				'/workflows/run',
@@ -1343,7 +1343,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 
 		async removeTestWebhook(workflowId: string): Promise<boolean> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'DELETE',
 				`/test-webhook/${workflowId}`,
@@ -1352,7 +1352,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 
 		async stopCurrentExecution(executionId: string): Promise<IExecutionsStopData> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(
+			return await makeRestApiRequest(
 				rootStore.getRestApiContext,
 				'POST',
 				`/executions-current/${executionId}/stop`,
@@ -1384,7 +1384,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 
 		async fetchExecutionDataById(executionId: string): Promise<IExecutionResponse | null> {
 			const rootStore = useRootStore();
-			return getExecutionData(rootStore.getRestApiContext, executionId);
+			return await getExecutionData(rootStore.getRestApiContext, executionId);
 		},
 
 		deleteExecution(execution: IExecutionsSummary): void {
@@ -1402,7 +1402,11 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 		// Returns all the available timezones
 		async getExecutionEvents(id: string): Promise<IAbstractEventMessage[]> {
 			const rootStore = useRootStore();
-			return makeRestApiRequest(rootStore.getRestApiContext, 'GET', '/eventbus/execution/' + id);
+			return await makeRestApiRequest(
+				rootStore.getRestApiContext,
+				'GET',
+				'/eventbus/execution/' + id,
+			);
 		},
 		// Binary data
 		getBinaryUrl(

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -139,7 +139,7 @@ export async function get(
 	params?: IDataObject,
 	headers?: IDataObject,
 ) {
-	return request({ method: 'GET', baseURL, endpoint, headers, data: params });
+	return await request({ method: 'GET', baseURL, endpoint, headers, data: params });
 }
 
 export async function post(
@@ -148,7 +148,7 @@ export async function post(
 	params?: IDataObject,
 	headers?: IDataObject,
 ) {
-	return request({ method: 'POST', baseURL, endpoint, headers, data: params });
+	return await request({ method: 'POST', baseURL, endpoint, headers, data: params });
 }
 
 /**

--- a/packages/editor-ui/src/utils/htmlUtils.ts
+++ b/packages/editor-ui/src/utils/htmlUtils.ts
@@ -57,7 +57,7 @@ export const capitalizeFirstLetter = (text: string): string => {
 };
 
 export const getBannerRowHeight = async (): Promise<number> => {
-	return new Promise((resolve) => {
+	return await new Promise((resolve) => {
 		setTimeout(() => {
 			resolve(document.getElementById('banners')?.clientHeight ?? 0);
 		}, 0);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -386,11 +386,15 @@ interface AddNodeOptions {
 	name?: string;
 }
 
-const NodeCreation = defineAsyncComponent(async () => import('@/components/Node/NodeCreation.vue'));
-const CanvasControls = defineAsyncComponent(async () => import('@/components/CanvasControls.vue'));
+const NodeCreation = defineAsyncComponent(
+	async () => await import('@/components/Node/NodeCreation.vue'),
+);
+const CanvasControls = defineAsyncComponent(
+	async () => await import('@/components/CanvasControls.vue'),
+);
 const SetupWorkflowCredentialsButton = defineAsyncComponent(
 	async () =>
-		import('@/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue'),
+		await import('@/components/SetupWorkflowCredentialsButton/SetupWorkflowCredentialsButton.vue'),
 );
 
 export default defineComponent({
@@ -2030,7 +2034,7 @@ export default defineComponent({
 					}
 				}
 
-				return this.importWorkflowData(workflowData!, 'paste', false);
+				return await this.importWorkflowData(workflowData!, 'paste', false);
 			}
 		},
 

--- a/packages/editor-ui/src/views/WorkflowHistory.vue
+++ b/packages/editor-ui/src/views/WorkflowHistory.vue
@@ -131,7 +131,7 @@ const openRestorationModal = async (
 	isWorkflowActivated: boolean,
 	formattedCreatedAt: string,
 ): Promise<WorkflowHistoryVersionRestoreModalActions> => {
-	return new Promise((resolve, reject) => {
+	return await new Promise((resolve, reject) => {
 		const buttons = [
 			{
 				text: i18n.baseText('workflowHistory.action.restore.modal.button.cancel'),


### PR DESCRIPTION

## Summary

Frontend follow-up of #8363

Returning a promise from function without awaiting it causes the function to be dropped from the stacktrace. This makes debugging harder. So this PR changes TS ESLint rule '@typescript-eslint/return-await' from its default value to 'always', so it is required to await any promises returned from async functions.


## Related tickets and issues

https://n8nio.slack.com/archives/C03MZF137FV/p1705496007084329


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
