### PR TITLE
fix(FTP Node): Fix issue with paireditems not always working

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -548,6 +548,7 @@ export class Ftp implements INodeType {
 				const newItem: INodeExecutionData = {
 					json: items[i].json,
 					binary: {},
+					pairedItem: items[i].pairedItem,
 				};
 
 				if (items[i].binary !== undefined && newItem.binary) {
@@ -814,6 +815,7 @@ export class Ftp implements INodeType {
 
 			throw error;
 		}
+
 		return [returnItems];
 	}
 }


### PR DESCRIPTION
## Summary
Fixes an issue that prevented paired items from being availble, Will check other nodes for the same issue shortly.



## Related tickets and issues
https://community.n8n.io/t/issue-backlinking/40061