### PR TITLE
fix(OpenAI Node): Message text operation parameters case fix

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -171,6 +171,16 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const options = this.getNodeParameter('options', i, {});
 	const jsonOutput = this.getNodeParameter('jsonOutput', i, false) as boolean;
 
+	if (options.maxTokens !== undefined) {
+		options.max_tokens = options.maxTokens;
+		delete options.maxTokens;
+	}
+
+	if (options.topP !== undefined) {
+		options.top_p = options.topP;
+		delete options.topP;
+	}
+
 	let response_format;
 	if (jsonOutput) {
 		response_format = { type: 'json_object' };


### PR DESCRIPTION
## Summary
 'Maximum Number of Tokens' for Text:Message a Model returns an error



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1189/open-ai-node-maximum-number-of-tokens-for-textmessage-a-model-returns
https://community.n8n.io/t/openai-message-model/41876