### PR TITLE
fix(core): Improve handling of wrapped errors (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -45,8 +45,7 @@ export abstract class NodeError extends ExecutionBaseError {
 		super(message, options);
 
 		if (error instanceof NodeError) {
-			this.level = 'error';
-			this.message = `[RE-WRAPPED]: ${message}`;
+			this.tags.reWrapped = true;
 		}
 	}
 

--- a/packages/workflow/src/errors/application.error.ts
+++ b/packages/workflow/src/errors/application.error.ts
@@ -10,7 +10,7 @@ export type ReportingOptions = {
 export class ApplicationError extends Error {
 	level: Level;
 
-	readonly tags?: Event['tags'];
+	readonly tags: NonNullable<Event['tags']>;
 
 	readonly extra?: Event['extra'];
 

--- a/packages/workflow/test/errors/node.error.test.ts
+++ b/packages/workflow/test/errors/node.error.test.ts
@@ -13,10 +13,10 @@ describe('NodeError', () => {
 		const wrapped2 = new NodeOperationError(node, opsError);
 
 		expect(wrapped1.level).toEqual('error');
-		expect(wrapped1.message).toEqual(
-			'[RE-WRAPPED]: The service was not able to process your request',
-		);
+		expect(wrapped1.message).toEqual('The service was not able to process your request');
+		expect(wrapped1.tags).toEqual(expect.objectContaining({ reWrapped: true }));
 		expect(wrapped2.level).toEqual('error');
-		expect(wrapped2.message).toEqual('[RE-WRAPPED]: Some operation failed');
+		expect(wrapped2.message).toEqual('Some operation failed');
+		expect(wrapped2.tags).toEqual(expect.objectContaining({ reWrapped: true }));
 	});
 });


### PR DESCRIPTION
We updated error wrapping to modify the outer error message to include a prefix in #8510, but this seems to be create a bad UX. So, updating this to use sentry tags to be able to track re-wrapped errors.

[Slack conversation](https://n8nio.slack.com/archives/C05NR911BDH/p1707478757917199).

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included