### PR TITLE
fix(core)!: Don't prevent starting when `executions.process` or `EXECUTIONS_PROCESS` is set

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -84,8 +84,8 @@ export abstract class BaseCommand extends Command {
 			);
 		}
 		if (process.env.EXECUTIONS_PROCESS === 'own') {
-			throw new ApplicationError(
-				'Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode.',
+			this.logger.warn(
+				'Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode. Defaulting to main mode now.',
 			);
 		}
 

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -73,6 +73,11 @@ if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHo
 
 	config.set('userManagement.jwtRefreshTimeoutHours', 0);
 }
+if (config.getEnv('executions.process') !== 'IGNORED') {
+	console.warn(
+		"`executions.process` has been removed. Please remove it from your config. In future releases n8n won't start if it is set. If you need the isolation and performance gains, please consider using queue mode. N8n will start in main mode now unless `executions.mode` is queue mode.",
+	);
+}
 
 setGlobalState({
 	defaultTimezone: config.getEnv('generic.timezone'),

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -234,6 +234,14 @@ export const schema = {
 	},
 
 	executions: {
+		// By default workflows get always executed in the main process.
+		// TODO: remove this and all usage of `executions.process` when we're sure that nobody has this in their config file anymore.
+		process: {
+			doc: 'Own mode has been removed and is only here for backwards compatibility of config files. N8n will use main mode for executions unless `executions.mode` is set to `queue`.',
+			format: ['main', 'own', 'IGNORED'] as const,
+			default: 'IGNORED',
+			env: 'EXECUTIONS_PROCESS',
+		},
 		mode: {
 			doc: 'If it should run executions directly or via queue',
 			format: ['regular', 'queue'] as const,


### PR DESCRIPTION
## Summary

Since https://github.com/n8n-io/n8n/pull/8490 n8n won't start if `executions.process` is set in a config file or if the environment variable `EXECUTIONS_PROCESS` is set.

This PR makes n8n still start but emits a warning informing users about the option being ignored and later being removed.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1363/removing-own-mode-wasnt-marked-as-a-breaking-change
https://n8nio.slack.com/archives/C036NDPUV40/p1707658150787809
https://n8nio.slack.com/archives/C04B1GZ4T0U/p1707726524712359

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

BREAKING CHANGE: Own mode has been removed.

If you need the isolation and performance gains, please consider using queue mode. N8n will now default to main mode now if queue mode is not set up.
The environment variable `EXECUTIONS_PROCESS` has no effect and will lead to a warning being printed if it is set.


DEPRECATED:  The configuration `executions.process` is being deprecated.

Setting it has no effect and will print a warning if it is set. Please remove it from your config. In future releases n8n won't start if it is set. 