### PR TITLE
fix(editor): Fix copy to clipboard on insecure contexts

### DIFF
--- a/packages/editor-ui/src/composables/useClipboard.ts
+++ b/packages/editor-ui/src/composables/useClipboard.ts
@@ -12,7 +12,7 @@ export function useClipboard(
 	},
 ) {
 	const { debounce } = useDebounce();
-	const { copy, copied, isSupported, text } = useClipboardCore();
+	const { copy, copied, isSupported, text } = useClipboardCore({ legacy: true });
 
 	const ignoreClasses = ['el-messsage-box', 'ignore-key-press'];
 	const initialized = ref(false);


### PR DESCRIPTION
Since we migrated to the native clipboard API (by migrating to `useClipboard` from `@vueuse/core`), the copy functionality has been broken on insecure contexts (`http://` pages where the domain isn't `localhost` or `127.0.0.1`).

vueuse has a fallback for this scenario, but it's not enabled by default. 
By setting [the `legacy` flag](https://github.com/vueuse/vueuse/blob/main/packages/core/useClipboard/index.ts#L38) to true, this fallback is enabled.


## Related tickets and issues
https://community.n8n.io/t/copy-paste-not-working-anymore/35476

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included (not sure how to test this in vitest)