### PR TITLE
feat(Telegram Node): Add editMessageCaption action

### DIFF
--- a/packages/editor-ui/src/utils/testData/nodeTypeTestData.ts
+++ b/packages/editor-ui/src/utils/testData/nodeTypeTestData.ts
@@ -1919,6 +1919,12 @@ export const nodeTypeTelegramV1 = {
 					action: 'Delete a chat message',
 				},
 				{
+					name: 'Edit Message Caption',
+					value: 'editMessageCaption',
+					description: 'Edit a caption of message',
+					action: 'Edit a caption of test message',
+				},
+				{
 					name: 'Edit Message Text',
 					value: 'editMessageText',
 					description: 'Edit a text message',
@@ -2231,7 +2237,9 @@ export const nodeTypeTelegramV1 = {
 			displayName: 'Message Type',
 			name: 'messageType',
 			type: 'options',
-			displayOptions: { show: { operation: ['editMessageText'], resource: ['message'] } },
+			displayOptions: {
+				show: { operation: ['editMessageText', 'editMessageCaption'], resource: ['message'] },
+			},
 			options: [
 				{ name: 'Inline Message', value: 'inlineMessage' },
 				{ name: 'Message', value: 'message' },
@@ -2245,7 +2253,11 @@ export const nodeTypeTelegramV1 = {
 			type: 'string',
 			default: '',
 			displayOptions: {
-				show: { messageType: ['message'], operation: ['editMessageText'], resource: ['message'] },
+				show: {
+					messageType: ['message'],
+					operation: ['editMessageText', 'editMessageCaption'],
+					resource: ['message'],
+				},
 			},
 			required: true,
 			description:
@@ -2301,7 +2313,11 @@ export const nodeTypeTelegramV1 = {
 			type: 'string',
 			default: '',
 			displayOptions: {
-				show: { messageType: ['message'], operation: ['editMessageText'], resource: ['message'] },
+				show: {
+					messageType: ['message'],
+					operation: ['editMessageText', 'editMessageCaption'],
+					resource: ['message'],
+				},
 			},
 			required: true,
 			description: 'Unique identifier of the message to edit',
@@ -2314,7 +2330,7 @@ export const nodeTypeTelegramV1 = {
 			displayOptions: {
 				show: {
 					messageType: ['inlineMessage'],
-					operation: ['editMessageText'],
+					operation: ['editMessageText', 'editMessageCaption'],
 					resource: ['message'],
 				},
 			},
@@ -2324,7 +2340,9 @@ export const nodeTypeTelegramV1 = {
 		{
 			displayName: 'Reply Markup',
 			name: 'replyMarkup',
-			displayOptions: { show: { operation: ['editMessageText'], resource: ['message'] } },
+			displayOptions: {
+				show: { operation: ['editMessageText', 'editMessageCaption'], resource: ['message'] },
+			},
 			type: 'options',
 			options: [
 				{ name: 'None', value: 'none' },
@@ -2520,6 +2538,7 @@ export const nodeTypeTelegramV1 = {
 			displayOptions: {
 				show: {
 					operation: [
+						'editMessageCaption',
 						'sendAnimation',
 						'sendDocument',
 						'sendMessage',
@@ -2788,6 +2807,7 @@ export const nodeTypeTelegramV1 = {
 			displayOptions: {
 				show: {
 					operation: [
+						'editMessageCaption',
 						'editMessageText',
 						'sendAnimation',
 						'sendAudio',
@@ -2820,6 +2840,7 @@ export const nodeTypeTelegramV1 = {
 					displayOptions: {
 						show: {
 							'/operation': [
+								'editMessageCaption',
 								'sendAnimation',
 								'sendAudio',
 								'sendDocument',
@@ -2836,7 +2857,7 @@ export const nodeTypeTelegramV1 = {
 					name: 'disable_notification',
 					type: 'boolean',
 					default: false,
-					displayOptions: { hide: { '/operation': ['editMessageText'] } },
+					displayOptions: { hide: { '/operation': ['editMessageText', 'editMessageCaption'] } },
 					description:
 						'Whether to send the message silently. Users will receive a notification with no sound.',
 				},
@@ -2899,6 +2920,7 @@ export const nodeTypeTelegramV1 = {
 					displayOptions: {
 						show: {
 							'/operation': [
+								'editMessageCaption',
 								'editMessageText',
 								'sendAnimation',
 								'sendAudio',
@@ -2924,7 +2946,7 @@ export const nodeTypeTelegramV1 = {
 					displayName: 'Reply To Message ID',
 					name: 'reply_to_message_id',
 					type: 'number',
-					displayOptions: { hide: { '/operation': ['editMessageText'] } },
+					displayOptions: { hide: { '/operation': ['editMessageText', 'editMessageCaption'] } },
 					default: 0,
 					description: 'If the message is a reply, ID of the original message',
 				},
@@ -3110,6 +3132,12 @@ export const nodeTypeTelegramV1_1 = {
 					action: 'Delete a chat message',
 				},
 				{
+					name: 'Edit Message Caption',
+					value: 'editMessageCaption',
+					description: 'Edit a caption of message',
+					action: 'Edit a caption of test message',
+				},
+				{
 					name: 'Edit Message Text',
 					value: 'editMessageText',
 					description: 'Edit a text message',
@@ -3422,7 +3450,9 @@ export const nodeTypeTelegramV1_1 = {
 			displayName: 'Message Type',
 			name: 'messageType',
 			type: 'options',
-			displayOptions: { show: { operation: ['editMessageText'], resource: ['message'] } },
+			displayOptions: {
+				show: { operation: ['editMessageText', 'editMessageCaption'], resource: ['message'] },
+			},
 			options: [
 				{ name: 'Inline Message', value: 'inlineMessage' },
 				{ name: 'Message', value: 'message' },
@@ -3436,7 +3466,11 @@ export const nodeTypeTelegramV1_1 = {
 			type: 'string',
 			default: '',
 			displayOptions: {
-				show: { messageType: ['message'], operation: ['editMessageText'], resource: ['message'] },
+				show: {
+					messageType: ['message'],
+					operation: ['editMessageText', 'editMessageCaption'],
+					resource: ['message'],
+				},
 			},
 			required: true,
 			description:
@@ -3492,7 +3526,11 @@ export const nodeTypeTelegramV1_1 = {
 			type: 'string',
 			default: '',
 			displayOptions: {
-				show: { messageType: ['message'], operation: ['editMessageText'], resource: ['message'] },
+				show: {
+					messageType: ['message'],
+					operation: ['editMessageText', 'editMessageCaption'],
+					resource: ['message'],
+				},
 			},
 			required: true,
 			description: 'Unique identifier of the message to edit',
@@ -3505,7 +3543,7 @@ export const nodeTypeTelegramV1_1 = {
 			displayOptions: {
 				show: {
 					messageType: ['inlineMessage'],
-					operation: ['editMessageText'],
+					operation: ['editMessageText', 'editMessageCaption'],
 					resource: ['message'],
 				},
 			},
@@ -3515,7 +3553,9 @@ export const nodeTypeTelegramV1_1 = {
 		{
 			displayName: 'Reply Markup',
 			name: 'replyMarkup',
-			displayOptions: { show: { operation: ['editMessageText'], resource: ['message'] } },
+			displayOptions: {
+				show: { operation: ['editMessageText', 'editMessageCaption'], resource: ['message'] },
+			},
 			type: 'options',
 			options: [
 				{ name: 'None', value: 'none' },
@@ -3711,6 +3751,7 @@ export const nodeTypeTelegramV1_1 = {
 			displayOptions: {
 				show: {
 					operation: [
+						'editMessageCaption',
 						'sendAnimation',
 						'sendDocument',
 						'sendMessage',
@@ -3979,6 +4020,7 @@ export const nodeTypeTelegramV1_1 = {
 			displayOptions: {
 				show: {
 					operation: [
+						'editMessageCaption',
 						'editMessageText',
 						'sendAnimation',
 						'sendAudio',
@@ -4011,6 +4053,7 @@ export const nodeTypeTelegramV1_1 = {
 					displayOptions: {
 						show: {
 							'/operation': [
+								'editMessageCaption',
 								'sendAnimation',
 								'sendAudio',
 								'sendDocument',
@@ -4027,7 +4070,7 @@ export const nodeTypeTelegramV1_1 = {
 					name: 'disable_notification',
 					type: 'boolean',
 					default: false,
-					displayOptions: { hide: { '/operation': ['editMessageText'] } },
+					displayOptions: { hide: { '/operation': ['editMessageText', 'editMessageCaption'] } },
 					description:
 						'Whether to send the message silently. Users will receive a notification with no sound.',
 				},
@@ -4090,6 +4133,7 @@ export const nodeTypeTelegramV1_1 = {
 					displayOptions: {
 						show: {
 							'/operation': [
+								'editMessageCaption',
 								'editMessageText',
 								'sendAnimation',
 								'sendAudio',
@@ -4115,7 +4159,7 @@ export const nodeTypeTelegramV1_1 = {
 					displayName: 'Reply To Message ID',
 					name: 'reply_to_message_id',
 					type: 'number',
-					displayOptions: { hide: { '/operation': ['editMessageText'] } },
+					displayOptions: { hide: { '/operation': ['editMessageText', 'editMessageCaption'] } },
 					default: 0,
 					description: 'If the message is a reply, ID of the original message',
 				},

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -211,8 +211,8 @@ export class Telegram implements INodeType {
 					{
 						name: 'Edit Message Caption',
 						value: 'editMessageCaption',
-						description: 'Edit a caption of message',
-						action: 'Edit a caption of test message',
+						description: 'Edit the caption of a message',
+						action: 'Edit the caption of a message',
 					},
 					{
 						name: 'Edit Message Text',

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -209,6 +209,12 @@ export class Telegram implements INodeType {
 						action: 'Delete a chat message',
 					},
 					{
+						name: 'Edit Message Caption',
+						value: 'editMessageCaption',
+						description: 'Edit a caption of message',
+						action: 'Edit a caption of test message',
+					},
+					{
 						name: 'Edit Message Text',
 						value: 'editMessageText',
 						description: 'Edit a text message',
@@ -641,7 +647,7 @@ export class Telegram implements INodeType {
 			// ----------------------------------
 
 			// ----------------------------------
-			//         message:editMessageText
+			//         message:editMessageText/editMessageCaption
 			// ----------------------------------
 
 			{
@@ -650,7 +656,7 @@ export class Telegram implements INodeType {
 				type: 'options',
 				displayOptions: {
 					show: {
-						operation: ['editMessageText'],
+						operation: ['editMessageText', 'editMessageCaption'],
 						resource: ['message'],
 					},
 				},
@@ -676,7 +682,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						messageType: ['message'],
-						operation: ['editMessageText'],
+						operation: ['editMessageText', 'editMessageCaption'],
 						resource: ['message'],
 					},
 				},
@@ -741,7 +747,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						messageType: ['message'],
-						operation: ['editMessageText'],
+						operation: ['editMessageText', 'editMessageCaption'],
 						resource: ['message'],
 					},
 				},
@@ -756,7 +762,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						messageType: ['inlineMessage'],
-						operation: ['editMessageText'],
+						operation: ['editMessageText', 'editMessageCaption'],
 						resource: ['message'],
 					},
 				},
@@ -1122,7 +1128,7 @@ export class Telegram implements INodeType {
 			},
 
 			// ----------------------------------
-			//         message:editMessageText/sendAnimation/sendAudio/sendLocation/sendMessage/sendPhoto/sendSticker/sendVideo
+			//         message:editMessageCaption/editMessageText/sendAnimation/sendAudio/sendLocation/sendMessage/sendPhoto/sendSticker/sendVideo
 			// ----------------------------------
 
 			{
@@ -1131,6 +1137,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						operation: [
+							'editMessageCaption',
 							'sendAnimation',
 							'sendDocument',
 							'sendMessage',
@@ -1451,6 +1458,7 @@ export class Telegram implements INodeType {
 				displayOptions: {
 					show: {
 						operation: [
+							'editMessageCaption',
 							'editMessageText',
 							'sendAnimation',
 							'sendAudio',
@@ -1488,6 +1496,7 @@ export class Telegram implements INodeType {
 						displayOptions: {
 							show: {
 								'/operation': [
+									'editMessageCaption',
 									'sendAnimation',
 									'sendAudio',
 									'sendDocument',
@@ -1506,7 +1515,7 @@ export class Telegram implements INodeType {
 						default: false,
 						displayOptions: {
 							hide: {
-								'/operation': ['editMessageText'],
+								'/operation': ['editMessageText', 'editMessageCaption'],
 							},
 						},
 						description:
@@ -1596,6 +1605,7 @@ export class Telegram implements INodeType {
 						displayOptions: {
 							show: {
 								'/operation': [
+									'editMessageCaption',
 									'editMessageText',
 									'sendAnimation',
 									'sendAudio',
@@ -1627,7 +1637,7 @@ export class Telegram implements INodeType {
 						type: 'number',
 						displayOptions: {
 							hide: {
-								'/operation': ['editMessageText'],
+								'/operation': ['editMessageText', 'editMessageCaption'],
 							},
 						},
 						default: 0,
@@ -1823,7 +1833,25 @@ export class Telegram implements INodeType {
 						body.file_id = this.getNodeParameter('fileId', i) as string;
 					}
 				} else if (resource === 'message') {
-					if (operation === 'editMessageText') {
+					if (operation === 'editMessageCaption') {
+						// ----------------------------------
+						//         message:editMessageCaption
+						// ----------------------------------
+
+						endpoint = 'editMessageCaption';
+
+						const messageType = this.getNodeParameter('messageType', i) as string;
+
+						if (messageType === 'inlineMessage') {
+							body.inline_message_id = this.getNodeParameter('inlineMessageId', i) as string;
+						} else {
+							body.chat_id = this.getNodeParameter('chatId', i) as string;
+							body.message_id = this.getNodeParameter('messageId', i) as string;
+						}
+
+						// Add additional fields and replyMarkup
+						addAdditionalFields.call(this, body, i);
+					} else if (operation === 'editMessageText') {
 						// ----------------------------------
 						//         message:editMessageText
 						// ----------------------------------


### PR DESCRIPTION
## Summary
> PR adds a telegram action for [editMessageCaption](https://core.telegram.org/bots/api#editmessagecaption) method.
<img width="658" alt="image" src="https://github.com/n8n-io/n8n/assets/121220673/96fe10a3-f870-4ad6-a8b6-fa63f930b955">





## Related tickets and issues
> https://community.n8n.io/t/telegram-edit-message-caption/10669



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created -> https://github.com/n8n-io/n8n-docs/pull/1964