### PR TITLE
fix(core): Ensure `maxRedirects` is used for any http request defining it

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -480,16 +480,13 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 	}
 
 	// Axios will follow redirects by default, so we simply tell it otherwise if needed.
+	const { method } = requestObject;
 	if (
-		requestObject.followRedirect === false &&
-		((requestObject.method as string | undefined) || 'get').toLowerCase() === 'get'
+		(requestObject.followRedirect && (!method || method === 'GET' || method === 'HEAD')) ||
+		requestObject.followAllRedirects
 	) {
-		axiosConfig.maxRedirects = 0;
-	}
-	if (
-		requestObject.followAllRedirects === false &&
-		((requestObject.method as string | undefined) || 'get').toLowerCase() !== 'get'
-	) {
+		axiosConfig.maxRedirects = requestObject.maxRedirects;
+	} else {
 		axiosConfig.maxRedirects = 0;
 	}
 

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -482,7 +482,8 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 	// Axios will follow redirects by default, so we simply tell it otherwise if needed.
 	const { method } = requestObject;
 	if (
-		(requestObject.followRedirect && (!method || method === 'GET' || method === 'HEAD')) ||
+		(requestObject.followRedirect !== false &&
+			(!method || method === 'GET' || method === 'HEAD')) ||
 		requestObject.followAllRedirects
 	) {
 		axiosConfig.maxRedirects = requestObject.maxRedirects;

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -11,6 +11,7 @@ import type { IncomingMessage } from 'http';
 import { mock } from 'jest-mock-extended';
 import type {
 	IBinaryData,
+	IHttpRequestMethods,
 	INode,
 	ITaskDataConnections,
 	IWorkflowExecuteAdditionalData,
@@ -317,6 +318,7 @@ describe('NodeExecuteFunctions', () => {
 						'X-Other-Header': 'otherHeaderContent',
 					},
 					resolveWithFullResponse: true,
+					followRedirect: true,
 				});
 
 				expect(response.statusCode).toBe(200);
@@ -334,6 +336,7 @@ describe('NodeExecuteFunctions', () => {
 				const response = await proxyRequestToAxios(workflow, additionalData, node, {
 					url: `${baseUrl}/redirect`,
 					resolveWithFullResponse: true,
+					followRedirect: true,
 				});
 
 				expect(response).toMatchObject({
@@ -367,6 +370,46 @@ describe('NodeExecuteFunctions', () => {
 				headers: { Host: 'other.host.com' },
 			});
 			expect((axiosOptions.httpsAgent as Agent).options.servername).toEqual('example.de');
+		});
+
+		describe('when followRedirect is true', () => {
+			test.each(['GET', 'HEAD'] as IHttpRequestMethods[])(
+				'should set maxRedirects on %s ',
+				async (method) => {
+					const axiosOptions = await parseRequestObject({
+						method,
+						followRedirect: true,
+						maxRedirects: 1234,
+					});
+					expect(axiosOptions.maxRedirects).toEqual(1234);
+				},
+			);
+
+			test.each(['POST', 'PUT', 'PATCH', 'DELETE'] as IHttpRequestMethods[])(
+				'should not set maxRedirects on %s ',
+				async (method) => {
+					const axiosOptions = await parseRequestObject({
+						method,
+						followRedirect: true,
+						maxRedirects: 1234,
+					});
+					expect(axiosOptions.maxRedirects).toEqual(0);
+				},
+			);
+		});
+
+		describe('when followAllRedirects is true', () => {
+			test.each(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'] as IHttpRequestMethods[])(
+				'should set maxRedirects on %s ',
+				async (method) => {
+					const axiosOptions = await parseRequestObject({
+						method,
+						followAllRedirects: true,
+						maxRedirects: 1234,
+					});
+					expect(axiosOptions.maxRedirects).toEqual(1234);
+				},
+			);
 		});
 	});
 

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -318,7 +318,6 @@ describe('NodeExecuteFunctions', () => {
 						'X-Other-Header': 'otherHeaderContent',
 					},
 					resolveWithFullResponse: true,
-					followRedirect: true,
 				});
 
 				expect(response.statusCode).toBe(200);
@@ -336,7 +335,6 @@ describe('NodeExecuteFunctions', () => {
 				const response = await proxyRequestToAxios(workflow, additionalData, node, {
 					url: `${baseUrl}/redirect`,
 					resolveWithFullResponse: true,
-					followRedirect: true,
 				});
 
 				expect(response).toMatchObject({

--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -325,14 +325,14 @@ export class HttpRequestV1 implements INodeType {
 							name: 'followAllRedirects',
 							type: 'boolean',
 							default: false,
-							description: 'Whether to follow non-GET HTTP 3xx redirects',
+							description: 'Whether to follow All HTTP 3xx redirects',
 						},
 						{
-							displayName: 'Follow GET Redirect',
+							displayName: 'Follow GET/HEAD Redirect',
 							name: 'followRedirect',
 							type: 'boolean',
 							default: true,
-							description: 'Whether to follow GET HTTP 3xx redirects',
+							description: 'Whether to follow GET or HEAD HTTP 3xx redirects',
 						},
 						{
 							displayName: 'Ignore Response Code',

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -340,14 +340,14 @@ export class HttpRequestV2 implements INodeType {
 							name: 'followAllRedirects',
 							type: 'boolean',
 							default: false,
-							description: 'Whether to follow non-GET HTTP 3xx redirects',
+							description: 'Whether to follow All HTTP 3xx redirects',
 						},
 						{
-							displayName: 'Follow GET Redirect',
+							displayName: 'Follow GET/HEAD Redirect',
 							name: 'followRedirect',
 							type: 'boolean',
 							default: true,
-							description: 'Whether to follow GET HTTP 3xx redirects',
+							description: 'Whether to follow GET or HEAD HTTP 3xx redirects',
 						},
 						{
 							displayName: 'Ignore Response Code',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -552,15 +552,21 @@ export interface IRequestOptions {
 	json?: boolean;
 	useStream?: boolean;
 	encoding?: string | null;
-	followRedirect?: boolean;
-	followAllRedirects?: boolean;
 	timeout?: number;
 	rejectUnauthorized?: boolean;
 	proxy?: string | AxiosProxyConfig;
 	simple?: boolean;
 	gzip?: boolean;
-	maxRedirects?: number;
 	resolveWithFullResponse?: boolean;
+
+	/** Whether to follow GET or HEAD HTTP 3xx redirects @default true */
+	followRedirect?: boolean;
+
+	/** Whether to follow **All** HTTP 3xx redirects @default false */
+	followAllRedirects?: boolean;
+
+	/** Max number of redirects to follow @default 21 */
+	maxRedirects?: number;
 }
 
 export interface PaginationOptions {


### PR DESCRIPTION
Right now when a node defines `maxRedirects` parameter, it's not getting picked up by the code in `NodeExecuteFunctions`, and that's why we are always defaulting to 21 max redirects.

This PR includes the following changes:
1. Add the code to copy over the `maxRedirects` parameter value into axios config
2. Refactor the block that deals with redirects in request config
3. Add unit tests for all config related to redirects to assert that the refactored block works as expected
4. Add jsdocs to redirect related properties in `IRequestOptions` to improve the dev UX 

## Related tickets and issues
Fixes parts of #8701

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included