### PR TITLE
ci: Update GH actions (no-changelog)

### DIFF
--- a/.github/workflows/check-documentation-urls.yml
+++ b/.github/workflows/check-documentation-urls.yml
@@ -14,11 +14,11 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
 
       - uses: pnpm/action-setup@v2.4.0
 
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -16,11 +16,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out branch
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
 
       - uses: pnpm/action-setup@v2.4.0
 
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'
@@ -30,6 +30,6 @@ jobs:
 
       - name: Validate PR title
         id: validate_pr_title
-        uses: n8n-io/validate-n8n-pull-request-title@v1.3
+        uses: n8n-io/validate-n8n-pull-request-title@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -15,12 +15,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
 

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -16,12 +16,12 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
 
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -33,7 +33,7 @@ jobs:
         run: pnpm build
 
       - name: Cache build artifacts
-        uses: actions/cache/save@v3.3.1
+        uses: actions/cache/save@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}-base:${{ matrix.node-version }}-test-lint
@@ -59,7 +59,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: ${{ inputs.branch }}
@@ -67,7 +67,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore cached build artifacts
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}-base:${{ matrix.node-version }}-test-lint

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -17,9 +17,9 @@ jobs:
     name: Install & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'
@@ -29,7 +29,7 @@ jobs:
         run: pnpm build:backend
 
       - name: Cache build artifacts
-        uses: actions/cache/save@v3.3.1
+        uses: actions/cache/save@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}:db-tests
@@ -42,16 +42,16 @@ jobs:
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
 
       - name: Restore cached build artifacts
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}:db-tests
@@ -75,16 +75,16 @@ jobs:
     env:
       DB_POSTGRESDB_PASSWORD: password
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
 
       - name: Restore cached build artifacts
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}:db-tests

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Install & Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -15,7 +15,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: pnpm
@@ -27,7 +27,7 @@ jobs:
         run: pnpm build
 
       - name: Cache build artifacts
-        uses: actions/cache/save@v3.3.1
+        uses: actions/cache/save@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}-base:18-test-lint
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
@@ -53,7 +53,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: pnpm
@@ -62,7 +62,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore cached build artifacts
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ github.sha }}-base:18-test-lint

--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -17,22 +17,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5.1.0
         with:
           context: ./docker/images/n8n-base
           build-args: |

--- a/.github/workflows/docker-image-beta.yml
+++ b/.github/workflows/docker-image-beta.yml
@@ -16,22 +16,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch || 'ai-beta' }}
 
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3.0.0
+      - uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           file: ./docker/images/n8n-custom/Dockerfile

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -52,19 +52,19 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ github.event.inputs.repository || 'n8n-io/n8n' }}
           ref: ${{ github.event.inputs.branch || 'master' }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -75,7 +75,7 @@ jobs:
         shell: bash
 
       - name: Build and push
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5.1.0
         with:
           context: .
           build-args: |

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,33 +9,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
 
       - name: Get the version
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:14})
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.2.0
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5.1.0
         with:
           context: ./docker/images/n8n
           build-args: |

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -76,7 +76,7 @@ jobs:
       image: cypress/${{ inputs.run-env }}
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: ${{ inputs.branch }}
@@ -93,7 +93,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cypress build
-        uses: cypress-io/github-action@v5.8.3
+        uses: cypress-io/github-action@v6.6.1
         with:
           # Disable running of tests within install job
           runTests: false
@@ -106,7 +106,7 @@ jobs:
         run: pnpm cypress:install
 
       - name: Cache build artifacts
-        uses: actions/cache/save@v3.3.1
+        uses: actions/cache/save@v4.0.0
         with:
           path: |
             /github/home/.cache
@@ -127,7 +127,7 @@ jobs:
         # running the same tests multiple times
         containers: ${{ fromJSON( inputs.spec == 'e2e/*' && inputs.containers || '[1]' ) }}
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: ${{ inputs.branch }}
@@ -141,7 +141,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Restore cached pnpm modules
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: |
             /github/home/.cache

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: E2E success comment
         if: ${{!contains(github.event.pull_request.labels.*.name, 'community') && needs.run-e2e-tests.outputs.tests_passed == 'true' }}
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: E2E fail comment
         if: needs.run-e2e-tests.result == 'failure'
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.base-branch }}
 
       - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
       - run: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@v2.2.0
+      - uses: docker/login-action@v3.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@v2.2.0
+      - uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           path: n8n
 
       - name: Checkout workflows repo
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/test-workflows
           path: test-workflows
@@ -27,7 +27,7 @@ jobs:
         with:
           package_json_file: n8n/package.json
 
-      - uses: actions/setup-node@v3.7.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
           cache: 'pnpm'

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
         with:
           repository: n8n-io/n8n
           ref: ${{ inputs.ref }}
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
 
       - name: Use Node.js ${{ inputs.nodeVersion }}
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: pnpm
@@ -52,7 +52,7 @@ jobs:
 
       - name: Restore cached build artifacts
         if: ${{ inputs.cacheKey != '' }}
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/**/dist
           key: ${{ inputs.cacheKey }}


### PR DESCRIPTION
Extracted from #8451 to get rid of all the Node.js 16 warnings.

![image](https://github.com/n8n-io/n8n/assets/196144/9fda1038-afdb-4069-9d63-f50a3da054a3)


Some test runs:
* [DB Tests](https://github.com/n8n-io/n8n/actions/runs/7666465700)
* [Docs check](https://github.com/n8n-io/n8n/actions/runs/7666458426)
* [E2E Tests](https://github.com/n8n-io/n8n/actions/runs/7666461101)
* [Workflow Tests](https://github.com/n8n-io/n8n/actions/runs/7666463745)

## Review / Merge checklist
- [x] PR title and summary are descriptive