### PR TITLE
fix(editor): Fix NDV output tabs resetting on any click

### DIFF
--- a/packages/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/editor-ui/src/components/ExpressionParameterInput.vue
@@ -149,9 +149,9 @@ export default defineComponent({
 
 			this.isFocused = false;
 
-			this.$emit('blur');
-
 			if (wasFocused) {
+				this.$emit('blur');
+
 				const telemetryPayload = createExpressionTelemetryPayload(
 					this.segments,
 					this.modelValue,

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -1473,7 +1473,8 @@ export default defineComponent({
 		},
 	},
 	watch: {
-		node() {
+		node(newNode: INodeUi, prevNode: INodeUi) {
+			if (newNode.id === prevNode.id) return;
 			this.init();
 		},
 		hasNodeRun() {

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -595,7 +595,7 @@ import { useNDVStore } from '@/stores/ndv.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useToast } from '@/composables/useToast';
-import { isObject } from 'lodash-es';
+import { isEqual, isObject } from 'lodash-es';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import RunDataPinButton from '@/components/RunDataPinButton.vue';
@@ -1492,9 +1492,10 @@ export default defineComponent({
 			immediate: true,
 			deep: true,
 		},
-		jsonData(value: IDataObject[]) {
+		jsonData(data: IDataObject[], prevData: IDataObject[]) {
+			if (isEqual(data, prevData)) return;
 			this.refreshDataSize();
-			this.showPinDataDiscoveryTooltip(value);
+			this.showPinDataDiscoveryTooltip(data);
 		},
 		binaryData(newData: IBinaryKeyData[], prevData: IBinaryKeyData[]) {
 			if (newData.length && !prevData.length && this.displayMode !== 'binary') {

--- a/packages/editor-ui/src/components/__tests__/ExpressionParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ExpressionParameterInput.test.ts
@@ -33,4 +33,24 @@ describe('ExpressionParameterInput', () => {
 		await userEvent.click(getByTestId('expander'));
 		expect(emitted().modalOpenerClick).toEqual(expected);
 	});
+
+	test('it should only emit blur when input had focus', async () => {
+		const { getByTestId, emitted, baseElement } = renderComponent({
+			props: {
+				modelValue: '={{$json.foo}}',
+			},
+		});
+
+		// trigger click outside -> blur
+		await userEvent.click(baseElement);
+		expect(emitted('blur')).toBeUndefined();
+
+		// focus expression editor
+		await userEvent.click(
+			getByTestId('inline-expression-editor-input').querySelector('.cm-line') as Element,
+		);
+		// trigger click outside -> blur
+		await userEvent.click(baseElement);
+		expect(emitted('blur')).toHaveLength(1);
+	});
 });


### PR DESCRIPTION
## Summary

NDV output tab would automatically switch back to the first tab because of a click outside listener (-> blur event -> node param change event)

**Fixes**
- `ExpressionParameterInput`: Make sure `blur` event is only emitted when the input was focused
- Make sure `RunData` doesn't reset the tab when the opened node is the same

See linear for reproduction and workflow

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1211/bug-ndv-output-switches-tabs-without-clicking



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 