### PR TITLE
fix: Force posthog recording to be disabled outside cloud

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1143,12 +1143,6 @@ export const schema = {
 					default: 'https://ph.n8n.io',
 					env: 'N8N_DIAGNOSTICS_POSTHOG_API_HOST',
 				},
-				disableSessionRecording: {
-					doc: 'Disable posthog session recording',
-					format: Boolean,
-					default: true,
-					env: 'N8N_DIAGNOSTICS_POSTHOG_DISABLE_RECORDING',
-				},
 			},
 			sentry: {
 				dsn: {

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -115,9 +115,7 @@ export class FrontendService {
 				apiHost: config.getEnv('diagnostics.config.posthog.apiHost'),
 				apiKey: config.getEnv('diagnostics.config.posthog.apiKey'),
 				autocapture: false,
-				disableSessionRecording: config.getEnv(
-					'diagnostics.config.posthog.disableSessionRecording',
-				),
+				disableSessionRecording: config.getEnv('deployment.type') !== 'cloud',
 				debug: config.getEnv('logs.level') === 'debug',
 			},
 			personalizationSurveyEnabled:


### PR DESCRIPTION

## Summary

The recordings are not enabled by default, but env variable enables opt-in. This changes the logic that opt-in requires also being a cloud deployment.


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1659/self-hosted-data-bleeding-into-posthog

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
