### PR TITLE
feat: Add a node that can delete the Execution record

### DIFF
--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -499,6 +499,16 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 							this.retryOf,
 						);
 					}
+
+					// DeleteAction logic. (After executeErrorWorkflow)
+					let lastNodeExecuted = fullExecutionData?.data?.resultData?.lastNodeExecuted;
+					if(lastNodeExecuted != undefined && lastNodeExecuted.startsWith('DeleteAction')) {
+						await Container.get(ExecutionRepository).hardDelete({
+							workflowId: this.workflowData.id,
+							executionId: this.executionId,
+						});
+					}
+					
 				} catch (error) {
 					ErrorReporter.error(error);
 					logger.error(`Failed saving execution data to DB on execution ID ${this.executionId}`, {

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -178,6 +178,7 @@ export const CRYPTO_NODE_TYPE = 'n8n-nodes-base.crypto';
 export const RSS_READ_NODE_TYPE = 'n8n-nodes-base.rssFeedRead';
 export const COMPRESSION_NODE_TYPE = 'n8n-nodes-base.compression';
 export const EDIT_IMAGE_NODE_TYPE = 'n8n-nodes-base.editImage';
+export const DELETE_ACTION_NODE_TYPE = 'n8n-nodes-base.delete-action';
 
 export const CREDENTIAL_ONLY_NODE_PREFIX = 'n8n-creds-base';
 export const CREDENTIAL_ONLY_HTTP_NODE_VERSION = 4.1;

--- a/packages/nodes-base/nodes/DeleteAction/DeleteAction.node.json
+++ b/packages/nodes-base/nodes/DeleteAction/DeleteAction.node.json
@@ -1,0 +1,24 @@
+{
+	"node": "n8n-nodes-base.delete-action",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Core Nodes"],
+	"resources": {
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.delete-action/"
+			}
+		],
+		"generic": [
+			{
+				"label": "What are APIs and how to use them with no code",
+				"icon": " 🪢",
+				"url": "https://n8n.io/blog/what-are-apis-how-to-use-them-with-no-code/"
+			}
+		]
+	},
+	"alias": ["nothing"],
+	"subcategories": {
+		"Core Nodes": ["Helpers"]
+	}
+}

--- a/packages/nodes-base/nodes/DeleteAction/DeleteAction.node.ts
+++ b/packages/nodes-base/nodes/DeleteAction/DeleteAction.node.ts
@@ -1,0 +1,67 @@
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+
+export class DeleteAction implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'DeleteAction',
+		name: 'DeleteAction',
+		icon: 'fa:database',
+		group: ['transform'],
+		version: 1,
+		// subtitle: 'DeleteAction',
+		description: 'Delete Action',
+		defaults: {
+			name: 'DeleteAction',
+			color: '#333377',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [
+			{
+				displayName: 'Mode',
+				name: 'mode',
+				type: 'options',
+				options: [
+					{
+						name: 'Delete Execution Record',
+						value: 'Delete Execution Record',
+						description: 'Delete Execution Record',
+					},
+					// {
+					// 	name: 'Nothing',
+					// 	value: 'Nothing',
+					// 	description: 'Nothing',
+					// },
+				],
+				default: 'Delete Execution Record',
+				description: 'If this node is executed, the deletion mode of execution',
+			},
+
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+
+		// Delete Execution Record
+		const mode = this.getNodeParameter('mode', 0) as string;
+
+		let itemIndex = 0;
+		if(mode === 'Delete Execution Record') {
+			// Do not take any action and use it as a marker.
+		} else {
+			throw new NodeOperationError(this.getNode(), `The operation "${mode}" is not known!`, {
+				itemIndex,
+			});
+		}
+
+		// return [];
+		const returnData: INodeExecutionData[] = [];
+		return [returnData];
+	}
+}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -794,7 +794,8 @@
       "dist/nodes/Transform/RemoveDuplicates/RemoveDuplicates.node.js",
       "dist/nodes/Transform/SplitOut/SplitOut.node.js",
       "dist/nodes/Transform/Sort/Sort.node.js",
-      "dist/nodes/Transform/Summarize/Summarize.node.js"
+      "dist/nodes/Transform/Summarize/Summarize.node.js",
+      "dist/nodes/DeleteAction/DeleteAction.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
### How to use it?
- Make it the last node of the workflow.
- If this node is executed, the execution of this execution will not be retained.
![g2](https://github.com/n8n-io/n8n/assets/157784072/5cef4b60-5524-4536-9b71-2f3f1ebe202b)
<br>

### How does it work?
- The `execute` function of this node does not perform any operations and is only used as a marker.
- After the execution of WorkFlow, after `updateExistingExecution` and `executeErrorWorkflow`, delete the record if it executed the node at the end.
<br>

### Scope
The main goal of this PR is to add one node.
This change will not affect other pages or features.
<br>

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 