### PR TITLE
fix(core): Apply correct hostname to redirected requests

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -475,22 +475,6 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 		axiosConfig.maxRedirects = 0;
 	}
 
-	axiosConfig.beforeRedirect = (redirectedRequest) => {
-		if (axiosConfig.headers?.Authorization) {
-			redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
-		}
-		if (axiosConfig.auth) {
-			redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
-		}
-	};
-
-	if (requestObject.rejectUnauthorized === false) {
-		axiosConfig.httpsAgent = new Agent({
-			rejectUnauthorized: false,
-			secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
-		});
-	}
-
 	const host = getHostFromRequestObject(requestObject);
 	const agentOptions: AgentOptions = {};
 	if (host) {
@@ -501,6 +485,22 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 		agentOptions.secureOptions = crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT;
 	}
 	axiosConfig.httpsAgent = new Agent(agentOptions);
+
+	axiosConfig.beforeRedirect = (redirectedRequest) => {
+		const redirectAgent = new Agent({
+			...agentOptions,
+			servername: redirectedRequest.hostname,
+		});
+		redirectedRequest.agent = redirectAgent;
+		redirectedRequest.agents.https = redirectAgent;
+
+		if (axiosConfig.headers?.Authorization) {
+			redirectedRequest.headers.Authorization = axiosConfig.headers.Authorization;
+		}
+		if (axiosConfig.auth) {
+			redirectedRequest.auth = `${axiosConfig.auth.username}:${axiosConfig.auth.password}`;
+		}
+	};
 
 	if (requestObject.timeout !== undefined) {
 		axiosConfig.timeout = requestObject.timeout;
@@ -893,6 +893,22 @@ function convertN8nRequestToAxios(n8nRequest: IHttpRequestOptions): AxiosRequest
 		agentOptions.rejectUnauthorized = false;
 	}
 	axiosRequest.httpsAgent = new Agent(agentOptions);
+
+	axiosRequest.beforeRedirect = (redirectedRequest) => {
+		const redirectAgent = new Agent({
+			...agentOptions,
+			servername: redirectedRequest.hostname,
+		});
+		redirectedRequest.agent = redirectAgent;
+		redirectedRequest.agents.https = redirectAgent;
+
+		if (axiosRequest.headers?.Authorization) {
+			redirectedRequest.headers.Authorization = axiosRequest.headers.Authorization;
+		}
+		if (axiosRequest.auth) {
+			redirectedRequest.auth = `${axiosRequest.auth.username}:${axiosRequest.auth.password}`;
+		}
+	};
 
 	if (n8nRequest.arrayFormat !== undefined) {
 		axiosRequest.paramsSerializer = (params) => {


### PR DESCRIPTION
## Summary

Broken in https://github.com/n8n-io/n8n/pull/8562

`servername` set on the httpsAgent was also being used for redirected requests. When redirected to another domain this breaks. This PR updates the `Agent.servername` when redirected.

workflow test added here: https://github.com/n8n-io/test-workflows/pull/263

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1149/recent-change-to-host-header-breaks-redirect-downloads
fixes https://github.com/n8n-io/n8n/issues/8668
https://community.n8n.io/t/ignore-ssl-setting-isnt-working-error-ssl-issue-consider-using-the-ignore-ssl-issues-option/40492



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 