### PR TITLE
fix(core): Ignore semver range when upgrading comunity packages

### DIFF
--- a/packages/cli/src/services/communityPackages.service.ts
+++ b/packages/cli/src/services/communityPackages.service.ts
@@ -320,7 +320,7 @@ export class CommunityPackagesService {
 	) {
 		const isUpdate = 'installedPackage' in options;
 		const command = isUpdate
-			? `npm update ${packageName}`
+			? `npm install ${packageName}@latest`
 			: `npm install ${packageName}${options.version ? `@${options.version}` : ''}`;
 
 		try {


### PR DESCRIPTION
## Summary

Before this community packages could only be updated within the semver range that was created when they were initially installed.

E.g. if you install `1.1.0`, this would create a package.json with the semver range of `^1.1.0` and thus allow updating up until, but not to, `2.0.0`.
For versions below `1.0.0` this is even more restrictive, e.g. not allowing update to the next minor, but only to the next patch release.

With this PR we install the latest version of the package, which is also the version that is shown in the UI when the user updates.

https://github.com/n8n-io/n8n/blob/78aa00133493af03f9b54fcfb5725b5f04c10e2a/packages/cli/src/services/communityPackages.service.ts#L177-L179

![image](https://github.com/n8n-io/n8n/assets/927609/3da20023-0c22-42f9-887c-1ecb93ccb567)


## Related tickets and issues

https://linear.app/n8n/issue/PAY-1424/community-nodes-cant-update
https://community.n8n.io/t/ommunity-node-version-is-not-updating/41742

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

