### PR TITLE
feat: Add settings.executionOrder workflow param in Public API

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -11,6 +11,10 @@ properties:
   saveDataSuccessExecution:
     type: string
     enum: ['all', 'none']
+  executionOrder:
+    type: string
+    enum: ['v0', 'v1']
+    default: 'v1'
   executionTimeout:
     type: number
     example: 3600


### PR DESCRIPTION
## Summary

When you create a new workflow from the UI, that workflow is created with the v1 execution order. However, when you create a workflow using the Public API, it is created with the v0 execution order.

Since you cannot set this parameter in the public API, I have added it as an enumeration. I have set v1 as the default value to match the UI behavior.

I am not sure if this configuration in the public API was intentionally left behind. If that is the case, feel free to close this PR.

## Review / Merge checklist
- [x] PR title and summary are descriptive.
- [x] No need to update docs, only changed the API definition.
- [x] Tests included.