### PR TITLE
feat(core): Allow using a custom certificates in docker containers

### DIFF
--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -3,6 +3,7 @@ if [ -d /opt/custom-certificates ]; then
   echo "Trusting custom certificates from /opt/custom-certificates."
   export NODE_OPTIONS=--use-openssl-ca $NODE_OPTIONS
   export SSL_CERT_DIR=/opt/custom-certificates
+  c_rehash /opt/custom-certificates
 fi
 
 if [ "$#" -gt 0 ]; then

--- a/docker/images/n8n/docker-entrypoint.sh
+++ b/docker/images/n8n/docker-entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+if [ -d /opt/custom-certificates ]; then
+  echo "Trusting custom certificates from /opt/custom-certificates."
+  export NODE_OPTIONS=--use-openssl-ca $NODE_OPTIONS
+  export SSL_CERT_DIR=/opt/custom-certificates
+fi
+
 if [ "$#" -gt 0 ]; then
   # Got started with arguments
   exec n8n "$@"


### PR DESCRIPTION
Right now we keep adding checks in code to allow people to skip SSL/TLS verification.
This is okay for external http requests, but for key infrastructure (like redis, postgres, SMTP) we should remove the option of n8n ignoring unsigned certificates, and instead let users mount a root CA cert at a specific path on docker containers. 

This way these certificates become trusted, and we don't need to modify any infrastructure code to disable TLS verification.
This would also make us less vulnerable to MITM at the infrastructure level.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included