### PR TITLE
fix(Microsoft Outlook Node): Download executes more than once per incoming item

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/messageAttachment/download.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/messageAttachment/download.operation.ts
@@ -49,7 +49,7 @@ export async function execute(this: IExecuteFunctions, index: number, items: INo
 	if (attachmentDetails.contentType) {
 		mimeType = attachmentDetails.contentType;
 	}
-	const fileName = attachmentDetails.name;
+	const fileName = attachmentDetails.name as string;
 
 	const response = await microsoftApiRequest.call(
 		this,
@@ -74,13 +74,17 @@ export async function execute(this: IExecuteFunctions, index: number, items: INo
 		Object.assign(newItem.binary!, items[index].binary);
 	}
 
-	items[index] = newItem;
 	const data = Buffer.from(response.body as string, 'utf8');
-	items[index].binary![dataPropertyNameDownload] = await this.helpers.prepareBinaryData(
-		data as unknown as Buffer,
-		fileName as string,
+	newItem.binary![dataPropertyNameDownload] = await this.helpers.prepareBinaryData(
+		data,
+		fileName,
 		mimeType,
 	);
 
-	return items;
+	const executionData = this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray(newItem),
+		{ itemData: { item: index } },
+	);
+
+	return executionData;
 }


### PR DESCRIPTION
## Summary
Outlook v2: Message Attachment -> Download executes more than once per incoming item



## Review / Merge checklist
https://community.n8n.io/t/outlook-attachments-to-filemaker/33996
https://linear.app/n8n/issue/NODE-1014/outlook-v2-message-attachment-download-executes-more-than-once-per