### PR TITLE
fix(editor): Send protocol and n8n version in templates destination parameter, stop redirecting template preview page to website

### DIFF
--- a/cypress/e2e/29-templates.cy.ts
+++ b/cypress/e2e/29-templates.cy.ts
@@ -25,6 +25,13 @@ describe('Workflow templates', () => {
 		mainSidebar.getters.menuItem('Templates').should('be.visible');
 		// Templates should be a link to the website
 		mainSidebar.getters.templates().parent('a').should('have.attr', 'href').and('include', 'https://n8n.io/workflows');
+		// Link should contain instance address and n8n version
+		mainSidebar.getters.templates().parent('a').then(($a) => {
+			const href = $a.attr('href');
+			// Link should have current instance address and n8n version
+			expect(href).to.include(`utm_instance=${window.location.origin}`);
+			expect(href).to.match(/utm_n8n_version=[0-9]+\.[0-9]+\.[0-9]+/);
+		});
 		mainSidebar.getters.templates().parent('a').should('have.attr', 'target', '_blank');
 	});
 
@@ -32,13 +39,6 @@ describe('Workflow templates', () => {
 		cy.visit(templatesPage.url);
 		cy.origin('https://n8n.io', () => {
 			cy.url().should('include', 'https://n8n.io/workflows');
-		})
-	});
-
-	it('Redirects to website when visiting template by id page directly', () => {
-		cy.visit(`${templatesPage.url}/1`);
-		cy.origin('https://n8n.io', () => {
-			cy.url().should('include', 'https://n8n.io/workflows/1');
 		})
 	});
 });

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -1379,6 +1379,7 @@ export interface ITemplateState {
 	};
 	currentSessionId: string;
 	previousSessionId: string;
+	currentN8nPath: string;
 }
 
 export interface IVersionsState {

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -107,9 +107,9 @@ export const routes = [
 			middleware: ['authenticated'],
 		},
 	},
-	// Single workflow view, this is no longer used in-app
-	// but is still reachable via direct link so we can redirect to it from the website
-	// an use for some other purposes (like template reviewing)
+	// Following two routes are kept in-app:
+	// Single workflow view, used when a custom template host is set
+	// Also, reachable directly from this URL
 	{
 		path: '/templates/:id',
 		name: VIEWS.TEMPLATE,
@@ -134,6 +134,7 @@ export const routes = [
 			middleware: ['authenticated'],
 		},
 	},
+	// Template setup view, this is the landing view for website users
 	{
 		path: '/templates/:id/setup',
 		name: VIEWS.TEMPLATE_SETUP,

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -130,15 +130,6 @@ export const routes = [
 			},
 			middleware: ['authenticated'],
 		},
-		beforeEnter: (to, _from, next) => {
-			const templatesStore = useTemplatesStore();
-			if (!templatesStore.hasCustomTemplatesHost) {
-				const id = Array.isArray(to.params.id) ? to.params.id[0] : to.params.id;
-				window.location.href = templatesStore.getWebsiteTemplatePageURL(id);
-			} else {
-				next();
-			}
-		},
 	},
 	{
 		path: '/templates/:id/setup',

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -107,6 +107,9 @@ export const routes = [
 			middleware: ['authenticated'],
 		},
 	},
+	// Single workflow view, this is no longer used in-app
+	// but is still reachable via direct link so we can redirect to it from the website
+	// an use for some other purposes (like template reviewing)
 	{
 		path: '/templates/:id',
 		name: VIEWS.TEMPLATE,

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -21,6 +21,7 @@ import {
 	getWorkflowTemplate,
 } from '@/api/templates';
 import { getFixedNodesList } from '@/utils/nodeViewUtils';
+import { useRootStore } from '@/stores/n8nRoot.store';
 
 const TEMPLATES_PAGE_SIZE = 20;
 
@@ -118,7 +119,9 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 * @returns {string}
 		 */
 		getWebsiteTemplateRepositoryURL(): string {
-			return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${this.getCurrentN8nPath}`;
+			return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
+				this.getCurrentN8nPath
+			}&utm_n8n_version=${useRootStore().versionCli}`;
 		},
 		/**
 		 * Construct the URL for the template page on the website for a given template id
@@ -126,7 +129,9 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 */
 		getWebsiteTemplatePageURL() {
 			return (id: string) => {
-				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/${id}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${this.getCurrentN8nPath}`;
+				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/${id}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
+					this.getCurrentN8nPath
+				}&utm_n8n_version=${useRootStore().versionCli}`;
 			};
 		},
 		/**
@@ -135,7 +140,9 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 */
 		getWebsiteCategoryURL() {
 			return (id: string) => {
-				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/?categories=${id}&${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${this.getCurrentN8nPath}`;
+				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/?categories=${id}&${
+					TEMPLATES_URLS.UTM_QUERY
+				}&utm_instance=${this.getCurrentN8nPath}&utm_n8n_version=${useRootStore().versionCli}`;
 			};
 		},
 		getCurrentN8nPath(): string {

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -40,6 +40,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		workflowSearches: {},
 		currentSessionId: '',
 		previousSessionId: '',
+		currentN8nPath: `${window.location.protocol}//${window.location.host}${window.BASE_PATH}`,
 	}),
 	getters: {
 		allCategories(): ITemplatesCategory[] {
@@ -120,7 +121,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 */
 		getWebsiteTemplateRepositoryURL(): string {
 			return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
-				this.getCurrentN8nPath
+				this.currentN8nPath
 			}&utm_n8n_version=${useRootStore().versionCli}`;
 		},
 		/**
@@ -130,7 +131,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		getWebsiteTemplatePageURL() {
 			return (id: string) => {
 				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/${id}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
-					this.getCurrentN8nPath
+					this.currentN8nPath
 				}&utm_n8n_version=${useRootStore().versionCli}`;
 			};
 		},
@@ -142,11 +143,8 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 			return (id: string) => {
 				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/?categories=${id}&${
 					TEMPLATES_URLS.UTM_QUERY
-				}&utm_instance=${this.getCurrentN8nPath}&utm_n8n_version=${useRootStore().versionCli}`;
+				}&utm_instance=${this.currentN8nPath}&utm_n8n_version=${useRootStore().versionCli}`;
 			};
-		},
-		getCurrentN8nPath(): string {
-			return `${window.location.protocol}//${window.location.host}${window.BASE_PATH}`;
 		},
 	},
 	actions: {

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -139,7 +139,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 			};
 		},
 		getCurrentN8nPath(): string {
-			return `${window.location.host}${window.BASE_PATH}`;
+			return `${window.location.protocol}//${window.location.host}${window.BASE_PATH}`;
 		},
 	},
 	actions: {


### PR DESCRIPTION
## Summary
- Adds protocol and n8n version to url website url parameters
- Stops redirecting to website when users land on `templates/<id>` route. This will enable us to still show template previews in-app but we are still not pointing to this page anywhere in the application.


## Related tickets and issues
Related to ADO-1789

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 