### PR TITLE
fix(Default Data Loader Node): Fix binary data loader in s3 mode

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
@@ -1,3 +1,5 @@
+import { pipeline } from 'stream/promises';
+import { createWriteStream } from 'fs';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError, BINARY_ENCODING } from 'n8n-workflow';
 
@@ -10,8 +12,6 @@ import { PDFLoader } from 'langchain/document_loaders/fs/pdf';
 import { TextLoader } from 'langchain/document_loaders/fs/text';
 import { EPubLoader } from 'langchain/document_loaders/fs/epub';
 import { file as tmpFile, type DirectoryResult } from 'tmp-promise';
-import { pipeline } from 'stream/promises';
-import { createWriteStream } from 'fs';
 
 import { getMetadataFiltersValues } from './helpers';
 
@@ -34,7 +34,12 @@ export class N8nBinaryLoader {
 
 	private textSplitter?: TextSplitter;
 
-	constructor(context: IExecuteFunctions, optionsPrefix = '', binaryDataKey = '', textSplitter?: TextSplitter) {
+	constructor(
+		context: IExecuteFunctions,
+		optionsPrefix = '',
+		binaryDataKey = '',
+		textSplitter?: TextSplitter,
+	) {
 		this.context = context;
 		this.textSplitter = textSplitter;
 		this.optionsPrefix = optionsPrefix;
@@ -67,7 +72,7 @@ export class N8nBinaryLoader {
 
 		if (!item) return [];
 
-		const binaryData = this.context.helpers.assertBinaryData(itemIndex, this.binaryDataKey)
+		const binaryData = this.context.helpers.assertBinaryData(itemIndex, this.binaryDataKey);
 		const { mimeType } = binaryData;
 
 		// Check if loader matches the mime-type of the data
@@ -98,7 +103,12 @@ export class N8nBinaryLoader {
 
 		let filePathOrBlob: string | Blob;
 		if (binaryData.id) {
-			filePathOrBlob = this.context.helpers.getBinaryPath(binaryData.id);
+			const binaryBuffer = await this.context.helpers.binaryToBuffer(
+				await this.context.helpers.getBinaryStream(binaryData.id),
+			);
+			filePathOrBlob = new Blob([binaryBuffer], {
+				type: mimeType,
+			});
 		} else {
 			filePathOrBlob = new Blob([Buffer.from(binaryData.data, BINARY_ENCODING)], {
 				type: mimeType,
@@ -175,8 +185,9 @@ export class N8nBinaryLoader {
 				loader = new TextLoader(filePathOrBlob);
 		}
 
-
-		const loadedDoc = this.textSplitter ? await loader.loadAndSplit(this.textSplitter) : await loader.load();
+		const loadedDoc = this.textSplitter
+			? await loader.loadAndSplit(this.textSplitter)
+			: await loader.load();
 
 		docs.push(...loadedDoc);
 


### PR DESCRIPTION
## Summary
When using S3 binary data mode, `helpers.getBinaryPath` would return s3 bucket path. So instead, we use `getBinaryStream` helper for universal access to the binary buffer and convert it to Blob. 


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 