### PR TITLE
fix(core): Improve the startup error when EXECUTIONS_PROCESS is set

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -83,11 +83,6 @@ export abstract class BaseCommand extends Command {
 				'Support for MySQL/MariaDB has been deprecated and will be removed with an upcoming version of n8n. Please migrate to PostgreSQL.',
 			);
 		}
-		if (process.env.EXECUTIONS_PROCESS === 'own') {
-			throw new ApplicationError(
-				'Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode.',
-			);
-		}
 
 		if (process.env.N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN) {
 			this.logger.warn(

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -73,10 +73,25 @@ if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHo
 
 	config.set('userManagement.jwtRefreshTimeoutHours', 0);
 }
-if (config.getEnv('executions.process') !== 'IGNORED') {
-	throw new ApplicationError(
-		'Own mode has been removed. If you need the isolation and performance gains, please consider using queue mode.',
+
+import colors from 'picocolors';
+const executionProcess = config.getEnv('executions.process');
+if (executionProcess) {
+	console.error(
+		colors.yellow('Please unset the deprecated env variable'),
+		colors.bold(colors.yellow('EXECUTIONS_PROCESS')),
 	);
+}
+if (executionProcess === 'own') {
+	console.error(
+		colors.bold(colors.red('Application failed to start because "Own" mode has been removed.')),
+	);
+	console.error(
+		colors.red(
+			'If you need the isolation and performance gains, please consider using queue mode instead.\n\n',
+		),
+	);
+	process.exit(-1);
 }
 
 setGlobalState({

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -234,12 +234,11 @@ export const schema = {
 	},
 
 	executions: {
-		// By default workflows get always executed in the main process.
 		// TODO: remove this and all usage of `executions.process` when we're sure that nobody has this in their config file anymore.
 		process: {
 			doc: 'Own mode has been removed and is only here for backwards compatibility of config files. N8n will use main mode for executions unless `executions.mode` is set to `queue`.',
-			format: ['main', 'own', 'IGNORED'] as const,
-			default: 'IGNORED',
+			format: String,
+			default: '',
 			env: 'EXECUTIONS_PROCESS',
 		},
 		mode: {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -236,7 +236,7 @@ export const schema = {
 	executions: {
 		// TODO: remove this and all usage of `executions.process` when we're sure that nobody has this in their config file anymore.
 		process: {
-			doc: 'Own mode has been removed and is only here for backwards compatibility of config files. N8n will use main mode for executions unless `executions.mode` is set to `queue`.',
+			doc: 'Deprecated key, that will be removed in the future. Please remove it from your configuration and environment variables to prevent issues in the future.',
 			format: String,
 			default: '',
 			env: 'EXECUTIONS_PROCESS',


### PR DESCRIPTION
This PR moves the check much early on, and removed all references to `EXECUTIONS_PROCESS` outside `bin/n8n`. It also adds a more clearly understandable error/warning message for when `EXECUTIONS_PROCESS` is set.

### Own mode
![own mode](https://github.com/n8n-io/n8n/assets/196144/d1c2bccd-dd98-4dcc-9d24-05f6cd5a5e03)

### Main Mode
![main mode](https://github.com/n8n-io/n8n/assets/196144/6020da11-aa75-462b-8f66-2bbcae33b791)


## Review / Merge checklist
- [x] PR title and summary are descriptive