### PR TITLE
fix(editor): Rerun failed nodes in manual executions

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -313,6 +313,6 @@ describe('useRunWorkflow({ router })', () => {
 
 			expect(result.startNodeNames).toContain('node1');
 			expect(result.runData).toEqual(undefined);
-		})
+		});
 	});
 });

--- a/packages/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -9,7 +9,7 @@ import { useToast } from '@/composables/useToast';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 import { useRouter } from 'vue-router';
-import type { IPinData, IRunData, Workflow } from 'n8n-workflow';
+import { ExpressionError, type IPinData, type IRunData, type Workflow } from 'n8n-workflow';
 
 vi.mock('@/stores/n8nRoot.store', () => ({
 	useRootStore: vi.fn().mockReturnValue({ pushConnectionActive: true }),
@@ -285,5 +285,34 @@ describe('useRunWorkflow({ router })', () => {
 			expect(result.startNodeNames).toContain('node1');
 			expect(result.runData).toBeUndefined();
 		});
+
+		it('should rerun failed parent nodes, adding them to the returned list of start nodes and not adding their result to runData', () => {
+			const { consolidateRunDataAndStartNodes } = useRunWorkflow({ router });
+			const directParentNodes = ['node1'];
+			const runData = {
+				node1: [
+					{
+						error: new ExpressionError('error'),
+					},
+				],
+			} as unknown as IRunData;
+			const workflowMock = {
+				getParentNodes: vi.fn().mockReturnValue([]),
+				nodes: {
+					node1: { disabled: false },
+					node2: { disabled: false },
+				},
+			} as unknown as Workflow;
+
+			const result = consolidateRunDataAndStartNodes(
+				directParentNodes,
+				runData,
+				undefined,
+				workflowMock,
+			);
+
+			expect(result.startNodeNames).toContain('node1');
+			expect(result.runData).toEqual(undefined);
+		})
 	});
 });

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -428,7 +428,10 @@ export function useRunWorkflow(options: { router: ReturnType<typeof useRouter> }
 				for (const parentNode of parentNodes) {
 					// We want to execute nodes that don't have run data neither pin data
 					// in addition, if a node failed we want to execute it again
-					if ((!runData[parentNode]?.length && !pinData?.[parentNode]?.length) || runData[parentNode]?.[0]?.error !== undefined) {
+					if (
+						(!runData[parentNode]?.length && !pinData?.[parentNode]?.length) ||
+						runData[parentNode]?.[0]?.error !== undefined
+					) {
 						// When we hit a node which has no data we stop and set it
 						// as a start node the execution from and then go on with other
 						// direct input nodes

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -426,14 +426,16 @@ export function useRunWorkflow(options: { router: ReturnType<typeof useRouter> }
 				parentNodes.push(directParentNode);
 
 				for (const parentNode of parentNodes) {
-					if (!runData[parentNode]?.length && !pinData?.[parentNode]?.length) {
+					// We want to execute nodes that don't have run data neither pin data
+					// in addition, if a node failed we want to execute it again
+					if ((!runData[parentNode]?.length && !pinData?.[parentNode]?.length) || runData[parentNode]?.[0]?.error !== undefined) {
 						// When we hit a node which has no data we stop and set it
 						// as a start node the execution from and then go on with other
 						// direct input nodes
 						startNodeNames.push(parentNode);
 						break;
 					}
-					if (runData[parentNode]) {
+					if (runData[parentNode] && !runData[parentNode]?.[0]?.error) {
 						newRunData[parentNode] = runData[parentNode]?.slice(0, 1);
 					}
 				}


### PR DESCRIPTION
## Summary
When a node fails executing and the user clicks to run another node in the chain, n8n takes the errored output and thinks it succeeded, showing "Workflow execution succeeded" instead of rerunning the failed node. This PR makes sure that we rerun failed nodes.



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1463/execution-logic-error-in-downstream-node


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.