### PR TITLE
build: Open editor in browser when running `pnpm dev` from root or editor-ui

### DIFF
--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint src --ext .js,.ts,.vue --quiet",
     "lintfix": "eslint src --ext .js,.ts,.vue --fix",
     "format": "prettier --write . --ignore-path ../../.prettierignore",
-    "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 dev",
+    "serve": "cross-env VUE_APP_URL_BASE_API=http://localhost:5678/ vite --host 0.0.0.0 --port 8080 --open 'http://localhost:8080' dev",
     "test": "vitest run",
     "test:dev": "vitest"
   },


### PR DESCRIPTION
## Summary
This should prevent contributors to accidentilly open localhost:5678 instead, which does not pick up changes to the editor, but only changes to the backend.

## Related tickets and issues
none

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
