### PR TITLE
refactor(core): Stop reporting error for execution with already stopped status

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -101,9 +101,10 @@ export class WaitTracker {
 		}
 
 		if (!['new', 'unknown', 'waiting', 'running'].includes(fullExecutionData.status)) {
-			throw new WorkflowOperationError(
-				`Only running or waiting executions can be stopped and ${executionId} is currently ${fullExecutionData.status}.`,
-			);
+			throw new ApplicationError('Cannot stop execution with this status', {
+				level: 'warning',
+				extra: { executionId, status: fullExecutionData.status },
+			});
 		}
 		// Set in execution in DB as failed and remove waitTill time
 		const error = new WorkflowOperationError('Workflow-Execution has been canceled!');


### PR DESCRIPTION
Currently some `WorkflowOperationError`s are being reported despite all of them being marked as `warning` level. Refactoring this unstoppable execution error here to stop [consuming Sentry quota](https://n8nio.sentry.io/issues/4939898559) until we pin down the root cause.

https://linear.app/n8n/issue/PAY-1327