### PR TITLE
fix(editor):  Issue with JSON editor getting cut off

### DIFF
--- a/cypress/pages/ndv.ts
+++ b/cypress/pages/ndv.ts
@@ -22,7 +22,7 @@ export class NDV extends BasePage {
 			this.getters.outputPanel().findChildByTestId('ndv-run-data-display-mode').first(),
 		pinDataButton: () => cy.getByTestId('ndv-pin-data'),
 		editPinnedDataButton: () => cy.getByTestId('ndv-edit-pinned-data'),
-		pinnedDataEditor: () => this.getters.outputPanel().find('.cm-editor .cm-scroller'),
+		pinnedDataEditor: () => this.getters.outputPanel().find('.cm-editor .cm-scroller .cm-content'),
 		runDataPaneHeader: () => cy.getByTestId('run-data-pane-header'),
 		nodeOutputHint: () => cy.getByTestId('ndv-output-run-node-hint'),
 		savePinnedDataButton: () =>

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -218,6 +218,7 @@
 					<JsonEditor
 						:model-value="editMode.value"
 						@update:model-value="ndvStore.setOutputPanelEditModeValue($event)"
+						:fill-parent="true"
 					/>
 				</div>
 				<div :class="$style.editModeFooter">


### PR DESCRIPTION
## Summary

Before:

https://www.loom.com/share/9ccac13bc96f4850aba007c073ea56f0


Now:

https://www.loom.com/share/fae003790145481898613a058ce5ae4d?sid=18906e16-4d8b-4f7f-b6e1-245e87a88c19


## Related tickets and issues
https://linear.app/n8n/issue/ADO-1925/edit-output-panel-is-cut-off


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
