### PR TITLE
fix(Microsoft Excel 365 Node): Upsert append new rows at the end of used range, option to append at the end of selected range

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
@@ -13,12 +13,13 @@ export class MicrosoftExcel extends VersionedNodeType {
 			group: ['input'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume Microsoft Excel API',
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new MicrosoftExcelV1(baseDescription),
 			2: new MicrosoftExcelV2(baseDescription),
+			2.1: new MicrosoftExcelV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
@@ -10,7 +10,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'microsoftExcel',
 	icon: 'file:excel.svg',
 	group: ['input'],
-	version: 2,
+	version: [2, 2.1],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 	description: 'Consume Microsoft Excel API',
 	defaults: {

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
@@ -134,6 +134,19 @@ const properties: INodeProperties[] = [
 		default: {},
 		options: [
 			{
+				displayName: 'Append After Selected Range',
+				name: 'appendAfterSelectedRange',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to append data after the selected range or used range',
+				displayOptions: {
+					show: {
+						'/dataMode': ['autoMap', 'define'],
+						'/useRange': [true],
+					},
+				},
+			},
+			{
 				displayName: 'RAW Data',
 				name: 'rawData',
 				type: 'boolean',
@@ -180,6 +193,7 @@ export async function execute(
 	items: INodeExecutionData[],
 ): Promise<INodeExecutionData[]> {
 	const returnData: INodeExecutionData[] = [];
+	const nodeVersion = this.getNode().typeVersion;
 
 	try {
 		const workbookId = this.getNodeParameter('workbook', 0, undefined, {
@@ -280,6 +294,27 @@ export async function execute(
 			);
 		}
 
+		const appendAfterSelectedRange = this.getNodeParameter(
+			'options.appendAfterSelectedRange',
+			0,
+			false,
+		) as boolean;
+
+		//remove empty rows from the end
+		if (nodeVersion > 2 && !appendAfterSelectedRange && updateSummary.updatedData.length) {
+			for (let i = updateSummary.updatedData.length - 1; i >= 0; i--) {
+				if (
+					updateSummary.updatedData[i].every(
+						(item) => item === '' || item === undefined || item === null,
+					)
+				) {
+					updateSummary.updatedData.pop();
+				} else {
+					break;
+				}
+			}
+		}
+
 		if (updateSummary.appendData.length) {
 			const appendValues: string[][] = [];
 			const columnsRow = (worksheetData.values as string[][])[0];
@@ -297,9 +332,24 @@ export async function execute(
 
 			updateSummary.updatedData = updateSummary.updatedData.concat(appendValues);
 			const [rangeFrom, rangeTo] = range.split(':');
-			const cellDataTo = rangeTo.match(/([a-zA-Z]{1,10})([0-9]{0,10})/) || [];
 
-			range = `${rangeFrom}:${cellDataTo[1]}${Number(cellDataTo[2]) + appendValues.length}`;
+			const cellDataTo = rangeTo.match(/([a-zA-Z]{1,10})([0-9]{0,10})/) || [];
+			let lastRow = cellDataTo[2];
+
+			if (nodeVersion > 2 && !appendAfterSelectedRange) {
+				const { address } = await microsoftApiRequest.call(
+					this,
+					'GET',
+					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+					undefined,
+					{ select: 'address' },
+				);
+
+				const addressTo = (address as string).split('!')[1].split(':')[1];
+				lastRow = addressTo.match(/([a-zA-Z]{1,10})([0-9]{0,10})/)![2];
+			}
+
+			range = `${rangeFrom}:${cellDataTo[1]}${Number(lastRow) + appendValues.length}`;
 		}
 
 		responseData = await microsoftApiRequest.call(


### PR DESCRIPTION
## Summary
Microsoft Excel 365: Sheet -> Append or Update appends data outside of specified range



## Related tickets and issues
https://linear.app/n8n/issue/NODE-963/microsoft-excel-365-sheet-append-or-update-appends-data-outside-of
https://community.n8n.io/t/microsoft-excel-overwrites-data-instead-of-updating-a-row/33384