### PR TITLE
fix(RSS Feed Trigger Node): Save last item's date instead of last execution date

### DIFF
--- a/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
@@ -42,9 +42,8 @@ export class RssFeedReadTrigger implements INodeType {
 		const feedUrl = this.getNodeParameter('feedUrl') as string;
 
 		const now = moment().utc().format();
-		const startDate = (pollData.lastTimeChecked as string) || now;
-
-		const endDate = now;
+		const dateToCheck =
+			(pollData.lastItemDate as string) || (pollData.lastTimeChecked as string) || now;
 
 		if (!feedUrl) {
 			throw new NodeOperationError(this.getNode(), 'The parameter "URL" has to be set!');
@@ -73,12 +72,12 @@ export class RssFeedReadTrigger implements INodeType {
 				return [this.helpers.returnJsonArray(feed.items[0])];
 			}
 			feed.items.forEach((item) => {
-				if (Date.parse(item.isoDate as string) >= Date.parse(startDate)) {
+				if (Date.parse(item.isoDate as string) > Date.parse(dateToCheck)) {
 					returnData.push(item);
 				}
 			});
+			pollData.lastItemDate = feed.items[0].isoDate;
 		}
-		pollData.lastTimeChecked = endDate;
 
 		if (Array.isArray(returnData) && returnData.length !== 0) {
 			return [this.helpers.returnJsonArray(returnData)];


### PR DESCRIPTION
## Summary
Some RSS feed won't update exactly at the time show on the last item. In order to have a more reliable node, we stop checking for the last time we polled the feed to know which items are new, but instead we store and check the last item's publication date.

## Related tickets and issues
Related to #8473.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests.
   
 I saw no tests were present for this node. I didn't add one. I did test the behavior locally, though.