### PR TITLE
fix(core): Handle http redirects with binary characters

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -254,7 +254,11 @@ const getHostFromRequestObject = (
 
 const getBeforeRedirectFn =
 	(agentOptions: AgentOptions, axiosConfig: AxiosRequestConfig) =>
-	(redirectedRequest: Record<string, any>) => {
+	(redirectedRequest: Record<string, any>, response: { headers: Record<string, string> }) => {
+		const { location } = response.headers;
+		const encodedUrl = new URL(encodeURI(Buffer.from(location, 'binary').toString('utf8')));
+		redirectedRequest.pathname = encodedUrl.pathname;
+
 		const redirectAgent = new Agent({
 			...agentOptions,
 			servername: redirectedRequest.hostname,


### PR DESCRIPTION
Fixes #8701

PS: If testing with chromewebstore URLs, please set the User-Agent to match a browser.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included