### PR TITLE
feat(core): Create names for personal projects in one place and resuse it

### DIFF
--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -9,6 +9,7 @@ import Container from 'typedi';
 import { ProjectRepository } from '../repositories/project.repository';
 import { ApplicationError, ErrorReporterProxy } from 'n8n-workflow';
 import { Logger } from '@/Logger';
+import { UserRepository } from '../repositories/user.repository';
 
 export type ProjectType = 'personal' | 'team' | 'public';
 
@@ -49,7 +50,9 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 					fields.includes('email')
 				) {
 					const oldUser = event.databaseEntity;
-					const name = `${newUserData.firstName} ${newUserData.lastName} <${newUserData.email}>`;
+					const name = Container.get(UserRepository)
+						.create(newUserData)
+						.createPersonalProjectName();
 
 					const project = await Container.get(ProjectRepository).getPersonalProjectForUser(
 						oldUser.id,

--- a/packages/cli/src/databases/entities/User.ts
+++ b/packages/cli/src/databases/entities/User.ts
@@ -155,4 +155,14 @@ export class User extends WithTimestamps implements IUser {
 		const { password, apiKey, mfaSecret, mfaRecoveryCodes, ...rest } = this;
 		return rest;
 	}
+
+	createPersonalProjectName() {
+		if (this.firstName && this.lastName && this.email) {
+			return `${this.firstName} ${this.lastName} <${this.email}>`;
+		} else if (this.email) {
+			return `<${this.email}>`;
+		} else {
+			return 'Unnamed Project';
+		}
+	}
 }

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -130,6 +130,7 @@ export class UserRepository extends Repository<User> {
 			const savedProject = await entityManager.save<Project>(
 				entityManager.create(Project, {
 					type: 'personal',
+					name: savedUser.createPersonalProjectName(),
 				}),
 			);
 			await entityManager.save<ProjectRelation>(

--- a/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
+++ b/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
@@ -306,7 +306,7 @@ describe('InvitationController', () => {
 			});
 
 			expect(projectRelation).not.toBeUndefined();
-			expect(projectRelation.project.name).toBeNull();
+			expect(projectRelation.project.name).toBe(storedUser.createPersonalProjectName());
 			expect(projectRelation.project.type).toBe('personal');
 		});
 

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -116,7 +116,7 @@ describe('GET /credentials', () => {
 		expect(ownerCredential.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
 			type: 'personal',
-			name: 'My n8n',
+			name: owner.createPersonalProjectName(),
 		});
 
 		expect(Array.isArray(ownerCredential.sharedWithProjects)).toBe(true);
@@ -132,14 +132,13 @@ describe('GET /credentials', () => {
 			expect(sharee).toMatchObject({
 				id: orderedSharedWith[idx].id,
 				type: orderedSharedWith[idx].type,
-				name: 'My n8n',
 			});
 		});
 
 		expect(memberCredential.homeProject).toMatchObject({
 			id: member1PersonalProject.id,
 			type: member1PersonalProject.type,
-			name: 'My n8n',
+			name: member1.createPersonalProjectName(),
 		});
 
 		expect(Array.isArray(memberCredential.sharedWithProjects)).toBe(true);
@@ -177,14 +176,14 @@ describe('GET /credentials', () => {
 
 		expect(member1Credential.homeProject).toMatchObject({
 			id: member1PersonalProject.id,
-			name: 'My n8n',
+			name: member1.createPersonalProjectName(),
 			type: member1PersonalProject.type,
 		});
 
 		expect(member1Credential.sharedWithProjects).toHaveLength(1);
 		expect(member1Credential.sharedWithProjects[0]).toMatchObject({
 			id: member2PersonalProject.id,
-			name: 'My n8n',
+			name: member2.createPersonalProjectName(),
 			type: member2PersonalProject.type,
 		});
 	});
@@ -232,7 +231,7 @@ describe('GET /credentials/:id', () => {
 
 		expect(firstCredential.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: 'My n8n',
+			name: owner.createPersonalProjectName(),
 			type: ownerPersonalProject.type,
 		});
 		expect(firstCredential.sharedWithProjects).toHaveLength(0);
@@ -271,13 +270,13 @@ describe('GET /credentials/:id', () => {
 		expect(credential).toMatchObject({
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: 'My n8n',
+				name: member1.createPersonalProjectName(),
 				type: member1PersonalProject.type,
 			},
 			sharedWithProjects: [
 				{
 					id: member2PersonalProject.id,
-					name: 'My n8n',
+					name: member2.createPersonalProjectName(),
 					type: member2PersonalProject.type,
 				},
 			],
@@ -322,18 +321,18 @@ describe('GET /credentials/:id', () => {
 		expect(firstCredential).toMatchObject({
 			homeProject: {
 				id: member1PersonalProject.id,
-				name: 'My n8n',
+				name: member1.createPersonalProjectName(),
 				type: 'personal',
 			},
 			sharedWithProjects: expect.arrayContaining([
 				{
 					id: member2PersonalProject.id,
-					name: 'My n8n',
+					name: member2.createPersonalProjectName(),
 					type: member2PersonalProject.type,
 				},
 				{
 					id: member3PersonalProject.id,
-					name: 'My n8n',
+					name: member3.createPersonalProjectName(),
 					type: member3PersonalProject.type,
 				},
 			]),

--- a/packages/cli/test/integration/me.api.test.ts
+++ b/packages/cli/test/integration/me.api.test.ts
@@ -71,9 +71,7 @@ describe('Owner shell', () => {
 				ProjectRepository,
 			).getPersonalProjectForUserOrFail(storedOwnerShell.id);
 
-			expect(storedPersonalProject.name).toBe(
-				`${storedOwnerShell.firstName} ${storedOwnerShell.lastName} <${storedOwnerShell.email}>`,
-			);
+			expect(storedPersonalProject.name).toBe(storedOwnerShell.createPersonalProjectName());
 		}
 	});
 
@@ -91,7 +89,7 @@ describe('Owner shell', () => {
 				ProjectRepository,
 			).getPersonalProjectForUserOrFail(storedOwnerShell.id);
 
-			expect(storedPersonalProject.name).toBeNull();
+			expect(storedPersonalProject.name).toBe(storedOwnerShell.createPersonalProjectName());
 		}
 	});
 
@@ -224,9 +222,7 @@ describe('Member', () => {
 			const storedPersonalProject =
 				await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(id);
 
-			expect(storedPersonalProject.name).toBe(
-				`${storedMember.firstName} ${storedMember.lastName} <${storedMember.email}>`,
-			);
+			expect(storedPersonalProject.name).toBe(storedMember.createPersonalProjectName());
 		}
 	});
 
@@ -244,7 +240,7 @@ describe('Member', () => {
 				ProjectRepository,
 			).getPersonalProjectForUserOrFail(storedMember.id);
 
-			expect(storedPersonalProject.name).toBeNull();
+			expect(storedPersonalProject.name).toBe(storedMember.createPersonalProjectName());
 		}
 	});
 
@@ -367,9 +363,7 @@ describe('Owner', () => {
 				ProjectRepository,
 			).getPersonalProjectForUserOrFail(storedOwner.id);
 
-			expect(storedPersonalProject.name).toBe(
-				`${storedOwner.firstName} ${storedOwner.lastName} <${storedOwner.email}>`,
-			);
+			expect(storedPersonalProject.name).toBe(storedOwner.createPersonalProjectName());
 		}
 	});
 });

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -67,7 +67,7 @@ describe('GET /projects/', () => {
 					return false;
 				}
 				const u = [testUser1, testUser2, testUser3][i];
-				return p.name === `${u.firstName} ${u.lastName}`;
+				return p.name === u.createPersonalProjectName();
 			}),
 		).toBe(true);
 		expect(respProjects.find((p) => p.id === teamProject1.id)).not.toBeUndefined();
