### PR TITLE
fix(editor): Fix SQL editors not always re-rendering when query changes

### DIFF
--- a/cypress/e2e/29-sql-editor.cy.ts
+++ b/cypress/e2e/29-sql-editor.cy.ts
@@ -27,6 +27,26 @@ describe('SQL editors', () => {
 		ndv.getters.sqlEditorContainer().should('contain', 'SELECT * FROM `testTable` LIMIT 10');
 	});
 
+	it('should update expression output dropdown as the query is edited', () => {
+		workflowPage.actions.addInitialNodeToCanvas('MySQL', {
+			action: 'Execute a SQL query',
+		});
+		ndv.actions.close();
+
+		workflowPage.actions.openNode('When clicking "Test workflow"');
+		ndv.actions.setPinnedData([{ table: 'test_table' }]);
+		ndv.actions.close();
+
+		workflowPage.actions.openNode('MySQL');
+		ndv.getters
+			.sqlEditorContainer()
+			.find('.cm-content')
+			.type('SELECT * FROM {{ $json.table }}', { parseSpecialCharSequences: false });
+		workflowPage.getters
+			.inlineExpressionEditorOutput()
+			.should('have.text', 'SELECT * FROM test_table');
+	});
+
 	it('should not push NDV header out with a lot of code in Postgres editor', () => {
 		workflowPage.actions.addInitialNodeToCanvas('Postgres', {
 			action: 'Execute a SQL query',

--- a/packages/editor-ui/src/mixins/expressionManager.ts
+++ b/packages/editor-ui/src/mixins/expressionManager.ts
@@ -13,6 +13,7 @@ import type { EditorView } from '@codemirror/view';
 import type { TargetItem } from '@/Interface';
 import type { Html, Plaintext, RawSegment, Resolvable, Segment } from '@/types/expressions';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
+import { isEqual } from 'lodash-es';
 
 export const expressionManager = defineComponent({
 	props: {
@@ -98,12 +99,17 @@ export const expressionManager = defineComponent({
 
 				if (skipSegments.includes(node.type.name)) return;
 
-				rawSegments.push({
+				const newSegment: RawSegment = {
 					from: node.from,
 					to: node.to,
 					text,
 					token: node.type.name === 'Resolvable' ? 'Resolvable' : 'Plaintext',
-				});
+				};
+
+				// Avoid duplicates
+				if (isEqual(newSegment, rawSegments.at(-1))) return;
+
+				rawSegments.push(newSegment);
 			});
 
 			return rawSegments.reduce<Segment[]>((acc, segment) => {


### PR DESCRIPTION
## Summary
Bugs fixed:
- Expression highlighting doesn't work until you open the node a second time
- Popunder has too much space at the bottom
- If you duplicate a node an immedately change the editor contents, the preview isn't updated
- Overflow of long lines in popunder

See linear for reproduction notes

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1115/bugs-with-sql-component
https://community.n8n.io/t/problem-with-mssql-node-since-update-its-just-me/39967
https://community.n8n.io/t/sql-nodes-both-mysql-and-mssql-unexpected-doubles/40172

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 