### PR TITLE
feat(core): Change api for deleting team projects to match FE expectations

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -99,7 +99,7 @@ export class ProjectController {
 	@ProjectScope('project:delete')
 	async deleteProject(req: ProjectRequest.Delete) {
 		await this.projectsService.deleteProject(req.user, req.params.projectId, {
-			migrateToProject: req.body.migrateToProject,
+			migrateToProject: req.query.transferId,
 		});
 	}
 }

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -558,5 +558,5 @@ export declare namespace ProjectRequest {
 		{},
 		{ name?: string; relations?: ProjectRelationPayload[] }
 	>;
-	type Delete = AuthenticatedRequest<{ projectId: string }, {}, { migrateToProject: string }>;
+	type Delete = AuthenticatedRequest<{ projectId: string }, {}, {}, { transferId?: string }>;
 }

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -697,7 +697,7 @@ describe('DELETE /project/:projectId', () => {
 		await testServer
 			.authAgentFor(member)
 			.delete(`/projects/${project.id}`)
-			.send({ migrateToProject: project.id })
+			.query({ transferId: project.id })
 			.expect(400);
 	});
 
@@ -717,8 +717,7 @@ describe('DELETE /project/:projectId', () => {
 		await testServer
 			.authAgentFor(member)
 			.delete(`/projects/${projectToBeDeleted.id}`)
-			.send({ migrateToProject: targetProject.id })
-
+			.query({ transferId: targetProject.id })
 			//
 			// ASSERT
 			//
@@ -754,7 +753,7 @@ describe('DELETE /project/:projectId', () => {
 		await testServer
 			.authAgentFor(member)
 			.delete(`/projects/${projectToBeDeleted.id}`)
-			.send({ migrateToProject: targetProject.id })
+			.query({ transferId: targetProject.id })
 			.expect(200);
 
 		//
@@ -834,7 +833,7 @@ describe('DELETE /project/:projectId', () => {
 		await testServer
 			.authAgentFor(member)
 			.delete(`/projects/${project.id}`)
-			.send({ migrateToProject: projectToMigrateTo.id })
+			.query({ transferId: projectToMigrateTo.id })
 			.expect(200);
 
 		//


### PR DESCRIPTION
## Summary

> Describe what the PR does and how to test. Photos and videos are recommended.

Change `DELETE /projects/:id`.
Instead of passing the id of the project to which all resources should be migrated to as a field in the body, pass it instead as a query param.

This is so that it matches how `DELETE /users/:id` works.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

