### PR TITLE
fix(core): Force postgres driver to use UTC

### DIFF
--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -79,6 +79,7 @@ export function getConnectionOptions(dbType: DatabaseType): ConnectionOptions {
 				...getPostgresConnectionOptions(),
 				...getOptionOverrides('postgresdb'),
 				ssl,
+				useUTC: true,
 			};
 
 		case 'mariadb':


### PR DESCRIPTION
We already do this for the MySQL driver by setting `timezone: 'Z'`
This might be the fix for the issues where timestamps are sometimes not parsed into valid `Date` objects.

## Review / Merge checklist
- [x] PR title and summary are descriptive