### PR TITLE
docs: Remove Vue TS plugin from recommended (no-changelog)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
 		"dbaeumer.vscode-eslint",
 		"EditorConfig.EditorConfig",
 		"esbenp.prettier-vscode",
-		"Vue.vscode-typescript-vue-plugin",
 		"Vue.volar"
 	]
 }


### PR DESCRIPTION

## Summary

The TypeScript Vue Plugin (Volar) and Takover Mode have been deprecated. The official Vue plugin now includes TS support.

https://github.com/vuejs/language-tools/releases/tag/v2.0.0


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 