### PR TITLE
fix(editor): Improve expression editor performance by removing watcher

### DIFF
--- a/packages/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -41,7 +41,6 @@ import { highlighter } from '@/plugins/codemirror/resolvableHighlighter';
 import { codeNodeEditorTheme } from '../CodeNodeEditor/theme';
 import type { Range, Section } from './types';
 import { nonTakenRanges } from './utils';
-import { isEqual } from 'lodash-es';
 import {
 	autocompleteKeyMap,
 	enterKeyMap,
@@ -85,16 +84,6 @@ export default defineComponent({
 			editor: null as EditorView | null,
 			editorState: null as EditorState | null,
 		};
-	},
-	watch: {
-		displayableSegments(segments, newSegments) {
-			if (isEqual(segments, newSegments)) return;
-
-			highlighter.removeColor(this.editor, this.plaintextSegments);
-			highlighter.addColor(this.editor, this.resolvableSegments);
-
-			this.$emit('update:modelValue', this.editor?.state.doc.toString());
-		},
 	},
 	computed: {
 		doc(): string {
@@ -144,6 +133,10 @@ export default defineComponent({
 
 					// Force segments value update by keeping track of editor state
 					this.editorState = this.editor.state;
+					highlighter.removeColor(this.editor, this.plaintextSegments);
+					highlighter.addColor(this.editor, this.resolvableSegments);
+
+					this.$emit('update:modelValue', this.editor?.state.doc.toString());
 				}),
 			];
 		},

--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -21,7 +21,6 @@ import {
 } from '@/plugins/codemirror/keymap';
 import { n8nAutocompletion, n8nLang } from '@/plugins/codemirror/n8nLang';
 import { highlighter } from '@/plugins/codemirror/resolvableHighlighter';
-import { isEqual } from 'lodash-es';
 import { createEventBus, type EventBus } from 'n8n-design-system/utils';
 import type { IDataObject } from 'n8n-workflow';
 import { inputTheme } from './theme';
@@ -83,17 +82,6 @@ export default defineComponent({
 				},
 			});
 		},
-		displayableSegments(segments, newSegments) {
-			if (isEqual(segments, newSegments)) return;
-
-			highlighter.removeColor(this.editor, this.plaintextSegments);
-			highlighter.addColor(this.editor, this.resolvableSegments);
-
-			this.$emit('change', {
-				value: this.unresolvedExpression,
-				segments: this.displayableSegments,
-			});
-		},
 	},
 	mounted() {
 		const extensions = [
@@ -122,6 +110,13 @@ export default defineComponent({
 
 				// Force segments value update by keeping track of editor state
 				this.editorState = this.editor.state;
+				highlighter.removeColor(this.editor, this.plaintextSegments);
+				highlighter.addColor(this.editor, this.resolvableSegments);
+
+				this.$emit('change', {
+					value: this.unresolvedExpression,
+					segments: this.displayableSegments,
+				});
 
 				setTimeout(() => {
 					try {

--- a/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -182,20 +182,14 @@ export default defineComponent({
 
 						// Force segments value update by keeping track of editor state
 						this.editorState = this.editor.state;
+						highlighter.removeColor(this.editor, this.plaintextSegments);
+						highlighter.addColor(this.editor, this.resolvableSegments);
+
+						this.$emit('update:modelValue', this.editor?.state.doc.toString());
 					}),
 				);
 			}
 			return extensions;
-		},
-	},
-	watch: {
-		displayableSegments(segments, newSegments) {
-			if (isEqual(segments, newSegments)) return;
-
-			highlighter.removeColor(this.editor, this.plaintextSegments);
-			highlighter.addColor(this.editor, this.resolvableSegments);
-
-			this.$emit('update:modelValue', this.editor?.state.doc.toString());
 		},
 	},
 	mounted() {

--- a/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -48,7 +48,6 @@ import {
 } from '@n8n/codemirror-lang-sql';
 import { defineComponent } from 'vue';
 import { codeNodeEditorTheme } from '../CodeNodeEditor/theme';
-import { isEqual } from 'lodash-es';
 import {
 	autocompleteKeyMap,
 	enterKeyMap,


### PR DESCRIPTION
## Summary

Improve SqlEditor performance by removing watcher

⚠️ The highlighting of expressions will now only update after changes to the editor (not after rerunning the node or hovering a table item)

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1227/opening-bigquery-node-hangs-fe

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 