### PR TITLE
feat: Fetch user cloud role and pass it on in website links

### DIFF
--- a/cypress/e2e/29-templates.cy.ts
+++ b/cypress/e2e/29-templates.cy.ts
@@ -20,7 +20,7 @@ describe('Workflow templates', () => {
 		}).as('settingsRequest');
 	});
 
-	it('Opens website when clicking templates sidebar link', () => {
+	it.only('Opens website when clicking templates sidebar link', () => {
 		cy.visit(workflowsPage.url);
 		mainSidebar.getters.menuItem('Templates').should('be.visible');
 		// Templates should be a link to the website
@@ -28,9 +28,11 @@ describe('Workflow templates', () => {
 		// Link should contain instance address and n8n version
 		mainSidebar.getters.templates().parent('a').then(($a) => {
 			const href = $a.attr('href');
-			// Link should have current instance address and n8n version
-			expect(href).to.include(`utm_instance=${window.location.origin}`);
-			expect(href).to.match(/utm_n8n_version=[0-9]+\.[0-9]+\.[0-9]+/);
+			const params = new URLSearchParams(href);
+			// Link should have all mandatory parameters expected on the website
+			expect(decodeURIComponent(`${params.get('utm_instance')}`)).to.include(window.location.origin);
+			expect(params.get('utm_n8n_version')).to.match(/[0-9]+\.[0-9]+\.[0-9]+/);
+			expect(params.get('utm_awc')).to.match(/[0-9]+/);
 		});
 		mainSidebar.getters.templates().parent('a').should('have.attr', 'target', '_blank');
 	});

--- a/cypress/e2e/29-templates.cy.ts
+++ b/cypress/e2e/29-templates.cy.ts
@@ -20,7 +20,7 @@ describe('Workflow templates', () => {
 		}).as('settingsRequest');
 	});
 
-	it.only('Opens website when clicking templates sidebar link', () => {
+	it('Opens website when clicking templates sidebar link', () => {
 		cy.visit(workflowsPage.url);
 		mainSidebar.getters.menuItem('Templates').should('be.visible');
 		// Templates should be a link to the website

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -1758,6 +1758,7 @@ export declare namespace Cloud {
 		username: string;
 		email: string;
 		hasEarlyAccess?: boolean;
+		role?: string;
 	};
 }
 

--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -387,7 +387,10 @@ export default defineComponent({
 			});
 		},
 		trackTemplatesClick() {
-			this.$telemetry.track('User clicked on templates', {});
+			this.$telemetry.track('User clicked on templates', {
+				role: this.usersStore.currentUserCloudInfo?.role,
+				active_workflow_count: this.workflowsStore.activeWorkflows.length,
+			});
 		},
 		async onUserActionToggle(action: string) {
 			switch (action) {

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -750,7 +750,10 @@ export const MOUSE_EVENT_BUTTONS = {
 export const TEMPLATES_URLS = {
 	DEFAULT_API_HOST: 'https://api.n8n.io/api/',
 	BASE_WEBSITE_URL: 'https://n8n.io/workflows',
-	UTM_QUERY: 'utm_source=n8n_app&utm_medium=template_library',
+	UTM_QUERY: {
+		utm_source: 'n8n_app',
+		utm_medium: 'template_library',
+	},
 };
 
 export const ROLE = {

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2091,6 +2091,7 @@
 	"workflows.empty.description": "Create your first workflow",
 	"workflows.empty.description.readOnlyEnv": "No workflows here yet",
 	"workflows.empty.startFromScratch": "Start from scratch",
+	"workflows.empty.browseTemplates": "Browse {category} templates",
 	"workflows.shareModal.title": "Share '{name}'",
 	"workflows.shareModal.select.placeholder": "Add users...",
 	"workflows.shareModal.list.delete": "Remove access",

--- a/packages/editor-ui/src/plugins/icons/index.ts
+++ b/packages/editor-ui/src/plugins/icons/index.ts
@@ -74,6 +74,7 @@ import {
 	faGraduationCap,
 	faGripLinesVertical,
 	faGripVertical,
+	faHandHoldingUsd,
 	faHandScissors,
 	faHandPointLeft,
 	faHashtag,
@@ -237,6 +238,7 @@ export const FontAwesomePlugin: Plugin<{}> = {
 		addIcon(faGlobe);
 		addIcon(faGlobeAmericas);
 		addIcon(faGraduationCap);
+		addIcon(faHandHoldingUsd);
 		addIcon(faHandScissors);
 		addIcon(faHandPointLeft);
 		addIcon(faHashtag);

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -22,6 +22,8 @@ import {
 } from '@/api/templates';
 import { getFixedNodesList } from '@/utils/nodeViewUtils';
 import { useRootStore } from '@/stores/n8nRoot.store';
+import { useUsersStore } from './users.store';
+import { useWorkflowsStore } from './workflows.store';
 
 const TEMPLATES_PAGE_SIZE = 20;
 
@@ -116,13 +118,37 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 			return settingsStore.templatesHost !== TEMPLATES_URLS.DEFAULT_API_HOST;
 		},
 		/**
+		 * Constructs URLSearchParams object based on the default parameters for the template repository
+		 * and provided additional parameters
+		 */
+		getWebsiteTemplateRepositoryParameters() {
+			const rootStore = useRootStore();
+			const userStore = useUsersStore();
+			const workflowsStore = useWorkflowsStore();
+			const defaultParameters: Record<string, string> = {
+				...TEMPLATES_URLS.UTM_QUERY,
+				utm_instance: this.currentN8nPath,
+				utm_n8n_version: rootStore.versionCli,
+				utm_active_count: String(workflowsStore.activeWorkflows.length),
+			};
+			if (userStore.currentUserCloudInfo?.role) {
+				defaultParameters.utm_user_role = userStore.currentUserCloudInfo.role;
+			}
+			return (additionalParameters: Record<string, string> = {}) => {
+				return new URLSearchParams({
+					...defaultParameters,
+					...additionalParameters,
+				});
+			};
+		},
+		/**
 		 * Construct the URL for the template repository on the website
 		 * @returns {string}
 		 */
 		getWebsiteTemplateRepositoryURL(): string {
-			return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
-				this.currentN8nPath
-			}&utm_n8n_version=${useRootStore().versionCli}`;
+			return `${
+				TEMPLATES_URLS.BASE_WEBSITE_URL
+			}?${this.getWebsiteTemplateRepositoryParameters().toString()}`;
 		},
 		/**
 		 * Construct the URL for the template page on the website for a given template id
@@ -130,9 +156,9 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 */
 		getWebsiteTemplatePageURL() {
 			return (id: string) => {
-				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/${id}?${TEMPLATES_URLS.UTM_QUERY}&utm_instance=${
-					this.currentN8nPath
-				}&utm_n8n_version=${useRootStore().versionCli}`;
+				return `${
+					TEMPLATES_URLS.BASE_WEBSITE_URL
+				}/${id}?${this.getWebsiteTemplateRepositoryParameters().toString()}`;
 			};
 		},
 		/**
@@ -141,9 +167,9 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		 */
 		getWebsiteCategoryURL() {
 			return (id: string) => {
-				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/?categories=${id}&${
-					TEMPLATES_URLS.UTM_QUERY
-				}&utm_instance=${this.currentN8nPath}&utm_n8n_version=${useRootStore().versionCli}`;
+				return `${TEMPLATES_URLS.BASE_WEBSITE_URL}/?${this.getWebsiteTemplateRepositoryParameters({
+					categories: id,
+				}).toString()}`;
 			};
 		},
 	},

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -129,7 +129,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 				...TEMPLATES_URLS.UTM_QUERY,
 				utm_instance: this.currentN8nPath,
 				utm_n8n_version: rootStore.versionCli,
-				utm_active_count: String(workflowsStore.activeWorkflows.length),
+				utm_awc: String(workflowsStore.activeWorkflows.length),
 			};
 			if (userStore.currentUserCloudInfo?.role) {
 				defaultParameters.utm_user_role = userStore.currentUserCloudInfo.role;

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -163,7 +163,6 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, {
 		},
 		/**
 		 * Construct the URL for the template category page on the website for a given category id
-		 * @returns {function(string): string}
 		 */
 		getWebsiteCategoryURL() {
 			return (id: string) => {

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -84,22 +84,27 @@
 					</n8n-text>
 				</div>
 				<div v-if="!readOnlyEnv" :class="['text-center', 'mt-2xl', $style.actionsContainer]">
-					<n8n-card
+					<a
 						v-if="userCloudAccount?.role === 'Sales'"
+						:href="getTemplateRepositoryURL('Sales')"
 						:class="$style.emptyStateCard"
-						hoverable
-						data-test-id="browse-sales-templates-card"
-						@click="openTemplateRepository('Sales')"
+						target="_blank"
 					>
-						<n8n-icon :class="$style.emptyStateCardIcon" icon="hand-holding-usd" />
-						<n8n-text size="large" class="mt-xs" color="text-base">
-							{{
-								$locale.baseText('workflows.empty.browseTemplates', {
-									interpolate: { category: 'Sales' },
-								})
-							}}
-						</n8n-text>
-					</n8n-card>
+						<n8n-card
+							hoverable
+							data-test-id="browse-sales-templates-card"
+							@click="trackCategoryLinkClick('Sales')"
+						>
+							<n8n-icon :class="$style.emptyStateCardIcon" icon="hand-holding-usd" />
+							<n8n-text size="large" class="mt-xs" color="text-base">
+								{{
+									$locale.baseText('workflows.empty.browseTemplates', {
+										interpolate: { category: 'Sales' },
+									})
+								}}
+							</n8n-text>
+						</n8n-card>
+					</a>
 					<n8n-card
 						:class="$style.emptyStateCard"
 						hoverable
@@ -294,13 +299,14 @@ const WorkflowsView = defineComponent({
 				source: 'Workflows list',
 			});
 		},
-		openTemplateRepository(category: string) {
-			const url = this.templatesStore.getWebsiteCategoryURL(category);
-			this.$telemetry.track('User clicked Browse Sales Templates', {
+		getTemplateRepositoryURL(category: string) {
+			return this.templatesStore.getWebsiteCategoryURL(category);
+		},
+		trackCategoryLinkClick(category: string) {
+			this.$telemetry.track(`User clicked Browse ${category} Templates`, {
 				role: this.usersStore.currentUserCloudInfo?.role,
 				active_workflow_count: this.workflowsStore.activeWorkflows.length,
 			});
-			window.open(url, '_blank');
 		},
 		async initialize() {
 			await Promise.all([

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -85,6 +85,22 @@
 				</div>
 				<div v-if="!readOnlyEnv" :class="['text-center', 'mt-2xl', $style.actionsContainer]">
 					<n8n-card
+						v-if="userCloudAccount?.role === 'Sales'"
+						:class="$style.emptyStateCard"
+						hoverable
+						data-test-id="browse-sales-templates-card"
+						@click="openTemplateRepository('Sales')"
+					>
+						<n8n-icon :class="$style.emptyStateCardIcon" icon="hand-holding-usd" />
+						<n8n-text size="large" class="mt-xs" color="text-base">
+							{{
+								$locale.baseText('workflows.empty.browseTemplates', {
+									interpolate: { category: 'Sales' },
+								})
+							}}
+						</n8n-text>
+					</n8n-card>
+					<n8n-card
 						:class="$style.emptyStateCard"
 						hoverable
 						data-test-id="new-workflow-card"
@@ -154,6 +170,7 @@ import { mapStores } from 'pinia';
 import { useUIStore } from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
+import { useTemplatesStore } from '@/stores/templates.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
@@ -205,6 +222,7 @@ const WorkflowsView = defineComponent({
 			useCredentialsStore,
 			useSourceControlStore,
 			useTagsStore,
+			useTemplatesStore,
 		),
 		readOnlyEnv(): boolean {
 			return this.sourceControlStore.preferences.branchReadOnly;
@@ -236,6 +254,9 @@ const WorkflowsView = defineComponent({
 		},
 		suggestedTemplates() {
 			return this.uiStore.suggestedTemplates;
+		},
+		userCloudAccount() {
+			return this.usersStore.currentUserCloudInfo;
 		},
 	},
 	watch: {
@@ -271,6 +292,10 @@ const WorkflowsView = defineComponent({
 			this.$telemetry.track('User clicked add workflow button', {
 				source: 'Workflows list',
 			});
+		},
+		openTemplateRepository(category: string) {
+			const url = this.templatesStore.getWebsiteCategoryURL(category);
+			window.open(url, '_blank');
 		},
 		async initialize() {
 			await Promise.all([

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -223,6 +223,7 @@ const WorkflowsView = defineComponent({
 			useSourceControlStore,
 			useTagsStore,
 			useTemplatesStore,
+			useUsersStore,
 		),
 		readOnlyEnv(): boolean {
 			return this.sourceControlStore.preferences.branchReadOnly;
@@ -295,6 +296,10 @@ const WorkflowsView = defineComponent({
 		},
 		openTemplateRepository(category: string) {
 			const url = this.templatesStore.getWebsiteCategoryURL(category);
+			this.$telemetry.track('User clicked Browse Sales Templates', {
+				role: this.usersStore.currentUserCloudInfo?.role,
+				active_workflow_count: this.workflowsStore.activeWorkflows.length,
+			});
 			window.open(url, '_blank');
 		},
 		async initialize() {


### PR DESCRIPTION
## Summary
- Fetching adding cloud role to `/me` reponse and passing it to website templates URL
- Sending number of active workflows and role in template links
- Showing a new welcome card for Sales users

### How to test
Follow the steps from the [Linear ticker](https://linear.app/n8n/issue/ADO-2073/send-user-details-from-n8n-app#comment-0a3f1b3f)

## Related tickets and issues
https://linear.app/n8n/issue/ADO-2073/send-user-details-from-n8n-app

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 