### PR TITLE
feat(core): Return all team projects if the user has global `project:read` permissions

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -12,17 +12,18 @@ import {
 import { ProjectRequest } from '@/requests';
 import { ProjectService } from '@/services/project.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import { combineScopes } from '@n8n/permissions';
-import type { GlobalScopes, ScopeLevels, Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 import { RoleService } from '@/services/role.service';
-import type { GlobalRole } from '@/databases/entities/User';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import { In, Not } from '@n8n/typeorm';
 
 @RestController('/projects')
 export class ProjectController {
 	constructor(
-		private projectsService: ProjectService,
-		private roleService: RoleService,
+		private readonly projectsService: ProjectService,
+		private readonly roleService: RoleService,
+		private readonly projectRepository: ProjectRepository,
 	) {}
 
 	@Get('/')
@@ -42,52 +43,67 @@ export class ProjectController {
 	@Get('/my-projects')
 	async getMyProjects(
 		req: ProjectRequest.GetMyProjects,
-	): Promise<Array<Project & { role: ProjectRole | GlobalRole; scopes?: Scope[] }>> {
+	): Promise<ProjectRequest.GetMyProjectsResponse> {
 		const relations = await this.projectsService.getProjectRelationsForUser(req.user);
+		const otherTeamProject = req.user.hasGlobalScope('project:read')
+			? await this.projectRepository.findBy({
+					type: 'team',
+					id: Not(In(relations.map((pr) => pr.projectId))),
+			  })
+			: [];
 
-		const resultHash: Record<
-			string,
-			Project & { role: ProjectRole | GlobalRole; scopes?: Scope[] }
-		> = {};
+		const results: ProjectRequest.GetMyProjectsResponse = [];
 
 		for (const pr of relations) {
-			const result = resultHash[pr.projectId] ?? {
-				...pr.project,
-				// If the user has the global `project:read` scope then they may not
-				// own this relationship in that case we use the global user role
-				// instead of the relation role, which is for another user.
-				role: pr.userId === req.user.id ? pr.role : req.user.role,
-				scopes: req.query.includeScopes ? [] : undefined,
-			};
-			resultHash[pr.projectId] = result;
-
-			// If the user has a relationship to the project then that one trumps the
-			// global role of the user
-			if (pr.userId === req.user.id) {
-				result.role = pr.role;
-			}
+			const result: ProjectRequest.GetMyProjectsResponse[number] = Object.assign(
+				this.projectRepository.create(pr.project),
+				{
+					role: pr.role,
+					scopes: req.query.includeScopes ? ([] as Scope[]) : undefined,
+				},
+			);
 
 			if (result.scopes) {
-				const scopes: GlobalScopes | ScopeLevels =
-					pr.userId === req.user.id
-						? {
-								global: this.roleService.getRoleScopes(req.user.role),
-								project: this.roleService.getRoleScopes(pr.role),
-						  }
-						: { global: this.roleService.getRoleScopes(req.user.role) };
-
-				result.scopes.push(...combineScopes(scopes));
+				result.scopes.push(
+					...combineScopes({
+						global: this.roleService.getRoleScopes(req.user.role),
+						project: this.roleService.getRoleScopes(pr.role),
+					}),
+				);
 			}
+
+			results.push(result);
 		}
 
-		// Deduplicate the scopes
-		for (const result of Object.values(resultHash)) {
+		for (const project of otherTeamProject) {
+			const result: ProjectRequest.GetMyProjectsResponse[number] = Object.assign(
+				this.projectRepository.create(project),
+				{
+					// If the user has the global `project:read` scope then they may not
+					// own this relationship in that case we use the global user role
+					// instead of the relation role, which is for another user.
+					role: req.user.role,
+					scopes: req.query.includeScopes ? [] : undefined,
+				},
+			);
+
+			if (result.scopes) {
+				result.scopes.push(
+					...combineScopes({ global: this.roleService.getRoleScopes(req.user.role) }),
+				);
+			}
+
+			results.push(result);
+		}
+
+		// Deduplicate and sort scopes
+		for (const result of results) {
 			if (result.scopes) {
 				result.scopes = [...new Set(result.scopes)].sort();
 			}
 		}
 
-		return Object.values(resultHash);
+		return results;
 	}
 
 	@Get('/personal')

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -13,8 +13,10 @@ import { ProjectRequest } from '@/requests';
 import { ProjectService } from '@/services/project.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
-import { combineScopes, type Scope } from '@n8n/permissions';
+import { combineScopes } from '@n8n/permissions';
+import type { GlobalScopes, ScopeLevels, Scope } from '@n8n/permissions';
 import { RoleService } from '@/services/role.service';
+import type { GlobalRole } from '@/databases/entities/User';
 
 @RestController('/projects')
 export class ProjectController {
@@ -40,26 +42,52 @@ export class ProjectController {
 	@Get('/my-projects')
 	async getMyProjects(
 		req: ProjectRequest.GetMyProjects,
-	): Promise<Array<Project & { role: ProjectRole; scopes?: Scope[] }>> {
+	): Promise<Array<Project & { role: ProjectRole | GlobalRole; scopes?: Scope[] }>> {
 		const relations = await this.projectsService.getProjectRelationsForUser(req.user);
 
-		return relations.map((pr) => {
-			return {
-				name: `Unclaimed Personal Project (${pr.projectId})`,
+		const resultHash: Record<
+			string,
+			Project & { role: ProjectRole | GlobalRole; scopes?: Scope[] }
+		> = {};
+
+		for (const pr of relations) {
+			const result = resultHash[pr.projectId] ?? {
 				...pr.project,
-				role: pr.role,
-				...(req.query.includeScopes
-					? {
-							scopes: [
-								...combineScopes({
-									global: this.roleService.getRoleScopes(req.user.role),
-									project: this.roleService.getRoleScopes(pr.role),
-								}),
-							],
-					  }
-					: {}),
-			} as Project & { role: ProjectRole; scopes?: Scope[] };
-		});
+				// If the user has the global `project:read` scope then they may not
+				// own this relationship in that case we use the global user role
+				// instead of the relation role, which is for another user.
+				role: pr.userId === req.user.id ? pr.role : req.user.role,
+				scopes: req.query.includeScopes ? [] : undefined,
+			};
+			resultHash[pr.projectId] = result;
+
+			// If the user has a relationship to the project then that one trumps the
+			// global role of the user
+			if (pr.userId === req.user.id) {
+				result.role = pr.role;
+			}
+
+			if (result.scopes) {
+				const scopes: GlobalScopes | ScopeLevels =
+					pr.userId === req.user.id
+						? {
+								global: this.roleService.getRoleScopes(req.user.role),
+								project: this.roleService.getRoleScopes(pr.role),
+						  }
+						: { global: this.roleService.getRoleScopes(req.user.role) };
+
+				result.scopes.push(...combineScopes(scopes));
+			}
+		}
+
+		// Deduplicate the scopes
+		for (const result of Object.values(resultHash)) {
+			if (result.scopes) {
+				result.scopes = [...new Set(result.scopes)].sort();
+			}
+		}
+
+		return Object.values(resultHash);
 	}
 
 	@Get('/personal')

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -44,14 +44,8 @@ export class ProjectController {
 		const relations = await this.projectsService.getProjectRelationsForUser(req.user);
 
 		return relations.map((pr) => {
-			let name = pr.project.name;
-			// Only personal projects don't have a name and the only
-			// personal project a user should be linked to is their own
-			if (!name) {
-				// TODO: confirm name with product
-				name = 'My n8n';
-			}
 			return {
+				name: `Unclaimed Personal Project (${pr.projectId})`,
 				...pr.project,
 				role: pr.role,
 				...(req.query.includeScopes

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -15,7 +15,7 @@ import type {
 import { IsBoolean, IsEmail, IsIn, IsOptional, IsString, Length } from 'class-validator';
 import { NoXss } from '@db/utils/customValidators';
 import type { PublicUser, SecretsProvider, SecretsProviderState } from '@/Interfaces';
-import { AssignableRole, type User } from '@db/entities/User';
+import { AssignableRole, GlobalRole, type User } from '@db/entities/User';
 import type { Variables } from '@db/entities/Variables';
 import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';
@@ -561,6 +561,9 @@ export declare namespace ProjectRequest {
 		{
 			includeScopes?: boolean;
 		}
+	>;
+	type GetMyProjectsResponse = Array<
+		Project & { role: ProjectRole | GlobalRole; scopes?: Scope[] }
 	>;
 
 	type GetPersonalProject = AuthenticatedRequest<{}, Project>;

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -15,7 +15,8 @@ import type {
 import { IsBoolean, IsEmail, IsIn, IsOptional, IsString, Length } from 'class-validator';
 import { NoXss } from '@db/utils/customValidators';
 import type { PublicUser, SecretsProvider, SecretsProviderState } from '@/Interfaces';
-import { AssignableRole, GlobalRole, type User } from '@db/entities/User';
+import { AssignableRole } from '@db/entities/User';
+import type { GlobalRole, User } from '@db/entities/User';
 import type { Variables } from '@db/entities/Variables';
 import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import type { CredentialsEntity } from '@db/entities/CredentialsEntity';

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -200,14 +200,8 @@ export class ProjectService {
 	}
 
 	async getProjectRelationsForUser(user: User): Promise<ProjectRelation[]> {
-		const where: Array<FindOptionsWhere<ProjectRelation>> = [{ userId: user.id }];
-
-		if (user.hasGlobalScope('project:read')) {
-			where.push({ project: { type: 'team' } });
-		}
-
 		return await this.projectRelationRepository.find({
-			where,
+			where: { userId: user.id },
 			relations: ['project'],
 		});
 	}

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -200,8 +200,14 @@ export class ProjectService {
 	}
 
 	async getProjectRelationsForUser(user: User): Promise<ProjectRelation[]> {
+		const where: Array<FindOptionsWhere<ProjectRelation>> = [{ userId: user.id }];
+
+		if (user.hasGlobalScope('project:read')) {
+			where.push({ project: { type: 'team' } });
+		}
+
 		return await this.projectRelationRepository.find({
-			where: { userId: user.id },
+			where,
 			relations: ['project'],
 		});
 	}

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -197,10 +197,15 @@ describe('GET /projects/my-projects', () => {
 			createUser(),
 			createUser(),
 		]);
-		const [teamProject1, teamProject2, teamProject3] = await Promise.all([
+		const [teamProject1, teamProject2, teamProject3, teamProject4] = await Promise.all([
+			// owner has no relation ship
 			createTeamProject(undefined, testUser1),
+			// owner is admin
 			createTeamProject(undefined, ownerUser),
+			// owner is viewer
 			createTeamProject(undefined, testUser2),
+			// this project has no relationship at all
+			createTeamProject(),
 		]);
 
 		await linkUserToProject(ownerUser, teamProject3, 'project:viewer');
@@ -226,7 +231,7 @@ describe('GET /projects/my-projects', () => {
 		//
 		// ASSERT
 		//
-		expect(respProjects.length).toBe(4);
+		expect(respProjects.length).toBe(5);
 
 		expect(respProjects.find((p) => p.id === ownerProject.id)).toMatchObject({
 			role: 'project:personalOwner',
@@ -259,6 +264,10 @@ describe('GET /projects/my-projects', () => {
 					...Container.get(RoleService).getRoleScopes('global:owner'),
 				]),
 			].sort(),
+		});
+		expect(respProjects.find((p) => p.id === teamProject4.id)).toMatchObject({
+			role: 'global:owner',
+			scopes: [...new Set([...Container.get(RoleService).getRoleScopes('global:owner')])].sort(),
 		});
 
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject1.id }));

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -124,6 +124,9 @@ describe('GET /projects/', () => {
 
 describe('GET /projects/my-projects', () => {
 	test('member should get all projects they are apart of', async () => {
+		//
+		// ARRANGE
+		//
 		const [testUser1, testUser2, testUser3] = await Promise.all([
 			createUser(),
 			createUser(),
@@ -140,28 +143,29 @@ describe('GET /projects/my-projects', () => {
 			getPersonalProject(testUser3),
 		]);
 
-		const memberAgent = testServer.authAgentFor(testUser1);
+		//
+		// ACT
+		//
+		const resp = await testServer.authAgentFor(testUser1).get('/projects/my-projects').expect(200);
+		const respProjects: Project[] = resp.body.data;
 
-		const resp = await memberAgent.get('/projects/my-projects');
-		expect(resp.status).toBe(200);
-		const respProjects = resp.body.data as Project[];
+		//
+		// ASSERT
+		//
 		expect(respProjects.length).toBe(2);
 
-		expect(
-			[personalProject2, personalProject3].every((v) => {
-				const p = respProjects.find((p) => p.id === v.id);
-				if (!p) {
-					return true;
-				}
-				return false;
-			}),
-		).toBe(true);
-		expect(respProjects.find((p) => p.id === personalProject1.id)).not.toBeUndefined();
-		expect(respProjects.find((p) => p.id === teamProject1.id)).not.toBeUndefined();
-		expect(respProjects.find((p) => p.id === teamProject2.id)).toBeUndefined();
+		expect(respProjects).toContainEqual(expect.objectContaining({ id: teamProject1.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: teamProject2.id }));
+
+		expect(respProjects).toContainEqual(expect.objectContaining({ id: personalProject1.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject3.id }));
 	});
 
 	test('owner should get all projects they are apart of', async () => {
+		//
+		// ARRANGE
+		//
 		const [ownerUser, testUser1, testUser2, testUser3] = await Promise.all([
 			createOwner(),
 			createUser(),
@@ -180,25 +184,24 @@ describe('GET /projects/my-projects', () => {
 			getPersonalProject(testUser3),
 		]);
 
-		const memberAgent = testServer.authAgentFor(ownerUser);
+		//
+		// ACT
+		//
+		const resp = await testServer.authAgentFor(ownerUser).get('/projects/my-projects').expect(200);
+		const respProjects: Project[] = resp.body.data;
 
-		const resp = await memberAgent.get('/projects/my-projects');
-		expect(resp.status).toBe(200);
-		const respProjects = resp.body.data as Project[];
-		expect(respProjects.length).toBe(2);
+		//
+		// ASSERT
+		//
+		expect(respProjects.length).toBe(3);
 
-		expect(
-			[personalProject1, personalProject2, personalProject3].every((v) => {
-				const p = respProjects.find((p) => p.id === v.id);
-				if (!p) {
-					return true;
-				}
-				return false;
-			}),
-		).toBe(true);
-		expect(respProjects.find((p) => p.id === ownerProject.id)).not.toBeUndefined();
-		expect(respProjects.find((p) => p.id === teamProject1.id)).toBeUndefined();
-		expect(respProjects.find((p) => p.id === teamProject2.id)).not.toBeUndefined();
+		expect(respProjects).toContainEqual(expect.objectContaining({ id: ownerProject.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject1.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject3.id }));
+
+		expect(respProjects).toContainEqual(expect.objectContaining({ id: teamProject1.id }));
+		expect(respProjects).toContainEqual(expect.objectContaining({ id: teamProject2.id }));
 	});
 });
 


### PR DESCRIPTION
## Summary

The endpoint `GET /my-projects` now returns the personal project and all team projects if the user has global `project:read` permissions.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1455/update-the-project-endpoint-to-return-all-team-projects-for

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

