### PR TITLE
fix(editor): Fix an issue with an empty chat response if not in `output` property

### DIFF
--- a/packages/@n8n/chat/src/plugins/chat.ts
+++ b/packages/@n8n/chat/src/plugins/chat.ts
@@ -45,9 +45,19 @@ export const ChatPlugin: Plugin<ChatOptions> = {
 				options,
 			);
 
+			let textMessage = sendMessageResponse.output ?? sendMessageResponse.text ?? '';
+
+			if (textMessage === '' && Object.keys(sendMessageResponse).length > 0) {
+				try {
+					textMessage = JSON.stringify(sendMessageResponse, null, 2);
+				} catch (e) {
+					// Failed to stringify the object so fallback to empty string
+				}
+			}
+
 			const receivedMessage: ChatMessage = {
 				id: uuidv4(),
-				text: sendMessageResponse.output,
+				text: textMessage,
 				sender: 'bot',
 				createdAt: new Date().toISOString(),
 			};

--- a/packages/@n8n/chat/src/types/webhook.ts
+++ b/packages/@n8n/chat/src/types/webhook.ts
@@ -13,5 +13,6 @@ export interface LoadPreviousSessionResponse {
 }
 
 export interface SendMessageResponse {
-	output: string;
+	output?: string;
+	text?: string;
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where the chat message would render as `<Empty response>` when using basic or QA chains.
When rendering the chat message, `@n8n/chat` looks for it in the `output` property of the response object. This is how we return it for agents but not for chains. So we add the `text` property fallback, and if none of them are defined, try to render a full stringified response.

