### PR TITLE
fix(Notion Node): Block with text results in a body validation error

### DIFF
--- a/packages/nodes-base/nodes/Notion/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/GenericFunctions.ts
@@ -307,7 +307,7 @@ export function formatBlocks(blocks: IDataObject[]) {
 				...(block.type === 'to_do' ? { checked: block.checked } : {}),
 				...(block.type === 'image' ? { type: 'external', external: { url: block.url } } : {}),
 				// prettier-ignore,
-				...(!['to_do', 'image'].includes(block.type as string) ? getTextBlocks(block) : {}),
+				...(!['image'].includes(block.type as string) ? getTextBlocks(block) : {}),
 			},
 		});
 	}

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -1,0 +1,33 @@
+import { formatBlocks } from '../GenericFunctions';
+
+describe('Test NotionV2, formatBlocks', () => {
+	it('should format to_do block', () => {
+		const blocks = [
+			{
+				type: 'to_do',
+				checked: false,
+				richText: false,
+				textContent: 'Testing',
+			},
+		];
+
+		const result = formatBlocks(blocks);
+
+		expect(result).toEqual([
+			{
+				object: 'block',
+				type: 'to_do',
+				to_do: {
+					checked: false,
+					text: [
+						{
+							text: {
+								content: 'Testing',
+							},
+						},
+					],
+				},
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
When sending a To Do block in the Notion node, you'll receive an error if you have any text associated with it:



## Related tickets and issues
https://community.n8n.io/t/notion-error-body-failed-validation-body-children-5-to-do-rich-text-should-be-defined/31872

https://community.n8n.io/t/bug-notion-append-block-node/33315

https://linear.app/n8n/issue/NODE-878/notion-node-using-a-to-do-block-with-text-results-in-a-body-validation