### PR TITLE
fix(editor): Fix a link routing regression in N8nRoute, and add tests (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nRoute/Route.vue
+++ b/packages/design-system/src/components/N8nRoute/Route.vue
@@ -17,7 +17,7 @@ interface RouteProps {
 }
 
 defineOptions({ name: 'N8nRoute' });
-const props = withDefaults(defineProps<RouteProps>(), {});
+const props = defineProps<RouteProps>();
 
 const useRouterLink = computed(() => {
 	if (props.newWindow) {
@@ -33,8 +33,8 @@ const useRouterLink = computed(() => {
 });
 
 const openNewWindow = computed(() => {
-	if (props.newWindow !== undefined) {
-		return props.newWindow;
+	if (props.newWindow) {
+		return true;
 	}
 
 	if (typeof props.to === 'string') {

--- a/packages/design-system/src/components/N8nRoute/Route.vue
+++ b/packages/design-system/src/components/N8nRoute/Route.vue
@@ -32,14 +32,5 @@ const useRouterLink = computed(() => {
 	return props.to !== undefined;
 });
 
-const openNewWindow = computed(() => {
-	if (props.newWindow) {
-		return true;
-	}
-
-	if (typeof props.to === 'string') {
-		return !props.to.startsWith('/');
-	}
-	return true;
-});
+const openNewWindow = computed(() => !useRouterLink.value);
 </script>

--- a/packages/design-system/src/components/N8nRoute/__tests__/Route.spec.ts
+++ b/packages/design-system/src/components/N8nRoute/__tests__/Route.spec.ts
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/vue';
+import N8nRoute from '../Route.vue';
+
+describe('N8nRoute', () => {
+	it('should render internal router links', () => {
+		const wrapper = render(N8nRoute, {
+			props: {
+				to: '/test',
+			},
+		});
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('should render internal links with newWindow=true', () => {
+		const wrapper = render(N8nRoute, {
+			props: {
+				to: '/test',
+				newWindow: true,
+			},
+		});
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('should render external links', () => {
+		const wrapper = render(N8nRoute, {
+			props: {
+				to: 'https://example.com/',
+			},
+		});
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+});

--- a/packages/design-system/src/components/N8nRoute/__tests__/__snapshots__/Route.spec.ts.snap
+++ b/packages/design-system/src/components/N8nRoute/__tests__/__snapshots__/Route.spec.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`N8nRoute > should render external links 1`] = `"<a href="https://example.com/" target="_blank"></a>"`;
+
+exports[`N8nRoute > should render internal links with newWindow=true 1`] = `"<a href="/test" target="_blank"></a>"`;
+
+exports[`N8nRoute > should render internal router links 1`] = `"<router-link to="/test"></router-link>"`;


### PR DESCRIPTION
This broke in https://github.com/n8n-io/n8n/pull/8794.
Added tests to prevent this regression from happening again.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included