### PR TITLE
fix(core): Forward authorization header when on same domain

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -452,16 +452,14 @@ async function parseRequestObject(requestObject: IDataObject) {
 		axiosConfig.maxRedirects = 0;
 	}
 
-	if (axiosConfig.maxRedirects !== 0) {
-		axiosConfig.beforeRedirect = (redirectedRequest) => {
-			if (axiosConfig.headers?.Authorization) {
-				redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
-			}
-			if (axiosConfig.auth) {
-				redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
-			}
-		};
-	}
+	axiosConfig.beforeRedirect = (redirectedRequest) => {
+		if (axiosConfig.headers?.Authorization) {
+			redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
+		}
+		if (axiosConfig.auth) {
+			redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
+		}
+	};
 
 	if (requestObject.rejectUnauthorized === false) {
 		axiosConfig.httpsAgent = new Agent({

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -454,15 +454,11 @@ async function parseRequestObject(requestObject: IDataObject) {
 
 	if (axiosConfig.maxRedirects !== 0) {
 		axiosConfig.beforeRedirect = (redirectedRequest) => {
-			const originalDomain = new URL(axiosConfig.url as string, axiosConfig.baseURL).hostname;
-			const redirectedDomain = new URL(redirectedRequest.href as string).hostname;
-			if (originalDomain === redirectedDomain) {
-				if (axiosConfig.headers?.Authorization) {
-					redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
-				}
-				if (axiosConfig.auth) {
-					redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
-				}
+			if (axiosConfig.headers?.Authorization) {
+				redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
+			}
+			if (axiosConfig.auth) {
+				redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
 			}
 		};
 	}

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -452,6 +452,21 @@ async function parseRequestObject(requestObject: IDataObject) {
 		axiosConfig.maxRedirects = 0;
 	}
 
+	if (axiosConfig.maxRedirects !== 0) {
+		axiosConfig.beforeRedirect = (redirectedRequest) => {
+			const originalDomain = new URL(axiosConfig.url as string, axiosConfig.baseURL).hostname;
+			const redirectedDomain = new URL(redirectedRequest.href as string).hostname;
+			if (originalDomain === redirectedDomain) {
+				if (axiosConfig.headers?.Authorization) {
+					redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
+				}
+				if (axiosConfig.auth) {
+					redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
+				}
+			}
+		};
+	}
+
 	if (requestObject.rejectUnauthorized === false) {
 		axiosConfig.httpsAgent = new Agent({
 			rejectUnauthorized: false,

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -295,6 +295,93 @@ describe('NodeExecuteFunctions', () => {
 				node,
 			]);
 		});
+
+		describe('redirects', () => {
+			describe('when redirect is on same domain', () => {
+				test('should forward authorization header', async () => {
+					nock(baseUrl)
+						.get('/redirect')
+						.reply(301, '', { Location: `${baseUrl}/test` });
+					nock(baseUrl)
+						.get('/test')
+						.reply(200, function () {
+							return this.req.headers;
+						});
+
+					const response = await proxyRequestToAxios(workflow, additionalData, node, {
+						url: `${baseUrl}/redirect`,
+						auth: {
+							username: 'testuser',
+							password: 'testpassword',
+						},
+						resolveWithFullResponse: true,
+					});
+
+					expect(response.statusCode).toBe(200);
+					const forwardedHeaders = JSON.parse(response.body);
+					expect(forwardedHeaders.authorization).toEqual('Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk');
+				});
+			});
+
+			describe('when redirect is not on same domain', () => {
+				test('should not forward authorization header', async () => {
+					nock(baseUrl)
+						.get('/redirect')
+						.reply(301, '', { Location: 'https://otherdomain.com/test' });
+					nock('https://otherdomain.com')
+						.get('/test')
+						.reply(200, function () {
+							return this.req.headers;
+						});
+
+					const response = await proxyRequestToAxios(workflow, additionalData, node, {
+						url: `${baseUrl}/redirect`,
+						auth: {
+							username: 'testuser',
+							password: 'testpassword',
+						},
+						resolveWithFullResponse: true,
+					});
+
+					expect(response.statusCode).toBe(200);
+					const forwardedHeaders = JSON.parse(response.body);
+					expect(forwardedHeaders.authorization).toBeUndefined();
+				});
+			});
+
+			test('should follow redirects by default', async () => {
+				nock(baseUrl)
+					.get('/redirect')
+					.reply(301, '', { Location: `${baseUrl}/test` });
+				nock(baseUrl).get('/test').reply(200, 'Redirected');
+
+				const response = await proxyRequestToAxios(workflow, additionalData, node, {
+					url: `${baseUrl}/redirect`,
+					resolveWithFullResponse: true,
+				});
+
+				expect(response).toMatchObject({
+					body: 'Redirected',
+					headers: {},
+					statusCode: 200,
+				});
+			});
+
+			test('should not follow redirects when configured', async () => {
+				nock(baseUrl)
+					.get('/redirect')
+					.reply(301, '', { Location: `${baseUrl}/test` });
+				nock(baseUrl).get('/test').reply(200, 'Redirected');
+
+				await expect(
+					proxyRequestToAxios(workflow, additionalData, node, {
+						url: `${baseUrl}/redirect`,
+						resolveWithFullResponse: true,
+						followRedirect: false,
+					}),
+				).rejects.toThrowError(expect.objectContaining({ statusCode: 301 }));
+			});
+		});
 	});
 
 	describe('copyInputItems', () => {

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -314,12 +314,16 @@ describe('NodeExecuteFunctions', () => {
 							username: 'testuser',
 							password: 'testpassword',
 						},
+						headers: {
+							'X-Other-Header': 'otherHeaderContent',
+						},
 						resolveWithFullResponse: true,
 					});
 
 					expect(response.statusCode).toBe(200);
 					const forwardedHeaders = JSON.parse(response.body);
 					expect(forwardedHeaders.authorization).toEqual('Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk');
+					expect(forwardedHeaders['x-other-header']).toBe('otherHeaderContent');
 				});
 			});
 
@@ -340,12 +344,16 @@ describe('NodeExecuteFunctions', () => {
 							username: 'testuser',
 							password: 'testpassword',
 						},
+						headers: {
+							'X-Other-Header': 'otherHeaderContent',
+						},
 						resolveWithFullResponse: true,
 					});
 
 					expect(response.statusCode).toBe(200);
 					const forwardedHeaders = JSON.parse(response.body);
 					expect(forwardedHeaders.authorization).toBeUndefined();
+					expect(forwardedHeaders['x-other-header']).toBe('otherHeaderContent');
 				});
 			});
 


### PR DESCRIPTION
## Summary
At some point between 1.22.1 and 1.22.4 when authenticating against a service that redirects the auth headers were being removed on redirect.

This PR forwards the authorization header

Reproduction notes + workflow JSON in Linear

<img width="1522" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/04b98fef-c2eb-4897-84d2-2e8ae76b7ad3">


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1091/http-request-auth-no-longer-working-on-redirects



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 