### PR TITLE
fix(core): Remove sensitive data from User entity during serialization (no-changelog)

### DIFF
--- a/packages/cli/src/databases/entities/User.ts
+++ b/packages/cli/src/databases/entities/User.ts
@@ -141,4 +141,9 @@ export class User extends WithTimestamps implements IUser {
 			scopeOptions,
 		);
 	}
+
+	toJSON() {
+		const { password, apiKey, mfaSecret, mfaRecoveryCodes, ...rest } = this;
+		return rest;
+	}
 }

--- a/packages/cli/test/unit/databases/entities/user.entity.test.ts
+++ b/packages/cli/test/unit/databases/entities/user.entity.test.ts
@@ -1,0 +1,20 @@
+import { User } from '@db/entities/User';
+
+describe('User Entity', () => {
+	describe('JSON.stringify', () => {
+		it('should not serialize sensitive data', () => {
+			const user = Object.assign(new User(), {
+				email: 'test@example.com',
+				firstName: 'Don',
+				lastName: 'Joe',
+				password: '123456789',
+				apiKey: '123',
+				mfaSecret: '123',
+				mfaRecoveryCodes: ['123'],
+			});
+			expect(JSON.stringify(user)).toEqual(
+				'{"email":"test@example.com","firstName":"Don","lastName":"Joe"}',
+			);
+		});
+	});
+});


### PR DESCRIPTION
Anywhere in the code where we include a `User` object in serialized data, there is always a risk that we might include `password` or `mfaSecret` accidentally.
This PR updates the default serialization of `User` to remove all sensitive data.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included