### PR TITLE
fix(Notion Node): Fix is_empty query on formula fields

### DIFF
--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -559,12 +559,16 @@ export function mapFilters(filtersList: IDataObject[], timezone: string) {
 		}
 
 		if (value.type === 'formula') {
-			const vpropertyName = value[`${camelCase(value.returnType as string)}Value`];
+			if (['is_empty', 'is_not_empty'].includes(value.condition as string)) {
+				key = value.returnType;
+			} else {
+				const vpropertyName = value[`${camelCase(value.returnType as string)}Value`];
 
-			return Object.assign(obj, {
-				['property']: getNameAndType(value.key as string).name,
-				[key]: { [value.returnType]: { [`${value.condition}`]: vpropertyName } },
-			});
+				return Object.assign(obj, {
+					['property']: getNameAndType(value.key as string).name,
+					[key]: { [value.returnType]: { [`${value.condition}`]: vpropertyName } },
+				});
+			}
 		}
 
 		return Object.assign(obj, {


### PR DESCRIPTION
## Summary

<img width="1172" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/746ff364-8e51-4b1b-bc13-37d9953425f0">

Use this comment to test, query should be successful
https://github.com/n8n-io/n8n/issues/4588#issuecomment-1409413760
Notion Formula: `prop("check") == true ? now() : parseDate("")`

## Related tickets and issues
fixes https://github.com/n8n-io/n8n/issues/4588
https://linear.app/n8n/issue/NODE-1033/notion-get-database-page-fails-when-using-formula-in-filter

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 