### PR TITLE
fix(editor): Allow sharee to use workflows with http request node without credential access

### DIFF
--- a/packages/editor-ui/src/composables/useNodeHelpers.ts
+++ b/packages/editor-ui/src/composables/useNodeHelpers.ts
@@ -373,8 +373,15 @@ export function useNodeHelpers() {
 			node.credentials !== undefined
 		) {
 			const stored = credentialsStore.getCredentialsByType(nodeCredentialType);
+			// Prevents HTTP Request node from being unusable if a sharee does not have direct
+			// access to a credential
+			const isCredentialUsedInWorkflow =
+				workflowsStore.usedCredentials?.[node.credentials?.[nodeCredentialType]?.id as string];
 
-			if (selectedCredsDoNotExist(node, nodeCredentialType, stored)) {
+			if (
+				selectedCredsDoNotExist(node, nodeCredentialType, stored) &&
+				!isCredentialUsedInWorkflow
+			) {
 				const credential = credentialsStore.getCredentialTypeByName(nodeCredentialType);
 				return credential ? reportUnsetCredential(credential) : null;
 			}


### PR DESCRIPTION
## Summary

This PR allows the HTTP Request credential selector to take into account the `usedCredentials` attribute in the workflows, where attributes owned by other people are sent as part of the payload to suppress potential credential errors since these are owned by other people.

## Related tickets and issues
https://linear.app/n8n/issue/PAY-1439/i-cant-use-nodes-with-creds-that-i-dont-own-anymore



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.