### PR TITLE
feat(editor): Skip RBAC checks in preview mode (no-changelog)

### DIFF
--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -83,6 +83,7 @@ export class FrontendService {
 		}
 
 		this.settings = {
+			previewMode: process.env.N8N_PREVIEW_MODE === 'true',
 			endpointForm: config.getEnv('endpoints.form'),
 			endpointFormTest: config.getEnv('endpoints.formTest'),
 			endpointFormWaiting: config.getEnv('endpoints.formWaiting'),

--- a/packages/editor-ui/src/rbac/checks/__tests__/isAuthenticated.test.ts
+++ b/packages/editor-ui/src/rbac/checks/__tests__/isAuthenticated.test.ts
@@ -7,8 +7,9 @@ vi.mock('@/stores/users.store', () => ({
 
 describe('Checks', () => {
 	describe('isAuthenticated()', () => {
+		const mockUser = { id: 'user123', name: 'Test User' };
+
 		it('should return true if there is a current user', () => {
-			const mockUser = { id: 'user123', name: 'Test User' };
 			vi.mocked(useUsersStore).mockReturnValue({ currentUser: mockUser } as unknown as ReturnType<
 				typeof useUsersStore
 			>);
@@ -22,6 +23,30 @@ describe('Checks', () => {
 			>);
 
 			expect(isAuthenticated()).toBe(false);
+		});
+
+		it('should return true if there is a current user and bypass returns false', () => {
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: mockUser } as ReturnType<
+				typeof useUsersStore
+			>);
+
+			expect(isAuthenticated({ bypass: () => false })).toBe(true);
+		});
+
+		it('should return true if there is no current user and bypass returns true', () => {
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as ReturnType<
+				typeof useUsersStore
+			>);
+
+			expect(isAuthenticated({ bypass: () => true })).toBe(true);
+		});
+
+		it('should return false if there is no current user and bypass returns false', () => {
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as ReturnType<
+				typeof useUsersStore
+			>);
+
+			expect(isAuthenticated({ bypass: () => false })).toBe(false);
 		});
 	});
 });

--- a/packages/editor-ui/src/rbac/checks/isAuthenticated.ts
+++ b/packages/editor-ui/src/rbac/checks/isAuthenticated.ts
@@ -1,7 +1,11 @@
 import { useUsersStore } from '@/stores/users.store';
 import type { RBACPermissionCheck, AuthenticatedPermissionOptions } from '@/types/rbac';
 
-export const isAuthenticated: RBACPermissionCheck<AuthenticatedPermissionOptions> = () => {
+export const isAuthenticated: RBACPermissionCheck<AuthenticatedPermissionOptions> = (options) => {
+	if (options?.bypass?.()) {
+		return true;
+	}
+
 	const usersStore = useUsersStore();
 	return !!usersStore.currentUser;
 };

--- a/packages/editor-ui/src/rbac/middleware/authenticated.ts
+++ b/packages/editor-ui/src/rbac/middleware/authenticated.ts
@@ -7,8 +7,9 @@ export const authenticatedMiddleware: RouterMiddleware<AuthenticatedPermissionOp
 	to,
 	from,
 	next,
+	options,
 ) => {
-	const valid = isAuthenticated();
+	const valid = isAuthenticated(options);
 	if (!valid) {
 		const redirect =
 			to.query.redirect ??

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -358,9 +358,15 @@ export const routes = [
 			default: NodeView,
 		},
 		meta: {
-			...(import.meta.env.VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE
-				? {}
-				: { middleware: ['authenticated'] }),
+			middleware: ['authenticated'],
+			middelwareOptions: {
+				authenticated: {
+					bypass: () => {
+						const settingsStore = useSettingsStore();
+						return settingsStore.isPreviewMode;
+					},
+				},
+			},
 		},
 	},
 	{

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -358,7 +358,9 @@ export const routes = [
 			default: NodeView,
 		},
 		meta: {
-			middleware: ['authenticated'],
+			...(import.meta.env.VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE
+				? {}
+				: { middleware: ['authenticated'] }),
 		},
 	},
 	{

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -359,7 +359,7 @@ export const routes = [
 		},
 		meta: {
 			middleware: ['authenticated'],
-			middelwareOptions: {
+			middlewareOptions: {
 				authenticated: {
 					bypass: () => {
 						const settingsStore = useSettingsStore();

--- a/packages/editor-ui/src/shims.d.ts
+++ b/packages/editor-ui/src/shims.d.ts
@@ -14,7 +14,6 @@ declare global {
 			NODE_ENV: 'development' | 'production';
 			VUE_APP_URL_BASE_API: string;
 			VUE_APP_MAX_PINNED_DATA_SIZE: string;
-			VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE: boolean;
 		};
 	}
 

--- a/packages/editor-ui/src/shims.d.ts
+++ b/packages/editor-ui/src/shims.d.ts
@@ -14,6 +14,7 @@ declare global {
 			NODE_ENV: 'development' | 'production';
 			VUE_APP_URL_BASE_API: string;
 			VUE_APP_MAX_PINNED_DATA_SIZE: string;
+			VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE: boolean;
 		};
 	}
 

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -85,6 +85,9 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 		isSwaggerUIEnabled(): boolean {
 			return this.api.swaggerUi.enabled;
 		},
+		isPreviewMode(): boolean {
+			return this.settings.previewModeEnabled;
+		},
 		publicApiLatestVersion(): number {
 			return this.api.latestVersion;
 		},

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -86,7 +86,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 			return this.api.swaggerUi.enabled;
 		},
 		isPreviewMode(): boolean {
-			return true; // || this.settings.previewMode;
+			return this.settings.previewMode;
 		},
 		publicApiLatestVersion(): number {
 			return this.api.latestVersion;

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -86,7 +86,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 			return this.api.swaggerUi.enabled;
 		},
 		isPreviewMode(): boolean {
-			return this.settings.previewModeEnabled;
+			return this.settings.previewMode;
 		},
 		publicApiLatestVersion(): number {
 			return this.api.latestVersion;

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -86,7 +86,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, {
 			return this.api.swaggerUi.enabled;
 		},
 		isPreviewMode(): boolean {
-			return this.settings.previewMode;
+			return true; // || this.settings.previewMode;
 		},
 		publicApiLatestVersion(): number {
 			return this.api.latestVersion;

--- a/packages/editor-ui/src/types/rbac.ts
+++ b/packages/editor-ui/src/types/rbac.ts
@@ -2,7 +2,9 @@ import type { EnterpriseEditionFeature } from '@/constants';
 import type { Resource, ScopeOptions, Scope } from '@n8n/permissions';
 import type { IRole } from '@/Interface';
 
-export type AuthenticatedPermissionOptions = {};
+export type AuthenticatedPermissionOptions = {
+	bypass?: () => boolean;
+};
 export type CustomPermissionOptions<C = {}> = RBACPermissionCheck<C>;
 export type DefaultUserMiddlewareOptions = {};
 export type InstanceOwnerMiddlewareOptions = {};

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -806,7 +806,7 @@ export default defineComponent({
 
 		this.canvasStore.startLoading();
 		const loadPromises =
-			import.meta.env.VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE && this.isDemo
+			this.settingsStore.isPreviewMode && this.isDemo
 				? []
 				: [
 						this.loadActiveWorkflows(),

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -805,15 +805,16 @@ export default defineComponent({
 		this.clipboard.onPaste.value = this.onClipboardPasteEvent;
 
 		this.canvasStore.startLoading();
-		const loadPromises = this.isDemo
-			? []
-			: [
-					this.loadActiveWorkflows(),
-					this.loadCredentials(),
-					this.loadCredentialTypes(),
-					this.loadVariables(),
-					this.loadSecrets(),
-			  ];
+		const loadPromises =
+			import.meta.env.VUE_APP_PUBLIC_WORKFLOWS_DEMO_ROUTE && this.isDemo
+				? []
+				: [
+						this.loadActiveWorkflows(),
+						this.loadCredentials(),
+						this.loadCredentialTypes(),
+						this.loadVariables(),
+						this.loadSecrets(),
+				  ];
 
 		if (this.nodeTypesStore.allNodeTypes.length === 0) {
 			loadPromises.push(this.loadNodeTypes());

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -805,13 +805,15 @@ export default defineComponent({
 		this.clipboard.onPaste.value = this.onClipboardPasteEvent;
 
 		this.canvasStore.startLoading();
-		const loadPromises = [
-			this.loadActiveWorkflows(),
-			this.loadCredentials(),
-			this.loadCredentialTypes(),
-			this.loadVariables(),
-			this.loadSecrets(),
-		];
+		const loadPromises = this.isDemo
+			? []
+			: [
+					this.loadActiveWorkflows(),
+					this.loadCredentials(),
+					this.loadCredentialTypes(),
+					this.loadVariables(),
+					this.loadSecrets(),
+			  ];
 
 		if (this.nodeTypesStore.allNodeTypes.length === 0) {
 			loadPromises.push(this.loadNodeTypes());

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2505,7 +2505,7 @@ export interface IN8nUISettings {
 	workflowTagsDisabled: boolean;
 	logLevel: LogLevel;
 	hiringBannerEnabled: boolean;
-	previewModeEnabled: boolean;
+	previewMode: boolean;
 	templates: {
 		enabled: boolean;
 		host: string;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2505,6 +2505,7 @@ export interface IN8nUISettings {
 	workflowTagsDisabled: boolean;
 	logLevel: LogLevel;
 	hiringBannerEnabled: boolean;
+	previewModeEnabled: boolean;
 	templates: {
 		enabled: boolean;
 		host: string;


### PR DESCRIPTION
This PR updated editor to skip frontend RBAC checks when the backend is running in the preview mode (`N8N_PREVIEW_MODE: true`).

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1325/bug-preview-instance-not-accessible

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included