### PR TITLE
refactor(editor): Do not use CodeNodeEditor anywhere except the Code node (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -158,8 +158,7 @@ export class Code implements INodeType {
 								name: 'code',
 								type: 'string',
 								typeOptions: {
-									editor: 'codeNodeEditor',
-									editorLanguage: 'javaScript',
+									editor: 'jsEditor',
 								},
 								default: defaultCodeExecute,
 								hint: 'This code will only run and return data if a "Main" input & output got created.',
@@ -176,8 +175,7 @@ export class Code implements INodeType {
 								name: 'code',
 								type: 'string',
 								typeOptions: {
-									editor: 'codeNodeEditor',
-									editorLanguage: 'javaScript',
+									editor: 'jsEditor',
 								},
 								default: defaultCodeSupplyData,
 								hint: 'This code will only run and return data if an output got created which is not "Main".',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -92,8 +92,7 @@ export class ToolCode implements INodeType {
 					},
 				},
 				typeOptions: {
-					editor: 'codeNodeEditor',
-					editorLanguage: 'javaScript',
+					editor: 'jsEditor',
 				},
 				default: '',
 				// TODO: Add proper text here later
@@ -112,7 +111,7 @@ export class ToolCode implements INodeType {
 					},
 				},
 				typeOptions: {
-					editor: 'codeNodeEditor',
+					editor: 'codeNodeEditor', // TODO: create a separate `pythonEditor` component
 					editorLanguage: 'python',
 				},
 				default: '',

--- a/packages/editor-ui/src/components/ChatEmbedModal.vue
+++ b/packages/editor-ui/src/components/ChatEmbedModal.vue
@@ -8,7 +8,7 @@ import { CHAT_EMBED_MODAL_KEY, CHAT_TRIGGER_NODE_TYPE, WEBHOOK_NODE_TYPE } from 
 import { useRootStore } from '@/stores/n8nRoot.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import HtmlEditor from '@/components/HtmlEditor/HtmlEditor.vue';
-import CodeNodeEditor from '@/components/CodeNodeEditor/CodeNodeEditor.vue';
+import JsEditor from '@/components/JsEditor/JsEditor.vue';
 import { useI18n } from '@/composables/useI18n';
 
 const props = defineProps({
@@ -150,7 +150,7 @@ function closeDialog() {
 							{{ i18n.baseText('chatEmbed.install') }}
 						</n8n-text>
 					</div>
-					<CodeNodeEditor :model-value="commonCode.install" is-read-only />
+					<HtmlEditor :model-value="commonCode.install" is-read-only />
 				</div>
 
 				<div class="mb-s">
@@ -165,8 +165,8 @@ function closeDialog() {
 
 				<HtmlEditor v-if="currentTab === 'cdn'" :model-value="cdnCode" is-read-only />
 				<HtmlEditor v-if="currentTab === 'vue'" :model-value="vueCode" is-read-only />
-				<CodeNodeEditor v-if="currentTab === 'react'" :model-value="reactCode" is-read-only />
-				<CodeNodeEditor v-if="currentTab === 'other'" :model-value="otherCode" is-read-only />
+				<JsEditor v-if="currentTab === 'react'" :model-value="reactCode" is-read-only />
+				<JsEditor v-if="currentTab === 'other'" :model-value="otherCode" is-read-only />
 
 				<n8n-text>
 					{{ i18n.baseText('chatEmbed.packageInfo.description') }}


### PR DESCRIPTION
Historically we've used `CodeNodeEditor` to display any kind of code in the UI. But since #8156 we have separate components for various types of code.
This PR updates removes all usage of `CodeNodeEditor` outside the `Code` node.

This also should fix the [issue](https://n8nio.slack.com/archives/C05NR911BDH/p1707892230807769) of the `AskAI` button showing up in `ChatEmbedModal`.

## Review / Merge checklist
- [x] PR title and summary are descriptive