### PR TITLE
fix(core): Handle missing testing function on credentials

### DIFF
--- a/packages/cli/src/LoadNodesAndCredentials.ts
+++ b/packages/cli/src/LoadNodesAndCredentials.ts
@@ -299,7 +299,9 @@ export class LoadNodesAndCredentials {
 					sourcePath: path.join(directory, sourcePath),
 					supportedNodes:
 						loader instanceof PackageDirectoryLoader
-							? supportedNodes?.map((nodeName) => `${loader.packageName}.${nodeName}`)
+							? Object.keys(loader.nodeTypes).length > 0
+								? Object.keys(loader.nodeTypes)
+								: supportedNodes?.map((nodeName) => `${loader.packageName}.${nodeName}`)
 							: undefined,
 					extends: extendsArr,
 				};


### PR DESCRIPTION
Fix: No testing function found for this credential (non-versioned node)

## Summary
Small change to the logic in `postProcessLoaders` to allow nodes loaded from custom directories to use the credentials test function specified in the node. The code was incorrectly concatenating the package name twice when mapping the node to the `supportedNodes `property of the `known.credentials`.


## Related tickets and issues
This addresses issue #8188 


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.