### PR TITLE
fix(core): Webhooks responding with binary data should not prematurely end the response stream

### DIFF
--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1834,7 +1834,7 @@ export interface IWebhookResponseData {
 }
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary' | 'noData';
-export type WebhookResponseMode = 'onReceived' | 'lastNode';
+export type WebhookResponseMode = 'onReceived' | 'lastNode' | 'responseNode';
 
 export interface INodeTypes {
 	getByName(nodeType: string): INodeType | IVersionedNodeType;


### PR DESCRIPTION
## Summary
Whenever piping a stream into response, there is always a chance that `await pipeline(stream, res)` (or `stream.pipe(res)`) closes the response stream before we are done with the stream object. 
To avoid this issue, any stream being piped into response should use the option `end: false`, and then explicitly close the response stream **after** `responseCallback` has been called. 

## Related tickets and issues
PAY-1326
PAY-1465
https://github.com/n8n-io/n8n/issues/9291

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included