### PR TITLE
feat(core): Refactor user deletion to support projects

### DIFF
--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -67,13 +67,20 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 		);
 	}
 
-	async makeOwner(workflowId: string, project: Project) {
-		return await this.upsert(
-			{
-				workflowId,
-				project,
-				role: 'workflow:owner',
-			},
+	async makeOwner(workflowIds: string[], projectId: string, trx?: EntityManager) {
+		trx = trx ?? this.manager;
+
+		return await trx.upsert(
+			SharedWorkflow,
+			workflowIds.map(
+				(workflowId) =>
+					({
+						workflowId,
+						projectId,
+						role: 'workflow:owner',
+					}) as const,
+			),
+
 			['projectId', 'workflowId'],
 		);
 	}
@@ -90,9 +97,11 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 		});
 	}
 
-	async deleteByIds(transaction: EntityManager, sharedWorkflowIds: string[], project?: Project) {
-		return await transaction.delete(SharedWorkflow, {
-			project,
+	async deleteByIds(sharedWorkflowIds: string[], projectId: string, trx?: EntityManager) {
+		trx = trx ?? this.manager;
+
+		return await trx.delete(SharedWorkflow, {
+			projectId,
 			workflowId: In(sharedWorkflowIds),
 		});
 	}

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -81,10 +81,14 @@ export class ProjectService {
 		const ownedSharedWorkflows = await this.sharedWorkflowRepository.find({
 			where: { projectId: project.id, role: 'workflow:owner' },
 		});
-		for (const sharedWorkflow of ownedSharedWorkflows) {
-			if (targetProject) {
-				await this.sharedWorkflowRepository.makeOwner(sharedWorkflow.workflowId, targetProject);
-			} else {
+
+		if (targetProject) {
+			await this.sharedWorkflowRepository.makeOwner(
+				ownedSharedWorkflows.map((sw) => sw.workflowId),
+				targetProject.id,
+			);
+		} else {
+			for (const sharedWorkflow of ownedSharedWorkflows) {
 				await workflowService.delete(user, sharedWorkflow.workflowId);
 			}
 		}
@@ -95,13 +99,13 @@ export class ProjectService {
 			relations: { credentials: true },
 		});
 
-		for (const sharedCredential of ownedCredentials) {
-			if (targetProject) {
-				await this.sharedCredentialsRepository.makeOwner(
-					sharedCredential.credentials,
-					targetProject,
-				);
-			} else {
+		if (targetProject) {
+			await this.sharedCredentialsRepository.makeOwner(
+				ownedCredentials.map((sc) => sc.credentialsId),
+				targetProject.id,
+			);
+		} else {
+			for (const sharedCredential of ownedCredentials) {
 				await credentialsService.delete(sharedCredential.credentials);
 			}
 		}

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -8,7 +8,6 @@ import type { ICredentialsDb } from '@/Interfaces';
 import type { CredentialPayload } from '../types';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import type { Project } from '@/databases/entities/Project';
-import { UserRepository } from '@/databases/repositories/user.repository';
 
 async function encryptCredentialData(credential: CredentialsEntity) {
 	const { createCredentialsFromCredentialsEntity } = await import('@/CredentialsHelper');
@@ -84,13 +83,8 @@ export async function saveCredential(
 		});
 	} else {
 		const project = options.project;
-		// TODO: remove this when we remove users from SharedWorkflow
-		const user = await Container.get(UserRepository).findOneByOrFail({
-			projectRelations: { projectId: project.id },
-		});
 
 		await Container.get(SharedCredentialsRepository).save({
-			user,
 			credentials: savedCredential,
 			role,
 			project,

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -430,7 +430,10 @@ describe('DELETE /users/:id', () => {
 		//
 		// ACT
 		//
-		await ownerAgent.delete(`/users/${member.id}`).query({ transferId: transferee.id }).expect(200);
+		await ownerAgent
+			.delete(`/users/${member.id}`)
+			.query({ transferId: transfereePersonalProject.id })
+			.expect(200);
 
 		//
 		// ASSERT


### PR DESCRIPTION
## Summary

Support projects when deleting users.

Team projects are not touched at all.
For personal projects:

- if the user owns a workflow or credential the ownership can be transferred to another user
- if a workflow or credential is shared with the user it can only be transferred if the other user has no relationship to it

Examples:

1. User 1 owns a workflow which is shared with User 2. User 1 is deleted and everything is transferred to User 2. Now User 2 owns the workflow.
2. User 1 owns nothing, but User 2 owns a workflow which they shared with User 1. User 1 is deleted and everything is transferred to User 2. User 2 still owns the workflow.
3. User 1 owns nothing, but User 3 owns a workflow which they shared with User 1, but not with User 2. User 1 is deleted and everything is transferred to User 2. The workflow is now shared with User 2.

I also made changes to the controller method to make it more procedural and less "clever":

1. the deletion logic is is not duplicated anymore (once for the transfer case and once for not transfering), instead it will first transfer everything and then delete the user like it would anyways, both things can be even seperated if we ever wanted to transfer resources without deletinga a user
2. it won't fetch the user to delete and the user to transfer together and then seperate them again via array.finds, which led to brittle types
3. it uses multiple smaller transactions and it's save to retry if one of them fails

Observable changes unrelated to the ticket:

1. binary data is now deleted when the workflows are deleted (outside a transaction)
2. internal hooks and external hooks are run when deleting workflows and credentials

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1432/delete-user-and-personal-project

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

