### PR TITLE
fix Make custom webhook works on the case that multiple main outputs are connected.

### DIFF
--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -1284,7 +1284,11 @@ export class Workflow {
 				if (inputData.main[0] === null) {
 					return { data: undefined };
 				}
-				return { data: [inputData.main[0]] };
+				// make it works on the case that multiple main outputs are connected.
+				// example: a multi-branch custom webhook node
+				return {
+					data: inputData.main.map((item) => (item === null ? [] : item)),
+				};
 			}
 			return { data: undefined };
 		}


### PR DESCRIPTION
make it works on the case that multiple main outputs are connected. example: a multi-branch custom webhook node

## Summary
		
I make a new cutom webhook node with 2 main outputs.
But the output always return the first main output.
So I need to change the code to return all main outputs.
<img width="558" alt="image" src="https://github.com/n8n-io/n8n/assets/1625704/6f3542e1-4d17-48c5-83f0-a2d702e8c6a4">


## Related tickets and issues
none.

## Review / Merge checklist
- [ x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 