### PR TITLE
fix(core): Stringify all Luxon DateTimes in cleanupParameterData

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2112,7 +2112,7 @@ export function cleanupParameterData(inputData: NodeParameterValueType): void {
 		(Object.keys(inputData) as Key[]).forEach((key) => {
 			const value = inputData[key];
 			if (typeof value === 'object') {
-				if (value instanceof DateTime) {
+				if (DateTime.isDateTime(value)) {
 					// Is a special luxon date so convert to string
 					inputData[key] = value.toString();
 				} else {

--- a/packages/core/test/NodeExecuteFunctions.test.ts
+++ b/packages/core/test/NodeExecuteFunctions.test.ts
@@ -30,6 +30,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import Container from 'typedi';
 import type { Agent } from 'https';
+import toPlainObject from 'lodash/toPlainObject';
 
 const temporaryDir = mkdtempSync(join(tmpdir(), 'n8n'));
 
@@ -420,6 +421,16 @@ describe('NodeExecuteFunctions', () => {
 	describe('cleanupParameterData', () => {
 		it('should stringify Luxon dates in-place', () => {
 			const input = { x: 1, y: DateTime.now() as unknown as NodeParameterValue };
+			expect(typeof input.y).toBe('object');
+			cleanupParameterData(input);
+			expect(typeof input.y).toBe('string');
+		});
+
+		it('should stringify plain Luxon dates in-place', () => {
+			const input = {
+				x: 1,
+				y: toPlainObject(DateTime.now()),
+			};
 			expect(typeof input.y).toBe('object');
 			cleanupParameterData(input);
 			expect(typeof input.y).toBe('string');


### PR DESCRIPTION
## Summary
After https://github.com/n8n-io/n8n/pull/8910, `cleanupParameterData` doesn't stringify all DateTime objects.

<img width="745" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/639d9b16-beec-430a-90f0-fdc286c888ce">


The bug in this Linear ticket is caused by the DateTime object not being converted to a string, and later on in the Set node being `JSON.stringify`-ed (causing it to be surrounded with `""`)

## Related tickets and issues
https://linear.app/n8n/issue/N8N-7278/datetimes-are-given-extra-when-stringified



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 