### PR TITLE
fix(Pinecone Vector Store Node): Fix vector store nodes execution issue

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -22,7 +22,7 @@ export function getMetadataFiltersValues(
 }
 
 export function isChatInstance(model: unknown): model is BaseChatModel {
-	const namespace = (model as BaseLLM | BaseChatModel).lc_namespace;
+	const namespace = (model as BaseLLM | BaseChatModel)?.lc_namespace ?? [];
 
 	return namespace.includes('chat_models');
 }


### PR DESCRIPTION
## Summary
- In #8953, we introduced a new check, `isChatInstance`, that looks into the `lc_namespace` of the passed LC object to determine if it contains `chat_models`. However, not all checked objects contain this property, which would result in an execution error. To fix this, we fall back to an empty array, as we only care for the `chat_models` namespace.
Passing AI WFs Tests:
![CleanShot 2024-03-26 at 09 48 16@2x](https://github.com/n8n-io/n8n/assets/12657221/9ec49ed7-0537-4898-b081-192a18b93737)


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 