### PR TITLE
fix: Remove ts-node from overrides and typeorm script (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
       "tough-cookie": "^4.1.3",
       "tslib": "^2.6.1",
       "tsconfig-paths": "^4.2.0",
-      "ts-node": "^10.9.1",
       "typescript": "^5.3.0",
       "xml2js": "^0.5.0",
       "cpy@8>globby": "^11.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "test:postgres": "N8N_LOG_LEVEL=silent DB_TYPE=postgresdb DB_POSTGRESDB_SCHEMA=alt_schema DB_TABLE_PREFIX=test_ jest --no-coverage",
     "test:mysql": "N8N_LOG_LEVEL=silent DB_TYPE=mysqldb DB_TABLE_PREFIX=test_ jest --no-coverage",
     "watch": "concurrently \"tsc -w -p tsconfig.build.json\" \"tsc-alias -w -p tsconfig.build.json\"",
-    "typeorm": "ts-node -T ../../node_modules/typeorm/cli.js"
+    "typeorm": "node ../../node_modules/typeorm/cli.js"
   },
   "bin": {
     "n8n": "./bin/n8n"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,6 @@ overrides:
   tough-cookie: ^4.1.3
   tslib: ^2.6.1
   tsconfig-paths: ^4.2.0
-  ts-node: ^10.9.1
   typescript: ^5.3.0
   xml2js: ^0.5.0
   cpy@8>globby: ^11.1.0
@@ -17673,7 +17672,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@types/node': ^18.16.16
-      ts-node: ^10.9.1
+      ts-node: '>=9.0.0'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -25377,7 +25376,7 @@ packages:
       redis: ^3.1.1 || ^4.0.0
       sql.js: ^1.4.0
       sqlite3: ^5.0.3
-      ts-node: ^10.9.1
+      ts-node: ^10.7.0
       typeorm-aurora-data-api-driver: ^2.0.0
     peerDependenciesMeta:
       '@google-cloud/spanner':
@@ -25458,7 +25457,7 @@ packages:
       redis: ^3.1.1 || ^4.0.0
       sql.js: ^1.4.0
       sqlite3: ^5.0.3
-      ts-node: ^10.9.1
+      ts-node: ^10.7.0
       typeorm-aurora-data-api-driver: ^2.0.0
     peerDependenciesMeta:
       '@google-cloud/spanner':


### PR DESCRIPTION
## Summary
No package depends on ts-node and the dependencies that depend on ts-node
only do so optionally or as a peer dependency. So it would never be installed or used.
So it does not need to be in the `overrides` and neither could we use it in
scripts.

Before:
![image](https://github.com/n8n-io/n8n/assets/927609/07b126c2-47fa-4328-b707-5a1cbe83c238)


Now:
![image](https://github.com/n8n-io/n8n/assets/927609/fc041fc8-5beb-4006-b38a-16e9ddf3936b)


## Related tickets and issues



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
