### PR TITLE
fix: Fix some vue warnings (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
@@ -11,8 +11,8 @@ import InlineExpressionTip from './InlineExpressionTip.vue';
 
 interface InlineExpressionEditorOutputProps {
 	segments: Segment[];
-	unresolvedExpression: string;
 	hoveringItemNumber: number;
+	unresolvedExpression?: string;
 	editorState?: EditorState;
 	selection?: SelectionRange;
 	isReadOnly?: boolean;
@@ -26,6 +26,7 @@ const props = withDefaults(defineProps<InlineExpressionEditorOutputProps>(), {
 	noInputData: false,
 	editorState: undefined,
 	selection: undefined,
+	unresolvedExpression: undefined,
 });
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -12,7 +12,7 @@
 					:label="buttonLabel"
 					:type="type"
 					:size="size"
-					:icon="!isListeningForEvents && !hideIcon && 'flask'"
+					:icon="!isListeningForEvents && !hideIcon ? 'flask' : undefined"
 					:transparent-background="transparent"
 					:title="!isTriggerNode ? $locale.baseText('ndv.execute.testNode.description') : ''"
 					@click="onClick"


### PR DESCRIPTION
## Summary

-  fix(editor): Fix missing required prop: "unresolvedExpression" warning 

![image](https://github.com/n8n-io/n8n/assets/10324676/109ee23e-5f4d-49d3-ade9-ba1b66e5dc5f)


-  fix(editor): Fix prop type check failed for prop "icon" warning 

![image](https://github.com/n8n-io/n8n/assets/10324676/47634d59-bc2b-4f05-baf3-57f157530b6f)


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 