### PR TITLE
fix(editor): Nodes connectors improvements

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -40,6 +40,9 @@
 
 	// Canvas
 	--color-canvas-background: var(--prim-gray-820);
+	--color-canvas-background-h: var(--prim-gray-h); // Used for connectors labels background
+	--color-canvas-background-s: 1%;
+	--color-canvas-background-l: 18%;
 	--color-canvas-dot: var(--prim-gray-670);
 	--color-canvas-read-only-line: var(--prim-gray-800);
 	--color-canvas-node-background: var(--prim-gray-40);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -73,6 +73,9 @@
 
 	// Canvas
 	--color-canvas-background: var(--prim-gray-10);
+	--color-canvas-background-h: var(--prim-gray-h); // Used for connectors labels background
+	--color-canvas-background-s: 47%;
+	--color-canvas-background-l: 99%;
 	--color-canvas-dot: var(--prim-gray-120);
 	--color-canvas-read-only-line: var(--prim-gray-30);
 	--color-canvas-node-background: var(--prim-gray-0);

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1238,13 +1238,13 @@ export default defineComponent({
 	// mouse over event.
 	pointer-events: none;
 	span {
-		border-radius: 7px;
 		background-color: hsla(
 			var(--color-canvas-background-h),
 			var(--color-canvas-background-s),
 			var(--color-canvas-background-l),
 			0.85
 		);
+		border-radius: var(--border-radius-base);
 		line-height: 1.3em;
 		padding: 0px 3px;
 		white-space: nowrap;

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1185,7 +1185,7 @@ export default defineComponent({
 	--endpoint-size-small: 14px;
 	--endpoint-size-medium: 18px;
 	--stalk-size: 40px;
-	--stalk-medium-size: 70px;
+	--stalk-medium-size: 60px;
 	--stalk-large-size: 90px;
 	--stalk-success-size: 87px;
 	--stalk-success-size-without-label: 40px;

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1458,6 +1458,11 @@ export default defineComponent({
 		text-overflow: ellipsis;
 		transform: translateY(-50%) !important;
 		margin-left: var(--endpoint-size-small);
+
+		&:hover {
+			max-width: none;
+			z-index: 6;
+		}
 	}
 }
 

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1459,11 +1459,6 @@ export default defineComponent({
 		text-overflow: ellipsis;
 		transform: translateY(-50%) !important;
 		margin-left: var(--endpoint-size-small);
-
-		&:hover {
-			max-width: none;
-			z-index: 6;
-		}
 	}
 }
 

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1185,7 +1185,8 @@ export default defineComponent({
 	--endpoint-size-small: 14px;
 	--endpoint-size-medium: 18px;
 	--stalk-size: 40px;
-	--stalk-switch-size: 90px;
+	--stalk-medium-size: 70px;
+	--stalk-large-size: 90px;
 	--stalk-success-size: 87px;
 	--stalk-success-size-without-label: 40px;
 	--stalk-long-size: 127px;
@@ -1452,7 +1453,7 @@ export default defineComponent({
 
 	// Some nodes allow for dynamic connection labels
 	// so we need to make sure the label does not overflow
-	&.node-connection-type-main[data-endpoint-label-length='medium'] {
+	&.node-connection-type-main[data-endpoint-label-length] {
 		max-width: calc(var(--stalk-size) - var(--endpoint-size-small) - var(--spacing-4xs));
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -1517,6 +1518,10 @@ export default defineComponent({
 }
 
 [data-endpoint-label-length='medium'] {
-	--stalk-size: var(--stalk-switch-size);
+	--stalk-size: var(--stalk-medium-size);
+}
+
+[data-endpoint-label-length='large'] {
+	--stalk-size: var(--stalk-large-size);
 }
 </style>

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1185,7 +1185,7 @@ export default defineComponent({
 	--endpoint-size-small: 14px;
 	--endpoint-size-medium: 18px;
 	--stalk-size: 40px;
-	--stalk-switch-size: 60px;
+	--stalk-switch-size: 90px;
 	--stalk-success-size: 87px;
 	--stalk-success-size-without-label: 40px;
 	--stalk-long-size: 127px;
@@ -1424,9 +1424,9 @@ export default defineComponent({
 		var(--color-canvas-background-l),
 		0.85
 	);
-	border-radius: 7px;
-	font-size: 0.7em;
-	padding: 2px;
+	border-radius: var(--border-radius-large);
+	font-size: var(--font-size-3xs);
+	padding: var(--spacing-5xs) var(--spacing-4xs);
 	white-space: nowrap;
 	transition: color var(--node-endpoint-label--transition-duration) ease;
 
@@ -1453,10 +1453,11 @@ export default defineComponent({
 	// Some nodes allow for dynamic connection labels
 	// so we need to make sure the label does not overflow
 	&.node-connection-type-main[data-endpoint-label-length='medium'] {
-		max-width: calc(var(--stalk-size) - (var(--endpoint-size-small)));
+		max-width: calc(var(--stalk-size) - var(--endpoint-size-small) - var(--spacing-4xs));
 		overflow: hidden;
 		text-overflow: ellipsis;
-		margin-left: calc(var(--endpoint-size-small) + var(--spacing-2xs) + 10px);
+		transform: translateY(-50%) !important;
+		margin-left: var(--endpoint-size-small);
 	}
 }
 

--- a/packages/editor-ui/src/mixins/nodeBase.ts
+++ b/packages/editor-ui/src/mixins/nodeBase.ts
@@ -28,6 +28,7 @@ import { useHistoryStore } from '@/stores/history.store';
 import { useCanvasStore } from '@/stores/canvas.store';
 import type { EndpointSpec } from '@jsplumb/common';
 import { useDeviceSupport } from 'n8n-design-system';
+import type { N8nEndpointLabelLength } from '@/plugins/jsplumb/N8nPlusEndpointType';
 
 const createAddInputEndpointSpec = (
 	connectionName: NodeConnectionType,
@@ -54,6 +55,12 @@ const createDiamondOutputEndpointSpec = (): EndpointSpec => ({
 		cssClass: 'diamond-output-endpoint',
 	},
 });
+
+const getEndpointLabelLength = (length: number): N8nEndpointLabelLength => {
+	if (length < 4) return 'small';
+	else if (length < 8) return 'medium';
+	return 'large';
+};
 
 export const nodeBase = defineComponent({
 	data() {
@@ -371,7 +378,7 @@ export const nodeBase = defineComponent({
 				outputConfigurations.push(outputConfiguration);
 			});
 
-			const endpointLabelLength = maxLabelLength < 4 ? 'short' : 'medium';
+			const endpointLabelLength = getEndpointLabelLength(maxLabelLength);
 
 			this.outputs.forEach((value, i) => {
 				const outputConfiguration = outputConfigurations[i];

--- a/packages/editor-ui/src/mixins/nodeBase.ts
+++ b/packages/editor-ui/src/mixins/nodeBase.ts
@@ -57,8 +57,8 @@ const createDiamondOutputEndpointSpec = (): EndpointSpec => ({
 });
 
 const getEndpointLabelLength = (length: number): N8nEndpointLabelLength => {
-	if (length < 4) return 'small';
-	else if (length < 8) return 'medium';
+	if (length <= 2) return 'small';
+	else if (length <= 6) return 'medium';
 	return 'large';
 };
 

--- a/packages/editor-ui/src/plugins/jsplumb/N8nPlusEndpointType.ts
+++ b/packages/editor-ui/src/plugins/jsplumb/N8nPlusEndpointType.ts
@@ -10,11 +10,12 @@ import {
 } from '@jsplumb/browser-ui';
 
 export type ComputedN8nPlusEndpoint = [number, number, number, number, number];
+export type N8nEndpointLabelLength = 'small' | 'medium' | 'large';
 interface N8nPlusEndpointParams extends EndpointRepresentationParams {
 	dimensions: number;
 	connectedEndpoint: Endpoint;
 	hoverMessage: string;
-	endpointLabelLength: 'small' | 'medium';
+	endpointLabelLength: N8nEndpointLabelLength;
 	size: 'small' | 'medium';
 	showOutputLabel: boolean;
 }


### PR DESCRIPTION
## Summary
- Bring the background color of the connectors labels back to improve the label readability
- Increase the width of the Switch/if output connector labels
- Left align the Switch/if output connector labels


## Related tickets and issues
- https://linear.app/n8n/issue/NODE-1258/background-color-of-nodes-connectors


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 