### PR TITLE
feat(RabbitMQ Trigger Node): Add options to configure assert of exchanges and queues

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/DefaultOptions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/DefaultOptions.ts
@@ -73,6 +73,20 @@ export const rabbitDefaultOptions: Array<
 		description: 'Whether the queue will be deleted when the number of consumers drops to zero',
 	},
 	{
+		displayName: 'Assert Exchange',
+		name: 'assertExchange',
+		type: 'boolean',
+		default: true,
+		description: 'Whether to assert the exchange exists before sending',
+	},
+	{
+		displayName: 'Assert Queue',
+		name: 'assertQueue',
+		type: 'boolean',
+		default: true,
+		description: 'Whether to assert the queue exists before sending',
+	},
+	{
 		displayName: 'Durable',
 		name: 'durable',
 		type: 'boolean',

--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -75,7 +75,11 @@ export async function rabbitmqConnectQueue(
 
 	return await new Promise(async (resolve, reject) => {
 		try {
-			await channel.assertQueue(queue, options);
+			if (options.assertQueue) {
+				await channel.assertQueue(queue, options);
+			} else {
+				await channel.checkQueue(queue);
+			}
 
 			if (options.binding && ((options.binding as IDataObject).bindings! as IDataObject[]).length) {
 				((options.binding as IDataObject).bindings as IDataObject[]).forEach(
@@ -106,7 +110,11 @@ export async function rabbitmqConnectExchange(
 
 	return await new Promise(async (resolve, reject) => {
 		try {
-			await channel.assertExchange(exchange, type, options);
+			if (options.assertExchange) {
+				await channel.assertExchange(exchange, type, options);
+			} else {
+				await channel.checkExchange(exchange);
+			}
 			resolve(channel);
 		} catch (error) {
 			reject(error);


### PR DESCRIPTION
## Summary
This PR introduces the ability to disable the _assertion_ of _exchanges_ and _queues_. In this way, the credentials provided to the RabbitMQ node can only have _write_ and _read_ permissions (and not _configure_ ones).

![Screenshot from 2024-01-24 15-37-31](https://github.com/n8n-io/n8n/assets/1838567/95cbf633-dbfe-421d-894d-67833c41058d)
![Screenshot from 2024-01-24 15-37-43](https://github.com/n8n-io/n8n/assets/1838567/2677d242-0840-4509-a690-762018014cb3)



## Related tickets and issues

[Rabbit MQ QueueDeclare for user with no "queue.declare" permissions](https://github.com/n8n-io/n8n/issues/8419)



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 