### PR TITLE
feat: Introduce prompt type option for Agent, Basic LLM Chain, and QA Chain nodes

### DIFF
--- a/cypress/composables/ndv.ts
+++ b/cypress/composables/ndv.ts
@@ -2,6 +2,8 @@
  * Getters
  */
 
+import { getVisibleSelect } from "../utils";
+
 export function getCredentialSelect(eq = 0) {
 	return cy.getByTestId('node-credentials-select').eq(eq);
 }
@@ -70,4 +72,13 @@ export function clickExecuteNode() {
 
 export function setParameterInputByName(name: string, value: string) {
 	getParameterInputByName(name).clear().type(value);
+}
+
+export function toggleParameterCheckboxInputByName(name: string) {
+	getParameterInputByName(name).find('input[type="checkbox"]').realClick()
+}
+
+export function setParameterSelectByContent(name: string, content: string) {
+	getParameterInputByName(name).realClick();
+	getVisibleSelect().find('.option-headline').contains(content).click();
 }

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -26,7 +26,10 @@ import {
 	clickExecuteNode,
 	clickGetBackToCanvas,
 	getOutputPanelTable,
+	getParameterInputByName,
 	setParameterInputByName,
+	setParameterSelectByContent,
+	toggleParameterCheckboxInputByName,
 } from '../composables/ndv';
 import { setCredentialValues } from '../composables/modals/credential-modal';
 import {
@@ -45,7 +48,9 @@ describe('Langchain Integration', () => {
 
 	it('should add nodes to all Agent node input types', () => {
 		addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME, true);
-		addNodeToCanvas(AGENT_NODE_NAME, true);
+		addNodeToCanvas(AGENT_NODE_NAME, true, true);
+		toggleParameterCheckboxInputByName('hasOutputParser');
+		clickGetBackToCanvas();
 
 		addLanguageModelNodeToParent(AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME, AGENT_NODE_NAME);
 		clickGetBackToCanvas();
@@ -94,10 +99,11 @@ describe('Langchain Integration', () => {
 
 		openNode(BASIC_LLM_CHAIN_NODE_NAME);
 
+		setParameterSelectByContent('promptType', 'Define below')
 		const inputMessage = 'Hello!';
 		const outputMessage = 'Hi there! How can I assist you today?';
 
-		setParameterInputByName('prompt', inputMessage);
+		setParameterInputByName('text', inputMessage);
 
 		runMockWorkflowExcution({
 			trigger: () => clickExecuteNode(),
@@ -135,6 +141,7 @@ describe('Langchain Integration', () => {
 		const inputMessage = 'Hello!';
 		const outputMessage = 'Hi there! How can I assist you today?';
 
+		setParameterSelectByContent('promptType', 'Define below')
 		setParameterInputByName('text', inputMessage);
 
 		runMockWorkflowExcution({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -273,7 +273,7 @@ export class Agent implements INodeType {
 				],
 				displayOptions: {
 					hide: {
-						'@version': [1, 1.1, 1.2],
+						'@version': [{ _cnd: { lte: 1.2 } }],
 					},
 				},
 				default: 'auto',
@@ -301,7 +301,7 @@ export class Agent implements INodeType {
 				default: false,
 				displayOptions: {
 					hide: {
-						'@version': [1, 1.1, 1.2],
+						'@version': [{ _cnd: { lte: 1.2 } }],
 						agent: ['sqlAgent'],
 					},
 				},

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -24,10 +24,12 @@ import { sqlAgentAgentExecute } from './agents/SqlAgent/execute';
 // display based on the agent type
 function getInputs(
 	agent: 'conversationalAgent' | 'openAiFunctionsAgent' | 'reActAgent' | 'sqlAgent',
+	hasOutputParser?: boolean,
 ): Array<ConnectionTypes | INodeInputConfiguration> {
 	interface SpecialInput {
 		type: ConnectionTypes;
 		filter?: INodeInputFilter;
+		required?: boolean;
 	}
 
 	const getInputData = (
@@ -40,7 +42,7 @@ function getInputs(
 			[NodeConnectionType.AiOutputParser]: 'Output Parser',
 		};
 
-		return inputs.map(({ type, filter }) => {
+		return inputs.map(({ type, filter, required }) => {
 			const input: INodeInputConfiguration = {
 				type,
 				displayName: type in displayNames ? displayNames[type] : undefined,
@@ -99,6 +101,7 @@ function getInputs(
 			},
 			{
 				type: NodeConnectionType.AiTool,
+				required: true,
 			},
 			{
 				type: NodeConnectionType.AiOutputParser,
@@ -136,6 +139,11 @@ function getInputs(
 		];
 	}
 
+	if (hasOutputParser === false) {
+		specialInputs = specialInputs.filter(
+			(input) => input.type !== NodeConnectionType.AiOutputParser,
+		);
+	}
 	return [NodeConnectionType.Main, ...getInputData(specialInputs)];
 }
 
@@ -145,7 +153,7 @@ export class Agent implements INodeType {
 		name: 'agent',
 		icon: 'fa:robot',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Generates an action plan and executes it. Can use external tools.',
 		subtitle:
 			"={{ {	conversationalAgent: 'Conversational Agent', openAiFunctionsAgent: 'OpenAI Functions Agent', reactAgent: 'ReAct Agent', sqlAgent: 'SQL Agent' }[$parameter.agent] }}",
@@ -167,7 +175,12 @@ export class Agent implements INodeType {
 				],
 			},
 		},
-		inputs: `={{ ((agent) => { ${getInputs.toString()}; return getInputs(agent) })($parameter.agent) }}`,
+		inputs: `={{
+			((agent, hasOutputParser) => {
+				${getInputs.toString()};
+				return getInputs(agent, hasOutputParser)
+			})($parameter.agent, $parameter.hasOutputParser === undefined || $parameter.hasOutputParser === true)
+		}}`,
 		outputs: [NodeConnectionType.Main],
 		credentials: [
 			{
@@ -238,6 +251,71 @@ export class Agent implements INodeType {
 					},
 				],
 				default: 'conversationalAgent',
+			},
+			{
+				displayName: 'Prompt',
+				name: 'promptType',
+				type: 'options',
+				options: [
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Take from previous node automatically',
+						value: 'auto',
+						description: 'Looks for an input field called chatInput',
+					},
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Define below',
+						value: 'define',
+						description:
+							'Use an expression to reference data in previous nodes or enter static text',
+					},
+				],
+				displayOptions: {
+					hide: {
+						'@version': [1, 1.1, 1.2],
+					},
+				},
+				default: 'auto',
+			},
+			{
+				displayName: 'Text',
+				name: 'text',
+				type: 'string',
+				required: true,
+				default: '',
+				placeholder: 'e.g. Hello, how can you help me?',
+				typeOptions: {
+					rows: 2,
+				},
+				displayOptions: {
+					show: {
+						promptType: ['define'],
+					},
+				},
+			},
+			{
+				displayName: 'Require Specific Output Format',
+				name: 'hasOutputParser',
+				type: 'boolean',
+				default: false,
+				displayOptions: {
+					hide: {
+						'@version': [1, 1.1, 1.2],
+						agent: ['sqlAgent'],
+					},
+				},
+			},
+			{
+				displayName: `Connect an <a data-action='openSelectiveNodeCreator' data-action-parameter-connectiontype='${NodeConnectionType.AiOutputParser}'>output parser</a> on the canvas to specify the output format you require`,
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						hasOutputParser: [true],
+					},
+				},
 			},
 
 			...conversationalAgentProperties,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/description.ts
@@ -39,7 +39,7 @@ export const planAndExecuteAgentProperties: INodeProperties[] = [
 				'@version': [1.2],
 			},
 		},
-		default: '={{ $json.chatInput } }',
+		default: '={{ $json.chatInput }}',
 	},
 	{
 		displayName: 'Options',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -12,7 +12,11 @@ import type { BaseOutputParser } from 'langchain/schema/output_parser';
 import { PromptTemplate } from 'langchain/prompts';
 import { CombiningOutputParser } from 'langchain/output_parsers';
 import type { BaseChatModel } from 'langchain/chat_models/base';
-import { isChatInstance } from '../../../../../utils/helpers';
+import {
+	getOptionalOutputParsers,
+	getPromptInputByType,
+	isChatInstance,
+} from '../../../../../utils/helpers';
 
 export async function reActAgentAgentExecute(
 	this: IExecuteFunctions,
@@ -25,10 +29,7 @@ export async function reActAgentAgentExecute(
 
 	const tools = (await this.getInputConnectionData(NodeConnectionType.AiTool, 0)) as Tool[];
 
-	const outputParsers = (await this.getInputConnectionData(
-		NodeConnectionType.AiOutputParser,
-		0,
-	)) as BaseOutputParser[];
+	const outputParsers = await getOptionalOutputParsers(this);
 
 	const options = this.getNodeParameter('options', 0, {}) as {
 		prefix?: string;
@@ -77,7 +78,18 @@ export async function reActAgentAgentExecute(
 
 	const items = this.getInputData();
 	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-		let input = this.getNodeParameter('text', itemIndex) as string;
+		let input;
+
+		if (this.getNode().typeVersion <= 1.2) {
+			input = this.getNodeParameter('text', itemIndex) as string;
+		} else {
+			input = getPromptInputByType({
+				ctx: this,
+				i: itemIndex,
+				inputKey: 'text',
+				promptTypeKey: 'promptType',
+			});
+		}
 
 		if (input === undefined) {
 			throw new NodeOperationError(this.getNode(), 'The ‘text‘ parameter is empty.');

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
@@ -38,6 +38,7 @@ export const sqlAgentAgentProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				agent: ['sqlAgent'],
+				'@version': [1, 1.1, 1.2],
 			},
 		},
 		default: '',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/description.ts
@@ -38,7 +38,7 @@ export const sqlAgentAgentProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				agent: ['sqlAgent'],
-				'@version': [1, 1.1, 1.2],
+				'@version': [{ _cnd: { lte: 1.2 } }],
 			},
 		},
 		default: '',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
@@ -11,6 +11,7 @@ import { SqlToolkit, createSqlAgent } from 'langchain/agents/toolkits/sql';
 import type { BaseLanguageModel } from 'langchain/dist/base_language';
 import type { DataSource } from '@n8n/typeorm';
 
+import { getPromptInputByType } from '../../../../../utils/helpers';
 import { getSqliteDataSource } from './other/handlers/sqlite';
 import { getPostgresDataSource } from './other/handlers/postgres';
 import { SQL_PREFIX, SQL_SUFFIX } from './other/prompts';
@@ -37,7 +38,17 @@ export async function sqlAgentAgentExecute(
 
 	for (let i = 0; i < items.length; i++) {
 		const item = items[i];
-		const input = this.getNodeParameter('input', i) as string;
+		let input;
+		if (this.getNode().typeVersion <= 1.2) {
+			input = this.getNodeParameter('input', i) as string;
+		} else {
+			input = getPromptInputByType({
+				ctx: this,
+				i,
+				inputKey: 'input',
+				promptTypeKey: 'promptType',
+			});
+		}
 
 		if (input === undefined) {
 			throw new NodeOperationError(this.getNode(), 'The ‘prompt’ parameter is empty.');

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -116,7 +116,7 @@ export class ChainRetrievalQa implements INodeType {
 				],
 				displayOptions: {
 					hide: {
-						'@version': [1, 1.1, 1.2],
+						'@version': [{ _cnd: { lte: 1.2 } }],
 					},
 				},
 				default: 'auto',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -11,6 +11,7 @@ import { RetrievalQAChain } from 'langchain/chains';
 import type { BaseLanguageModel } from 'langchain/dist/base_language';
 import type { BaseRetriever } from 'langchain/schema/retriever';
 import { getTemplateNoticeField } from '../../../utils/sharedFields';
+import { getPromptInputByType } from '../../../utils/helpers';
 
 export class ChainRetrievalQa implements INodeType {
 	description: INodeTypeDescription = {
@@ -18,7 +19,7 @@ export class ChainRetrievalQa implements INodeType {
 		name: 'chainRetrievalQa',
 		icon: 'fa:link',
 		group: ['transform'],
-		version: [1, 1.1, 1.2],
+		version: [1, 1.1, 1.2, 1.3],
 		description: 'Answer questions about retrieved documents',
 		defaults: {
 			name: 'Question and Answer Chain',
@@ -94,6 +95,47 @@ export class ChainRetrievalQa implements INodeType {
 					},
 				},
 			},
+			{
+				displayName: 'Prompt',
+				name: 'promptType',
+				type: 'options',
+				options: [
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Take from previous node automatically',
+						value: 'auto',
+						description: 'Looks for an input field called chatInput',
+					},
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Define below',
+						value: 'define',
+						description:
+							'Use an expression to reference data in previous nodes or enter static text',
+					},
+				],
+				displayOptions: {
+					hide: {
+						'@version': [1, 1.1, 1.2],
+					},
+				},
+				default: 'auto',
+			},
+			{
+				displayName: 'Text',
+				name: 'text',
+				type: 'string',
+				required: true,
+				default: '',
+				typeOptions: {
+					rows: 2,
+				},
+				displayOptions: {
+					show: {
+						promptType: ['define'],
+					},
+				},
+			},
 		],
 	};
 
@@ -117,7 +159,18 @@ export class ChainRetrievalQa implements INodeType {
 
 		// Run for each item
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			const query = this.getNodeParameter('query', itemIndex) as string;
+			let query;
+
+			if (this.getNode().typeVersion <= 1.2) {
+				query = this.getNodeParameter('query', itemIndex) as string;
+			} else {
+				query = getPromptInputByType({
+					ctx: this,
+					i: itemIndex,
+					inputKey: 'text',
+					promptTypeKey: 'promptType',
+				});
+			}
 
 			if (query === undefined) {
 				throw new NodeOperationError(this.getNode(), 'The ‘query‘ parameter is empty.');

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -1,6 +1,7 @@
-import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeConnectionType, type IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
 import { BaseChatModel } from 'langchain/chat_models/base';
 import { BaseChatModel as BaseChatModelCore } from '@langchain/core/language_models/chat_models';
+import type { BaseOutputParser } from '@langchain/core/output_parsers';
 
 export function getMetadataFiltersValues(
 	ctx: IExecuteFunctions,
@@ -18,6 +19,48 @@ export function getMetadataFiltersValues(
 }
 
 // TODO: Remove this function once langchain package is updated to 0.1.x
+// eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents
 export function isChatInstance(model: any): model is BaseChatModel | BaseChatModelCore {
 	return model instanceof BaseChatModel || model instanceof BaseChatModelCore;
+}
+
+export async function getOptionalOutputParsers(
+	ctx: IExecuteFunctions,
+): Promise<Array<BaseOutputParser<unknown>>> {
+	let outputParsers: BaseOutputParser[] = [];
+
+	if (ctx.getNodeParameter('hasOutputParser', 0, true) === true) {
+		outputParsers = (await ctx.getInputConnectionData(
+			NodeConnectionType.AiOutputParser,
+			0,
+		)) as BaseOutputParser[];
+	}
+
+	return outputParsers;
+}
+
+export function getPromptInputByType(options: {
+	ctx: IExecuteFunctions;
+	i: number;
+	promptTypeKey: string;
+	inputKey: string;
+}) {
+	const { ctx, i, promptTypeKey, inputKey } = options;
+	const prompt = ctx.getNodeParameter(promptTypeKey, i) as string;
+
+	let input;
+	if (prompt === 'auto') {
+		input = ctx.evaluateExpression('{{ $json["chatInput"] }}', i) as string;
+	} else {
+		input = ctx.getNodeParameter(inputKey, i) as string;
+	}
+
+	if (input === undefined) {
+		throw new NodeOperationError(ctx.getNode(), 'No prompt specified', {
+			description:
+				"Expected to find the prompt in an input field called 'chatInput' (this is what the chat trigger node outputs). To use something else, change the 'Prompt' parameter",
+		});
+	}
+
+	return input;
 }


### PR DESCRIPTION
## Summary
This PR enhances Agent and Chains nodes:
- Add prompt type option
- - Auto(default) mode automatically tries to populate the input using `{{ $json["chatInput"] }}` expression
- - Define let's use specify the message using a regular parameter input
- Hides the output parsers behind a toggle so they are not visible by default


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 