### PR TITLE
fix(core): Always register webhooks on startup

### DIFF
--- a/packages/cli/src/services/orchestration.service.ts
+++ b/packages/cli/src/services/orchestration.service.ts
@@ -128,7 +128,11 @@ export class OrchestrationService {
 	 * Whether this instance may add webhooks to the `webhook_entity` table.
 	 */
 	shouldAddWebhooks(activationMode: WorkflowActivateMode) {
-		if (activationMode === 'init') return false;
+		// Always try to populate the webhook entity table as well as register the webhooks
+		// to prevent issues with users upgrading from a version < 1.15, where the webhook entity
+		// was cleared on shutdown to anything past 1.28.0, where we stopped populating it on init,
+		// causing all webhooks to break
+		if (activationMode === 'init') return true;
 
 		if (activationMode === 'leadershipChange') return false;
 


### PR DESCRIPTION
## Summary
On version 1.15 we stopped deregistering webhooks on shutdown but on 1.28 we also stopped registering on init, given that if a workflow was already active, the database would be populated.

The problem is that users upgrading from < 1.15 to >= 1.28 would end up with webhooks not registered at all, so this changes prevents this from happening by always ensuring webhooks are registered.



## Related tickets and issues
https://linear.app/n8n/issue/HELP-479/webhooks-not-working-after-upgrade



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.