### PR TITLE
fix: Fix execution error when using AI chain nodes with non-chat model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -1,7 +1,7 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
 import type { VectorStore } from 'langchain/vectorstores/base';
-import { NodeConnectionType, NodeOperationError, jsonStringify } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import type {
 	INodeCredentialDescription,
 	INodeProperties,
@@ -18,7 +18,7 @@ import type { Document } from 'langchain/document';
 import { logWrapper } from '../../../utils/logWrapper';
 import type { N8nJsonLoader } from '../../../utils/N8nJsonLoader';
 import type { N8nBinaryLoader } from '../../../utils/N8nBinaryLoader';
-import { getMetadataFiltersValues } from '../../../utils/helpers';
+import { getMetadataFiltersValues, logAiEvent } from '../../../utils/helpers';
 import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
 import { processDocument } from './processDocuments';
 
@@ -237,7 +237,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					});
 
 					resultData.push(...serializedDocs);
-					void this.logAiEvent('n8n.ai.vector.store.searched', jsonStringify({ query: prompt }));
+					void logAiEvent(this, 'n8n.ai.vector.store.searched', { query: prompt });
 				}
 
 				return await this.prepareOutputData(resultData);
@@ -264,7 +264,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					try {
 						await args.populateVectorStore(this, embeddings, processedDocuments, itemIndex);
 
-						void this.logAiEvent('n8n.ai.vector.store.populated');
+						void logAiEvent(this, 'n8n.ai.vector.store.populated');
 					} catch (error) {
 						throw error;
 					}

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -66,13 +66,13 @@ export function getPromptInputByType(options: {
 	return input;
 }
 
-export function logAiEvent(
+export async function logAiEvent(
 	executeFunctions: IExecuteFunctions,
 	event: EventNamesAiNodesType,
 	data?: IDataObject,
 ) {
 	try {
-		void executeFunctions.logAiEvent(event, data ? jsonStringify(data) : undefined);
+		await executeFunctions.logAiEvent(event, data ? jsonStringify(data) : undefined);
 	} catch (error) {
 		executeFunctions.logger.debug(`Error logging AI event: ${event}`);
 	}

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -1,4 +1,5 @@
-import { NodeConnectionType, type IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, jsonStringify } from 'n8n-workflow';
+import type { EventNamesAiNodesType, IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import { BaseChatModel } from 'langchain/chat_models/base';
 import { BaseChatModel as BaseChatModelCore } from '@langchain/core/language_models/chat_models';
 import type { BaseOutputParser } from '@langchain/core/output_parsers';
@@ -63,4 +64,16 @@ export function getPromptInputByType(options: {
 	}
 
 	return input;
+}
+
+export function logAiEvent(
+	executeFunctions: IExecuteFunctions,
+	event: EventNamesAiNodesType,
+	data?: IDataObject,
+) {
+	try {
+		void executeFunctions.logAiEvent(event, data ? jsonStringify(data) : undefined);
+	} catch (error) {
+		executeFunctions.logger.debug(`Error logging AI event: ${event}`);
+	}
 }

--- a/packages/@n8n/nodes-langchain/utils/logWrapper.ts
+++ b/packages/@n8n/nodes-langchain/utils/logWrapper.ts
@@ -8,9 +8,9 @@ import {
 } from 'n8n-workflow';
 
 import { Tool } from 'langchain/tools';
-import type { BaseMessage, ChatResult, InputValues } from 'langchain/schema';
+import type { ChatResult, InputValues, BaseMessage } from 'langchain/schema';
 import { BaseChatMessageHistory } from 'langchain/schema';
-import { BaseChatModel } from 'langchain/chat_models/base';
+import type { BaseChatModel } from 'langchain/chat_models/base';
 import type { CallbackManagerForLLMRun } from 'langchain/callbacks';
 
 import { Embeddings } from 'langchain/embeddings/base';
@@ -255,14 +255,20 @@ export function logWrapper(
 									runManager,
 								],
 							})) as ChatResult;
+							const parsedMessages =
+								typeof messages === 'string'
+									? messages
+									: messages.map((message) => {
+											if (typeof message === 'string') return message;
+											if (typeof message?.toJSON === 'function') return message.toJSON();
+
+											return message;
+									  });
 
 							void executeFunctions.logAiEvent(
 								'n8n.ai.llm.generated',
 								jsonStringify({
-									messages:
-										typeof messages === 'string'
-											? messages
-											: messages.map((message) => message.toJSON()),
+									messages: parsedMessages,
 									options,
 									response,
 								}),


### PR DESCRIPTION
## Summary
When parsing the messages for log streaming we assumed that the message could only be a string or of class `BaseMessage`. But non-chat models return an array of strings in which case we should return it as is instead of calling `toJSON`.


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.

- https://github.com/n8n-io/n8n/issues/8721


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 