### PR TITLE
fix(editor): Canvas showing error toast when clicking outside of "import workflow by url" modal

### DIFF
--- a/cypress/e2e/39-import-workflow.cy.ts
+++ b/cypress/e2e/39-import-workflow.cy.ts
@@ -1,0 +1,56 @@
+import { WorkflowPage } from '../pages';
+import { MessageBox as MessageBoxClass } from '../pages/modals/message-box';
+
+const workflowPage = new WorkflowPage();
+const messageBox = new MessageBoxClass();
+
+before(() => {
+	cy.fixture('Onboarding_workflow.json').then((data) => {
+		cy.intercept('GET', '/rest/workflows/from-url*', {
+			body: { data },
+		}).as('downloadWorkflowFromURL');
+	});
+});
+
+describe('Import workflow', () => {
+	it('should allow importing workflow via URL', () => {
+		workflowPage.actions.visit(true);
+		workflowPage.getters.workflowMenu().click();
+		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+
+		messageBox.getters.modal().should('be.visible');
+
+		messageBox.getters.content().type('https://fakepage.com/workflow.json');
+
+		messageBox.getters.confirm().click();
+
+		workflowPage.actions.zoomToFit();
+
+		workflowPage.getters.canvasNodes().should('have.length', 4);
+
+		workflowPage.getters.errorToast().should('not.exist');
+
+		workflowPage.getters.successToast().should('not.exist');
+	});
+
+	it('clicking outside import workflow by URL modal should not show error toast', () => {
+		workflowPage.actions.visit(true);
+
+		workflowPage.getters.workflowMenu().click();
+		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+
+		cy.get('body').click(0, 0);
+
+		workflowPage.getters.errorToast().should('not.exist');
+	});
+
+	it('canceling workflow by URL modal should not show error toast', () => {
+		workflowPage.actions.visit(true);
+
+		workflowPage.getters.workflowMenu().click();
+		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+		messageBox.getters.cancel().click();
+
+		workflowPage.getters.errorToast().should('not.exist');
+	});
+});

