### PR TITLE
fix(core): Don't report executions that have been paused as failed to rudderstack and log streams

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -301,6 +301,11 @@ export class InternalHooks {
 			return;
 		}
 
+		if (runData?.status === 'waiting') {
+			// No need to send telemetry or logs when the workflow hasn't finished yet.
+			return;
+		}
+
 		const promises = [];
 
 		const telemetryProperties: IExecutionTrackProperties = {
@@ -439,7 +444,7 @@ export class InternalHooks {
 				? this.eventBus.sendWorkflowEvent({
 						eventName: 'n8n.workflow.success',
 						payload: sharedEventPayload,
-				  })
+					})
 				: this.eventBus.sendWorkflowEvent({
 						eventName: 'n8n.workflow.failed',
 						payload: {
@@ -449,7 +454,7 @@ export class InternalHooks {
 							errorNodeId: telemetryProperties.error_node_id?.toString(),
 							errorMessage: telemetryProperties.error_message?.toString(),
 						},
-				  }),
+					}),
 		);
 
 		void Promise.all([...promises, this.telemetry.trackWorkflowExecution(telemetryProperties)]);

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -444,7 +444,7 @@ export class InternalHooks {
 				? this.eventBus.sendWorkflowEvent({
 						eventName: 'n8n.workflow.success',
 						payload: sharedEventPayload,
-					})
+				  })
 				: this.eventBus.sendWorkflowEvent({
 						eventName: 'n8n.workflow.failed',
 						payload: {
@@ -454,7 +454,7 @@ export class InternalHooks {
 							errorNodeId: telemetryProperties.error_node_id?.toString(),
 							errorMessage: telemetryProperties.error_message?.toString(),
 						},
-					}),
+				  }),
 		);
 
 		void Promise.all([...promises, this.telemetry.trackWorkflowExecution(telemetryProperties)]);

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -583,7 +583,7 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 
 					const workflowStatusFinal = determineFinalExecutionStatus(fullRunData);
 
-					if (workflowStatusFinal !== 'success') {
+					if (workflowStatusFinal !== 'success' && workflowStatusFinal !== 'waiting') {
 						executeErrorWorkflow(
 							this.workflowData,
 							fullRunData,


### PR DESCRIPTION
## Summary
This prevents the `onWorkflowPostExecute` and `executeErrorWorkflow` functions from executing if the workflow is just paused (persisted to the db with a wait node longer than 60 seconds) and hasn't finished.

This PR has no tests, but we want to merge it to get the fix into today's release to unblock a user.
This part of the code is not covered by tests so far and is up for refactoring, at which point we'll add tests.

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1298/bug-log-streaming-fires-failed-workflow-notification-on-long-wait


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
