### PR TITLE
fix(editor): Escape node names with quotes in autocomplete and drag'n'drop

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
@@ -7,7 +7,7 @@ import { mapStores } from 'pinia';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { escapeMappingString } from '@/utils/mappingUtils';
 
-function getAutoCompletableNodeNames(nodes: INodeUi[])a {
+function getAutoCompletableNodeNames(nodes: INodeUi[]) {
 	return nodes
 		.filter((node: INodeUi) => !NODE_TYPES_EXCLUDED_FROM_AUTOCOMPLETION.includes(node.type))
 		.map((node: INodeUi) => node.name);

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
@@ -5,8 +5,9 @@ import type { Completion, CompletionContext, CompletionResult } from '@codemirro
 import type { INodeUi } from '@/Interface';
 import { mapStores } from 'pinia';
 import { useWorkflowsStore } from '@/stores/workflows.store';
+import { escapeMappingString } from '@/utils/mappingUtils';
 
-function getAutoCompletableNodeNames(nodes: INodeUi[]) {
+function getAutoCompletableNodeNames(nodes: INodeUi[])a {
 	return nodes
 		.filter((node: INodeUi) => !NODE_TYPES_EXCLUDED_FROM_AUTOCOMPLETION.includes(node.type))
 		.map((node: INodeUi) => node.name);
@@ -98,7 +99,7 @@ export const baseCompletions = defineComponent({
 			options.push(
 				...getAutoCompletableNodeNames(this.workflowsStore.allNodes).map((nodeName) => {
 					return {
-						label: `${prefix}('${nodeName}')`,
+						label: `${prefix}('${escapeMappingString(nodeName)}')`,
 						type: 'variable',
 						info: this.$locale.baseText('codeNodeEditor.completer.$()', {
 							interpolate: { nodeName },
@@ -138,7 +139,7 @@ export const baseCompletions = defineComponent({
 			const options: Completion[] = getAutoCompletableNodeNames(this.workflowsStore.allNodes).map(
 				(nodeName) => {
 					return {
-						label: `${prefix}('${nodeName}')`,
+						label: `${prefix}('${escapeMappingString(nodeName)}')`,
 						type: 'variable',
 						info: this.$locale.baseText('codeNodeEditor.completer.$()', {
 							interpolate: { nodeName },

--- a/packages/editor-ui/src/components/VariableSelector.vue
+++ b/packages/editor-ui/src/components/VariableSelector.vue
@@ -50,6 +50,7 @@ import { useRootStore } from '@/stores/n8nRoot.store';
 import { useNDVStore } from '@/stores/ndv.store';
 import { useRouter } from 'vue-router';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
+import { escapeMappingString } from '@/utils/mappingUtils';
 
 // Node types that should not be displayed in variable selector
 const SKIPPED_NODE_TYPES = [STICKY_NODE_TYPE];
@@ -398,7 +399,9 @@ export default defineComponent({
 
 			// Get json data
 			if (outputData.hasOwnProperty('json')) {
-				const jsonPropertyPrefix = useShort ? '$json' : `$('${nodeName}').item.json`;
+				const jsonPropertyPrefix = useShort
+					? '$json'
+					: `$('${escapeMappingString(nodeName)}').item.json`;
 
 				const jsonDataOptions: IVariableSelectorOption[] = [];
 				for (const propertyName of Object.keys(outputData.json)) {
@@ -423,7 +426,9 @@ export default defineComponent({
 
 			// Get binary data
 			if (outputData.hasOwnProperty('binary')) {
-				const binaryPropertyPrefix = useShort ? '$binary' : `$('${nodeName}').item.binary`;
+				const binaryPropertyPrefix = useShort
+					? '$binary'
+					: `$('${escapeMappingString(nodeName)}').item.binary`;
 
 				const binaryData = [];
 				let binaryPropertyData = [];
@@ -537,7 +542,7 @@ export default defineComponent({
 
 				returnData.push({
 					name: key,
-					key: `$('${nodeName}').context["${key}"]`,
+					key: `$('${escapeMappingString(nodeName)}').context['${escapeMappingString(key)}']`,
 					// @ts-ignore
 					value: nodeContext[key],
 				});
@@ -793,7 +798,12 @@ export default defineComponent({
 					{
 						name: this.$locale.baseText('variableSelector.parameters'),
 						options: this.sortOptions(
-							this.getNodeParameters(nodeName, `$('${nodeName}').params`, undefined, filterText),
+							this.getNodeParameters(
+								nodeName,
+								`$('${escapeMappingString(nodeName)}').params`,
+								undefined,
+								filterText,
+							),
 						),
 					} as IVariableSelectorOption,
 				];

--- a/packages/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/dollar.completions.ts
@@ -11,6 +11,7 @@ import {
 } from './utils';
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { useExternalSecretsStore } from '@/stores/externalSecrets.ee.store';
+import { escapeMappingString } from '@/utils/mappingUtils';
 
 /**
  * Completions offered at the dollar position: `$|`
@@ -90,7 +91,7 @@ export function dollarOptions() {
 		})
 		.concat(
 			autocompletableNodeNames().map((nodeName) => ({
-				label: `$('${nodeName}')`,
+				label: `$('${escapeMappingString(nodeName)}')`,
 				type: 'keyword',
 				info: i18n.baseText('codeNodeEditor.completer.$()', { interpolate: { nodeName } }),
 			})),

--- a/packages/editor-ui/src/utils/__tests__/mappingUtils.test.ts
+++ b/packages/editor-ui/src/utils/__tests__/mappingUtils.test.ts
@@ -1,5 +1,5 @@
 import type { INodeProperties } from 'n8n-workflow';
-import { getMappedResult, getMappedExpression } from '../mappingUtils';
+import { getMappedResult, getMappedExpression, escapeMappingString } from '../mappingUtils';
 
 const RLC_PARAM: INodeProperties = {
 	displayName: 'Base',
@@ -271,6 +271,14 @@ describe('Mapping Utils', () => {
 			expect(result).toBe(
 				"{{ $json.propertyName.capitalizedName.stringVal['some-value'].capitalizedProp }}",
 			);
+		});
+	});
+	describe('escapeMappingString', () => {
+		test.each([
+			{ input: 'Normal node name (here)', output: 'Normal node name (here)' },
+			{ input: "'Should es'ape quotes here'", output: "\\'Should es\\'ape quotes here\\'" },
+		])('should escape "$input" to "$output"', ({ input, output }) => {
+			expect(escapeMappingString(input)).toEqual(output);
 		});
 	});
 });

--- a/packages/editor-ui/src/utils/mappingUtils.ts
+++ b/packages/editor-ui/src/utils/mappingUtils.ts
@@ -18,6 +18,10 @@ export function generatePath(root: string, path: Array<string | number>): string
 	}, root);
 }
 
+export function escapeMappingString(str: string): string {
+	return str.replace(/\'/g, "\\'");
+}
+
 export function getMappedExpression({
 	nodeName,
 	distanceFromActive,
@@ -28,7 +32,9 @@ export function getMappedExpression({
 	path: Array<string | number> | string;
 }) {
 	const root =
-		distanceFromActive === 1 ? '$json' : generatePath(`$('${nodeName}')`, ['item', 'json']);
+		distanceFromActive === 1
+			? '$json'
+			: generatePath(`$('${escapeMappingString(nodeName)}')`, ['item', 'json']);
 
 	if (typeof path === 'string') {
 		return `{{ ${root}${path} }}`;


### PR DESCRIPTION
## Summary

Expressions that use nodes with quotes `'` in their name did not work correctly., this PR fixes it by escaping them.

<img width="1128" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/985d223a-bb21-4f33-a907-9f06063bc83c">




## Related tickets and issues
https://linear.app/n8n/issue/NODE-1134/bug-quotes-in-node-names-breaks-data-mapping-using-dollar



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 