### PR TITLE
fix(Microsoft SQL Node): Prevent MSSQL max parameters error by chunking

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/test/utils.test.ts
@@ -4,6 +4,7 @@ import {
 	configurePool,
 	deleteOperation,
 	insertOperation,
+	mssqlChunk,
 	updateOperation,
 } from '../GenericFunctions';
 
@@ -141,5 +142,16 @@ describe('MSSQL tests', () => {
 		expect(querySpy).toHaveBeenCalledTimes(1);
 		expect(querySpy).toHaveBeenCalledWith('DELETE FROM [users] WHERE [id] IN (@v0);');
 		assertParameters({ v0: 2 });
+	});
+
+	describe('mssqlChunk', () => {
+		it('should chunk insert values correctly', () => {
+			const chunks = mssqlChunk(
+				new Array(3000)
+					.fill(null)
+					.map((_, index) => ({ id: index, name: 'John Doe', verified: true })),
+			);
+			expect(chunks.map((chunk) => chunk.length)).toEqual([699, 699, 699, 699, 204]);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

With this fix it is possible to insert large datasets in the Microsoft SQL node:

<img width="937" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/a4ceacd7-e9bc-4cf2-a852-89454a39fb87">

## Related tickets and issues
https://community.n8n.io/t/microsoft-sql-node-insert-problem-bug/32509
https://linear.app/n8n/issue/NODE-909/mssql-too-many-parameters

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 