### PR TITLE
feat: Return project related information from `GET /workflows` and `GET /credentials`

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -68,7 +68,7 @@ export class CredentialsController {
 
 			let credential = await this.credentialsRepository.findOne({
 				where: { id: credentialId },
-				relations: ['shared', 'shared.user'],
+				relations: { shared: { user: true, project: true } },
 			});
 
 			if (!credential) {

--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -45,7 +45,7 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 
 		type Select = Array<keyof CredentialsEntity>;
 
-		const defaultRelations = ['shared', 'shared.user'];
+		const defaultRelations = ['shared', 'shared.user', 'shared.project'];
 		const defaultSelect: Select = ['id', 'name', 'type', 'nodesAccess', 'createdAt', 'updatedAt'];
 
 		if (!listQueryOptions) return { select: defaultSelect, relations: defaultRelations };

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -152,7 +152,7 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			select.tags = { id: true, name: true };
 		}
 
-		if (isOwnedByIncluded) relations.push('shared', 'shared.user');
+		if (isOwnedByIncluded) relations.push('shared', 'shared.user', 'shared.project');
 
 		if (typeof where.name === 'string' && where.name !== '') {
 			where.name = Like(`%${where.name}%`);

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -104,7 +104,7 @@ export namespace ListQuery {
 
 		type SharedField = Partial<Pick<WorkflowEntity, 'shared'>>;
 
-		type OwnedByField = { ownedBy: SlimUser | null };
+		type OwnedByField = { ownedBy: SlimUser | null; ownedByProject: SlimProject | null };
 
 		export type Plain = BaseFields;
 
@@ -112,15 +112,15 @@ export namespace ListQuery {
 
 		export type WithOwnership = BaseFields & OwnedByField;
 
-		type SharedWithField = { sharedWith: SlimUser[] };
+		type SharedWithField = { sharedWith: SlimUser[]; sharedWithProjects: SlimProject[] };
 
 		export type WithOwnedByAndSharedWith = BaseFields & OwnedByField & SharedWithField;
 	}
 
 	export namespace Credentials {
-		type OwnedByField = { ownedBy: SlimUser | null };
+		type OwnedByField = { ownedBy: SlimUser | null; ownedByProject: SlimProject | null };
 
-		type SharedWithField = { sharedWith: SlimUser[] };
+		type SharedWithField = { sharedWith: SlimUser[]; sharedWithProjects: SlimProject[] };
 
 		export type WithSharing = CredentialsEntity & Partial<Pick<CredentialsEntity, 'shared'>>;
 
@@ -129,6 +129,7 @@ export namespace ListQuery {
 }
 
 type SlimUser = Pick<IUser, 'id' | 'email' | 'firstName' | 'lastName'>;
+type SlimProject = Pick<Project, 'id' | 'type' | 'name'>;
 
 export function hasSharing(
 	workflows: ListQuery.Workflow.Plain[] | ListQuery.Workflow.WithSharing[],

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -104,7 +104,7 @@ export namespace ListQuery {
 
 		type SharedField = Partial<Pick<WorkflowEntity, 'shared'>>;
 
-		type OwnedByField = { ownedBy: SlimUser | null; ownedByProject: SlimProject | null };
+		type OwnedByField = { ownedBy: SlimUser | null; homeProject: SlimProject | null };
 
 		export type Plain = BaseFields;
 
@@ -118,7 +118,7 @@ export namespace ListQuery {
 	}
 
 	export namespace Credentials {
-		type OwnedByField = { ownedBy: SlimUser | null; ownedByProject: SlimProject | null };
+		type OwnedByField = { ownedBy: SlimUser | null; homeProject: SlimProject | null };
 
 		type SharedWithField = { sharedWith: SlimUser[]; sharedWithProjects: SlimProject[] };
 

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -49,15 +49,32 @@ export class OwnershipService {
 			| ListQuery.Workflow.WithOwnedByAndSharedWith
 			| ListQuery.Credentials.WithOwnedByAndSharedWith;
 
-		Object.assign(entity, { ownedBy: null, sharedWith: [] });
+		Object.assign(entity, {
+			ownedBy: null,
+			sharedWith: [],
+			ownedByProject: null,
+			sharedWithProjects: [],
+		});
 
-		shared?.forEach(({ user, role }) => {
+		shared?.forEach(({ user, role, project }) => {
 			const { id, email, firstName, lastName } = user;
 
 			if (role === 'credential:owner' || role === 'workflow:owner') {
 				entity.ownedBy = { id, email, firstName, lastName };
+				entity.ownedByProject = {
+					id: project.id,
+					type: project.type,
+					// TODO: confirm name with product
+					name: project.name ?? 'My n8n',
+				};
 			} else {
 				entity.sharedWith.push({ id, email, firstName, lastName });
+				entity.sharedWithProjects.push({
+					id: project.id,
+					type: project.type,
+					// TODO: confirm name with product
+					name: project.name ?? 'My n8n',
+				});
 			}
 		});
 

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -52,7 +52,7 @@ export class OwnershipService {
 		Object.assign(entity, {
 			ownedBy: null,
 			sharedWith: [],
-			ownedByProject: null,
+			homeProject: null,
 			sharedWithProjects: [],
 		});
 
@@ -61,7 +61,7 @@ export class OwnershipService {
 
 			if (role === 'credential:owner' || role === 'workflow:owner') {
 				entity.ownedBy = { id, email, firstName, lastName };
-				entity.ownedByProject = {
+				entity.homeProject = {
 					id: project.id,
 					type: project.type,
 					// TODO: confirm name with product

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -173,7 +173,7 @@ describe('GET /credentials', () => {
 			lastName: member2.lastName,
 		});
 
-		expect(member1Credential.ownedByProject).toMatchObject({
+		expect(member1Credential.homeProject).toMatchObject({
 			id: member1PersonalProject.id,
 			name: 'My n8n',
 			type: member1PersonalProject.type,
@@ -208,7 +208,7 @@ describe('GET /credentials/:id', () => {
 			lastName: owner.lastName,
 		});
 		expect(firstCredential.sharedWith).toHaveLength(0);
-		expect(firstCredential.ownedByProject).toMatchObject({
+		expect(firstCredential.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
 			name: 'My n8n',
 			type: ownerPersonalProject.type,
@@ -261,7 +261,7 @@ describe('GET /credentials/:id', () => {
 					lastName: member2.lastName,
 				},
 			],
-			ownedByProject: {
+			homeProject: {
 				id: member1PersonalProject.id,
 				name: 'My n8n',
 				type: member1PersonalProject.type,
@@ -321,7 +321,7 @@ describe('GET /credentials/:id', () => {
 				expect.objectContaining({ id: member2.id }),
 				expect.objectContaining({ id: member3.id }),
 			]),
-			ownedByProject: {
+			homeProject: {
 				id: member1PersonalProject.id,
 				name: 'My n8n',
 				type: 'personal',

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -17,6 +17,8 @@ import { UserManagementMailer } from '@/UserManagement/email';
 
 import { mockInstance } from '../shared/mocking';
 import config from '@/config';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import type { Project } from '@/databases/entities/Project';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['credentials'],
@@ -24,6 +26,7 @@ const testServer = utils.setupTestServer({
 });
 
 let owner: User;
+let ownerPersonalProject: Project;
 let member: User;
 let anotherMember: User;
 let authOwnerAgent: SuperAgentTest;
@@ -31,8 +34,13 @@ let authAnotherMemberAgent: SuperAgentTest;
 let saveCredential: SaveCredentialFunction;
 const mailer = mockInstance(UserManagementMailer);
 
+let projectRepository: ProjectRepository;
+
 beforeAll(async () => {
+	projectRepository = Container.get(ProjectRepository);
+
 	owner = await createUser({ role: 'global:owner' });
+	ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 	member = await createUser({ role: 'global:member' });
 	anotherMember = await createUser({ role: 'global:member' });
 
@@ -122,6 +130,12 @@ describe('GET /credentials', () => {
 		const [member1, member2] = await createManyUsers(2, {
 			role: 'global:member',
 		});
+		const member1PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member1.id,
+		);
+		const member2PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member2.id,
+		);
 
 		await saveCredential(randomCredentialPayload(), { user: member2 });
 		const savedMemberCredential = await saveCredential(randomCredentialPayload(), {
@@ -158,6 +172,18 @@ describe('GET /credentials', () => {
 			firstName: member2.firstName,
 			lastName: member2.lastName,
 		});
+
+		expect(member1Credential.ownedByProject).toMatchObject({
+			id: member1PersonalProject.id,
+			name: 'My n8n',
+			type: member1PersonalProject.type,
+		});
+		expect(member1Credential.sharedWithProjects).toHaveLength(1);
+		expect(member1Credential.sharedWithProjects[0]).toMatchObject({
+			id: member2PersonalProject.id,
+			name: 'My n8n',
+			type: member2PersonalProject.type,
+		});
 	});
 });
 
@@ -182,6 +208,12 @@ describe('GET /credentials/:id', () => {
 			lastName: owner.lastName,
 		});
 		expect(firstCredential.sharedWith).toHaveLength(0);
+		expect(firstCredential.ownedByProject).toMatchObject({
+			id: ownerPersonalProject.id,
+			name: 'My n8n',
+			type: ownerPersonalProject.type,
+		});
+		expect(firstCredential.sharedWithProjects).toHaveLength(0);
 
 		const secondResponse = await authOwnerAgent
 			.get(`/credentials/${savedCredential.id}`)
@@ -198,6 +230,12 @@ describe('GET /credentials/:id', () => {
 		const [member1, member2] = await createManyUsers(2, {
 			role: 'global:member',
 		});
+		const member1PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member1.id,
+		);
+		const member2PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member2.id,
+		);
 
 		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member1 });
 		await shareCredentialWithUsers(savedCredential, [member2]);
@@ -208,18 +246,33 @@ describe('GET /credentials/:id', () => {
 
 		validateMainCredentialData(response1.body.data);
 		expect(response1.body.data.data).toBeUndefined();
-		expect(response1.body.data.ownedBy).toMatchObject({
-			id: member1.id,
-			email: member1.email,
-			firstName: member1.firstName,
-			lastName: member1.lastName,
-		});
-		expect(response1.body.data.sharedWith).toHaveLength(1);
-		expect(response1.body.data.sharedWith[0]).toMatchObject({
-			id: member2.id,
-			email: member2.email,
-			firstName: member2.firstName,
-			lastName: member2.lastName,
+		expect(response1.body.data).toMatchObject({
+			ownedBy: {
+				id: member1.id,
+				email: member1.email,
+				firstName: member1.firstName,
+				lastName: member1.lastName,
+			},
+			sharedWith: [
+				{
+					id: member2.id,
+					email: member2.email,
+					firstName: member2.firstName,
+					lastName: member2.lastName,
+				},
+			],
+			ownedByProject: {
+				id: member1PersonalProject.id,
+				name: 'My n8n',
+				type: member1PersonalProject.type,
+			},
+			sharedWithProjects: [
+				{
+					id: member2PersonalProject.id,
+					name: 'My n8n',
+					type: member2PersonalProject.type,
+				},
+			],
 		});
 
 		const response2 = await authOwnerAgent
@@ -237,6 +290,15 @@ describe('GET /credentials/:id', () => {
 		const [member1, member2, member3] = await createManyUsers(3, {
 			role: 'global:member',
 		});
+		const member1PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member1.id,
+		);
+		const member2PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member2.id,
+		);
+		const member3PersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+			member3.id,
+		);
 		const authMemberAgent = testServer.authAgentFor(member1);
 		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member1 });
 		await shareCredentialWithUsers(savedCredential, [member2, member3]);
@@ -248,15 +310,34 @@ describe('GET /credentials/:id', () => {
 		const { data: firstCredential } = firstResponse.body;
 		validateMainCredentialData(firstCredential);
 		expect(firstCredential.data).toBeUndefined();
-		expect(firstCredential.ownedBy).toMatchObject({
-			id: member1.id,
-			email: member1.email,
-			firstName: member1.firstName,
-			lastName: member1.lastName,
-		});
-		expect(firstCredential.sharedWith).toHaveLength(2);
-		firstCredential.sharedWith.forEach((sharee: IUser) => {
-			expect([member2.id, member3.id]).toContain(sharee.id);
+		expect(firstCredential).toMatchObject({
+			ownedBy: {
+				id: member1.id,
+				email: member1.email,
+				firstName: member1.firstName,
+				lastName: member1.lastName,
+			},
+			sharedWith: expect.arrayContaining([
+				expect.objectContaining({ id: member2.id }),
+				expect.objectContaining({ id: member3.id }),
+			]),
+			ownedByProject: {
+				id: member1PersonalProject.id,
+				name: 'My n8n',
+				type: 'personal',
+			},
+			sharedWithProjects: expect.arrayContaining([
+				{
+					id: member2PersonalProject.id,
+					name: 'My n8n',
+					type: member2PersonalProject.type,
+				},
+				{
+					id: member3PersonalProject.id,
+					name: 'My n8n',
+					type: member3PersonalProject.type,
+				},
+			]),
 		});
 
 		const secondResponse = await authMemberAgent

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -339,7 +339,7 @@ describe('GET /workflows', () => {
 						lastName: any(String),
 					},
 					sharedWith: [],
-					ownedByProject: {
+					homeProject: {
 						id: ownerPersonalProject.id,
 						name: 'My n8n',
 						type: ownerPersonalProject.type,
@@ -361,7 +361,7 @@ describe('GET /workflows', () => {
 						lastName: any(String),
 					},
 					sharedWith: [],
-					ownedByProject: {
+					homeProject: {
 						id: ownerPersonalProject.id,
 						name: 'My n8n',
 						type: ownerPersonalProject.type,
@@ -569,7 +569,7 @@ describe('GET /workflows', () => {
 							lastName: any(String),
 						},
 						sharedWith: [],
-						ownedByProject: {
+						homeProject: {
 							id: ownerPersonalProject.id,
 							name: 'My n8n',
 							type: ownerPersonalProject.type,
@@ -585,7 +585,7 @@ describe('GET /workflows', () => {
 							lastName: any(String),
 						},
 						sharedWith: [],
-						ownedByProject: {
+						homeProject: {
 							id: ownerPersonalProject.id,
 							name: 'My n8n',
 							type: ownerPersonalProject.type,

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -37,7 +37,10 @@ const { objectContaining, arrayContaining, any } = expect;
 
 const activeWorkflowRunnerLike = mockInstance(ActiveWorkflowRunner);
 
+let projectRepository: ProjectRepository;
+
 beforeAll(async () => {
+	projectRepository = Container.get(ProjectRepository);
 	owner = await createOwner();
 	authOwnerAgent = testServer.authAgentFor(owner);
 });
@@ -159,7 +162,6 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
-		const projectRepository = Container.get(ProjectRepository);
 		const workflow = makeWorkflow();
 		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
@@ -183,7 +185,6 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
-		const projectRepository = Container.get(ProjectRepository);
 		const workflow = makeWorkflow();
 		const project = await projectRepository.save(
 			projectRepository.create({
@@ -216,7 +217,6 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
-		const projectRepository = Container.get(ProjectRepository);
 		const workflow = makeWorkflow();
 		const project = await projectRepository.save(
 			projectRepository.create({
@@ -244,7 +244,6 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
-		const projectRepository = Container.get(ProjectRepository);
 		const workflow = makeWorkflow();
 		const project = await projectRepository.save(
 			projectRepository.create({
@@ -296,6 +295,7 @@ describe('GET /workflows', () => {
 			user: owner,
 			role: 'credential:owner',
 		});
+		const ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
 		const nodes: INode[] = [
 			{
@@ -339,6 +339,12 @@ describe('GET /workflows', () => {
 						lastName: any(String),
 					},
 					sharedWith: [],
+					ownedByProject: {
+						id: ownerPersonalProject.id,
+						name: 'My n8n',
+						type: ownerPersonalProject.type,
+					},
+					sharedWithProjects: [],
 				}),
 				objectContaining({
 					id: any(String),
@@ -355,6 +361,12 @@ describe('GET /workflows', () => {
 						lastName: any(String),
 					},
 					sharedWith: [],
+					ownedByProject: {
+						id: ownerPersonalProject.id,
+						name: 'My n8n',
+						type: ownerPersonalProject.type,
+					},
+					sharedWithProjects: [],
 				}),
 			]),
 		});
@@ -536,6 +548,9 @@ describe('GET /workflows', () => {
 		test('should select workflow field: ownedBy', async () => {
 			await createWorkflow({}, owner);
 			await createWorkflow({}, owner);
+			const ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
+				owner.id,
+			);
 
 			const response = await authOwnerAgent
 				.get('/workflows')
@@ -554,6 +569,12 @@ describe('GET /workflows', () => {
 							lastName: any(String),
 						},
 						sharedWith: [],
+						ownedByProject: {
+							id: ownerPersonalProject.id,
+							name: 'My n8n',
+							type: ownerPersonalProject.type,
+						},
+						sharedWithProjects: [],
 					},
 					{
 						id: any(String),
@@ -564,6 +585,12 @@ describe('GET /workflows', () => {
 							lastName: any(String),
 						},
 						sharedWith: [],
+						ownedByProject: {
+							id: ownerPersonalProject.id,
+							name: 'My n8n',
+							type: ownerPersonalProject.type,
+						},
+						sharedWithProjects: [],
 					},
 				]),
 			});

--- a/packages/cli/test/unit/services/ownership.service.test.ts
+++ b/packages/cli/test/unit/services/ownership.service.test.ts
@@ -7,7 +7,7 @@ import { mockInstance } from '../../shared/mocking';
 import { WorkflowEntity } from '@/databases/entities/WorkflowEntity';
 import { UserRepository } from '@/databases/repositories/user.repository';
 import { mock } from 'jest-mock-extended';
-import { mockCredential, mockUser } from '../shared/mockObjects';
+import { mockCredential, mockProject, mockUser } from '../shared/mockObjects';
 
 describe('OwnershipService', () => {
 	const userRepository = mockInstance(UserRepository);
@@ -48,14 +48,18 @@ describe('OwnershipService', () => {
 			const owner = mockUser();
 			const editor = mockUser();
 
+			const ownerProject = mockProject();
+			const editorProject = mockProject();
+
 			const credential = mockCredential();
 
 			credential.shared = [
-				{ role: 'credential:owner', user: owner },
-				{ role: 'credential:editor', user: editor },
+				{ role: 'credential:owner', user: owner, project: ownerProject },
+				{ role: 'credential:editor', user: editor, project: editorProject },
 			] as SharedCredentials[];
 
-			const { ownedBy, sharedWith } = ownershipService.addOwnedByAndSharedWith(credential);
+			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+				ownershipService.addOwnedByAndSharedWith(credential);
 
 			expect(ownedBy).toStrictEqual({
 				id: owner.id,
@@ -72,20 +76,38 @@ describe('OwnershipService', () => {
 					lastName: editor.lastName,
 				},
 			]);
+
+			expect(ownedByProject).toMatchObject({
+				id: ownerProject.id,
+				name: 'My n8n',
+				type: ownerProject.type,
+			});
+
+			expect(sharedWithProjects).toMatchObject([
+				{
+					id: editorProject.id,
+					name: 'My n8n',
+					type: editorProject.type,
+				},
+			]);
 		});
 
 		test('should add `ownedBy` and `sharedWith` to workflow', async () => {
 			const owner = mockUser();
 			const editor = mockUser();
 
+			const projectOwner = mockProject();
+			const projectEditor = mockProject();
+
 			const workflow = new WorkflowEntity();
 
 			workflow.shared = [
-				{ role: 'workflow:owner', user: owner },
-				{ role: 'workflow:editor', user: editor },
+				{ role: 'workflow:owner', user: owner, project: projectOwner },
+				{ role: 'workflow:editor', user: editor, project: projectEditor },
 			] as SharedWorkflow[];
 
-			const { ownedBy, sharedWith } = ownershipService.addOwnedByAndSharedWith(workflow);
+			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+				ownershipService.addOwnedByAndSharedWith(workflow);
 
 			expect(ownedBy).toStrictEqual({
 				id: owner.id,
@@ -100,6 +122,19 @@ describe('OwnershipService', () => {
 					email: editor.email,
 					firstName: editor.firstName,
 					lastName: editor.lastName,
+				},
+			]);
+
+			expect(ownedByProject).toMatchObject({
+				id: projectOwner.id,
+				name: 'My n8n',
+				type: projectOwner.type,
+			});
+			expect(sharedWithProjects).toMatchObject([
+				{
+					id: projectEditor.id,
+					name: 'My n8n',
+					type: projectEditor.type,
 				},
 			]);
 		});
@@ -109,9 +144,14 @@ describe('OwnershipService', () => {
 
 			const credential = mockCredential();
 
-			credential.shared = [{ role: 'credential:owner', user: owner }] as SharedCredentials[];
+			const project = mockProject();
 
-			const { ownedBy, sharedWith } = ownershipService.addOwnedByAndSharedWith(credential);
+			credential.shared = [
+				{ role: 'credential:owner', user: owner, project },
+			] as SharedCredentials[];
+
+			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+				ownershipService.addOwnedByAndSharedWith(credential);
 
 			expect(ownedBy).toStrictEqual({
 				id: owner.id,
@@ -121,6 +161,14 @@ describe('OwnershipService', () => {
 			});
 
 			expect(sharedWith).toHaveLength(0);
+
+			expect(ownedByProject).toMatchObject({
+				id: project.id,
+				name: 'My n8n',
+				type: project.type,
+			});
+
+			expect(sharedWithProjects).toHaveLength(0);
 		});
 	});
 

--- a/packages/cli/test/unit/services/ownership.service.test.ts
+++ b/packages/cli/test/unit/services/ownership.service.test.ts
@@ -58,7 +58,7 @@ describe('OwnershipService', () => {
 				{ role: 'credential:editor', user: editor, project: editorProject },
 			] as SharedCredentials[];
 
-			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+			const { ownedBy, sharedWith, homeProject, sharedWithProjects } =
 				ownershipService.addOwnedByAndSharedWith(credential);
 
 			expect(ownedBy).toStrictEqual({
@@ -77,7 +77,7 @@ describe('OwnershipService', () => {
 				},
 			]);
 
-			expect(ownedByProject).toMatchObject({
+			expect(homeProject).toMatchObject({
 				id: ownerProject.id,
 				name: 'My n8n',
 				type: ownerProject.type,
@@ -106,7 +106,7 @@ describe('OwnershipService', () => {
 				{ role: 'workflow:editor', user: editor, project: projectEditor },
 			] as SharedWorkflow[];
 
-			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+			const { ownedBy, sharedWith, homeProject, sharedWithProjects } =
 				ownershipService.addOwnedByAndSharedWith(workflow);
 
 			expect(ownedBy).toStrictEqual({
@@ -125,7 +125,7 @@ describe('OwnershipService', () => {
 				},
 			]);
 
-			expect(ownedByProject).toMatchObject({
+			expect(homeProject).toMatchObject({
 				id: projectOwner.id,
 				name: 'My n8n',
 				type: projectOwner.type,
@@ -150,7 +150,7 @@ describe('OwnershipService', () => {
 				{ role: 'credential:owner', user: owner, project },
 			] as SharedCredentials[];
 
-			const { ownedBy, sharedWith, ownedByProject, sharedWithProjects } =
+			const { ownedBy, sharedWith, homeProject, sharedWithProjects } =
 				ownershipService.addOwnedByAndSharedWith(credential);
 
 			expect(ownedBy).toStrictEqual({
@@ -162,7 +162,7 @@ describe('OwnershipService', () => {
 
 			expect(sharedWith).toHaveLength(0);
 
-			expect(ownedByProject).toMatchObject({
+			expect(homeProject).toMatchObject({
 				id: project.id,
 				name: 'My n8n',
 				type: project.type,

--- a/packages/cli/test/unit/shared/mockObjects.ts
+++ b/packages/cli/test/unit/shared/mockObjects.ts
@@ -6,7 +6,9 @@ import {
 	randomEmail,
 	randomInteger,
 	randomName,
+	uniqueId,
 } from '../../integration/shared/random';
+import { Project } from '@/databases/entities/Project';
 
 export const mockCredential = (): CredentialsEntity =>
 	Object.assign(new CredentialsEntity(), randomCredentialPayload());
@@ -17,4 +19,10 @@ export const mockUser = (): User =>
 		email: randomEmail(),
 		firstName: randomName(),
 		lastName: randomName(),
+	});
+
+export const mockProject = (): Project =>
+	Object.assign(new Project(), {
+		id: uniqueId(),
+		type: 'personal',
 	});


### PR DESCRIPTION
## Summary

This adds `ownedByProject` and `sharedWithProjects` to every workflow and credential returned by `GET /workflows` and `GET /credentials`.

The properties contain the project's `id`, `name` and `type`.
Personal projects return `My n8n` as a name for now. We haven't decided on how they will be named yet.

Since workflows and credentials will be owned by project instead of users we will remove `ownedBy` and `sharedWith` in the future.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1408/enrich-get-workflows-and-get-credentials-to-return-project-data

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

