### PR TITLE
fix(editor): Do not throw an error when calculating dynamic inputs/outputs (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -285,6 +285,7 @@ export class Agent implements INodeType {
 				name: 'hasOutputParser',
 				type: 'boolean',
 				default: false,
+				noDataExpression: true,
 				displayOptions: {
 					hide: {
 						'@version': [{ _cnd: { lte: 1.2 } }],

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -343,6 +343,7 @@ export class ChainLlm implements INodeType {
 				name: 'hasOutputParser',
 				type: 'boolean',
 				default: false,
+				noDataExpression: true,
 				displayOptions: {
 					hide: {
 						'@version': [1, 1.1, 1.3],

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -1104,9 +1104,8 @@ export function getNodeInputs(
 			{},
 		) || []) as ConnectionTypes[];
 	} catch (e) {
-		throw new ApplicationError('Could not calculate inputs dynamically for node', {
-			extra: { nodeName: node.name },
-		});
+		console.warn('Could not calculate inputs dynamically for node: ', node.name);
+		return [];
 	}
 }
 
@@ -1129,9 +1128,7 @@ export function getNodeOutputs(
 				{},
 			) || []) as ConnectionTypes[];
 		} catch (e) {
-			throw new ApplicationError('Could not calculate outputs dynamically for node', {
-				extra: { nodeName: node.name },
-			});
+			console.warn('Could not calculate outputs dynamically for node: ', node.name);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Disable data expression for `hasOutputParsers` parameters of Basic LLM Chain & Agent
- Show console warning instead of throwing an error when dynamic inputs/outputs couldn't be computed. 


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://linear.app/n8n/issue/AI-129/ui-breaks-when-using-llm-chain-with-expression
- https://linear.app/n8n/issue/AI-136/workflow-crash-when-copy-pasting-node-with-pinned-data-and-dynamic

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 