### PR TITLE
fix(editor): Send template id as a number in telemetry events

### DIFF
--- a/packages/editor-ui/src/mixins/workflowHelpers.ts
+++ b/packages/editor-ui/src/mixins/workflowHelpers.ts
@@ -1094,7 +1094,7 @@ export const workflowHelpers = defineComponent({
 				const templateId = this.$route.query.templateId;
 				if (templateId) {
 					this.$telemetry.track('User saved new workflow from template', {
-						template_id: templateId,
+						template_id: isNaN(+templateId) ? templateId : +templateId,
 						workflow_id: workflowData.id,
 						wf_template_repo_session_id: this.templatesStore.previousSessionId,
 					});

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/setupTemplate.store.ts
@@ -207,7 +207,7 @@ export const useSetupTemplateStore = defineStore('setupTemplate', () => {
 			);
 
 			telemetry.track('User saved new workflow from template', {
-				template_id: templateId.value,
+				template_id: isNaN(+templateId.value) ? templateId : +templateId.value,
 				workflow_id: createdWorkflow.id,
 				wf_template_repo_session_id: templatesStore.currentSessionId,
 			});


### PR DESCRIPTION
## Summary
Our event database expects template id in these events as numbers. 
Agreed with @nik8n  to send strings if, for some reason, id cannot be parsed to number. This will end up as `null` in DB as a signal that something is wrong.

## Related tickets and issues
Fixes ADO-1764

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 