### PR TITLE
test: Update fix test that broke due to the global:owner having the credential:update scope now

### DIFF
--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -422,8 +422,16 @@ describe('PATCH /credentials/:id', () => {
 		}
 	});
 
-	test('should fail if cred not found', async () => {
+	test('should fail with a 404 if the credential does not exist and the actor has the global credential:update scope', async () => {
 		const response = await authOwnerAgent.patch('/credentials/123').send(randomCredentialPayload());
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	test('should fail with a 403 if the credential does not exist and the actor does not have the global credential:update scope', async () => {
+		const response = await authMemberAgent
+			.patch('/credentials/123')
+			.send(randomCredentialPayload());
 
 		expect(response.statusCode).toBe(403);
 	});


### PR DESCRIPTION
## Summary

If the user has the scope it will fail in the controller (with a 404), if the user does not have the scope it will fail in the scope middleware (with a 403).

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

