### PR TITLE
ci: Replace `pnpm/action-setup` action with corepack (no-changelog)

### DIFF
--- a/.github/workflows/check-documentation-urls.yml
+++ b/.github/workflows/check-documentation-urls.yml
@@ -16,8 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4.0.1
         with:
@@ -64,8 +63,7 @@ jobs:
           repository: n8n-io/n8n
           ref: ${{ inputs.branch }}
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4.0.1
         with:

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v2.4.0
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
@@ -43,7 +43,7 @@ jobs:
       DB_MYSQLDB_PASSWORD: password
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v2.4.0
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x
@@ -76,7 +76,7 @@ jobs:
       DB_POSTGRESDB_PASSWORD: password
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v2.4.0
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -12,8 +12,7 @@ jobs:
           repository: n8n-io/n8n
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - name: Use Node.js 18
         uses: actions/setup-node@v4.0.1
         with:
@@ -50,8 +49,7 @@ jobs:
           repository: n8n-io/n8n
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - name: Use Node.js 18
         uses: actions/setup-node@v4.0.1
         with:

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -35,7 +35,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.base-branch }}
 
-      - uses: pnpm/action-setup@v2.4.0
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.4.0
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.1
         with:
           node-version: 18.x

--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -23,9 +23,8 @@ jobs:
           repository: n8n-io/test-workflows
           path: test-workflows
 
-      - uses: pnpm/action-setup@v2.4.0
-        with:
-          package_json_file: n8n/package.json
+      - run: corepack enable
+        working-directory: n8n
 
       - uses: actions/setup-node@v4.0.1
         with:

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -35,8 +35,7 @@ jobs:
           repository: n8n-io/n8n
           ref: ${{ inputs.ref }}
 
-      - uses: pnpm/action-setup@v2.4.0
-
+      - run: corepack enable
       - name: Use Node.js ${{ inputs.nodeVersion }}
         uses: actions/setup-node@v4.0.1
         with:


### PR DESCRIPTION
We added the `pnpm/action-setup` action before corepack was available across all supported node.js versions. Since then we've upgraded node.js, and don't need to use this action anymore.

PS: Had to exclude the e2e workflows because those jobs run as user 1001, who does not have the permissions to run `corepack enable`.

## Review / Merge checklist
- [x] PR title and summary are descriptive

* [Check Docs](https://github.com/n8n-io/n8n/actions/runs/7724955338)
* [Workflow Tests](https://github.com/n8n-io/n8n/actions/runs/7724958216)
* [DB Tests](https://github.com/n8n-io/n8n/actions/runs/7724959270)