### PR TITLE
fix: Fix vue type warnings (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nIcon/Icon.vue
+++ b/packages/design-system/src/components/N8nIcon/Icon.vue
@@ -5,14 +5,15 @@
 </template>
 
 <script lang="ts" setup>
+import type { FontAwesomeIconProps } from '@fortawesome/vue-fontawesome';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import type { IconSize, IconColor } from '@/types/icon';
 import N8nText from '../N8nText';
 
 interface IconProps {
-	icon: string;
+	icon: FontAwesomeIconProps['icon'];
 	size?: IconSize;
-	spin?: boolean;
+	spin?: FontAwesomeIconProps['spin'];
 	color?: IconColor;
 }
 

--- a/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
+++ b/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
@@ -27,7 +27,8 @@ interface RadioOption {
 interface RadioButtonsProps {
 	modelValue?: string;
 	options?: RadioOption[];
-	size: 'small' | 'medium';
+	/** @default medium */
+	size?: 'small' | 'medium';
 	disabled?: boolean;
 }
 

--- a/packages/design-system/src/types/button.ts
+++ b/packages/design-system/src/types/button.ts
@@ -13,7 +13,7 @@ export interface IconButtonProps {
 	active?: boolean;
 	disabled?: boolean;
 	float?: TextFloat;
-	icon?: string;
+	icon?: string | string[];
 	loading?: boolean;
 	outline?: boolean;
 	size?: ButtonSize;

--- a/packages/editor-ui/src/components/Sticky.vue
+++ b/packages/editor-ui/src/components/Sticky.vue
@@ -52,7 +52,7 @@
 					v-touch:tap="deleteNode"
 					class="option"
 					data-test-id="delete-sticky"
-					:title="$locale.baseText('node.deleteNode')"
+					:title="$locale.baseText('node.delete')"
 				>
 					<font-awesome-icon icon="trash" />
 				</div>


### PR DESCRIPTION
## Summary

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/1de2c4b2-d867-417f-8e4f-652257c0d89e)


After:

![image](https://github.com/n8n-io/n8n/assets/10324676/53619b50-3764-4990-a0f8-a09a06024e51)

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 