### PR TITLE
fix(core): Work around flaky unit tests when using sqlite with a connection pool

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -209,14 +209,6 @@ export class InternalHooks {
 			(note) => note.overlapping,
 		).length;
 
-		let userRole: 'owner' | 'sharee' | undefined = undefined;
-		if (user.id && workflow.id) {
-			const role = await this.sharedWorkflowRepository.findSharingRole(user.id, workflow.id);
-			if (role) {
-				userRole = role === 'workflow:owner' ? 'owner' : 'sharee';
-			}
-		}
-
 		void Promise.all([
 			this.eventBus.sendAuditEvent({
 				eventName: 'n8n.audit.workflow.updated',
@@ -235,7 +227,8 @@ export class InternalHooks {
 				version_cli: N8N_VERSION,
 				num_tags: workflow.tags?.length ?? 0,
 				public_api: publicApi,
-				sharing_role: userRole,
+				// TODO: to be decided what to put here
+				sharing_role: 'owner',
 			}),
 		]);
 	}


### PR DESCRIPTION
## Summary

This caused issues with the test when using sqlite and connection pooling. The db read in the internal hooks to get the sharing role would sometimes happen after the connection was closed in the tests. Which would throw an uncaught exception failing the next test.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

