### PR TITLE
fix(editor): Debounce expression changes

### DIFF
--- a/packages/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/editor-ui/src/components/ExpressionParameterInput.vue
@@ -62,6 +62,7 @@ import { createExpressionTelemetryPayload } from '@/utils/telemetryUtils';
 import type { Segment } from '@/types/expressions';
 import type { TargetItem } from '@/Interface';
 import type { IDataObject } from 'n8n-workflow';
+import { useDebounce } from '@/composables/useDebounce';
 
 type InlineExpressionEditorInputRef = InstanceType<typeof InlineExpressionEditorInput>;
 
@@ -95,6 +96,10 @@ export default defineComponent({
 			type: Object as PropType<IDataObject>,
 			default: () => ({}),
 		},
+	},
+	setup() {
+		const { callDebounced } = useDebounce();
+		return { callDebounced };
 	},
 	data() {
 		return {
@@ -154,7 +159,10 @@ export default defineComponent({
 				this.$telemetry.track('User closed Expression Editor', telemetryPayload);
 			}
 		},
-		onChange({ value, segments }: { value: string; segments: Segment[] }) {
+		onChange(value: { value: string; segments: Segment[] }) {
+			void this.callDebounced(this.onChangeDebounced, { debounceTime: 100, trailing: true }, value);
+		},
+		onChangeDebounced({ value, segments }: { value: string; segments: Segment[] }) {
 			this.segments = segments;
 
 			if (this.isDragging) return;


### PR DESCRIPTION
## Summary
Debounce expression changes to avoid infinite loop for $now/new Date() (changes every ms)



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1131/bug-using-dollarnow-or-new-date-in-parameters-expresion-crushes-n8n



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 