### PR TITLE
fix(core): Create personal project when a user is created via LDAP

### DIFF
--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -272,14 +272,11 @@ export const createLdapAuthIdentity = async (user: User, ldapId: string) => {
 };
 
 export const createLdapUserOnLocalDb = async (data: Partial<User>, ldapId: string) => {
-	const user = await Container.get(UserRepository).save(
-		{
-			password: randomPassword(),
-			role: 'global:member',
-			...data,
-		},
-		{ transaction: false },
-	);
+	const { user } = await Container.get(UserRepository).createUserWithProject({
+		password: randomPassword(),
+		role: 'global:member',
+		...data,
+	});
 	await createLdapAuthIdentity(user, ldapId);
 	return user;
 };

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -21,6 +21,7 @@ import { createLdapUser, createUser, getAllUsers, getLdapIdentities } from '../s
 import { UserRepository } from '@db/repositories/user.repository';
 import { SettingsRepository } from '@db/repositories/settings.repository';
 import { AuthProviderSyncHistoryRepository } from '@db/repositories/authProviderSyncHistory.repository';
+import { getPersonalProject } from '../shared/db/projects';
 
 jest.mock('@/telemetry');
 
@@ -509,6 +510,8 @@ describe('POST /login', () => {
 		expect(localLdapUsers[0].firstName).toBe(ldapUser.givenName);
 		expect(localLdapIdentities[0].providerId).toBe(ldapUser.uid);
 		expect(localLdapUsers[0].disabled).toBe(false);
+
+		await expect(getPersonalProject(localLdapUsers[0])).resolves.toBeDefined();
 	};
 
 	test('should allow new LDAP user to login and synchronize data', async () => {


### PR DESCRIPTION
## Summary

We're not creating a personal project for users that are created via LDAP.
With this PR we do.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

