### PR TITLE
test(core): Fix multiple parallel private key checks (no-changelog)

### DIFF
--- a/packages/cli/src/databases/migrations/common/1711390882123-MoveSshKeysToDatabase.ts
+++ b/packages/cli/src/databases/migrations/common/1711390882123-MoveSshKeysToDatabase.ts
@@ -46,6 +46,11 @@ export class MoveSshKeysToDatabase1711390882123 implements ReversibleMigration {
 			return;
 		}
 
+		if (!privateKey) {
+			logger.error(`[${migrationName}] No private key found, skipping`);
+			return;
+		}
+
 		const value = JSON.stringify({
 			encryptedPrivateKey: this.cipher.encrypt(privateKey),
 			publicKey,


### PR DESCRIPTION
Prevent migration `MoveSshKeysToDatabase1711390882123` from failing during multiple parallel private key checks during test runs, leading to `this.cipher.encrypt(undefined)`.

```
  ● Metrics › should not return default metrics only when disabled

    TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined

      14 | 		const [key, iv] = this.getKeyAndIv(salt);
      15 | 		const cipher = createCipheriv('aes-256-cbc', key, iv);
    > 16 | 		const encrypted = cipher.update(typeof data === 'string' ? data : JSON.stringify(data));
         | 		                         ^
      17 | 		return Buffer.concat([RANDOM_BYTES, salt, encrypted, cipher.final()]).toString('base64');
      18 | 	}
      19 |

      at Cipher.encrypt (../core/src/Cipher.ts:16:28)
      at MoveSshKeysToDatabase1711390882123.up (src/databases/migrations/common/1711390882123-MoveSshKeysToDatabase.ts:50:37)
      at MoveSshKeysToDatabase1711390882123.up (src/databases/utils/migrationHelpers.ts:186:5)
      at MigrationExecutor.executePendingMigrations (../../node_modules/.pnpm/@n8n+typeorm@0.3.20-7_@sentry+node@7.87.0_ioredis@5.3.2_mysql2@2.3.3_pg@8.11.3_sqlite3@5.1.7/node_modules/src/migration/MigrationExecutor.ts:336:17)
      at DataSource.runMigrations (../../node_modules/.pnpm/@n8n+typeorm@0.3.20-7_@sentry+node@7.87.0_ioredis@5.3.2_mysql2@2.3.3_pg@8.11.3_sqlite3@5.1.7/node_modules/src/data-source/DataSource.ts:404:13)
      at Object.migrate (src/Db.ts:80:2)
      at Object.init (test/integration/shared/testDb.ts:38:2)
      at Object.<anonymous> (test/integration/shared/utils/testServer.ts:93:3)
```