### PR TITLE
fix: Fix resolving of expressions of deeply nested sub-nodes

### DIFF
--- a/packages/editor-ui/src/components/VariableSelector.vue
+++ b/packages/editor-ui/src/components/VariableSelector.vue
@@ -81,10 +81,7 @@ export default defineComponent({
 			if (!activeNode) {
 				return null;
 			}
-			return this.workflowHelpers.getParentMainInputNode(
-				this.workflowHelpers.getCurrentWorkflow(),
-				activeNode,
-			);
+			return this.workflow.getParentMainInputNode(activeNode);
 		},
 		extendAll(): boolean {
 			if (this.variableFilter) {

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -73,41 +73,6 @@ import { useI18n } from '@/composables/useI18n';
 import type { Router } from 'vue-router';
 import { useTelemetry } from '@/composables/useTelemetry';
 
-export function getParentMainInputNode(workflow: Workflow, node: INode): INode {
-	const nodeType = useNodeTypesStore().getNodeType(node.type);
-	if (nodeType) {
-		const outputs = NodeHelpers.getNodeOutputs(workflow, node, nodeType);
-
-		if (!!outputs.find((output) => output !== NodeConnectionType.Main)) {
-			// Get the first node which is connected to a non-main output
-			const nonMainNodesConnected = outputs?.reduce((acc, outputName) => {
-				const parentNodes = workflow.getChildNodes(node.name, outputName);
-				if (parentNodes.length > 0) {
-					acc.push(...parentNodes);
-				}
-				return acc;
-			}, [] as string[]);
-
-			if (nonMainNodesConnected.length) {
-				const returnNode = workflow.getNode(nonMainNodesConnected[0]);
-				if (returnNode === null) {
-					// This should theoretically never happen as the node is connected
-					// but who knows and it makes TS happy
-					throw new Error(
-						`The node "${nonMainNodesConnected[0]}" which is a connection of "${node.name}" could not be found!`,
-					);
-				}
-
-				// The chain of non-main nodes is potentially not finished yet so
-				// keep on going
-				return getParentMainInputNode(workflow, returnNode);
-			}
-		}
-	}
-
-	return node;
-}
-
 export function resolveParameter(
 	parameter: NodeParameterValue | INodeParameters | NodeParameterValue[] | INodeParameters[],
 	opts: {
@@ -127,7 +92,7 @@ export function resolveParameter(
 	const workflow = getCurrentWorkflow();
 
 	if (activeNode) {
-		contextNode = getParentMainInputNode(workflow, activeNode);
+		contextNode = workflow.getParentMainInputNode(activeNode);
 	}
 
 	const workflowRunData = useWorkflowsStore().getWorkflowRunData;
@@ -1187,7 +1152,6 @@ export function useWorkflowHelpers(router: Router) {
 		getCurrentWorkflow,
 		getConnectedNodes,
 		getNodes,
-		getParentMainInputNode,
 		getWorkflow,
 		getNodeTypes,
 		connectionInputData,

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -44,7 +44,7 @@ import type {
 	ConnectionTypes,
 	CloseFunction,
 } from './Interfaces';
-import { Node } from './Interfaces';
+import { Node, NodeConnectionType } from './Interfaces';
 import type { IDeferredPromise } from './DeferredPromise';
 
 import * as NodeHelpers from './NodeHelpers';
@@ -843,6 +843,39 @@ export class Workflow {
 		}
 
 		return returnConns;
+	}
+
+	getParentMainInputNode(node: INode): INode {
+		if (node) {
+			const nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+			const outputs = NodeHelpers.getNodeOutputs(this, node, nodeType.description);
+
+			if (!!outputs.find((output) => (output?.type ?? output) !== NodeConnectionType.Main)) {
+				// Get the first node which is connected to a non-main output
+				const nonMainNodesConnected = outputs?.reduce((acc, outputName) => {
+					const parentNodes = this.getChildNodes(node.name, outputName?.type ?? outputName);
+					if (parentNodes.length > 0) {
+						acc.push(...parentNodes);
+					}
+					return acc;
+				}, [] as string[]);
+
+				if (nonMainNodesConnected.length) {
+					const returnNode = this.getNode(nonMainNodesConnected[0]);
+					if (returnNode === null) {
+						// This should theoretically never happen as the node is connected
+						// but who knows and it makes TS happy
+						throw new ApplicationError(`Node "${nonMainNodesConnected[0]}" not found`);
+					}
+
+					// The chain of non-main nodes is potentially not finished yet so
+					// keep on going
+					return this.getParentMainInputNode(returnNode);
+				}
+			}
+		}
+
+		return node;
 	}
 
 	/**

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -43,6 +43,7 @@ import type {
 	NodeParameterValueType,
 	ConnectionTypes,
 	CloseFunction,
+	INodeOutputConfiguration,
 } from './Interfaces';
 import { Node, NodeConnectionType } from './Interfaces';
 import type { IDeferredPromise } from './DeferredPromise';
@@ -850,10 +851,18 @@ export class Workflow {
 			const nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 			const outputs = NodeHelpers.getNodeOutputs(this, node, nodeType.description);
 
-			if (!!outputs.find((output) => (output?.type ?? output) !== NodeConnectionType.Main)) {
+			if (
+				!!outputs.find(
+					(output) =>
+						((output as INodeOutputConfiguration)?.type ?? output) !== NodeConnectionType.Main,
+				)
+			) {
 				// Get the first node which is connected to a non-main output
 				const nonMainNodesConnected = outputs?.reduce((acc, outputName) => {
-					const parentNodes = this.getChildNodes(node.name, outputName?.type ?? outputName);
+					const parentNodes = this.getChildNodes(
+						node.name,
+						(outputName as INodeOutputConfiguration)?.type ?? outputName,
+					);
 					if (parentNodes.length > 0) {
 						acc.push(...parentNodes);
 					}

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -993,7 +993,13 @@ export class WorkflowDataProxy {
 
 									// Before resolving the pairedItem make sure that the requested node comes in the
 									// graph before the current one
-									const parentNodes = that.workflow.getParentNodes(that.contextNodeName);
+									const activeNode = that.workflow.getNode(that.activeNodeName);
+									let contextNode = that.contextNodeName;
+									if (activeNode) {
+										const parentMainInputNode = that.workflow.getParentMainInputNode(activeNode);
+										contextNode = parentMainInputNode.name ?? contextNode;
+									}
+									const parentNodes = that.workflow.getParentNodes(contextNode);
 									if (!parentNodes.includes(nodeName)) {
 										throw createExpressionError('Invalid expression', {
 											messageTemplate: 'Invalid expression under ‘%%PARAMETER%%’',


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.
- Move the `getParentMainInputNode` method to WorkflowProxy so it can be reused on the backend
- Update the expression guard in WorkflowDataProxy to check for sub-node's root node to determine if expression is valid

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 