### PR TITLE
fix(core): Missing pairedItem fixes

### DIFF
--- a/packages/nodes-base/nodes/Airtable/v1/AirtableV1.node.ts
+++ b/packages/nodes-base/nodes/Airtable/v1/AirtableV1.node.ts
@@ -718,10 +718,12 @@ export class AirtableV1 implements INodeType {
 					const downloadFieldNames = (
 						this.getNodeParameter('downloadFieldNames', 0) as string
 					).split(',');
+					const pairedItem = generatePairedItemData(items.length);
 					const data = await downloadRecordAttachments.call(
 						this,
 						responseData.records as IRecord[],
 						downloadFieldNames,
+						pairedItem,
 					);
 					return [data];
 				}

--- a/packages/nodes-base/nodes/Airtable/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Airtable/v1/GenericFunctions.ts
@@ -7,6 +7,7 @@ import type {
 	IPollFunctions,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
+	IPairedItemData,
 } from 'n8n-workflow';
 
 interface IAttachment {
@@ -100,10 +101,14 @@ export async function downloadRecordAttachments(
 	this: IExecuteFunctions | IPollFunctions,
 	records: IRecord[],
 	fieldNames: string[],
+	pairedItem?: IPairedItemData[],
 ): Promise<INodeExecutionData[]> {
 	const elements: INodeExecutionData[] = [];
 	for (const record of records) {
 		const element: INodeExecutionData = { json: {}, binary: {} };
+		if (pairedItem) {
+			element.pairedItem = pairedItem;
+		}
 		element.json = record as unknown as IDataObject;
 		for (const fieldName of fieldNames) {
 			if (record.fields[fieldName] !== undefined) {

--- a/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/record/search.operation.ts
@@ -194,10 +194,12 @@ export async function execute(
 		returnData = responseData.records as INodeExecutionData[];
 
 		if (options.downloadFields) {
+			const pairedItem = generatePairedItemData(items.length);
 			return await downloadRecordAttachments.call(
 				this,
 				responseData.records as IRecord[],
 				options.downloadFields as string[],
+				pairedItem,
 			);
 		}
 

--- a/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
@@ -7,6 +7,7 @@ import type {
 	IPollFunctions,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
+	IPairedItemData,
 } from 'n8n-workflow';
 import { ApplicationError } from 'n8n-workflow';
 import type { IAttachment, IRecord } from '../helpers/interfaces';
@@ -87,6 +88,7 @@ export async function downloadRecordAttachments(
 	this: IExecuteFunctions | IPollFunctions,
 	records: IRecord[],
 	fieldNames: string | string[],
+	pairedItem?: IPairedItemData[],
 ): Promise<INodeExecutionData[]> {
 	if (typeof fieldNames === 'string') {
 		fieldNames = fieldNames.split(',').map((item) => item.trim());
@@ -99,6 +101,9 @@ export async function downloadRecordAttachments(
 	const elements: INodeExecutionData[] = [];
 	for (const record of records) {
 		const element: INodeExecutionData = { json: {}, binary: {} };
+		if (pairedItem) {
+			element.pairedItem = pairedItem;
+		}
 		element.json = flattenOutput(record as unknown as IDataObject);
 		for (const fieldName of fieldNames) {
 			if (record.fields[fieldName] !== undefined) {

--- a/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
+++ b/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
@@ -13,6 +13,7 @@ import type {
 import { deepCopy } from 'n8n-workflow';
 
 import { oldVersionNotice } from '@utils/descriptions';
+import { generatePairedItemData } from '../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Merge',
@@ -477,7 +478,8 @@ export class MergeV1 implements INodeType {
 				returnData.push.apply(returnData, this.getInputData(1));
 			}
 		} else if (mode === 'wait') {
-			returnData.push({ json: {} });
+			const pairedItem = generatePairedItemData(this.getInputData(0).length);
+			returnData.push({ json: {}, pairedItem });
 		}
 
 		return [returnData];

--- a/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
+++ b/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
@@ -29,6 +29,7 @@ import {
 } from './GenericFunctions';
 
 import { optionsDescription } from './OptionsDescription';
+import { generatePairedItemData } from '../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Merge',
@@ -599,7 +600,8 @@ export class MergeV2 implements INodeType {
 					returnData.push.apply(returnData, this.getInputData(1));
 				}
 				if (output === 'empty') {
-					returnData.push({ json: {} });
+					const itemData = generatePairedItemData(this.getInputData(0).length);
+					returnData.push({ json: {}, pairedItem: itemData });
 				}
 			}
 		}

--- a/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NocoDB/GenericFunctions.ts
@@ -7,6 +7,7 @@ import type {
 	IHookFunctions,
 	ILoadOptionsFunctions,
 	INodeExecutionData,
+	IPairedItemData,
 	IPollFunctions,
 } from 'n8n-workflow';
 import { jsonParse, NodeOperationError } from 'n8n-workflow';
@@ -106,11 +107,15 @@ export async function downloadRecordAttachments(
 	this: IExecuteFunctions | IPollFunctions,
 	records: IDataObject[],
 	fieldNames: string[],
+	pairedItem?: IPairedItemData[],
 ): Promise<INodeExecutionData[]> {
 	const elements: INodeExecutionData[] = [];
 
 	for (const record of records) {
 		const element: INodeExecutionData = { json: {}, binary: {} };
+		if (pairedItem) {
+			element.pairedItem = pairedItem;
+		}
 		element.json = record as unknown as IDataObject;
 		for (const fieldName of fieldNames) {
 			let attachments = record[fieldName] as IAttachment[];

--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -521,6 +521,7 @@ export class NocoDB implements INodeType {
 								this,
 								responseData as IDataObject[],
 								downloadFieldNames,
+								[{ item: i }],
 							);
 							data.push(...response);
 						}
@@ -584,6 +585,7 @@ export class NocoDB implements INodeType {
 								this,
 								[responseData as IDataObject],
 								downloadFieldNames,
+								[{ item: i }],
 							);
 							const newItem = {
 								binary: data[0].binary,

--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -9,6 +9,7 @@ import type {
 	ILoadOptionsFunctions,
 	INodeExecutionData,
 	INodeProperties,
+	IPairedItemData,
 	IPollFunctions,
 	JsonObject,
 } from 'n8n-workflow';
@@ -860,12 +861,15 @@ export type FileRecord = {
 	};
 };
 // prettier-ignore
-export async function downloadFiles(this: IExecuteFunctions | IPollFunctions, records: FileRecord[]): Promise<INodeExecutionData[]> {
+export async function downloadFiles(this: IExecuteFunctions | IPollFunctions, records: FileRecord[], pairedItem?: IPairedItemData[]): Promise<INodeExecutionData[]> {
 
 	const elements: INodeExecutionData[] = [];
 	for (const record of records) {
 		const element: INodeExecutionData = { json: {}, binary: {} };
 		element.json = record as unknown as IDataObject;
+		if (pairedItem) {
+			element.pairedItems = pairedItem;
+		}
 		for (const key of Object.keys(record.properties)) {
 			if (record.properties[key].type === 'files') {
 				if (record.properties[key].files.length) {

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -591,7 +591,9 @@ export class NotionV2 implements INodeType {
 						responseData = responseData.results;
 					}
 					if (download) {
-						responseData = await downloadFiles.call(this, responseData as FileRecord[]);
+						responseData = await downloadFiles.call(this, responseData as FileRecord[], [
+							{ item: i },
+						]);
 					}
 					if (simple) {
 						responseData = simplifyObjects(responseData, download);

--- a/packages/nodes-base/nodes/Redis/Redis.node.ts
+++ b/packages/nodes-base/nodes/Redis/Redis.node.ts
@@ -530,7 +530,7 @@ export class Redis implements INodeType {
 
 				let item: INodeExecutionData;
 				for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-					item = { json: {} };
+					item = { json: {}, pairedItem: { item: itemIndex } };
 
 					if (operation === 'delete') {
 						const keyDelete = this.getNodeParameter('key', itemIndex) as string;

--- a/packages/nodes-base/nodes/Set/v1/SetV1.node.ts
+++ b/packages/nodes-base/nodes/Set/v1/SetV1.node.ts
@@ -150,7 +150,7 @@ export class SetV1 implements INodeType {
 		const nodeVersion = this.getNode().typeVersion;
 
 		if (items.length === 0) {
-			items.push({ json: {} });
+			items.push({ json: {}, pairedItem: { item: 0 } });
 		}
 
 		const returnData: INodeExecutionData[] = [];


### PR DESCRIPTION
## Summary
If you use the merge node and tell it to wait for both to finish and to output a single empty item you are no longer able to reference previous data



## Related tickets and issues
https://community.n8n.io/t/issue-with-http-node-output-containing-error/35062
https://linear.app/n8n/issue/NODE-1049/merge-node-output-single-item-loses-paired-items