### PR TITLE
fix(core): Don't return personal projects from `GET /projects/my-projects`

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -44,7 +44,9 @@ export class ProjectController {
 	async getMyProjects(
 		req: ProjectRequest.GetMyProjects,
 	): Promise<ProjectRequest.GetMyProjectsResponse> {
-		const relations = await this.projectsService.getProjectRelationsForUser(req.user);
+		const relations = (await this.projectsService.getProjectRelationsForUser(req.user)).filter(
+			(pr) => pr.project.type === 'team',
+		);
 		const otherTeamProject = req.user.hasGlobalScope('project:read')
 			? await this.projectRepository.findBy({
 					type: 'team',

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -160,17 +160,7 @@ describe('GET /projects/my-projects', () => {
 		//
 		// ASSERT
 		//
-		expect(respProjects.length).toBe(2);
-
-		expect(respProjects.find((p) => p.id === personalProject1.id)).toMatchObject({
-			role: 'project:personalOwner',
-			scopes: [
-				...new Set([
-					...Container.get(RoleService).getRoleScopes('project:personalOwner'),
-					...Container.get(RoleService).getRoleScopes('global:member'),
-				]),
-			].sort(),
-		});
+		expect(respProjects.length).toBe(1);
 
 		expect(respProjects.find((p) => p.id === teamProject1.id)).toMatchObject({
 			role: 'project:admin',
@@ -182,6 +172,7 @@ describe('GET /projects/my-projects', () => {
 			].sort(),
 		});
 
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject1.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject3.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: teamProject2.id }));
@@ -231,17 +222,7 @@ describe('GET /projects/my-projects', () => {
 		//
 		// ASSERT
 		//
-		expect(respProjects.length).toBe(5);
-
-		expect(respProjects.find((p) => p.id === ownerProject.id)).toMatchObject({
-			role: 'project:personalOwner',
-			scopes: [
-				...new Set([
-					...Container.get(RoleService).getRoleScopes('project:personalOwner'),
-					...Container.get(RoleService).getRoleScopes('global:owner'),
-				]),
-			].sort(),
-		});
+		expect(respProjects.length).toBe(4);
 
 		expect(respProjects.find((p) => p.id === teamProject1.id)).toMatchObject({
 			role: 'global:owner',
@@ -270,6 +251,7 @@ describe('GET /projects/my-projects', () => {
 			scopes: [...new Set([...Container.get(RoleService).getRoleScopes('global:owner')])].sort(),
 		});
 
+		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: ownerProject.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject1.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject3.id }));


### PR DESCRIPTION
## Summary

`GET /projects/my-projects` must not return personal projects, also not the one of the user making the request.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

