### PR TITLE
feat: Add telemetry event when users click on templates link

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -388,6 +388,9 @@ export default defineComponent({
 				workflow_id: this.workflowsStore.workflowId,
 			});
 		},
+		trackTemplatesClick() {
+			this.$telemetry.track('User clicked on templates', {});
+		},
 		async onUserActionToggle(action: string) {
 			switch (action) {
 				case 'logout':
@@ -419,6 +422,14 @@ export default defineComponent({
 		},
 		async handleSelect(key: string) {
 			switch (key) {
+				case 'templates':
+					if (
+						this.settingsStore.isTemplatesEnabled &&
+						!this.templatesStore.hasCustomTemplatesHost
+					) {
+						this.trackTemplatesClick();
+					}
+					break;
 				case 'about': {
 					this.trackHelpItemClick('about');
 					this.uiStore.openModal(ABOUT_MODAL_KEY);


### PR DESCRIPTION
## Summary
This PR adds telemetry event for new template link clicks.



## Related tickets and issues
Related to ADO-1789


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 