### PR TITLE
feat: Add includeScopes query param to credentials, workflows, and projects

### DIFF
--- a/packages/@n8n/permissions/src/combineScopes.ts
+++ b/packages/@n8n/permissions/src/combineScopes.ts
@@ -1,0 +1,23 @@
+import type { Scope, ScopeLevels, GlobalScopes, MaskLevels } from './types';
+
+export function combineScopes(userScopes: GlobalScopes, masks?: MaskLevels): Set<Scope>;
+export function combineScopes(userScopes: ScopeLevels, masks?: MaskLevels): Set<Scope>;
+export function combineScopes(
+	userScopes: GlobalScopes | ScopeLevels,
+	masks?: MaskLevels,
+): Set<Scope> {
+	const maskedScopes: GlobalScopes | ScopeLevels = Object.fromEntries(
+		Object.entries(userScopes).map((e) => [e[0], [...e[1]]]),
+	) as GlobalScopes | ScopeLevels;
+
+	if (masks?.sharing) {
+		if ('project' in maskedScopes) {
+			maskedScopes.project = maskedScopes.project.filter((v) => masks.sharing.includes(v));
+		}
+		if ('resource' in maskedScopes) {
+			maskedScopes.resource = maskedScopes.resource.filter((v) => masks.sharing.includes(v));
+		}
+	}
+
+	return new Set(Object.values(maskedScopes).flat());
+}

