### PR TITLE
fix(editor): Hover and active states not showing in execution list on dark mode

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -135,6 +135,9 @@
 	// Notification
 	--color-notification-background: var(--prim-gray-740);
 
+	// Execution card
+	--execution-card-background-hover: var(--color-foreground-base);
+
 	// NDV
 	--color-run-data-background: var(--prim-gray-800);
 	--color-ndv-droppable-parameter: var(--prim-color-primary);
@@ -185,9 +188,6 @@
 
 	// Input Triple
 	--color-background-input-triple: var(--prim-gray-800);
-
-	// Execution Card
-	--execution-card-background-hover: var(--color-foreground-base);
 
 	// Various
 	--color-info-tint-1: var(--prim-gray-420);

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -186,6 +186,9 @@
 	// Input Triple
 	--color-background-input-triple: var(--prim-gray-800);
 
+	// Execution Card
+	--execution-card-background-hover: var(--color-foreground-base);
+
 	// Various
 	--color-info-tint-1: var(--prim-gray-420);
 	--color-info-tint-2: var(--prim-gray-740);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -202,6 +202,7 @@
 	--execution-card-border-waiting: var(--prim-color-secondary-tint-300);
 	--execution-card-border-running: var(--prim-color-alt-b-tint-250);
 	--execution-card-border-unknown: var(--prim-gray-120);
+	--execution-card-background-hover: var(--color-foreground-light);
 
 	// NDV
 	--color-run-data-background: var(--color-background-base);
@@ -262,9 +263,6 @@
 
 	// Input Triple
 	--color-background-input-triple: var(--color-background-light);
-
-	// Execution Card
-	--execution-card-background-hover: var(--color-foreground-light);
 
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -263,6 +263,9 @@
 	// Input Triple
 	--color-background-input-triple: var(--color-background-light);
 
+	// Execution Card
+	--execution-card-background-hover: var(--color-foreground-light);
+
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);
 	--color-avatar-accent-2: var(--prim-color-alt-e-shade-100);

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 	&:hover,
 	&.active {
 		.executionLink {
-			background-color: var(--color-foreground-light);
+			background-color: var(--color-foreground-base);
 		}
 	}
 

--- a/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
+++ b/packages/editor-ui/src/components/ExecutionsView/ExecutionCard.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 	&:hover,
 	&.active {
 		.executionLink {
-			background-color: var(--color-foreground-base);
+			background-color: var(--execution-card-background-hover);
 		}
 	}
 


### PR DESCRIPTION
## Summary

issue: https://www.loom.com/share/faef7fcfdb2c41e88f4e981f508ed12a

Before:

<img width="341" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/8791fa08-b69f-4d82-bebd-8731ad5d272b">


Now:

Active:

<img width="293" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/d179eac3-b1a1-42ed-b3f2-10005748266b">

Hover:

<img width="320" alt="image" src="https://github.com/n8n-io/n8n/assets/16496553/1bf4631f-a0a6-4d8b-9103-a15e3b4ce7a5">


## Related tickets and issues
https://linear.app/n8n/issue/ADO-1676/bug-execution-on-the-execution-list-is-not-marked-as-selected-on-dark


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))