### PR TITLE
feat(editor): Add chevron to filter component operator select

### DIFF
--- a/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
+++ b/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
@@ -83,12 +83,15 @@ function onGroupSelect(group: string) {
 				>
 					<template #reference>
 						<div
-							:class="$style.groupTitle"
+							:class="$style.group"
 							@mouseenter="() => onGroupSelect(group.id)"
 							@click="() => onGroupSelect(group.id)"
 						>
-							<n8n-icon v-if="group.icon" :icon="group.icon" color="text-light" size="small" />
-							<span>{{ i18n.baseText(group.name) }}</span>
+							<div :class="$style.groupTitle">
+								<n8n-icon v-if="group.icon" :icon="group.icon" color="text-light" size="small" />
+								<span>{{ i18n.baseText(group.name) }}</span>
+							</div>
+							<n8n-icon icon="chevron-right" color="text-light" size="xsmall" />
 						</div>
 					</template>
 					<div>
@@ -121,10 +124,11 @@ function onGroupSelect(group: string) {
 	flex-direction: column;
 }
 
-.groupTitle {
+.group {
 	display: flex;
 	gap: var(--spacing-2xs);
 	align-items: center;
+	justify-content: space-between;
 	font-size: var(--font-size-s);
 	font-weight: var(--font-weight-bold);
 	line-height: var(--font-line-height-regular);
@@ -135,5 +139,11 @@ function onGroupSelect(group: string) {
 	&:hover {
 		background: var(--color-background-base);
 	}
+}
+
+.groupTitle {
+	display: flex;
+	gap: var(--spacing-2xs);
+	align-items: center;
 }
 </style>


### PR DESCRIPTION
## Summary
The menu did not make a good job of suggesting that each of these items have sub-menu.

<img width="696" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/9dd0b237-6e2d-4042-bf58-8d8b917a869b">


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1118/new-if-node-component-hard-to-know-that-fields-have-sub-items


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 