@@ -107,7 +107,7 @@ describe('GET /projects/', () => {
 					return false;
 				}
 				const u = [ownerUser, testUser1, testUser2, testUser3][i];
-				return p.name === `${u.firstName} ${u.lastName}`;
+				return p.name === u.createPersonalProjectName();
 			}),
 		).toBe(true);
 		expect(respProjects.find((p) => p.id === teamProject1.id)).not.toBeUndefined();

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -25,6 +25,7 @@ import { RESPONSE_ERROR_MESSAGES } from '@/constants';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { createTeamProject, getPersonalProject, linkUserToProject } from './shared/db/projects';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+import { v4 as uuid } from 'uuid';
 
 mockInstance(ExecutionService);
 
@@ -543,7 +544,7 @@ describe('DELETE /users/:id', () => {
 	});
 
 	test('should fail to delete a user that does not exist', async () => {
-		await ownerAgent.delete('/users/foobar').query({ transferId: '' }).expect(404);
+		await ownerAgent.delete(`/users/${uuid()}`).query({ transferId: '' }).expect(404);
 	});
 
 	test('should fail to transfer to a project that does not exist', async () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -297,7 +297,7 @@ describe('GET /workflows/:id', () => {
 
 		expect(responseWorkflow.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: 'My n8n',
+			name: owner.createPersonalProjectName(),
 			type: 'personal',
 		});
 
@@ -313,14 +313,14 @@ describe('GET /workflows/:id', () => {
 
 		expect(responseWorkflow.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: 'My n8n',
+			name: owner.createPersonalProjectName(),
 			type: 'personal',
 		});
 
 		expect(responseWorkflow.sharedWithProjects).toHaveLength(1);
 		expect(responseWorkflow.sharedWithProjects[0]).toMatchObject({
 			id: memberPersonalProject.id,
-			name: 'My n8n',
+			name: member.createPersonalProjectName(),
 			type: 'personal',
 		});
 	});
@@ -334,7 +334,7 @@ describe('GET /workflows/:id', () => {
 
 		expect(responseWorkflow.homeProject).toMatchObject({
 			id: ownerPersonalProject.id,
-			name: 'My n8n',
+			name: owner.createPersonalProjectName(),
 			type: 'personal',
 		});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -343,7 +343,7 @@ describe('GET /workflows', () => {
 					versionId: any(String),
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: 'My n8n',
+						name: owner.createPersonalProjectName(),
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -358,7 +358,7 @@ describe('GET /workflows', () => {
 					versionId: any(String),
 					homeProject: {
 						id: ownerPersonalProject.id,
-						name: 'My n8n',
+						name: owner.createPersonalProjectName(),
 						type: ownerPersonalProject.type,
 					},
 					sharedWithProjects: [],
@@ -704,7 +704,7 @@ describe('GET /workflows', () => {
 						id: any(String),
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: 'My n8n',
+							name: owner.createPersonalProjectName(),
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],
@@ -713,7 +713,7 @@ describe('GET /workflows', () => {
 						id: any(String),
 						homeProject: {
 							id: ownerPersonalProject.id,
-							name: 'My n8n',
+							name: owner.createPersonalProjectName(),
 							type: ownerPersonalProject.type,
 						},
 						sharedWithProjects: [],

--- a/packages/cli/test/unit/databases/entities/user.entity.test.ts
+++ b/packages/cli/test/unit/databases/entities/user.entity.test.ts
@@ -17,4 +17,22 @@ describe('User Entity', () => {
 			);
 		});
 	});
+
+	describe('createPersonalProjectName', () => {
+		test.each([
+			['Nathan', 'Nathaniel', 'nathan@nathaniel.n8n', 'Nathan Nathaniel <nathan@nathaniel.n8n>'],
+			[undefined, 'Nathaniel', 'nathan@nathaniel.n8n', '<nathan@nathaniel.n8n>'],
+			['Nathan', undefined, 'nathan@nathaniel.n8n', '<nathan@nathaniel.n8n>'],
+			[undefined, undefined, 'nathan@nathaniel.n8n', '<nathan@nathaniel.n8n>'],
+			[undefined, undefined, undefined, 'Unnamed Project'],
+			['Nathan', 'Nathaniel', undefined, 'Unnamed Project'],
+		])(
+			'given fistName: %s, lastName: %s and email: %s this gives the projectName: "%s"',
+			async (firstName, lastName, email, projectName) => {
+				const user = new User();
+				Object.assign(user, { firstName, lastName, email });
+				expect(user.createPersonalProjectName()).toBe(projectName);
+			},
+		);
+	});
 });


### PR DESCRIPTION
## Summary

This adds a helper function to the user entity that generates the name for the user's personal project.
Next step would be to mark the field as non-nullable in the entity and the migration.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

