### PR TITLE
refactor: Remove any appcues events

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -105,9 +105,6 @@ declare global {
 		};
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		Cypress: unknown;
-		Appcues?: {
-			track(event: string, properties?: ITelemetryTrackProperties): void;
-		};
 	}
 }
 

--- a/packages/editor-ui/src/plugins/__tests__/telemetry.test.ts
+++ b/packages/editor-ui/src/plugins/__tests__/telemetry.test.ts
@@ -141,39 +141,17 @@ describe('telemetry', () => {
 	});
 
 	describe('track function', () => {
-		it('should call Rudderstack track method with correct parameters and', () => {
+		it('should call Rudderstack track method with correct parameters', () => {
 			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');
 
 			const event = 'testEvent';
 			const properties = { test: '1' };
-			const options = { withPostHog: false, withAppCues: false };
+			const options = { withPostHog: false };
 
 			telemetry.track(event, properties, options);
 
 			expect(trackFunction).toHaveBeenCalledTimes(1);
 			expect(trackFunction).toHaveBeenCalledWith(event, {
-				...properties,
-				version_cli: MOCK_VERSION_CLI,
-			});
-		});
-
-		it('should call Rudderstack track method with correct parameters and withAppCues option set to true', () => {
-			window.Appcues = { track: () => {} };
-			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');
-			const appCuesTrackFunction = vi.spyOn(window.Appcues, 'track');
-
-			const event = 'testEvent';
-			const properties = { test: '1' };
-			const options = { withPostHog: false, withAppCues: true };
-
-			telemetry.track(event, properties, options);
-
-			expect(trackFunction).toHaveBeenCalledTimes(1);
-			expect(trackFunction).toHaveBeenCalledWith(event, {
-				...properties,
-				version_cli: MOCK_VERSION_CLI,
-			});
-			expect(appCuesTrackFunction).toHaveBeenCalledWith(event, {
 				...properties,
 				version_cli: MOCK_VERSION_CLI,
 			});

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -99,7 +99,7 @@ export class Telemetry {
 	track(
 		event: string,
 		properties?: ITelemetryTrackProperties,
-		options: { withPostHog?: boolean; withAppCues?: boolean } = {},
+		options: { withPostHog?: boolean } = {},
 	) {
 		if (!this.rudderStack) return;
 
@@ -112,10 +112,6 @@ export class Telemetry {
 
 		if (options.withPostHog) {
 			usePostHog().capture(event, updatedProperties);
-		}
-
-		if (options.withAppCues && window.Appcues) {
-			window.Appcues.track(event, updatedProperties);
 		}
 	}
 

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3579,7 +3579,6 @@ export default defineComponent({
 								},
 								{
 									withPostHog: true,
-									withAppCues: true,
 								},
 							);
 						}


### PR DESCRIPTION
## Summary
We used AppCues to trigger one flow in-app when users are onboarded. We are getting rid of that.

## Related tickets and issues
https://linear.app/n8n/issue/ADO-1872/remove-appues-from-app


## Review / Merge checklist
- [X] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 