### PR TITLE
fix(MySQL Node): Query Parameters parse string to number

### DIFF
--- a/packages/nodes-base/nodes/MySql/MySql.node.ts
+++ b/packages/nodes-base/nodes/MySql/MySql.node.ts
@@ -11,7 +11,7 @@ export class MySql extends VersionedNodeType {
 			name: 'mySql',
 			icon: 'file:mysql.svg',
 			group: ['input'],
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 			description: 'Get, add and update data in MySQL',
 			parameterPane: 'wide',
 		};
@@ -21,6 +21,7 @@ export class MySql extends VersionedNodeType {
 			2: new MySqlV2(baseDescription),
 			2.1: new MySqlV2(baseDescription),
 			2.2: new MySqlV2(baseDescription),
+			2.3: new MySqlV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/database/executeQuery.operation.ts
@@ -81,6 +81,13 @@ export async function execute(
 
 		const preparedQuery = prepareQueryAndReplacements(rawQuery, values);
 
+		if ((nodeOptions.nodeVersion as number) >= 2.3) {
+			const parsedNumbers = preparedQuery.values.map((value) => {
+				return Number(value) ? Number(value) : value;
+			});
+			preparedQuery.values = parsedNumbers;
+		}
+
 		queries.push(preparedQuery);
 	}
 

--- a/packages/nodes-base/nodes/MySql/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/versionDescription.ts
@@ -8,7 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'mySql',
 	icon: 'file:mysql.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2],
+	version: [2, 2.1, 2.2, 2.3],
 	subtitle: '={{ $parameter["operation"] }}',
 	description: 'Get, add and update data in MySQL',
 	defaults: {


### PR DESCRIPTION
## Summary
The query parameters in the MySQL node are converted to strings which causes errors if you are using specific data types or tying to use a parameter for a limit.



## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8779
https://linear.app/n8n/issue/NODE-1200/mysql-query-parameters-incorrectly-converted-to-strings