### PR TITLE
feat(Slack Node): Add block support for message updates

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -934,7 +934,7 @@ export const messageFields: INodeProperties[] = [
 			show: {
 				resource: ['message'],
 				operation: ['update'],
-				messageType: ["text"],
+				messageType: ['text'],
 			},
 		},
 		description:

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -860,6 +860,72 @@ export const messageFields: INodeProperties[] = [
 		placeholder: '1663233118.856619',
 	},
 	{
+		displayName: 'Message Type',
+		name: 'messageType',
+		type: 'options',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['message'],
+			},
+		},
+		description:
+			'Whether to send a simple text message, or use Slack’s Blocks UI builder for more sophisticated messages that include form fields, sections and more',
+		options: [
+			{
+				name: 'Simple Text Message',
+				value: 'text',
+				description: 'Supports basic Markdown',
+			},
+			{
+				name: 'Blocks',
+				value: 'block',
+				description:
+					"Combine text, buttons, form elements, dividers and more in Slack 's visual builder",
+			},
+			{
+				name: 'Attachments',
+				value: 'attachment',
+			},
+		],
+		default: 'text',
+	},
+	{
+		displayName: 'Blocks',
+		name: 'blocksUi',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['message'],
+				messageType: ['block'],
+			},
+		},
+		typeOptions: {
+			rows: 3,
+		},
+		description:
+			"Enter the JSON output from Slack's visual Block Kit Builder here. You can then use expressions to add variable content to your blocks. To create blocks, use <a target='_blank' href='https://app.slack.com/block-kit-builder'>Slack's Block Kit Builder</a>",
+		hint: "To create blocks, use <a target='_blank' href='https://app.slack.com/block-kit-builder'>Slack's Block Kit Builder</a>",
+		default: '',
+	},
+	{
+		displayName: 'Notification Text',
+		name: 'text',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['message'],
+				messageType: ['block'],
+			},
+		},
+		description:
+			'Fallback text to display in slack notifications. Supports <a href="https://api.slack.com/reference/surfaces/formatting">markdown</a> by default - this can be disabled in "Options".',
+	},
+	{
 		displayName: 'Message Text',
 		name: 'text',
 		type: 'string',
@@ -868,6 +934,7 @@ export const messageFields: INodeProperties[] = [
 			show: {
 				resource: ['message'],
 				operation: ['update'],
+				messageType: ["text"],
 			},
 		},
 		description:

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -780,20 +780,6 @@ export class SlackV2 implements INodeType {
 							body.username = sendAsUser;
 						}
 
-						const messageType = this.getNodeParameter('messageType', i, 'text');
-						if (messageType === 'blocks') {
-							const blocksJson = this.getNodeParameter('blocksUi', i, []) as string;
-
-							if (blocksJson !== '' && validateJSON(blocksJson) === undefined) {
-								throw new NodeOperationError(this.getNode(), 'Blocks it is not a valid json', {
-									itemIndex: i,
-								});
-							}
-							if (blocksJson !== '') {
-								body.blocks = blocksJson;
-							}
-						}
-
 						// Add all the other options to the request
 						const otherOptions = this.getNodeParameter('otherOptions', i) as IDataObject;
 						let action = 'postMessage';
@@ -851,27 +837,15 @@ export class SlackV2 implements INodeType {
 							{},
 							{ extractValue: true },
 						) as string;
-						const text = this.getNodeParameter('text', i) as string;
 						const ts = this.getNodeParameter('ts', i)?.toString() as string;
+						const content = getMessageContent.call(this, i, nodeVersion, instanceId);
+
 						const body: IDataObject = {
 							channel,
-							text,
-							ts
+							ts,
+							... content
 						};
 
-						const messageType = this.getNodeParameter('messageType', i, 'text');
-						if (messageType === 'blocks') {
-							const blocksJson = this.getNodeParameter('blocksUi', i, []) as string;
-
-							if (blocksJson !== '' && validateJSON(blocksJson) === undefined) {
-								throw new NodeOperationError(this.getNode(), 'Blocks it is not a valid json', {
-									itemIndex: i,
-								});
-							}
-							if (blocksJson !== '') {
-								body.blocks = blocksJson;
-							}
-						}
 						// Add all the other options to the request
 						const updateFields = this.getNodeParameter('updateFields', i);
 						Object.assign(body, updateFields);

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -25,12 +25,7 @@ import { fileFields, fileOperations } from './FileDescription';
 import { reactionFields, reactionOperations } from './ReactionDescription';
 import { userGroupFields, userGroupOperations } from './UserGroupDescription';
 import { userFields, userOperations } from './UserDescription';
-import {
-	slackApiRequest,
-	slackApiRequestAllItems,
-	validateJSON,
-	getMessageContent,
-} from './GenericFunctions';
+import { slackApiRequest, slackApiRequestAllItems, getMessageContent } from './GenericFunctions';
 
 export class SlackV2 implements INodeType {
 	description: INodeTypeDescription;
@@ -843,7 +838,7 @@ export class SlackV2 implements INodeType {
 						const body: IDataObject = {
 							channel,
 							ts,
-							... content
+							...content,
 						};
 
 						// Add all the other options to the request

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -779,6 +779,21 @@ export class SlackV2 implements INodeType {
 						if (authentication === 'accessToken' && sendAsUser !== '' && sendAsUser !== undefined) {
 							body.username = sendAsUser;
 						}
+
+						const messageType = this.getNodeParameter('messageType', i, 'text');
+						if (messageType === 'blocks') {
+							const blocksJson = this.getNodeParameter('blocksUi', i, []) as string;
+
+							if (blocksJson !== '' && validateJSON(blocksJson) === undefined) {
+								throw new NodeOperationError(this.getNode(), 'Blocks it is not a valid json', {
+									itemIndex: i,
+								});
+							}
+							if (blocksJson !== '') {
+								body.blocks = blocksJson;
+							}
+						}
+
 						// Add all the other options to the request
 						const otherOptions = this.getNodeParameter('otherOptions', i) as IDataObject;
 						let action = 'postMessage';
@@ -841,12 +856,12 @@ export class SlackV2 implements INodeType {
 						const body: IDataObject = {
 							channel,
 							text,
-							ts,
+							ts
 						};
 
-						const jsonParameters = this.getNodeParameter('jsonParameters', i, false);
-						if (jsonParameters) {
-							const blocksJson = this.getNodeParameter('blocksJson', i, []) as string;
+						const messageType = this.getNodeParameter('messageType', i, 'text');
+						if (messageType === 'blocks') {
+							const blocksJson = this.getNodeParameter('blocksUi', i, []) as string;
 
 							if (blocksJson !== '' && validateJSON(blocksJson) === undefined) {
 								throw new NodeOperationError(this.getNode(), 'Blocks it is not a valid json', {


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

This adds slack blocks back to the update action for Slack. It somehow got lost from previous versions.

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.

https://community.n8n.io/t/under-slack-node-update-option-attachment-option-is-missing/23113/4

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 