### PR TITLE
feat(Jira Trigger Node): Add support for Jira webhook signatures

### DIFF
--- a/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
+++ b/packages/nodes-base/nodes/Cisco/Webex/CiscoWebexTrigger.node.ts
@@ -582,8 +582,7 @@ export class CiscoWebexTrigger implements INodeType {
 		const req = this.getRequestObject();
 		const resolveData = this.getNodeParameter('resolveData', false) as boolean;
 
-		//@ts-ignore
-		const computedSignature = createHmac('sha1', webhookData.secret)
+		const computedSignature = createHmac('sha1', webhookData.secret as string)
 			.update(req.rawBody)
 			.digest('hex');
 		if (headers['x-spark-signature'] !== computedSignature) {

--- a/packages/nodes-base/nodes/Jira/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jira/GenericFunctions.ts
@@ -10,6 +10,7 @@ import type {
 	JsonObject,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
+import { randomBytes } from 'crypto';
 
 export async function jiraSoftwareCloudApiRequest(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
@@ -262,4 +263,20 @@ export async function getUsers(this: ILoadOptionsFunctions): Promise<INodeProper
 		.sort((a: INodePropertyOptions, b: INodePropertyOptions) => {
 			return a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1;
 		});
+}
+
+export function generateWebhookSecret(length: number): string {
+	let result = '';
+	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	const charactersLength = characters.length;
+
+	while (result.length < length) {
+		const buffer = randomBytes(length);
+		for (let i = 0; i < buffer.length && result.length < length; ++i) {
+			const randomValue = buffer[i] % charactersLength;
+			result += characters[randomValue];
+		}
+	}
+
+	return result;
 }


### PR DESCRIPTION
## Summary
This PR adds support for Jira Webhook signatures based on [websub](https://www.w3.org/TR/websub/#signing-content)

Effectively we generate a random secret when we create the webhook with the same character set and length as the default Atlassian generated secrets. https://developer.atlassian.com/cloud/jira/platform/webhooks/#secure-admin-webhooks

This PR allows using signature auth, query auth, both, or none.


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 