### PR TITLE
fix(GitHub Document Loader Node): Fix issue with ignore paths not working correctly

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
@@ -83,7 +83,7 @@ export class DocumentGithubLoader implements INodeType {
 					},
 					{
 						displayName: 'Ignore Paths',
-						name: 'recursive',
+						name: 'ignorePaths',
 						type: 'string',
 						description: 'Comma-separated list of paths to ignore, e.g. "docs, src/tests',
 						default: '',


### PR DESCRIPTION
Fixed for duplicate option name in DocumentGithubLoader. 

Option Ignore Paths was using the same name as Recursive, which was 'recursive'

## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

Fixed a small typo in DocumentGithubLoader

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [X] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [N/A] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 