### PR TITLE
fix(MongoDB Node): Fix "Maximum call stack size exceeded" error on too many rows

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -108,7 +108,6 @@ export class MongoDb implements INodeType {
 
 		const mdb = client.db(database);
 
-		const returnItems: INodeExecutionData[] = [];
 		let responseData: IDataObject | IDataObject[] = [];
 
 		const items = this.getInputData();
@@ -369,12 +368,10 @@ export class MongoDb implements INodeType {
 
 		const itemData = generatePairedItemData(items.length);
 
-		const executionData = this.helpers.constructExecutionMetaData(
+		const returnItems = this.helpers.constructExecutionMetaData(
 			this.helpers.returnJsonArray(responseData),
 			{ itemData },
 		);
-
-		returnItems.push(...executionData);
 
 		return [returnItems];
 	}


### PR DESCRIPTION
Previous similar fixes:

* Google Sheets Node #7384
* Microsoft SQL Node #8334

Fixes #8529

## Review / Merge checklist
- [x] PR title and summary are descriptive