### PR TITLE
fix(editor): Hide previous execution data for sub-nodes in debug mode if it has execution error

### DIFF
--- a/packages/editor-ui/src/components/InputPanel.vue
+++ b/packages/editor-ui/src/components/InputPanel.vue
@@ -395,6 +395,8 @@ export default defineComponent({
 				if (val === 'mapping') {
 					this.onUnlinkRun();
 					this.mappedNode = this.rootNodesParents[0];
+				} else {
+					this.mappedNode = null;
 				}
 			},
 			immediate: true,

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -173,6 +173,7 @@
 
 		<div
 			v-else-if="
+				!hasRunError &&
 				hasNodeRun &&
 				((dataCount > 0 && maxRunIndex === 0) || search) &&
 				!isArtificialRecoveredEventItem


### PR DESCRIPTION
## Summary
https://github.com/n8n-io/n8n/assets/12657221/e8f70b96-fcef-47a9-96a2-be3114913263

This PR fixes an issue when swapping between debugging and mapping mode in the sub-node with an execution error. Before, we incorrectly kept a reference to `mappedNode`, so in the debugging mode, we would treat it as a current node and not show the error.

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 