### PR TITLE
feat(Wordpress Node): Support WordPress pages

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/PageDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/PageDescription.ts
@@ -1,6 +1,6 @@
 import type { INodeProperties } from 'n8n-workflow';
 
-export const postOperations: INodeProperties[] = [
+export const pageOperations: INodeProperties[] = [
 	{
 		displayName: 'Operation',
 		name: 'operation',
@@ -8,42 +8,42 @@ export const postOperations: INodeProperties[] = [
 		noDataExpression: true,
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 			},
 		},
 		options: [
 			{
 				name: 'Create',
 				value: 'create',
-				description: 'Create a post',
-				action: 'Create a post',
+				description: 'Create a page',
+				action: 'Create a page',
 			},
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get a post',
-				action: 'Get a post',
+				description: 'Get a page',
+				action: 'Get a page',
 			},
 			{
 				name: 'Get Many',
 				value: 'getAll',
-				description: 'Get many posts',
-				action: 'Get many posts',
+				description: 'Get many pages',
+				action: 'Get many pages',
 			},
 			{
 				name: 'Update',
 				value: 'update',
-				description: 'Update a post',
-				action: 'Update a post',
+				description: 'Update a page',
+				action: 'Update a page',
 			},
 		],
 		default: 'create',
 	},
 ];
 
-export const postFields: INodeProperties[] = [
+export const pageFields: INodeProperties[] = [
 	/* -------------------------------------------------------------------------- */
-	/*                                post:create                                 */
+	/*                                page:create                                 */
 	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Title',
@@ -53,11 +53,11 @@ export const postFields: INodeProperties[] = [
 		default: '',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['create'],
 			},
 		},
-		description: 'The title for the post',
+		description: 'The title for the page',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -67,7 +67,7 @@ export const postFields: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['create'],
 			},
 		},
@@ -84,11 +84,18 @@ export const postFields: INodeProperties[] = [
 					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 			},
 			{
+				displayName: 'Parent ID',
+				name: 'parent',
+				type: 'number',
+				default: '',
+				description: 'The ID for the parent of the post',
+			},
+			{
 				displayName: 'Content',
 				name: 'content',
 				type: 'string',
 				default: '',
-				description: 'The content for the post',
+				description: 'The content for the page',
 			},
 			{
 				displayName: 'Slug',
@@ -132,7 +139,7 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'draft',
-				description: 'A named status for the post',
+				description: 'A named status for the page',
 			},
 			{
 				displayName: 'Comment Status',
@@ -149,7 +156,7 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'open',
-				description: 'Whether or not comments are open on the post',
+				description: 'Whether or not comments are open on the page',
 			},
 			{
 				displayName: 'Ping Status',
@@ -166,89 +173,11 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'open',
-				description: 'If the a message should be send to announce the post',
-			},
-			{
-				displayName: 'Format',
-				name: 'format',
-				type: 'options',
-				options: [
-					{
-						name: 'Aside',
-						value: 'aside',
-					},
-					{
-						name: 'Audio',
-						value: 'audio',
-					},
-					{
-						name: 'Chat',
-						value: 'chat',
-					},
-					{
-						name: 'Gallery',
-						value: 'gallery',
-					},
-					{
-						name: 'Image',
-						value: 'image',
-					},
-					{
-						name: 'Link',
-						value: 'link',
-					},
-					{
-						name: 'Quote',
-						value: 'quote',
-					},
-					{
-						name: 'Standard',
-						value: 'standard',
-					},
-					{
-						name: 'Status',
-						value: 'status',
-					},
-					{
-						name: 'Video',
-						value: 'video',
-					},
-				],
-				default: 'standard',
-				description: 'Whether or not comments are open on the post',
-			},
-			{
-				displayName: 'Sticky',
-				name: 'sticky',
-				type: 'boolean',
-				default: false,
-				description: 'Whether or not the object should be treated as sticky',
-			},
-			{
-				displayName: 'Category Names or IDs',
-				name: 'categories',
-				type: 'multiOptions',
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				default: [],
-				description:
-					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
-			},
-			{
-				displayName: 'Tag Names or IDs',
-				name: 'tags',
-				type: 'multiOptions',
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				default: [],
-				description:
-					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				description: 'If the a message should be send to announce the page',
 			},
 			{
 				displayName: 'Template',
-				name: 'postTemplate',
+				name: 'pageTemplate',
 				type: 'fixedCollection',
 				default: {},
 				typeOptions: {
@@ -312,20 +241,51 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 			},
+			{
+				displayName: 'Menu Order',
+				name: 'menuOrder',
+				type: 'number',
+				default: 0,
+				description: 'The order of the page in relation to other pages',
+			},
+			{
+				displayName: 'Comment Status',
+				name: 'commentStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Closed',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the page',
+			},
+			{
+				displayName: 'Featured Media ID',
+				name: 'featuredMediaId',
+				type: 'number',
+				default: '',
+				description: 'The ID of the featured media for the page',
+			},
 		],
 	},
 	/* -------------------------------------------------------------------------- */
