### PR TITLE
fix(Extract From File Node): Remove unimplemented `xml` operation (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/ExtractFromFile.node.ts
@@ -80,12 +80,6 @@ export class ExtractFromFile implements INodeType {
 						description: 'Extracts the content of a text file',
 					},
 					{
-						name: 'Extract From XML',
-						value: 'xml',
-						action: 'Extract from XLS',
-						description: 'Extracts the content of an XML file',
-					},
-					{
 						name: 'Extract From XLS',
 						value: 'xls',
 						action: 'Extract from XLS',
@@ -121,7 +115,7 @@ export class ExtractFromFile implements INodeType {
 			returnData = await spreadsheet.execute.call(this, items, 'operation');
 		}
 
-		if (['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'].includes(operation)) {
+		if (['binaryToPropery', 'fromJson', 'text', 'fromIcs'].includes(operation)) {
 			returnData = await moveTo.execute.call(this, items, operation);
 		}
 

--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/moveTo.operation.ts
@@ -94,7 +94,7 @@ export const properties: INodeProperties[] = [
 
 const displayOptions = {
 	show: {
-		operation: ['binaryToPropery', 'fromJson', 'text', 'fromIcs', 'xml'],
+		operation: ['binaryToPropery', 'fromJson', 'text', 'fromIcs'],
 	},
 };
 


### PR DESCRIPTION
This operation was added in #7651, but it doesn't seem to have an implementation.
Since we still have the `Xml` node, until we consolidate that into `ExtractFromFile` / `ConvertToFile`, we should delete this operation.

## Review / Merge checklist
- [x] PR title and summary are descriptive