### PR TITLE
fix: Simplify Structured Output Parser wrapping and fix auto-fixing output parser

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -41,6 +41,7 @@ class N8nStructuredOutputParser<T extends z.ZodTypeAny> extends StructuredOutput
 
 	static fromZedJsonSchema(
 		schema: JSONSchema7,
+		nodeVersion: number,
 	): StructuredOutputParser<z.ZodType<object, z.ZodTypeDef, object>> {
 		// Make sure to remove the description from root schema
 		const { description, ...restOfSchema } = schema;
@@ -51,30 +52,37 @@ class N8nStructuredOutputParser<T extends z.ZodTypeAny> extends StructuredOutput
 		// eslint-disable-next-line @typescript-eslint/no-implied-eval
 		const itemSchema = new Function('z', `return (${zodSchemaString})`)(z) as z.ZodSchema<object>;
 
-		const returnSchema = z.object({
-			[STRUCTURED_OUTPUT_KEY]: z
-				.object({
-					[STRUCTURED_OUTPUT_OBJECT_KEY]: itemSchema.optional(),
-					[STRUCTURED_OUTPUT_ARRAY_KEY]: z.array(itemSchema).optional(),
-				})
-				.describe(
-					`Wrapper around the output data. It can only contain ${STRUCTURED_OUTPUT_OBJECT_KEY} or ${STRUCTURED_OUTPUT_ARRAY_KEY} but never both.`,
-				)
-				.refine(
-					(data) => {
-						// Validate that one and only one of the properties exists
-						return (
-							Boolean(data[STRUCTURED_OUTPUT_OBJECT_KEY]) !==
-							Boolean(data[STRUCTURED_OUTPUT_ARRAY_KEY])
-						);
-					},
-					{
-						message:
-							'One and only one of __structured__output__object and __structured__output__array should be present.',
-						path: [STRUCTURED_OUTPUT_KEY],
-					},
-				),
-		});
+		let returnSchema: z.ZodSchema<object>;
+		if (nodeVersion === 1) {
+			returnSchema = z.object({
+				[STRUCTURED_OUTPUT_KEY]: z
+					.object({
+						[STRUCTURED_OUTPUT_OBJECT_KEY]: itemSchema.optional(),
+						[STRUCTURED_OUTPUT_ARRAY_KEY]: z.array(itemSchema).optional(),
+					})
+					.describe(
+						`Wrapper around the output data. It can only contain ${STRUCTURED_OUTPUT_OBJECT_KEY} or ${STRUCTURED_OUTPUT_ARRAY_KEY} but never both.`,
+					)
+					.refine(
+						(data) => {
+							// Validate that one and only one of the properties exists
+							return (
+								Boolean(data[STRUCTURED_OUTPUT_OBJECT_KEY]) !==
+								Boolean(data[STRUCTURED_OUTPUT_ARRAY_KEY])
+							);
+						},
+						{
+							message:
+								'One and only one of __structured__output__object and __structured__output__array should be present.',
+							path: [STRUCTURED_OUTPUT_KEY],
+						},
+					),
+			});
+		} else {
+			returnSchema = z.object({
+				output: itemSchema.optional(),
+			});
+		}
 
 		return N8nStructuredOutputParser.fromZodSchema(returnSchema);
 	}
@@ -85,7 +93,8 @@ export class OutputParserStructured implements INodeType {
 		name: 'outputParserStructured',
 		icon: 'fa:code',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
+		defaultVersion: 1.1,
 		description: 'Return data in a defined JSON format',
 		defaults: {
 			name: 'Structured Output Parser',
@@ -152,11 +161,20 @@ export class OutputParserStructured implements INodeType {
 		let itemSchema: JSONSchema7;
 		try {
 			itemSchema = jsonParse<JSONSchema7>(schema);
+
+			// If the type is not defined, we assume it's an object
+			if (itemSchema.type === undefined) {
+				itemSchema = {
+					type: 'object',
+					properties: itemSchema.properties || (itemSchema as { [key: string]: JSONSchema7 }),
+				};
+			}
 		} catch (error) {
 			throw new NodeOperationError(this.getNode(), 'Error during parsing of JSON Schema.');
 		}
 
-		const parser = N8nStructuredOutputParser.fromZedJsonSchema(itemSchema);
+		const nodeVersion = this.getNode().typeVersion;
+		const parser = N8nStructuredOutputParser.fromZedJsonSchema(itemSchema, nodeVersion);
 
 		return {
 			response: logWrapper(parser, this),

--- a/packages/@n8n/nodes-langchain/utils/logWrapper.ts
+++ b/packages/@n8n/nodes-langchain/utils/logWrapper.ts
@@ -18,7 +18,7 @@ import { BaseChatMemory } from 'langchain/memory';
 import type { MemoryVariables } from 'langchain/dist/memory/base';
 import { BaseRetriever } from 'langchain/schema/retriever';
 import type { FormatInstructionsOptions } from 'langchain/schema/output_parser';
-import { BaseOutputParser } from 'langchain/schema/output_parser';
+import { BaseOutputParser, OutputParserException } from 'langchain/schema/output_parser';
 import { isObject } from 'lodash';
 import { N8nJsonLoader } from './N8nJsonLoader';
 import { N8nBinaryLoader } from './N8nBinaryLoader';
@@ -44,6 +44,10 @@ export async function callMethodAsync<T>(
 	try {
 		return await parameters.method.call(this, ...parameters.arguments);
 	} catch (e) {
+		// Langchain checks for OutputParserException to run retry chain
+		// for auto-fixing the output so skip wrapping in this case
+		if (e instanceof OutputParserException) throw e;
+
 		// Propagate errors from sub-nodes
 		if (e.functionality === 'configuration-node') throw e;
 		const connectedNode = parameters.executeFunctions.getNode();


### PR DESCRIPTION
## Summary
- Use more straightforward wrapping for the `1.1` version of Structured Output Parser, universally wrapping it in `output` instead of letting the LM choose the wrapping approach 
- Prevent wrapping of `OutputParserException` when calling parsing method, since Langchain relies on it to run the retry chain for auto-fixing the output
![CleanShot 2024-02-29 at 21 31 37](https://github.com/n8n-io/n8n/assets/12657221/9ac5e525-efb4-4cd6-b9a9-3df19c0ccf1b)


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://community.n8n.io/t/auto-fixing-ourput-parser-am-i-doing-it-wrong/35846


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 