### PR TITLE
fix(editor): Allow pinning of AI root nodes

### DIFF
--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -134,7 +134,7 @@ describe('Data pinning', () => {
 		ndv.getters.pinDataButton().should('not.exist');
 		ndv.getters.editPinnedDataButton().should('be.visible');
 
-		ndv.actions.setPinnedData([
+		ndv.actions.pastePinnedData([
 			{
 				test: '1'.repeat(Cypress.env('MAX_PINNED_DATA_SIZE')),
 			},

--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -206,7 +206,7 @@ describe('Data mapping', () => {
 		workflowPage.actions.addInitialNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
 		workflowPage.getters.canvasNodeByName(MANUAL_TRIGGER_NODE_DISPLAY_NAME).click();
 		workflowPage.actions.openNode(MANUAL_TRIGGER_NODE_DISPLAY_NAME);
-		ndv.actions.setPinnedData([
+		ndv.actions.pastePinnedData([
 			{
 				input: [
 					{

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -324,7 +324,7 @@ describe('NDV', () => {
 		];
 		/* prettier-ignore */
 		workflowPage.actions.openNode('Get thread details1');
-		ndv.actions.setPinnedData(PINNED_DATA);
+		ndv.actions.pastePinnedData(PINNED_DATA);
 		ndv.actions.close();
 
 		workflowPage.actions.executeWorkflow();

--- a/cypress/pages/ndv.ts
+++ b/cypress/pages/ndv.ts
@@ -155,6 +155,17 @@ export class NDV extends BasePage {
 
 			this.actions.savePinnedData();
 		},
+		pastePinnedData: (data: object) => {
+			this.getters.editPinnedDataButton().click();
+
+			this.getters.pinnedDataEditor().click();
+			this.getters
+				.pinnedDataEditor()
+				.type('{selectall}{backspace}', { delay: 0 })
+				.paste(JSON.stringify(data));
+
+			this.actions.savePinnedData();
+		},
 		clearParameterInput: (parameterName: string) => {
 			this.getters.parameterInput(parameterName).type(`{selectall}{backspace}`);
 		},

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -768,7 +768,7 @@ export default defineComponent({
 				return false;
 			}
 
-			const canPinNode = usePinnedData(this.node).canPinNode.value;
+			const canPinNode = usePinnedData(this.node).canPinNode(false);
 
 			return (
 				canPinNode &&

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -217,8 +217,8 @@
 				<div :class="[$style.editModeBody, 'ignore-key-press']">
 					<JsonEditor
 						:model-value="editMode.value"
-						@update:model-value="ndvStore.setOutputPanelEditModeValue($event)"
 						:fill-parent="true"
+						@update:model-value="ndvStore.setOutputPanelEditModeValue($event)"
 					/>
 				</div>
 				<div :class="$style.editModeFooter">
@@ -803,21 +803,14 @@ export default defineComponent({
 			return this.nodeTypesStore.isTriggerNode(this.node.type);
 		},
 		canPinData(): boolean {
-			// Only "main" inputs can pin data
-
 			if (this.node === null) {
 				return false;
 			}
 
-			const workflow = this.workflowsStore.getCurrentWorkflow();
-			const workflowNode = workflow.getNode(this.node.name);
-			const inputs = NodeHelpers.getNodeInputs(workflow, workflowNode!, this.nodeType!);
-			const inputNames = NodeHelpers.getConnectionTypes(inputs);
-
-			const nonMainInputs = !!inputNames.find((inputName) => inputName !== NodeConnectionType.Main);
+			const canPinNode = usePinnedData(this.node).canPinNode.value;
 
 			return (
-				!nonMainInputs &&
+				canPinNode &&
 				!this.isPaneTypeInput &&
 				this.pinnedData.isValidNodeType.value &&
 				!(this.binaryData && this.binaryData.length > 0)

--- a/packages/editor-ui/src/composables/useContextMenu.ts
+++ b/packages/editor-ui/src/composables/useContextMenu.ts
@@ -1,20 +1,15 @@
 import type { XYPosition } from '@/Interface';
-import {
-	NOT_DUPLICATABE_NODE_TYPES,
-	PIN_DATA_NODE_TYPES_DENYLIST,
-	STICKY_NODE_TYPE,
-} from '@/constants';
+import { NOT_DUPLICATABE_NODE_TYPES, STICKY_NODE_TYPE } from '@/constants';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import type { IActionDropdownItem } from 'n8n-design-system/src/components/N8nActionDropdown/ActionDropdown.vue';
-import { NodeHelpers, NodeConnectionType } from 'n8n-workflow';
 import type { INode, INodeTypeDescription } from 'n8n-workflow';
 import { computed, ref, watch } from 'vue';
 import { getMousePosition } from '../utils/nodeViewUtils';
 import { useI18n } from './useI18n';
-import { useDataSchema } from './useDataSchema';
+import { usePinnedData } from './usePinnedData';
 
 export type ContextMenuTarget =
 	| { source: 'canvas' }
@@ -47,7 +42,7 @@ export const useContextMenu = (onAction: ContextMenuActionCallback = () => {}) =
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowsStore = useWorkflowsStore();
 	const sourceControlStore = useSourceControlStore();
-	const { getInputDataWithPinned } = useDataSchema();
+
 	const i18n = useI18n();
 
 	const isReadOnly = computed(
@@ -81,13 +76,6 @@ export const useContextMenu = (onAction: ContextMenuActionCallback = () => {}) =
 		if (NOT_DUPLICATABE_NODE_TYPES.includes(nodeType.name)) return false;
 
 		return canAddNodeOfType(nodeType);
-	};
-
-	const canPinNode = (node: INode): boolean => {
-		const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
-		const dataToPin = getInputDataWithPinned(node);
-		if (!nodeType || dataToPin.length === 0) return false;
-		return nodeType.outputs.length === 1 && !PIN_DATA_NODE_TYPES_DENYLIST.includes(node.type);
 	};
 
 	const hasPinData = (node: INode): boolean => {
@@ -159,16 +147,6 @@ export const useContextMenu = (onAction: ContextMenuActionCallback = () => {}) =
 				...selectionActions,
 			];
 		} else {
-			const nonMainInputs = (node: INode) => {
-				const workflow = workflowsStore.getCurrentWorkflow();
-				const workflowNode = workflow.getNode(node.name);
-				const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
-				const inputs = NodeHelpers.getNodeInputs(workflow, workflowNode!, nodeType!);
-				const inputNames = NodeHelpers.getConnectionTypes(inputs);
-
-				return !!inputNames.find((inputName) => inputName !== NodeConnectionType.Main);
-			};
-
 			const menuActions: IActionDropdownItem[] = [
 				!onlyStickies && {
 					id: 'toggle_activation',
@@ -184,7 +162,7 @@ export const useContextMenu = (onAction: ContextMenuActionCallback = () => {}) =
 						? i18n.baseText('contextMenu.unpin', i18nOptions)
 						: i18n.baseText('contextMenu.pin', i18nOptions),
 					shortcut: { keys: ['p'] },
-					disabled: nodes.some(nonMainInputs) || isReadOnly.value || !nodes.every(canPinNode),
+					disabled: isReadOnly.value || !nodes.every((n) => usePinnedData(n).canPinNode.value),
 				},
 				{
 					id: 'copy',

--- a/packages/editor-ui/src/composables/useContextMenu.ts
+++ b/packages/editor-ui/src/composables/useContextMenu.ts
@@ -162,7 +162,7 @@ export const useContextMenu = (onAction: ContextMenuActionCallback = () => {}) =
 						? i18n.baseText('contextMenu.unpin', i18nOptions)
 						: i18n.baseText('contextMenu.pin', i18nOptions),
 					shortcut: { keys: ['p'] },
-					disabled: isReadOnly.value || !nodes.every((n) => usePinnedData(n).canPinNode.value),
+					disabled: isReadOnly.value || !nodes.every((n) => usePinnedData(n).canPinNode(true)),
 				},
 				{
 					id: 'copy',

--- a/packages/editor-ui/src/composables/usePinnedData.ts
+++ b/packages/editor-ui/src/composables/usePinnedData.ts
@@ -76,15 +76,15 @@ export function usePinnedData(
 		);
 	});
 
-	const canPinNode = computed(() => {
+	function canPinNode(checkDataEmpty = false) {
 		const targetNode = unref(node);
 		if (targetNode === null) return false;
 
 		const nodeType = useNodeTypesStore().getNodeType(targetNode.type, targetNode.typeVersion);
 		const dataToPin = getInputDataWithPinned(targetNode);
-		if (!nodeType || dataToPin.length === 0) return false;
+		if (!nodeType || (checkDataEmpty && dataToPin.length === 0)) return false;
 		return nodeType.outputs.length === 1 && !PIN_DATA_NODE_TYPES_DENYLIST.includes(targetNode.type);
-	});
+	}
 
 	function isValidJSON(data: string): boolean {
 		try {

--- a/packages/editor-ui/src/composables/usePinnedData.ts
+++ b/packages/editor-ui/src/composables/usePinnedData.ts
@@ -1,7 +1,7 @@
 import { useToast } from '@/composables/useToast';
 import { useI18n } from '@/composables/useI18n';
 import type { INodeExecutionData, IPinData } from 'n8n-workflow';
-import { jsonParse, jsonStringify } from 'n8n-workflow';
+import { jsonParse, jsonStringify, NodeConnectionType, NodeHelpers } from 'n8n-workflow';
 import {
 	MAX_EXPECTED_REQUEST_SIZE,
 	MAX_PINNED_DATA_SIZE,
@@ -82,8 +82,18 @@ export function usePinnedData(
 
 		const nodeType = useNodeTypesStore().getNodeType(targetNode.type, targetNode.typeVersion);
 		const dataToPin = getInputDataWithPinned(targetNode);
+
 		if (!nodeType || (checkDataEmpty && dataToPin.length === 0)) return false;
-		return nodeType.outputs.length === 1 && !PIN_DATA_NODE_TYPES_DENYLIST.includes(targetNode.type);
+
+		const workflow = workflowsStore.getCurrentWorkflow();
+		const outputs = NodeHelpers.getNodeOutputs(workflow, targetNode, nodeType);
+		const mainOutputs = outputs.filter((output) =>
+			typeof output === 'string'
+				? output === NodeConnectionType.Main
+				: output.type === NodeConnectionType.Main,
+		);
+
+		return mainOutputs.length === 1 && !PIN_DATA_NODE_TYPES_DENYLIST.includes(targetNode.type);
 	}
 
 	function isValidJSON(data: string): boolean {


### PR DESCRIPTION
## Summary
- Disable data pinning only for nodes without `main` output
- Consolidate the `canPinNode` logic into `usePinnedData` composable and replace usage
- Fix the linting warning for `RunData.vue` component



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://community.n8n.io/t/cant-pin-assistant-node-anymore/43750


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 