### PR TITLE
feat: Dynamically create project name for personal projects

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -38,13 +38,6 @@ export class ProjectController {
 		const relations = await this.projectsService.getProjectRelationsForUser(req.user);
 
 		return relations.map((pr) => {
-			let name = pr.project.name;
-			// Only personal projects don't have a name and the only
-			// personal project a user should be linked to is their own
-			if (!name) {
-				// TODO: confirm name with product
-				name = 'My n8n';
-			}
 			return {
 				...pr.project,
 				role: pr.role,

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -66,7 +66,7 @@ export class CredentialsController {
 
 			let credential = await this.credentialsRepository.findOne({
 				where: { id: credentialId },
-				relations: { shared: { user: true, project: true } },
+				relations: { shared: { user: true, project: { projectRelations: { user: true } } } },
 			});
 
 			if (!credential) {

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -25,8 +25,6 @@ export class Project extends WithTimestampsAndStringId {
 			return `${user.firstName} ${user.lastName} <${user.email}>`; // generate name
 		}
 
-		console.trace(JSON.stringify(this.projectRelations, null, 2));
-
 		throw new ApplicationError(
 			'You asked for the actual name of a personal project. I can only generate the actual name if `projectRelations: { user: true }` is part of the relations when querying the database. Please make sure to add this to your query.',
 		);

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -3,7 +3,7 @@ import { WithTimestampsAndStringId } from './AbstractEntity';
 import type { ProjectRelation } from './ProjectRelation';
 import type { SharedCredentials } from './SharedCredentials';
 import type { SharedWorkflow } from './SharedWorkflow';
-import { ApplicationError } from '../../../../workflow/src';
+import { ApplicationError } from 'n8n-workflow';
 
 export type ProjectType = 'personal' | 'team' | 'public';
 

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -3,6 +3,7 @@ import { WithTimestampsAndStringId } from './AbstractEntity';
 import type { ProjectRelation } from './ProjectRelation';
 import type { SharedCredentials } from './SharedCredentials';
 import type { SharedWorkflow } from './SharedWorkflow';
+import { ApplicationError } from '../../../../workflow/src';
 
 export type ProjectType = 'personal' | 'team' | 'public';
 
@@ -11,10 +12,30 @@ export class Project extends WithTimestampsAndStringId {
 	@Column({ length: 255, nullable: true })
 	name?: string;
 
+	get actualName(): string {
+		if (this.name) {
+			return this.name;
+		}
+
+		const owningRelation = this.projectRelations?.find(
+			(pr) => pr.role === 'project:personalOwner' && pr.user !== undefined,
+		);
+		if (owningRelation) {
+			const user = owningRelation.user;
+			return `${user.firstName} ${user.lastName} <${user.email}>`; // generate name
+		}
+
+		console.trace(JSON.stringify(this.projectRelations, null, 2));
+
+		throw new ApplicationError(
+			'You asked for the actual name of a personal project. I can only generate the actual name if `projectRelations: { user: true }` is part of the relations when querying the database. Please make sure to add this to your query.',
+		);
+	}
+
 	@Column({ length: 36 })
 	type: ProjectType;
 
-	@OneToMany('ProjectRelation', 'project')
+	@OneToMany('ProjectRelation', 'project', { eager: true })
 	projectRelations: ProjectRelation[];
 
 	@OneToMany('SharedCredentials', 'project')

--- a/packages/cli/src/databases/entities/ProjectRelation.ts
+++ b/packages/cli/src/databases/entities/ProjectRelation.ts
@@ -15,7 +15,7 @@ export class ProjectRelation extends WithTimestamps {
 	@Column()
 	role: ProjectRole;
 
-	@ManyToOne('User', 'projectRelations')
+	@ManyToOne('User', 'projectRelations', { eager: true })
 	user: User;
 
 	@PrimaryColumn('uuid')

--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -1,6 +1,13 @@
 import { Service } from 'typedi';
 import { DataSource, In, Not, Repository, Like } from '@n8n/typeorm';
-import type { FindManyOptions, DeleteResult, EntityManager, FindOptionsWhere } from '@n8n/typeorm';
+import type {
+	FindManyOptions,
+	DeleteResult,
+	EntityManager,
+	FindOptionsWhere,
+	FindOptionsSelect,
+	FindOptionsRelations,
+} from '@n8n/typeorm';
 import { CredentialsEntity } from '../entities/CredentialsEntity';
 import { SharedCredentials } from '../entities/SharedCredentials';
 import type { ListQuery } from '@/requests';
@@ -43,10 +50,24 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 	private toFindManyOptions(listQueryOptions?: ListQuery.Options) {
 		const findManyOptions: FindManyOptions<CredentialsEntity> = {};
 
-		type Select = Array<keyof CredentialsEntity>;
-
-		const defaultRelations = ['shared', 'shared.user', 'shared.project'];
-		const defaultSelect: Select = ['id', 'name', 'type', 'nodesAccess', 'createdAt', 'updatedAt'];
+		const defaultRelations: FindOptionsRelations<CredentialsEntity> = {
+			shared: {
+				user: true,
+				project: {
+					projectRelations: {
+						user: true,
+					},
+				},
+			},
+		};
+		const defaultSelect: FindOptionsSelect<CredentialsEntity> = {
+			id: true,
+			name: true,
+			type: true,
+			nodesAccess: true,
+			createdAt: true,
+			updatedAt: true,
+		};
 
 		if (!listQueryOptions) return { select: defaultSelect, relations: defaultRelations };
 

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -140,7 +140,6 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 					createdAt: true,
 					updatedAt: true,
 					versionId: true,
-					shared: { userId: true, role: true },
 			  };
 
 		delete select?.ownedBy; // remove non-entity field, handled after query
@@ -157,7 +156,8 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			select.tags = { id: true, name: true };
 		}
 
-		if (isOwnedByIncluded) relations.push('shared', 'shared.user', 'shared.project');
+		if (isOwnedByIncluded)
+			relations.push('shared', 'shared.user', 'shared.project.projectRelations.user');
 
 		if (typeof where.name === 'string' && where.name !== '') {
 			where.name = Like(`%${where.name}%`);

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -64,16 +64,14 @@ export class OwnershipService {
 				entity.homeProject = {
 					id: project.id,
 					type: project.type,
-					// TODO: confirm name with product
-					name: project.name ?? 'My n8n',
+					name: project.actualName,
 				};
 			} else {
 				entity.sharedWith.push({ id, email, firstName, lastName });
 				entity.sharedWithProjects.push({
 					id: project.id,
 					type: project.type,
-					// TODO: confirm name with product
-					name: project.name ?? 'My n8n',
+					name: project.actualName,
 				});
 			}
 		});

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -47,6 +47,7 @@ export class WorkflowService {
 	async getMany(sharedWorkflowIds: string[], options?: ListQuery.Options) {
 		const { workflows, count } = await this.workflowRepository.getMany(sharedWorkflowIds, options);
 
+		// update so that it checks the relations
 		return hasSharing(workflows)
 			? {
 					workflows: workflows.map((w) => this.ownershipService.addOwnedByAndSharedWith(w)),

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -47,7 +47,6 @@ export class WorkflowService {
 	async getMany(sharedWorkflowIds: string[], options?: ListQuery.Options) {
 		const { workflows, count } = await this.workflowRepository.getMany(sharedWorkflowIds, options);
 
-		// update so that it checks the relations
 		return hasSharing(workflows)
 			? {
 					workflows: workflows.map((w) => this.ownershipService.addOwnedByAndSharedWith(w)),

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -175,13 +175,13 @@ describe('GET /credentials', () => {
 
 		expect(member1Credential.homeProject).toMatchObject({
 			id: member1PersonalProject.id,
-			name: 'My n8n',
+			name: member1PersonalProject.actualName,
 			type: member1PersonalProject.type,
 		});
 		expect(member1Credential.sharedWithProjects).toHaveLength(1);
 		expect(member1Credential.sharedWithProjects[0]).toMatchObject({
 			id: member2PersonalProject.id,
-			name: 'My n8n',
+			name: member2PersonalProject.actualName,
 			type: member2PersonalProject.type,
 		});
 	});
@@ -210,7 +210,7 @@ describe('GET /credentials/:id', () => {
 		expect(firstCredential.sharedWith).toHaveLength(0);
 		expect(firstCredential.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: 'My n8n',
+			name: ownerPersonalProject.actualName,
 			type: ownerPersonalProject.type,
 		});
 		expect(firstCredential.sharedWithProjects).toHaveLength(0);
@@ -263,13 +263,13 @@ describe('GET /credentials/:id', () => {
 			],
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: 'My n8n',
+				name: member1PersonalProject.actualName,
 				type: member1PersonalProject.type,
 			},
 			sharedWithProjects: [
 				{
 					id: member2PersonalProject.id,
-					name: 'My n8n',
+					name: member2PersonalProject.actualName,
 					type: member2PersonalProject.type,
 				},
 			],
@@ -323,18 +323,18 @@ describe('GET /credentials/:id', () => {
 			]),
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: 'My n8n',
-				type: 'personal',
+				name: member1PersonalProject.actualName,
+				type: member1PersonalProject.type,
 			},
 			sharedWithProjects: expect.arrayContaining([
 				{
 					id: member2PersonalProject.id,
-					name: 'My n8n',
+					name: member2PersonalProject.actualName,
 					type: member2PersonalProject.type,
 				},
 				{
 					id: member3PersonalProject.id,
-					name: 'My n8n',
+					name: member3PersonalProject.actualName,
 					type: member3PersonalProject.type,
 				},
 			]),

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -175,13 +175,13 @@ describe('GET /credentials', () => {
 
 		expect(member1Credential.homeProject).toMatchObject({
 			id: member1PersonalProject.id,
-			name: member1PersonalProject.actualName,
+			name: `${member1.firstName} ${member1.lastName} <${member1.email}>`,
 			type: member1PersonalProject.type,
 		});
 		expect(member1Credential.sharedWithProjects).toHaveLength(1);
 		expect(member1Credential.sharedWithProjects[0]).toMatchObject({
 			id: member2PersonalProject.id,
-			name: member2PersonalProject.actualName,
+			name: `${member2.firstName} ${member2.lastName} <${member2.email}>`,
 			type: member2PersonalProject.type,
 		});
 	});
@@ -210,7 +210,7 @@ describe('GET /credentials/:id', () => {
 		expect(firstCredential.sharedWith).toHaveLength(0);
 		expect(firstCredential.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: ownerPersonalProject.actualName,
+			name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 			type: ownerPersonalProject.type,
 		});
 		expect(firstCredential.sharedWithProjects).toHaveLength(0);
@@ -263,13 +263,13 @@ describe('GET /credentials/:id', () => {
 			],
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: member1PersonalProject.actualName,
+				name: `${member1.firstName} ${member1.lastName} <${member1.email}>`,
 				type: member1PersonalProject.type,
 			},
 			sharedWithProjects: [
 				{
 					id: member2PersonalProject.id,
-					name: member2PersonalProject.actualName,
+					name: `${member2.firstName} ${member2.lastName} <${member2.email}>`,
 					type: member2PersonalProject.type,
 				},
 			],
@@ -323,18 +323,18 @@ describe('GET /credentials/:id', () => {
 			]),
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: member1PersonalProject.actualName,
+				name: `${member1.firstName} ${member1.lastName} <${member1.email}>`,
 				type: member1PersonalProject.type,
 			},
 			sharedWithProjects: expect.arrayContaining([
 				{
 					id: member2PersonalProject.id,
-					name: member2PersonalProject.actualName,
+					name: `${member2.firstName} ${member2.lastName} <${member2.email}>`,
 					type: member2PersonalProject.type,
 				},
 				{
 					id: member3PersonalProject.id,
-					name: member3PersonalProject.actualName,
+					name: `${member3.firstName} ${member3.lastName} <${member3.email}>`,
 					type: member3PersonalProject.type,
 				},
 			]),

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -341,7 +341,7 @@ describe('GET /workflows', () => {
 					sharedWith: [],
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: 'My n8n',
+						name: ownerPersonalProject.actualName,
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -363,7 +363,7 @@ describe('GET /workflows', () => {
 					sharedWith: [],
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: 'My n8n',
+						name: ownerPersonalProject.actualName,
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -591,7 +591,7 @@ describe('GET /workflows', () => {
 						sharedWith: [],
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: 'My n8n',
+							name: ownerPersonalProject.actualName,
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],
@@ -607,7 +607,7 @@ describe('GET /workflows', () => {
 						sharedWith: [],
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: 'My n8n',
+							name: ownerPersonalProject.actualName,
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -341,7 +341,7 @@ describe('GET /workflows', () => {
 					sharedWith: [],
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: ownerPersonalProject.actualName,
+						name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -363,7 +363,8 @@ describe('GET /workflows', () => {
 					sharedWith: [],
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: ownerPersonalProject.actualName,
+						name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
+
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -591,7 +592,7 @@ describe('GET /workflows', () => {
 						sharedWith: [],
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: ownerPersonalProject.actualName,
+							name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],
@@ -607,7 +608,7 @@ describe('GET /workflows', () => {
 						sharedWith: [],
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: ownerPersonalProject.actualName,
+							name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],

--- a/packages/cli/test/unit/services/ownership.service.test.ts
+++ b/packages/cli/test/unit/services/ownership.service.test.ts
@@ -8,6 +8,7 @@ import { WorkflowEntity } from '@/databases/entities/WorkflowEntity';
 import { UserRepository } from '@/databases/repositories/user.repository';
 import { mock } from 'jest-mock-extended';
 import { mockCredential, mockProject, mockUser } from '../shared/mockObjects';
+import type { ProjectRelation } from '@/databases/entities/ProjectRelation';
 
 describe('OwnershipService', () => {
 	const userRepository = mockInstance(UserRepository);
@@ -49,7 +50,22 @@ describe('OwnershipService', () => {
 			const editor = mockUser();
 
 			const ownerProject = mockProject();
+			ownerProject.projectRelations = [
+				{
+					project: { ...ownerProject },
+					user: owner,
+					role: 'project:personalOwner',
+				},
+			] as ProjectRelation[];
+
 			const editorProject = mockProject();
+			editorProject.projectRelations = [
+				{
+					project: { ...editorProject },
+					user: editor,
+					role: 'project:personalOwner',
+				},
+			] as ProjectRelation[];
 
 			const credential = mockCredential();
 
@@ -79,14 +95,14 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: ownerProject.id,
-				name: 'My n8n',
+				name: ownerProject.actualName,
 				type: ownerProject.type,
 			});
 
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: editorProject.id,
-					name: 'My n8n',
+					name: editorProject.actualName,
 					type: editorProject.type,
 				},
 			]);
@@ -97,7 +113,22 @@ describe('OwnershipService', () => {
 			const editor = mockUser();
 
 			const projectOwner = mockProject();
+			projectOwner.projectRelations = [
+				{
+					project: { ...projectOwner },
+					user: owner,
+					role: 'project:personalOwner',
+				},
+			] as ProjectRelation[];
+
 			const projectEditor = mockProject();
+			projectEditor.projectRelations = [
+				{
+					project: { ...projectEditor },
+					user: editor,
+					role: 'project:personalOwner',
+				},
+			] as ProjectRelation[];
 
 			const workflow = new WorkflowEntity();
 
@@ -127,13 +158,13 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: projectOwner.id,
-				name: 'My n8n',
+				name: projectOwner.actualName,
 				type: projectOwner.type,
 			});
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: projectEditor.id,
-					name: 'My n8n',
+					name: projectEditor.actualName,
 					type: projectEditor.type,
 				},
 			]);
@@ -145,6 +176,14 @@ describe('OwnershipService', () => {
 			const credential = mockCredential();
 
 			const project = mockProject();
+
+			project.projectRelations = [
+				{
+					user: owner,
+					project: { ...project },
+					role: 'project:personalOwner',
+				},
+			] as ProjectRelation[];
 
 			credential.shared = [
 				{ role: 'credential:owner', user: owner, project },
@@ -164,7 +203,7 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: project.id,
-				name: 'My n8n',
+				name: project.actualName,
 				type: project.type,
 			});
 

--- a/packages/cli/test/unit/services/ownership.service.test.ts
+++ b/packages/cli/test/unit/services/ownership.service.test.ts
@@ -95,14 +95,14 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: ownerProject.id,
-				name: ownerProject.actualName,
+				name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 				type: ownerProject.type,
 			});
 
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: editorProject.id,
-					name: editorProject.actualName,
+					name: `${editor.firstName} ${editor.lastName} <${editor.email}>`,
 					type: editorProject.type,
 				},
 			]);
@@ -158,13 +158,13 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: projectOwner.id,
-				name: projectOwner.actualName,
+				name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 				type: projectOwner.type,
 			});
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: projectEditor.id,
-					name: projectEditor.actualName,
+					name: `${editor.firstName} ${editor.lastName} <${editor.email}>`,
 					type: projectEditor.type,
 				},
 			]);
@@ -203,7 +203,7 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: project.id,
-				name: project.actualName,
+				name: `${owner.firstName} ${owner.lastName} <${owner.email}>`,
 				type: project.type,
 			});
 


### PR DESCRIPTION
## Summary

This creates the project name for personal project dynamically.

This probably introduces over-fetching from the db, because every part of the codebase that needs the actual name of a project will have to query all project relations.
This means if you want 1 `Credential` and the homeProject field you have to fetch all `SharedCredentials`, for each the `Project`, for each the `ProjectRelation` and for each the `User`.
Before it was only the SharedCredentials and the `User` that was associated with it.

I tested our current approach (fetching all data necessary to create it whenever we fetch workflows) on a copy of internal and compared it against feature/rbac and master.

On master getting all workflows takes ca. 120ms
On feature/rbac it takes ca. 150ms
On this branch it takes ca. 220ms.
Internal has ca. 1200 workflows.

An alternative is to make `Project.name` non-nullable and update it for personal projects whenever the owner's data changes (.e.g. firstName, lastName and email).

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1412/autogenerate-name-for-personal-projects

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

