### PR TITLE
feat: Add AND mask to hasScope

### DIFF
--- a/packages/@n8n/permissions/src/hasScope.ts
+++ b/packages/@n8n/permissions/src/hasScope.ts
@@ -1,25 +1,41 @@
-import type { Scope, ScopeLevels, GlobalScopes, ScopeOptions } from './types';
+import type { Scope, ScopeLevels, GlobalScopes, ScopeOptions, MaskLevels } from './types';
 
 export function hasScope(
 	scope: Scope | Scope[],
 	userScopes: GlobalScopes,
+	masks?: MaskLevels,
 	options?: ScopeOptions,
 ): boolean;
 export function hasScope(
 	scope: Scope | Scope[],
 	userScopes: ScopeLevels,
+	masks?: MaskLevels,
 	options?: ScopeOptions,
 ): boolean;
 export function hasScope(
 	scope: Scope | Scope[],
 	userScopes: GlobalScopes | ScopeLevels,
+	masks?: MaskLevels,
 	options: ScopeOptions = { mode: 'oneOf' },
 ): boolean {
 	if (!Array.isArray(scope)) {
 		scope = [scope];
 	}
 
-	const userScopeSet = new Set(Object.values(userScopes).flat());
+	const maskedScopes: GlobalScopes | ScopeLevels = Object.fromEntries(
+		Object.entries(userScopes).map((e) => [e[0], [...e[1]]]),
+	) as GlobalScopes | ScopeLevels;
+
+	if (masks?.sharing) {
+		if ('project' in maskedScopes) {
+			maskedScopes.project = maskedScopes.project.filter((v) => masks.sharing.includes(v));
+		}
+		if ('resource' in maskedScopes) {
+			maskedScopes.resource = maskedScopes.resource.filter((v) => masks.sharing.includes(v));
+		}
+	}
+
+	const userScopeSet = new Set(Object.values(maskedScopes).flat());
 
 	if (options.mode === 'allOf') {
 		return !!scope.length && scope.every((s) => userScopeSet.has(s));

--- a/packages/@n8n/permissions/src/types.ts
+++ b/packages/@n8n/permissions/src/types.ts
@@ -81,5 +81,10 @@ export type ProjectScopes = GetScopeLevel<'project'>;
 export type ResourceScopes = GetScopeLevel<'resource'>;
 export type ScopeLevels = GlobalScopes & (ProjectScopes | (ProjectScopes & ResourceScopes));
 
+export type MaskLevel = 'sharing';
+export type GetMaskLevel<T extends MaskLevel> = Record<T, Scope[]>;
+export type SharingMasks = GetMaskLevel<'sharing'>;
+export type MaskLevels = SharingMasks;
+
 export type ScopeMode = 'oneOf' | 'allOf';
 export type ScopeOptions = { mode: ScopeMode };

--- a/packages/@n8n/permissions/test/hasScope.test.ts
+++ b/packages/@n8n/permissions/test/hasScope.test.ts
@@ -33,6 +33,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'oneOf' },
 			),
 		).toBe(true);
@@ -43,6 +44,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
 			),
 		).toBe(true);
@@ -53,6 +55,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'oneOf' },
 			),
 		).toBe(false);
@@ -63,6 +66,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
 			),
 		).toBe(false);
@@ -95,6 +99,7 @@ describe('hasScope', () => {
 				{
 					global: ownerPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
 			),
 		).toBe(true);
@@ -105,6 +110,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
 			),
 		).toBe(false);
@@ -115,6 +121,7 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
 			),
 		).toBe(false);