-	/*                                 post:update                                */
+	/*                                 page:update                                */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Post ID',
-		name: 'postId',
+		displayName: 'Page ID',
+		name: 'pageId',
 		type: 'string',
 		required: true,
 		default: '',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['update'],
 			},
 		},
@@ -339,7 +299,7 @@ export const postFields: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['update'],
 			},
 		},
@@ -356,18 +316,25 @@ export const postFields: INodeProperties[] = [
 					'The ID for the author of the object. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 			},
 			{
+				displayName: 'Parent ID',
+				name: 'parent',
+				type: 'number',
+				default: '',
+				description: 'The ID for the parent of the post',
+			},
+			{
 				displayName: 'Title',
 				name: 'title',
 				type: 'string',
 				default: '',
-				description: 'The title for the post',
+				description: 'The title for the page',
 			},
 			{
 				displayName: 'Content',
 				name: 'content',
 				type: 'string',
 				default: '',
-				description: 'The content for the post',
+				description: 'The content for the page',
 			},
 			{
 				displayName: 'Slug',
@@ -411,7 +378,7 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'draft',
-				description: 'A named status for the post',
+				description: 'A named status for the page',
 			},
 			{
 				displayName: 'Comment Status',
@@ -428,7 +395,7 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'open',
-				description: 'Whether or not comments are open on the post',
+				description: 'Whether or not comments are open on the page',
 			},
 			{
 				displayName: 'Ping Status',
@@ -445,89 +412,11 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'open',
-				description: 'Whether or not comments are open on the post',
-			},
-			{
-				displayName: 'Format',
-				name: 'format',
-				type: 'options',
-				options: [
-					{
-						name: 'Aside',
-						value: 'aside',
-					},
-					{
-						name: 'Audio',
-						value: 'audio',
-					},
-					{
-						name: 'Chat',
-						value: 'chat',
-					},
-					{
-						name: 'Gallery',
-						value: 'gallery',
-					},
-					{
-						name: 'Image',
-						value: 'image',
-					},
-					{
-						name: 'Link',
-						value: 'link',
-					},
-					{
-						name: 'Quote',
-						value: 'quote',
-					},
-					{
-						name: 'Standard',
-						value: 'standard',
-					},
-					{
-						name: 'Status',
-						value: 'status',
-					},
-					{
-						name: 'Video',
-						value: 'video',
-					},
-				],
-				default: 'standard',
-				description: 'The format of the post',
-			},
-			{
-				displayName: 'Sticky',
-				name: 'sticky',
-				type: 'boolean',
-				default: false,
-				description: 'Whether or not the object should be treated as sticky',
-			},
-			{
-				displayName: 'Category Names or IDs',
-				name: 'categories',
-				type: 'multiOptions',
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				default: [],
-				description:
-					'The terms assigned to the object in the category taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
-			},
-			{
-				displayName: 'Tag Names or IDs',
-				name: 'tags',
-				type: 'multiOptions',
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				default: [],
-				description:
-					'The terms assigned to the object in the post_tag taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				description: 'Whether or not comments are open on the page',
 			},
 			{
 				displayName: 'Template',
-				name: 'postTemplate',
+				name: 'pageTemplate',
 				type: 'fixedCollection',
 				default: {},
 				typeOptions: {
@@ -591,20 +480,51 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 			},
+			{
+				displayName: 'Menu Order',
+				name: 'menuOrder',
+				type: 'number',
+				default: 0,
+				description: 'The order of the page in relation to other pages',
+			},
+			{
+				displayName: 'Comment Status',
+				name: 'commentStatus',
+				type: 'options',
+				options: [
+					{
+						name: 'Open',
+						value: 'open',
+					},
+					{
+						name: 'Closed',
+						value: 'closed',
+					},
+				],
+				default: 'open',
+				description: 'Whether or not comments are open on the page',
+			},
+			{
+				displayName: 'Featured Media ID',
+				name: 'featuredMediaId',
+				type: 'number',
+				default: '',
+				description: 'The ID of the featured media for the page',
+			},
 		],
 	},
 	/* -------------------------------------------------------------------------- */
