### PR TITLE
feat(core): Link all shared credentials to the personal project of the user it's shared with

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/credentials/credentials.service.ts
@@ -16,6 +16,7 @@ import type { CredentialRequest } from '@/requests';
 import { Container } from 'typedi';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export async function getCredentials(credentialId: string): Promise<ICredentialsDb | null> {
 	return await Container.get(CredentialsRepository).findOneBy({ id: credentialId });
@@ -72,10 +73,15 @@ export async function saveCredential(
 
 		const newSharedCredential = new SharedCredentials();
 
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			user.id,
+		);
+
 		Object.assign(newSharedCredential, {
 			role: 'credential:owner',
 			user,
 			credentials: savedCredential,
+			projectId: personalProject.id,
 		});
 
 		await transactionManager.save<SharedCredentials>(newSharedCredential);

--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -15,6 +15,7 @@ import type { ICredentialsEncrypted } from 'n8n-workflow';
 import { ApplicationError, jsonParse } from 'n8n-workflow';
 import { UM_FIX_INSTRUCTION } from '@/constants';
 import { UserRepository } from '@db/repositories/user.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export class ImportCredentialsCommand extends BaseCommand {
 	static description = 'Import credentials';
@@ -145,12 +146,16 @@ export class ImportCredentialsCommand extends BaseCommand {
 			credential.nodesAccess = [];
 		}
 		const result = await this.transactionManager.upsert(CredentialsEntity, credential, ['id']);
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			user.id,
+		);
 		await this.transactionManager.upsert(
 			SharedCredentials,
 			{
 				credentialsId: result.identifiers[0].id as string,
 				userId: user.id,
 				role: 'credential:owner',
+				project: personalProject,
 			},
 			['credentialsId', 'userId'],
 		);

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -25,6 +25,7 @@ import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import { Service } from 'typedi';
 import { CredentialsTester } from '@/services/credentials-tester.service';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export type CredentialsGetSharedOptions =
 	| { allowGlobalScope: true; globalScope: Scope }
@@ -40,6 +41,7 @@ export class CredentialsService {
 		private readonly credentialsTester: CredentialsTester,
 		private readonly externalHooks: ExternalHooks,
 		private readonly credentialTypes: CredentialTypes,
+		private readonly projectRepository: ProjectRepository,
 	) {}
 
 	async get(where: FindOptionsWhere<ICredentialsDb>, options?: { relations: string[] }) {
@@ -193,12 +195,15 @@ export class CredentialsService {
 
 			savedCredential.data = newCredential.data;
 
+			const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(user.id);
+
 			const newSharedCredential = new SharedCredentials();
 
 			Object.assign(newSharedCredential, {
 				role: 'credential:owner',
 				user,
 				credentials: savedCredential,
+				projectId: personalProject.id,
 			});
 
 			await transactionManager.save<SharedCredentials>(newSharedCredential);

--- a/packages/cli/src/databases/repositories/project.repository.ts
+++ b/packages/cli/src/databases/repositories/project.repository.ts
@@ -7,4 +7,12 @@ export class ProjectRepository extends Repository<Project> {
 	constructor(dataSource: DataSource) {
 		super(Project, dataSource.manager);
 	}
+
+	async getPersonalProjectForUser(userId: string) {
+		return await this.findOne({ where: { projectRelations: { userId } } });
+	}
+
+	async getPersonalProjectForUserOrFail(userId: string) {
+		return await this.findOneOrFail({ where: { projectRelations: { userId } } });
+	}
 }

--- a/packages/cli/test/unit/services/user.service.test.ts
+++ b/packages/cli/test/unit/services/user.service.test.ts
@@ -8,6 +8,8 @@ import { UserService } from '@/services/user.service';
 import { mockInstance } from '../../shared/mocking';
 import { v4 as uuid } from 'uuid';
 import { InternalHooks } from '@/InternalHooks';
+import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 describe('UserService', () => {
 	config.set('userManagement.jwtSecret', 'random-secret');
@@ -16,6 +18,9 @@ describe('UserService', () => {
 	mockInstance(InternalHooks);
 
 	const userRepository = mockInstance(UserRepository);
+	mockInstance(ProjectRepository);
+	mockInstance(ProjectRelationRepository);
+
 	const userService = Container.get(UserService);
 
 	const commonMockUser = Object.assign(new User(), {


### PR DESCRIPTION
## Summary

Make sure every shared credential is linked to the personal project of the user it's shared with.

This also contains code that makes sure every user created via integration test helpers has a personal project. This may become obsolete when https://github.com/n8n-io/n8n/pull/8550 lands.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1349/make-sure-that-sharedcredentials-always-link-to-a-project


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
