### PR TITLE
fix(Postgres Node): Close connection pool only if it's not already closed or closing

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -237,7 +237,7 @@ export class PostgresTrigger implements INodeType {
 			this.emit([this.helpers.returnJsonArray([data])]);
 		};
 
-		// create trigger, funstion and channel or use existing channel
+		// create trigger, function and channel or use existing channel
 		const pgNames = prepareNames(this.getNode().id, this.getMode(), additionalFields);
 		if (triggerMode === 'createTrigger') {
 			await pgTriggerFunction.call(
@@ -284,7 +284,7 @@ export class PostgresTrigger implements INodeType {
 					`Postgres Trigger Error: ${(error as Error).message}`,
 				);
 			} finally {
-				await db.$pool.end();
+				if (!db.$pool.ending) await db.$pool.end();
 			}
 		};
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
@@ -58,7 +58,7 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			sshClient.end();
 		}
 
-		await db.$pool.end();
+		if (!db.$pool.ending) await db.$pool.end();
 	}
 
 	return [returnData];

--- a/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/listSearch.ts
@@ -23,7 +23,7 @@ export async function schemaSearch(this: ILoadOptionsFunctions): Promise<INodeLi
 		if (sshClient) {
 			sshClient.end();
 		}
-		await db.$pool.end();
+		if (!db.$pool.ending) await db.$pool.end();
 	}
 }
 export async function tableSearch(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
@@ -54,6 +54,6 @@ export async function tableSearch(this: ILoadOptionsFunctions): Promise<INodeLis
 		if (sshClient) {
 			sshClient.end();
 		}
-		await db.$pool.end();
+		if (!db.$pool.ending) await db.$pool.end();
 	}
 }

--- a/packages/nodes-base/nodes/Postgres/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/loadOptions.ts
@@ -31,7 +31,7 @@ export async function getColumns(this: ILoadOptionsFunctions): Promise<INodeProp
 		if (sshClient) {
 			sshClient.end();
 		}
-		await db.$pool.end();
+		if (!db.$pool.ending) await db.$pool.end();
 	}
 }
 

--- a/packages/nodes-base/nodes/Postgres/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/methods/resourceMapping.ts
@@ -94,6 +94,6 @@ export async function getMappingColumns(
 		if (sshClient) {
 			sshClient.end();
 		}
-		await db.$pool.end();
+		if (!db.$pool.ending) await db.$pool.end();
 	}
 }


### PR DESCRIPTION
This possible fixes [a dozen or so issues reported on Sentry](https://n8nio.sentry.io/issues/?project=4503924908883968&query=is%3Aunresolved+Called+end+on+pool+more+than+once&referrer=issue-list&statsPeriod=90d).

[HELP-467](https://linear.app/n8n/issue/HELP-467/editingdeleting-workflows-fails-for-user-audifonoes-called-end-on-pool)

## Review / Merge checklist
- [x] PR title and summary are descriptive