### PR TITLE
docs: Add section to tell contributors to install cypress before running e2e tests (no-changelog)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,8 @@ tests of all packages.
 
 #### E2E tests
 
+⚠️ You have to run `pnpm cypress:install` to install cypress before running the tests for the first time and to update cypress.
+
 E2E tests can be started via one of the following commands:
 
 - `pnpm test:e2e:ui`: Start n8n and run e2e tests interactively using built UI code. Does not react to code changes (i.e. runs `pnpm start` and `cypress open`)


### PR DESCRIPTION
## Summary
I was wondering why cypress didn't install the necessary version automatically. I eventually found that there is a script for doing so.
I thought it makes sense to update the contributing guide to mentione that.



## Related tickets and issues
none



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
