### PR TITLE
fix(editor): Decouple project sharing component from project type

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -61,6 +61,7 @@
 				:projects="projectsStore.personalProjects"
 				:home-project="credential.homeProject"
 				:readonly="!credentialPermissions.share"
+				multiple
 			/>
 		</div>
 	</div>

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -59,7 +59,7 @@
 			<ProjectSharing
 				v-model="sharedWithProjects"
 				:projects="projectsStore.personalProjects"
-				:home-project="credential.homeProject"
+				:ignore-project="credential.homeProject"
 				:readonly="!credentialPermissions.share"
 				multiple
 			/>

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -58,7 +58,7 @@
 			</n8n-info-tip>
 			<ProjectSharing
 				v-model="sharedWithProjects"
-				:projects="projectsStore.projects"
+				:projects="projectsStore.personalProjects"
 				:home-project="credential.homeProject"
 				:readonly="!credentialPermissions.share"
 			/>

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -60,7 +60,6 @@
 				v-model="sharedWithProjects"
 				:projects="projects"
 				:readonly="!credentialPermissions.share"
-				multiple
 			/>
 		</div>
 	</div>

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -58,8 +58,7 @@
 			</n8n-info-tip>
 			<ProjectSharing
 				v-model="sharedWithProjects"
-				:projects="projectsStore.personalProjects"
-				:ignore-project="credential.homeProject"
+				:projects="projects"
 				:readonly="!credentialPermissions.share"
 				multiple
 			/>
@@ -81,7 +80,7 @@ import { useUsageStore } from '@/stores/usage.store';
 import { EnterpriseEditionFeature, VIEWS } from '@/constants';
 import ProjectSharing from '@/features/projects/components/ProjectSharing.vue';
 import { useProjectsStore } from '@/features/projects/projects.store';
-import type { ProjectSharingData } from '@/features/projects/projects.types';
+import type { ProjectListItem, ProjectSharingData } from '@/features/projects/projects.types';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 import type { IPermissions } from '@/permissions';
 import type { EventBus } from 'n8n-design-system/utils';
