### PR TITLE
fix(FTP Node): Fix "Maximum call stack size exceeded" error when dealing with too many files

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -502,9 +502,7 @@ export class Ftp implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		// const returnData: IDataObject[] = [];
-		const returnItems: INodeExecutionData[] = [];
-		let responseData;
+		let returnItems: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
 
 		let credentials: ICredentialDataDecryptedObject | undefined = undefined;
@@ -569,22 +567,19 @@ export class Ftp implements INodeType {
 
 						const recursive = this.getNodeParameter('recursive', i) as boolean;
 
+						let responseData: sftpClient.FileInfo[];
 						if (recursive) {
 							responseData = await callRecursiveList(path, sftp!, normalizeSFtpItem);
-							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
-								{ itemData: { item: i } },
-							);
-							returnItems.push.apply(returnItems, executionData);
 						} else {
 							responseData = await sftp!.list(path);
 							responseData.forEach((item) => normalizeSFtpItem(item, path));
-							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
-								{ itemData: { item: i } },
-							);
-							returnItems.push.apply(returnItems, executionData);
 						}
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'delete') {
@@ -592,15 +587,15 @@ export class Ftp implements INodeType {
 						const options = this.getNodeParameter('options', i);
 
 						if (options.folder === true) {
-							responseData = await sftp!.rmdir(path, !!options.recursive);
+							await sftp!.rmdir(path, !!options.recursive);
 						} else {
-							responseData = await sftp!.delete(path);
+							await sftp!.delete(path);
 						}
 						const executionData = this.helpers.constructExecutionMetaData(
 							[{ json: { success: true } }],
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'rename') {
@@ -614,12 +609,12 @@ export class Ftp implements INodeType {
 							await recursivelyCreateSftpDirs(sftp!, newPath);
 						}
 
-						responseData = await sftp!.rename(oldPath, newPath);
+						await sftp!.rename(oldPath, newPath);
 						const executionData = this.helpers.constructExecutionMetaData(
 							[{ json: { success: true } }],
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'download') {
@@ -640,7 +635,7 @@ export class Ftp implements INodeType {
 								this.helpers.returnJsonArray(items[i]),
 								{ itemData: { item: i } },
 							);
-							returnItems.push(...executionData);
+							returnItems = returnItems.concat(executionData);
 						} finally {
 							await binaryFile.cleanup();
 						}
@@ -671,7 +666,7 @@ export class Ftp implements INodeType {
 							this.helpers.returnJsonArray(items[i]),
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 				}
 
@@ -681,24 +676,21 @@ export class Ftp implements INodeType {
 
 						const recursive = this.getNodeParameter('recursive', i) as boolean;
 
+						let responseData;
 						if (recursive) {
 							responseData = await callRecursiveList(path, ftp!, normalizeFtpItem);
-							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
-								{ itemData: { item: i } },
-							);
-							returnItems.push.apply(returnItems, executionData);
 						} else {
 							responseData = await ftp!.list(path);
 							responseData.forEach((item) =>
 								normalizeFtpItem(item as ftpClient.ListingElement, path),
 							);
-							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
-								{ itemData: { item: i } },
-							);
-							returnItems.push.apply(returnItems, executionData);
 						}
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
+							{ itemData: { item: i } },
+						);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'delete') {
@@ -706,15 +698,16 @@ export class Ftp implements INodeType {
 						const options = this.getNodeParameter('options', i);
 
 						if (options.folder === true) {
-							responseData = await ftp!.rmdir(path, !!options.recursive);
+							await ftp!.rmdir(path, !!options.recursive);
 						} else {
-							responseData = await ftp!.delete(path);
+							await ftp!.delete(path);
 						}
+
 						const executionData = this.helpers.constructExecutionMetaData(
 							[{ json: { success: true } }],
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'download') {
@@ -736,7 +729,7 @@ export class Ftp implements INodeType {
 								this.helpers.returnJsonArray(items[i]),
 								{ itemData: { item: i } },
 							);
-							returnItems.push(...executionData);
+							returnItems = returnItems.concat(executionData);
 						} finally {
 							await binaryFile.cleanup();
 						}
@@ -747,12 +740,12 @@ export class Ftp implements INodeType {
 
 						const newPath = this.getNodeParameter('newPath', i) as string;
 
-						responseData = await ftp!.rename(oldPath, newPath);
+						await ftp!.rename(oldPath, newPath);
 						const executionData = this.helpers.constructExecutionMetaData(
 							[{ json: { success: true } }],
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 
 					if (operation === 'upload') {
@@ -801,7 +794,7 @@ export class Ftp implements INodeType {
 							this.helpers.returnJsonArray(items[i]),
 							{ itemData: { item: i } },
 						);
-						returnItems.push(...executionData);
+						returnItems = returnItems.concat(executionData);
 					}
 				}
 			}


### PR DESCRIPTION
Previous similar fixes:

* Google Sheets Node #7384
* Microsoft SQL Node #8334
* MongoDB Node #8530

## Related tickets and issues

https://community.n8n.io/t/cannot-list-files-of-a-big-sftp/40296

## Review / Merge checklist
- [x] PR title and summary are descriptive