### PR TITLE
feat(core): Link all shared workflows to the personal project of the user it's shared with

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -27,6 +27,7 @@ import { WorkflowHistoryService } from '@/workflows/workflowHistory/workflowHist
 import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 import { TagRepository } from '@/databases/repositories/tag.repository';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export = {
 	createWorkflow: [
@@ -41,7 +42,10 @@ export = {
 
 			addNodeIds(workflow);
 
-			const createdWorkflow = await createWorkflow(workflow, req.user, 'workflow:owner');
+			const project = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+				req.user.id,
+			);
+			const createdWorkflow = await createWorkflow(workflow, req.user, project, 'workflow:owner');
 
 			await Container.get(WorkflowHistoryService).saveVersion(
 				req.user,

--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.service.ts
@@ -6,6 +6,7 @@ import { SharedWorkflow, type WorkflowSharingRole } from '@db/entities/SharedWor
 import config from '@/config';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
+import type { Project } from '@/databases/entities/Project';
 
 function insertIf(condition: boolean, elements: string[]): string[] {
 	return condition ? elements : [];
@@ -42,6 +43,7 @@ export async function getWorkflowById(id: string): Promise<WorkflowEntity | null
 export async function createWorkflow(
 	workflow: WorkflowEntity,
 	user: User,
+	personalProject: Project,
 	role: WorkflowSharingRole,
 ): Promise<WorkflowEntity> {
 	return await Db.transaction(async (transactionManager) => {
@@ -53,6 +55,7 @@ export async function createWorkflow(
 		Object.assign(newSharedWorkflow, {
 			role,
 			user,
+			project: personalProject,
 			workflow: savedWorkflow,
 		});
 		await transactionManager.save<SharedWorkflow>(newSharedWorkflow);

--- a/packages/cli/src/databases/entities/SharedCredentials.ts
+++ b/packages/cli/src/databases/entities/SharedCredentials.ts
@@ -2,7 +2,7 @@ import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { CredentialsEntity } from './CredentialsEntity';
 import { User } from './User';
 import { WithTimestamps } from './AbstractEntity';
-import type { Project } from './Project';
+import { Project } from './Project';
 
 export type CredentialSharingRole = 'credential:owner' | 'credential:user';
 
@@ -23,9 +23,9 @@ export class SharedCredentials extends WithTimestamps {
 	@PrimaryColumn()
 	credentialsId: string;
 
-	@ManyToOne('Project', 'sharedCredentials', { nullable: true })
-	project: Project | null;
+	@ManyToOne('Project', 'sharedCredentials')
+	project: Project;
 
-	@Column({ nullable: true })
-	projectId: string | null;
+	@Column()
+	projectId: string;
 }

--- a/packages/cli/src/databases/entities/SharedWorkflow.ts
+++ b/packages/cli/src/databases/entities/SharedWorkflow.ts
@@ -2,7 +2,7 @@ import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { WorkflowEntity } from './WorkflowEntity';
 import { User } from './User';
 import { WithTimestamps } from './AbstractEntity';
-import type { Project } from './Project';
+import { Project } from './Project';
 
 export type WorkflowSharingRole = 'workflow:owner' | 'workflow:editor' | 'workflow:user';
 
@@ -23,9 +23,9 @@ export class SharedWorkflow extends WithTimestamps {
 	@PrimaryColumn()
 	workflowId: string;
 
-	@ManyToOne('Project', 'sharedWorkflows', { nullable: true })
-	project: Project | null;
+	@ManyToOne('Project', 'sharedWorkflows')
+	project: Project;
 
-	@Column({ nullable: true })
-	projectId: string | null;
+	@Column()
+	projectId: string;
 }

--- a/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
+++ b/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
@@ -52,7 +52,7 @@ export class CreateProject1705928727784 implements IrreversibleMigration {
 		}: MigrationContext,
 	) {
 		// Add projectId column, this is set to a blank string by default because it's a primary key
-		const projectIdColumn = column('projectId').varchar(36).default('NULL');
+		const projectIdColumn = column('projectId').varchar(36).notNull;
 		const projectIdColumnName = escape.columnName('projectId');
 		const userIdColumnName = escape.columnName('userId');
 		await addColumns(table, [projectIdColumn]);

--- a/packages/cli/test/integration/PermissionChecker.test.ts
+++ b/packages/cli/test/integration/PermissionChecker.test.ts
@@ -27,6 +27,7 @@ import type { SaveCredentialFunction } from '../integration/shared/types';
 import { mockNodeTypesData } from '../unit/Helpers';
 import { affixRoleToSaveCredential } from '../integration/shared/db/credentials';
 import { createOwner, createUser } from '../integration/shared/db/users';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 export const toTargetCallErrorMsg = (subworkflowId: string) =>
 	`Target workflow ID ${subworkflowId} may not be called`;
@@ -240,10 +241,14 @@ describe('check()', () => {
 		};
 
 		const workflowEntity = await Container.get(WorkflowRepository).save(workflowDetails);
+		const project = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			member.id,
+		);
 
 		await Container.get(SharedWorkflowRepository).save({
 			workflow: workflowEntity,
 			user: member,
+			project,
 			role: 'workflow:owner',
 		});
 


### PR DESCRIPTION
## Summary

This updates the migration to make sure the new `projectId` fields are not nullable.
That's possible because additionally to the shared credentials (https://github.com/n8n-io/n8n/pull/8564) this PR makes sure that all shared workflows are linked to a project.


## Related tickets and issues
https://linear.app/n8n/issue/PAY-1352/make-sure-that-sharedworkflows-always-link-to-a-project


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
