### PR TITLE
docs: Update cursor description in the public api documentation

### DIFF
--- a/packages/cli/src/PublicApi/v1/shared/spec/parameters/cursor.yml
+++ b/packages/cli/src/PublicApi/v1/shared/spec/parameters/cursor.yml
@@ -1,6 +1,6 @@
 name: cursor
 in: query
-description: Paginate through users by setting the cursor parameter to a nextCursor attribute returned by a previous request's response. Default value fetches the first "page" of the collection. See pagination for more detail.
+description: Paginate by setting the cursor parameter to the nextCursor attribute returned by the previous request's response. Default value fetches the first "page" of the collection. See pagination for more detail.
 required: false
 style: form
 schema:


### PR DESCRIPTION
## Summary
The cursor is also used for other paginating other resources, like workflows and executions. The old description was confusing by always referencing users:

![image](https://github.com/n8n-io/n8n/assets/927609/ea9252c2-d7f6-4c6c-a513-e7c5495beae0)



## Related tickets and issues
none


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
