### PR TITLE
fix(Summarization Chain Node): 'Final Prompt to Combine' and 'Individual Summary Prompt' options

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -211,10 +211,10 @@ export class ChainSummarizationV2 implements INodeType {
 											],
 										},
 										{
-											displayName: 'Final Prompt to Combine',
+											displayName: 'Individual Summary Prompt',
 											name: 'combineMapPrompt',
 											type: 'string',
-											hint: 'The prompt to combine individual summaries',
+											hint: 'The prompt to summarize an individual document (or chunk)',
 											displayOptions: {
 												hide: {
 													'/options.summarizationMethodAndPrompts.values.summarizationMethod': [
@@ -229,11 +229,11 @@ export class ChainSummarizationV2 implements INodeType {
 											},
 										},
 										{
-											displayName: 'Individual Summary Prompt',
+											displayName: 'Final Prompt to Combine',
 											name: 'prompt',
 											type: 'string',
 											default: DEFAULT_PROMPT_TEMPLATE,
-											hint: 'The prompt to summarize an individual document (or chunk)',
+											hint: 'The prompt to combine individual summaries',
 											displayOptions: {
 												hide: {
 													'/options.summarizationMethodAndPrompts.values.summarizationMethod': [


### PR DESCRIPTION
## Summary
Inverts the display names for Final Prompt to Combine and Individual Summary Prompt parameters in the the Summarization Chain V2 node.
This is how it was before the PR:
![Screenshot from 2024-01-18 14-21-05](https://github.com/n8n-io/n8n/assets/107938570/d7b25000-8ffc-4305-bcaa-6f0758498f0f)


This is how it is after the PR:
![Screenshot from 2024-01-18 14-43-05](https://github.com/n8n-io/n8n/assets/107938570/e841a37e-f064-423b-af2b-42c8c3ea989c)

## Related tickets and issues
This is a question created regarding this issue:
https://community.n8n.io/t/summarization-chain-final-prompt-and-individual-summary-descriptions-are-inverted/35511



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 