### PR TITLE
fix(core): Update xml2js to address CVE-2023-0842 (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,10 +88,7 @@
       "semver": "^7.5.4",
       "tslib": "^2.6.1",
       "tsconfig-paths": "^4.2.0",
-      "typescript": "^5.3.0",
-      "xml2js": "^0.5.0",
-      "cpy@8>globby": "^11.1.0",
-      "qqjs>globby": "^11.1.0"
+      "typescript": "^5.3.0"
     },
     "patchedDependencies": {
       "typedi@0.10.0": "patches/typedi@0.10.0.patch",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -149,7 +149,7 @@
     "basic-auth": "2.0.1",
     "cohere-ai": "6.2.2",
     "d3-dsv": "2.0.0",
-    "epub2": "3.0.1",
+    "epub2": "3.0.2",
     "form-data": "4.0.0",
     "html-to-text": "9.0.5",
     "json-schema-to-zod": "2.0.14",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,7 +82,7 @@
     "@types/uuid": "^8.3.2",
     "@types/validator": "^13.7.0",
     "@types/ws": "^8.5.4",
-    "@types/xml2js": "^0.4.11",
+    "@types/xml2js": "^0.4.14",
     "@types/yamljs": "^0.2.31",
     "chokidar": "^3.5.2",
     "concurrently": "^8.2.0",
@@ -178,7 +178,7 @@
     "validator": "13.7.0",
     "winston": "3.8.2",
     "ws": "8.14.2",
-    "xml2js": "0.5.0",
+    "xml2js": "0.6.2",
     "xmllint-wasm": "3.0.1",
     "yamljs": "0.3.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@types/lodash": "^4.14.195",
     "@types/mime-types": "^2.1.0",
     "@types/uuid": "^8.3.2",
-    "@types/xml2js": "^0.4.11"
+    "@types/xml2js": "^0.4.14"
   },
   "peerDependencies": {
     "n8n-nodes-base": "workspace:*"
@@ -65,6 +65,6 @@
     "qs": "6.11.0",
     "typedi": "0.10.0",
     "uuid": "8.3.2",
-    "xml2js": "0.5.0"
+    "xml2js": "0.6.2"
   }
 }

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -825,7 +825,7 @@
     "@types/ssh2-sftp-client": "^5.1.0",
     "@types/tmp": "^0.2.0",
     "@types/uuid": "^8.3.2",
-    "@types/xml2js": "^0.4.11",
+    "@types/xml2js": "^0.4.14",
     "eslint-plugin-n8n-nodes-base": "^1.16.0",
     "gulp": "^4.0.0",
     "n8n-core": "workspace:*"
@@ -883,7 +883,7 @@
     "rfc2047": "4.0.1",
     "rhea": "1.0.24",
     "rrule": "^2.8.1",
-    "rss-parser": "3.12.0",
+    "rss-parser": "3.13.0",
     "semver": "7.5.4",
     "showdown": "2.1.0",
     "simple-git": "3.17.0",
@@ -894,6 +894,6 @@
     "typedi": "0.10.0",
     "uuid": "8.3.2",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz",
-    "xml2js": "0.5.0"
+    "xml2js": "0.6.2"
   }
 }

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -45,7 +45,7 @@
     "@types/lodash": "^4.14.195",
     "@types/luxon": "^3.2.0",
     "@types/md5": "^2.3.5",
