### PR TITLE
feat: Make `GET /credentials` return all credentials the user is allowed to see based on the `credential:read` scope

### DIFF
--- a/packages/cli/src/UserManagement/PermissionChecker.ts
+++ b/packages/cli/src/UserManagement/PermissionChecker.ts
@@ -51,7 +51,9 @@ export class PermissionChecker {
 		}
 
 		const accessibleCredIds = isSharingEnabled
-			? await this.sharedCredentialsRepository.getAccessibleCredentialIds(workflowUserIds)
+			? await this.sharedCredentialsRepository.getCredentialIdsByUserAndRole(workflowUserIds, {
+					scopes: ['credential:read'],
+			  })
 			: await this.sharedCredentialsRepository.getOwnedCredentialIds(workflowUserIds);
 
 		const inaccessibleCredIds = workflowCredIds.filter((id) => !accessibleCredIds.includes(id));

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -69,7 +69,9 @@ export class CredentialsService {
 				: credentials;
 		}
 
-		const ids = await this.sharedCredentialsRepository.getAccessibleCredentialIds([user.id]);
+		const ids = await this.sharedCredentialsRepository.getCredentialIdsByUserAndRole([user.id], {
+			scopes: ['credential:read'],
+		});
 
 		const credentials = await this.credentialsRepository.findMany(
 			options.listQueryOptions,
@@ -145,7 +147,7 @@ export class CredentialsService {
 		}
 
 		// Do not overwrite the oauth data else data like the access or refresh token would get lost
-		// everytime anybody changes anything on the credentials even if it is just the name.
+		// every time anybody changes anything on the credentials even if it is just the name.
 		if (decryptedData.oauthTokenData) {
 			// @ts-ignore
 			updateData.data.oauthTokenData = decryptedData.oauthTokenData;

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -7,6 +7,8 @@ import type { CredentialSharingRole } from '@db/entities/SharedCredentials';
 import type { ICredentialsDb } from '@/Interfaces';
 import type { CredentialPayload } from '../types';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
+import type { Project } from '@/databases/entities/Project';
+import { UserRepository } from '@/databases/repositories/user.repository';
 
 async function encryptCredentialData(credential: CredentialsEntity) {
 	const { createCredentialsFromCredentialsEntity } = await import('@/CredentialsHelper');
@@ -48,8 +50,14 @@ export async function createCredentials(attributes: Partial<CredentialsEntity> =
  */
 export async function saveCredential(
 	credentialPayload: CredentialPayload,
-	{ user, role }: { user: User; role: CredentialSharingRole },
+	options:
+		| { user: User; role: CredentialSharingRole }
+		| {
+				project: Project;
+				role: CredentialSharingRole;
+		  },
 ) {
+	const role = options.role;
 	const newCredential = new CredentialsEntity();
 
 	Object.assign(newCredential, credentialPayload);
@@ -62,16 +70,32 @@ export async function saveCredential(
 
 	savedCredential.data = newCredential.data;
 
-	const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
-		user.id,
-	);
+	if ('user' in options) {
+		const user = options.user;
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			user.id,
+		);
 
-	await Container.get(SharedCredentialsRepository).save({
-		user,
-		credentials: savedCredential,
-		role,
-		project: personalProject,
-	});
+		await Container.get(SharedCredentialsRepository).save({
+			user,
+			credentials: savedCredential,
+			role,
+			project: personalProject,
+		});
+	} else {
+		const project = options.project;
+		// TODO: remove this when we remove users from SharedWorkflow
+		const user = await Container.get(UserRepository).findOneByOrFail({
+			projectRelations: { projectId: project.id },
+		});
+
+		await Container.get(SharedCredentialsRepository).save({
+			user,
+			credentials: savedCredential,
+			role,
+			project,
+		});
+	}
 
 	return savedCredential;
 }
@@ -96,8 +120,10 @@ export async function shareCredentialWithUsers(credential: CredentialsEntity, us
 }
 
 export function affixRoleToSaveCredential(role: CredentialSharingRole) {
-	return async (credentialPayload: CredentialPayload, { user }: { user: User }) =>
-		await saveCredential(credentialPayload, { user, role });
+	return async (
+		credentialPayload: CredentialPayload,
+		options: { user: User } | { project: Project },
+	) => await saveCredential(credentialPayload, { ...options, role });
 }
 
 export async function getAllCredentials() {

--- a/packages/cli/test/integration/shared/testDb.ts
+++ b/packages/cli/test/integration/shared/testDb.ts
@@ -57,6 +57,7 @@ const repositories = [
 	'InstalledNodes',
 	'InstalledPackages',
 	'Project',
+	'ProjectRelation',
 	'Role',
 	'Settings',
 	'SharedCredentials',

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -7,6 +7,7 @@ import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
 import type { User } from '@db/entities/User';
 import type { BooleanLicenseFeature, ICredentialsDb, NumericLicenseFeature } from '@/Interfaces';
 import type { LicenseMocker } from './license';
+import type { Project } from '@/databases/entities/Project';
 
 type EndpointGroup =
 	| 'me'
@@ -60,5 +61,5 @@ export type CredentialPayload = {
 
 export type SaveCredentialFunction = (
 	credentialPayload: CredentialPayload,
-	{ user }: { user: User },
+	options: { user: User } | { project: Project },
 ) => Promise<CredentialsEntity & ICredentialsDb>;

--- a/packages/cli/test/unit/PermissionChecker.test.ts
+++ b/packages/cli/test/unit/PermissionChecker.test.ts
@@ -48,7 +48,7 @@ describe('PermissionChecker', () => {
 			expect(license.isSharingEnabled).not.toHaveBeenCalled();
 			expect(sharedWorkflowRepo.getSharedUserIds).not.toBeCalled();
 			expect(sharedCredentialsRepo.getOwnedCredentialIds).not.toHaveBeenCalled();
-			expect(sharedCredentialsRepo.getAccessibleCredentialIds).not.toHaveBeenCalled();
+			expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).not.toHaveBeenCalled();
 		});
 
 		it('should allow a user if they have a global `workflow:execute` scope', async () => {
@@ -58,7 +58,7 @@ describe('PermissionChecker', () => {
 			expect(license.isSharingEnabled).not.toHaveBeenCalled();
 			expect(sharedWorkflowRepo.getSharedUserIds).not.toBeCalled();
 			expect(sharedCredentialsRepo.getOwnedCredentialIds).not.toHaveBeenCalled();
-			expect(sharedCredentialsRepo.getAccessibleCredentialIds).not.toHaveBeenCalled();
+			expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).not.toHaveBeenCalled();
 		});
 
 		describe('When sharing is disabled', () => {
@@ -75,7 +75,7 @@ describe('PermissionChecker', () => {
 
 				expect(sharedWorkflowRepo.getSharedUserIds).not.toBeCalled();
 				expect(sharedCredentialsRepo.getOwnedCredentialIds).toBeCalledWith([user.id]);
-				expect(sharedCredentialsRepo.getAccessibleCredentialIds).not.toHaveBeenCalled();
+				expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).not.toHaveBeenCalled();
 			});
 
 			it('should throw when the user does not have access to the credential', async () => {
@@ -87,7 +87,7 @@ describe('PermissionChecker', () => {
 
 				expect(sharedWorkflowRepo.getSharedUserIds).not.toBeCalled();
 				expect(sharedCredentialsRepo.getOwnedCredentialIds).toBeCalledWith([user.id]);
-				expect(sharedCredentialsRepo.getAccessibleCredentialIds).not.toHaveBeenCalled();
+				expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).not.toHaveBeenCalled();
 			});
 		});
 
@@ -100,30 +100,30 @@ describe('PermissionChecker', () => {
 			});
 
 			it('should validate credential access using only owned credentials', async () => {
-				sharedCredentialsRepo.getAccessibleCredentialIds.mockResolvedValue(['cred-id']);
+				sharedCredentialsRepo.getCredentialIdsByUserAndRole.mockResolvedValue(['cred-id']);
 
 				await expect(permissionChecker.check(workflowId, user.id, nodes)).resolves.not.toThrow();
 
 				expect(sharedWorkflowRepo.getSharedUserIds).toBeCalledWith(workflowId);
-				expect(sharedCredentialsRepo.getAccessibleCredentialIds).toBeCalledWith([
-					user.id,
-					'another-user',
-				]);
+				expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).toBeCalledWith(
+					[user.id, 'another-user'],
+					{ scopes: ['credential:read'] },
+				);
 				expect(sharedCredentialsRepo.getOwnedCredentialIds).not.toHaveBeenCalled();
 			});
 
 			it('should throw when the user does not have access to the credential', async () => {
-				sharedCredentialsRepo.getAccessibleCredentialIds.mockResolvedValue(['cred-id2']);
+				sharedCredentialsRepo.getCredentialIdsByUserAndRole.mockResolvedValue(['cred-id2']);
 
 				await expect(permissionChecker.check(workflowId, user.id, nodes)).rejects.toThrow(
 					'Node has no access to credential',
 				);
 
 				expect(sharedWorkflowRepo.find).not.toBeCalled();
-				expect(sharedCredentialsRepo.getAccessibleCredentialIds).toBeCalledWith([
-					user.id,
-					'another-user',
-				]);
+				expect(sharedCredentialsRepo.getCredentialIdsByUserAndRole).toBeCalledWith(
+					[user.id, 'another-user'],
+					{ scopes: ['credential:read'] },
+				);
 				expect(sharedCredentialsRepo.getOwnedCredentialIds).not.toHaveBeenCalled();
 			});
 		});


### PR DESCRIPTION
## Summary

This changes `GET /credentials` so that it returns all credentials the user has read access to based on projects.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1414/bug-member-user-cannot-list-workflows-created-by-other-users-in-a

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

