### PR TITLE
fix(Google Sheets Trigger Node): First non-header row is ignored when using on row added event

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
@@ -473,7 +473,7 @@ export class GoogleSheetsTrigger implements INodeType {
 
 			const [from, to] = range.split(':');
 			let keyRange = `${from}${keyRow}:${to}${keyRow}`;
-			let rangeToCheck = `${from}${startIndex}:${to}`;
+			let rangeToCheck = `${from}${keyRow}:${to}`;
 
 			if (options.dataLocationOnSheet) {
 				const locationDefine = (options.dataLocationOnSheet as IDataObject).values as IDataObject;
@@ -503,7 +503,7 @@ export class GoogleSheetsTrigger implements INodeType {
 					rangeToCheck = `${cellDataFrom[1]}${+cellDataFrom[2] + 1}:${rangeTo}`;
 				} else {
 					keyRange = `${cellDataFrom[1]}${keyRow}:${cellDataTo[1]}${keyRow}`;
-					rangeToCheck = `${cellDataFrom[1]}${startIndex}:${rangeTo}`;
+					rangeToCheck = `${cellDataFrom[1]}${keyRow}:${rangeTo}`;
 				}
 			}
 


### PR DESCRIPTION
## Summary
Google Sheets Trigger: First non-header row is ignored



## Related tickets and issues
https://community.n8n.io/t/google-sheet-trigger-issue-first-row-not-triggering/35545?u=mutedjam
https://linear.app/n8n/issue/NODE-1073/google-sheets-trigger-first-non-header-row-is-ignored