### PR TITLE
fix: Fix typeorm .save usages (no-changelog)

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -157,14 +157,11 @@ export class License {
 	async saveCertStr(value: TLicenseBlock): Promise<void> {
 		// if we have an ephemeral license, we don't want to save it to the database
 		if (config.get('license.cert')) return;
-		await this.settingsRepository.upsert(
-			{
-				key: SETTINGS_LICENSE_CERT_KEY,
-				value,
-				loadOnStartup: false,
-			},
-			['key'],
-		);
+		await this.settingsRepository.upsertByKey({
+			key: SETTINGS_LICENSE_CERT_KEY,
+			value,
+			loadOnStartup: false,
+		});
 	}
 
 	async activate(activationKey: string): Promise<void> {

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -166,13 +166,9 @@ export class MeController {
 			throw new BadRequestError('Personalization answers are mandatory');
 		}
 
-		await this.userRepository.save(
-			{
-				id: req.user.id,
-				personalizationAnswers,
-			},
-			{ transaction: false },
-		);
+		await this.userRepository.update(req.user.id, {
+			personalizationAnswers,
+		});
 
 		this.logger.info('User survey updated successfully', { userId: req.user.id });
 

--- a/packages/cli/src/sso/ssoHelpers.ts
+++ b/packages/cli/src/sso/ssoHelpers.ts
@@ -13,14 +13,11 @@ export async function setCurrentAuthenticationMethod(
 	authenticationMethod: AuthProviderType,
 ): Promise<void> {
 	config.set('userManagement.authenticationMethod', authenticationMethod);
-	await Container.get(SettingsRepository).save(
-		{
-			key: 'userManagement.authenticationMethod',
-			value: authenticationMethod,
-			loadOnStartup: true,
-		},
-		{ transaction: false },
-	);
+	await Container.get(SettingsRepository).upsertByKey({
+		key: 'userManagement.authenticationMethod',
+		value: authenticationMethod,
+		loadOnStartup: true,
+	});
 }
 
 export function getCurrentAuthenticationMethod(): AuthProviderType {

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -110,15 +110,13 @@ export class WorkflowsController {
 		await Db.transaction(async (transactionManager) => {
 			savedWorkflow = await transactionManager.save<WorkflowEntity>(newWorkflow);
 
-			const newSharedWorkflow = new SharedWorkflow();
-
-			Object.assign(newSharedWorkflow, {
+			const newSharedWorkflow = this.sharedWorkflowRepository.create({
 				role: 'workflow:owner',
 				user: req.user,
 				workflow: savedWorkflow,
 			});
 
-			await transactionManager.save<SharedWorkflow>(newSharedWorkflow);
+			await transactionManager.insert(SharedWorkflow, newSharedWorkflow);
 		});
 
 		if (!savedWorkflow) {

--- a/packages/cli/test/integration/database/repositories/settings.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/settings.repository.test.ts
@@ -1,0 +1,105 @@
+import Container from 'typedi';
+
+import * as testDb from '../../shared/testDb';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
+import { createSettings, getSettingsByKey } from '../../shared/db/settings';
+
+describe('SettingsRepository', () => {
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['Settings']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('upsert', () => {
+		it('should insert a new row if none exists', async () => {
+			// Arrange
+			const settingsRepository = Container.get(SettingsRepository);
+
+			// Act
+			await settingsRepository.upsertByKey({
+				key: 'test-key',
+				value: 'test-value',
+				loadOnStartup: true,
+			});
+
+			// Assert
+			const after = await getSettingsByKey('test-key');
+			expect(after).toEqual({
+				key: 'test-key',
+				value: 'test-value',
+				loadOnStartup: true,
+			});
+		});
+
+		it('should update the row if one exists', async () => {
+			// Arrange
+			const settingsRepository = Container.get(SettingsRepository);
+			await createSettings({
+				key: 'test-key',
+				value: '{}',
+				loadOnStartup: true,
+			});
+
+			// Act
+			await settingsRepository.upsertByKey({
+				key: 'test-key',
+				value: 'test-value',
+				loadOnStartup: true,
+			});
+
+			// Assert
+			const after = await getSettingsByKey('test-key');
+			expect(after).toEqual({
+				key: 'test-key',
+				value: 'test-value',
+				loadOnStartup: true,
+			});
+		});
+	});
+
+	describe('dismissBanner', () => {
+		it('store the dismissed banner when none are dismissed', async () => {
+			// Arrange
+			const settingsRepository = Container.get(SettingsRepository);
+
+			// Act
+			await settingsRepository.dismissBanner({ bannerName: 'test-banner' });
+
+			// Assert
+			const after = await getSettingsByKey('ui.banners.dismissed');
+			expect(after).toEqual({
+				key: 'ui.banners.dismissed',
+				value: '["test-banner"]',
+				loadOnStartup: true,
+			});
+		});
+
+		it('store the dismissed banner when one already is dismissed', async () => {
+			// Arrange
+			const settingsRepository = Container.get(SettingsRepository);
+			await createSettings({
+				key: 'ui.banners.dismissed',
+				value: '["other-banner"]',
+				loadOnStartup: true,
+			});
+
+			// Act
+			await settingsRepository.dismissBanner({ bannerName: 'test-banner' });
+
+			// Assert
+			const after = await getSettingsByKey('ui.banners.dismissed');
+			expect(after).toEqual({
+				key: 'ui.banners.dismissed',
+				value: '["other-banner","test-banner"]',
+				loadOnStartup: true,
+			});
+		});
+	});
+});

--- a/packages/cli/test/integration/shared/db/settings.ts
+++ b/packages/cli/test/integration/shared/db/settings.ts
@@ -1,0 +1,16 @@
+import type { Settings } from '@/databases/entities/Settings';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
+import Container from 'typedi';
+
+const getRepo = () => Container.get(SettingsRepository);
+
+export async function createSettings(attributes: Settings) {
+	const settingsEntity = getRepo().create(attributes);
+	const settings = await getRepo().save(settingsEntity);
+
+	return settings;
+}
+
+export async function getSettingsByKey(key: string) {
+	return await getRepo().findOneBy({ key });
+}

--- a/packages/cli/test/unit/SourceControl.test.ts
+++ b/packages/cli/test/unit/SourceControl.test.ts
@@ -19,6 +19,7 @@ import { constants as fsConstants, accessSync } from 'fs';
 import type { SourceControlledFile } from '@/environments/sourceControl/types/sourceControlledFile';
 import type { SourceControlPreferences } from '@/environments/sourceControl/types/sourceControlPreferences';
 import { mockInstance } from '../shared/mocking';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
 
 const pushResult: SourceControlledFile[] = [
 	{
@@ -151,6 +152,7 @@ const pullResult: SourceControlledFile[] = [
 ];
 
 const license = mockInstance(License);
+mockInstance(SettingsRepository);
 
 beforeAll(async () => {
 	jest.resetAllMocks();

--- a/packages/cli/test/unit/controllers/me.controller.test.ts
+++ b/packages/cli/test/unit/controllers/me.controller.test.ts
@@ -201,6 +201,26 @@ describe('MeController', () => {
 				new BadRequestError('Personalization answers are mandatory'),
 			);
 		});
+
+		it('should update the user in the DB', async () => {
+			const user = mock<User>({
+				id: '123',
+				password: 'password',
+				authIdentities: [],
+				role: 'global:owner',
+				personalizationAnswers: {},
+			});
+			const reqBody = { answer: '42' };
+			const req = mock<MeRequest.SurveyAnswers>({ user, body: reqBody });
+
+			await controller.storeSurveyAnswers(req);
+
+			expect(userRepository.update).toHaveBeenCalledWith(user.id, {
+				personalizationAnswers: reqBody,
+			});
+
+			expect(internalHooks.onPersonalizationSurveySubmitted).toHaveBeenCalledWith(user.id, reqBody);
+		});
 	});
 
 	describe('API Key methods', () => {


### PR DESCRIPTION

## Summary

Continuation of #8678

To mitigate issues caused by typeorm's implicit transactions in .save, this PR goes through (almost) all .save usages and either replaces them with .insert/.update/.upsert or adds an explicit transaction or { transaction: false } parameter.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 