### PR TITLE
feat(core): Add support for $("NodeName").isExecuted

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -922,10 +922,6 @@ export class WorkflowDataProxy {
 					throw createExpressionError(`"${nodeName}" node doesn't exist`);
 				}
 
-				if (!that?.runExecutionData?.resultData?.runData.hasOwnProperty(nodeName)) {
-					throw createExpressionError(`no data, execute "${nodeName}" node first`);
-				}
-
 				return new Proxy(
 					{},
 					{
@@ -933,6 +929,7 @@ export class WorkflowDataProxy {
 						ownKeys() {
 							return [
 								'pairedItem',
+								'isExecuted',
 								'itemMatching',
 								'item',
 								'first',
@@ -944,6 +941,12 @@ export class WorkflowDataProxy {
 						},
 						get(target, property, receiver) {
 							if (property === 'isProxy') return true;
+
+							if (!that?.runExecutionData?.resultData?.runData.hasOwnProperty(nodeName)) {
+								if (property === 'isExecuted') return false;
+								throw createExpressionError(`no data, execute "${nodeName}" node first`);
+							}
+							if (property === 'isExecuted') return true;
 
 							if (['pairedItem', 'itemMatching', 'item'].includes(property as string)) {
 								const pairedItemMethod = (itemIndex?: number) => {

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -294,8 +294,9 @@ describe('WorkflowDataProxy', () => {
 			expect(() => proxy.$('doNotExist')).toThrowError(ExpressionError);
 		});
 
-		test('$("NodeName")', () => {
-			expect(() => proxy.$('Set')).toThrowError(ExpressionError);
+		test('test $("NodeName").isExecuted', () => {
+			expect(proxy.$('Function').isExecuted).toEqual(true);
+			expect(proxy.$('Set').isExecuted).toEqual(false);
 		});
 
 		test('test $input.all()', () => {


### PR DESCRIPTION
## Summary
It makes it possible to check if a node has been executed already.

Example:
```
$('NodeName').isExecuted
```


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 