### PR TITLE
fix(OpenAI Node): Always show jsonOutput toggle for OpenAI message operation (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -6,9 +6,9 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, updateDisplayOptions } from 'n8n-workflow';
 
+import type { Tool } from 'langchain/tools';
 import { apiRequest } from '../../transport';
 import type { ChatCompletion } from '../../helpers/interfaces';
-import type { Tool } from 'langchain/tools';
 import { formatToOpenAIAssistantTool } from '../../helpers/utils';
 import { modelRLC } from '../descriptions';
 
@@ -81,13 +81,8 @@ const properties: INodeProperties[] = [
 		name: 'jsonOutput',
 		type: 'boolean',
 		description:
-			'Whether to attempt to return the response in JSON format, supported by gpt-3.5-turbo-1106 and gpt-4-1106-preview',
+			'Whether to attempt to return the response in JSON format. Compatible with GPT-4 Turbo and all GPT-3.5 Turbo models newer than gpt-3.5-turbo-1106.',
 		default: false,
-		displayOptions: {
-			show: {
-				modelId: ['gpt-3.5-turbo-1106', 'gpt-4-1106-preview'],
-			},
-		},
 	},
 	{
 		displayName: 'Connect your own custom n8n tools to this node on the canvas',
@@ -212,7 +207,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	let toolCalls = response?.choices[0]?.message?.tool_calls;
 
-	while (toolCalls && toolCalls.length) {
+	while (toolCalls?.length) {
 		messages.push(response.choices[0].message);
 
 		for (const toolCall of toolCalls) {


### PR DESCRIPTION
## Summary
In the recent [Open AI node overhaul](https://github.com/n8n-io/n8n/pull/8335), we've added a toggle to support JSON response. But this toggle was only enabled if `gpt-3.5-turbo-1106` or`gpt-4-1106-preview` model was selected. This would prevent the user from enabling the JSON response for the latest models(`gpt-3.5-turbo-0125`, `gpt-4-turbo-preview`, etc.). So, instead, we always show this toggle with a hint that it's supported only with the newer models.

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 