@@ -125,7 +132,126 @@ describe('hasScope', () => {
 				{
 					global: memberPermissions,
 				},
+				undefined,
 				{ mode: 'allOf' },
+			),
+		).toBe(false);
+	});
+});
+
+describe('hasScope masking', () => {
+	test('should return true without mask when scopes present', () => {
+		expect(
+			hasScope('workflow:read', {
+				global: ['user:list'],
+				project: ['workflow:read'],
+				resource: [],
+			}),
+		).toBe(true);
+	});
+
+	test('should return false without mask when scopes are not present', () => {
+		expect(
+			hasScope('workflow:update', {
+				global: ['user:list'],
+				project: ['workflow:read'],
+				resource: [],
+			}),
+		).toBe(false);
+	});
+
+	test('should return false when mask does not include scope but scopes list does contain required scope', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['user:list'],
+					project: ['workflow:read', 'workflow:update'],
+					resource: [],
+				},
+				{
+					sharing: ['workflow:read'],
+				},
+			),
+		).toBe(false);
+	});
+
+	test('should return true when mask does include scope and scope list includes scope', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['user:list'],
+					project: ['workflow:read', 'workflow:update'],
+					resource: [],
+				},
+				{
+					sharing: ['workflow:read', 'workflow:update'],
+				},
+			),
+		).toBe(true);
+	});
+
+	test('should return true when mask does include scope and scopes list includes scope on multiple levels', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['user:list'],
+					project: ['workflow:read', 'workflow:update'],
+					resource: ['workflow:update'],
+				},
+				{
+					sharing: ['workflow:read', 'workflow:update'],
+				},
+			),
+		).toBe(true);
+	});
+
+	test('should not mask out global scopes', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['workflow:read', 'workflow:update'],
+					project: ['workflow:read'],
+					resource: ['workflow:read'],
+				},
+				{
+					sharing: ['workflow:read'],
+				},
+			),
+		).toBe(true);
+	});
+
+	test('should return false when scope is not in mask or scope list', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['workflow:read'],
+					project: ['workflow:read'],
+					resource: ['workflow:read'],
+				},
+				{
+					sharing: ['workflow:read'],
+				},
+			),
+		).toBe(false);
+	});
+
+	test('should return false when scope is in mask or not scope list', () => {
+		expect(
+			hasScope(
+				'workflow:update',
+				{
+					global: ['workflow:read'],
+					project: ['workflow:read'],
+					resource: ['workflow:read'],
+				},
+				{
+					sharing: ['workflow:read', 'workflow:update'],
+				},
 			),
 		).toBe(false);
 	});

--- a/packages/cli/src/databases/entities/User.ts
+++ b/packages/cli/src/databases/entities/User.ts
@@ -140,6 +140,7 @@ export class User extends WithTimestamps implements IUser {
 			{
 				global: this.globalScopes,
 			},
+			undefined,
 			scopeOptions,
 		);
 	}

--- a/packages/editor-ui/src/stores/__tests__/rbac.store.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/rbac.store.test.ts
@@ -87,6 +87,7 @@ describe('RBAC store', () => {
 					resource: [],
 				},
 				undefined,
+				undefined,
 			);
 		});
 
@@ -105,6 +106,7 @@ describe('RBAC store', () => {
 					resource: [],
 				},
 				undefined,
+				undefined,
 			);
 		});
 
@@ -122,6 +124,7 @@ describe('RBAC store', () => {
 					project: [],
 					resource: expect.arrayContaining([newScope]),
 				},
+				undefined,
 				undefined,
 			);
 		});
@@ -145,6 +148,7 @@ describe('RBAC store', () => {
 					project: expect.arrayContaining([newScope]),
 					resource: expect.arrayContaining([newScope]),
 				},
+				undefined,
 				undefined,
 			);
 		});

--- a/packages/editor-ui/src/stores/rbac.store.ts
+++ b/packages/editor-ui/src/stores/rbac.store.ts
@@ -92,6 +92,7 @@ export const useRBACStore = defineStore(STORES.RBAC, () => {
 						? scopesByResourceId.value[context.resourceType][context.resourceId]
 						: [],
 			},
+			undefined,
 			options,
 		);
 	}


### PR DESCRIPTION
## Summary

Add an AND mask to the `hasScope` function for sharing. This will be used in later RBAC P2 work.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- ~~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~~
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 