### PR TITLE
feat(core): Prevent session hijacking

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -62,7 +62,11 @@ Cypress.Commands.add('signinAsOwner', () => {
 });
 
 Cypress.Commands.add('signout', () => {
-	cy.request('POST', `${BACKEND_BASE_URL}/rest/logout`);
+	cy.request({
+		method: 'POST',
+		url: `${BACKEND_BASE_URL}/rest/logout`,
+		headers: { 'browser-id': localStorage.getItem('n8n-browserId') }
+	});
 	cy.getCookie(N8N_AUTH_COOKIE).should('not.exist');
 });
 

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -33,7 +33,7 @@ import {
 	TEMPLATES_DIR,
 } from '@/constants';
 import { CredentialsController } from '@/credentials/credentials.controller';
-import type { CurlHelper } from '@/requests';
+import type { APIRequest, CurlHelper } from '@/requests';
 import { registerController } from '@/decorators';
 import { AuthController } from '@/controllers/auth.controller';
 import { BinaryDataController } from '@/controllers/binaryData.controller';
@@ -235,6 +235,13 @@ export class Server extends AbstractServer {
 				frontendService.settings.publicApi.latestVersion = apiLatestVersion;
 			}
 		}
+
+		// Extract BrowserId from headers
+		this.app.use((req: APIRequest, _, next) => {
+			req.browserId = req.headers['browser-id'] as string;
+			next();
+		});
+
 		// Parse cookies for easier access
 		this.app.use(cookieParser());
 

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -20,6 +20,8 @@ interface AuthJwtPayload {
 	id: string;
 	/** This hash is derived from email and bcrypt of password */
 	hash: string;
+	/** This is a client generated unique string to prevent session hijacking */
+	browserId?: string;
 }
 
 interface IssuedJWT extends AuthJwtPayload {
@@ -48,7 +50,9 @@ export class AuthService {
 		const token = req.cookies[AUTH_COOKIE_NAME];
 		if (token) {
 			try {
-				req.user = await this.resolveJwt(token, res);
+				// TODO: set this on `skipAuth` endpoints as well
+				req.browserId = req.headers['browser-id'] as string;
+				req.user = await this.resolveJwt(token, req, res);
 			} catch (error) {
 				if (error instanceof JsonWebTokenError || error instanceof AuthError) {
 					this.clearCookie(res);
@@ -66,7 +70,8 @@ export class AuthService {
 		res.clearCookie(AUTH_COOKIE_NAME);
 	}
 
-	issueCookie(res: Response, user: User) {
+	issueCookie(res: Response, user: User, browserId?: string) {
+		// TODO: move this check to the login endpoint in AuthController
 		// If the instance has exceeded its user quota, prevent non-owners from logging in
 		const isWithinUsersLimit = this.license.isWithinUsersLimit();
 		if (
@@ -77,7 +82,7 @@ export class AuthService {
 			throw new UnauthorizedError(RESPONSE_ERROR_MESSAGES.USERS_QUOTA_REACHED);
 		}
 
-		const token = this.issueJWT(user);
+		const token = this.issueJWT(user, browserId);
 		res.cookie(AUTH_COOKIE_NAME, token, {
 			maxAge: this.jwtExpiration * Time.seconds.toMilliseconds,
 			httpOnly: true,
@@ -86,17 +91,18 @@ export class AuthService {
 		});
 	}
 
-	issueJWT(user: User) {
+	issueJWT(user: User, browserId?: string) {
 		const payload: AuthJwtPayload = {
 			id: user.id,
 			hash: this.createJWTHash(user),
+			browserId,
 		};
 		return this.jwtService.sign(payload, {
 			expiresIn: this.jwtExpiration,
 		});
 	}
 
-	async resolveJwt(token: string, res: Response): Promise<User> {
+	async resolveJwt(token: string, req: AuthenticatedRequest, res: Response): Promise<User> {
 		const jwtPayload: IssuedJWT = this.jwtService.verify(token, {
 			algorithms: ['HS256'],
 		});
@@ -112,14 +118,16 @@ export class AuthService {
 			// or, If the user has been deactivated (i.e. LDAP users)
 			user.disabled ||
 			// or, If the email or password has been updated
-			jwtPayload.hash !== this.createJWTHash(user)
+			jwtPayload.hash !== this.createJWTHash(user) ||
+			// If the token was issued for another browser session
+			(jwtPayload.browserId && jwtPayload.browserId !== req.browserId)
 		) {
 			throw new AuthError('Unauthorized');
 		}
 
 		if (jwtPayload.exp * 1000 - Date.now() < this.jwtRefreshTimeout) {
 			this.logger.debug('JWT about to expire. Will be refreshed');
-			this.issueCookie(res, user);
+			this.issueCookie(res, user, jwtPayload.browserId);
 		}
 
 		return user;

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -52,8 +52,6 @@ export class AuthService {
 		const token = req.cookies[AUTH_COOKIE_NAME];
 		if (token) {
 			try {
-				// TODO: set this on `skipAuth` endpoints as well
-				req.browserId = req.headers['browser-id'] as string;
 				req.user = await this.resolveJwt(token, req, res);
 			} catch (error) {
 				if (error instanceof JsonWebTokenError || error instanceof AuthError) {

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -94,7 +94,7 @@ export class AuthController {
 				}
 			}
 
-			this.authService.issueCookie(res, user, req.headers['browser-id'] as string);
+			this.authService.issueCookie(res, user, req.browserId);
 			void this.internalHooks.onUserLoginSuccess({
 				user,
 				authenticationMethod: usedAuthenticationMethod,

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -94,7 +94,7 @@ export class AuthController {
 				}
 			}
 
-			this.authService.issueCookie(res, user);
+			this.authService.issueCookie(res, user, req.headers['browser-id'] as string);
 			void this.internalHooks.onUserLoginSuccess({
 				user,
 				authenticationMethod: usedAuthenticationMethod,

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -164,7 +164,7 @@ export class InvitationController {
 
 		const updatedUser = await this.userRepository.save(invitee, { transaction: false });
 
-		this.authService.issueCookie(res, updatedUser);
+		this.authService.issueCookie(res, updatedUser, req.browserId);
 
 		void this.internalHooks.onUserSignup(updatedUser, {
 			user_type: 'email',

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -85,7 +85,7 @@ export class MeController {
 
 		this.logger.info('User updated successfully', { userId });
 
-		this.authService.issueCookie(res, user);
+		this.authService.issueCookie(res, user, req.browserId);
 
 		const updatedKeys = Object.keys(payload);
 		void this.internalHooks.onUserUpdate({
@@ -138,7 +138,7 @@ export class MeController {
 		const updatedUser = await this.userRepository.save(user, { transaction: false });
 		this.logger.info('Password updated successfully', { userId: user.id });
 
-		this.authService.issueCookie(res, updatedUser);
+		this.authService.issueCookie(res, updatedUser, req.browserId);
 
 		void this.internalHooks.onUserUpdate({
 			user: updatedUser,

--- a/packages/cli/src/controllers/owner.controller.ts
+++ b/packages/cli/src/controllers/owner.controller.ts
@@ -83,7 +83,7 @@ export class OwnerController {
 
 		this.logger.debug('Setting isInstanceOwnerSetUp updated successfully');
 
-		this.authService.issueCookie(res, owner);
+		this.authService.issueCookie(res, owner, req.browserId);
 
 		void this.internalHooks.onInstanceOwnerSetup({ user_id: owner.id });
 

--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -208,7 +208,7 @@ export class PasswordResetController {
 
 		this.logger.info('User password updated successfully', { userId: user.id });
 
-		this.authService.issueCookie(res, user);
+		this.authService.issueCookie(res, user, req.browserId);
 
 		void this.internalHooks.onUserUpdate({
 			user,

--- a/packages/cli/src/middlewares/cors.ts
+++ b/packages/cli/src/middlewares/cors.ts
@@ -8,7 +8,7 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 		res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Origin, X-Requested-With, Content-Type, Accept, push-ref',
+			'Origin, X-Requested-With, Content-Type, Accept, push-ref, Browser-Id',
 		);
 	}
 

--- a/packages/cli/src/middlewares/cors.ts
+++ b/packages/cli/src/middlewares/cors.ts
@@ -8,7 +8,7 @@ export const corsMiddleware: RequestHandler = (req, res, next) => {
 		res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
 		res.header(
 			'Access-Control-Allow-Headers',
-			'Origin, X-Requested-With, Content-Type, Accept, push-ref, Browser-Id',
+			'Origin, X-Requested-With, Content-Type, Accept, push-ref, browser-id',
 		);
 	}
 

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -117,7 +117,6 @@ export const setupPushHandler = (restEndpoint: string, app: Application) => {
 	app.use(
 		endpoint,
 		// eslint-disable-next-line @typescript-eslint/unbound-method
-		// TODO: handle the missing browserId on WebSocket requests
 		authService.authMiddleware,
 		(req: SSEPushRequest | WebSocketPushRequest, res: PushResponse) => push.handleRequest(req, res),
 	);

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -117,6 +117,7 @@ export const setupPushHandler = (restEndpoint: string, app: Application) => {
 	app.use(
 		endpoint,
 		// eslint-disable-next-line @typescript-eslint/unbound-method
+		// TODO: handle the missing browserId on WebSocket requests
 		authService.authMiddleware,
 		(req: SSEPushRequest | WebSocketPushRequest, res: PushResponse) => push.handleRequest(req, res),
 	);

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -50,7 +50,7 @@ export class UserRoleChangePayload {
 	newRoleName: AssignableRole;
 }
 
-export type AuthlessRequest<
+export type APIRequest<
 	RouteParams = {},
 	ResponseBody = {},
 	RequestBody = {},
@@ -59,18 +59,23 @@ export type AuthlessRequest<
 	browserId?: string;
 };
 
+export type AuthlessRequest<
+	RouteParams = {},
+	ResponseBody = {},
+	RequestBody = {},
+	RequestQuery = {},
+> = APIRequest<RouteParams, ResponseBody, RequestBody, RequestQuery> & {
+	user: never;
+};
+
 export type AuthenticatedRequest<
 	RouteParams = {},
 	ResponseBody = {},
 	RequestBody = {},
 	RequestQuery = {},
-> = Omit<
-	express.Request<RouteParams, ResponseBody, RequestBody, RequestQuery>,
-	'user' | 'cookies'
-> & {
+> = Omit<APIRequest<RouteParams, ResponseBody, RequestBody, RequestQuery>, 'user' | 'cookies'> & {
 	user: User;
 	cookies: Record<string, string | undefined>;
-	browserId?: string;
 };
 
 // ----------------------------------

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -55,7 +55,9 @@ export type AuthlessRequest<
 	ResponseBody = {},
 	RequestBody = {},
 	RequestQuery = {},
-> = express.Request<RouteParams, ResponseBody, RequestBody, RequestQuery>;
+> = express.Request<RouteParams, ResponseBody, RequestBody, RequestQuery> & {
+	browserId?: string;
+};
 
 export type AuthenticatedRequest<
 	RouteParams = {},
@@ -68,6 +70,7 @@ export type AuthenticatedRequest<
 > & {
 	user: User;
 	cookies: Record<string, string | undefined>;
+	browserId?: string;
 };
 
 // ----------------------------------

--- a/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
+++ b/packages/cli/src/sso/saml/routes/saml.controller.ee.ts
@@ -138,7 +138,7 @@ export class SamlController {
 				});
 				// Only sign in user if SAML is enabled, otherwise treat as test connection
 				if (isSamlLicensedAndEnabled()) {
-					this.authService.issueCookie(res, loginResult.authenticatedUser);
+					this.authService.issueCookie(res, loginResult.authenticatedUser, req.browserId);
 					if (loginResult.onboardingRequired) {
 						return res.redirect(this.urlService.getInstanceBaseUrl() + SamlUrls.samlOnboarding);
 					} else {

--- a/packages/cli/test/unit/auth/auth.service.test.ts
+++ b/packages/cli/test/unit/auth/auth.service.test.ts
@@ -1,7 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { mock } from 'jest-mock-extended';
 import type { NextFunction, Response } from 'express';
-import type { Cipher } from 'n8n-core';
 
 import { AuthService } from '@/auth/auth.service';
 import config from '@/config';
@@ -15,6 +14,7 @@ import type { AuthenticatedRequest } from '@/requests';
 describe('AuthService', () => {
 	config.set('userManagement.jwtSecret', 'random-secret');
 
+	const browserId = 'test-browser-id';
 	const userData = {
 		id: '123',
 		email: 'test@example.com',
@@ -22,34 +22,23 @@ describe('AuthService', () => {
 		disabled: false,
 		mfaEnabled: false,
 	};
-	const validToken =
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEyMyIsImhhc2giOiJtSkFZeDRXYjdrIiwiYnJvd3NlcklkIjoiZW5jcnlwdGVkIiwiaWF0IjoxNzA2NzUwNjI1LCJleHAiOjE3MDczNTU0MjV9.sL__QUGt0MqidQrSgZ_y4AQSos_k4xsN6wKhn0D2drM';
-
-	const browserId = 'test-browser-id';
 	const user = mock<User>(userData);
-	const cipher = mock<Cipher>();
 	const jwtService = new JwtService(mock());
 	const urlService = mock<UrlService>();
 	const userRepository = mock<UserRepository>();
-	const authService = new AuthService(
-		mock(),
-		cipher,
-		mock(),
-		jwtService,
-		urlService,
-		userRepository,
-	);
+	const authService = new AuthService(mock(), mock(), jwtService, urlService, userRepository);
 
-	jest.useFakeTimers();
 	const now = new Date('2024-02-01T01:23:45.678Z');
+	jest.useFakeTimers({ now });
+
+	const validToken =
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEyMyIsImhhc2giOiJtSkFZeDRXYjdrIiwiYnJvd3NlcklkIjoiOFpDVXE1YU1uSFhnMFZvcURLcm9hMHNaZ0NwdWlPQ1AzLzB2UmZKUXU0MD0iLCJpYXQiOjE3MDY3NTA2MjUsImV4cCI6MTcwNzM1NTQyNX0.YE-ZGGIQRNQ4DzUe9rjXvOOFFN9ufU34WibsCxAsc4o'; // Generated using `authService.issueJWT(user, browserId)`
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.setSystemTime(now);
 		config.set('userManagement.jwtSessionDurationHours', 168);
 		config.set('userManagement.jwtRefreshTimeoutHours', 0);
-
-		cipher.encrypt.calledWith(browserId).mockReturnValue('encrypted');
-		cipher.decrypt.calledWith('encrypted').mockReturnValue(browserId);
 	});
 
 	describe('createJWTHash', () => {

--- a/packages/cli/test/unit/controllers/me.controller.test.ts
+++ b/packages/cli/test/unit/controllers/me.controller.test.ts
@@ -16,6 +16,8 @@ import { UserRepository } from '@/databases/repositories/user.repository';
 import { badPasswords } from '../shared/testData';
 import { mockInstance } from '../../shared/mocking';
 
+const browserId = 'test-browser-id';
+
 describe('MeController', () => {
 	const externalHooks = mockInstance(ExternalHooks);
 	const internalHooks = mockInstance(InternalHooks);
@@ -47,7 +49,7 @@ describe('MeController', () => {
 				role: 'global:owner',
 			});
 			const reqBody = { email: 'valid@email.com', firstName: 'John', lastName: 'Potato' };
-			const req = mock<MeRequest.UserUpdate>({ user, body: reqBody });
+			const req = mock<MeRequest.UserUpdate>({ user, body: reqBody, browserId });
 			const res = mock<Response>();
 			userRepository.findOneOrFail.mockResolvedValue(user);
 			jest.spyOn(jwt, 'sign').mockImplementation(() => 'signed-token');
@@ -88,7 +90,7 @@ describe('MeController', () => {
 				role: 'global:owner',
 			});
 			const reqBody = { email: 'valid@email.com', firstName: 'John', lastName: 'Potato' };
-			const req = mock<MeRequest.UserUpdate>({ user, body: reqBody });
+			const req = mock<MeRequest.UserUpdate>({ user, body: reqBody, browserId });
 			const res = mock<Response>();
 			userRepository.findOneOrFail.mockResolvedValue(user);
 			jest.spyOn(jwt, 'sign').mockImplementation(() => 'signed-token');
@@ -160,6 +162,7 @@ describe('MeController', () => {
 					const req = mock<MeRequest.Password>({
 						user: mock({ password: passwordHash }),
 						body: { currentPassword: 'old_password', newPassword },
+						browserId,
 					});
 					await expect(controller.updatePassword(req, mock())).rejects.toThrowError(
 						new BadRequestError(errorMessage),
@@ -172,6 +175,7 @@ describe('MeController', () => {
 			const req = mock<MeRequest.Password>({
 				user: mock({ password: passwordHash }),
 				body: { currentPassword: 'old_password', newPassword: 'NewPassword123' },
+				browserId,
 			});
 			const res = mock<Response>();
 			userRepository.save.calledWith(req.user).mockResolvedValue(req.user);

--- a/packages/cli/test/unit/controllers/owner.controller.test.ts
+++ b/packages/cli/test/unit/controllers/owner.controller.test.ts
@@ -82,6 +82,7 @@ describe('OwnerController', () => {
 				role: 'global:owner',
 				authIdentities: [],
 			});
+			const browserId = 'test-browser-id';
 			const req = mock<OwnerRequest.Post>({
 				body: {
 					email: 'valid@email.com',
@@ -90,6 +91,7 @@ describe('OwnerController', () => {
 					lastName: 'Doe',
 				},
 				user,
+				browserId,
 			});
 			const res = mock<Response>();
 			configGetSpy.mockReturnValue(false);
@@ -103,7 +105,7 @@ describe('OwnerController', () => {
 				where: { role: 'global:owner' },
 			});
 			expect(userRepository.save).toHaveBeenCalledWith(user, { transaction: false });
-			expect(authService.issueCookie).toHaveBeenCalledWith(res, user);
+			expect(authService.issueCookie).toHaveBeenCalledWith(res, user, browserId);
 		});
 	});
 });

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -78,11 +78,8 @@ export async function request(config: {
 		method,
 		url: endpoint,
 		baseURL,
-		headers: headers ?? {},
+		headers,
 	};
-	if (browserId) {
-		options.headers!['browser-id'] = browserId;
-	}
 	if (
 		import.meta.env.NODE_ENV !== 'production' &&
 		!baseURL.includes('api.n8n.io') &&
@@ -131,11 +128,15 @@ export async function makeRestApiRequest<T>(
 	endpoint: string,
 	data?: IDataObject | IDataObject[],
 ) {
+	const headers: RawAxiosRequestHeaders = { 'push-ref': context.pushRef };
+	if (browserId) {
+		headers['browser-id'] = browserId;
+	}
 	const response = await request({
 		method,
 		baseURL: context.baseUrl,
 		endpoint,
-		headers: { 'push-ref': context.pushRef },
+		headers,
 		data,
 	});
 

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -91,7 +91,7 @@ export async function request(config: {
 		method,
 		url: endpoint,
 		baseURL,
-		headers: { ...headers, 'Browser-Id': browserId },
+		headers: { ...headers, 'browser-id': browserId },
 	};
 	if (
 		import.meta.env.NODE_ENV !== 'production' &&


### PR DESCRIPTION
This PR adds mechanisms to prevent Cross-site request forgery and Session-hijacking by
1. Generating a ~~pseudo-unique~~ Cryptographically secure pseudorandom `browserId` on the frontend using ~~simple fingerprinting~~ the Web Crypto API, and sending it as a header on all backend requests.
2. On the backend, adding a hash of this `browserId` in the issued JWT payload, and then validating for all requests that the id in the headers matches the id in the decoded token.

This prevents the possibility of someone sending requests to an n8n instance via a redirect or a html form. 
This also prevents people from copying the issues cookie over to other browsers.

## Related tickets and issues
N8N-7266
ADO-1321
ADO-2126

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included