### PR TITLE
fix(editor): Fix error message color in output panel for dark mode (no-changelog)

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -138,7 +138,7 @@
 	--color-ndv-droppable-parameter-background: var(--prim-color-primary-alpha-010);
 	--color-ndv-droppable-parameter-active-background: var(--prim-color-alt-a-alpha-015);
 	--color-ndv-back-font: var(--prim-gray-0);
-	--color-ndv-ouptut-error-message: var(--prim-color-alt-c-tint-150);
+	--color-ndv-output-error-message: var(--prim-color-alt-c-tint-150);
 
 	// Notice
 	--color-notice-warning-border: var(--prim-color-alt-b-tint-250);

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -138,7 +138,7 @@
 	--color-ndv-droppable-parameter-background: var(--prim-color-primary-alpha-010);
 	--color-ndv-droppable-parameter-active-background: var(--prim-color-alt-a-alpha-015);
 	--color-ndv-back-font: var(--prim-gray-0);
-	--color-ndv-ouptut-error-font: var(--prim-color-alt-c-tint-150);
+	--color-ndv-ouptut-error-message: var(--prim-color-alt-c-tint-150);
 
 	// Notice
 	--color-notice-warning-border: var(--prim-color-alt-b-tint-250);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -206,7 +206,7 @@
 	--color-ndv-droppable-parameter-background: var(--prim-color-secondary-alpha-010);
 	--color-ndv-droppable-parameter-active-background: var(--prim-color-alt-a-alpha-015);
 	--color-ndv-back-font: var(--prim-gray-0);
-	--color-ndv-ouptut-error-message: var(--prim-color-alt-c);
+	--color-ndv-output-error-message: var(--prim-color-alt-c);
 
 	// Notice
 	--color-notice-warning-border: var(--color-warning-tint-1);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -206,7 +206,7 @@
 	--color-ndv-droppable-parameter-background: var(--prim-color-secondary-alpha-010);
 	--color-ndv-droppable-parameter-active-background: var(--prim-color-alt-a-alpha-015);
 	--color-ndv-back-font: var(--prim-gray-0);
-	--color-ndv-ouptut-error-font: var(--prim-color-alt-c);
+	--color-ndv-ouptut-error-message: var(--prim-color-alt-c);
 
 	// Notice
 	--color-notice-warning-border: var(--color-warning-tint-1);

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -669,7 +669,7 @@ function copySuccess() {
 		align-items: center;
 		gap: var(--spacing-xs);
 		padding: var(--spacing-xs) var(--spacing-s) var(--spacing-3xs) var(--spacing-s);
-		color: var(--color-ndv-ouptut-error-message);
+		color: var(--color-ndv-output-error-message);
 		font-weight: var(--font-weight-bold);
 		font-size: var(--font-size-s);
 	}

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -669,7 +669,7 @@ function copySuccess() {
 		align-items: center;
 		gap: var(--spacing-xs);
 		padding: var(--spacing-xs) var(--spacing-s) var(--spacing-3xs) var(--spacing-s);
-		color: var(--color-danger);
+		color: var(--color-ndv-ouptut-error-message);
 		font-weight: var(--font-weight-bold);
 		font-size: var(--font-size-s);
 	}


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.
- Fixes the color of the error message in the output panel for the dark mode (which was almost unreadable)


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://linear.app/n8n/issue/NODE-1259/error-in-output-improvements-for-dark-mode



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 