-    "@types/xml2js": "^0.4.11"
+    "@types/xml2js": "^0.4.14"
   },
   "dependencies": {
     "@n8n/tournament": "1.0.2",
@@ -65,6 +65,6 @@
     "recast": "0.21.5",
     "title-case": "3.0.3",
     "transliteration": "2.3.5",
-    "xml2js": "0.5.0"
+    "xml2js": "0.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ overrides:
   tslib: ^2.6.1
   tsconfig-paths: ^4.2.0
   typescript: ^5.3.0
-  xml2js: ^0.5.0
-  cpy@8>globby: ^11.1.0
-  qqjs>globby: ^11.1.0
 
 patchedDependencies:
   '@sentry/cli@2.17.0':
@@ -248,8 +245,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       epub2:
-        specifier: 3.0.1
-        version: 3.0.1(ts-toolbelt@9.6.0)
+        specifier: 3.0.2
+        version: 3.0.2(ts-toolbelt@9.6.0)
       form-data:
         specifier: 4.0.0
         version: 4.0.0
@@ -261,7 +258,7 @@ importers:
         version: 2.0.14
       langchain:
         specifier: 0.1.25
-        version: 0.1.25(@aws-sdk/client-bedrock-runtime@3.454.0)(@aws-sdk/credential-provider-node@3.451.0)(@getzep/zep-js@0.9.0)(@google-ai/generativelanguage@0.2.1)(@huggingface/inference@2.6.4)(@pinecone-database/pinecone@2.1.0)(@qdrant/js-client-rest@1.7.0)(@supabase/supabase-js@2.38.5)(@xata.io/client@0.28.0)(cohere-ai@6.2.2)(d3-dsv@2.0.0)(epub2@3.0.1)(html-to-text@9.0.5)(lodash@4.17.21)(mammoth@1.6.0)(pdf-parse@1.1.1)(pg@8.11.3)(redis@4.6.12)
+        version: 0.1.25(@aws-sdk/client-bedrock-runtime@3.454.0)(@aws-sdk/credential-provider-node@3.451.0)(@getzep/zep-js@0.9.0)(@google-ai/generativelanguage@0.2.1)(@huggingface/inference@2.6.4)(@pinecone-database/pinecone@2.1.0)(@qdrant/js-client-rest@1.7.0)(@supabase/supabase-js@2.38.5)(@xata.io/client@0.28.0)(cohere-ai@6.2.2)(d3-dsv@2.0.0)(epub2@3.0.2)(html-to-text@9.0.5)(lodash@4.17.21)(mammoth@1.6.0)(pdf-parse@1.1.1)(pg@8.11.3)(redis@4.6.12)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -689,8 +686,8 @@ importers:
         specifier: 8.14.2
         version: 8.14.2
       xml2js:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: 0.6.2
+        version: 0.6.2
       xmllint-wasm:
         specifier: 3.0.1
         version: 3.0.1
@@ -765,8 +762,8 @@ importers:
         specifier: ^8.5.4
         version: 8.5.4(patch_hash=nbzuqaoyqbrfwipijj5qriqqju)
       '@types/xml2js':
-        specifier: ^0.4.11
-        version: 0.4.11
+        specifier: ^0.4.14
+        version: 0.4.14
       '@types/yamljs':
         specifier: ^0.2.31
         version: 0.2.31
@@ -843,8 +840,8 @@ importers:
         specifier: 8.3.2
         version: 8.3.2
       xml2js:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: 0.6.2
+        version: 0.6.2
     devDependencies:
       '@types/aws4':
         specifier: ^1.5.1
@@ -868,8 +865,8 @@ importers:
         specifier: ^8.3.2
         version: 8.3.4
       '@types/xml2js':
-        specifier: ^0.4.11
-        version: 0.4.11
+        specifier: ^0.4.14
+        version: 0.4.14
 
   packages/design-system:
     dependencies:
@@ -1375,8 +1372,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       rss-parser:
-        specifier: 3.12.0
-        version: 3.12.0
+        specifier: 3.13.0
+        version: 3.13.0
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -1408,8 +1405,8 @@ importers:
         specifier: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz
         version: '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz'
       xml2js:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: 0.6.2
+        version: 0.6.2
     devDependencies:
       '@types/amqplib':
         specifier: ^0.10.1
@@ -1490,8 +1487,8 @@ importers:
         specifier: ^8.3.2
         version: 8.3.4
       '@types/xml2js':
-        specifier: ^0.4.11
-        version: 0.4.11
+        specifier: ^0.4.14
+        version: 0.4.14
       eslint-plugin-n8n-nodes-base:
         specifier: ^1.16.0
         version: 1.16.0(eslint@8.54.0)(typescript@5.3.2)
@@ -1556,8 +1553,8 @@ importers:
         specifier: 2.3.5
         version: 2.3.5
       xml2js:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: 0.6.2
+        version: 0.6.2
     devDependencies:
       '@types/deep-equal':
         specifier: ^1.0.1
@@ -1578,8 +1575,8 @@ importers:
         specifier: ^2.3.5
         version: 2.3.5
       '@types/xml2js':
-        specifier: ^0.4.11
-        version: 0.4.11
+        specifier: ^0.4.14
+        version: 0.4.14
 
 packages:
 
@@ -9919,8 +9916,8 @@ packages:
     dev: true
     patched: true
 
-  /@types/xml2js@0.4.11:
-    resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
+  /@types/xml2js@0.4.14:
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
     dependencies:
       '@types/node': 18.16.16
     dev: true
@@ -13907,15 +13904,15 @@ packages:
     hasBin: true
     dev: true
 
-  /epub2@3.0.1(ts-toolbelt@9.6.0):
-    resolution: {integrity: sha512-qwAPzDvcfKOZza1FU38BHo7qyiHMZXpJKVkdLK7I+wHi4nUhIhh+6qQbOGxPdiPaqAuI985d/nIUuJmbZ1ACrA==}
+  /epub2@3.0.2(ts-toolbelt@9.6.0):
+    resolution: {integrity: sha512-rhvpt27CV5MZfRetfNtdNwi3XcNg1Am0TwfveJkK8YWeHItHepQ8Js9J06v8XRIjuTrCW/NSGYMTy55Of7BfNQ==}
     dependencies:
       adm-zip: 0.5.10
       array-hyper-unique: 2.1.4
       bluebird: 3.7.2
       crlf-normalize: 1.0.19(ts-toolbelt@9.6.0)
       tslib: 2.6.1
-      xml2js: 0.5.0
+      xml2js: 0.6.2
     transitivePeerDependencies:
       - ts-toolbelt
     dev: false
@@ -18134,7 +18131,7 @@ packages:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
 
-  /langchain@0.1.25(@aws-sdk/client-bedrock-runtime@3.454.0)(@aws-sdk/credential-provider-node@3.451.0)(@getzep/zep-js@0.9.0)(@google-ai/generativelanguage@0.2.1)(@huggingface/inference@2.6.4)(@pinecone-database/pinecone@2.1.0)(@qdrant/js-client-rest@1.7.0)(@supabase/supabase-js@2.38.5)(@xata.io/client@0.28.0)(cohere-ai@6.2.2)(d3-dsv@2.0.0)(epub2@3.0.1)(html-to-text@9.0.5)(lodash@4.17.21)(mammoth@1.6.0)(pdf-parse@1.1.1)(pg@8.11.3)(redis@4.6.12):
+  /langchain@0.1.25(@aws-sdk/client-bedrock-runtime@3.454.0)(@aws-sdk/credential-provider-node@3.451.0)(@getzep/zep-js@0.9.0)(@google-ai/generativelanguage@0.2.1)(@huggingface/inference@2.6.4)(@pinecone-database/pinecone@2.1.0)(@qdrant/js-client-rest@1.7.0)(@supabase/supabase-js@2.38.5)(@xata.io/client@0.28.0)(cohere-ai@6.2.2)(d3-dsv@2.0.0)(epub2@3.0.2)(html-to-text@9.0.5)(lodash@4.17.21)(mammoth@1.6.0)(pdf-parse@1.1.1)(pg@8.11.3)(redis@4.6.12):
     resolution: {integrity: sha512-sfEChvr4H2CklHdSByNBbytwBrFhgtA5kPOnwcBrxuXGg1iOaTzhVxQA0QcNcQucI3hZrsNbZjxGp+Can1ooZQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -18304,7 +18301,7 @@ packages:
       '@xata.io/client': 0.28.0(typescript@5.3.2)
       binary-extensions: 2.2.0
       d3-dsv: 2.0.0
-      epub2: 3.0.1(ts-toolbelt@9.6.0)
+      epub2: 3.0.2(ts-toolbelt@9.6.0)
       expr-eval: 2.0.2
       html-to-text: 9.0.5
       js-tiktoken: 1.0.8
@@ -22807,8 +22804,8 @@ packages:
     resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
     dev: true
 
-  /rss-parser@3.12.0:
-    resolution: {integrity: sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==}
+  /rss-parser@3.13.0:
+    resolution: {integrity: sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==}
     dependencies:
       entities: 2.2.0
       xml2js: 0.5.0
@@ -26251,6 +26248,14 @@ packages:
 
   /xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
     dependencies:
       sax: 1.2.4


### PR DESCRIPTION
In releases (where we don't have version locking), `epub2` version `3.0.1` was pulling in `xml2js` version `0.4.23`, which marks our npm and docker releases as vulnerable to CVE-2023-0842

N8N-7261

## Review / Merge checklist
- [x] PR title and summary are descriptive