### PR TITLE
feat(Telegram Trigger Node): Verify Webhook requests

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -235,3 +235,9 @@ export function getImageBySize(photos: IDataObject[], size: string): IDataObject
 export function getPropertyName(operation: string) {
 	return operation.replace('send', '').toLowerCase();
 }
+
+export function getSecretToken(this: IHookFunctions | IWebhookFunctions) {
+	// Only characters A-Z, a-z, 0-9, _ and - are allowed.
+	const secret_token = `${this.getWorkflow().id}_${this.getNode().id}`;
+	return secret_token.replace(/[^a-zA-Z0-9\_\-]+/g, '');
+}

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -17,7 +17,8 @@ export class TelegramTrigger implements INodeType {
 		name: 'telegramTrigger',
 		icon: 'file:telegram.svg',
 		group: ['trigger'],
-		version: 1,
+		version: [1, 1.1],
+		defaultVersion: 1.1,
 		subtitle: '=Updates: {{$parameter["updates"].join(", ")}}',
 		description: 'Starts the workflow on a Telegram update',
 		defaults: {
@@ -228,13 +229,16 @@ export class TelegramTrigger implements INodeType {
 		const bodyData = this.getBodyData() as IEvent;
 		const headerData = this.getHeaderData();
 
-		const secret = getSecretToken.call(this);
-		if (secret !== headerData['x-telegram-bot-api-secret-token']) {
-			const res = this.getResponseObject();
-			res.status(403).json({ message: 'Provided secret is not valid' });
-			return {
-				noWebhookResponse: true,
-			};
+		const nodeVersion = this.getNode().typeVersion;
+		if (nodeVersion > 1) {
+			const secret = getSecretToken.call(this);
+			if (secret !== headerData['x-telegram-bot-api-secret-token']) {
+				const res = this.getResponseObject();
+				res.status(403).json({ message: 'Provided secret is not valid' });
+				return {
+					noWebhookResponse: true,
+				};
+			}
 		}
 
 		const additionalFields = this.getNodeParameter('additionalFields') as IDataObject;

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -7,7 +7,7 @@ import type {
 	IWebhookResponseData,
 } from 'n8n-workflow';
 
-import { apiRequest, getImageBySize } from './GenericFunctions';
+import { apiRequest, getImageBySize, getSecretToken } from './GenericFunctions';
 
 import type { IEvent } from './IEvent';
 
@@ -188,9 +188,12 @@ export class TelegramTrigger implements INodeType {
 
 				const endpoint = 'setWebhook';
 
+				const secret_token = getSecretToken.call(this);
+
 				const body = {
 					url: webhookUrl,
 					allowed_updates: allowedUpdates,
+					secret_token,
 				};
 
 				await apiRequest.call(this, 'POST', endpoint, body);
@@ -216,6 +219,14 @@ export class TelegramTrigger implements INodeType {
 		const credentials = await this.getCredentials('telegramApi');
 
 		const bodyData = this.getBodyData() as IEvent;
+		const headerData = this.getHeaderData();
+		console.log(headerData);
+
+		const secret = getSecretToken.call(this);
+		if (secret !== headerData['x-telegram-bot-api-secret-token']) {
+			console.log('secret INVALID:', secret, headerData['x-telegram-bot-api-secret-token']);
+			return {};
+		}
 
 		const additionalFields = this.getNodeParameter('additionalFields') as IDataObject;
 

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -220,12 +220,14 @@ export class TelegramTrigger implements INodeType {
 
 		const bodyData = this.getBodyData() as IEvent;
 		const headerData = this.getHeaderData();
-		console.log(headerData);
 
 		const secret = getSecretToken.call(this);
 		if (secret !== headerData['x-telegram-bot-api-secret-token']) {
-			console.log('secret INVALID:', secret, headerData['x-telegram-bot-api-secret-token']);
-			return {};
+			const res = this.getResponseObject();
+			res.status(403).json({ message: 'Provided secret is not valid' });
+			return {
+				noWebhookResponse: true,
+			};
 		}
 
 		const additionalFields = this.getNodeParameter('additionalFields') as IDataObject;

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -44,7 +44,7 @@ export class TelegramTrigger implements INodeType {
 			{
 				displayName:
 					'Due to Telegram API limitations, you can use just one Telegram trigger for each bot at a time',
-				name: 'facebookLeadAdsNotice',
+				name: 'telegramTriggerNotice',
 				type: 'notice',
 				default: '',
 			},

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -41,6 +41,13 @@ export class TelegramTrigger implements INodeType {
 		],
 		properties: [
 			{
+				displayName:
+					'Due to Telegram API limitations, you can use just one Telegram trigger for each bot at a time',
+				name: 'facebookLeadAdsNotice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Trigger On',
 				name: 'updates',
 				type: 'multiOptions',


### PR DESCRIPTION
## Summary
To make sure webhook requests are actually coming from Telegram we can use the secret_token parameter from [setWebhook](https://core.telegram.org/bots/api#setwebhook) for validation.


## Related tickets and issues
[NODE-1006](https://linear.app/n8n/issue/NODE-1006/telegram-trigger-missing-webhook-verification)

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 