### PR TITLE
fix(HubSpot Node): Include properties for contact and deal in getAll operation

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/Hubspot.node.ts
@@ -14,12 +14,13 @@ export class Hubspot extends VersionedNodeType {
 			group: ['output'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume HubSpot API',
-			defaultVersion: 2,
+			defaultVersion: 2.1,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new HubspotV1(baseDescription),
 			2: new HubspotV2(baseDescription),
+			2.1: new HubspotV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
@@ -590,6 +590,40 @@ export const dealFields: INodeProperties[] = [
 			},
 			{
 				displayName: 'Deal Properties to Include',
+				name: 'properties',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getDealProperties',
+				},
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description:
+					'Include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gt: 2 } }],
+					},
+				},
+			},
+			{
+				displayName: 'Deal Properties with History to Include',
+				name: 'propertiesWithHistory',
+				type: 'multiOptions',
+				typeOptions: {
+					loadOptionsMethod: 'getDealProperties',
+				},
+				default: [],
+				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
+				description:
+					'Works similarly to properties, but this parameter will include the history for the specified property',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gt: 2 } }],
+					},
+				},
+			},
+			{
+				displayName: 'Deal Properties to Include',
 				name: 'propertiesCollection',
 				type: 'fixedCollection',
 				default: {},
@@ -603,7 +637,7 @@ export const dealFields: INodeProperties[] = [
 								name: 'properties',
 								type: 'multiOptions',
 								typeOptions: {
-									loadOptionsMethod: 'getDealPropertiesWithType',
+									loadOptionsMethod: 'getDealProperties',
 								},
 								default: [],
 								description:
@@ -632,6 +666,11 @@ export const dealFields: INodeProperties[] = [
 				],
 				description:
 					'<p>Used to include specific deal properties in the results. By default, the results will only include Deal ID and will not include the values for any properties for your Deals.</p><p>Including this parameter will include the data for the specified property in the results. You can include this parameter multiple times to request multiple properties separated by a comma: <code>,</code>.</p>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				displayOptions: {
+					show: {
+						'@version': [2],
+					},
+				},
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -339,7 +339,18 @@ export class HubspotV2 implements INodeType {
 			async getContactProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+
+				let properties = (await hubspotApiRequest.call(this, 'GET', endpoint, {})) as Array<{
+					label: string;
+					name: string;
+				}>;
+
+				properties = properties.sort((a, b) => {
+					if (a.label < b.label) return -1;
+					if (a.label > b.label) return 1;
+					return 0;
+				});
+
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -348,6 +359,7 @@ export class HubspotV2 implements INodeType {
 						value: propertyId,
 					});
 				}
+
 				return returnData;
 			},
 			// Get all the contact properties to display them to user so that they can


### PR DESCRIPTION
## Summary
If you use the Contact Properties to Include option with the Hubspot v2 node (Contact > Get Many) it doesn't appear to make any change to the returned output.

The field to select the properties is also horrible to use, It is not alphabetical and you can't search for a value.



## Related tickets and issues
https://community.n8n.io/t/hubspot-get-many-contacts-v2-doensnt-include-additonal-properties/27412
https://community.n8n.io/t/hubspot-deal-getmany-does-not-return-the-requested-deal-properties/40125/2
https://linear.app/n8n/issue/NODE-604/hubspot-v2-contact-properties-to-include-does-not-work