### PR TITLE
fix(core): Ensure TTL safeguard for test webhooks applies only to multi-main setup

### DIFF
--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'node:events';
 
 import { Service } from 'typedi';
 import { caching } from 'cache-manager';
-import { jsonStringify } from 'n8n-workflow';
+import { ApplicationError, jsonStringify } from 'n8n-workflow';
 
 import config from '@/config';
 import { getDefaultRedisClient, getRedisPrefix } from '@/services/redis/RedisServiceHelper';
@@ -137,10 +137,9 @@ export class CacheService extends EventEmitter {
 		if (!key?.length) return;
 
 		if (this.cache.kind === 'memory') {
-			setTimeout(async () => {
-				await this.cache.store.del(key);
-			}, ttlMs);
-			return;
+			throw new ApplicationError('Method `expire` not yet implemented for in-memory cache', {
+				level: 'warning',
+			});
 		}
 
 		await this.cache.store.expire(key, ttlMs / TIME.SECOND);

--- a/packages/cli/src/services/test-webhook-registrations.service.ts
+++ b/packages/cli/src/services/test-webhook-registrations.service.ts
@@ -3,6 +3,7 @@ import { CacheService } from '@/services/cache/cache.service';
 import type { IWebhookData } from 'n8n-workflow';
 import type { IWorkflowDb } from '@/Interfaces';
 import { TEST_WEBHOOK_TIMEOUT, TEST_WEBHOOK_TIMEOUT_BUFFER } from '@/constants';
+import { OrchestrationService } from './orchestration.service';
 
 export type TestWebhookRegistration = {
 	pushRef?: string;
@@ -13,7 +14,10 @@ export type TestWebhookRegistration = {
 
 @Service()
 export class TestWebhookRegistrationsService {
-	constructor(private readonly cacheService: CacheService) {}
+	constructor(
+		private readonly cacheService: CacheService,
+		private readonly orchestrationService: OrchestrationService,
+	) {}
 
 	private readonly cacheKey = 'test-webhooks';
 
@@ -21,6 +25,8 @@ export class TestWebhookRegistrationsService {
 		const hashKey = this.toKey(registration.webhook);
 
 		await this.cacheService.setHash(this.cacheKey, { [hashKey]: registration });
+
+		if (!this.orchestrationService.isMultiMainSetupEnabled) return;
 
 		/**
 		 * Multi-main setup: In a manual webhook execution, the main process that


### PR DESCRIPTION
In multi-main setup, in a manual webhook execution, it is possible that the main process that handles a webhook is not the same as the main process that created the webhook. It is the creator's responsibility to deregister all test webhooks from the cache, so for the case where the creator crashes before deregistering, we set a TTL as a safeguard. See #8267.

However, in single-main setup, setting the TTL via [`setTimeout` in the in-memory cache](https://github.com/n8n-io/n8n/pull/8267/files#diff-6166c3d1fe5d8bcaf1b5940f08410e9063d0b654b879b1316f31ee2a942c9508R140) is causing the webhook to be deregistered whenever the TTL expires, e.g. a test webhook can be blocked from cancelling because it was prematurely removed by an unrelated TTL. The root issue is that the timeout from the in-memory cache is not managed - it survives and is never cleared.

Since the risk that the TTL protects against exists only in a multi-main setup, and since the in-memory implementation of `expire` is not used elsewhere at all, this PR skips the TTL in single-main setup and throws an error on trying to use `expire` with the in-memory cache.

Thanks @valya for pointing this out.