### PR TITLE
fix(GraphQL Node): Fix request format JSON error

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -424,9 +424,8 @@ export class GraphQL implements INodeType {
 					requestOptions.qs.query = gqlQuery;
 				} else {
 					if (requestFormat === 'json') {
-						const jsonBody = requestOptions.body as IDataObject;
-						requestOptions.body = {
-							...jsonBody,
+						const jsonBody = {
+							...requestOptions.body,
 							query: gqlQuery,
 							variables: this.getNodeParameter('variables', itemIndex, {}) as object,
 							operationName: this.getNodeParameter('operationName', itemIndex) as string,
@@ -449,6 +448,7 @@ export class GraphQL implements INodeType {
 							jsonBody.operationName = null;
 						}
 						requestOptions.json = true;
+						requestOptions.body = jsonBody;
 					} else {
 						requestOptions.body = gqlQuery;
 					}

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -1,0 +1,55 @@
+import type { WorkflowTestData } from '@test/nodes/types';
+import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
+import * as Helpers from '@test/nodes/Helpers';
+
+describe('GraphQL Node', () => {
+
+	const mockResponse = {
+			data: {
+				nodes: {}
+			}
+	}
+
+	const tests: WorkflowTestData[] = [
+		{
+			description: 'should run Request Format JSON',
+			input: {
+				workflowData: Helpers.readJsonFileSync('nodes/GraphQL/test/workflow.json'),
+			},
+			output: {
+				nodeExecutionOrder: ['Start'],
+				nodeData: {
+					"Fetch Request Format JSON": [
+						[
+							{
+								json: mockResponse,
+							},
+						],
+					],
+				},
+			},
+			nock: {
+				baseUrl: 'https://api.n8n.io',
+				mocks: [
+					{
+						method: 'post',
+						path: '/graphql',
+						statusCode: 200,
+						responseBody: mockResponse,
+					},
+				],
+			},
+		}
+	];
+
+	const nodeTypes = Helpers.setup(tests);
+
+	test.each(tests)('$description', async (testData) => {
+		const { result } = await executeWorkflow(testData, nodeTypes);
+		const resultNodeData = Helpers.getResultNodeData(result, testData);
+		resultNodeData.forEach(({ nodeName, resultData }) =>
+			expect(resultData).toEqual(testData.output.nodeData[nodeName]),
+		);
+		expect(result.finished).toEqual(true);
+	});
+});

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -3,12 +3,11 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import * as Helpers from '@test/nodes/Helpers';
 
 describe('GraphQL Node', () => {
-
 	const mockResponse = {
-			data: {
-				nodes: {}
-			}
-	}
+		data: {
+			nodes: {},
+		},
+	};
 
 	const tests: WorkflowTestData[] = [
 		{
@@ -19,7 +18,7 @@ describe('GraphQL Node', () => {
 			output: {
 				nodeExecutionOrder: ['Start'],
 				nodeData: {
-					"Fetch Request Format JSON": [
+					'Fetch Request Format JSON': [
 						[
 							{
 								json: mockResponse,
@@ -39,7 +38,7 @@ describe('GraphQL Node', () => {
 					},
 				],
 			},
-		}
+		},
 	];
 
 	const nodeTypes = Helpers.setup(tests);

--- a/packages/nodes-base/nodes/GraphQL/test/workflow.json
+++ b/packages/nodes-base/nodes/GraphQL/test/workflow.json
@@ -10,10 +10,7 @@
 			"name": "When clicking \"Test workflow\"",
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [
-				180,
-				160
-			]
+			"position": [180, 160]
 		},
 		{
 			"parameters": {
@@ -24,10 +21,7 @@
 			"name": "Fetch Request Format JSON",
 			"type": "n8n-nodes-base.graphql",
 			"typeVersion": 1,
-			"position": [
-				420,
-				160
-			],
+			"position": [420, 160],
 			"id": "7f8ceaf4-b82f-48d5-be0b-9fe3bfb35ee4"
 		}
 	],

--- a/packages/nodes-base/nodes/GraphQL/test/workflow.json
+++ b/packages/nodes-base/nodes/GraphQL/test/workflow.json
@@ -1,0 +1,48 @@
+{
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "104a4d08d8897b8bdeb38aaca515021075e0bd8544c983c2bb8c86e6a8e6081c"
+	},
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "fb826323-2e48-4f11-bb0e-e12de32e22ee",
+			"name": "When clicking \"Test workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [
+				180,
+				160
+			]
+		},
+		{
+			"parameters": {
+				"endpoint": "https://api.n8n.io/graphql",
+				"requestFormat": "json",
+				"query": "query {\n  nodes(pagination: { limit: 1 }) {\n    data {\n      id\n      attributes {\n        name\n        displayName\n        description\n        group\n        codex\n        createdAt\n      }\n    }\n  }\n}"
+			},
+			"name": "Fetch Request Format JSON",
+			"type": "n8n-nodes-base.graphql",
+			"typeVersion": 1,
+			"position": [
+				420,
+				160
+			],
+			"id": "7f8ceaf4-b82f-48d5-be0b-9fe3bfb35ee4"
+		}
+	],
+	"connections": {
+		"When clicking \"Test workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Fetch Request Format JSON",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2125,6 +2125,15 @@ export interface WorkflowTestData {
 			[key: string]: any[][];
 		};
 	};
+	nock: {
+		baseUrl: string;
+		mocks: {
+			method: string;
+			path: string;
+			statusCode: number;
+			responseBody: any;
+		}[];
+	};
 	trigger?: {
 		mode: WorkflowExecuteMode;
 		input: INodeExecutionData;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2127,12 +2127,12 @@ export interface WorkflowTestData {
 	};
 	nock: {
 		baseUrl: string;
-		mocks: {
+		mocks: Array<{
 			method: string;
 			path: string;
 			statusCode: number;
 			responseBody: any;
-		}[];
+		}>;
 	};
 	trigger?: {
 		mode: WorkflowExecuteMode;


### PR DESCRIPTION
## Summary
The GraphQL node does not work for json body requests. Bug was introduced in n8n@1.29.0 in [PR-8563](https://github.com/n8n-io/n8n/pull/8563).

![image](https://github.com/n8n-io/n8n/assets/56945030/56e1f2e5-952a-4428-9a01-f28bf88ad0e5)

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 