@@ -154,6 +153,11 @@ export default defineComponent({
 			return (this.credentialData.sharedWithProjects || []).some((sharee: IUser) => {
 				return sharee.id === this.usersStore.currentUser?.id;
 			});
+		},
+		projects(): ProjectListItem[] {
+			return this.projectsStore.personalProjects.filter(
+				(project) => project.id !== this.credential.homeProject?.id,
+			);
 		},
 	},
 	watch: {

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -34,7 +34,7 @@
 					<ProjectSharing
 						v-model="sharedWithProjects"
 						:projects="projectsStore.personalProjects"
-						:home-project="workflow.homeProject"
+						:ignore-project="workflow.homeProject"
 						:readonly="!workflowPermissions.updateSharing"
 						multiple
 					/>

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -35,7 +35,6 @@
 						v-model="sharedWithProjects"
 						:projects="projects"
 						:readonly="!workflowPermissions.updateSharing"
-						multiple
 					/>
 					<template #fallback>
 						<n8n-text>

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -33,8 +33,7 @@
 				<enterprise-edition :features="[EnterpriseEditionFeature.Sharing]">
 					<ProjectSharing
 						v-model="sharedWithProjects"
-						:projects="projectsStore.personalProjects"
-						:ignore-project="workflow.homeProject"
+						:projects="projects"
 						:readonly="!workflowPermissions.updateSharing"
 						multiple
 					/>
@@ -119,7 +118,7 @@ import type { BaseTextKey } from '@/plugins/i18n';
 import { isNavigationFailure } from 'vue-router';
 import ProjectSharing from '@/features/projects/components/ProjectSharing.vue';
 import { useProjectsStore } from '@/features/projects/projects.store';
-import type { ProjectSharingData } from '@/features/projects/projects.types';
+import type { ProjectListItem, ProjectSharingData } from '@/features/projects/projects.types';
 
 export default defineComponent({
 	name: 'WorkflowShareModal',
@@ -194,6 +193,11 @@ export default defineComponent({
 		},
 		workflowOwnerName(): string {
 			return this.workflowsEEStore.getWorkflowOwnerName(`${this.workflow.id}`);
+		},
+		projects(): ProjectListItem[] {
+			return this.projectsStore.personalProjects.filter(
+				(project) => project.id !== this.workflow.homeProject?.id,
+			);
 		},
 	},
 	watch: {

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -33,7 +33,7 @@
 				<enterprise-edition :features="[EnterpriseEditionFeature.Sharing]">
 					<ProjectSharing
 						v-model="sharedWithProjects"
-						:projects="projectsStore.projects"
+						:projects="projectsStore.personalProjects"
 						:home-project="workflow.homeProject"
 						:readonly="!workflowPermissions.updateSharing"
 					/>

--- a/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
+++ b/packages/editor-ui/src/components/WorkflowShareModal.ee.vue
@@ -36,6 +36,7 @@
 						:projects="projectsStore.personalProjects"
 						:home-project="workflow.homeProject"
 						:readonly="!workflowPermissions.updateSharing"
+						multiple
 					/>
 					<template #fallback>
 						<n8n-text>

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -2,10 +2,9 @@
 import { computed, ref } from 'vue';
 import { useI18n } from '@/composables/useI18n';
 import type {
-	ProjectListItem,
 	ProjectRole,
 	ProjectSharingData,
-	Project,
+	ProjectListItem,
 } from '@/features/projects/projects.types';
 import ProjectSharingInfo from '@/features/projects/components/ProjectSharingInfo.vue';
 
@@ -13,7 +12,6 @@ const locale = useI18n();
 
 type Props = {
 	projects: ProjectListItem[];
-	ignoreProject?: Project | ProjectSharingData;
 	readonly?: boolean;
 	multiple?: boolean;
 };
@@ -34,7 +32,6 @@ const filteredProjects = computed(() =>
 		.filter(
 			(project) =>
 				project.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
-				project.id !== props.ignoreProject?.id &&
 				!selectedProjects.value?.find((p) => p.id === project.id && props.multiple),
 		)
 		.sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name) : 0)),

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -48,7 +48,7 @@ const onProjectSelected = (projectId: string) => {
 	}
 
 	if (Array.isArray(model.value)) {
-		model.value.push(project);
+		model.value = [...model.value, project];
 		selectedProject.value = '';
 	} else {
 		model.value = project;
@@ -66,7 +66,7 @@ const onRoleAction = (project: ProjectSharingData, role: string) => {
 	}
 
 	if (role === 'remove') {
-		model.value?.splice(index, 1);
+		model.value = model.value.filter((p) => p.id !== project.id);
 	}
 };
 </script>

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -14,6 +14,7 @@ type Props = {
 	projects: ProjectListItem[];
 	homeProject?: ProjectSharingData;
 	readonly?: boolean;
+	multiple?: boolean;
 };
 
 const props = defineProps<Props>();
@@ -33,7 +34,7 @@ const filteredProjects = computed(() =>
 			(project) =>
 				project.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
 				project.id !== props.homeProject?.id &&
-				!selectedProjects.value?.find((p) => p.id === project.id),
+				!selectedProjects.value?.find((p) => p.id === project.id && props.multiple),
 		)
 		.sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name) : 0)),
 );
