### PR TITLE
fix(editor): Improve filter component error handling

### DIFF
--- a/packages/editor-ui/src/components/FilterConditions/Condition.vue
+++ b/packages/editor-ui/src/components/FilterConditions/Condition.vue
@@ -16,6 +16,7 @@ import { type FilterOperatorId } from './constants';
 import {
 	getFilterOperator,
 	handleOperatorChange,
+	isEmptyInput,
 	operatorTypeToNodeProperty,
 	resolveCondition,
 } from './utils';
@@ -54,12 +55,20 @@ const operatorId = computed<FilterOperatorId>(() => {
 });
 const operator = computed(() => getFilterOperator(operatorId.value));
 
+const isEmpty = computed(() => {
+	if (operator.value.singleValue) {
+		return isEmptyInput(condition.value.leftValue);
+	}
+
+	return isEmptyInput(condition.value.leftValue) && isEmptyInput(condition.value.rightValue);
+});
+
 const conditionResult = computed(() =>
 	resolveCondition({ condition: condition.value, options: props.options }),
 );
 
 const allIssues = computed(() => {
-	if (conditionResult.value.status === 'validation_error') {
+	if (conditionResult.value.status === 'validation_error' && !isEmpty.value) {
 		return [conditionResult.value.error];
 	}
 

--- a/packages/editor-ui/src/components/FilterConditions/utils.ts
+++ b/packages/editor-ui/src/components/FilterConditions/utils.ts
@@ -56,6 +56,10 @@ export const handleOperatorChange = ({
 	return condition;
 };
 
+export const isEmptyInput = (value: unknown): boolean => {
+	return value === '' || value === '=';
+};
+
 export const resolveCondition = ({
 	condition,
 	options,

--- a/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
+++ b/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
@@ -83,7 +83,7 @@ export class FilterV2 implements INodeType {
 						set(
 							error,
 							'description',
-							"Try to change the operator, switch ON the option 'Less Strict Type Validation', or change the type with an expression",
+							"Try changing the type of comparison. Alternatively you can enable 'Less Strict Type Validation' in the options.",
 						);
 					}
 					throw error;

--- a/packages/nodes-base/nodes/If/V2/IfV2.node.ts
+++ b/packages/nodes-base/nodes/If/V2/IfV2.node.ts
@@ -83,7 +83,7 @@ export class IfV2 implements INodeType {
 						set(
 							error,
 							'description',
-							"Try to change the operator, switch ON the option 'Less Strict Type Validation', or change the type with an expression",
+							"Try changing the type of comparison. Alternatively you can enable 'Less Strict Type Validation' in the options.",
 						);
 					}
 					throw error;

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -349,7 +349,7 @@ export class SwitchV3 implements INodeType {
 						} catch (error) {
 							if (!options.looseTypeValidation) {
 								error.description =
-									"Try to change the operator, switch ON the option 'Less Strict Type Validation', or change the type with an expression";
+									"Try changing the type of comparison. Alternatively you can enable 'Less Strict Type Validation' in the options.";
 							}
 							throw error;
 						}

--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -37,6 +37,11 @@ function parseSingleFilterValue(
 		: validateFieldType('filter', value, type, { strict, parseStrings: true });
 }
 
+const withIndefiniteArticle = (noun: string): string => {
+	const article = 'aeiou'.includes(noun.charAt(0)) ? 'an' : 'a';
+	return `${article} ${noun}`;
+};
+
 function parseFilterConditionValues(
 	condition: FilterConditionValue,
 	options: FilterOptionsValue,
@@ -63,15 +68,19 @@ function parseFilterConditionValues(
 			condition.rightValue.startsWith('='));
 	const leftValueString = String(condition.leftValue);
 	const rightValueString = String(condition.rightValue);
-	const inCondition = errorFormat === 'full' ? `in condition ${index + 1}` : ' ';
-	const itemSuffix = `[item ${itemIndex}]`;
+	const suffix =
+		errorFormat === 'full' ? `[condition ${index}, item ${itemIndex}]` : `[item ${itemIndex}]`;
 
 	const composeInvalidTypeMessage = (type: string, fromType: string, value: string) => {
 		fromType = fromType.toLocaleLowerCase();
 		if (strict) {
-			return `Wrong type: expected ${type} ${inCondition}, received '${value}' (${fromType}) ${itemSuffix}`;
+			return `Wrong type: '${value}' is ${withIndefiniteArticle(
+				fromType,
+			)} but was expecting ${withIndefiniteArticle(type)} ${suffix}`;
 		}
-		return `Conversion error: '${value}' (${fromType}) cannot be converted to type '${type}' ${inCondition} ${itemSuffix}`;
+		return `Conversion error: the ${fromType} '${value}' can't be converted to ${withIndefiniteArticle(
+			type,
+		)} ${suffix}`;
 	};
 
 	const invalidTypeDescription = 'Try changing the type of comparison.';

--- a/packages/workflow/test/FilterParameter.test.ts
+++ b/packages/workflow/test/FilterParameter.test.ts
@@ -1011,8 +1011,8 @@ describe('FilterParameter', () => {
 				it.each([
 					{ left: {}, expected: true },
 					{ left: { foo: 'bar' }, expected: false },
-					{ left: undefined, expected: false },
-					{ left: null, expected: false },
+					{ left: undefined, expected: true },
+					{ left: null, expected: true },
 				])('object:empty($left) === $expected', ({ left, expected }) => {
 					const result = executeFilter(
 						filterFactory({

--- a/packages/workflow/test/FilterParameter.test.ts
+++ b/packages/workflow/test/FilterParameter.test.ts
@@ -116,7 +116,7 @@ describe('FilterParameter', () => {
 							}),
 						),
 					).toThrowError(
-						"The provided values '15' and 'true' in condition 1 are not of the expected type 'number' [item 0]",
+						"Wrong type: '15' is a string but was expecting a number [condition 0, item 0]",
 					);
 				});
 
@@ -136,7 +136,7 @@ describe('FilterParameter', () => {
 							}),
 						),
 					).toThrowError(
-						"The provided value 1 '[]' in condition 1 is not of the expected type 'array' [item 0]",
+						"Wrong type: '[]' is a string but was expecting an array [condition 0, item 0]",
 					);
 				});
 
@@ -155,7 +155,7 @@ describe('FilterParameter', () => {
 							}),
 						),
 					).toThrowError(
-						"The provided value 1 '{}' in condition 1 is not of the expected type 'object' [item 0]",
+						"Wrong type: '{}' is a string but was expecting an object [condition 0, item 0]",
 					);
 				});
 			});
@@ -201,7 +201,7 @@ describe('FilterParameter', () => {
 							}),
 						),
 					).toThrowError(
-						"The provided values 'a string' and '15' in condition 1 cannot be converted to the expected type 'boolean'",
+						"Conversion error: the string 'a string' can't be converted to a boolean [condition 0, item 0]",
 					);
 				});
 			});


### PR DESCRIPTION
## Summary
- Improved error messages for type errors in filter component
- Object > is empty now returns true for `null`, `undefined`
- Empty strings are included in type checks

<img width="884" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/067bec90-47a3-4a8e-8a39-df2b7a515b39">


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1212/filter-component-type-handling-bugsclarifications



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 