### PR TITLE
fix(core): Ensure webhooks are added on workflow update on multi-main setup

### DIFF
--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -570,7 +570,10 @@ export class ActiveWorkflowRunner {
 		 * running when the former leader became unresponsive.
 		 */
 		if (this.orchestrationService.isMultiMainSetupEnabled) {
-			if (activationMode !== 'leadershipChange') {
+			if (activationMode === 'update') {
+				shouldAddWebhooks = true;
+				shouldAddTriggersAndPollers = this.orchestrationService.isLeader;
+			} else if (activationMode !== 'leadershipChange') {
 				shouldAddWebhooks = this.orchestrationService.isLeader;
 				shouldAddTriggersAndPollers = this.orchestrationService.isLeader;
 			} else {
@@ -759,7 +762,7 @@ export class ActiveWorkflowRunner {
 	async remove(workflowId: string) {
 		// Remove all the webhooks of the workflow
 		try {
-			if (this.orchestrationService.isLeader) await this.clearWebhooks(workflowId);
+			await this.clearWebhooks(workflowId);
 		} catch (error) {
 			ErrorReporter.error(error);
 			this.logger.error(

--- a/packages/cli/src/ActiveWorkflowRunner.ts
+++ b/packages/cli/src/ActiveWorkflowRunner.ts
@@ -759,7 +759,7 @@ export class ActiveWorkflowRunner {
 	async remove(workflowId: string) {
 		// Remove all the webhooks of the workflow
 		try {
-			await this.clearWebhooks(workflowId);
+			if (this.orchestrationService.isLeader) await this.clearWebhooks(workflowId);
 		} catch (error) {
 			ErrorReporter.error(error);
 			this.logger.error(

--- a/packages/cli/test/integration/ActiveWorkflowRunner.test.ts
+++ b/packages/cli/test/integration/ActiveWorkflowRunner.test.ts
@@ -48,13 +48,7 @@ let activeWorkflowsService: ActiveWorkflowsService;
 let activeWorkflowRunner: ActiveWorkflowRunner;
 let owner: User;
 
-const NON_LEADERSHIP_CHANGE_MODES: WorkflowActivateMode[] = [
-	'init',
-	'create',
-	'update',
-	'activate',
-	'manual',
-];
+const TESTED_MODES: WorkflowActivateMode[] = ['init', 'create', 'activate', 'manual'];
 
 beforeAll(async () => {
 	await testDb.init();
@@ -239,7 +233,7 @@ describe('executeErrorWorkflow()', () => {
 describe('add()', () => {
 	describe('in single-main scenario', () => {
 		test('should add webhooks, triggers and pollers', async () => {
-			const mode = chooseRandomly(NON_LEADERSHIP_CHANGE_MODES);
+			const mode = chooseRandomly(TESTED_MODES);
 
 			const workflow = await createWorkflow({ active: true }, owner);
 
@@ -262,7 +256,7 @@ describe('add()', () => {
 		describe('leader', () => {
 			describe('on non-leadership-change activation mode', () => {
 				test('should add webhooks only', async () => {
-					const mode = chooseRandomly(NON_LEADERSHIP_CHANGE_MODES);
+					const mode = chooseRandomly(TESTED_MODES);
 
 					const workflow = await createWorkflow({ active: true }, owner);
 
@@ -316,7 +310,7 @@ describe('add()', () => {
 		describe('follower', () => {
 			describe('on any activation mode', () => {
 				test('should not add webhooks, triggers or pollers', async () => {
-					const mode = chooseRandomly(NON_LEADERSHIP_CHANGE_MODES);
+					const mode = chooseRandomly(TESTED_MODES);
 
 					jest.replaceProperty(orchestrationService, 'isMultiMainSetupEnabled', true);
 					jest.replaceProperty(orchestrationService, 'isLeader', false);


### PR DESCRIPTION
In multi-main setup, a workflow update should always lead to adding webhook-based workflows to active workflows, regardless of whether the instance is a leader or a follower, so that any changes to the webhook (e.g. to the endpoint) are reflected. Currently, the activation mode `update` triggers the check `activationMode !== 'leadershipChange'` and so only the leader adds webhook-based workflows to active workflows.

To test: 
1. Run ngrok.
2. Launch a worker.
3. Launch two mains, both using the ngrok URL as `WEBHOOK_URL`.
4. Activate a webhook-based workflow and call it → The webhook should be registered.
6. Move the node and save the workflow and call it → The webhook should remain registered.
8. Edit the endpoint and call it → The webhook should be registered.

More generally, this increasing branching (six activation modes, regular mode vs. single-main queue mode vs. multi-main queue mode, leader vs. follower, webhooks handling vs. triggers and pollers handling) is showing that we need to rethink our approach rather than patch `ActiveWorkflowRunner.add()`. This PR fixes the immediate issue, but we will look at simplifying these flows next.