### PR TITLE
fix(editor): Fix canvas selection for touch devices that use mouse

### DIFF
--- a/packages/design-system/src/composables/useDeviceSupport.test.ts
+++ b/packages/design-system/src/composables/useDeviceSupport.test.ts
@@ -69,12 +69,5 @@ describe('useDeviceSupport()', () => {
 			const event = new KeyboardEvent('keydown', { ctrlKey: true });
 			expect(isCtrlKeyPressed(event)).toEqual(true);
 		});
-
-		it('should return true for touch device on MouseEvent', () => {
-			Object.defineProperty(window, 'ontouchstart', { value: {} });
-			const { isCtrlKeyPressed } = useDeviceSupport();
-			const mockEvent = new MouseEvent('click');
-			expect(isCtrlKeyPressed(mockEvent)).toEqual(true);
-		});
 	});
 });

--- a/packages/design-system/src/composables/useDeviceSupport.ts
+++ b/packages/design-system/src/composables/useDeviceSupport.ts
@@ -12,9 +12,6 @@ export function useDeviceSupport() {
 	const controlKeyCode = ref(isMacOs.value ? 'Meta' : 'Control');
 
 	function isCtrlKeyPressed(e: MouseEvent | KeyboardEvent): boolean {
-		if (isTouchDevice.value && e instanceof MouseEvent) {
-			return true;
-		}
 		if (isMacOs.value) {
 			return (e as KeyboardEvent).metaKey;
 		}


### PR DESCRIPTION
## Summary
This PR disables automatic `crtl` key detection for touch devices which seems to break mouse selection for those devices.

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 