@@ -48,8 +49,13 @@ const onProjectSelected = (projectId: string) => {
 	if (!project) {
 		return;
 	}
-	selectedProjects.value?.push(project);
-	selectedProject.value = '';
+
+	if (props.multiple) {
+		selectedProjects.value?.push(project);
+		selectedProject.value = '';
+	} else {
+		selectedProjects.value = [project];
+	}
 };
 
 const onRoleAction = (project: ProjectSharingData, role: string) => {
@@ -89,7 +95,7 @@ const onRoleAction = (project: ProjectSharingData, role: string) => {
 				<ProjectSharingInfo :project="project" />
 			</N8nOption>
 		</N8nSelect>
-		<ul :class="$style.selectedProjects">
+		<ul v-if="props.multiple" :class="$style.selectedProjects">
 			<li
 				v-for="project in selectedProjects"
 				:key="project.id"

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -5,6 +5,7 @@ import type {
 	ProjectListItem,
 	ProjectRole,
 	ProjectSharingData,
+	Project,
 } from '@/features/projects/projects.types';
 import ProjectSharingInfo from '@/features/projects/components/ProjectSharingInfo.vue';
 
@@ -12,7 +13,7 @@ const locale = useI18n();
 
 type Props = {
 	projects: ProjectListItem[];
-	homeProject?: ProjectSharingData;
+	ignoreProject?: Project | ProjectSharingData;
 	readonly?: boolean;
 	multiple?: boolean;
 };
@@ -33,7 +34,7 @@ const filteredProjects = computed(() =>
 		.filter(
 			(project) =>
 				project.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
-				project.id !== props.homeProject?.id &&
+				project.id !== props.ignoreProject?.id &&
 				!selectedProjects.value?.find((p) => p.id === project.id && props.multiple),
 		)
 		.sort((a, b) => (a.name && b.name ? a.name.localeCompare(b.name) : 0)),

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -32,7 +32,6 @@ const filteredProjects = computed(() =>
 		.filter(
 			(project) =>
 				project.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
-				project.type === 'personal' &&
 				project.id !== props.homeProject?.id &&
 				!selectedProjects.value?.find((p) => p.id === project.id),
 		)

--- a/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectSharing.vue
@@ -2,9 +2,9 @@
 import { computed, ref } from 'vue';
 import { useI18n } from '@/composables/useI18n';
 import type {
+	ProjectListItem,
 	ProjectRole,
 	ProjectSharingData,
-	ProjectListItem,
 } from '@/features/projects/projects.types';
 import ProjectSharingInfo from '@/features/projects/components/ProjectSharingInfo.vue';
 

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
@@ -1,15 +1,13 @@
 import { waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
-import { createProjectListItem, createProjectSharingData } from '@/__tests__/data/projects';
+import { createProjectListItem } from '@/__tests__/data/projects';
 import ProjectSharing from '@/features/projects/components/ProjectSharing.vue';
 
 const renderComponent = createComponentRenderer(ProjectSharing);
 
-const homeProject = createProjectSharingData();
 const personalProjects = Array.from({ length: 3 }, createProjectListItem);
 const teamProjects = Array.from({ length: 3 }, () => createProjectListItem('team'));
-const projects = [homeProject, ...personalProjects];
 
 const getDropdownItems = async (dropdownTriggerParent: HTMLElement) => {
 	await userEvent.click(within(dropdownTriggerParent).getByRole('textbox'));
@@ -30,7 +28,6 @@ describe('ProjectSharing', () => {
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: {
 				projects: [],
-				ignoreProject: homeProject,
 				modelValue: [],
 				multiple: true,
 			},
@@ -43,8 +40,7 @@ describe('ProjectSharing', () => {
 	it('should filter, add and remove projects', async () => {
 		const { getByTestId, getAllByTestId, queryAllByTestId } = renderComponent({
 			props: {
-				projects,
-				ignoreProject: homeProject,
+				projects: personalProjects,
 				modelValue: [personalProjects[0]],
 				multiple: true,
 			},

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
@@ -37,7 +37,7 @@ describe('ProjectSharing', () => {
 	});
 
 	it('should filter, add and remove projects', async () => {
-		const { getByTestId, getAllByTestId, queryAllByTestId, emitted, rerender } = renderComponent({
+		const { getByTestId, getAllByTestId, queryAllByTestId, emitted } = renderComponent({
 			props: {
 				projects: personalProjects,
 				modelValue: [personalProjects[0]],
@@ -56,6 +56,7 @@ describe('ProjectSharing', () => {
 
 		// Add a project (first from the dropdown list)
 		await userEvent.click(projectSelectDropdownItems[0]);
+		expect(emitted()['update:modelValue']).toEqual([[[expect.any(Object), expect.any(Object)]]]);
 
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(2);
 		expect(projectSelectInput.value).toBe('');
@@ -70,6 +71,10 @@ describe('ProjectSharing', () => {
 
 		// Click on the remove action which is the second item in the dropdown
 		await userEvent.click(actionDropDownItems[1]);
+		expect(emitted()['update:modelValue']).toEqual([
+			[[expect.any(Object), expect.any(Object)]],
+			[[expect.any(Object)]],
+		]);
 
 		// Check the state
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(1);
@@ -81,6 +86,11 @@ describe('ProjectSharing', () => {
 		expect(actionDropDownItems).toHaveLength(2);
 
 		await userEvent.click(actionDropDownItems[1]);
+		expect(emitted()['update:modelValue']).toEqual([
+			[[expect.any(Object), expect.any(Object)]],
+			[[expect.any(Object)]],
+			[[]],
+		]);
 
 		// Check the final state
 		expect(queryAllByTestId('project-sharing-list-item')).toHaveLength(0);
@@ -88,7 +98,7 @@ describe('ProjectSharing', () => {
 		expect(projectSelectDropdownItems).toHaveLength(3);
 	});
 
-	it('should work as a simple select when no multiple is set', async () => {
+	it('should work as a simple select when model is not an array', async () => {
 		const { getByTestId, queryByTestId, emitted } = renderComponent({
 			props: {
 				projects: teamProjects,

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
@@ -31,6 +31,7 @@ describe('ProjectSharing', () => {
 				projects: [],
 				homeProject,
 				modelValue: [],
+				multiple: true,
 			},
 		});
 
@@ -44,6 +45,7 @@ describe('ProjectSharing', () => {
 				projects,
 				homeProject,
 				modelValue: [personalProjects[0]],
+				multiple: true,
 			},
 		});
 

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
@@ -8,8 +8,7 @@ const renderComponent = createComponentRenderer(ProjectSharing);
 
 const homeProject = createProjectSharingData();
 const personalProjects = Array.from({ length: 3 }, createProjectListItem);
-const teamProjects = Array.from({ length: 2 }, () => createProjectListItem('team'));
-const projects = [homeProject, ...personalProjects, ...teamProjects];
+const projects = [homeProject, ...personalProjects];
 
 const getDropdownItems = async (dropdownTriggerParent: HTMLElement) => {
 	await userEvent.click(within(dropdownTriggerParent).getByRole('textbox'));

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectSharing.test.ts
@@ -56,10 +56,6 @@ describe('ProjectSharing', () => {
 
 		// Add a project (first from the dropdown list)
 		await userEvent.click(projectSelectDropdownItems[0]);
-		const [[addedProjects]] = emitted()['update:modelValue'];
-		expect(addedProjects).toHaveLength(2);
-		// Rerender the component with the updated `modelValue` to simulate parent component behavior
-		await rerender({ modelValue: addedProjects });
 
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(2);
 		expect(projectSelectInput.value).toBe('');
@@ -74,10 +70,6 @@ describe('ProjectSharing', () => {
 
 		// Click on the remove action which is the second item in the dropdown
 		await userEvent.click(actionDropDownItems[1]);
-		const [_, [deletedProjects]] = emitted()['update:modelValue'];
-		expect(deletedProjects).toHaveLength(1);
-		// Rerender the component with the updated `modelValue` to simulate parent component behavior
-		await rerender({ modelValue: deletedProjects });
 
 		// Check the state
 		expect(getAllByTestId('project-sharing-list-item')).toHaveLength(1);
@@ -89,10 +81,6 @@ describe('ProjectSharing', () => {
 		expect(actionDropDownItems).toHaveLength(2);
 
 		await userEvent.click(actionDropDownItems[1]);
-		const [__, ___, [emptyProjects]] = emitted()['update:modelValue'];
-		expect(emptyProjects).toHaveLength(0);
-		// Rerender the component with the updated `modelValue` to simulate parent component behavior
-		await rerender({ modelValue: emptyProjects });
 
 		// Check the final state
 		expect(queryAllByTestId('project-sharing-list-item')).toHaveLength(0);

--- a/packages/editor-ui/src/features/projects/projects.store.ts
+++ b/packages/editor-ui/src/features/projects/projects.store.ts
@@ -26,6 +26,9 @@ export const useProjectsStore = defineStore('projects', () => {
 			currentProject.value?.id,
 	);
 
+	const personalProjects = computed(() => projects.value.filter((p) => p.type === 'personal'));
+	const teamProjects = computed(() => projects.value.filter((p) => p.type === 'team'));
+
 	const setCurrentProject = (project: Project | null) => {
 		currentProject.value = project;
 	};
@@ -89,6 +92,8 @@ export const useProjectsStore = defineStore('projects', () => {
 		myProjects,
 		currentProject,
 		currentProjectId,
+		personalProjects,
+		teamProjects,
 		setCurrentProject,
 		getAllProjects,
 		getMyProjects,


### PR DESCRIPTION
The component should work in both sharing workflows and credentials where personal project must be selected and it should work when deleting a project where a team project must be selected to transfer data from the deleted project