### PR TITLE
fix(editor): Make inputs in the filter component regular inputs by default

### DIFF
--- a/cypress/e2e/30-if-node.cy.ts
+++ b/cypress/e2e/30-if-node.cy.ts
@@ -24,16 +24,8 @@ describe('If Node (filter component)', () => {
 
 		// Add
 		ndv.actions.addFilterCondition(FILTER_PARAM_NAME);
-		ndv.getters
-			.filterConditionLeft(FILTER_PARAM_NAME, 0)
-			.find('.cm-content')
-			.first()
-			.type('first left');
-		ndv.getters
-			.filterConditionLeft(FILTER_PARAM_NAME, 1)
-			.find('.cm-content')
-			.first()
-			.type('second left');
+		ndv.getters.filterConditionLeft(FILTER_PARAM_NAME, 0).find('input').type('first left');
+		ndv.getters.filterConditionLeft(FILTER_PARAM_NAME, 1).find('input').type('second left');
 		ndv.actions.addFilterCondition(FILTER_PARAM_NAME);
 		ndv.getters.filterConditions(FILTER_PARAM_NAME).should('have.length', 3);
 
@@ -42,9 +34,8 @@ describe('If Node (filter component)', () => {
 		ndv.getters.filterConditions(FILTER_PARAM_NAME).should('have.length', 2);
 		ndv.getters
 			.filterConditionLeft(FILTER_PARAM_NAME, 0)
-			.find('.cm-content')
-			.first()
-			.should('have.text', 'second left');
+			.find('input')
+			.should('have.value', 'second left');
 		ndv.actions.removeFilterCondition(FILTER_PARAM_NAME, 1);
 		ndv.getters.filterConditions(FILTER_PARAM_NAME).should('have.length', 1);
 	});

--- a/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
+++ b/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
@@ -43,7 +43,7 @@ const ndvStore = useNDVStore();
 const { debounce } = useDebounce();
 
 function createCondition(): FilterConditionValue {
-	return { id: uuid(), leftValue: '=', rightValue: '=', operator: DEFAULT_OPERATOR_VALUE };
+	return { id: uuid(), leftValue: '', rightValue: '', operator: DEFAULT_OPERATOR_VALUE };
 }
 
 const allowedCombinators = computed<FilterTypeCombinator[]>(

--- a/packages/editor-ui/src/components/FilterConditions/__tests__/FilterConditions.test.ts
+++ b/packages/editor-ui/src/components/FilterConditions/__tests__/FilterConditions.test.ts
@@ -43,14 +43,7 @@ describe('FilterConditions.vue', () => {
 		expect(getByTestId('filter-conditions')).toBeInTheDocument();
 		expect(await findAllByTestId('filter-condition')).toHaveLength(1);
 		expect(getByTestId('filter-condition-left')).toBeInTheDocument();
-		expect(
-			within(getByTestId('filter-condition-left')).getByTestId('inline-expression-editor-input'),
-		).toBeInTheDocument();
 		expect(getByTestId('filter-operator-select')).toBeInTheDocument();
-		expect(getByTestId('filter-condition-right')).toBeInTheDocument();
-		expect(
-			within(getByTestId('filter-condition-right')).getByTestId('inline-expression-editor-input'),
-		).toBeInTheDocument();
 
 		// Only visible when multiple conditions
 		expect(queryByTestId('filter-combinator-select')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
Revert https://github.com/n8n-io/n8n/pull/8784 because it causes confusion with type conversion

![image](https://github.com/n8n-io/n8n/assets/8850410/c258496b-9652-46a8-a9b8-241b218c4c4d)

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1142/make-filter-component-fields-expressions-by-default
https://n8nio.slack.com/archives/C035KBDA917/p1711461615618279

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 