### PR TITLE
fix(core): Add fallback for pairedItem info in runPartialWorkflow

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -211,7 +211,7 @@ export class WorkflowExecute {
 							}
 						}
 
-						incomingSourceData.main.push(startNode.sourceData);
+						incomingSourceData.main.push(startNode.sourceData ?? { previousNode: connection.node });
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
Adds a fallback for the changed pairedItem info in https://github.com/n8n-io/n8n/pull/8575

Fixes breaking AI workflow (reproduction workflow in linear)

## Related tickets and issues
https://github.com/n8n-io/n8n/pull/8575/files#diff-0bfa6f1919bce33f0a8185d4496af9b38028eee2ed829ae01b225e2ff42a294bL213-L216
https://linear.app/n8n/issue/AI-116



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 