### PR TITLE
fix(core): Run the down migration correctly when `transaction: false` is set (no-changelog)

### DIFF
--- a/packages/cli/src/databases/utils/migrationHelpers.ts
+++ b/packages/cli/src/databases/utils/migrationHelpers.ts
@@ -191,7 +191,7 @@ export const wrapMigration = (migration: Migration) => {
 			if (down) {
 				const context = createContext(queryRunner, migration);
 				if (this.transaction === false) {
-					await runDisablingForeignKeys(this, context, up);
+					await runDisablingForeignKeys(this, context, down);
 				} else {
 					await down.call(this, context);
 				}


### PR DESCRIPTION
This bug was introduced 6 months ago in https://github.com/n8n-io/n8n/pull/6594

## Review / Merge checklist
- [x] PR title and summary are descriptive