### PR TITLE
fix(core): Use hostname from URL instead of Host header for SNI

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -499,7 +499,6 @@ export async function parseRequestObject(requestObject: RequestObject) {
 		axiosConfig.maxRedirects = 0;
 	}
 
-<<<<<<< Updated upstream
 	axiosConfig.beforeRedirect = (redirectedRequest) => {
 		if (axiosConfig.headers?.Authorization) {
 			redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
@@ -514,12 +513,12 @@ export async function parseRequestObject(requestObject: RequestObject) {
 			rejectUnauthorized: false,
 			secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
 		});
-=======
+	}
+
 	const host = getHostFromRequestObject(requestObject);
 	const agentOptions: AgentOptions = {};
 	if (host) {
 		agentOptions.servername = host;
->>>>>>> Stashed changes
 	}
 	if (requestObject.rejectUnauthorized === false) {
 		agentOptions.rejectUnauthorized = false;

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -2,6 +2,7 @@ import {
 	copyInputItems,
 	getBinaryDataBuffer,
 	parseIncomingMessage,
+	parseRequestObject,
 	proxyRequestToAxios,
 	setBinaryDataBuffer,
 } from '@/NodeExecuteFunctions';
@@ -21,6 +22,7 @@ import nock from 'nock';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import Container from 'typedi';
+import type { Agent } from 'https';
 
 const temporaryDir = mkdtempSync(join(tmpdir(), 'n8n'));
 
@@ -355,6 +357,16 @@ describe('NodeExecuteFunctions', () => {
 					}),
 				).rejects.toThrowError(expect.objectContaining({ statusCode: 301 }));
 			});
+		});
+	});
+
+	describe('parseRequestObject', () => {
+		test('should not use Host header for SNI', async () => {
+			const axiosOptions = await parseRequestObject({
+				url: 'https://example.de/foo/bar',
+				headers: { Host: 'other.host.com' },
+			});
+			expect((axiosOptions.httpsAgent as Agent).options.servername).toEqual('example.de');
 		});
 	});
 


### PR DESCRIPTION
## Summary

Due to a bug in Node.js, the Host header is being used for TLS SNI instead of the host in the request URL.
This behavior is inconsistent with other HTTP clients such as `curl`.

This fix sets the host name used for TLS to be the one from the URL to be consistent with other HTTP clients.

https://github.com/nodejs/node/issues/37104

## Related tickets and issues
https://linear.app/n8n/issue/NODE-745/http-request-fails-for-server-only-supporting-tls%E2%89%A512
https://community.n8n.io/t/ssl-error-when-using-http-node/29928
https://github.com/n8n-io/test-workflows/pull/260

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 