### PR TITLE
feat(core): Allow creating credentials in other projects than the personal one

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -196,7 +196,12 @@ export class CredentialsController {
 		const newCredential = await this.credentialsService.prepareCreateData(req.body);
 
 		const encryptedData = this.credentialsService.createEncryptedData(null, newCredential);
-		const credential = await this.credentialsService.save(newCredential, encryptedData, req.user);
+		const credential = await this.credentialsService.save(
+			newCredential,
+			encryptedData,
+			req.user,
+			req.body.projectId,
+		);
 
 		void this.internalHooks.onUserCreatedCredentials({
 			user: req.user,

--- a/packages/cli/src/decorators/registerController.ts
+++ b/packages/cli/src/decorators/registerController.ts
@@ -1,7 +1,6 @@
 import { Container } from 'typedi';
 import { Router } from 'express';
 import type { Application, Request, Response, RequestHandler } from 'express';
-import type { Scope } from '@n8n/permissions';
 import { In } from '@n8n/typeorm';
 import { ApplicationError } from 'n8n-workflow';
 import type { Class } from 'n8n-core';

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -157,11 +157,12 @@ export function hasSharing(
 
 export declare namespace CredentialRequest {
 	type CredentialProperties = Partial<{
-		id: string; // delete if sent
+		id: string; // deleted if sent
 		name: string;
 		type: string;
 		nodesAccess: ICredentialNodeAccess[];
 		data: ICredentialDataDecryptedObject;
+		projectId?: string;
 	}>;
 
 	type Create = AuthenticatedRequest<{}, {}, CredentialProperties>;

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -2,7 +2,7 @@ import { Container, Service } from 'typedi';
 import type { IUserSettings } from 'n8n-workflow';
 import { ApplicationError, ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
 
-import { type AssignableRole, User } from '@db/entities/User';
+import type { User, AssignableRole } from '@db/entities/User';
 import { UserRepository } from '@db/repositories/user.repository';
 import type { PublicUser } from '@/Interfaces';
 import type { PostHogClient } from '@/posthog';

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -15,20 +15,31 @@ import * as utils from './shared/utils/';
 import { affixRoleToSaveCredential, shareCredentialWithUsers } from './shared/db/credentials';
 import { createManyUsers, createUser } from './shared/db/users';
 import { Credentials } from 'n8n-core';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import type { Project } from '@/databases/entities/Project';
+import { ProjectService } from '@/services/project.service';
 
 // mock that credentialsSharing is not enabled
 jest.spyOn(License.prototype, 'isSharingEnabled').mockReturnValue(false);
 const testServer = utils.setupTestServer({ endpointGroups: ['credentials'] });
 
 let owner: User;
+let ownerPersonalProject: Project;
 let member: User;
 let secondMember: User;
 let authOwnerAgent: SuperAgentTest;
 let authMemberAgent: SuperAgentTest;
 let saveCredential: SaveCredentialFunction;
+let projectRepository: ProjectRepository;
+let sharedCredentialsRepository: SharedCredentialsRepository;
+let projectService: ProjectService;
 
 beforeAll(async () => {
+	projectRepository = Container.get(ProjectRepository);
+	sharedCredentialsRepository = Container.get(SharedCredentialsRepository);
+	projectService = Container.get(ProjectService);
 	owner = await createUser({ role: 'global:owner' });
+	ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 	member = await createUser({ role: 'global:member' });
 	secondMember = await createUser({ role: 'global:member' });
 
@@ -141,6 +152,96 @@ describe('POST /credentials', () => {
 			.send({ id: 8, ...randomCredentialPayload() });
 
 		expect(secondResponse.body.data.id).not.toBe(8);
+	});
+
+	test('creates credential in personal project by default', async () => {
+		//
+		// ACT
+		//
+		const response = await authOwnerAgent.post('/credentials').send(randomCredentialPayload());
+
+		//
+		// ASSERT
+		//
+		await sharedCredentialsRepository.findOneByOrFail({
+			projectId: ownerPersonalProject.id,
+			credentialsId: response.body.data.id,
+		});
+	});
+
+	test('creates credential in a specific project if the projectId is passed', async () => {
+		//
+		// ARRANGE
+		//
+		const project = await Container.get(ProjectService).createTeamProject('Team Project', owner);
+
+		//
+		// ACT
+		//
+		const response = await authOwnerAgent
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), projectId: project.id });
+
+		//
+		// ASSERT
+		//
+		await sharedCredentialsRepository.findOneByOrFail({
+			projectId: project.id,
+			credentialsId: response.body.data.id,
+		});
+	});
+
+	test('does not create the credential in a specific project if the user is not part of the project', async () => {
+		//
+		// ARRANGE
+		//
+		const project = await projectRepository.save(
+			projectRepository.create({
+				name: 'Team Project',
+				type: 'team',
+			}),
+		);
+
+		//
+		// ACT
+		//
+		await authOwnerAgent
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), projectId: project.id })
+			//
+			// ASSERT
+			//
+			.expect(400, {
+				code: 400,
+				message: "You don't have the permissions to save the workflow in this project.",
+			});
+	});
+
+	test('does not create the credential in a specific project if the user does not have the right role to do so', async () => {
+		//
+		// ARRANGE
+		//
+		const project = await projectRepository.save(
+			projectRepository.create({
+				name: 'Team Project',
+				type: 'team',
+			}),
+		);
+		await projectService.addUser(project.id, owner.id, 'project:viewer');
+
+		//
+		// ACT
+		//
+		await authOwnerAgent
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), projectId: project.id })
+			//
+			// ASSERT
+			//
+			.expect(400, {
+				code: 400,
+				message: "You don't have the permissions to save the workflow in this project.",
+			});
 	});
 });
 


### PR DESCRIPTION
## Summary

This allow calling `POST /credentials` with `projectId` in the body.

If the field is not there, the credential will be shared with the user's personal project.

If the field is there, the credential will be shared with that project, **if the user has the permissions to do so**. Otherwise the request will fail with a 400 status code.

## Related tickets and issues

https://linear.app/n8n/project/role-based-access-control-bep2-2a54ea17a852/PAY

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

