### PR TITLE
fix(core): Fix trigger and poller activation on vacant leadership

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -247,6 +247,12 @@ export class Start extends BaseCommand {
 				await this.activeWorkflowRunner.removeAllTriggerAndPollerBasedWorkflows();
 			}
 		});
+
+		orchestrationService.multiMainSetup.addListener('leadershipVacant', async () => {
+			this.logger.debug('[Leadership vacant] Removing all trigger- and poller-based workflows...');
+
+			await this.activeWorkflowRunner.removeAllTriggerAndPollerBasedWorkflows();
+		});
 	}
 
 	async run() {
@@ -373,6 +379,10 @@ export class Start extends BaseCommand {
 			} else {
 				if (this.pruningService.isPruningEnabled()) this.pruningService.stopPruning();
 			}
+		});
+
+		orchestrationService.multiMainSetup.addListener('leadershipVacant', () => {
+			if (this.pruningService.isPruningEnabled()) this.pruningService.stopPruning();
 		});
 	}
 

--- a/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
+++ b/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
@@ -60,13 +60,13 @@ export class MultiMainSetup extends EventEmitter {
 			this.logger.debug(`[Instance ID ${this.instanceId}] Leader is other instance "${leaderId}"`);
 
 			if (config.getEnv('multiMainSetup.instanceType') === 'leader') {
+				config.set('multiMainSetup.instanceType', 'follower');
+
 				this.emit('leadershipChange', leaderId); // stop triggers, pruning, etc.
 
 				EventReporter.report('[Multi-main setup] Leader failed to renew leader key', {
 					level: 'info',
 				});
-
-				config.set('multiMainSetup.instanceType', 'follower');
 			}
 
 			return;
@@ -78,6 +78,8 @@ export class MultiMainSetup extends EventEmitter {
 			);
 
 			config.set('multiMainSetup.instanceType', 'follower');
+
+			this.emit('leadershipVacant'); // stop triggers, pruning, etc.
 
 			await this.tryBecomeLeader();
 		}


### PR DESCRIPTION
This PR fixes two issues:

- If a (former) leader finds it is no longer the leader, the former leader emits the `leadershipChange` event and then marks itself via config as follower, so there is a slight chance that the former leader may still believe itself to be the leader at the time of reacting to the `leadershipChange` event - if this happens, the former leader will react by re-adding already active triggers and pollers, instead of removing them. To fix, the former leader should first mark itself as follower and then emit the event.
- If a (former) leader finds that leadership suddenly became vacant for any reason (i.e. Redis key missing), the former leader attempts to become leader again, and if it succeeds in regaining leadership, the former leader emits the `leadershipChange` event and so re-adds its already active triggers and pollers. To fix, as soon as any main finds that leadership is vacant, that main should remove all active triggers and pollers.

To test, activate a workflow with a 10-second Cron trigger, launch a worker and two mains and delete the leader key, e.g. `docker exec n8n-redis redis-cli DEL "n8n:main_instance_leader"`

- If the former leader becomes leader again, triggers and pollers should be active only there. Trigger frequency should remain at 10 seconds.
- If the former leader does not become leader again, the normal transition flow will take over, so retry the leader key deletion until the former leader becomes the leader again. Trigger frequency should remain at 10 seconds.

Context: https://n8nio.slack.com/archives/C069KJBJ8HE/p1705743545444889?thread_ts=1705394934.984829&cid=C069KJBJ8HE