### PR TITLE
docs: Document own mode removal in `BREAKING-CHANGES.md` (no-changelog)

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,19 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.27.0
+
+### What changed?
+
+The execution mode `own` was removed.
+If `EXECUTIONS_PROCESS` is set to `main` or if `executions.process` in a config file is set to `main` n8n will print a warning, but start up normally.
+If `EXECUTIONS_PROCESS` is set to `own` or if `executions.process` in a config file is set to `own` n8n will print an error message and refuse to start up.
+
+### When is action necessary?
+
+If you use `own` mode and need the isolation and performance gains, please consider using queue mode instead, otherwise switch to main mode by removing the environment variable or config field.
+If you have the environment variable `EXECUTIONS_PROCESS` or the config field `executions.process` set, please remove them. The environment variable has no effect anymore and the configuration field will be removed in future releases, prevent n8n from starting if it is still set.
+
 ## 1.25.0
 
 ### What changed?


### PR DESCRIPTION
## Summary

Update packages/cli/BREAKING-CHANGES.md to document the removal of own mode and how to update the environment variable and config field.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1363/removing-own-mode-wasnt-marked-as-a-breaking-change

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

