### PR TITLE
ci: Move docs check notification to #alerts-build (no-changelog)

### DIFF
--- a/.github/workflows/check-documentation-urls.yml
+++ b/.github/workflows/check-documentation-urls.yml
@@ -39,6 +39,7 @@ jobs:
         if: failure()
         with:
           status: ${{ job.status }}
-          channel: '#mission-docs'
+          channel: '#alerts-build'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: Documentation URLs check failed (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          message: |
+            <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}| Documentation URLs check failed >


### PR DESCRIPTION
As discussed on Slack.

