### PR TITLE
fix(editor): Wrap expressions in resource locator component

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/theme.ts
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/theme.ts
@@ -44,6 +44,9 @@ export const inputTheme = ({ rows } = { rows: 5 }) => {
 		'.cm-scroller': {
 			lineHeight: '1.68',
 		},
+		'.cm-lineWrapping': {
+			wordBreak: 'break-all',
+		},
 	});
 
 	return [theme, highlighter.resolvableStyle];

--- a/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -48,7 +48,6 @@
 				<div v-if="hasMultipleModes" :class="$style.modeSelector">
 					<n8n-select
 						:model-value="selectedMode"
-						filterable
 						:size="inputSize"
 						:disabled="isReadOnly"
 						:placeholder="$locale.baseText('resourceLocator.modeSelector.placeholder')"

--- a/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/editor-ui/src/components/ResourceLocator/ResourceLocator.vue
@@ -44,6 +44,7 @@
 					[$style.multipleModes]: hasMultipleModes,
 				}"
 			>
+				<div :class="$style.background"></div>
 				<div v-if="hasMultipleModes" :class="$style.modeSelector">
 					<n8n-select
 						:model-value="selectedMode"
@@ -93,7 +94,7 @@
 									ref="input"
 									:model-value="expressionDisplayValue"
 									:path="path"
-									:rows="1"
+									:rows="3"
 									@update:modelValue="onInputChange"
 									@modalOpenerClick="$emit('modalOpenerClick')"
 								/>
@@ -819,15 +820,32 @@ $--mode-selector-width: 92px;
 .resourceLocator {
 	display: flex;
 	flex-wrap: wrap;
+	position: relative;
+
+	--input-issues-width: 28px;
 
 	.inputContainer {
 		display: flex;
 		align-items: center;
 		width: 100%;
 
+		--input-border-top-left-radius: 0;
+		--input-border-bottom-left-radius: 0;
+
 		> div {
 			width: 100%;
 		}
+	}
+
+	.background {
+		position: absolute;
+		background-color: var(--color-background-input-triple);
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: var(--input-issues-width);
+		border: 1px solid var(--border-color-base);
+		border-radius: var(--border-radius-base);
 	}
 
 	&.multipleModes {
@@ -889,7 +907,9 @@ $--mode-selector-width: 92px;
 
 .openResourceLink {
 	width: 25px !important;
-	margin-left: var(--spacing-2xs);
+	padding-left: var(--spacing-2xs);
+	padding-top: var(--spacing-4xs);
+	align-self: flex-start;
 }
 
 .parameter-issues {


### PR DESCRIPTION
## Summary

Expressions in Resource Locator can now wrap (up to 3 lines)

When it was only 1 line, it was not clear to the user that there is more content in an expression.

<img width="851" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/e4eac9db-6275-43f3-ac2c-469a6cbc9a73">

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1135/expressions-are-getting-cut-off-in-new-drag-and-drop-components

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 