### PR TITLE
fix(Merge Node): Fixing how paired items are handled in the merge node, when choosing a branch and selecting to return an empty object

### DIFF
--- a/packages/nodes-base/nodes/Merge/test/node/workflow.chooseBranch.empty.paired.items.json
+++ b/packages/nodes-base/nodes/Merge/test/node/workflow.chooseBranch.empty.paired.items.json
@@ -1,0 +1,145 @@
+{
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "8d731d98fab18fb8e68289d44c50faa5d5c5378aedc3f892abdd7d5d3b7061c5"
+  },
+  "nodes": [
+    {
+      "parameters": {
+        "fields": {
+          "values": [
+            {
+              "name": "one",
+              "stringValue": "={{ $('Code').item.json.id }}"
+            },
+            {
+              "name": "two",
+              "stringValue": "={{ $('Code1').item.json.id }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "853f9e11-e59b-4f21-81ba-08ec2d69c87a",
+      "name": "Edit Fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.2,
+      "position": [
+        900,
+        580
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "8310a9da-b02b-4a77-80d4-7c2de5bcbae8",
+      "name": "When clicking \"Execute Workflow\"",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        180,
+        600
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return [\n  {id: 1},\n];"
+      },
+      "id": "0f1fb40d-0c6c-455d-bb3b-0c0fa818e063",
+      "name": "Code",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        420,
+        520
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return [\n  {id: 2},\n];"
+      },
+      "id": "873fcccc-86c1-40fd-bdae-2bb31e971382",
+      "name": "Code1",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        420,
+        680
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "chooseBranch",
+        "output": "empty"
+      },
+      "id": "b81a2372-9f8b-4899-b2fd-c581bcf930d8",
+      "name": "Merge3",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [
+        700,
+        580
+      ]
+    }
+  ],
+  "connections": {
+    "When clicking \"Execute Workflow\"": {
+      "main": [
+        [
+          {
+            "node": "Code",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Code1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Code": {
+      "main": [
+        [
+          {
+            "node": "Merge3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Code1": {
+      "main": [
+        [
+          {
+            "node": "Merge3",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge3": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {
+    "Edit Fields": [
+			{
+				"json": {
+					"one": "1",
+					"two": "2"
+				}
+			}
+    ]
+  }
+}

--- a/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
+++ b/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
@@ -29,7 +29,6 @@ import {
 } from './GenericFunctions';
 
 import { optionsDescription } from './OptionsDescription';
-import { generatePairedItemData } from '../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Merge',
@@ -605,8 +604,36 @@ export class MergeV2 implements INodeType {
 					returnData.push.apply(returnData, this.getInputData(1));
 				}
 				if (output === 'empty') {
-					const itemData = generatePairedItemData(this.getInputData(0).length);
-					returnData.push({ json: {}, pairedItem: itemData });
+					// TODO: was necessary to satisfies types.
+					// I'm wondering if there is already a function that does exactly that? That turns
+					// Array<IPairedItemData | IPairedItemData[] | number | undefined> -> IPairedItemData[]
+					// or
+					// IPairedItemData | IPairedItemData[] | number | undefined -> IPairedItemData | undefined
+					function numberToPairedItem(
+						possiblyPairedItems: Array<INodeExecutionData['pairedItem']>,
+					): IPairedItemData[] {
+						return possiblyPairedItems.reduce((pairedItems: IPairedItemData[], pairedItem) => {
+							if (typeof pairedItem === 'number') {
+								pairedItems.push({ item: pairedItem });
+							} else if (Array.isArray(pairedItem)) {
+								pairedItems.push(...pairedItem);
+							} else if (pairedItem) {
+								pairedItems.push(pairedItem);
+							}
+
+							return pairedItems;
+						}, [] as IPairedItemData[]);
+					}
+
+					const pairedItem = numberToPairedItem([
+						...this.getInputData(0).map((inputData) => inputData.pairedItem),
+						...this.getInputData(1).map((inputData) => inputData.pairedItem),
+					]);
+
+					returnData.push({
+						json: {},
+						pairedItem,
+					});
 				}
 			}
 		}

--- a/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
+++ b/packages/nodes-base/nodes/Merge/v2/MergeV2.node.ts
@@ -29,6 +29,7 @@ import {
 } from './GenericFunctions';
 
 import { optionsDescription } from './OptionsDescription';
+import { preparePairedItemDataArray } from '@utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
 	displayName: 'Merge',
@@ -604,31 +605,10 @@ export class MergeV2 implements INodeType {
 					returnData.push.apply(returnData, this.getInputData(1));
 				}
 				if (output === 'empty') {
-					// TODO: was necessary to satisfies types.
-					// I'm wondering if there is already a function that does exactly that? That turns
-					// Array<IPairedItemData | IPairedItemData[] | number | undefined> -> IPairedItemData[]
-					// or
-					// IPairedItemData | IPairedItemData[] | number | undefined -> IPairedItemData | undefined
-					function numberToPairedItem(
-						possiblyPairedItems: Array<INodeExecutionData['pairedItem']>,
-					): IPairedItemData[] {
-						return possiblyPairedItems.reduce((pairedItems: IPairedItemData[], pairedItem) => {
-							if (typeof pairedItem === 'number') {
-								pairedItems.push({ item: pairedItem });
-							} else if (Array.isArray(pairedItem)) {
-								pairedItems.push(...pairedItem);
-							} else if (pairedItem) {
-								pairedItems.push(pairedItem);
-							}
-
-							return pairedItems;
-						}, [] as IPairedItemData[]);
-					}
-
-					const pairedItem = numberToPairedItem([
+					const pairedItem = [
 						...this.getInputData(0).map((inputData) => inputData.pairedItem),
 						...this.getInputData(1).map((inputData) => inputData.pairedItem),
-					]);
+					].flatMap(preparePairedItemDataArray);
 
 					returnData.push({
 						json: {},


### PR DESCRIPTION
## Summary
Referencing items before a merge node was broken when you chose to return a single empty object due to how the paired items were handled.

I stumbled on this while attempting to solve the level 2 course.



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
