### PR TITLE
fix: Project API GET (no-changelog)

### DIFF
--- a/packages/cli/src/permissions/project-roles.ts
+++ b/packages/cli/src/permissions/project-roles.ts
@@ -53,6 +53,8 @@ export const PROJECT_EDITOR_SCOPES: Scope[] = [
 	'credential:update',
 	'credential:delete',
 	'credential:list',
+	'project:list',
+	'project:read',
 ];
 
 export const PROJECT_VIEWER_SCOPES: Scope[] = [
@@ -60,4 +62,6 @@ export const PROJECT_VIEWER_SCOPES: Scope[] = [
 	'workflow:list',
 	'credential:read',
 	'credential:list',
+	'project:list',
+	'project:read',
 ];

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -167,7 +167,7 @@ export class ProjectService {
 	async getProjectRelations(projectId: string): Promise<ProjectRelation[]> {
 		return await this.projectRelationRepository.find({
 			where: { projectId },
-			select: ['user'],
+			relations: ['user'],
 		});
 	}
 }


### PR DESCRIPTION
## Summary
Fixes the GET request for the project API

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 