### PR TITLE
fix(core): Fix test runs of triggers that rely on static data

### DIFF
--- a/packages/cli/src/TestWebhooks.ts
+++ b/packages/cli/src/TestWebhooks.ts
@@ -91,9 +91,11 @@ export class TestWebhooks implements IWebhookManager {
 			});
 		}
 
-		const { destinationNode, sessionId, workflowEntity } = registration;
+		const { destinationNode, sessionId, workflowEntity, webhook: testWebhook } = registration;
 
 		const workflow = this.toWorkflow(workflowEntity);
+
+		if (testWebhook.staticData) workflow.setTestStaticData(testWebhook.staticData);
 
 		const workflowStartNode = workflow.getNode(webhook.node);
 
@@ -405,14 +407,7 @@ export class TestWebhooks implements IWebhookManager {
 			connections: workflowEntity.connections,
 			active: false,
 			nodeTypes: this.nodeTypes,
-
-			/**
-			 * `staticData` in the original workflow entity has production webhook IDs.
-			 * Since we are creating here a temporary workflow only for a test webhook,
-			 * `staticData` from the original workflow entity should not be transferred.
-			 */
-			staticData: undefined,
-
+			staticData: {},
 			settings: workflowEntity.settings,
 		});
 	}

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -81,6 +81,8 @@ export class Workflow {
 	// ids of registered webhooks of nodes
 	staticData: IDataObject;
 
+	testStaticData: IDataObject | undefined;
+
 	pinData?: IPinData;
 
 	// constructor(id: string | undefined, nodes: INode[], connections: IConnections, active: boolean, nodeTypes: INodeTypes, staticData?: IDataObject, settings?: IWorkflowSettings) {
@@ -328,6 +330,8 @@ export class Workflow {
 			});
 		}
 
+		if (this.testStaticData?.[key]) return this.testStaticData[key] as IDataObject;
+
 		if (this.staticData[key] === undefined) {
 			// Create it as ObservableObject that we can easily check if the data changed
 			// to know if the workflow with its data has to be saved afterwards or not.
@@ -335,6 +339,10 @@ export class Workflow {
 		}
 
 		return this.staticData[key] as IDataObject;
+	}
+
+	setTestStaticData(testStaticData: IDataObject) {
+		this.testStaticData = testStaticData;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

For multi-main setup we had to externalize test webhook registrations to a cache, Redis in multi-main setup and in-memory in single-main mode. Static data is part of the webhook in the test webhook registration in the cache and is available when activating and deactivating the test webhook, but there are trigger nodes that require static data (e.g. computing a signature) and in test runs they are receiving production static data instead of static data in the test webhook registration. This PR introduces test static data for test webhooks and makes it available to nodes.

As discussed with Omar, test webhooks are hard to properly test at the moment. To protect functionality, ideally we'd need to refactor test webhooks to make them more testable first.

## Related tickets and issues

- https://linear.app/n8n/issue/PAY-1339
- https://community.n8n.io/t/typeerror-the-key-argument-must-be-of-type-string-or-an-instance-of-buffer-typedarray-dataview-or-keyobject-received-undefined/35837