### PR TITLE
fix(editor): Do not break NDV for version-less nodes

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -517,6 +517,11 @@ describe('NDV', () => {
 		ndv.getters.nodeVersion().should('have.text', 'Edit Fields (Set) node version 3.3 (Latest)');
 		ndv.actions.close();
 
+		workflowPage.actions.openNode('Edit Fields (no typeVersion)');
+		ndv.actions.openSettings();
+		ndv.getters.nodeVersion().should('have.text', 'Edit Fields (Set) node version 3.3 (Latest)');
+		ndv.actions.close();
+
 		workflowPage.actions.openNode('Function');
 		ndv.actions.openSettings();
 		ndv.getters.nodeVersion().should('have.text', 'Function node version 1 (Deprecated)');

--- a/cypress/fixtures/Test_workflow_ndv_version.json
+++ b/cypress/fixtures/Test_workflow_ndv_version.json
@@ -1,49 +1,41 @@
 {
 	"name": "Node versions",
 	"nodes": [
-	  {
-		"parameters": {},
-		"id": "aadaed66-84ed-4cf8-bf21-082e9a65db76",
-		"name": "When clicking \"Test workflow\"",
-		"type": "n8n-nodes-base.manualTrigger",
-		"typeVersion": 1,
-		"position": [
-		  1540,
-		  780
-		]
-	  },
-	  {
-		"parameters": {},
-		"id": "93d73a85-82f0-4380-a032-713d5dc82b32",
-		"name": "Function",
-		"type": "n8n-nodes-base.function",
-		"typeVersion": 1,
-		"position": [
-		  2040,
-		  780
-		]
-	  },
-	  {
-		"id": "50f322d9-c622-4dd0-8d38-e851502739dd",
-		"name": "Edit Fields (old)",
-		"type": "n8n-nodes-base.set",
-		"typeVersion": 2,
-		"position": [
-		  1880,
-		  780
-		]
-	  },
-	  {
-		"id": "93aaadac-55fe-4618-b1eb-f63e61d1446a",
-		"name": "Edit Fields (latest)",
-		"type": "n8n-nodes-base.set",
-		"typeVersion": 3.3,
-		"position": [
-		  1720,
-		  780
-		]
-	  }
+		{
+			"id": "2acca986-10a6-451e-b20a-86e95b50e627",
+			"name": "When clicking \"Test workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [460, 460]
+		},
+		{
+			"id": "1ea0a87c-3395-4bd9-84fb-cf8b0f769cc4",
+			"name": "Function",
+			"type": "n8n-nodes-base.function",
+			"typeVersion": 1,
+			"position": [960, 460]
+		},
+		{
+			"id": "30bb9fab-bc89-4309-b42b-0fc586519c76",
+			"name": "Edit Fields (old)",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 2,
+			"position": [800, 460]
+		},
+		{
+			"id": "a266b96c-3539-4034-b24c-c86c6d0ca31e",
+			"name": "Edit Fields (no typeVersion)",
+			"type": "n8n-nodes-base.set",
+			"position": [1120, 460]
+		},
+		{
+			"id": "273f60c9-08e7-457e-b01d-31e16c565171",
+			"name": "Edit Fields (latest)",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.3,
+			"position": [640, 460]
+		}
 	],
-	"pinData": {},
-	"connections": {}
-  }
+	"connections": {},
+	"pinData": {}
+}

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -157,7 +157,7 @@
 						$locale.baseText('nodeSettings.nodeVersion', {
 							interpolate: {
 								node: nodeType?.displayName as string,
-								version: node.typeVersion.toString(),
+								version: (node.typeVersion ?? latestVersion).toString(),
 							},
 						})
 					}}
@@ -284,7 +284,7 @@ export default defineComponent({
 			return Math.max(...this.nodeTypeVersions);
 		},
 		isLatestNodeVersion(): boolean {
-			return this.latestVersion === this.node?.typeVersion;
+			return !this.node?.typeVersion || this.latestVersion === this.node.typeVersion;
 		},
 		nodeVersionTag(): string {
 			if (!this.nodeType || this.nodeType.hidden) {


### PR DESCRIPTION
On the backend we already assume the node version to be latest, when it is not defined.

NODE-1164

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included