### PR TITLE
fix(editor): Fix issues in dark mode

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -96,7 +96,7 @@
 	--color-json-boolean: var(--prim-color-alt-a);
 	--color-json-number: var(--prim-color-alt-a);
 	--color-json-string: var(--prim-color-secondary-tint-200);
-	--color-json-key: var(--prim-gray-670);
+	--color-json-key: var(--color-text-dark);
 	--color-json-brackets: var(--prim-gray-670);
 	--color-json-brackets-hover: var(--prim-color-alt-e);
 	--color-json-line: var(--prim-gray-200);

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -191,6 +191,9 @@
 	// Input Triple
 	--color-background-input-triple: var(--prim-gray-800);
 
+	// Node error
+	--color-node-error-output-text-color: var(--prim-color-alt-c-tint-150);
+
 	// Various
 	--color-info-tint-1: var(--prim-gray-420);
 	--color-info-tint-2: var(--prim-gray-740);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -268,7 +268,7 @@
 	--color-background-input-triple: var(--color-background-light);
 
 	// Node error
-	--color-node-error-output-text-color: var(--prim-color-alt-c-tint-150);
+	--color-node-error-output-text-color: var(--color-danger);
 
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -267,6 +267,9 @@
 	// Input Triple
 	--color-background-input-triple: var(--color-background-light);
 
+	// Node error
+	--color-node-error-output-text-color: var(--prim-color-alt-c-tint-150);
+
 	// Various
 	--color-avatar-accent-1: var(--prim-gray-120);
 	--color-avatar-accent-2: var(--prim-color-alt-e-shade-100);

--- a/packages/editor-ui/src/components/BinaryDataDisplay.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplay.vue
@@ -99,7 +99,7 @@ export default defineComponent({
 	z-index: 10;
 	width: 100%;
 	height: calc(100% - 50px);
-	background-color: var(--color-background-base);
+	background-color: var(--color-run-data-background);
 	overflow: hidden;
 	text-align: center;
 

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1294,10 +1294,10 @@ export default defineComponent({
 
 	&.error {
 		path {
-			fill: var(--color-danger);
+			fill: var(--color-node-error-output-text-color);
 		}
 		rect {
-			stroke: var(--color-danger);
+			stroke: var(--color-node-error-output-text-color);
 		}
 	}
 

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -1294,10 +1294,10 @@ export default defineComponent({
 
 	&.error {
 		path {
-			fill: var(--node-error-output-color);
+			fill: var(--color-danger);
 		}
 		rect {
-			stroke: var(--node-error-output-color);
+			stroke: var(--color-danger);
 		}
 	}
 
@@ -1436,7 +1436,7 @@ export default defineComponent({
 }
 
 .node-output-endpoint-label.node-connection-category-error {
-	color: var(--node-error-output-color);
+	color: var(--color-node-error-output-text-color);
 }
 
 .node-output-endpoint-label {

--- a/packages/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
@@ -130,7 +130,7 @@ defineExpose({
 }
 
 .clear {
-	background-color: $node-creator-search-clear-color;
+	background-color: transparent;
 	padding: 0;
 	border: none;
 	cursor: pointer;

--- a/packages/editor-ui/src/mixins/nodeBase.ts
+++ b/packages/editor-ui/src/mixins/nodeBase.ts
@@ -600,7 +600,7 @@ export const nodeBase = defineComponent({
 								nodeTypeData,
 								this.__getEndpointColor(NodeConnectionType.Main),
 							),
-							fill: 'var(--node-error-output-color)',
+							fill: 'var(--color-danger)',
 						},
 						cssClass: `dot-${type}-endpoint`,
 					};

--- a/packages/editor-ui/src/n8n-theme.scss
+++ b/packages/editor-ui/src/n8n-theme.scss
@@ -170,7 +170,6 @@
 		var(--node-type-ai_vectorStore-color-s),
 		var(--node-type-background-l)
 	);
-	--node-error-output-color: #991818;
 
 	--chat--spacing: var(--spacing-s);
 

--- a/packages/editor-ui/src/utils/nodeViewUtils.ts
+++ b/packages/editor-ui/src/utils/nodeViewUtils.ts
@@ -113,7 +113,7 @@ export const CONNECTOR_PAINT_STYLE_DATA: PaintStyle = {
 
 export const getConnectorColor = (type: ConnectionTypes, category?: string): string => {
 	if (category === 'error') {
-		return '--node-error-output-color';
+		return '--color-node-error-output-text-color';
 	}
 
 	if (type === NodeConnectionType.Main) {


### PR DESCRIPTION
## Summary

-  fix(editor): Fix binary data preview in dark mode 

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/25047df0-4e2d-461a-a12b-117f2cd2c0c4)

After:

![image](https://github.com/n8n-io/n8n/assets/10324676/2000b2bc-2f6c-4703-ad24-d656911b9b3d)


-  fix(editor): Fix node error output in dark mode 

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/1c568c32-5340-45bd-b3b1-b7063ceba8df)


After:

![image](https://github.com/n8n-io/n8n/assets/10324676/00127de1-4596-4f7f-bd0c-745c31fc9906)


-  fix(editor): Fix clear search icon in dark mode 

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/449ebaf4-6ef7-4a74-bbf8-5fd0bacec18c)


After:


![image](https://github.com/n8n-io/n8n/assets/10324676/84f6ac0f-7a9a-4789-a7d6-a66c36a7bf29)


## Related tickets and issues

https://linear.app/n8n/issue/ADO-2017/feature-dark-mode-improvements-p5
https://linear.app/n8n/issue/ADO-2114/bug-couple-issues-in-dark-mode

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 