### PR TITLE
fix(core): Fail correctly when trying to transfer resources to the user that is being deleted

### DIFF
--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -155,12 +155,6 @@ export class UsersController {
 
 		const { transferId } = req.query;
 
-		if (transferId === idToDelete) {
-			throw new BadRequestError(
-				'Request to delete a user failed because the user to delete and the transferee are the same user',
-			);
-		}
-
 		const userToDelete = await this.userRepository.findOneBy({ id: idToDelete });
 
 		if (!userToDelete) {
@@ -172,6 +166,12 @@ export class UsersController {
 		const personalProjectToDelete = await this.projectRepository.getPersonalProjectForUserOrFail(
 			userToDelete.id,
 		);
+
+		if (transferId === personalProjectToDelete.id) {
+			throw new BadRequestError(
+				'Request to delete a user failed because the user to delete and the transferee are the same user',
+			);
+		}
 
 		const telemetryData: ITelemetryUserDeletionData = {
 			user_id: req.user.id,

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -542,6 +542,20 @@ describe('DELETE /users/:id', () => {
 		expect(user).toBeDefined();
 	});
 
+	test('should fail to delete a user that does not exist', async () => {
+		await ownerAgent.delete('/users/foobar').query({ transferId: '' }).expect(404);
+	});
+
+	test('should fail to transfer to a project that does not exist', async () => {
+		const member = await createMember();
+
+		await ownerAgent.delete(`/users/${member.id}`).query({ transferId: 'foobar' }).expect(404);
+
+		const user = await Container.get(UserRepository).findOneBy({ id: member.id });
+
+		expect(user).toBeDefined();
+	});
+
 	test('should fail to delete if user to delete is transferee', async () => {
 		const member = await createMember();
 		const personalProject = await getPersonalProject(member);

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -544,8 +544,12 @@ describe('DELETE /users/:id', () => {
 
 	test('should fail to delete if user to delete is transferee', async () => {
 		const member = await createMember();
+		const personalProject = await getPersonalProject(member);
 
-		await ownerAgent.delete(`/users/${member.id}`).query({ transferId: member.id }).expect(400);
+		await ownerAgent
+			.delete(`/users/${member.id}`)
+			.query({ transferId: personalProject.id })
+			.expect(400);
 
 		const user = await Container.get(UserRepository).findOneBy({ id: member.id });
 


### PR DESCRIPTION
## Summary

Before the code was comparing a user ID to a project ID, now it's comparing a project ID with a project ID and thus fails correctly.

I also added 2 more tests for failure scenarios:

1. trying to delete a user that does not exist
2. trying to transfer to a project that does not exist

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

