### PR TITLE
fix(core): Give better error message if `executions.process` is still used in the configs

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -73,6 +73,11 @@ if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHo
 
 	config.set('userManagement.jwtRefreshTimeoutHours', 0);
 }
+if (config.getEnv('executions.process') !== 'IGNORED') {
+	throw new ApplicationError(
+		'Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode.',
+	);
+}
 
 setGlobalState({
 	defaultTimezone: config.getEnv('generic.timezone'),

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -234,6 +234,14 @@ export const schema = {
 	},
 
 	executions: {
+		// By default workflows get always executed in the main process.
+		// TODO: remove this and all usage of `executions.process` when we're sure that nobody has this in their config file anymore.
+		process: {
+			doc: 'Own mode has been removed and is only here for backwards compatibility of config files. N8n will use main mode for executions unless `executions.mode` is set to `queue`.',
+			format: ['main', 'own', 'IGNORED'] as const,
+			default: 'IGNORED',
+			env: 'EXECUTIONS_PROCESS',
+		},
 		mode: {
 			doc: 'If it should run executions directly or via queue',
 			format: ['regular', 'queue'] as const,


### PR DESCRIPTION
## Summary

Print something actionable instead of `Error Plugin: n8n: configuration param 'executions.process' not declared in the schema`.
This will print `Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode.` instead. Just the same as when `EXECUTIONS_PROCESS` is set.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1363/removing-own-mode-wasnt-marked-as-a-breaking-change

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

