### PR TITLE
feat(core): Move execution permission checks earlier in the lifecycle

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -62,7 +62,7 @@ export class PermissionChecker {
 		const inaccessibleCredId = inaccessibleCredIds[0];
 		const nodeToFlag = credIdsToNodes[inaccessibleCredId][0];
 
-		throw new CredentialAccessError(nodeToFlag, inaccessibleCredId, workflow);
+		throw new CredentialAccessError(nodeToFlag, inaccessibleCredId, workflowId);
 	}
 
 	async checkSubworkflowExecutePolicy(

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -389,7 +389,7 @@ export function hookFunctionsPreExecute(): IWorkflowExecuteHooks {
  * Returns hook functions to save workflow execution and call error workflow
  *
  */
-function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
+function hookFunctionsSave(): IWorkflowExecuteHooks {
 	const logger = Container.get(Logger);
 	const internalHooks = Container.get(InternalHooks);
 	const eventsService = Container.get(EventsService);
@@ -418,7 +418,7 @@ function hookFunctionsSave(parentProcessMode?: string): IWorkflowExecuteHooks {
 
 				await restoreBinaryDataId(fullRunData, this.executionId, this.mode);
 
-				const isManualMode = [this.mode, parentProcessMode].includes('manual');
+				const isManualMode = this.mode === 'manual';
 
 				try {
 					if (!isManualMode && isWorkflowIdValid(this.workflowData.id) && newStaticData) {
@@ -795,7 +795,11 @@ async function executeWorkflow(
 
 	let data;
 	try {
-		await Container.get(PermissionChecker).check(workflow, additionalData.userId);
+		await Container.get(PermissionChecker).check(
+			workflowData.id,
+			additionalData.userId,
+			workflowData.nodes,
+		);
 		await Container.get(PermissionChecker).checkSubworkflowExecutePolicy(
 			workflow,
 			options.parentWorkflowId,
@@ -809,7 +813,6 @@ async function executeWorkflow(
 			runData.executionMode,
 			executionId,
 			workflowData,
-			{ parentProcessMode: additionalData.hooks!.mode },
 		);
 		additionalDataIntegrated.executionId = executionId;
 
@@ -1011,10 +1014,8 @@ function getWorkflowHooksIntegrated(
 	mode: WorkflowExecuteMode,
 	executionId: string,
 	workflowData: IWorkflowBase,
-	optionalParameters?: IWorkflowHooksOptionalParameters,
 ): WorkflowHooks {
-	optionalParameters = optionalParameters || {};
-	const hookFunctions = hookFunctionsSave(optionalParameters.parentProcessMode);
+	const hookFunctions = hookFunctionsSave();
 	const preExecuteFunctions = hookFunctionsPreExecute();
 	for (const key of Object.keys(preExecuteFunctions)) {
 		if (hookFunctions[key] === undefined) {
@@ -1022,7 +1023,7 @@ function getWorkflowHooksIntegrated(
 		}
 		hookFunctions[key]!.push.apply(hookFunctions[key], preExecuteFunctions[key]);
 	}
-	return new WorkflowHooks(hookFunctions, mode, executionId, workflowData, optionalParameters);
+	return new WorkflowHooks(hookFunctions, mode, executionId, workflowData);
 }
 
 /**
@@ -1064,7 +1065,7 @@ export function getWorkflowHooksWorkerMain(
 	// TODO: simplifying this for now to just leave the bare minimum hooks
 
 	// const hookFunctions = hookFunctionsPush();
-	// const preExecuteFunctions = hookFunctionsPreExecute(optionalParameters.parentProcessMode);
+	// const preExecuteFunctions = hookFunctionsPreExecute();
 	// for (const key of Object.keys(preExecuteFunctions)) {
 	// 	if (hookFunctions[key] === undefined) {
 	// 		hookFunctions[key] = [];
@@ -1105,7 +1106,6 @@ export function getWorkflowHooksWorkerMain(
 export function getWorkflowHooksMain(
 	data: IWorkflowExecutionDataProcess,
 	executionId: string,
-	isMainProcess = false,
 ): WorkflowHooks {
 	const hookFunctions = hookFunctionsSave();
 	const pushFunctions = hookFunctionsPush();
@@ -1116,14 +1116,12 @@ export function getWorkflowHooksMain(
 		hookFunctions[key]!.push.apply(hookFunctions[key], pushFunctions[key]);
 	}
 
-	if (isMainProcess) {
-		const preExecuteFunctions = hookFunctionsPreExecute();
-		for (const key of Object.keys(preExecuteFunctions)) {
-			if (hookFunctions[key] === undefined) {
-				hookFunctions[key] = [];
-			}
-			hookFunctions[key]!.push.apply(hookFunctions[key], preExecuteFunctions[key]);
+	const preExecuteFunctions = hookFunctionsPreExecute();
+	for (const key of Object.keys(preExecuteFunctions)) {
+		if (hookFunctions[key] === undefined) {
+			hookFunctions[key] = [];
 		}
+		hookFunctions[key]!.push.apply(hookFunctions[key], preExecuteFunctions[key]);
 	}
 
 	if (!hookFunctions.nodeExecuteBefore) hookFunctions.nodeExecuteBefore = [];

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -158,6 +158,21 @@ export class WorkflowRunner {
 	): Promise<string> {
 		// Register a new execution
 		const executionId = await this.activeExecutions.add(data, restartExecutionId);
+
+		const { id: workflowId, nodes } = data.workflowData;
+		try {
+			await this.permissionChecker.check(workflowId, data.userId, nodes);
+		} catch (error) {
+			// Create a failed execution with the data for the node, save it and abort execution
+			const runData = generateFailedExecutionFromError(data.executionMode, error, error.node);
+			const workflowHooks = WorkflowExecuteAdditionalData.getWorkflowHooksMain(data, executionId);
+			await workflowHooks.executeHookFunctions('workflowExecuteBefore', []);
+			await workflowHooks.executeHookFunctions('workflowExecuteAfter', [runData]);
+			responsePromise?.reject(error);
+			this.activeExecutions.remove(executionId);
+			return executionId;
+		}
+
 		if (responsePromise) {
 			this.activeExecutions.attachResponsePromise(executionId, responsePromise);
 		}
@@ -267,27 +282,7 @@ export class WorkflowRunner {
 		await this.executionRepository.updateStatus(executionId, 'running');
 
 		try {
-			additionalData.hooks = WorkflowExecuteAdditionalData.getWorkflowHooksMain(
-				data,
-				executionId,
-				true,
-			);
-
-			try {
-				await this.permissionChecker.check(workflow, data.userId);
-			} catch (error) {
-				ErrorReporter.error(error);
-				// Create a failed execution with the data for the node
-				// save it and abort execution
-				const failedExecution = generateFailedExecutionFromError(
-					data.executionMode,
-					error,
-					error.node,
-				);
-				await additionalData.hooks.executeHookFunctions('workflowExecuteAfter', [failedExecution]);
-				this.activeExecutions.remove(executionId, failedExecution);
-				return;
-			}
+			additionalData.hooks = WorkflowExecuteAdditionalData.getWorkflowHooksMain(data, executionId);
 
 			additionalData.hooks.hookFunctions.sendResponse = [
 				async (response: IExecuteResponsePromiseData): Promise<void> => {

--- a/packages/cli/test/integration/PermissionChecker.test.ts
+++ b/packages/cli/test/integration/PermissionChecker.test.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 import { Container } from 'typedi';
-import type { WorkflowSettings } from 'n8n-workflow';
+import type { INode, WorkflowSettings } from 'n8n-workflow';
 import { SubworkflowOperationError, Workflow } from 'n8n-workflow';
 
 import config from '@/config';
@@ -87,6 +87,8 @@ beforeAll(async () => {
 });
 
 describe('check()', () => {
+	const workflowId = randomPositiveDigit().toString();
+
 	beforeEach(async () => {
 		await testDb.truncate(['Workflow', 'Credentials']);
 	});
@@ -97,56 +99,40 @@ describe('check()', () => {
 
 	test('should allow if workflow has no creds', async () => {
 		const userId = uuid();
+		const nodes: INode[] = [
+			{
+				id: uuid(),
+				name: 'Start',
+				type: 'n8n-nodes-base.start',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0],
+			},
+		];
 
-		const workflow = new Workflow({
-			id: randomPositiveDigit().toString(),
-			name: 'test',
-			active: false,
-			connections: {},
-			nodeTypes: mockNodeTypes,
-			nodes: [
-				{
-					id: uuid(),
-					name: 'Start',
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					parameters: {},
-					position: [0, 0],
-				},
-			],
-		});
-
-		expect(async () => await permissionChecker.check(workflow, userId)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflowId, userId, nodes)).not.toThrow();
 	});
 
 	test('should allow if requesting user is instance owner', async () => {
 		const owner = await createOwner();
-
-		const workflow = new Workflow({
-			id: randomPositiveDigit().toString(),
-			name: 'test',
-			active: false,
-			connections: {},
-			nodeTypes: mockNodeTypes,
-			nodes: [
-				{
-					id: uuid(),
-					name: 'Action Network',
-					type: 'n8n-nodes-base.actionNetwork',
-					parameters: {},
-					typeVersion: 1,
-					position: [0, 0],
-					credentials: {
-						actionNetworkApi: {
-							id: randomPositiveDigit().toString(),
-							name: 'Action Network Account',
-						},
+		const nodes: INode[] = [
+			{
+				id: uuid(),
+				name: 'Action Network',
+				type: 'n8n-nodes-base.actionNetwork',
+				parameters: {},
+				typeVersion: 1,
+				position: [0, 0],
+				credentials: {
+					actionNetworkApi: {
+						id: randomPositiveDigit().toString(),
+						name: 'Action Network Account',
 					},
 				},
-			],
-		});
+			},
+		];
 
-		expect(async () => await permissionChecker.check(workflow, owner.id)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflowId, owner.id, nodes)).not.toThrow();
 	});
 
 	test('should allow if workflow creds are valid subset', async () => {
@@ -154,46 +140,38 @@ describe('check()', () => {
 
 		const ownerCred = await saveCredential(randomCred(), { user: owner });
 		const memberCred = await saveCredential(randomCred(), { user: member });
-
-		const workflow = new Workflow({
-			id: randomPositiveDigit().toString(),
-			name: 'test',
-			active: false,
-			connections: {},
-			nodeTypes: mockNodeTypes,
-			nodes: [
-				{
-					id: uuid(),
-					name: 'Action Network',
-					type: 'n8n-nodes-base.actionNetwork',
-					parameters: {},
-					typeVersion: 1,
-					position: [0, 0],
-					credentials: {
-						actionNetworkApi: {
-							id: ownerCred.id,
-							name: ownerCred.name,
-						},
+		const nodes: INode[] = [
+			{
+				id: uuid(),
+				name: 'Action Network',
+				type: 'n8n-nodes-base.actionNetwork',
+				parameters: {},
+				typeVersion: 1,
+				position: [0, 0],
+				credentials: {
+					actionNetworkApi: {
+						id: ownerCred.id,
+						name: ownerCred.name,
 					},
 				},
-				{
-					id: uuid(),
-					name: 'Action Network 2',
-					type: 'n8n-nodes-base.actionNetwork',
-					parameters: {},
-					typeVersion: 1,
-					position: [0, 0],
-					credentials: {
-						actionNetworkApi: {
-							id: memberCred.id,
-							name: memberCred.name,
-						},
+			},
+			{
+				id: uuid(),
+				name: 'Action Network 2',
+				type: 'n8n-nodes-base.actionNetwork',
+				parameters: {},
+				typeVersion: 1,
+				position: [0, 0],
+				credentials: {
+					actionNetworkApi: {
+						id: memberCred.id,
+						name: memberCred.name,
 					},
 				},
-			],
-		});
+			},
+		];
 
-		expect(async () => await permissionChecker.check(workflow, owner.id)).not.toThrow();
+		expect(async () => await permissionChecker.check(workflowId, owner.id, nodes)).not.toThrow();
 	});
 
 	test('should deny if workflow creds are not valid subset', async () => {
@@ -247,9 +225,9 @@ describe('check()', () => {
 			role: 'workflow:owner',
 		});
 
-		const workflow = new Workflow(workflowDetails);
-
-		await expect(permissionChecker.check(workflow, member.id)).rejects.toThrow();
+		await expect(
+			permissionChecker.check(workflowDetails.id, member.id, workflowDetails.nodes),
+		).rejects.toThrow();
 	});
 });
 

--- a/packages/editor-ui/src/mixins/pushConnection.ts
+++ b/packages/editor-ui/src/mixins/pushConnection.ts
@@ -264,7 +264,8 @@ export const pushConnection = defineComponent({
 					pushData = receivedData.data as IPushDataExecutionFinished;
 				}
 
-				if (this.workflowsStore.activeExecutionId === pushData.executionId) {
+				const { activeExecutionId } = this.workflowsStore;
+				if (activeExecutionId === pushData.executionId) {
 					const activeRunData =
 						this.workflowsStore.workflowExecutionData?.data?.resultData?.runData;
 					if (activeRunData) {
@@ -285,7 +286,6 @@ export const pushConnection = defineComponent({
 					return false;
 				}
 
-				const { activeExecutionId } = this.workflowsStore;
 				if (activeExecutionId !== pushData.executionId) {
 					// The workflow which did finish execution did either not get started
 					// by this session or we do not have the execution id yet.
@@ -318,7 +318,6 @@ export const pushConnection = defineComponent({
 
 				const workflow = this.workflowHelpers.getCurrentWorkflow();
 				if (runDataExecuted.waitTill !== undefined) {
-					const activeExecutionId = this.workflowsStore.activeExecutionId;
 					const workflowSettings = this.workflowsStore.workflowSettings;
 					const saveManualExecutions = this.rootStore.saveManualExecutions;
 

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -1191,6 +1191,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				return;
 			}
 			this.activeExecutions.unshift(newActiveExecution);
+			this.activeExecutionId = newActiveExecution.id;
 		},
 		finishActiveExecution(
 			finishedActiveExecution: IPushDataExecutionFinished | IPushDataUnsavedExecutionFinished,

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2083,7 +2083,6 @@ export type WorkflowActivateMode =
 	| 'leadershipChange';
 
 export interface IWorkflowHooksOptionalParameters {
-	parentProcessMode?: string;
 	retryOf?: string;
 	sessionId?: string;
 }

--- a/packages/workflow/src/errors/credential-access-error.ts
+++ b/packages/workflow/src/errors/credential-access-error.ts
@@ -10,16 +10,15 @@ export class CredentialAccessError extends ExecutionBaseError {
 	constructor(
 		readonly node: INode,
 		credentialId: string,
-		workflow: { id: string; name?: string },
+		workflowId: string,
 	) {
 		super('Node has no access to credential', {
 			tags: {
 				nodeType: node.type,
 			},
 			extra: {
-				workflowId: workflow.id,
-				workflowName: workflow.name ?? '',
 				credentialId,
+				workflowId,
 			},
 		});
 	}


### PR DESCRIPTION
This change move the execution permission check before the execution start. 
This fixes issues like [this](https://n8nio.sentry.io/issues/4965073076) and [this](https://n8nio.sentry.io/issues/4965073078).

Also, deleted some own-mode related code.


## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included