### PR TITLE
ci: Upgrade pnpm (no-changelog)

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.4.0
         with:
-          version: 8.9.0
+          package_json_file: n8n/package.json
 
       - uses: actions/setup-node@v3.7.0
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+update-notifier = false
 auto-install-peers = true
 strict-peer-dependencies = false
 prefer-workspace-packages = true

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "n8n",
+  "name": "n8n-monorepo",
   "version": "1.26.0",
   "private": true,
   "homepage": "https://n8n.io",
   "engines": {
     "node": ">=18.10",
-    "pnpm": ">=8.9"
+    "pnpm": ">=8.14"
   },
-  "packageManager": "pnpm@8.9.0",
+  "packageManager": "pnpm@8.14.3",
   "scripts": {
     "preinstall": "node scripts/block-npm-install.js",
     "build": "turbo run build",


### PR DESCRIPTION
Tested that publishing won't break by running `pnpm publish -r --no-git-checks --dry-run --force`

## Review / Merge checklist
- [x] PR title and summary are descriptive