### PR TITLE
fix(editor): Handle drag-n-dropping from other nodes in assignment component

### DIFF
--- a/packages/editor-ui/src/components/AssignmentCollection/__tests__/utils.test.ts
+++ b/packages/editor-ui/src/components/AssignmentCollection/__tests__/utils.test.ts
@@ -1,0 +1,15 @@
+import { nameFromExpression } from '../utils';
+
+describe('AssignmentCollection > utils', () => {
+	describe('nameFromExpression', () => {
+		test('should extract assignment name from previous node', () => {
+			expect(nameFromExpression('{{ $json.foo.bar }}')).toBe('foo.bar');
+		});
+
+		test('should extract assignment name from another node', () => {
+			expect(nameFromExpression("{{ $('Node's \"Name\" (copy)').item.json.foo.bar }}")).toBe(
+				'foo.bar',
+			);
+		});
+	});
+});

--- a/packages/editor-ui/src/components/AssignmentCollection/utils.ts
+++ b/packages/editor-ui/src/components/AssignmentCollection/utils.ts
@@ -4,7 +4,10 @@ import { resolveParameter } from '@/composables/useWorkflowHelpers';
 import { v4 as uuid } from 'uuid';
 
 export function nameFromExpression(expression: string): string {
-	return expression.replace(/^{{\s*|\s*}}$/g, '').replace('$json.', '');
+	return expression
+		.replace(/^{{\s*|\s*}}$/g, '')
+		.replace('$json.', '')
+		.replace(/^\$\(.*\)(\.item\.json)?\.(.*)/, '$2');
 }
 
 export function inferAssignmentType(value: unknown): string {


### PR DESCRIPTION
## Summary

Drag-and-drop data mapping using $() inserted the wrong field name.

When drag-n-dropping from a Node earlier in the workflow, the assignment key should be set to `name` instead of `$('NodeName').item.json.name`

<img width="1124" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/61ab1eb9-a151-4da3-82b8-47d2e81ca3ab">

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1137/edit-fields-drag-and-drop-data-mapping-using-dollar-inserts-the-wrong



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 