### PR TITLE
test(core): Add tests for creating credentials and getting them by ID (no-changelog)

### DIFF
--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -31,12 +31,12 @@ describe('POST /credentials', () => {
 	};
 
 	describe('as unauthorized user', () => {
-		it('return 401', async () => {
+		it('returns 401', async () => {
 			await testServer.authlessAgent.post('/credentials').send(testPayload).expect(401);
 		});
 	});
 
-	describe('as member', () => {
+	describe('as a member', () => {
 		it('persists the credential', async () => {
 			//
 			// ACT
@@ -74,7 +74,7 @@ describe('POST /credentials', () => {
 		});
 	});
 
-	describe('as owner', () => {
+	describe('as an owner', () => {
 		it('persists the credential', async () => {
 			//
 			// ACT
@@ -139,7 +139,7 @@ describe('GET /credentials/:id', () => {
 		});
 	});
 
-	describe('as member user', () => {
+	describe('as a member', () => {
 		it('does not return decrypted data by default', async () => {
 			//
 			// ARRANGE
@@ -161,7 +161,6 @@ describe('GET /credentials/:id', () => {
 			//
 			// ASSERT
 			//
-			console.log(getResponse.body);
 			expect(getResponse.body.data.data).toBeUndefined();
 		});
 
@@ -185,7 +184,7 @@ describe('GET /credentials/:id', () => {
 		});
 	});
 
-	describe('as owner user', () => {
+	describe('as an owner', () => {
 		it("returns another user's credential", async () => {
 			//
 			// ARRANGE

--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -106,7 +106,7 @@ describe('POST /credentials', () => {
 
 			expect(getResponse.body.data).toMatchObject({
 				...postResponse.body.data,
-				// match against decryped data
+				// match against decrypted data
 				data: testPayload.data,
 			});
 		});
@@ -164,7 +164,7 @@ describe('GET /credentials/:id', () => {
 			expect(getResponse.body.data.data).toBeUndefined();
 		});
 
-		it("does not return anothers user's credentials", async () => {
+		it("does not return another user's credentials", async () => {
 			//
 			// ARRANGE
 			//


### PR DESCRIPTION
## Summary
This PR adds test for the current behaviour of `POST /credentials` and `GET /credentials/:id`

This is to make it safer to introduce projects for sharing credentials and workflows.

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1247/update-credentials-crud-apis



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
