### PR TITLE
fix(core): Define `SHELL` env variable on docker images

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -37,5 +37,6 @@ RUN \
 	mkdir .n8n && \
 	chown node:node .n8n
 
+ENV SHELL /bin/sh
 USER node
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -21,5 +21,6 @@ COPY docker-entrypoint.sh /
 RUN \
 	mkdir .n8n && \
 	chown node:node .n8n
+ENV SHELL /bin/sh
 USER node
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
Since #8381, we have `oclif` [code trying to determine the user's shell](https://github.com/oclif/core/blob/3.18.1/src/config/config.ts#L699) using `require('os').userInfo().shell` if `process.env.SHELL` isn't set.

This fails in scenarios where the user doesn't have the permissions to read `/etc/passwd`, and prevents the app from starting up.


## Related tickets and issues
Fixes #8664


## Review / Merge checklist
- [x] PR title and summary are descriptive