### PR TITLE
fix(Basic LLM Chain Node): Fix retrieving of prompt parameter for v1.3 of the node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -504,7 +504,7 @@ export class ChainLlm implements INodeType {
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			let prompt: string;
-			if (this.getNode().typeVersion <= 1.2) {
+			if (this.getNode().typeVersion <= 1.3) {
 				prompt = this.getNodeParameter('prompt', itemIndex) as string;
 			} else {
 				prompt = getPromptInputByType({


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

The older versions of Basic LLM Chain node should still use the old `prompt` parameter for user input