### PR TITLE
fix: Get all parent nodes > useRunWorkflow (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -183,7 +183,7 @@ export function useRunWorkflow(options: { router: ReturnType<typeof useRouter> }
 				directParentNodes = workflow.getParentNodes(
 					options.destinationNode,
 					NodeConnectionType.Main,
-					1,
+					-1,
 				);
 			}
 


### PR DESCRIPTION
## Summary
Get all parent nodes, not just depth 1



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1266/form-trigger-is-not-opening-when-running-the-wf-via-a-node-execute