### PR TITLE
fix(Anthropic Chat Model Node): Fix detection of chat models in docker build & add support Claude Haiku

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -27,6 +27,10 @@ const modelField: INodeProperties = {
 			value: 'claude-3-sonnet-20240229',
 		},
 		{
+			name: 'Claude 3 Haiku(20240307)',
+			value: 'claude-3-haiku-20240307',
+		},
+		{
 			name: 'LEGACY: Claude 2',
 			value: 'claude-2',
 		},

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -1,9 +1,10 @@
 import { NodeConnectionType, NodeOperationError, jsonStringify } from 'n8n-workflow';
 import type { EventNamesAiNodesType, IDataObject, IExecuteFunctions } from 'n8n-workflow';
-import { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseOutputParser } from '@langchain/core/output_parsers';
 import type { BaseMessage } from '@langchain/core/messages';
 import { DynamicTool, type Tool } from '@langchain/core/tools';
+import type { BaseLLM } from '@langchain/core/language_models/llms';
 
 export function getMetadataFiltersValues(
 	ctx: IExecuteFunctions,
@@ -20,10 +21,10 @@ export function getMetadataFiltersValues(
 	return undefined;
 }
 
-// TODO: Remove this function once langchain package is updated to 0.1.x
-// eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents
-export function isChatInstance(model: any): model is BaseChatModel {
-	return model instanceof BaseChatModel;
+export function isChatInstance(model: unknown): model is BaseChatModel {
+	const namespace = (model as BaseLLM | BaseChatModel).lc_namespace;
+
+	return namespace.includes('chat_models');
 }
 
 export async function getOptionalOutputParsers(


### PR DESCRIPTION
## Summary
- Fix the detection of Chat Models in Docker container by using `lc_namespace` instead of relying on the base class
- Add Claude Haiku model



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 