### PR TITLE
fix(core): Fix new graceful shutdown env being always overridden by deprecated env

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -44,7 +44,7 @@ export abstract class BaseCommand extends Command {
 	/**
 	 * How long to wait for graceful shutdown before force killing the process.
 	 */
-	protected gracefulShutdownTimeoutInS: number = config.getEnv('generic.gracefulShutdownTimeout');
+	protected gracefulShutdownTimeoutInS = config.getEnv('generic.gracefulShutdownTimeout');
 
 	async init(): Promise<void> {
 		await initErrorHandling();

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -267,9 +267,10 @@ export class Worker extends BaseCommand {
 	}
 
 	async init() {
-		const shutdownTimeoutFromDeprecatedEnv = config.getEnv('queue.bull.gracefulShutdownTimeout');
-		if (shutdownTimeoutFromDeprecatedEnv !== config.default('queue.bull.gracefulShutdownTimeout')) {
-			this.gracefulShutdownTimeoutInS = shutdownTimeoutFromDeprecatedEnv;
+		const { QUEUE_WORKER_TIMEOUT } = process.env;
+		if (QUEUE_WORKER_TIMEOUT) {
+			this.gracefulShutdownTimeoutInS =
+				parseInt(QUEUE_WORKER_TIMEOUT, 10) || config.default('queue.bull.gracefulShutdownTimeout');
 			this.logger.warn(
 				'QUEUE_WORKER_TIMEOUT has been deprecated. Rename it to N8N_GRACEFUL_SHUTDOWN_TIMEOUT.',
 			);

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -267,9 +267,9 @@ export class Worker extends BaseCommand {
 	}
 
 	async init() {
-		const configuredShutdownTimeout = config.getEnv('queue.bull.gracefulShutdownTimeout');
-		if (configuredShutdownTimeout) {
-			this.gracefulShutdownTimeoutInS = configuredShutdownTimeout;
+		const shutdownTimeoutFromDeprecatedEnv = config.getEnv('queue.bull.gracefulShutdownTimeout');
+		if (shutdownTimeoutFromDeprecatedEnv !== config.default('queue.bull.gracefulShutdownTimeout')) {
+			this.gracefulShutdownTimeoutInS = shutdownTimeoutFromDeprecatedEnv;
 			this.logger.warn(
 				'QUEUE_WORKER_TIMEOUT has been deprecated. Rename it to N8N_GRACEFUL_SHUTDOWN_TIMEOUT.',
 			);


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1321