### PR TITLE
fix(Execute Workflow Node): Passing the workflow that is supposed to be executed as a paramter

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/GenericFunctions.ts
@@ -1,6 +1,6 @@
 import { readFile as fsReadFile } from 'fs/promises';
 import { NodeOperationError, jsonParse } from 'n8n-workflow';
-import type { IWorkflowBase, IExecuteFunctions, IExecuteWorkflowInfo } from 'n8n-workflow';
+import type { IExecuteFunctions, IExecuteWorkflowInfo } from 'n8n-workflow';
 
 export async function getWorkflowInfo(this: IExecuteFunctions, source: string, itemIndex = 0) {
 	const workflowInfo: IExecuteWorkflowInfo = {};
@@ -29,7 +29,8 @@ export async function getWorkflowInfo(this: IExecuteFunctions, source: string, i
 		workflowInfo.code = jsonParse(workflowJson);
 	} else if (source === 'parameter') {
 		// Read workflow from parameter
-		workflowInfo.code = this.getNodeParameter('workflowJson', itemIndex) as IWorkflowBase;
+		const workflowJson = this.getNodeParameter('workflowJson', itemIndex) as string;
+		workflowInfo.code = jsonParse(workflowJson);
 	} else if (source === 'url') {
 		// Read workflow from url
 		const workflowUrl = this.getNodeParameter('workflowUrl', itemIndex) as string;


### PR DESCRIPTION
## Summary

This fixes a regression introduced with https://github.com/n8n-io/n8n/commit/216ec079c9a2efcfe139e6ba1c9905a7a0cda654, e.g. in version 1.23.0.

I'd love to write a test for this too, but the node is not testable right now with the unit test framework. First this function here has to be implemented:
https://github.com/n8n-io/n8n/blob/32281d12d775281e4b8e419d76e46ca9e3b47267/packages/nodes-base/test/nodes/Helpers.ts#L177

I've tried, but I stopped after a while, not to loose too much time on it. Maybe the nodes team can take a look at adding a test for this.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1362/execute-workflow-node-with-source-parameter-does-not-work-anymore

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

