### PR TITLE
fix(Postgres Trigger Node): `closeFunction` errors should not prevent a workflow from being deactivated

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -1,5 +1,5 @@
 import {
-	NodeOperationError,
+	TriggerCloseError,
 	type IDataObject,
 	type INodeType,
 	type INodeTypeDescription,
@@ -257,33 +257,42 @@ export class PostgresTrigger implements INodeType {
 
 		const cleanUpDb = async () => {
 			try {
-				await connection.none('UNLISTEN $1:name', [pgNames.channelName]);
-				if (triggerMode === 'createTrigger') {
-					const functionName = pgNames.functionName.includes('(')
-						? pgNames.functionName.split('(')[0]
-						: pgNames.functionName;
-					await connection.any('DROP FUNCTION IF EXISTS $1:name CASCADE', [functionName]);
-
-					const schema = this.getNodeParameter('schema', undefined, {
-						extractValue: true,
-					}) as string;
-					const table = this.getNodeParameter('tableName', undefined, {
-						extractValue: true,
-					}) as string;
-
-					await connection.any('DROP TRIGGER IF EXISTS $1:name ON $2:name.$3:name CASCADE', [
-						pgNames.triggerName,
-						schema,
-						table,
-					]);
+				try {
+					// check if the connection is healthy
+					await connection.query('SELECT 1');
+				} catch {
+					// connection already closed. Can't perform cleanup
+					// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+					throw new TriggerCloseError(this.getNode(), { level: 'warning' });
 				}
-				connection.client.removeListener('notification', onNotification);
-			} catch (error) {
-				throw new NodeOperationError(
-					this.getNode(),
-					`Postgres Trigger Error: ${(error as Error).message}`,
-				);
+
+				try {
+					await connection.none('UNLISTEN $1:name', [pgNames.channelName]);
+					if (triggerMode === 'createTrigger') {
+						const functionName = pgNames.functionName.includes('(')
+							? pgNames.functionName.split('(')[0]
+							: pgNames.functionName;
+						await connection.any('DROP FUNCTION IF EXISTS $1:name CASCADE', [functionName]);
+
+						const schema = this.getNodeParameter('schema', undefined, {
+							extractValue: true,
+						}) as string;
+						const table = this.getNodeParameter('tableName', undefined, {
+							extractValue: true,
+						}) as string;
+
+						await connection.any('DROP TRIGGER IF EXISTS $1:name ON $2:name.$3:name CASCADE', [
+							pgNames.triggerName,
+							schema,
+							table,
+						]);
+					}
+				} catch (error) {
+					// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+					throw new TriggerCloseError(this.getNode(), { cause: error as Error, level: 'error' });
+				}
 			} finally {
+				connection.client.removeListener('notification', onNotification);
 				if (!db.$pool.ending) await db.$pool.end();
 			}
 		};

--- a/packages/workflow/src/errors/application.error.ts
+++ b/packages/workflow/src/errors/application.error.ts
@@ -1,7 +1,7 @@
 import callsites from 'callsites';
 import type { Event } from '@sentry/node';
 
-type Level = 'warning' | 'error' | 'fatal' | 'info';
+export type Level = 'warning' | 'error' | 'fatal' | 'info';
 
 export type ReportingOptions = {
 	level?: Level;

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -10,6 +10,7 @@ export { WorkflowDeactivationError } from './workflow-deactivation.error';
 export { WorkflowOperationError } from './workflow-operation.error';
 export { SubworkflowOperationError } from './subworkflow-operation.error';
 export { CliWorkflowOperationError } from './cli-subworkflow-operation.error';
+export { TriggerCloseError } from './trigger-close.error';
 
 export { NodeError } from './abstract/node.error';
 export { ExecutionBaseError } from './abstract/execution-base.error';

--- a/packages/workflow/src/errors/trigger-close.error.ts
+++ b/packages/workflow/src/errors/trigger-close.error.ts
@@ -1,0 +1,16 @@
+import type { INode } from '../Interfaces';
+import { ApplicationError, type Level } from './application.error';
+
+interface TriggerCloseErrorOptions extends ErrorOptions {
+	level: Level;
+}
+
+export class TriggerCloseError extends ApplicationError {
+	constructor(
+		readonly node: INode,
+		{ cause, level }: TriggerCloseErrorOptions,
+	) {
+		super('Trigger Close Failed', { cause, extra: { nodeName: node.name } });
+		this.level = level;
+	}
+}


### PR DESCRIPTION
Calls to `closeFunction` during deactivation or shutdown can throw errors. These errors can be logged or reported, but should not fail the action (like deactivation) that they are a part of.

## Related tickets and issues
HELP-467

## Review / Merge checklist
- [x] PR title and summary are descriptive