### PR TITLE
test(core): Add test that makes sure the api returns a 403 when trying to delete a project that does not exist

### DIFF
--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -684,6 +684,12 @@ describe('DELETE /project/:projectId', () => {
 
 	// Tests related to migrating workflows and credentials to new project:
 
+	test('should fail if the project to delete does not exist', async () => {
+		const member = await createMember();
+
+		await testServer.authAgentFor(member).delete('/projects/1234').expect(403);
+	});
+
 	test('should fail to delete if project to migrate to and the project to delete are the same', async () => {
 		const member = await createMember();
 		const project = await createTeamProject(undefined, member);


### PR DESCRIPTION
## Summary

Add a test that makes sure the API returns a 403 if a user tries to delete a project that does not exist.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1427/delete-team-project

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

