### PR TITLE
fix(editor): UI enhancements and fixes for expression inputs

### DIFF
--- a/packages/editor-ui/src/__tests__/setup.ts
+++ b/packages/editor-ui/src/__tests__/setup.ts
@@ -12,3 +12,10 @@ window.ResizeObserver =
 	}));
 
 Element.prototype.scrollIntoView = vi.fn();
+
+Range.prototype.getBoundingClientRect = vi.fn();
+Range.prototype.getClientRects = vi.fn(() => ({
+	item: vi.fn(),
+	length: 0,
+	[Symbol.iterator]: vi.fn(),
+}));

--- a/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -169,7 +169,6 @@ const onBlur = (): void => {
 						display-options
 						hide-label
 						hide-hint
-						:rows="3"
 						:is-read-only="isReadOnly"
 						:parameter="nameParameter"
 						:value="assignment.name"
@@ -196,7 +195,6 @@ const onBlur = (): void => {
 							hide-label
 							hide-issues
 							hide-hint
-							:rows="3"
 							is-assignment
 							:is-read-only="isReadOnly"
 							:options-position="breakpoint === 'default' ? 'top' : 'bottom'"

--- a/packages/editor-ui/src/components/FilterConditions/Condition.vue
+++ b/packages/editor-ui/src/components/FilterConditions/Condition.vue
@@ -156,7 +156,6 @@ const onBlur = (): void => {
 					hide-label
 					hide-hint
 					hide-issues
-					:rows="3"
 					:is-read-only="readOnly"
 					:parameter="leftParameter"
 					:value="condition.leftValue"
@@ -181,7 +180,6 @@ const onBlur = (): void => {
 					hide-label
 					hide-hint
 					hide-issues
-					:rows="3"
 					:is-read-only="readOnly"
 					:options-position="breakpoint === 'default' ? 'top' : 'bottom'"
 					:parameter="rightParameter"

--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
@@ -72,8 +72,8 @@ const resolvedSegments = computed<Resolved[]>(() => {
 				segment.kind === 'plaintext'
 					? segment.plaintext.length
 					: segment.resolved
-					  ? (segment.resolved as string | number | boolean).toString().length
-					  : 0;
+						? (segment.resolved as string | number | boolean).toString().length
+						: 0;
 			segment.to = cursor;
 			return segment;
 		})

--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
@@ -45,21 +45,24 @@ const resolvedExpression = computed(() => {
 });
 
 const plaintextSegments = computed<Plaintext[]>(() => {
-	if (props.segments.length === 0) {
-		return [
-			{
-				from: 0,
-				to: resolvedExpression.value.length - 1,
-				plaintext: resolvedExpression.value,
-				kind: 'plaintext',
-			},
-		];
-	}
-
 	return props.segments.filter((s): s is Plaintext => s.kind === 'plaintext');
 });
 
 const resolvedSegments = computed<Resolved[]>(() => {
+	if (props.segments.length === 0) {
+		const emptyExpression = resolvedExpression.value;
+		const emptySegment: Resolved = {
+			from: 0,
+			to: emptyExpression.length,
+			kind: 'resolvable',
+			error: null,
+			resolvable: '',
+			resolved: emptyExpression,
+			state: 'pending',
+		};
+		return [emptySegment];
+	}
+
 	let cursor = 0;
 
 	return props.segments
@@ -69,8 +72,8 @@ const resolvedSegments = computed<Resolved[]>(() => {
 				segment.kind === 'plaintext'
 					? segment.plaintext.length
 					: segment.resolved
-						? (segment.resolved as string | number | boolean).toString().length
-						: 0;
+					  ? (segment.resolved as string | number | boolean).toString().length
+					  : 0;
 			segment.to = cursor;
 			return segment;
 		})

--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -1,6 +1,6 @@
 <template>
 	<n8n-input-label
-		:class="$style.wrapper"
+		:class="[$style.wrapper, { [$style.tipVisible]: showDragnDropTip }]"
 		:label="hideLabel ? '' : i18n.nodeText().inputLabelDisplayName(parameter, path)"
 		:tooltip-text="hideLabel ? '' : i18n.nodeText().inputLabelDescription(parameter, path)"
 		:show-tooltip="focused"
@@ -355,6 +355,11 @@ export default defineComponent({
 			opacity: 1;
 		}
 	}
+}
+
+.tipVisible {
+	--input-border-bottom-left-radius: 0;
+	--input-border-bottom-right-radius: 0;
 }
 
 .tip {

--- a/packages/editor-ui/src/components/__tests__/ExpressionEditorModalInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ExpressionEditorModalInput.test.ts
@@ -6,8 +6,6 @@ import { setActivePinia } from 'pinia';
 import { waitFor } from '@testing-library/vue';
 
 describe('ExpressionParameterInput', () => {
-	const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
-	const originalRangeGetClientRects = Range.prototype.getClientRects;
 	const renderComponent = createComponentRenderer(ExpressionEditorModalInput);
 	let pinia: TestingPinia;
 
@@ -16,19 +14,6 @@ describe('ExpressionParameterInput', () => {
 		setActivePinia(pinia);
 	});
 
-	beforeAll(() => {
-		Range.prototype.getBoundingClientRect = vi.fn();
-		Range.prototype.getClientRects = () => ({
-			item: vi.fn(),
-			length: 0,
-			[Symbol.iterator]: vi.fn(),
-		});
-	});
-
-	afterAll(() => {
-		Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
-		Range.prototype.getClientRects = originalRangeGetClientRects;
-	});
 	test.each([
 		['not be editable', 'readonly', true, ''],
 		['be editable', 'not readonly', false, 'test'],

--- a/packages/editor-ui/src/components/__tests__/HtmlEditor.test.ts
+++ b/packages/editor-ui/src/components/__tests__/HtmlEditor.test.ts
@@ -17,9 +17,6 @@ const DEFAULT_SETUP = {
 };
 
 describe('HtmlEditor.vue', () => {
-	const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
-	const originalRangeGetClientRects = Range.prototype.getClientRects;
-
 	const pinia = createTestingPinia({
 		initialState: {
 			[STORES.SETTINGS]: {
@@ -28,20 +25,6 @@ describe('HtmlEditor.vue', () => {
 		},
 	});
 	setActivePinia(pinia);
-
-	beforeAll(() => {
-		Range.prototype.getBoundingClientRect = vi.fn();
-		Range.prototype.getClientRects = () => ({
-			item: vi.fn(),
-			length: 0,
-			[Symbol.iterator]: vi.fn(),
-		});
-	});
-
-	afterAll(() => {
-		Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
-		Range.prototype.getClientRects = originalRangeGetClientRects;
-	});
 
 	afterAll(() => {
 		vi.clearAllMocks();

--- a/packages/editor-ui/src/composables/__tests__/useAutocompleteTelemetry.test.ts
+++ b/packages/editor-ui/src/composables/__tests__/useAutocompleteTelemetry.test.ts
@@ -28,29 +28,12 @@ vi.mock('@/stores/n8nRoot.store', () => ({
 }));
 
 describe('useAutocompleteTelemetry', () => {
-	const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
-	const originalRangeGetClientRects = Range.prototype.getClientRects;
-
 	beforeEach(() => {
 		setActivePinia(createTestingPinia());
 	});
 
 	afterEach(() => {
 		vi.clearAllMocks();
-	});
-
-	beforeAll(() => {
-		Range.prototype.getBoundingClientRect = vi.fn();
-		Range.prototype.getClientRects = () => ({
-			item: vi.fn(),
-			length: 0,
-			[Symbol.iterator]: vi.fn(),
-		});
-	});
-
-	afterAll(() => {
-		Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
-		Range.prototype.getClientRects = originalRangeGetClientRects;
 	});
 
 	const getEditor = (defaultDoc = '') => {

--- a/packages/editor-ui/src/composables/__tests__/useExpressionEditor.test.ts
+++ b/packages/editor-ui/src/composables/__tests__/useExpressionEditor.test.ts
@@ -21,9 +21,6 @@ vi.mock('@/stores/ndv.store', () => ({
 }));
 
 describe('useExpressionEditor', () => {
-	const originalRangeGetBoundingClientRect = Range.prototype.getBoundingClientRect;
-	const originalRangeGetClientRects = Range.prototype.getClientRects;
-
 	const mockResolveExpression = () => {
 		const mock = vi.fn();
 		vi.spyOn(workflowHelpers, 'useWorkflowHelpers').mockReturnValueOnce({
@@ -40,20 +37,6 @@ describe('useExpressionEditor', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
-	});
-
-	beforeAll(() => {
-		Range.prototype.getBoundingClientRect = vi.fn();
-		Range.prototype.getClientRects = () => ({
-			item: vi.fn(),
-			length: 0,
-			[Symbol.iterator]: vi.fn(),
-		});
-	});
-
-	afterAll(() => {
-		Range.prototype.getBoundingClientRect = originalRangeGetBoundingClientRect;
-		Range.prototype.getClientRects = originalRangeGetClientRects;
 	});
 
 	test('should create an editor', async () => {

--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -385,10 +385,8 @@ export const useExpressionEditor = ({
 	function setCursorPosition(pos: number | 'lastExpression' | 'end'): void {
 		if (pos === 'lastExpression') {
 			const END_OF_EXPRESSION = ' }}';
-			pos = Math.max(
-				readEditorValue().lastIndexOf(END_OF_EXPRESSION),
-				editor.value?.state.doc.length ?? 0,
-			);
+			const endOfLastExpression = readEditorValue().lastIndexOf(END_OF_EXPRESSION);
+			pos = endOfLastExpression !== -1 ? endOfLastExpression : editor.value?.state.doc.length ?? 0;
 		} else if (pos === 'end') {
 			pos = editor.value?.state.doc.length ?? 0;
 		}

--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -185,7 +185,7 @@ export const useExpressionEditor = ({
 		if (editor.value) {
 			editor.value.destroy();
 		}
-		editor.value = new EditorView({ parent, state });
+		editor.value = new EditorView({ parent, state, scrollTo: EditorView.scrollIntoView(0) });
 		debouncedUpdateSegments();
 	});
 
@@ -385,7 +385,10 @@ export const useExpressionEditor = ({
 	function setCursorPosition(pos: number | 'lastExpression' | 'end'): void {
 		if (pos === 'lastExpression') {
 			const END_OF_EXPRESSION = ' }}';
-			pos = Math.max(readEditorValue().lastIndexOf(END_OF_EXPRESSION), 0);
+			pos = Math.max(
+				readEditorValue().lastIndexOf(END_OF_EXPRESSION),
+				editor.value?.state.doc.length ?? 0,
+			);
 		} else if (pos === 'end') {
 			pos = editor.value?.state.doc.length ?? 0;
 		}

--- a/packages/workflow/src/Extensions/StringExtensions.ts
+++ b/packages/workflow/src/Extensions/StringExtensions.ts
@@ -382,7 +382,10 @@ function parseJson(value: string): unknown {
 	try {
 		return JSON.parse(value);
 	} catch (error) {
-		return undefined;
+		if (value.includes("'")) {
+			throw new ExpressionExtensionError("Parsing failed. Check you're using double quotes");
+		}
+		throw new ExpressionExtensionError('Parsing failed');
 	}
 }
 

--- a/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/StringExtensions.test.ts
@@ -270,7 +270,13 @@ describe('Data Transformation Functions', () => {
 				test1: 1,
 				test2: '2',
 			});
-			expect(evaluate('={{ "hi".parseJson() }}')).toBeUndefined();
+		});
+
+		test('.parseJson should throw on invalid JSON', () => {
+			expect(() => evaluate("={{ \"{'test1':1,'test2':'2'}\".parseJson() }}")).toThrowError(
+				"Parsing failed. Check you're using double quotes",
+			);
+			expect(() => evaluate('={{ "No JSON here".parseJson() }}')).toThrowError('Parsing failed');
 		});
 
 		test('.toBoolean should work on a string', () => {


### PR DESCRIPTION
## Summary

- Increase height of an expression field (3 -> 5 rows)
- `[empty]` in expression output: use a lighter text color
- Fix: Long expressions were scrolled halfway down when opening NDV
- Fix: Remove rounded corners in Fixed fields with the popunder on
- parseJson(): If there’s a parse error at a single quote, display the following error: Parsing failed. Check you’re using double quotes


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1272/ui-enhancements-and-fixes-for-expression-inputs



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 