### PR TITLE
docs: Update OpenAI Node primaryDocumentation URL to match docs URL change

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
@@ -74,7 +74,7 @@ export const versionDescription: INodeTypeDescription = {
 		resources: {
 			primaryDocumentation: [
 				{
-					url: 'https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.openai/',
+					url: 'https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/',
 				},
 			],
 		},


### PR DESCRIPTION
## Summary
Update primaryDocumentation URL to reflect change in docs URL for OpenAI node once docs changes are released. 

This PR needs to be reviewed by @StarfallProjects so it can be merged once docs changes are done.



## Related tickets and issues
[See Linear ticket](https://linear.app/n8n/issue/NODE-1106/docs-for-ai-node-tweaks-and-openai-node-update)



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.