### PR TITLE
fix(API): Fire workflowExecuteBefore hook in runMainProcess (no-changelog)

### DIFF
--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -303,6 +303,7 @@ export class WorkflowRunner {
 				sessionId: data.sessionId,
 			});
 
+			await additionalData.hooks.executeHookFunctions('workflowExecuteBefore', []);
 			if (data.executionData !== undefined) {
 				this.logger.debug(`Execution ID ${executionId} had Execution data. Running with payload.`, {
 					executionId,


### PR DESCRIPTION
## Summary
Due to changes in #8487, `workflowExecuteBefore` is no longer fired, which breaks some of our FE functionality(AI Logs).  

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 