### PR TITLE
fix(core): Display readable error when manual executions contains large payload

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1915,6 +1915,7 @@
 	"workflowPreview.showError.previewError.title": "Preview error",
 	"workflowRun.noActiveConnectionToTheServer": "Lost connection to the server",
 	"workflowRun.showError.title": "Problem running workflow",
+	"workflowRun.showError.payloadTooLarge": "Please execute the whole workflow, rather than just the node. (Existing execution data is too large.)",
 	"workflowRun.showMessage.message": "Please fix them before executing",
 	"workflowRun.showMessage.title": "Workflow has issues",
 	"workflowSettings.callerIds": "IDs of workflows that can call this one",

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -83,6 +83,7 @@ import { useUsersStore } from '@/stores/users.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { getCredentialOnlyNodeTypeName } from '@/utils/credentialOnlyNodes';
 import { ResponseError } from '@/utils/apiUtils';
+import { i18n } from '@/plugins/i18n';
 
 const defaults: Omit<IWorkflowDb, 'id'> & { settings: NonNullable<IWorkflowDb['settings']> } = {
 	name: '',
@@ -1348,13 +1349,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 				);
 			} catch (error) {
 				if (error.response?.status === 413) {
-					throw new ResponseError(
-						'Please execute the whole workflow, rather than just the node. (Existing execution data is too large.)',
-						{
-							errorCode: 413,
-							httpStatusCode: 413,
-						},
-					);
+					throw new ResponseError(i18n.baseText('workflowRun.showError.payloadTooLarge'), {
+						errorCode: 413,
+						httpStatusCode: 413,
+					});
 				}
 				throw error;
 			}

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -1349,7 +1349,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, {
 			} catch (error) {
 				if (error.response?.status === 413) {
 					throw new ResponseError(
-						'The execution data is too large for n8n to process. Try reducing the data and try again.',
+						'Please execute the whole workflow, rather than just the node. (Existing execution data is too large.)',
 						{
 							errorCode: 413,
 							httpStatusCode: 413,

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -6,7 +6,7 @@ import { parse } from 'flatted';
 
 export const NO_NETWORK_ERROR_CODE = 999;
 
-class ResponseError extends Error {
+export class ResponseError extends Error {
 	// The HTTP status code of response
 	httpStatusCode?: number;
 


### PR DESCRIPTION
## Summary
When manually running a workflow, in case the run data is too large (currently the backend refuses to accept payloads larger than 12mb iirc), the request would fail with a 413.

n8n was not handling this error properly and would display a generic error message that was confusing.

This PR aims to capture this error specifically and suggesting a solution to users


## Related tickets and issues
https://linear.app/n8n/issue/PAY-1419/bug-partial-execution-gives-confusing-413-error



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.