### PR TITLE
fix(n8n Form Trigger Node): Do not open pop up when data is pinned in trigger

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -278,8 +278,11 @@ export function useRunWorkflow(options: { router: ReturnType<typeof useRouter> }
 			nodeHelpers.updateNodesExecutionIssues();
 
 			const runWorkflowApiResponse = await runWorkflowApi(startRunData);
+			const pinData = workflowData.pinData ?? {};
 
 			for (const node of workflowData.nodes) {
+				if (pinData[node.name]) continue;
+
 				if (![FORM_TRIGGER_NODE_TYPE, WAIT_NODE_TYPE].includes(node.type)) {
 					continue;
 				}


### PR DESCRIPTION
## Summary
Form trigger: form window opens when doing a partial execution of a downstream node and the form node is pinned



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1136/form-trigger-form-window-opens-when-doing-a-partial-execution-of-a