-	/*                                  post:get                                  */
+	/*                                  page:get                                  */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Post ID',
-		name: 'postId',
+		displayName: 'Page ID',
+		name: 'pageId',
 		type: 'string',
 		required: true,
 		default: '',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['get'],
 			},
 		},
@@ -618,7 +538,7 @@ export const postFields: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['get'],
 			},
 		},
@@ -629,7 +549,7 @@ export const postFields: INodeProperties[] = [
 				type: 'string',
 				typeOptions: { password: true },
 				default: '',
-				description: 'The password for the post if it is password protected',
+				description: 'The password for the page if it is password protected',
 			},
 			{
 				displayName: 'Context',
@@ -655,7 +575,7 @@ export const postFields: INodeProperties[] = [
 		],
 	},
 	/* -------------------------------------------------------------------------- */
-	/*                                   post:getAll                              */
+	/*                                   page:getAll                              */
 	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Return All',
@@ -663,7 +583,7 @@ export const postFields: INodeProperties[] = [
 		type: 'boolean',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['getAll'],
 			},
 		},
@@ -676,7 +596,7 @@ export const postFields: INodeProperties[] = [
 		type: 'number',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['getAll'],
 				returnAll: [false],
 			},
@@ -696,7 +616,7 @@ export const postFields: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['getAll'],
 			},
 		},
@@ -706,7 +626,7 @@ export const postFields: INodeProperties[] = [
 				name: 'after',
 				type: 'dateTime',
 				default: '',
-				description: 'Limit response to posts published after a given ISO8601 compliant date',
+				description: 'Limit response to pages published after a given ISO8601 compliant date',
 			},
 			{
 				displayName: 'Author Names or IDs',
@@ -717,25 +637,14 @@ export const postFields: INodeProperties[] = [
 					loadOptionsMethod: 'getAuthors',
 				},
 				description:
-					'Limit result set to posts assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+					'Limit result set to pages assigned to specific authors. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Before',
 				name: 'before',
 				type: 'dateTime',
 				default: '',
-				description: 'Limit response to posts published before a given ISO8601 compliant date',
-			},
-			{
-				displayName: 'Category Names or IDs',
-				name: 'categories',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				description:
-					'Limit result set to all items that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				description: 'Limit response to pages published before a given ISO8601 compliant date',
 			},
 			{
 				displayName: 'Context',
@@ -759,28 +668,11 @@ export const postFields: INodeProperties[] = [
 				description: 'Scope under which the request is made; determines fields present in response',
 			},
 			{
-				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-multi-options
-				displayName: 'Exclude Categories',
-				name: 'excludedCategories',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getCategories',
-				},
-				description:
-					'Limit result set to all items except those that have the specified term assigned in the categories taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
-			},
-			{
-				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-wrong-for-dynamic-multi-options
-				displayName: 'Exclude Tags',
-				name: 'excludedTags',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				description:
-					'Limit result set to all items except those that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				displayName: 'Menu Order',
+				name: 'menuOrder',
+				type: 'number',
+				default: 0,
+				description: 'Limit result set to items with a specific menu order value',
 			},
 			{
 				displayName: 'Order',
@@ -849,6 +741,20 @@ export const postFields: INodeProperties[] = [
 				description: 'Sort collection by object attribute',
 			},
 			{
+				displayName: 'Page',
+				name: 'page',
+				type: 'number',
+				default: 1,
+				description: 'Current page of the collection',
+			},
+			{
+				displayName: 'Parent Page ID',
+				name: 'parent',
+				type: 'number',
+				default: '',
+				description: 'Limit result set to items with a particular parent page ID',
+			},
+			{
 				displayName: 'Search',
 				name: 'search',
 				type: 'string',
@@ -882,40 +788,22 @@ export const postFields: INodeProperties[] = [
 					},
 				],
 				default: 'publish',
-				description: 'The status of the post',
-			},
-			{
-				displayName: 'Sticky',
-				name: 'sticky',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to limit the result set to items that are sticky',
-			},
-			{
-				displayName: 'Tag Names or IDs',
-				name: 'tags',
-				type: 'multiOptions',
-				default: [],
-				typeOptions: {
-					loadOptionsMethod: 'getTags',
-				},
-				description:
-					'Limit result set to all items that have the specified term assigned in the tags taxonomy. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+				description: 'The status of the page',
 			},
 		],
 	},
 	/* -------------------------------------------------------------------------- */
