### PR TITLE
fix: Update BaseChatModel import checks for MistralAI compatibility

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -6,24 +6,21 @@ import {
 } from 'n8n-workflow';
 
 import { initializeAgentExecutorWithOptions } from 'langchain/agents';
-import { BaseChatModel } from 'langchain/chat_models/base';
 import type { Tool } from 'langchain/tools';
 import type { BaseChatMemory } from 'langchain/memory';
 import type { BaseOutputParser } from 'langchain/schema/output_parser';
 import { PromptTemplate } from 'langchain/prompts';
 import { CombiningOutputParser } from 'langchain/output_parsers';
+import { isChatInstance } from '../../../../../utils/helpers';
 
 export async function conversationalAgentExecute(
 	this: IExecuteFunctions,
 ): Promise<INodeExecutionData[][]> {
 	this.logger.verbose('Executing Conversational Agent');
 
-	const model = (await this.getInputConnectionData(
-		NodeConnectionType.AiLanguageModel,
-		0,
-	)) as BaseChatModel;
+	const model = await this.getInputConnectionData(NodeConnectionType.AiLanguageModel, 0);
 
-	if (!(model instanceof BaseChatModel)) {
+	if (!isChatInstance(model)) {
 		throw new NodeOperationError(this.getNode(), 'Conversational Agent requires Chat Model');
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -11,7 +11,8 @@ import type { Tool } from 'langchain/tools';
 import type { BaseOutputParser } from 'langchain/schema/output_parser';
 import { PromptTemplate } from 'langchain/prompts';
 import { CombiningOutputParser } from 'langchain/output_parsers';
-import { BaseChatModel } from 'langchain/chat_models/base';
+import type { BaseChatModel } from 'langchain/chat_models/base';
+import { isChatInstance } from '../../../../../utils/helpers';
 
 export async function reActAgentAgentExecute(
 	this: IExecuteFunctions,
@@ -38,7 +39,7 @@ export async function reActAgentAgentExecute(
 	};
 	let agent: ChatAgent | ZeroShotAgent;
 
-	if (model instanceof BaseChatModel) {
+	if (isChatInstance(model)) {
 		agent = ChatAgent.fromLLMAndTools(model, tools, {
 			prefix: options.prefix,
 			suffix: options.suffixChat,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -19,9 +19,10 @@ import {
 import type { BaseOutputParser } from 'langchain/schema/output_parser';
 import { CombiningOutputParser } from 'langchain/output_parsers';
 import { LLMChain } from 'langchain/chains';
-import { BaseChatModel } from 'langchain/chat_models/base';
+import type { BaseChatModel } from 'langchain/chat_models/base';
 import { HumanMessage } from 'langchain/schema';
 import { getTemplateNoticeField } from '../../../utils/sharedFields';
+import { isChatInstance } from '../../../utils/helpers';
 
 interface MessagesTemplate {
 	type: string;
@@ -94,7 +95,7 @@ async function getChainPromptTemplate(
 		partialVariables: formatInstructions ? { formatInstructions } : undefined,
 	});
 
-	if (llm instanceof BaseChatModel) {
+	if (isChatInstance(llm)) {
 		const parsedMessages = await Promise.all(
 			(messages ?? []).map(async (message) => {
 				const messageClass = [

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -1,4 +1,6 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
+import { BaseChatModel } from 'langchain/chat_models/base';
+import { BaseChatModel as BaseChatModelCore } from '@langchain/core/language_models/chat_models';
 
 export function getMetadataFiltersValues(
 	ctx: IExecuteFunctions,
@@ -13,4 +15,9 @@ export function getMetadataFiltersValues(
 	}
 
 	return undefined;
+}
+
+// TODO: Remove this function once langchain package is updated to 0.1.x
+export function isChatInstance(model: any): model is BaseChatModel | BaseChatModelCore {
+	return model instanceof BaseChatModel || model instanceof BaseChatModelCore;
 }

--- a/packages/@n8n/nodes-langchain/utils/logWrapper.ts
+++ b/packages/@n8n/nodes-langchain/utils/logWrapper.ts
@@ -27,6 +27,7 @@ import { BaseOutputParser } from 'langchain/schema/output_parser';
 import { isObject } from 'lodash';
 import { N8nJsonLoader } from './N8nJsonLoader';
 import { N8nBinaryLoader } from './N8nBinaryLoader';
+import { isChatInstance } from './helpers';
 
 const errorsMap: { [key: string]: { message: string; description: string } } = {
 	'You exceeded your current quota, please check your plan and billing details.': {
@@ -225,7 +226,7 @@ export function logWrapper(
 			}
 
 			// ========== BaseChatModel ==========
-			if (originalInstance instanceof BaseLLM || originalInstance instanceof BaseChatModel) {
+			if (originalInstance instanceof BaseLLM || isChatInstance(originalInstance)) {
 				if (prop === '_generate' && '_generate' in target) {
 					return async (
 						messages: BaseMessage[] & string[],


### PR DESCRIPTION
## Summary
`@langchain/mistralai` module extends `BaseChatModel` imported from `@langchain/core/language_models/chat_models` while the older models(at least in the version we're using(0.0.192)) import it from `langchain/chat_models/base`. So when we're doing check in our code if models extends `BaseChatModel` we check for both imports. Since we use this at multiple places, I've created a small utility function for it.
Once we upgrade to 0.1.x we can get rid of the `langchain/chat_models/base` check and only keep the other one.


## Related tickets and issues
- https://community.n8n.io/t/erreur-mistral-ai/36073

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 