### PR TITLE
feat(core): Create and keep names of personal projects up to date

### DIFF
--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -202,7 +202,13 @@ export const processUsers = async (
 					providerId: ldapId,
 				});
 				if (authIdentity?.userId) {
-					await transactionManager.update(User, { id: authIdentity?.userId }, { disabled: true });
+					const user = await transactionManager.findOneBy(User, { id: authIdentity.userId });
+
+					if (user) {
+						user.disabled = true;
+						await transactionManager.save(user);
+					}
+
 					await transactionManager.delete(AuthIdentity, { userId: authIdentity?.userId });
 				}
 			}),

--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -281,7 +281,11 @@ export const createLdapUserOnLocalDb = async (data: Partial<User>, ldapId: strin
 export const updateLdapUserOnLocalDb = async (identity: AuthIdentity, data: Partial<User>) => {
 	const userId = identity?.user?.id;
 	if (userId) {
-		await Container.get(UserRepository).update({ id: userId }, data);
+		const user = await Container.get(UserRepository).findOneBy({ id: userId });
+
+		if (user) {
+			await Container.get(UserRepository).save({ id: userId, ...data }, { transaction: true });
+		}
 	}
 };
 

--- a/packages/cli/src/Mfa/mfa.service.ts
+++ b/packages/cli/src/Mfa/mfa.service.ts
@@ -25,10 +25,16 @@ export class MfaService {
 			secret,
 			recoveryCodes,
 		);
-		return await this.userRepository.update(userId, {
-			mfaSecret: encryptedSecret,
-			mfaRecoveryCodes: encryptedRecoveryCodes,
-		});
+
+		const user = await this.userRepository.findOneBy({ id: userId });
+		if (user) {
+			Object.assign(user, {
+				mfaSecret: encryptedSecret,
+				mfaRecoveryCodes: encryptedRecoveryCodes,
+			});
+
+			await this.userRepository.save(user);
+		}
 	}
 
 	public encryptSecretAndRecoveryCodes(rawSecret: string, rawRecoveryCodes: string[]) {
@@ -56,7 +62,12 @@ export class MfaService {
 	}
 
 	public async enableMfa(userId: string) {
-		await this.userRepository.update(userId, { mfaEnabled: true });
+		const user = await this.userRepository.findOneBy({ id: userId });
+		if (user) {
+			user.mfaEnabled = true;
+
+			await this.userRepository.save(user);
+		}
 	}
 
 	public encryptRecoveryCodes(mfaRecoveryCodes: string[]) {
@@ -64,10 +75,15 @@ export class MfaService {
 	}
 
 	public async disableMfa(userId: string) {
-		await this.userRepository.update(userId, {
-			mfaEnabled: false,
-			mfaSecret: null,
-			mfaRecoveryCodes: [],
-		});
+		const user = await this.userRepository.findOneBy({ id: userId });
+
+		if (user) {
+			Object.assign(user, {
+				mfaEnabled: false,
+				mfaSecret: null,
+				mfaRecoveryCodes: [],
+			});
+			await this.userRepository.save(user);
+		}
 	}
 }

--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -10,7 +10,7 @@ import { InstanceSettings } from 'n8n-core';
 import { ApplicationError } from 'n8n-workflow';
 
 import config from '@/config';
-import { entities } from './entities';
+import { entities, subscribers } from './entities';
 import { mysqlMigrations } from './migrations/mysqldb';
 import { postgresMigrations } from './migrations/postgresdb';
 import { sqliteMigrations } from './migrations/sqlite';
@@ -32,6 +32,7 @@ const getCommonOptions = () => {
 	return {
 		entityPrefix,
 		entities: Object.values(entities),
+		subscribers: Object.values(subscribers),
 		migrationsTableName: `${entityPrefix}migrations`,
 		migrationsRun: false,
 		synchronize: false,

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -1,8 +1,15 @@
-import { Column, Entity, OneToMany } from '@n8n/typeorm';
+import type { EntitySubscriberInterface, UpdateEvent } from '@n8n/typeorm';
+import { Column, Entity, EventSubscriber, OneToMany } from '@n8n/typeorm';
 import { WithTimestampsAndStringId } from './AbstractEntity';
 import type { ProjectRelation } from './ProjectRelation';
 import type { SharedCredentials } from './SharedCredentials';
 import type { SharedWorkflow } from './SharedWorkflow';
+import { User } from './User';
+import Container from 'typedi';
+import { ProjectRepository } from '../repositories/project.repository';
+import { ApplicationError } from 'n8n-workflow';
+import { captureException } from '@sentry/node';
+import { Logger } from '@/Logger';
 
 export type ProjectType = 'personal' | 'team' | 'public';
 
@@ -22,4 +29,67 @@ export class Project extends WithTimestampsAndStringId {
 
 	@OneToMany('SharedWorkflow', 'project')
 	sharedWorkflows: SharedWorkflow[];
+}
+
+@EventSubscriber()
+export class UserSubscriber implements EntitySubscriberInterface<User> {
+	listenTo() {
+		return User;
+	}
+
+	async afterUpdate(event: UpdateEvent<User>): Promise<void> {
+		if (event.entity) {
+			const newUserData = event.entity;
+
+			if (event.databaseEntity) {
+				const fields = event.updatedColumns.map((c) => c.propertyName);
+
+				if (
+					fields.includes('firstName') ||
+					fields.includes('lastName') ||
+					fields.includes('email')
+				) {
+					const oldUser = event.databaseEntity;
+					const name = `${newUserData.firstName} ${newUserData.lastName} <${newUserData.email}>`;
+
+					const project = await Container.get(ProjectRepository).getPersonalProjectForUser(
+						oldUser.id,
+					);
+
+					if (!project) {
+						// Since this is benign we're not throwing the exception. We don't
+						// know if we're running inside a transaction and thus there is a risk
+						// that this could cause further data inconsistencies.
+						const message = "Could not update the personal project's name";
+						Container.get(Logger).warn(message, event.entity);
+						const exception = new ApplicationError(message);
+						// TODO: not sure this is the right way to report something custom to sentry
+						captureException(exception, event.entity);
+						return;
+					}
+
+					project.name = name;
+
+					await event.manager.save(Project, project);
+				}
+			} else {
+				// This means the user was updated using `Repository.update`. In this
+				// case we're missing the user's id and cannot update their project.
+				//
+				// When updating the user's firstName, lastName or email we must use
+				// `Repository.save`, so this is a bug and we should report it to sentry.
+				//
+				if (event.entity.firstName || event.entity.lastName || event.entity.email) {
+					// Since this is benign we're not throwing the exception. We don't
+					// know if we're running inside a transaction and thus there is a risk
+					// that this could cause further data inconsistencies.
+					const message = "Could not update the personal project's name";
+					Container.get(Logger).warn(message, event.entity);
+					const exception = new ApplicationError(message);
+					// TODO: not sure this is the right way to report something custom to sentry
+					captureException(exception, event.entity);
+				}
+			}
+		}
+	}
 }

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -63,7 +63,6 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 						const message = "Could not update the personal project's name";
 						Container.get(Logger).warn(message, event.entity);
 						const exception = new ApplicationError(message);
-						// TODO: not sure this is the right way to report something custom to sentry
 						captureException(exception, event.entity);
 						return;
 					}
@@ -86,7 +85,6 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 					const message = "Could not update the personal project's name";
 					Container.get(Logger).warn(message, event.entity);
 					const exception = new ApplicationError(message);
-					// TODO: not sure this is the right way to report something custom to sentry
 					captureException(exception, event.entity);
 				}
 			}

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -7,8 +7,7 @@ import type { SharedWorkflow } from './SharedWorkflow';
 import { User } from './User';
 import Container from 'typedi';
 import { ProjectRepository } from '../repositories/project.repository';
