### PR TITLE
fix(editor): Add proper scroll to Environments push modal

### DIFF
--- a/packages/editor-ui/src/components/SourceControlPushModal.ee.vue
+++ b/packages/editor-ui/src/components/SourceControlPushModal.ee.vue
@@ -235,6 +235,7 @@ async function commitAndPush() {
 		:title="i18n.baseText('settings.sourceControl.modals.push.title')"
 		:event-bus="data.eventBus"
 		:name="SOURCE_CONTROL_PUSH_MODAL_KEY"
+		max-height="80%"
 	>
 		<template #content>
 			<div :class="$style.container">


### PR DESCRIPTION
## Summary
A simple style change that makes the push modal display proper scrollbars when the number of workflows being pushed is large.



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1444/bug-enterprise-list-of-push-requests-to-workflow-is-cut-off-at-top-of
https://linear.app/n8n/issue/PAY-477/commit-and-push-changes-modal-height-and-structure


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))