### PR TITLE
fix(editor): Toggle not visible in credentials modal, page background, info icon and expression switch background (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -118,13 +118,13 @@ const addTargetBlank = (html: string) =>
 	align-items: center;
 	color: var(--color-text-light);
 	padding-left: var(--spacing-4xs);
-	background-color: var(--color-background-xlight);
+	// background-color: var(--color-background-xlight);
 	z-index: 1;
 }
 
 .options {
 	opacity: 0;
-	background-color: var(--color-background-xlight);
+	// background-color: var(--color-background-xlight);
 	transition: opacity 250ms cubic-bezier(0.98, -0.06, 0.49, -0.2); // transition on hover out
 
 	> * {

--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -118,13 +118,11 @@ const addTargetBlank = (html: string) =>
 	align-items: center;
 	color: var(--color-text-light);
 	padding-left: var(--spacing-4xs);
-	// background-color: var(--color-background-xlight);
 	z-index: 1;
 }
 
 .options {
 	opacity: 0;
-	// background-color: var(--color-background-xlight);
 	transition: opacity 250ms cubic-bezier(0.98, -0.06, 0.49, -0.2); // transition on hover out
 
 	> * {

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -166,6 +166,8 @@
 	--color-callout-secondary-font: var(--prim-gray-0);
 
 	// Dialogs and overlays
+	--color-dialog-background: var(--prim-gray-800);
+	--color-dialog-border-color: var(--prim-gray-670);
 	--color-dialog-overlay-background: var(--prim-color-alt-j-alpha-075);
 	--color-dialog-overlay-background-dark: var(--prim-color-alt-j-alpha-075);
 

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -167,7 +167,6 @@
 
 	// Dialogs and overlays
 	--color-dialog-background: var(--prim-gray-800);
-	--color-dialog-border-color: var(--prim-gray-670);
 	--color-dialog-overlay-background: var(--prim-color-alt-j-alpha-075);
 	--color-dialog-overlay-background-dark: var(--prim-color-alt-j-alpha-075);
 
@@ -180,6 +179,7 @@
 
 	// Switch (Activation, boolean)
 	--color-switch-background: var(--prim-gray-820);
+	--color-switch-border-color: var(--prim-gray-670);
 	--color-switch-toggle: var(--prim-gray-40);
 
 	// Action Dropdown

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -240,7 +240,6 @@
 
 	// Dialogs and overlays
 	--color-dialog-background: var(--prim-gray-0);
-	--color-dialog-border-color: var(--prim-gray-0);
 	--color-dialog-overlay-background: var(--prim-gray-0-alpha-075);
 	--color-dialog-overlay-background-dark: var(--prim-color-alt-j-alpha-075);
 	--color-block-ui-overlay: var(--prim-gray-820);
@@ -258,6 +257,7 @@
 	// Switch (Activation, boolean)
 	--color-switch-background: var(--prim-gray-420);
 	--color-switch-active-background: var(--prim-color-alt-i);
+	--color-switch-border-color: transparent;
 	--color-switch-toggle: var(--prim-gray-0);
 
 	// Feature Request

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -239,6 +239,8 @@
 	--color-callout-secondary-icon: var(--color-secondary);
 
 	// Dialogs and overlays
+	--color-dialog-background: var(--prim-gray-0);
+	--color-dialog-border-color: var(--prim-gray-0);
 	--color-dialog-overlay-background: var(--prim-gray-0-alpha-075);
 	--color-dialog-overlay-background-dark: var(--prim-color-alt-j-alpha-075);
 	--color-block-ui-overlay: var(--prim-gray-820);
@@ -252,6 +254,7 @@
 
 	// Action Dropdown
 	--color-action-dropdown-item-active-background: var(--color-background-base);
+
 	// Switch (Activation, boolean)
 	--color-switch-background: var(--prim-gray-420);
 	--color-switch-active-background: var(--prim-color-alt-i);

--- a/packages/design-system/src/css/common/var.scss
+++ b/packages/design-system/src/css/common/var.scss
@@ -673,7 +673,7 @@ $switch-button-size: 16px;
 
 /* Dialog
 -------------------------- */
-$dialog-background-color: $color-white;
+$dialog-background-color: var(--color-dialog-background);
 $dialog-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 /// fontSize||Font|1
 $dialog-content-font-size: 14px;

--- a/packages/design-system/src/css/reset.scss
+++ b/packages/design-system/src/css/reset.scss
@@ -96,7 +96,7 @@ body {
 	font-size: var(--font-size-m);
 	font-weight: var(--font-weight-regular);
 	color: var(--color-text-dark);
-	background-color: var(--color-background-xlight);
+	background-color: var(--color-background-light);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }

--- a/packages/design-system/src/css/switch.scss
+++ b/packages/design-system/src/css/switch.scss
@@ -65,6 +65,7 @@
 		border-radius: var.$switch-core-border-radius;
 		box-sizing: border-box;
 		background: var.$switch-off-color;
+		border: 1px solid var(--color-dialog-border-color);
 		cursor: pointer;
 		transition:
 			border-color 0.1s,

--- a/packages/design-system/src/css/switch.scss
+++ b/packages/design-system/src/css/switch.scss
@@ -65,7 +65,7 @@
 		border-radius: var.$switch-core-border-radius;
 		box-sizing: border-box;
 		background: var.$switch-off-color;
-		border: 1px solid var(--color-dialog-border-color);
+		border: 1px solid var(--color-switch-border-color);
 		cursor: pointer;
 		transition:
 			border-color 0.1s,


### PR DESCRIPTION
## Summary

- Fixes toggle (switch) not visible in credentials modal
- Brings back the darker page background in light mode and lighter in dark mode
- Remove unwanted background of info icon and fixed/expr switch


## Related tickets and issues

- https://linear.app/n8n/issue/ADO-1649/bug-toggles-not-clear-in-dark-mode-in-creds-modal#comment-cee59605


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))