### PR TITLE
feat: Add new 'is empty' and 'is not empty' operators to Filter

### DIFF
--- a/packages/editor-ui/src/components/FilterConditions/constants.ts
+++ b/packages/editor-ui/src/components/FilterConditions/constants.ts
@@ -23,6 +23,18 @@ export const OPERATORS_BY_ID = {
 		name: 'filter.operator.notExists',
 		singleValue: true,
 	},
+	'string:empty': {
+		type: 'string',
+		operation: 'empty',
+		name: 'filter.operator.empty',
+		singleValue: true,
+	},
+	'string:notEmpty': {
+		type: 'string',
+		operation: 'notEmpty',
+		name: 'filter.operator.notEmpty',
+		singleValue: true,
+	},
 	'string:equals': { type: 'string', operation: 'equals', name: 'filter.operator.equals' },
 	'string:notEquals': { type: 'string', operation: 'notEquals', name: 'filter.operator.notEquals' },
 	'string:contains': { type: 'string', operation: 'contains', name: 'filter.operator.contains' },

--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -179,6 +179,10 @@ export function executeFilterCondition(
 			const right = (rightValue ?? '') as string;
 
 			switch (condition.operator.operation) {
+				case 'empty':
+					return left.length === 0;
+				case 'notEmpty':
+					return left.length !== 0;
 				case 'equals':
 					return left === right;
 				case 'notEquals':

--- a/packages/workflow/test/FilterParameter.test.ts
+++ b/packages/workflow/test/FilterParameter.test.ts
@@ -251,6 +251,38 @@ describe('FilterParameter', () => {
 
 			describe('string', () => {
 				it.each([
+					{ left: null, expected: true },
+					{ left: undefined, expected: true },
+					{ left: '', expected: true },
+					{ left: '🐛', expected: false },
+				])('string:empty($left) === $expected', ({ left, expected }) => {
+					const result = executeFilter(
+						filterFactory({
+							conditions: [
+								{ id: '1', leftValue: left, operator: { operation: 'empty', type: 'string' } },
+							],
+						}),
+					);
+					expect(result).toBe(expected);
+				});
+
+				it.each([
+					{ left: null, expected: false },
+					{ left: undefined, expected: false },
+					{ left: '', expected: false },
+					{ left: '🐛', expected: true },
+				])('string:notEmpty($left) === $expected', ({ left, expected }) => {
+					const result = executeFilter(
+						filterFactory({
+							conditions: [
+								{ id: '1', leftValue: left, operator: { operation: 'notEmpty', type: 'string' } },
+							],
+						}),
+					);
+					expect(result).toBe(expected);
+				});
+
+				it.each([
 					{ left: 'first string', right: 'first string', expected: true },
 					{ left: 'first string', right: 'second string', expected: false },
 					{ left: '', right: '🐛', expected: false },


### PR DESCRIPTION
## Summary

<img width="1136" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/127b2836-51bb-4002-af65-6b799e2ceacf">

- New operators should work as expected
- Empty operators in old and new If node should behave the same (use workflow JSON from linear to check)

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1072/is-not-empty-operation-missing-from-latest-if-node



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 