### PR TITLE
fix(editor): Prune values that are not in the schema in the ResourceMapper component

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -430,15 +430,17 @@ function emitValueChanged(): void {
 }
 
 function pruneParamValues(): void {
-	if (!state.paramValue.value) {
+	const { value, schema } = state.paramValue;
+	if (!value) {
 		return;
 	}
-	const valueKeys = Object.keys(state.paramValue.value);
-	valueKeys.forEach((key) => {
-		if (state.paramValue.value && state.paramValue.value[key] === null) {
-			delete state.paramValue.value[key];
+
+	const schemaKeys = new Set(schema.map((s) => s.id));
+	for (const key of Object.keys(value)) {
+		if (value[key] === null || !schemaKeys.has(key)) {
+			delete value[key];
 		}
-	});
+	}
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary

Resource mapper should discard values that are not in the schema.

For example, when a column is renamed, the old name should not be saved.

### Steps to reproduce

1. Create an update operation in the Google Sheets node, and make sure RLC loads in the columns
2. Map the columns with expressions
3. Rename a column in the google sheet
4. Refresh the columns in the node and re-map
5. Execute. The old column appears in the node output

Bug should no longer be reproducible

## Related tickets and issues
https://linear.app/n8n/issue/NODE-944/rlc-update-produces-phantom-columns-in-googlesheetsupdate

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 