### PR TITLE
refactor(core): Delete all auth exclusion config and checks (no-changelog)

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Container, Service } from 'typedi';
-import assert from 'assert';
 import { exec as callbackExec } from 'child_process';
 import { access as fsAccess } from 'fs/promises';
 import { join as pathJoin } from 'path';
@@ -224,22 +223,6 @@ export class Server extends AbstractServer {
 		await Container.get(PostHogClient).init();
 
 		const publicApiEndpoint = config.getEnv('publicApi.path');
-		const excludeEndpoints = config.getEnv('security.excludeEndpoints');
-
-		const ignoredEndpoints: Readonly<string[]> = [
-			'assets',
-			'healthz',
-			'metrics',
-			'e2e',
-			this.endpointPresetCredentials,
-			isApiEnabled() ? '' : publicApiEndpoint,
-			...excludeEndpoints.split(':'),
-		].filter((u) => !!u);
-
-		assert(
-			!ignoredEndpoints.includes(this.restEndpoint),
-			`REST endpoint cannot be set to any of these values: ${ignoredEndpoints.join()} `,
-		);
 
 		// ----------------------------------------
 		// Public API
@@ -258,15 +241,24 @@ export class Server extends AbstractServer {
 		const { restEndpoint, app } = this;
 		setupPushHandler(restEndpoint, app);
 
+		const nonUIRoutes: Readonly<string[]> = [
+			'assets',
+			'healthz',
+			'metrics',
+			'e2e',
+			this.restEndpoint,
+			this.endpointPresetCredentials,
+			isApiEnabled() ? '' : publicApiEndpoint,
+		].filter((u) => !!u);
+		const nonUIRoutesRegex = new RegExp(`^/(${nonUIRoutes.join('|')})/?.*$`);
+
 		// Make sure that Vue history mode works properly
 		this.app.use(
 			history({
 				rewrites: [
 					{
-						from: new RegExp(`^/(${[this.restEndpoint, ...ignoredEndpoints].join('|')})/?.*$`),
-						to: (context) => {
-							return context.parsedUrl.pathname!.toString();
-						},
+						from: nonUIRoutesRegex,
+						to: ({ parsedUrl }) => parsedUrl.pathname!.toString(),
 					},
 				],
 			}),

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -590,12 +590,6 @@ export const schema = {
 				env: 'N8N_SECURITY_AUDIT_DAYS_ABANDONED_WORKFLOW',
 			},
 		},
-		excludeEndpoints: {
-			doc: 'Additional endpoints to exclude auth checks. Multiple endpoints can be separated by colon (":")',
-			format: String,
-			default: '',
-			env: 'N8N_AUTH_EXCLUDE_ENDPOINTS',
-		},
 	},
 
 	endpoints: {

--- a/packages/cli/src/security-audit/risk-reporters/InstanceRiskReporter.ts
+++ b/packages/cli/src/security-audit/risk-reporters/InstanceRiskReporter.ts
@@ -88,10 +88,6 @@ export class InstanceRiskReporter implements RiskReporter {
 			publicApiEnabled: isApiEnabled(),
 		};
 
-		settings.auth = {
-			authExcludeEndpoints: config.getEnv('security.excludeEndpoints') || 'none',
-		};
-
 		settings.nodes = {
 			nodesExclude: config.getEnv('nodes.exclude') ?? 'none',
 			nodesInclude: config.getEnv('nodes.include') ?? 'none',

--- a/packages/cli/test/integration/security-audit/InstanceRiskReporter.test.ts
+++ b/packages/cli/test/integration/security-audit/InstanceRiskReporter.test.ts
@@ -252,9 +252,6 @@ test('should report security settings', async () => {
 			templatesEnabled: true,
 			publicApiEnabled: false,
 		},
-		auth: {
-			authExcludeEndpoints: 'none',
-		},
 		nodes: { nodesExclude: 'none', nodesInclude: 'none' },
 		telemetry: { diagnosticsEnabled: true },
 	});


### PR DESCRIPTION
Since we do not have a global middleware anymore, and all auth is configured on a per route basis, the code to allow excluding endpoints from auth checks isn't relevant anymore.

Addresses #9031 

[Docs PR](https://github.com/n8n-io/n8n-docs/pull/2001)

## Review / Merge checklist
- [x] PR title and summary are descriptive