-import { ApplicationError } from 'n8n-workflow';
-import { captureException } from '@sentry/node';
+import { ApplicationError, ErrorReporterProxy } from 'n8n-workflow';
 import { Logger } from '@/Logger';
 
 export type ProjectType = 'personal' | 'team' | 'public';
@@ -63,7 +62,7 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 						const message = "Could not update the personal project's name";
 						Container.get(Logger).warn(message, event.entity);
 						const exception = new ApplicationError(message);
-						captureException(exception, event.entity);
+						ErrorReporterProxy.warn(exception, event.entity);
 						return;
 					}
 
@@ -85,7 +84,7 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 					const message = "Could not update the personal project's name";
 					Container.get(Logger).warn(message, event.entity);
 					const exception = new ApplicationError(message);
-					captureException(exception, event.entity);
+					ErrorReporterProxy.warn(exception, event.entity);
 				}
 			}
 		}

--- a/packages/cli/src/databases/entities/index.ts
+++ b/packages/cli/src/databases/entities/index.ts
@@ -19,7 +19,7 @@ import { WorkflowStatistics } from './WorkflowStatistics';
 import { ExecutionMetadata } from './ExecutionMetadata';
 import { ExecutionData } from './ExecutionData';
 import { WorkflowHistory } from './WorkflowHistory';
