### PR TITLE
fix(core): Ensure AxiosError status always gets copied over to NodeApiError

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -51,6 +51,7 @@
     "@n8n/tournament": "1.0.2",
     "@n8n_io/riot-tmpl": "4.0.0",
     "ast-types": "0.15.2",
+    "axios": "1.6.7",
     "callsites": "3.1.0",
     "deep-equal": "2.2.0",
     "esprima-next": "5.8.4",

--- a/packages/workflow/src/errors/node-api.error.ts
+++ b/packages/workflow/src/errors/node-api.error.ts
@@ -14,6 +14,7 @@ import type {
 import { NodeError } from './abstract/node.error';
 import { removeCircularRefs } from '../utils';
 import type { ReportingOptions } from './application.error';
+import { AxiosError } from 'axios';
 
 export interface NodeOperationErrorOptions {
 	message?: string;
@@ -126,6 +127,10 @@ export class NodeApiError extends NodeError {
 		}: NodeApiErrorOptions = {},
 	) {
 		super(node, errorResponse);
+
+		if (!httpCode && errorResponse instanceof AxiosError) {
+			httpCode = errorResponse.response?.status?.toString();
+		}
 
 		// only for request library error
 		if (errorResponse.error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1502,6 +1502,9 @@ importers:
       ast-types:
         specifier: 0.15.2
         version: 0.15.2
+      axios:
+        specifier: 1.6.7
+        version: 1.6.7(debug@3.2.7)
       callsites:
         specifier: 3.1.0
         version: 3.1.0


### PR DESCRIPTION
This should address https://n8nio.sentry.io/issues/4748177608

## Review / Merge checklist
- [x] PR title and summary are descriptive