### PR TITLE
fix(core): Point users to the official documentation when they use `n8n --help`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
   "types": "dist/index.d.ts",
   "oclif": {
     "commands": "./dist/commands",
+    "helpClass": "./dist/help",
     "bin": "n8n"
   },
   "scripts": {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,17 @@
+import type { Command } from '@oclif/core';
+import { HelpBase } from '@oclif/core';
+
+// oclif expects a default export
+// eslint-disable-next-line import/no-default-export
+export default class CustomHelp extends HelpBase {
+	async showHelp(_args: string[]) {
+		console.log(
+			'You can find up to date information about the CLI here:\nhttps://docs.n8n.io/hosting/cli-commands/',
+		);
+	}
+
+	async showCommandHelp(_command: Command.Loadable) {
+		// This is not used because we have a multi-command CLI, but it needs to
+		// be defined to satisfy the abstract base class.
+	}
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,17 +1,11 @@
-import type { Command } from '@oclif/core';
-import { HelpBase } from '@oclif/core';
+import { Help } from '@oclif/core';
 
 // oclif expects a default export
 // eslint-disable-next-line import/no-default-export
-export default class CustomHelp extends HelpBase {
-	async showHelp(_args: string[]) {
+export default class CustomHelp extends Help {
+	async showRootHelp() {
 		console.log(
 			'You can find up to date information about the CLI here:\nhttps://docs.n8n.io/hosting/cli-commands/',
 		);
-	}
-
-	async showCommandHelp(_command: Command.Loadable) {
-		// This is not used because we have a multi-command CLI, but it needs to
-		// be defined to satisfy the abstract base class.
 	}
 }


### PR DESCRIPTION
## Summary

The help users got with `n8n --help` was misleading. Some commands had no documentation. If a command had multiple subcommands, only the documentation for the first one would be shown in the main page, e.g. `import` would only mention that you can import `credentials`, but not that you can import workflows.

An idea here is that we can point the user directly to docs.n8n.io instead.

Downside may be that the docs will always document the latest version, but the user may run an older version of n8n. We're willing to accept that though. And the help for commands and topics would still be available.

This PR has no tests. I don't think it needs one, because the damage that is caused by the custom help message disappearing and the old one appearing again is limited. 
If you disagree let me know and I write one, but right now it seams there are no tests that execute `bin/n8n` and check what it prints. So that would a completely new kind of test.

https://github.com/n8n-io/n8n/assets/927609/b3271961-c80d-43a7-80c9-b718855de7a6

## Related tickets and issues
https://linear.app/n8n/issue/PAY-195/ensure-n8n-help-gives-useful-and-accurate-info


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