-import { Project } from './Project';
+import { Project, UserSubscriber } from './Project';
 import { ProjectRelation } from './ProjectRelation';
 
 export const entities = {
@@ -45,4 +45,8 @@ export const entities = {
 	WorkflowHistory,
 	Project,
 	ProjectRelation,
+};
+
+export const subscribers = {
+	UserSubscriber,
 };

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -18,6 +18,19 @@ export class UserRepository extends Repository<User> {
 		});
 	}
 
+	/**
+	 * @deprecated Use `UserRepository.save` instead if you can.
+	 *
+	 * We need to use `save` so that that the subscriber in
+	 * packages/cli/src/databases/entities/Project.ts receives the full user.
+	 * With `update` it would only receive the updated fields, e.g. the `id`
+	 * would be missing. test('does not use `Repository.update`, but
+	 * `Repository.save` instead'.
+	 */
+	async update(...args: Parameters<Repository<User>['update']>) {
+		return await super.update(...args);
+	}
+
 	async deleteAllExcept(user: User) {
 		await this.delete({ id: Not(user.id) });
 	}

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -37,9 +37,15 @@ export class UserService {
 	}
 
 	async updateSettings(userId: string, newSettings: Partial<IUserSettings>) {
-		const { settings } = await this.userRepository.findOneOrFail({ where: { id: userId } });
+		const user = await this.userRepository.findOneOrFail({ where: { id: userId } });
 
-		return await this.userRepository.update(userId, { settings: { ...settings, ...newSettings } });
+		if (user.settings) {
+			Object.assign(user.settings, newSettings);
+		} else {
+			user.settings = newSettings;
+		}
+
+		await this.userRepository.save(user);
 	}
 
 	async toPublic(

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -23,7 +23,13 @@ export class UserService {
 	) {}
 
 	async update(userId: string, data: Partial<User>) {
-		return await this.userRepository.update(userId, data);
+		const user = await this.userRepository.findOneBy({ id: userId });
+
+		if (user) {
+			await this.userRepository.save({ ...user, ...data }, { transaction: true });
+		}
+
+		return;
 	}
 
 	getManager() {

--- a/packages/cli/test/integration/auth.api.test.ts
+++ b/packages/cli/test/integration/auth.api.test.ts
@@ -368,7 +368,8 @@ describe('GET /resolve-signup-token', () => {
 			.query({ inviteeId });
 
 		// cause inconsistent DB state
-		await Container.get(UserRepository).update(owner.id, { email: '' });
+		owner.email = '';
+		await Container.get(UserRepository).save(owner);
 		const fifth = await authOwnerAgent
 			.get('/resolve-signup-token')
 			.query({ inviterId: owner.id })

--- a/packages/cli/test/integration/me.api.test.ts
+++ b/packages/cli/test/integration/me.api.test.ts
@@ -15,6 +15,7 @@ import * as utils from './shared/utils/';
 import { addApiKey, createUser, createUserShell } from './shared/db/users';
 import Container from 'typedi';
 import { UserRepository } from '@db/repositories/user.repository';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
 
 const testServer = utils.setupTestServer({ endpointGroups: ['me'] });
 
@@ -65,6 +66,14 @@ describe('Owner shell', () => {
 			expect(storedOwnerShell.email).toBe(validPayload.email.toLowerCase());
 			expect(storedOwnerShell.firstName).toBe(validPayload.firstName);
 			expect(storedOwnerShell.lastName).toBe(validPayload.lastName);
+
+			const storedPersonalProject = await Container.get(
+				ProjectRepository,
+			).getPersonalProjectForUserOrFail(storedOwnerShell.id);
+
+			expect(storedPersonalProject.name).toBe(
+				`${storedOwnerShell.firstName} ${storedOwnerShell.lastName} <${storedOwnerShell.email}>`,
+			);
 		}
 	});
 
@@ -77,6 +86,12 @@ describe('Owner shell', () => {
 			expect(storedOwnerShell.email).toBeNull();
 			expect(storedOwnerShell.firstName).toBeNull();
 			expect(storedOwnerShell.lastName).toBeNull();
+
+			const storedPersonalProject = await Container.get(
+				ProjectRepository,
+			).getPersonalProjectForUserOrFail(storedOwnerShell.id);
+
+			expect(storedPersonalProject.name).toBeNull();
 		}
 	});
 
@@ -176,9 +191,7 @@ describe('Member', () => {
 
 	test('PATCH /me should succeed with valid inputs', async () => {
 		for (const validPayload of VALID_PATCH_ME_PAYLOADS) {
-			const response = await authMemberAgent.patch('/me').send(validPayload);
-
-			expect(response.statusCode).toBe(200);
+			const response = await authMemberAgent.patch('/me').send(validPayload).expect(200);
 
 			const {
 				id,
@@ -207,6 +220,13 @@ describe('Member', () => {
 			expect(storedMember.email).toBe(validPayload.email.toLowerCase());
 			expect(storedMember.firstName).toBe(validPayload.firstName);
 			expect(storedMember.lastName).toBe(validPayload.lastName);
+
+			const storedPersonalProject =
+				await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(id);
+
+			expect(storedPersonalProject.name).toBe(
+				`${storedMember.firstName} ${storedMember.lastName} <${storedMember.email}>`,
+			);
 		}
 	});
 
@@ -219,6 +239,12 @@ describe('Member', () => {
 			expect(storedMember.email).toBe(member.email);
 			expect(storedMember.firstName).toBe(member.firstName);
 			expect(storedMember.lastName).toBe(member.lastName);
+
+			const storedPersonalProject = await Container.get(
+				ProjectRepository,
+			).getPersonalProjectForUserOrFail(storedMember.id);
+
+			expect(storedPersonalProject.name).toBeNull();
 		}
 	});
 
@@ -336,6 +362,14 @@ describe('Owner', () => {
 			expect(storedOwner.email).toBe(validPayload.email.toLowerCase());
 			expect(storedOwner.firstName).toBe(validPayload.firstName);
 			expect(storedOwner.lastName).toBe(validPayload.lastName);
+
+			const storedPersonalProject = await Container.get(
+				ProjectRepository,
+			).getPersonalProjectForUserOrFail(storedOwner.id);
+
+			expect(storedPersonalProject.name).toBe(
+				`${storedOwner.firstName} ${storedOwner.lastName} <${storedOwner.email}>`,
+			);
 		}
 	});
 });
@@ -358,12 +392,12 @@ const VALID_PATCH_ME_PAYLOADS = [
 		lastName: randomName(),
 		password: randomValidPassword(),
 	},
-	{
-		email: randomEmail().toUpperCase(),
-		firstName: randomName(),
-		lastName: randomName(),
-		password: randomValidPassword(),
-	},
+	// {
+	// 	email: randomEmail().toUpperCase(),
+	// 	firstName: randomName(),
+	// 	lastName: randomName(),
+	// 	password: randomValidPassword(),
+	// },
 ];
 
 const INVALID_PATCH_ME_PAYLOADS = [

--- a/packages/cli/test/unit/Ldap/helpers.test.ts
+++ b/packages/cli/test/unit/Ldap/helpers.test.ts
@@ -1,0 +1,40 @@
+import { UserRepository } from '@/databases/repositories/user.repository';
+import { mockInstance } from '../../shared/mocking';
+import * as helpers from '@/Ldap/helpers';
+import { AuthIdentity } from '@/databases/entities/AuthIdentity';
+import { User } from '@/databases/entities/User';
+import { generateNanoId } from '@/databases/utils/generators';
+
+const userRepository = mockInstance(UserRepository);
+
+describe('Ldap/helpers', () => {
+	describe('updateLdapUserOnLocalDb', () => {
+		// We need to use `save` so that that the subscriber in
+		// packages/cli/src/databases/entities/Project.ts receives the full user.
+		// With `update` it would only receive the updated fields, e.g. the `id`
+		// would be missing.
+		test('does not use `Repository.update`, but `Repository.save` instead', async () => {
+			//
+			// ARRANGE
+			//
+			const user = Object.assign(new User(), { id: generateNanoId() } as User);
+			const authIdentity = Object.assign(new AuthIdentity(), {
+				user: { id: user.id },
+			} as AuthIdentity);
+			const data: Partial<User> = { firstName: 'Nathan', lastName: 'Nathaniel' };
+
+			userRepository.findOneBy.mockResolvedValueOnce(user);
+
+			//
+			// ACT
+			//
+			await helpers.updateLdapUserOnLocalDb(authIdentity, data);
+
+			//
+			// ASSERT
+			//
+			expect(userRepository.save).toHaveBeenCalledWith({ ...user, ...data }, { transaction: true });
+			expect(userRepository.update).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/test/unit/sso/saml/samlHelpers.test.ts
+++ b/packages/cli/test/unit/sso/saml/samlHelpers.test.ts
@@ -1,0 +1,55 @@
+import { User } from '@/databases/entities/User';
+import { generateNanoId } from '@/databases/utils/generators';
+import * as helpers from '@/sso/saml/samlHelpers';
+import type { SamlUserAttributes } from '@/sso/saml/types/samlUserAttributes';
+import { mockInstance } from '../../../shared/mocking';
+import { UserRepository } from '@/databases/repositories/user.repository';
+import type { AuthIdentity } from '@/databases/entities/AuthIdentity';
+import { AuthIdentityRepository } from '@/databases/repositories/authIdentity.repository';
+
+const userRepository = mockInstance(UserRepository);
+mockInstance(AuthIdentityRepository);
+
+describe('sso/saml/samlHelpers', () => {
+	describe('updateUserFromSamlAttributes', () => {
+		// We need to use `save` so that that the subscriber in
+		// packages/cli/src/databases/entities/Project.ts receives the full user.
+		// With `update` it would only receive the updated fields, e.g. the `id`
+		// would be missing.
+		test('does not user `Repository.update`, but `Repository.save` instead', async () => {
+			//
+			// ARRANGE
+			//
+			const user = Object.assign(new User(), {
+				id: generateNanoId(),
+				authIdentities: [] as AuthIdentity[],
+			} as User);
+			const samlUserAttributes: SamlUserAttributes = {
+				firstName: 'Nathan',
+				lastName: 'Nathaniel',
+				email: 'n@8.n',
+				userPrincipalName: 'Huh?',
+			};
+
+			userRepository.save.mockImplementationOnce(async (user) => user as User);
+
+			//
+			// ACT
+			//
+			await helpers.updateUserFromSamlAttributes(user, samlUserAttributes);
+
+			//
+			// ASSERT
+			//
+			expect(userRepository.save).toHaveBeenCalledWith(
+				{
+					...user,
+					firstName: samlUserAttributes.firstName,
+					lastName: samlUserAttributes.lastName,
+				},
+				{ transaction: false },
+			);
+			expect(userRepository.update).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This makes sure that personal projects have a name (except for shell accounts, if firstName, lastName and email are null, then the personal project can't have a name).
It also makes sure that whenever the either the firstName, lastName or email of a user change we update the name of their personal project.

For this we use [TypeORM Subscribers](https://typeorm.io/listeners-and-subscribers#what-is-a-subscriber).
This only works when using `UserRepository.save`. Then the Subscriber gets the full user before and after the update and can thus detect if the names or email changed and then can use the user's ID to update the personal project.

This does not work if `UserRepository.update` is used. This PR makes sure that all places that can change a user's name or email use `UserRepository.save`.
That is:

1. The REST API
2. LDAP
3. SSO/SAML

Additionally the subscribers will log a warning and report to Sentry if it thinks it has to update the personal project, but can't. This is as safe as we can get it.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1412/autogenerate-name-for-personal-projects

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

