### PR TITLE
fix: Fix issue preventing secrets with a - in the path from being imported

### DIFF
--- a/packages/cli/src/ExternalSecrets/constants.ts
+++ b/packages/cli/src/ExternalSecrets/constants.ts
@@ -2,4 +2,4 @@ export const EXTERNAL_SECRETS_DB_KEY = 'feature.externalSecrets';
 export const EXTERNAL_SECRETS_INITIAL_BACKOFF = 10 * 1000;
 export const EXTERNAL_SECRETS_MAX_BACKOFF = 5 * 60 * 1000;
 
-export const EXTERNAL_SECRETS_NAME_REGEX = /^[a-zA-Z0-9\_\/]+$/;
+export const EXTERNAL_SECRETS_NAME_REGEX = /^[a-zA-Z0-9\-\_\/]+$/;


### PR DESCRIPTION
## Summary
When I added the secrets change to add support for `/` and `-` I was working on 2 branches and forgot to add the `\-` for the regex so we include it.