### PR TITLE
fix(editor): UX improvements to mfa setup modal

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -197,6 +197,7 @@
 	// MFA Recovery codes
 	--color-mfa-recovery-code-background: var(--color-background-xlight);
 	--color-mfa-recovery-code-color: var(--color-text-dark);
+	--color-mfa-lose-access-text-color: var(--prim-color-alt-c-tint-150);
 
 	// Various
 	--color-info-tint-1: var(--prim-gray-420);

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -194,6 +194,10 @@
 	// Node error
 	--color-node-error-output-text-color: var(--prim-color-alt-c-tint-150);
 
+	// MFA Recovery codes
+	--color-mfa-recovery-code-background: var(--color-background-xlight);
+	--color-mfa-recovery-code-color: var(--color-text-dark);
+
 	// Various
 	--color-info-tint-1: var(--prim-gray-420);
 	--color-info-tint-2: var(--prim-gray-740);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -270,6 +270,10 @@
 	// Node error
 	--color-node-error-output-text-color: var(--color-danger);
 
+	// MFA Recovery codes
+	--color-mfa-recovery-code-background: var(--color-background-base);
+	--color-mfa-recovery-code-color: var(--prim-gray-490);
+
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);
 	--color-avatar-accent-2: var(--prim-color-alt-e-shade-100);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -273,6 +273,7 @@
 	// MFA Recovery codes
 	--color-mfa-recovery-code-background: var(--color-background-base);
 	--color-mfa-recovery-code-color: var(--prim-gray-490);
+	--color-mfa-lose-access-text-color: var(--color-danger);
 
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);

--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -2,7 +2,7 @@
 	<Modal
 		width="460px"
 		height="80%"
-		maxHeight="640px"
+		max-height="640px"
 		:title="
 			!showRecoveryCodes
 				? $locale.baseText('mfa.setup.step1.title')
@@ -75,7 +75,7 @@
 				</div>
 				<div :class="$style.recoveryCodesContainer">
 					<div v-for="recoveryCode in recoveryCodes" :key="recoveryCode">
-						<n8n-text size="medium">{{ recoveryCode }}</n8n-text>
+						<n8n-text size="medium">xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</n8n-text>
 					</div>
 				</div>
 				<n8n-info-tip :bold="false" :class="$style['edit-mode-footer-infotip']">

--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -1,6 +1,8 @@
 <template>
 	<Modal
 		width="460px"
+		height="80%"
+		maxHeight="640px"
 		:title="
 			!showRecoveryCodes
 				? $locale.baseText('mfa.setup.step1.title')
@@ -274,6 +276,12 @@ export default defineComponent({
 </script>
 
 <style module lang="scss">
+.container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
 .container > * {
 	overflow: visible;
 	margin-bottom: var(--spacing-s);
@@ -303,7 +311,6 @@ export default defineComponent({
 	text-align: center;
 }
 .recoveryCodesContainer {
-	height: 140px;
 	display: flex;
 	flex-direction: column;
 	background-color: var(--color-background-base);
@@ -316,7 +323,7 @@ export default defineComponent({
 	padding-bottom: var(--spacing-xs);
 	gap: var(--spacing-xs);
 	margin-bottom: var(--spacing-2xs);
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 
 .recoveryCodesContainer span {
@@ -361,9 +368,5 @@ export default defineComponent({
 
 .notice {
 	margin: 0;
-}
-
-.modalContent {
-	overflow: hidden;
 }
 </style>

--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -348,7 +348,7 @@ export default defineComponent({
 }
 
 .loseAccessText {
-	color: var(--color-danger);
+	color: var(--color-mfa-lose-access-text-color);
 }
 
 .error input {

--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -313,7 +313,7 @@ export default defineComponent({
 .recoveryCodesContainer {
 	display: flex;
 	flex-direction: column;
-	background-color: var(--color-background-base);
+	background-color: var(--color-mfa-recovery-code-background);
 	text-align: center;
 	flex-wrap: nowrap;
 	justify-content: space-between;
@@ -330,7 +330,7 @@ export default defineComponent({
 	font-size: var(--font-size-s);
 	font-weight: var(--font-weight-regular);
 	line-height: var(--spacing-m);
-	color: #7d7d87;
+	color: var(--color-mfa-recovery-code-color);
 }
 
 .form:first-child span {

--- a/packages/editor-ui/src/components/MfaSetupModal.vue
+++ b/packages/editor-ui/src/components/MfaSetupModal.vue
@@ -75,7 +75,7 @@
 				</div>
 				<div :class="$style.recoveryCodesContainer">
 					<div v-for="recoveryCode in recoveryCodes" :key="recoveryCode">
-						<n8n-text size="medium">xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</n8n-text>
+						<n8n-text size="medium">{{ recoveryCode }}</n8n-text>
 					</div>
 				</div>
 				<n8n-info-tip :bold="false" :class="$style['edit-mode-footer-infotip']">


### PR DESCRIPTION
## Summary

- fix(editor): Make MfaSetupModal responsive
- fix(editor): Fix MFA setup modal in dark mode

Before:

Note: The actual codes have been replaced with x's in these

![image](https://github.com/n8n-io/n8n/assets/10324676/7605af16-ddff-48d5-a3ea-c3dab3237e7a)


![image](https://github.com/n8n-io/n8n/assets/10324676/cf0b456d-b47a-4f52-b14f-a6d8de644025)


After:

Note: The actual codes have been replaced with x's in these

![image](https://github.com/n8n-io/n8n/assets/10324676/3e86b01f-887c-4319-8531-dde737f7a409)

![image](https://github.com/n8n-io/n8n/assets/10324676/918139b7-682c-4af1-89b1-60a0ef7380c9)

https://github.com/n8n-io/n8n/assets/10324676/1d06489a-7596-4760-8be9-306cbed910ed



## Related tickets and issues

https://linear.app/n8n/issue/ADO-2017/feature-dark-mode-improvements-p5


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))