### PR TITLE
feat: Track self serve trial (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/PersonalizationModal.vue
+++ b/packages/editor-ui/src/components/PersonalizationModal.vue
@@ -726,6 +726,10 @@ export default defineComponent({
 				if (this.registerForEnterpriseTrial && this.canRegisterForEnterpriseTrial) {
 					await this.usageStore.requestEnterpriseLicenseTrial();
 					licenseRequestSucceeded = true;
+					this.$telemetry.track('User registered for self serve trial', {
+						email: this.usersStore.currentUser?.email,
+						instance_id: this.rootStore.instanceId,
+					});
 				}
 			} catch (e) {
 				this.showError(

--- a/packages/editor-ui/src/components/__tests__/PersonalizationModal.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/PersonalizationModal.spec.ts
@@ -1,31 +1,57 @@
 import PersonalizationModal from '@/components/PersonalizationModal.vue';
 import { createTestingPinia } from '@pinia/testing';
-import { PERSONALIZATION_MODAL_KEY, STORES } from '@/constants';
+import { PERSONALIZATION_MODAL_KEY, STORES, VIEWS } from '@/constants';
 import { retry } from '@/__tests__/utils';
 import { createComponentRenderer } from '@/__tests__/render';
 import { fireEvent } from '@testing-library/vue';
+import { useUsersStore } from '@/stores/users.store';
+import { useUsageStore } from '@/stores/usage.store';
+
+const pinia = createTestingPinia({
+	initialState: {
+		[STORES.UI]: {
+			modals: {
+				[PERSONALIZATION_MODAL_KEY]: { open: true },
+			},
+		},
+		[STORES.SETTINGS]: {
+			settings: {
+				templates: {
+					host: '',
+				},
+			},
+		},
+		[STORES.USERS]: {
+			users: {
+				123: {
+					email: 'john@doe.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					isDefaultUser: false,
+					isPendingUser: false,
+					hasRecoveryCodesLeft: true,
+					isOwner: true,
+					mfaEnabled: false,
+				},
+			},
+			currentUserId: '123',
+		},
+	},
+});
 
 const renderComponent = createComponentRenderer(PersonalizationModal, {
 	props: {
 		teleported: false,
 		appendToBody: false,
 	},
-	pinia: createTestingPinia({
-		initialState: {
-			[STORES.UI]: {
-				modals: {
-					[PERSONALIZATION_MODAL_KEY]: { open: true },
-				},
-			},
-			[STORES.SETTINGS]: {
-				settings: {
-					templates: {
-						host: '',
-					},
-				},
+	pinia,
+	global: {
+		mocks: {
+			$route: {
+				name: VIEWS.NEW_WORKFLOW,
 			},
 		},
-	}),
+	},
 });
 
 describe('PersonalizationModal.vue', () => {
@@ -60,5 +86,51 @@ describe('PersonalizationModal.vue', () => {
 				expect(wrapper.container.querySelector('[name^="automationGoal"]')).toBeInTheDocument();
 			});
 		}
+	});
+
+	it('should display self serve trial option when company size is larger than 500', async () => {
+		const wrapper = renderComponent();
+
+		await retry(() =>
+			expect(wrapper.container.querySelector('.modal-content')).toBeInTheDocument(),
+		);
+
+		const select = wrapper.container.querySelectorAll('.n8n-select')[3]!;
+		await fireEvent.click(select);
+
+		const item = select.querySelectorAll('.el-select-dropdown__item')[3];
+		await fireEvent.click(item);
+
+		await retry(() => {
+			expect(wrapper.container.querySelector('.card')).not.toBeNull();
+		});
+	});
+
+	it('should display send telemetry when requesting enterprise trial', async () => {
+		const usersStore = useUsersStore(pinia);
+		vi.spyOn(usersStore, 'submitPersonalizationSurvey').mockResolvedValue();
+
+		const usageStore = useUsageStore(pinia);
+		const spyLicenseTrial = vi.spyOn(usageStore, 'requestEnterpriseLicenseTrial');
+
+		const wrapper = renderComponent();
+
+		await retry(() =>
+			expect(wrapper.container.querySelector('.modal-content')).toBeInTheDocument(),
+		);
+
+		const select = wrapper.container.querySelectorAll('.n8n-select')[3]!;
+		await fireEvent.click(select);
+
+		const item = select.querySelectorAll('.el-select-dropdown__item')[3];
+		await fireEvent.click(item);
+
+		const agreeCheckbox = wrapper.container.querySelector('.n8n-checkbox')!;
+		await fireEvent.click(agreeCheckbox);
+
+		const submitButton = wrapper.container.querySelector('button')!;
+		await fireEvent.click(submitButton);
+
+		await retry(() => expect(spyLicenseTrial).toHaveBeenCalled());
 	});
 });

--- a/packages/editor-ui/src/components/__tests__/PersonalizationModal.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/PersonalizationModal.spec.ts
@@ -1,5 +1,6 @@
 import PersonalizationModal from '@/components/PersonalizationModal.vue';
 import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
 import { PERSONALIZATION_MODAL_KEY, STORES, VIEWS } from '@/constants';
 import { retry } from '@/__tests__/utils';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -128,8 +129,8 @@ describe('PersonalizationModal.vue', () => {
 		const agreeCheckbox = wrapper.container.querySelector('.n8n-checkbox')!;
 		await fireEvent.click(agreeCheckbox);
 
-		const submitButton = wrapper.container.querySelector('button')!;
-		await fireEvent.click(submitButton);
+		const submitButton = wrapper.getByRole('button')!;
+		await userEvent.click(submitButton);
 
 		await retry(() => expect(spyLicenseTrial).toHaveBeenCalled());
 	});

--- a/packages/editor-ui/src/views/SetupView.vue
+++ b/packages/editor-ui/src/views/SetupView.vue
@@ -18,6 +18,7 @@ import { mapStores } from 'pinia';
 import { useUIStore } from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
+import { useRootStore } from '@/stores/n8nRoot.store';
 
 export default defineComponent({
 	name: 'SetupView',

--- a/packages/editor-ui/src/views/SetupView.vue
+++ b/packages/editor-ui/src/views/SetupView.vue
@@ -18,7 +18,6 @@ import { mapStores } from 'pinia';
 import { useUIStore } from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
-import { useRootStore } from '@/stores/n8nRoot.store';
 
 export default defineComponent({
 	name: 'SetupView',


### PR DESCRIPTION
## Summary
Track self serve trial events



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1418/add-telemetry-for-self-serve-trial-opt-in



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.