### PR TITLE
fix(editor): Enable ctrl/cmd click in workflow editor header

### DIFF
--- a/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
+++ b/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
@@ -10,7 +10,7 @@
 			:active="modelValue === option.value"
 			:size="size"
 			:disabled="disabled || option.disabled"
-			@click.prevent.stop="onClick(option)"
+			@click.prevent.stop="onClick(option, $event)"
 		/>
 	</div>
 </template>
@@ -47,12 +47,13 @@ export default defineComponent({
 			type: Boolean,
 		},
 	},
+	emits: ['update:modelValue'],
 	methods: {
-		onClick(option: { label: string; value: string; disabled?: boolean }) {
+		onClick(option: { label: string; value: string; disabled?: boolean }, event: MouseEvent) {
 			if (this.disabled || option.disabled) {
 				return;
 			}
-			this.$emit('update:modelValue', option.value);
+			this.$emit('update:modelValue', option.value, event);
 		},
 	},
 });


### PR DESCRIPTION
## Summary

Follow-up to #8385

Open new tab if user cmd/ctrl clicks workflow editor header tabs.

https://github.com/n8n-io/n8n/assets/10324676/78463339-4647-4f89-9047-4417f0bac5bb


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1723/fix-wf-executions-to-work-with-cmdclick-and-right-click


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
