### PR TITLE
ci: Skip running `postInstall` scripts for all packages except sqlite3 (no-changelog)

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -8,7 +8,8 @@ ENV N8N_VERSION=${N8N_VERSION}
 ENV NODE_ENV=production
 ENV N8N_RELEASE_TYPE=stable
 RUN set -eux; \
-	npm install -g --omit=dev n8n@${N8N_VERSION} && \
+	npm install -g --omit=dev n8n@${N8N_VERSION} --ignore-scripts && \
+	npm rebuild --prefix=/usr/local/lib/node_modules/n8n sqlite3 && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/@n8n/chat && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/n8n-design-system && \
 	rm -rf /usr/local/lib/node_modules/n8n/node_modules/n8n-editor-ui/node_modules && \


### PR DESCRIPTION
`postInstall` script from updated `@rudderstack/rudder-sdk-node` is causing our release builds to fail. 
On non-release docker builds we skip all `postInstall` scripts. This PR updates our release docker builds to do the same.

[Related issue](https://github.com/rudderlabs/rudder-sdk-node/issues/129)

## Review / Merge checklist
- [x] PR title and summary are descriptive