### PR TITLE
fix(editor): Correctly set condition operator when changed

### DIFF
--- a/packages/editor-ui/src/components/FilterConditions/__tests__/utils.test.ts
+++ b/packages/editor-ui/src/components/FilterConditions/__tests__/utils.test.ts
@@ -12,16 +12,15 @@ describe('FilterConditions > utils', () => {
 			expect(
 				handleOperatorChange({
 					condition,
-					newOperator: getFilterOperator('number:equals'),
+					newOperator: getFilterOperator('number:gt'),
 				}),
 			).toEqual({
 				id: '1',
 				leftValue: 45,
 				rightValue: 'notANumber',
 				operator: {
-					name: 'filter.operator.equals',
-					operation: 'equals',
-					type: 'string',
+					operation: 'gt',
+					type: 'number',
 				},
 			});
 		});
@@ -36,16 +35,15 @@ describe('FilterConditions > utils', () => {
 			expect(
 				handleOperatorChange({
 					condition,
-					newOperator: getFilterOperator('boolean:equals'),
+					newOperator: getFilterOperator('boolean:notEquals'),
 				}),
 			).toEqual({
 				id: '1',
 				leftValue: false,
 				rightValue: true,
 				operator: {
-					name: 'filter.operator.equals',
-					operation: 'equals',
-					type: 'string',
+					operation: 'notEquals',
+					type: 'boolean',
 				},
 			});
 		});
@@ -62,7 +60,15 @@ describe('FilterConditions > utils', () => {
 					condition,
 					newOperator: getFilterOperator('boolean:equals'),
 				}),
-			).toEqual(condition);
+			).toEqual({
+				id: '1',
+				leftValue: '={{ $json.foo }}',
+				rightValue: '={{ $("nodename").foo }}',
+				operator: {
+					operation: 'equals',
+					type: 'boolean',
+				},
+			});
 		});
 	});
 });

--- a/packages/editor-ui/src/components/FilterConditions/utils.ts
+++ b/packages/editor-ui/src/components/FilterConditions/utils.ts
@@ -46,6 +46,13 @@ export const handleOperatorChange = ({
 		condition.rightValue = convertToType(condition.rightValue, newRightType);
 	}
 
+	condition.operator = {
+		type: newOperator.type,
+		operation: newOperator.operation,
+		rightType: newOperator.rightType,
+		singleValue: newOperator.singleValue,
+	};
+
 	return condition;
 };
 


### PR DESCRIPTION
## Summary
Bugfix for issue introduced in https://github.com/n8n-io/n8n/pull/8635

Operator was not correctly updating



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 