### PR TITLE
feat: Allow filtering credentials and workflows by project ID

### DIFF
--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -60,6 +60,11 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 			filter.type = Like(`%${filter.type}%`);
 		}
 
+		if (typeof filter?.projectId === 'string' && filter.projectId !== '') {
+			filter.shared = { projectId: filter.projectId };
+			delete filter.projectId;
+		}
+
 		if (filter) findManyOptions.where = filter;
 		if (select) findManyOptions.select = select;
 		if (take) findManyOptions.take = take;

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -114,6 +114,11 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	async getMany(sharedWorkflowIds: string[], options?: ListQuery.Options) {
 		if (sharedWorkflowIds.length === 0) return { workflows: [], count: 0 };
 
+		if (typeof options?.filter?.projectId === 'string' && options.filter.projectId !== '') {
+			options.filter.shared = { projectId: options.filter.projectId };
+			delete options.filter.projectId;
+		}
+
 		const where: FindOptionsWhere<WorkflowEntity> = {
 			...options?.filter,
 			id: In(sharedWorkflowIds),

--- a/packages/cli/src/middlewares/listQuery/dtos/credentials.filter.dto.ts
+++ b/packages/cli/src/middlewares/listQuery/dtos/credentials.filter.dto.ts
@@ -13,6 +13,11 @@ export class CredentialsFilter extends BaseFilter {
 	@Expose()
 	type?: string;
 
+	@IsString()
+	@IsOptional()
+	@Expose()
+	projectId?: string;
+
 	static async fromString(rawFilter: string) {
 		return await this.toFilter(rawFilter, CredentialsFilter);
 	}

--- a/packages/cli/src/middlewares/listQuery/dtos/workflow.filter.dto.ts
+++ b/packages/cli/src/middlewares/listQuery/dtos/workflow.filter.dto.ts
@@ -20,6 +20,11 @@ export class WorkflowFilter extends BaseFilter {
 	@Expose()
 	tags?: string[];
 
+	@IsString()
+	@IsOptional()
+	@Expose()
+	projectId?: string;
+
 	static async fromString(rawFilter: string) {
 		return await this.toFilter(rawFilter, WorkflowFilter);
 	}

--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -5,6 +5,8 @@ import { setupTestServer } from './shared/utils/';
 import { randomCredentialPayload as payload } from './shared/random';
 import { saveCredential } from './shared/db/credentials';
 import { createMember, createOwner } from './shared/db/users';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import Container from 'typedi';
 
 const { any } = expect;
 
@@ -170,6 +172,28 @@ describe('GET /credentials', () => {
 				.expect(200);
 
 			expect(_response.body.data).toHaveLength(0);
+		});
+
+		test('should filter credentials by projectId', async () => {
+			const credential = await saveCredential(payload(), { user: owner, role: 'credential:owner' });
+			const pp = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(owner.id);
+
+			const response1: GetAllResponse = await testServer
+				.authAgentFor(owner)
+				.get('/credentials')
+				.query(`filter={ "projectId": "${pp.id}" }`)
+				.expect(200);
+
+			expect(response1.body.data).toHaveLength(1);
+			expect(response1.body.data[0].id).toBe(credential.id);
+
+			const response2 = await testServer
+				.authAgentFor(owner)
+				.get('/credentials')
+				.query('filter={ "projectId": "Non-Existing Project ID" }')
+				.expect(200);
+
+			expect(response2.body.data).toHaveLength(0);
 		});
 	});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -415,6 +415,26 @@ describe('GET /workflows', () => {
 				data: [objectContaining({ name: 'First', tags: [{ id: any(String), name: 'A' }] })],
 			});
 		});
+
+		test('should filter workflows by projectId', async () => {
+			const workflow = await createWorkflow({ name: 'First' }, owner);
+			const pp = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(owner.id);
+
+			const response1 = await authOwnerAgent
+				.get('/workflows')
+				.query(`filter={ "projectId": "${pp.id}" }`)
+				.expect(200);
+
+			expect(response1.body.data).toHaveLength(1);
+			expect(response1.body.data[0].id).toBe(workflow.id);
+
+			const response2 = await authOwnerAgent
+				.get('/workflows')
+				.query('filter={ "projectId": "Non-Existing Project ID" }')
+				.expect(200);
+
+			expect(response2.body.data).toHaveLength(0);
+		});
 	});
 
 	describe('select', () => {


### PR DESCRIPTION
## Summary

This allows filtering credentials and workflows by project ID.
This affects the endpoints

- `GET /credentials`
- `GET /workflows`

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1406/add-project-filter-to-get-workflows-get-credentials

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

