### PR TITLE
fix(Google Drive Node): Add supportsAllDrives: true to update and download

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
@@ -50,13 +50,13 @@ describe('test GoogleDriveV2: file download', () => {
 			'GET',
 			'/drive/v3/files/fileIDxxxxxx',
 			{},
-			{ fields: 'mimeType,name', supportsTeamDrives: true },
+			{ fields: 'mimeType,name', supportsTeamDrives: true, supportsAllDrives: true },
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'GET',
 			'/drive/v3/files/fileIDxxxxxx',
 			{},
-			{ alt: 'media' },
+			{ alt: 'media',  supportsAllDrives: true },
 			undefined,
 			{ encoding: 'arraybuffer', json: false, returnFullResponse: true, useStream: true },
 		);

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
@@ -56,7 +56,7 @@ describe('test GoogleDriveV2: file download', () => {
 			'GET',
 			'/drive/v3/files/fileIDxxxxxx',
 			{},
-			{ alt: 'media',  supportsAllDrives: true },
+			{ alt: 'media', supportsAllDrives: true },
 			undefined,
 			{ encoding: 'arraybuffer', json: false, returnFullResponse: true, useStream: true },
 		);

--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/download.operation.ts
@@ -202,7 +202,7 @@ export async function execute(
 		'GET',
 		`/drive/v3/files/${fileId}`,
 		{},
-		{ fields: 'mimeType,name', supportsTeamDrives: true },
+		{ fields: 'mimeType,name', supportsTeamDrives: true, supportsAllDrives: true },
 	);
 	let response;
 
@@ -236,7 +236,7 @@ export async function execute(
 			'GET',
 			`/drive/v3/files/${fileId}/export`,
 			{},
-			{ mimeType: mime },
+			{ mimeType: mime, supportsAllDrives: true },
 			undefined,
 			requestOptions,
 		);
@@ -246,7 +246,7 @@ export async function execute(
 			'GET',
 			`/drive/v3/files/${fileId}`,
 			{},
-			{ alt: 'media' },
+			{ alt: 'media', supportsAllDrives: true },
 			undefined,
 			requestOptions,
 		);

--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/file/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/file/update.operation.ts
@@ -185,6 +185,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				fileContent,
 				{
 					uploadType: 'media',
+					supportsAllDrives: true,
 				},
 				undefined,
 				{
@@ -200,7 +201,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				'PATCH',
 				`/upload/drive/v3/files/${fileId}`,
 				undefined,
-				{ uploadType: 'resumable' },
+				{ uploadType: 'resumable', supportsAllDrives: true },
 				undefined,
 				{
 					returnFullResponse: true,


### PR DESCRIPTION
## Summary

Update & Download from shared drives did not work



## Related tickets and issues
https://linear.app/n8n/issue/NODE-961/google-drive-file-update-fails-for-shared-drive-when-change-file



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 