### PR TITLE
fix(MySQL Node): Set paired items correctly in single query batch mode

### DIFF
--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -159,9 +159,9 @@ export function prepareOutput(
 	} else {
 		response
 			.filter((entry) => Array.isArray(entry))
-			.forEach((entry) => {
+			.forEach((entry, index) => {
 				const executionData = constructExecutionHelper(wrapData(entry), {
-					itemData,
+					itemData: Array.isArray(itemData) ? itemData[index] : itemData,
 				});
 
 				returnData.push(...executionData);


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1436
https://community.n8n.io/t/if-node-causing-errors-further-down-workflow-after-update-to-1-11-2/32081
