### PR TITLE
fix(Gotify Node): Add option to set content type to support Markdown messages

### DIFF
--- a/packages/nodes-base/nodes/Gotify/Gotify.node.ts
+++ b/packages/nodes-base/nodes/Gotify/Gotify.node.ts
@@ -84,7 +84,7 @@ export class Gotify implements INodeType {
 					},
 				},
 				default: '',
-				description: 'The message. Markdown (excluding html) is allowed.',
+				description: 'The message to send, If using Markdown add the Content Type option',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -112,6 +112,38 @@ export class Gotify implements INodeType {
 						type: 'string',
 						default: '',
 						description: 'The title of the message',
+					},
+				],
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				placeholder: 'Add Option',
+				displayOptions: {
+					show: {
+						resource: ['message'],
+						operation: ['create'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Content Type',
+						name: 'contentType',
+						type: 'options',
+						default: 'text/plain',
+						description: 'The message content type',
+						options: [
+							{
+								name: 'Plain',
+								value: 'text/plain',
+							},
+							{
+								name: 'Markdown',
+								value: 'text/markdown',
+							},
+						],
 					},
 				],
 			},
@@ -176,10 +208,19 @@ export class Gotify implements INodeType {
 						const message = this.getNodeParameter('message', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const options = this.getNodeParameter('options', i);
 
 						const body: IDataObject = {
 							message,
 						};
+
+						if (options.contentType) {
+							body.extras = {
+								'client::display': {
+									contentType: options.contentType,
+								},
+							};
+						}
 
 						Object.assign(body, additionalFields);
 


### PR DESCRIPTION
## Summary
In the node message description we mention that the message can be sent using Markdown but we were not setting the content type for this. This PR adds an Options list (so we can support more in the future) and a content type option that defaults to the current behavior so we don't break anything.


## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8433