--- a/cypress/e2e/39-import-workflow.cy.ts
+++ b/cypress/e2e/39-import-workflow.cy.ts
@@ -13,44 +13,62 @@ before(() => {
 });
 
 describe('Import workflow', () => {
-	it('should allow importing workflow via URL', () => {
-		workflowPage.actions.visit(true);
-		workflowPage.getters.workflowMenu().click();
-		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+	describe('From URL', () => {
+		it('should import workflow', () => {
+			workflowPage.actions.visit(true);
+			workflowPage.getters.workflowMenu().click();
+			workflowPage.getters.workflowMenuItemImportFromURLItem().click();
 
-		messageBox.getters.modal().should('be.visible');
+			messageBox.getters.modal().should('be.visible');
 
-		messageBox.getters.content().type('https://fakepage.com/workflow.json');
+			messageBox.getters.content().type('https://fakepage.com/workflow.json');
 
-		messageBox.getters.confirm().click();
+			messageBox.getters.confirm().click();
 
-		workflowPage.actions.zoomToFit();
+			workflowPage.actions.zoomToFit();
 
-		workflowPage.getters.canvasNodes().should('have.length', 4);
+			workflowPage.getters.canvasNodes().should('have.length', 4);
 
-		workflowPage.getters.errorToast().should('not.exist');
+			workflowPage.getters.errorToast().should('not.exist');
 
-		workflowPage.getters.successToast().should('not.exist');
+			workflowPage.getters.successToast().should('not.exist');
+		});
+
+		it('clicking outside modal should not show error toast', () => {
+			workflowPage.actions.visit(true);
+
+			workflowPage.getters.workflowMenu().click();
+			workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+
+			cy.get('body').click(0, 0);
+
+			workflowPage.getters.errorToast().should('not.exist');
+		});
+
+		it('canceling modal should not show error toast', () => {
+			workflowPage.actions.visit(true);
+
+			workflowPage.getters.workflowMenu().click();
+			workflowPage.getters.workflowMenuItemImportFromURLItem().click();
+			messageBox.getters.cancel().click();
+
+			workflowPage.getters.errorToast().should('not.exist');
+		});
 	});
 
-	it('clicking outside import workflow by URL modal should not show error toast', () => {
-		workflowPage.actions.visit(true);
+	describe('From File', () => {
+		it('should import workflow', () => {
+			workflowPage.actions.visit(true);
 
-		workflowPage.getters.workflowMenu().click();
-		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
-
-		cy.get('body').click(0, 0);
-
-		workflowPage.getters.errorToast().should('not.exist');
-	});
-
-	it('canceling workflow by URL modal should not show error toast', () => {
-		workflowPage.actions.visit(true);
-
-		workflowPage.getters.workflowMenu().click();
-		workflowPage.getters.workflowMenuItemImportFromURLItem().click();
-		messageBox.getters.cancel().click();
-
-		workflowPage.getters.errorToast().should('not.exist');
+			workflowPage.getters.workflowMenu().click();
+			workflowPage.getters.workflowMenuItemImportFromFile().click();
+			workflowPage.getters
+				.workflowImportInput()
+				.selectFile('cypress/fixtures/Test_workflow-actions_paste-data.json', { force: true });
+			cy.waitForLoad(false);
+			workflowPage.actions.zoomToFit();
+			workflowPage.getters.canvasNodes().should('have.length', 5);
+			workflowPage.getters.nodeConnections().should('have.length', 5);
+		});
 	});
 });

--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -13,8 +13,6 @@ import { getVisibleSelect } from '../utils';
 import { WorkflowExecutionsTab } from '../pages';
 
 const NEW_WORKFLOW_NAME = 'Something else';
-const IMPORT_WORKFLOW_URL =
-	'https://gist.githubusercontent.com/OlegIvaniv/010bd3f45c8a94f8eb7012e663a8b671/raw/3afea1aec15573cc168d9af7e79395bd76082906/test-workflow.json';
 const DUPLICATE_WORKFLOW_NAME = 'Duplicated workflow';
 const DUPLICATE_WORKFLOW_TAG = 'Duplicate';
 
@@ -127,30 +125,6 @@ describe('Workflow Actions', () => {
 			WorkflowPage.getters.canvasNodes().should('have.length', 5);
 			WorkflowPage.getters.nodeConnections().should('have.length', 5);
 		});
-	});
-
-	it('should import workflow from url', () => {
-		WorkflowPage.getters.workflowMenu().should('be.visible');
-		WorkflowPage.getters.workflowMenu().click();
-		WorkflowPage.getters.workflowMenuItemImportFromURLItem().should('be.visible');
-		WorkflowPage.getters.workflowMenuItemImportFromURLItem().click();
-		cy.get('.el-message-box').should('be.visible');
-		cy.get('.el-message-box').find('input').type(IMPORT_WORKFLOW_URL);
-		cy.get('body').type('{enter}');
-		cy.waitForLoad(false);
-		WorkflowPage.actions.zoomToFit();
-		WorkflowPage.getters.canvasNodes().should('have.length', 2);
-		WorkflowPage.getters.nodeConnections().should('have.length', 1);
-	});
-
-	it('should import workflow from file', () => {
-		WorkflowPage.getters
-			.workflowImportInput()
-			.selectFile('cypress/fixtures/Test_workflow-actions_paste-data.json', { force: true });
-		cy.waitForLoad(false);
-		WorkflowPage.actions.zoomToFit();
-		WorkflowPage.getters.canvasNodes().should('have.length', 5);
-		WorkflowPage.getters.nodeConnections().should('have.length', 5);
 	});
 
 	it('should update workflow settings', () => {

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -582,6 +582,10 @@ export default defineComponent({
 							},
 						)) as MessageBoxInputData;
 
+						if (promptResponse === 'cancel') {
+							return;
+						}
+
 						nodeViewEventBus.emit('importWorkflowUrl', { url: promptResponse.value });
 					} catch (e) {}
 					break;


### PR DESCRIPTION
## Summary

FE attempted to import workflow even when the modal was closed - by clicking outside the modal.

Before:

https://www.loom.com/share/67ab4c920c334ecfa7ac1341603c882a

Now:

https://www.loom.com/share/8ce132a9edd2423a9995c05a07982c29


## Related tickets and issues
https://linear.app/n8n/issue/ADO-960/closing-import-form-url-modal-by-clicking-outside-causes-error


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
