### PR TITLE
fix(core): Errors are returned on the success branch if error item has other keys in addition to 'error'

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -1114,6 +1114,12 @@ export class WorkflowExecute {
 												item.error = undefined;
 											} else if (item.json.error && Object.keys(item.json).length === 1) {
 												errorData = item.json.error;
+											} else if (
+												item.json.error &&
+												item.json.message &&
+												Object.keys(item.json).length === 2
+											) {
+												errorData = item.json.error;
 											}
 
 											if (errorData) {


### PR DESCRIPTION
## Summary
Errors are returned on the success branch if error item has other keys in addition to 'error'



## Related tickets and issues
https://community.n8n.io/t/mysql-error-shows-as-success/34589
https://linear.app/n8n/issue/NODE-1032/errors-are-returned-on-the-success-branch-if-error-item-has-other-keys