### PR TITLE
feat(core): Allow creating workflows in other projects than the personal one

### DIFF
--- a/packages/cli/src/databases/repositories/project.repository.ts
+++ b/packages/cli/src/databases/repositories/project.repository.ts
@@ -1,4 +1,5 @@
 import { Service } from 'typedi';
+import type { EntityManager } from '@n8n/typeorm';
 import { DataSource, Repository } from '@n8n/typeorm';
 import { Project } from '../entities/Project';
 
@@ -8,8 +9,10 @@ export class ProjectRepository extends Repository<Project> {
 		super(Project, dataSource.manager);
 	}
 
-	async getPersonalProjectForUser(userId: string) {
-		return await this.findOne({
+	async getPersonalProjectForUser(userId: string, entityManager?: EntityManager) {
+		const em = entityManager ?? this.manager;
+
+		return await em.findOne(Project, {
 			where: { type: 'personal', projectRelations: { userId, role: 'project:personalOwner' } },
 		});
 	}

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -13,7 +13,6 @@ import { RoleService } from './role.service';
 @Service()
 export class ProjectService {
 	constructor(
-		private readonly projectsRepository: ProjectRepository,
 		private readonly projectRepository: ProjectRepository,
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly roleService: RoleService,
@@ -22,9 +21,9 @@ export class ProjectService {
 	async getAccessibleProjects(user: User): Promise<Project[]> {
 		// This user is probably an admin, show them everything
 		if (user.hasGlobalScope('project:read')) {
-			return await this.projectsRepository.find();
+			return await this.projectRepository.find();
 		}
-		return await this.projectsRepository.getAccessibleProjects(user.id);
+		return await this.projectRepository.getAccessibleProjects(user.id);
 	}
 
 	async getPersonalProjectOwners(projectIds: string[]): Promise<ProjectRelation[]> {
@@ -45,7 +44,7 @@ export class ProjectService {
 			} else if (pr) {
 				name = pr.user.email;
 			}
-			return this.projectsRepository.create({
+			return this.projectRepository.create({
 				...p,
 				name,
 			});
@@ -53,8 +52,8 @@ export class ProjectService {
 	}
 
 	async createTeamProject(name: string, adminUser: User): Promise<Project> {
-		const project = await this.projectsRepository.save(
-			this.projectsRepository.create({
+		const project = await this.projectRepository.save(
+			this.projectRepository.create({
 				name,
 				type: 'team',
 			}),
@@ -73,7 +72,7 @@ export class ProjectService {
 	}
 
 	async getPersonalProject(user: User): Promise<Project | null> {
-		return await this.projectsRepository.getPersonalProjectForUser(user.id);
+		return await this.projectRepository.getPersonalProjectForUser(user.id);
 	}
 
 	async getProjectRelationsForUser(user: User): Promise<ProjectRelation[]> {
@@ -87,7 +86,7 @@ export class ProjectService {
 		projectId: string,
 		relations: Array<{ userId: string; role: ProjectRole }>,
 	) {
-		const project = await this.projectsRepository.findOneOrFail({
+		const project = await this.projectRepository.findOneOrFail({
 			where: { id: projectId, type: Not('personal') },
 		});
 		await this.projectRelationRepository.manager.transaction(async (em) => {

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -1,4 +1,4 @@
-import type { Project } from '@/databases/entities/Project';
+import { Project } from '@/databases/entities/Project';
 import { ProjectRelation } from '@/databases/entities/ProjectRelation';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { User } from '@/databases/entities/User';
@@ -116,10 +116,16 @@ export class ProjectService {
 		);
 	}
 
-	async getProjectWithScope(user: User, projectId: string, scope: Scope) {
+	async getProjectWithScope(
+		user: User,
+		projectId: string,
+		scope: Scope,
+		entityManager?: EntityManager,
+	) {
+		const em = entityManager ?? this.projectRepository.manager;
 		const projectRoles = this.roleService.rolesWithScope('project', [scope]);
 
-		return await this.projectRepository.findOne({
+		return await em.findOne(Project, {
 			where: {
 				id: projectId,
 				projectRelations: {

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -4,7 +4,7 @@ import type { INode, IConnections, IWorkflowSettings, IRunData, IPinData } from 
 
 export declare namespace WorkflowRequest {
 	type CreateUpdatePayload = Partial<{
-		id: string; // delete if sent
+		id: string; // deleted if sent
 		name: string;
 		nodes: INode[];
 		connections: IConnections;
@@ -13,6 +13,7 @@ export declare namespace WorkflowRequest {
 		tags: string[];
 		hash: string;
 		meta: Record<string, unknown>;
+		projectId: string;
 	}>;
 
 	type ManualRunPayload = {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -127,8 +127,13 @@ export class WorkflowsController {
 			const { projectId } = req.body;
 			const project =
 				projectId === undefined
-					? await this.projectRepository.getPersonalProjectForUser(req.user.id)
-					: await this.projectService.getProjectWithScope(req.user, projectId, 'workflow:create');
+					? await this.projectRepository.getPersonalProjectForUser(req.user.id, transactionManager)
+					: await this.projectService.getProjectWithScope(
+							req.user,
+							projectId,
+							'workflow:create',
+							transactionManager,
+					  );
 
 			if (typeof projectId === 'string' && project === null) {
 				throw new BadRequestError(

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -49,7 +49,7 @@ import { WorkflowSharingService } from './workflowSharing.service';
 import { UserManagementMailer } from '@/UserManagement/email';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { ProjectService } from '@/services/project.service';
-import { ApplicationError } from '../../../workflow/src';
+import { ApplicationError } from 'n8n-workflow';
 
 @Authorized()
 @RestController('/workflows')

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -49,6 +49,7 @@ import { WorkflowSharingService } from './workflowSharing.service';
 import { UserManagementMailer } from '@/UserManagement/email';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { ProjectService } from '@/services/project.service';
+import { ApplicationError } from '../../../workflow/src';
 
 @Authorized()
 @RestController('/workflows')
@@ -138,7 +139,7 @@ export class WorkflowsController {
 
 			// Safe guard in case the personal project does not exist for whatever reason.
 			if (project === null) {
-				throw new InternalServerError('Failed to save workflow');
+				throw new ApplicationError('No personal project found');
 			}
 
 			const newSharedWorkflow = this.sharedWorkflowRepository.create({

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -127,8 +127,7 @@ export class WorkflowsController {
 			const { projectId } = req.body;
 			const project =
 				projectId === undefined
-					? // TODO: pass the transaction manager optionally?
-					  await this.projectRepository.getPersonalProjectForUser(req.user.id)
+					? await this.projectRepository.getPersonalProjectForUser(req.user.id)
 					: await this.projectService.getProjectWithScope(req.user, projectId, 'workflow:create');
 
 			if (typeof projectId === 'string' && project === null) {

--- a/packages/cli/test/integration/services/project.service.test.ts
+++ b/packages/cli/test/integration/services/project.service.test.ts
@@ -62,7 +62,7 @@ describe('ProjectService', () => {
 			},
 		);
 
-		it('changes the role the user has to the project instead of creating a new relationship if the user already has a relationship to the project', async () => {
+		it('changes the role the user has in the project if the user is already part of the project, instead of creating a new relationship', async () => {
 			//
 			// ARRANGE
 			//
@@ -174,7 +174,7 @@ describe('ProjectService', () => {
 			},
 		);
 
-		it('should not return the project if the user is not related to it', async () => {
+		it('should not return the project if the user is not part of it', async () => {
 			//
 			// ARRANGE
 			//

--- a/packages/cli/test/integration/services/project.service.test.ts
+++ b/packages/cli/test/integration/services/project.service.test.ts
@@ -3,10 +3,7 @@ import * as testDb from '../shared/testDb';
 import Container from 'typedi';
 import { createMember } from '../shared/db/users';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
-import type { DeepPartial } from 'ts-essentials';
-import type { Project } from '@/databases/entities/Project';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
-import { EntityNotFoundError } from '@n8n/typeorm';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { Scope } from '@n8n/permissions';
 
@@ -30,20 +27,6 @@ afterEach(async () => {
 	await testDb.truncate(['User']);
 });
 
-async function createTeamProject(project?: DeepPartial<Project>) {
-	const projectRepository = Container.get(ProjectRepository);
-
-	let projectEntity = projectRepository.create({
-		name: 'Team Project',
-		...project,
-		type: 'team',
-	});
-
-	projectEntity = await projectRepository.save(projectEntity);
-
-	return projectEntity;
-}
-
 describe('ProjectService', () => {
 	describe('addUser', () => {
 		it.each([
@@ -58,7 +41,12 @@ describe('ProjectService', () => {
 				// ARRANGE
 				//
 				const member = await createMember();
-				const project = await createTeamProject();
+				const project = await projectRepository.save(
+					projectRepository.create({
+						name: 'Team Project',
+						type: 'team',
+					}),
+				);
 
 				//
 				// ACT
@@ -79,7 +67,12 @@ describe('ProjectService', () => {
 			// ARRANGE
 			//
 			const member = await createMember();
-			const project = await createTeamProject();
+			const project = await projectRepository.save(
+				projectRepository.create({
+					name: 'Team Project',
+					type: 'team',
+				}),
+			);
 			await projectService.addUser(project.id, member.id, 'project:viewer');
 
 			await projectRelationRepository.findOneOrFail({
@@ -117,7 +110,12 @@ describe('ProjectService', () => {
 				// ARRANGE
 				//
 				const projectOwner = await createMember();
-				const project = await createTeamProject();
+				const project = await projectRepository.save(
+					projectRepository.create({
+						name: 'Team Project',
+						type: 'team',
+					}),
+				);
 				await projectService.addUser(project.id, projectOwner.id, role);
 
 				//
@@ -152,7 +150,12 @@ describe('ProjectService', () => {
 				// ARRANGE
 				//
 				const projectViewer = await createMember();
-				const project = await createTeamProject();
+				const project = await projectRepository.save(
+					projectRepository.create({
+						name: 'Team Project',
+						type: 'team',
+					}),
+				);
 				await projectService.addUser(project.id, projectViewer.id, role);
 
 				//
@@ -176,7 +179,12 @@ describe('ProjectService', () => {
 			// ARRANGE
 			//
 			const member = await createMember();
-			const project = await createTeamProject();
+			const project = await projectRepository.save(
+				projectRepository.create({
+					name: 'Team Project',
+					type: 'team',
+				}),
+			);
 
 			//
 			// ACT

--- a/packages/cli/test/integration/services/project.service.test.ts
+++ b/packages/cli/test/integration/services/project.service.test.ts
@@ -1,0 +1,196 @@
+import { ProjectService } from '@/services/project.service';
+import * as testDb from '../shared/testDb';
+import Container from 'typedi';
+import { createMember } from '../shared/db/users';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import type { DeepPartial } from 'ts-essentials';
+import type { Project } from '@/databases/entities/Project';
+import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+import { EntityNotFoundError } from '@n8n/typeorm';
+import type { ProjectRole } from '@/databases/entities/ProjectRelation';
+import type { Scope } from '@n8n/permissions';
+
+let projectRepository: ProjectRepository;
+let projectService: ProjectService;
+let projectRelationRepository: ProjectRelationRepository;
+
+beforeAll(async () => {
+	await testDb.init();
+
+	projectRepository = Container.get(ProjectRepository);
+	projectService = Container.get(ProjectService);
+	projectRelationRepository = Container.get(ProjectRelationRepository);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+afterEach(async () => {
+	await testDb.truncate(['User']);
+});
+
+async function createTeamProject(project?: DeepPartial<Project>) {
+	const projectRepository = Container.get(ProjectRepository);
+
+	let projectEntity = projectRepository.create({
+		name: 'Team Project',
+		...project,
+		type: 'team',
+	});
+
+	projectEntity = await projectRepository.save(projectEntity);
+
+	return projectEntity;
+}
+
+describe('ProjectService', () => {
+	describe('addUser', () => {
+		it.each([
+			'project:viewer',
+			'project:admin',
+			'project:editor',
+			'project:personalOwner',
+		] as ProjectRole[])(
+			'creates a relation between the user and the project using the role %s',
+			async (role) => {
+				//
+				// ARRANGE
+				//
+				const member = await createMember();
+				const project = await createTeamProject();
+
+				//
+				// ACT
+				//
+				await projectService.addUser(project.id, member.id, role);
+
+				//
+				// ASSERT
+				//
+				await projectRelationRepository.findOneOrFail({
+					where: { userId: member.id, projectId: project.id, role },
+				});
+			},
+		);
+
+		it('changes the role the user has to the project instead of creating a new relationship if the user already has a relationship to the project', async () => {
+			//
+			// ARRANGE
+			//
+			const member = await createMember();
+			const project = await createTeamProject();
+			await projectService.addUser(project.id, member.id, 'project:viewer');
+
+			await projectRelationRepository.findOneOrFail({
+				where: { userId: member.id, projectId: project.id, role: 'project:viewer' },
+			});
+
+			//
+			// ACT
+			//
+			await projectService.addUser(project.id, member.id, 'project:admin');
+
+			//
+			// ASSERT
+			//
+			const relationships = await projectRelationRepository.find({
+				where: { userId: member.id, projectId: project.id },
+			});
+
+			expect(relationships).toHaveLength(1);
+			expect(relationships[0]).toHaveProperty('role', 'project:admin');
+		});
+	});
+
+	describe('getProjectWithScope', () => {
+		it.each([
+			{ role: 'project:admin', scope: 'workflow:list' },
+			{ role: 'project:admin', scope: 'workflow:create' },
+		] as Array<{
+			role: ProjectRole;
+			scope: Scope;
+		}>)(
+			'should return the project if the user has the role $role and wants the scope $scope',
+			async ({ role, scope }) => {
+				//
+				// ARRANGE
+				//
+				const projectOwner = await createMember();
+				const project = await createTeamProject();
+				await projectService.addUser(project.id, projectOwner.id, role);
+
+				//
+				// ACT
+				//
+				const projectFromService = await projectService.getProjectWithScope(
+					projectOwner,
+					project.id,
+					scope,
+				);
+
+				//
+				// ASSERT
+				//
+				if (projectFromService === null) {
+					fail('Expected projectFromService not to be null');
+				}
+				expect(project.id).toBe(projectFromService.id);
+			},
+		);
+
+		it.each([
+			{ role: 'project:viewer', scope: 'workflow:create' },
+			{ role: 'project:viewer', scope: 'credential:create' },
+		] as Array<{
+			role: ProjectRole;
+			scope: Scope;
+		}>)(
+			'should return the project if the user has the role $role and wants the scope $scope',
+			async ({ role, scope }) => {
+				//
+				// ARRANGE
+				//
+				const projectViewer = await createMember();
+				const project = await createTeamProject();
+				await projectService.addUser(project.id, projectViewer.id, role);
+
+				//
+				// ACT
+				//
+				const projectFromService = await projectService.getProjectWithScope(
+					projectViewer,
+					project.id,
+					scope,
+				);
+
+				//
+				// ASSERT
+				//
+				expect(projectFromService).toBeNull();
+			},
+		);
+
+		it('should not return the project if the user is not related to it', async () => {
+			//
+			// ARRANGE
+			//
+			const member = await createMember();
+			const project = await createTeamProject();
+
+			//
+			// ACT
+			//
+			const projectFromService = await projectService.getProjectWithScope(
+				member,
+				project.id,
+				'workflow:list',
+			);
+
+			//
+			// ASSERT
+			//
+			expect(projectFromService).toBeNull();
+		});
+	});
+});

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -179,7 +179,7 @@ describe('POST /workflows', () => {
 		});
 	});
 
-	test('creates workflow in other project if projectId is passed', async () => {
+	test('creates workflow in a specific project if the projectId is passed', async () => {
 		//
 		// ARRANGE
 		//
@@ -212,7 +212,7 @@ describe('POST /workflows', () => {
 		});
 	});
 
-	test('does not create the workflow in specific project if the project is not shared with user', async () => {
+	test('does not create the workflow in a specific project if the user is not part of the project', async () => {
 		//
 		// ARRANGE
 		//
@@ -240,7 +240,7 @@ describe('POST /workflows', () => {
 			});
 	});
 
-	test('does not create workflow in other project if the user does not have the right role', async () => {
+	test('does not create the workflow in a specific project if the user does not have the right role to do so', async () => {
 		//
 		// ARRANGE
 		//

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -21,6 +21,9 @@ import { createOwner } from '../shared/db/users';
 import { createWorkflow } from '../shared/db/workflows';
 import { createTag } from '../shared/db/tags';
 import { License } from '@/License';
+import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import { ProjectService } from '@/services/project.service';
 
 let owner: User;
 let authOwnerAgent: SuperAgentTest;
@@ -150,6 +153,120 @@ describe('POST /workflows', () => {
 		expect(
 			await Container.get(WorkflowHistoryRepository).count({ where: { workflowId: id } }),
 		).toBe(0);
+	});
+
+	test('create workflow in personal project by default', async () => {
+		//
+		// ARRANGE
+		//
+		const projectRepository = Container.get(ProjectRepository);
+		const workflow = makeWorkflow();
+		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
+
+		//
+		// ACT
+		//
+		const response = await authOwnerAgent.post('/workflows').send(workflow).expect(200);
+
+		//
+		// ASSERT
+		//
+		await Container.get(SharedWorkflowRepository).findOneOrFail({
+			where: {
+				projectId: personalProject.id,
+				workflowId: response.body.data.id,
+			},
+		});
+	});
+
+	test('creates workflow in other project if projectId is passed', async () => {
+		//
+		// ARRANGE
+		//
+		const projectRepository = Container.get(ProjectRepository);
+		const workflow = makeWorkflow();
+		const project = await projectRepository.save(
+			projectRepository.create({
+				name: 'Team Project',
+				type: 'team',
+			}),
+		);
+		await Container.get(ProjectService).addUser(project.id, owner.id, 'project:admin');
+
+		//
+		// ACT
+		//
+		const response = await authOwnerAgent
+			.post('/workflows')
+			.send({ ...workflow, projectId: project.id })
+			.expect(200);
+
+		//
+		// ASSERT
+		//
+		await Container.get(SharedWorkflowRepository).findOneOrFail({
+			where: {
+				projectId: project.id,
+				workflowId: response.body.data.id,
+			},
+		});
+	});
+
+	test('does not create the workflow in specific project if the project is not shared with user', async () => {
+		//
+		// ARRANGE
+		//
+		const projectRepository = Container.get(ProjectRepository);
+		const workflow = makeWorkflow();
+		const project = await projectRepository.save(
+			projectRepository.create({
+				name: 'Team Project',
+				type: 'team',
+			}),
+		);
+
+		//
+		// ACT
+		//
+		await authOwnerAgent
+			.post('/workflows')
+			.send({ ...workflow, projectId: project.id })
+			//
+			// ASSERT
+			//
+			.expect(400, {
+				code: 400,
+				message: "You don't have the permissions to save the workflow in this project.",
+			});
+	});
+
+	test('does not create workflow in other project if the user does not have the right role', async () => {
+		//
+		// ARRANGE
+		//
+		const projectRepository = Container.get(ProjectRepository);
+		const workflow = makeWorkflow();
+		const project = await projectRepository.save(
+			projectRepository.create({
+				name: 'Team Project',
+				type: 'team',
+			}),
+		);
+		await Container.get(ProjectService).addUser(project.id, owner.id, 'project:viewer');
+
+		//
+		// ACT
+		//
+		await authOwnerAgent
+			.post('/workflows')
+			.send({ ...workflow, projectId: project.id })
+			//
+			// ASSERT
+			//
+			.expect(400, {
+				code: 400,
+				message: "You don't have the permissions to save the workflow in this project.",
+			});
 	});
 });
 


### PR DESCRIPTION
## Summary
This allow calling `POST /workflows` with `projectId` in the body.

If the field is not there, the workflow will be shared with the user's personal project.

If the field is there, the workflow will be shared with that project, **if the user has the permissions to do so**. Otherwise the request will fail with a 400 status code.

## Related tickets and issues
There is no linear ticket for this as far as I know.

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

