### PR TITLE
fix(core): Handle zero execution statistics on metrics collection during license renewal

### DIFF
--- a/packages/cli/src/databases/repositories/usageMetrics.repository.ts
+++ b/packages/cli/src/databases/repositories/usageMetrics.repository.ts
@@ -60,13 +60,8 @@ export class UsageMetricsRepository extends Repository<UsageMetrics> {
 				(SELECT SUM(count) FROM ${workflowStatsTable} WHERE name IN ('manual_success', 'manual_error')) AS manual_executions_count;
 		`)) as Row[];
 
-		const toNumber = (value: string | number) => {
-			const num = typeof value === 'number' ? value : parseInt(value, 10);
-
-			if (isNaN(num)) return 0;
-
-			return num;
-		};
+		const toNumber = (value: string | number) =>
+			(typeof value === 'number' ? value : parseInt(value, 10)) || 0;
 
 		return {
 			enabledUsers: toNumber(enabledUsers),

--- a/packages/cli/src/databases/repositories/usageMetrics.repository.ts
+++ b/packages/cli/src/databases/repositories/usageMetrics.repository.ts
@@ -60,8 +60,13 @@ export class UsageMetricsRepository extends Repository<UsageMetrics> {
 				(SELECT SUM(count) FROM ${workflowStatsTable} WHERE name IN ('manual_success', 'manual_error')) AS manual_executions_count;
 		`)) as Row[];
 
-		const toNumber = (value: string | number) =>
-			typeof value === 'number' ? value : parseInt(value, 10);
+		const toNumber = (value: string | number) => {
+			const num = typeof value === 'number' ? value : parseInt(value, 10);
+
+			if (isNaN(num)) return 0;
+
+			return num;
+		};
 
 		return {
 			enabledUsers: toNumber(enabledUsers),


### PR DESCRIPTION
Fix the case where the two `SELECT SUM...` queries in the metrics collector return `NaN` because there are zero execution statistics, e.g. when first initializing an empty DB.

```
Initializing n8n process
n8n ready on 0.0.0.0, port 5678
[license] license renewal failed: request/body/usageMetrics/4/value must be number, request/body/usageMetrics/5/value must be number
```