### PR TITLE
fix(editor): Use bracket notation for all invalid identifiers in expressions

### DIFF
--- a/packages/editor-ui/src/utils/__tests__/mappingUtils.test.ts
+++ b/packages/editor-ui/src/utils/__tests__/mappingUtils.test.ts
@@ -216,19 +216,19 @@ describe('Mapping Utils', () => {
 			expect(result).toBe("{{ $('nodeName').item.json.sample[0].path }}");
 		});
 
-		it('should generate a mapped expression with special characters in array path', () => {
+		it('should generate a mapped expression with invalid identifier names in array path', () => {
 			const input = {
 				nodeName: 'nodeName',
 				distanceFromActive: 2,
-				path: ['sample', 'path with-space', 'path-with-hyphen'],
+				path: ['sample', 'path with-space', 'path-with-hyphen', '2iStartWithANumber'],
 			};
 			const result = getMappedExpression(input);
 			expect(result).toBe(
-				"{{ $('nodeName').item.json.sample['path with-space']['path-with-hyphen'] }}",
+				"{{ $('nodeName').item.json.sample['path with-space']['path-with-hyphen']['2iStartWithANumber'] }}",
 			);
 		});
 
-		it('should handle paths with special characters', () => {
+		it('should handle paths with invalid identifier names', () => {
 			const input = {
 				nodeName: 'nodeName',
 				distanceFromActive: 2,
@@ -243,11 +243,12 @@ describe('Mapping Utils', () => {
 					'test,',
 					'test:',
 					'path.',
+					'2iStartWithANumber',
 				],
 			};
 			const result = getMappedExpression(input);
 			expect(result).toBe(
-				"{{ $('nodeName').item.json.sample['\"Execute\"']['`Execute`']['\\'Execute\\'']['[Execute]']['{Execute}']['execute?']['test,']['test:']['path.'] }}",
+				"{{ $('nodeName').item.json.sample['\"Execute\"']['`Execute`']['\\'Execute\\'']['[Execute]']['{Execute}']['execute?']['test,']['test:']['path.']['2iStartWithANumber'] }}",
 			);
 		});
 

--- a/packages/editor-ui/src/utils/mappingUtils.ts
+++ b/packages/editor-ui/src/utils/mappingUtils.ts
@@ -1,17 +1,20 @@
 import type { INodeProperties, NodeParameterValueType } from 'n8n-workflow';
 import { isResourceLocatorValue } from 'n8n-workflow';
 
+const validJsIdNameRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+function isValidJsIdentifierName(name: string | number): boolean {
+	return validJsIdNameRegex.test(name.toString());
+}
+
 export function generatePath(root: string, path: Array<string | number>): string {
 	return path.reduce((accu: string, part: string | number) => {
 		if (typeof part === 'number') {
 			return `${accu}[${part}]`;
 		}
 
-		const special = ['-', ' ', '.', "'", '"', '`', '[', ']', '{', '}', '(', ')', ':', ',', '?'];
-		const hasSpecial = !!special.find((s) => part.includes(s));
-		if (hasSpecial) {
-			const escaped = part.replaceAll("'", "\\'");
-			return `${accu}['${escaped}']`;
+		if (!isValidJsIdentifierName(part)) {
+			return `${accu}['${escapeMappingString(part)}']`;
 		}
 
 		return `${accu}.${part}`;


### PR DESCRIPTION
## Summary

Invalid identifier names in input should always be in bracket notation when drag-n-dropping into an expression.

for example: dragging key `61f44` should drop expression `$json['61f44']`

<img width="622" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/4dd13c1b-63db-4d3d-9c6c-6452fbb69821">


## Related tickets and issues
https://linear.app/n8n/issue/PAY-1395/drag-and-drop-for-expressions-break-with-very-long-inputs

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 