-	/*                                 post:delete                                */
+	/*                                 page:delete                                */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Post ID',
-		name: 'postId',
+		displayName: 'Page ID',
+		name: 'pageId',
 		type: 'string',
 		required: true,
 		default: '',
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['delete'],
 			},
 		},
@@ -929,7 +817,7 @@ export const postFields: INodeProperties[] = [
 		default: {},
 		displayOptions: {
 			show: {
-				resource: ['post'],
+				resource: ['page'],
 				operation: ['delete'],
 			},
 		},

--- a/packages/nodes-base/nodes/Wordpress/PageInterface.ts
+++ b/packages/nodes-base/nodes/Wordpress/PageInterface.ts
@@ -1,0 +1,16 @@
+export interface IPage {
+	author?: number;
+	comment_status?: string;
+	content?: string;
+	featured_media?: number;
+	id?: number;
+	menu_order?: number;
+	page?: number;
+	parent?: number;
+	password?: string;
+	ping_status?: string;
+	slug?: string;
+	status?: string;
+	template?: string;
+	title?: string;
+}

--- a/packages/nodes-base/nodes/Wordpress/UserDescription.ts
+++ b/packages/nodes-base/nodes/Wordpress/UserDescription.ts
@@ -18,11 +18,6 @@ export const userOperations: INodeProperties[] = [
 				description: 'Create a user',
 				action: 'Create a user',
 			},
-			// {
-			// 	name: 'Delete',
-			// 	value: 'delete',
-			// 	description: 'Delete a user',
-			// },
 			{
 				name: 'Get',
 				value: 'get',

--- a/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
+++ b/packages/nodes-base/nodes/Wordpress/Wordpress.node.ts
@@ -9,8 +9,11 @@ import type {
 } from 'n8n-workflow';
 import { wordpressApiRequest, wordpressApiRequestAllItems } from './GenericFunctions';
 import { postFields, postOperations } from './PostDescription';
+import { pageFields, pageOperations } from './PageDescription';
 import { userFields, userOperations } from './UserDescription';
+
 import type { IPost } from './PostInterface';
+import type { IPage } from './PageInterface';
 import type { IUser } from './UserInterface';
 
 export class Wordpress implements INodeType {
@@ -45,6 +48,10 @@ export class Wordpress implements INodeType {
 						value: 'post',
 					},
 					{
+						name: 'Page',
+						value: 'page',
+					},
+					{
 						name: 'User',
 						value: 'user',
 					},
@@ -53,6 +60,8 @@ export class Wordpress implements INodeType {
 			},
 			...postOperations,
 			...postFields,
+			...pageOperations,
+			...pageFields,
 			...userOperations,
 			...userFields,
 		],
@@ -300,6 +309,171 @@ export class Wordpress implements INodeType {
 							this,
 							'DELETE',
 							`/posts/${postId}`,
+							{},
+							qs,
+						);
+					}
+				}
+				if (resource === 'page') {
+					//https://developer.wordpress.org/rest-api/reference/pages/#create-a-page
+					if (operation === 'create') {
+						const title = this.getNodeParameter('title', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const body: IPage = {
+							title,
+						};
+						if (additionalFields.authorId) {
+							body.author = additionalFields.authorId as number;
+						}
+						if (additionalFields.content) {
+							body.content = additionalFields.content as string;
+						}
+						if (additionalFields.slug) {
+							body.slug = additionalFields.slug as string;
+						}
+						if (additionalFields.password) {
+							body.password = additionalFields.password as string;
+						}
+						if (additionalFields.status) {
+							body.status = additionalFields.status as string;
+						}
+						if (additionalFields.commentStatus) {
+							body.comment_status = additionalFields.commentStatus as string;
+						}
+						if (additionalFields.pingStatus) {
+							body.ping_status = additionalFields.pingStatus as string;
+						}
+						if (additionalFields.pageTemplate) {
+							body.template = this.getNodeParameter(
+								'additionalFields.pageTemplate.values.template',
+								i,
+								'',
+							) as string;
+						}
+						if (additionalFields.menuOrder) {
+							body.menu_order = additionalFields.menuOrder as number;
+						}
+						if (additionalFields.parent) {
+							body.parent = additionalFields.parent as number;
+						}
+						if (additionalFields.featuredMediaId) {
+							body.featured_media = additionalFields.featuredMediaId as number;
+						}
+						responseData = await wordpressApiRequest.call(this, 'POST', '/pages', body);
+					}
+					//https://developer.wordpress.org/rest-api/reference/pages/#update-a-page
+					if (operation === 'update') {
+						const pageId = this.getNodeParameter('pageId', i) as string;
+						const updateFields = this.getNodeParameter('updateFields', i);
+						const body: IPage = {
+							id: parseInt(pageId, 10),
+						};
+						if (updateFields.authorId) {
+							body.author = updateFields.authorId as number;
+						}
+						if (updateFields.title) {
+							body.title = updateFields.title as string;
+						}
+						if (updateFields.content) {
+							body.content = updateFields.content as string;
+						}
+						if (updateFields.slug) {
+							body.slug = updateFields.slug as string;
+						}
+						if (updateFields.password) {
+							body.password = updateFields.password as string;
+						}
+						if (updateFields.status) {
+							body.status = updateFields.status as string;
+						}
+						if (updateFields.commentStatus) {
+							body.comment_status = updateFields.commentStatus as string;
+						}
+						if (updateFields.pingStatus) {
+							body.ping_status = updateFields.pingStatus as string;
+						}
+						if (updateFields.pageTemplate) {
+							body.template = this.getNodeParameter(
+								'updateFields.pageTemplate.values.template',
+								i,
+								'',
+							) as string;
+						}
+						if (updateFields.menuOrder) {
+							body.menu_order = updateFields.menuOrder as number;
+						}
+						if (updateFields.parent) {
+							body.parent = updateFields.parent as number;
+						}
+						if (updateFields.featuredMediaId) {
+							body.featured_media = updateFields.featuredMediaId as number;
+						}
+						responseData = await wordpressApiRequest.call(this, 'POST', `/pages/${pageId}`, body);
+					}
+					//https://developer.wordpress.org/rest-api/reference/pages/#retrieve-a-page
+					if (operation === 'get') {
+						const pageId = this.getNodeParameter('pageId', i) as string;
+						const options = this.getNodeParameter('options', i);
+						if (options.password) {
+							qs.password = options.password as string;
+						}
+						if (options.context) {
+							qs.context = options.context as string;
+						}
+						responseData = await wordpressApiRequest.call(this, 'GET', `/pages/${pageId}`, {}, qs);
+					}
+					//https://developer.wordpress.org/rest-api/reference/pages/#list-pages
+					if (operation === 'getAll') {
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i);
+						if (options.context) {
+							qs.context = options.context as string;
+						}
+						if (options.orderBy) {
+							qs.orderby = options.orderBy as string;
+						}
+						if (options.order) {
+							qs.order = options.order as string;
+						}
+						if (options.search) {
+							qs.search = options.search as string;
+						}
+						if (options.after) {
+							qs.after = options.after as string;
+						}
+						if (options.author) {
+							qs.author = options.author as number[];
+						}
+						if (options.parent) {
+							qs.parent = options.parent as number;
+						}
+						if (options.menuOrder) {
+							qs.menu_order = options.menuOrder as number;
+						}
+						if (options.status) {
+							qs.status = options.status as string;
+						}
+						if (options.page) {
+							qs.page = options.page as number;
+						}
+						if (returnAll) {
+							responseData = await wordpressApiRequestAllItems.call(this, 'GET', '/pages', {}, qs);
+						} else {
+							qs.per_page = this.getNodeParameter('limit', i);
+							responseData = await wordpressApiRequest.call(this, 'GET', '/pages', {}, qs);
+						}
+					}
+					//https://developer.wordpress.org/rest-api/reference/pages/#delete-a-page
+					if (operation === 'delete') {
+						const pageId = this.getNodeParameter('pageId', i) as string;
+						const options = this.getNodeParameter('options', i);
+						if (options.force) {
+							qs.force = options.force as boolean;
+						}
+						responseData = await wordpressApiRequest.call(
+							this,
+							'DELETE',
+							`/pages/${pageId}`,
 							{},
 							qs,
 						);


### PR DESCRIPTION
## Summary
Adds support for the [WordPress pages API endpoint](https://developer.wordpress.org/rest-api/reference/pages/) to the WordPress node.

<img width="734" alt="Screenshot 2024-03-08 at 1 56 09 PM" src="https://github.com/n8n-io/n8n/assets/16154655/ae3c15a7-e8d6-47d0-a3af-7090787f8036">
<img width="1505" alt="Screenshot 2024-03-08 at 1 56 02 PM" src="https://github.com/n8n-io/n8n/assets/16154655/524a67c1-5c35-491c-8755-c237939ffed0">


## Related tickets and issues
https://community.n8n.io/t/need-more-api-for-wordpress-node/7520



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 