### PR TITLE
fix(editor): Issue showing Auth2 callback section when all properties are overriden

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -78,7 +78,7 @@
 			/>
 
 			<CopyInput
-				v-if="isOAuthType && credentialProperties.length"
+				v-if="isOAuthType && !allOAuth2BasePropertiesOverridden"
 				:label="$locale.baseText('credentialEdit.credentialConfig.oAuthRedirectUrl')"
 				:value="oAuthCallbackUrl"
 				:copy-button-text="$locale.baseText('credentialEdit.credentialConfig.clickToCopy')"
@@ -202,6 +202,9 @@ export default defineComponent({
 			type: Boolean,
 		},
 		isOAuthType: {
+			type: Boolean,
+		},
+		allOAuth2BasePropertiesOverridden: {
 			type: Boolean,
 		},
 		isOAuthConnected: {

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -435,7 +435,7 @@ export default defineComponent({
 				return [];
 			}
 
-			return this.credentialType.properties.filter((propertyData: INodeProperties) => {
+			const properties = this.credentialType.properties.filter((propertyData: INodeProperties) => {
 				if (!this.displayCredentialParameter(propertyData)) {
 					return false;
 				}
@@ -444,6 +444,19 @@ export default defineComponent({
 					!this.credentialType!.__overwrittenProperties.includes(propertyData.name)
 				);
 			});
+
+			/**
+			 * If after all credentials overrides are applied only "notice"
+			 * properties are left, do not return them. This will avoid:
+			 * 1 - Showing notices that refer to a property that was overridden.
+			 * 2 - Showing callback URL copy section when all non notice properties
+			 * are overridden.
+			 */
+			if (properties.every((p) => p.type === 'notice')) {
+				return [];
+			}
+
+			return properties;
 		},
 		requiredPropertiesFilled(): boolean {
 			for (const property of this.credentialProperties) {

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -75,6 +75,7 @@
 						:parent-types="parentTypes"
 						:required-properties-filled="requiredPropertiesFilled"
 						:credential-permissions="credentialPermissions"
+						:all-o-auth2-base-properties-overridden="allOAuth2BasePropertiesOverridden"
 						:mode="mode"
 						:selected-credential="selectedCredential"
 						:show-auth-type-selector="requiredCredentials"
@@ -427,6 +428,15 @@ export default defineComponent({
 					this.parentTypes.includes('oAuth1Api'))
 			);
 		},
+		allOAuth2BasePropertiesOverridden() {
+			if (this.credentialType?.__overwrittenProperties) {
+				return (
+					this.credentialType.__overwrittenProperties.includes('clientId') &&
+					this.credentialType.__overwrittenProperties.includes('clientSecret')
+				);
+			}
+			return false;
+		},
 		isOAuthConnected(): boolean {
 			return this.isOAuthType && !!this.credentialData.oauthTokenData;
 		},
@@ -447,10 +457,8 @@ export default defineComponent({
 
 			/**
 			 * If after all credentials overrides are applied only "notice"
-			 * properties are left, do not return them. This will avoid:
-			 * 1 - Showing notices that refer to a property that was overridden.
-			 * 2 - Showing callback URL copy section when all non notice properties
-			 * are overridden.
+			 * properties are left, do not return them. This will avoid
+			 * showing notices that refer to a property that was overridden.
 			 */
 			if (properties.every((p) => p.type === 'notice')) {
 				return [];


### PR DESCRIPTION
## Summary

We show the copy section when the credentials are OAuth2 and no properties are left after the override. Sadly, there are a couple of problems with this approach:

1. If the OAuth2 credential has more properties than the base ones (client ID and client secret), when we override the base ones, we still show the OAuth2 callback section, and we should not.
2. We show notices that most likely refer to an overridden property that the user cannot see.

To locally override credentials, see ->  https://docs.n8n.io/embed/configuration/#credential-overwrites

### Before - overridden credentials:

<img width="875" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/d953ca5c-6ea2-47ab-9de3-30e1a9fd5305">


### Now-  overridden credential:

<img width="829" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/facbee88-83b6-4467-918d-ed8cbbebe479">

### Before - non overridden credential:

<img width="867" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/6f5811dc-7159-4916-961f-868d931b5956">

### Now - non-overridden credential:

<img width="867" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/c7c0c920-6740-4e19-b626-a18c13e9f3df">


## Related tickets and issues
https://linear.app/n8n/issue/ADO-1627/bug-oauth-redirect-url-shows-in-slack-cred-on-cloud


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 