--- a/packages/@n8n/permissions/src/hasScope.ts
+++ b/packages/@n8n/permissions/src/hasScope.ts
@@ -1,3 +1,4 @@
+import { combineScopes } from './combineScopes';
 import type { Scope, ScopeLevels, GlobalScopes, ScopeOptions, MaskLevels } from './types';
 
 export function hasScope(
@@ -22,20 +23,7 @@ export function hasScope(
 		scope = [scope];
 	}
 
-	const maskedScopes: GlobalScopes | ScopeLevels = Object.fromEntries(
-		Object.entries(userScopes).map((e) => [e[0], [...e[1]]]),
-	) as GlobalScopes | ScopeLevels;
-
-	if (masks?.sharing) {
-		if ('project' in maskedScopes) {
-			maskedScopes.project = maskedScopes.project.filter((v) => masks.sharing.includes(v));
-		}
-		if ('resource' in maskedScopes) {
-			maskedScopes.resource = maskedScopes.resource.filter((v) => masks.sharing.includes(v));
-		}
-	}
-
-	const userScopeSet = new Set(Object.values(maskedScopes).flat());
+	const userScopeSet = combineScopes(userScopes, masks);
 
 	if (options.mode === 'allOf') {
 		return !!scope.length && scope.every((s) => userScopeSet.has(s));

--- a/packages/@n8n/permissions/src/index.ts
+++ b/packages/@n8n/permissions/src/index.ts
@@ -1,2 +1,3 @@
 export type * from './types';
 export * from './hasScope';
+export * from './combineScopes';

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -10,7 +10,11 @@ export class RoleController {
 		return Object.fromEntries(
 			Object.entries(this.roleService.getRoles()).map((e) => [
 				e[0],
-				(e[1] as AllRoleTypes[]).map((r) => ({ name: this.roleService.getRoleName(r), role: r })),
+				(e[1] as AllRoleTypes[]).map((r) => ({
+					name: this.roleService.getRoleName(r),
+					role: r,
+					scopes: this.roleService.getRoleScopes(r),
+				})),
 			]),
 		);
 	}

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -41,9 +41,10 @@ export class CredentialsController {
 	) {}
 
 	@Get('/', { middlewares: listQueryMiddleware })
-	async getMany(req: ListQuery.Request) {
+	async getMany(req: CredentialRequest.GetMany) {
 		return await this.credentialsService.getMany(req.user, {
 			listQueryOptions: req.listQueryOptions,
+			includeScopes: req.query.includeScopes,
 		});
 	}
 

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -1,7 +1,7 @@
 import { deepCopy } from 'n8n-workflow';
 import config from '@/config';
 import { CredentialsService } from './credentials.service';
-import { CredentialRequest, ListQuery } from '@/requests';
+import { CredentialRequest } from '@/requests';
 import { InternalHooks } from '@/InternalHooks';
 import { Logger } from '@/Logger';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -67,9 +67,8 @@ export class OwnershipService {
 	addOwnedByAndSharedWith(
 		rawEntity: ListQuery.Workflow.WithSharing | ListQuery.Credentials.WithSharing,
 	): ListQuery.Workflow.WithOwnedByAndSharedWith | ListQuery.Credentials.WithOwnedByAndSharedWith {
-		const { shared, ...rest } = rawEntity;
-
-		const entity = rest as
+		const shared = rawEntity.shared;
+		const entity = rawEntity as
 			| ListQuery.Workflow.WithOwnedByAndSharedWith
 			| ListQuery.Credentials.WithOwnedByAndSharedWith;
 

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -1,7 +1,7 @@
-import type { ProjectRole } from '@/databases/entities/ProjectRelation';
+import type { ProjectRelation, ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { CredentialSharingRole } from '@/databases/entities/SharedCredentials';
 import type { WorkflowSharingRole } from '@/databases/entities/SharedWorkflow';
-import type { GlobalRole } from '@/databases/entities/User';
+import type { GlobalRole, User } from '@/databases/entities/User';
 import {
 	GLOBAL_ADMIN_SCOPES,
 	GLOBAL_MEMBER_SCOPES,
@@ -19,8 +19,10 @@ import {
 	WORKFLOW_SHARING_EDITOR_SCOPES,
 	WORKFLOW_SHARING_OWNER_SCOPES,
 } from '@/permissions/resource-roles';
-import type { Scope } from '@n8n/permissions';
+import type { ListQuery } from '@/requests';
+import { combineScopes, type Scope } from '@n8n/permissions';
 import { Service } from 'typedi';
+import { ApplicationError } from 'n8n-workflow';
 
 export type RoleNamespace = 'global' | 'project' | 'credential' | 'workflow';
 
@@ -63,6 +65,10 @@ const ALL_MAPS: AllMaps = {
 	credential: CREDENTIALS_SHARING_SCOPE_MAP,
 	workflow: WORKFLOW_SHARING_SCOPE_MAP,
 } as const;
+
+const COMBINED_MAP = Object.fromEntries(
+	Object.values(ALL_MAPS).flatMap((o: Record<string, Scope[]>) => Object.entries(o)),
+) as Record<GlobalRole | ProjectRole | CredentialSharingRole | WorkflowSharingRole, Scope[]>;
 
 export interface RoleMap {
 	global: GlobalRole[];
@@ -120,6 +126,12 @@ export class RoleService {
 		return ROLE_NAMES[role];
 	}
 
+	getRoleScopes(
+		role: GlobalRole | ProjectRole | WorkflowSharingRole | CredentialSharingRole,
+	): Scope[] {
+		return COMBINED_MAP[role];
+	}
+
 	/**
 	 * Find all distinct scopes in a set of project roles.
 	 */
@@ -131,5 +143,69 @@ export class RoleService {
 
 			return acc;
 		}, new Set());
+	}
+
+	addScopes(
+		rawWorkflow: ListQuery.Workflow.WithSharing | ListQuery.Workflow.WithOwnedByAndSharedWith,
+		user: User,
+		userProjectRelations: ProjectRelation[],
+	): ListQuery.Workflow.WithScopes;
+	addScopes(
+		rawCredential:
+			| ListQuery.Credentials.WithSharing
+			| ListQuery.Credentials.WithOwnedByAndSharedWith,
+		user: User,
+		userProjectRelations: ProjectRelation[],
+	): ListQuery.Credentials.WithScopes;
+	addScopes(
+		rawEntity:
+			| ListQuery.Workflow.WithSharing
+			| ListQuery.Credentials.WithOwnedByAndSharedWith
+			| ListQuery.Credentials.WithSharing
+			| ListQuery.Workflow.WithOwnedByAndSharedWith,
+		user: User,
+		userProjectRelations: ProjectRelation[],
+	): ListQuery.Workflow.WithScopes | ListQuery.Credentials.WithScopes {
+		const shared = rawEntity.shared;
+		const entity = rawEntity as ListQuery.Workflow.WithScopes | ListQuery.Credentials.WithScopes;
+
+		Object.assign(entity, {
+			scopes: [],
+		});
+
+		if (shared === undefined) {
+			return entity;
+		}
+
+		if (!('active' in entity) && !('type' in entity)) {
+			throw new ApplicationError('Cannot detect if entity is a workflow or credential.');
+		}
+
+		const globalScopes = this.getRoleScopes(user.role).filter((s) =>
+			s.startsWith('active' in entity ? 'workflow:' : 'credential:'),
+		);
+		const scopesSet: Set<Scope> = new Set();
+		for (const sharedEntity of shared) {
+			const pr = userProjectRelations.find(
+				(p) => p.projectId === (sharedEntity.projectId ?? sharedEntity.project.id),
+			);
+			let projectScopes: Scope[] = [];
+			if (pr) {
+				projectScopes = this.getRoleScopes(pr.role);
+			}
+			const resourceMask = this.getRoleScopes(sharedEntity.role);
+			const mergedScopes = combineScopes(
+				{
+					global: globalScopes,
+					project: projectScopes,
+				},
+				{ sharing: resourceMask },
+			);
+			mergedScopes.forEach((s) => scopesSet.add(s));
+		}
+
+		entity.scopes = [...scopesSet];
+
+		return entity;
 	}
 }

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,5 +1,5 @@
 import type { IWorkflowDb } from '@/Interfaces';
-import type { AuthenticatedRequest } from '@/requests';
+import type { AuthenticatedRequest, ListQuery } from '@/requests';
 import type {
 	INode,
 	IConnections,
@@ -34,6 +34,10 @@ export declare namespace WorkflowRequest {
 	type Create = AuthenticatedRequest<{}, {}, CreateUpdatePayload>;
 
 	type Get = AuthenticatedRequest<{ workflowId: string }>;
+
+	type GetMany = AuthenticatedRequest<{}, {}, {}, ListQuery.Params & { includeScopes?: string }> & {
+		listQueryOptions: ListQuery.Options;
+	};
 
 	type Delete = Get;
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -16,7 +16,6 @@ import { TagRepository } from '@db/repositories/tag.repository';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
 import { validateEntity } from '@/GenericHelpers';
 import { ExternalHooks } from '@/ExternalHooks';
-import { ListQuery } from '@/requests';
 import { WorkflowService } from './workflow.service';
 import { License } from '@/License';
 import { InternalHooks } from '@/InternalHooks';
@@ -35,7 +34,6 @@ import { CredentialsService } from '../credentials/credentials.service';
 import { WorkflowRequest } from './workflow.request';
 import { EnterpriseWorkflowService } from './workflow.service.ee';
 import { WorkflowExecutionService } from './workflowExecution.service';
-import { WorkflowSharingService } from './workflowSharing.service';
 import { UserManagementMailer } from '@/UserManagement/email';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { ProjectService } from '@/services/project.service';
@@ -57,7 +55,6 @@ export class WorkflowsController {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowService: WorkflowService,
 		private readonly workflowExecutionService: WorkflowExecutionService,
-		private readonly workflowSharingService: WorkflowSharingService,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly license: License,
 		private readonly mailer: UserManagementMailer,
@@ -165,15 +162,12 @@ export class WorkflowsController {
 	}
 
 	@Get('/', { middlewares: listQueryMiddleware })
-	async getAll(req: ListQuery.Request, res: express.Response) {
+	async getAll(req: WorkflowRequest.GetMany, res: express.Response) {
 		try {
-			const sharedWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(req.user, {
-				scopes: ['workflow:read'],
-			});
-
 			const { workflows: data, count } = await this.workflowService.getMany(
-				sharedWorkflowIds,
+				req.user,
 				req.listQueryOptions,
+				!!req.query.includeScopes,
 			);
 
 			res.json({ count, data });

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -1,6 +1,7 @@
 import { Container } from 'typedi';
 import type { SuperAgentTest } from 'supertest';
 
+import type { Scope } from '@n8n/permissions';
 import config from '@/config';
 import type { ListQuery } from '@/requests';
 import type { User } from '@db/entities/User';
@@ -12,12 +13,17 @@ import { randomCredentialPayload, randomName, randomString } from './shared/rand
 import * as testDb from './shared/testDb';
 import type { SaveCredentialFunction } from './shared/types';
 import * as utils from './shared/utils/';
-import { affixRoleToSaveCredential, shareCredentialWithUsers } from './shared/db/credentials';
+import {
+	affixRoleToSaveCredential,
+	shareCredentialWithProjects,
+	shareCredentialWithUsers,
+} from './shared/db/credentials';
 import { createManyUsers, createUser } from './shared/db/users';
 import { Credentials } from 'n8n-core';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import type { Project } from '@/databases/entities/Project';
 import { ProjectService } from '@/services/project.service';
+import { createTeamProject, linkUserToProject } from './shared/db/projects';
 
 // mock that credentialsSharing is not enabled
 jest.spyOn(License.prototype, 'isSharingEnabled').mockReturnValue(false);
@@ -96,6 +102,102 @@ describe('GET /credentials', () => {
 		validateMainCredentialData(member1Credential);
 		expect(member1Credential.data).toBeUndefined();
 		expect(member1Credential.id).toBe(savedCredential1.id);
+	});
+
+	test('should return scopes when ?includeScopes=true', async () => {
+		const [member1, member2] = await createManyUsers(2, {
+			role: 'global:member',
+		});
+
+		const teamProject = await createTeamProject(undefined, member1);
+		await linkUserToProject(member2, teamProject, 'project:viewer');
+
+		const [savedCredential1, savedCredential2] = await Promise.all([
+			saveCredential(randomCredentialPayload(), { project: teamProject }),
+			saveCredential(randomCredentialPayload(), { user: member2 }),
+		]);
+
+		await shareCredentialWithProjects(savedCredential2, [teamProject]);
+
+		{
+			const response = await testServer
+				.authAgentFor(member1)
+				.get('/credentials?includeScopes=true');
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.length).toBe(2);
+
+			const creds = response.body.data as Array<Credentials & { scopes: Scope[] }>;
+			const cred1 = creds.find((c) => c.id === savedCredential1.id)!;
+			const cred2 = creds.find((c) => c.id === savedCredential2.id)!;
+
+			// Team cred
+			expect(cred1.id).toBe(savedCredential1.id);
+			expect(cred1.scopes).toEqual(['credential:read', 'credential:update', 'credential:delete']);
+
+			// Shared cred
+			expect(cred2.id).toBe(savedCredential2.id);
+			expect(cred2.scopes).toEqual(['credential:read']);
+		}
+
+		{
+			const response = await testServer
+				.authAgentFor(member2)
+				.get('/credentials?includeScopes=true');
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.length).toBe(2);
+
+			const creds = response.body.data as Array<Credentials & { scopes: Scope[] }>;
+			const cred1 = creds.find((c) => c.id === savedCredential1.id)!;
+			const cred2 = creds.find((c) => c.id === savedCredential2.id)!;
+
+			// Team cred
+			expect(cred1.id).toBe(savedCredential1.id);
+			expect(cred1.scopes).toEqual(['credential:read']);
+
+			// Shared cred
+			expect(cred2.id).toBe(savedCredential2.id);
+			expect(cred2.scopes).toEqual([
+				'credential:read',
+				'credential:update',
+				'credential:delete',
+				'credential:share',
+			]);
+		}
+
+		{
+			const response = await testServer.authAgentFor(owner).get('/credentials?includeScopes=true');
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.length).toBe(2);
+
+			const creds = response.body.data as Array<Credentials & { scopes: Scope[] }>;
+			const cred1 = creds.find((c) => c.id === savedCredential1.id)!;
+			const cred2 = creds.find((c) => c.id === savedCredential2.id)!;
+
+			// Team cred
+			expect(cred1.id).toBe(savedCredential1.id);
+			expect(cred1.scopes).toEqual([
+				'credential:create',
+				'credential:read',
+				'credential:update',
+				'credential:delete',
+				'credential:list',
+				'credential:share',
+			]);
+
+			// Shared cred
+			expect(cred2.id).toBe(savedCredential2.id);
+			expect(cred2.scopes).toEqual([
+				'credential:create',
+				'credential:read',
+				'credential:update',
+				'credential:delete',
+				'credential:list',
+				'credential:share',
+			]);
+		}
 	});
 });
 

--- a/packages/cli/test/integration/role.api.test.ts
+++ b/packages/cli/test/integration/role.api.test.ts
@@ -7,7 +7,7 @@ import type { CredentialSharingRole } from '@/databases/entities/SharedCredentia
 import type { WorkflowSharingRole } from '@/databases/entities/SharedWorkflow';
 import { RoleService } from '@/services/role.service';
 import Container from 'typedi';
-import { Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['role'],

--- a/packages/cli/test/integration/role.api.test.ts
+++ b/packages/cli/test/integration/role.api.test.ts
@@ -5,6 +5,9 @@ import type { GlobalRole } from '@/databases/entities/User';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { CredentialSharingRole } from '@/databases/entities/SharedCredentials';
 import type { WorkflowSharingRole } from '@/databases/entities/SharedWorkflow';
+import { RoleService } from '@/services/role.service';
+import Container from 'typedi';
+import { Scope } from '@n8n/permissions';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['role'],
@@ -13,25 +16,77 @@ const testServer = utils.setupTestServer({
 let memberAgent: SuperAgentTest;
 
 const expectedCategories = ['global', 'project', 'credential', 'workflow'] as const;
-const expectedGlobalRoles: Array<{ name: string; role: GlobalRole }> = [
-	{ name: 'Owner', role: 'global:owner' },
-	{ name: 'Admin', role: 'global:admin' },
-	{ name: 'Member', role: 'global:member' },
+const expectedGlobalRoles: Array<{ name: string; role: GlobalRole; scopes: Scope[] }> = [
+	{
+		name: 'Owner',
+		role: 'global:owner',
+		scopes: Container.get(RoleService).getRoleScopes('global:owner'),
+	},
+	{
+		name: 'Admin',
+		role: 'global:admin',
+		scopes: Container.get(RoleService).getRoleScopes('global:admin'),
+	},
+	{
+		name: 'Member',
+		role: 'global:member',
+		scopes: Container.get(RoleService).getRoleScopes('global:member'),
+	},
 ];
-const expectedProjectRoles: Array<{ name: string; role: ProjectRole }> = [
-	{ name: 'Project Owner', role: 'project:personalOwner' },
-	{ name: 'Project Admin', role: 'project:admin' },
-	{ name: 'Project Editor', role: 'project:editor' },
-	{ name: 'Project Viewer', role: 'project:viewer' },
+const expectedProjectRoles: Array<{ name: string; role: ProjectRole; scopes: Scope[] }> = [
+	{
+		name: 'Project Owner',
+		role: 'project:personalOwner',
+		scopes: Container.get(RoleService).getRoleScopes('project:personalOwner'),
+	},
+	{
+		name: 'Project Admin',
+		role: 'project:admin',
+		scopes: Container.get(RoleService).getRoleScopes('project:admin'),
+	},
+	{
+		name: 'Project Editor',
+		role: 'project:editor',
+		scopes: Container.get(RoleService).getRoleScopes('project:editor'),
+	},
+	{
+		name: 'Project Viewer',
+		role: 'project:viewer',
+		scopes: Container.get(RoleService).getRoleScopes('project:viewer'),
+	},
 ];
-const expectedCredentialRoles: Array<{ name: string; role: CredentialSharingRole }> = [
-	{ name: 'Credential Owner', role: 'credential:owner' },
-	{ name: 'Credential User', role: 'credential:user' },
+const expectedCredentialRoles: Array<{
+	name: string;
+	role: CredentialSharingRole;
+	scopes: Scope[];
+}> = [
+	{
+		name: 'Credential Owner',
+		role: 'credential:owner',
+		scopes: Container.get(RoleService).getRoleScopes('credential:owner'),
+	},
+	{
+		name: 'Credential User',
+		role: 'credential:user',
+		scopes: Container.get(RoleService).getRoleScopes('credential:user'),
+	},
 ];
-const expectedWorkflowRoles: Array<{ name: string; role: WorkflowSharingRole }> = [
-	{ name: 'Workflow Owner', role: 'workflow:owner' },
-	{ name: 'Workflow Editor', role: 'workflow:editor' },
-	{ name: 'Workflow User', role: 'workflow:user' },
+const expectedWorkflowRoles: Array<{ name: string; role: WorkflowSharingRole; scopes: Scope[] }> = [
+	{
+		name: 'Workflow Owner',
+		role: 'workflow:owner',
+		scopes: Container.get(RoleService).getRoleScopes('workflow:owner'),
+	},
+	{
+		name: 'Workflow Editor',
+		role: 'workflow:editor',
+		scopes: Container.get(RoleService).getRoleScopes('workflow:editor'),
+	},
+	{
+		name: 'Workflow User',
+		role: 'workflow:user',
+		scopes: Container.get(RoleService).getRoleScopes('workflow:user'),
+	},
 ];
 
 beforeAll(async () => {

--- a/packages/cli/test/integration/shared/db/workflows.ts
+++ b/packages/cli/test/integration/shared/db/workflows.ts
@@ -94,6 +94,17 @@ export async function shareWorkflowWithUsers(workflow: WorkflowEntity, users: Us
 	return await Container.get(SharedWorkflowRepository).save(sharedWorkflows);
 }
 
+export async function shareWorkflowWithProjects(workflow: WorkflowEntity, projects: Project[]) {
+	const sharedWorkflows: Array<DeepPartial<SharedWorkflow>> = projects.map((project) => {
+		return {
+			projectId: project.id,
+			workflowId: workflow.id,
+			role: 'workflow:editor',
+		};
+	});
+	return await Container.get(SharedWorkflowRepository).save(sharedWorkflows);
+}
+
 export async function getWorkflowSharing(workflow: WorkflowEntity) {
 	return await Container.get(SharedWorkflowRepository).findBy({
 		workflowId: workflow.id,


### PR DESCRIPTION
## Summary
Add `includeScopes` query parameter to return the scopes that the user had on specific credentials, workflows, and projects.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 