### PR TITLE
docs(OpenAI Node): Use the correct docs url (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
@@ -74,7 +74,7 @@ export const versionDescription: INodeTypeDescription = {
 		resources: {
 			primaryDocumentation: [
 				{
-					url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.openai/',
+					url: 'https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.openai/',
 				},
 			],
 		},


### PR DESCRIPTION
Since #8335, [Docs URLs check has been failing](https://github.com/n8n-io/n8n/actions/workflows/check-documentation-urls.yml). This PR fixes that.

## Review / Merge checklist
- [x] PR title and summary are descriptive