### PR TITLE
test: Test that pinned data is not used in production executions

### DIFF
--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -5,11 +5,10 @@ import {
 	EDIT_FIELDS_SET_NODE_NAME,
 	BACKEND_BASE_URL,
 } from '../constants';
-import { WorkflowPage, NDV, WorkflowExecutionsTab } from '../pages';
+import { WorkflowPage, NDV } from '../pages';
 
 const workflowPage = new WorkflowPage();
 const ndv = new NDV();
-const workflowExecutionsTab = new WorkflowExecutionsTab();
 
 describe('Data pinning', () => {
 	beforeEach(() => {
@@ -153,7 +152,7 @@ describe('Data pinning', () => {
 		cy.get('div').contains(output).should('be.visible');
 	});
 
-	it.only('should use pin data in manual executions that are started by a webhook', () => {
+	it('should use pin data in manual executions that are started by a webhook', () => {
 		cy.createFixtureWorkflow('Test_workflow_webhook_with_pin_data.json', 'Test');
 
 		workflowPage.actions.executeWorkflow();
@@ -177,26 +176,11 @@ describe('Data pinning', () => {
 		cy.request('GET', `${BACKEND_BASE_URL}/webhook/b0d79ddb-df2d-49b1-8555-9fa2b482608f`).then(
 			(response) => {
 				expect(response.status).to.eq(200);
+				expect(response.body).to.deep.equal({
+					nodeData: 'pin',
+				});
 			},
 		);
-
-		workflowExecutionsTab.actions.switchToExecutionsTab();
-		const getIframe = () => cy.get('iframe').its('0.contentDocument').should('exist');
-
-		getIframe()
-			.its('body')
-			.should('not.be.undefined')
-			.find('[data-test-id="canvas-node"][data-name="End"]')
-			.first()
-			.dblclick();
-
-		getIframe()
-			.find('[data-test-id="output-panel"]')
-			.findChildByTestId('ndv-data-container')
-			.find('table tr')
-			.eq(1)
-			.should('exist')
-			.should('have.text', 'pin');
 	});
 });
 

--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -169,13 +169,15 @@ describe('Data pinning', () => {
 		ndv.getters.outputTableRow(1).should('have.text', 'pin-overwritten');
 	});
 
-	it.only('should not use pin data in production executions that are started by a webhook', () => {
+	it('should not use pin data in production executions that are started by a webhook', () => {
 		cy.createFixtureWorkflow('Test_workflow_webhook_with_pin_data.json', 'Test');
 
 		workflowPage.actions.activateWorkflow();
 		cy.request('GET', `${BACKEND_BASE_URL}/webhook/b0d79ddb-df2d-49b1-8555-9fa2b482608f`).then(
 			(response) => {
 				expect(response.status).to.eq(200);
+				// Assert that we get the data hard coded in the edit fields node,
+				// instead of the data pinned in said node.
 				expect(response.body).to.deep.equal({
 					nodeData: 'pin',
 				});

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -259,10 +259,12 @@ export class WorkflowRunner {
 			workflowTimeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout'));
 		}
 
-		let pinData: IPinData | undefined;
-		if (data.executionMode === 'manual') {
-			pinData = data.pinData ?? data.workflowData.pinData;
-		}
+		// TODO: both tests pass even if this is disabled.
+		// This change comes from the PR that added the initial test: https://github.com/n8n-io/n8n/commit/ea7e76fa3b3dc1f37b0415e14ea5ff90b8017b9a#diff-f1214419cabb6abb8ec771d5f35be7d8059f52cae9dd610562119fa452490e3f
+		// let pinData: IPinData | undefined;
+		// if (data.executionMode === 'manual') {
+		// 	pinData = data.pinData ?? data.workflowData.pinData;
+		// }
 
 		const workflow = new Workflow({
 			id: workflowId,
@@ -273,7 +275,9 @@ export class WorkflowRunner {
 			nodeTypes: this.nodeTypes,
 			staticData: data.workflowData.staticData,
 			settings: workflowSettings,
-			pinData,
+			// TODO: both tests pass even if this is disabled.
+			// This change comes from the PR that added the initial test: https://github.com/n8n-io/n8n/commit/ea7e76fa3b3dc1f37b0415e14ea5ff90b8017b9a#diff-f1214419cabb6abb8ec771d5f35be7d8059f52cae9dd610562119fa452490e3f
+			// pinData,
 		});
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
 			data.userId,

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -259,12 +259,10 @@ export class WorkflowRunner {
 			workflowTimeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout'));
 		}
 
-		// TODO: both tests pass even if this is disabled.
-		// This change comes from the PR that added the initial test: https://github.com/n8n-io/n8n/commit/ea7e76fa3b3dc1f37b0415e14ea5ff90b8017b9a#diff-f1214419cabb6abb8ec771d5f35be7d8059f52cae9dd610562119fa452490e3f
-		// let pinData: IPinData | undefined;
-		// if (data.executionMode === 'manual') {
-		// 	pinData = data.pinData ?? data.workflowData.pinData;
-		// }
+		let pinData: IPinData | undefined;
+		if (data.executionMode === 'manual') {
+			pinData = data.pinData ?? data.workflowData.pinData;
+		}
 
 		const workflow = new Workflow({
 			id: workflowId,
@@ -275,9 +273,7 @@ export class WorkflowRunner {
 			nodeTypes: this.nodeTypes,
 			staticData: data.workflowData.staticData,
 			settings: workflowSettings,
-			// TODO: both tests pass even if this is disabled.
-			// This change comes from the PR that added the initial test: https://github.com/n8n-io/n8n/commit/ea7e76fa3b3dc1f37b0415e14ea5ff90b8017b9a#diff-f1214419cabb6abb8ec771d5f35be7d8059f52cae9dd610562119fa452490e3f
-			// pinData,
+			pinData,
 		});
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(
 			data.userId,


### PR DESCRIPTION
## Summary
This is adding an e2e test making sure that data that is pinned in the middle of a workflow is not used for production executions.



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1175/create-test-for-pinned-data-in-production



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
