### PR TITLE
fix(editor): Fix issue with case insensitive tags

### DIFF
--- a/cypress/e2e/17-workflow-tags.cy.ts
+++ b/cypress/e2e/17-workflow-tags.cy.ts
@@ -14,7 +14,7 @@ describe('Workflow tags', () => {
 		wf.actions.addTags(TEST_TAGS.slice(0, 2));
 		wf.getters.tagPills().should('have.length', 2);
 		wf.getters.nthTagPill(1).click();
-		wf.actions.addTags(TEST_TAGS[2]);
+		wf.actions.addTags(TEST_TAGS[1].toUpperCase());
 		wf.getters.tagPills().should('have.length', 3);
 		wf.getters.isWorkflowSaved();
 	});

--- a/packages/editor-ui/src/components/TagsDropdown.vue
+++ b/packages/editor-ui/src/components/TagsDropdown.vue
@@ -124,9 +124,7 @@ export default defineComponent({
 		});
 
 		const options = computed<ITag[]>(() => {
-			return allTags.value.filter(
-				(tag: ITag) => tag && tag.name.toLowerCase().includes(filter.value.toLowerCase()),
-			);
+			return allTags.value.filter((tag: ITag) => tag && tag.name.includes(filter.value));
 		});
 
 		const appliedTags = computed<string[]>(() => {
@@ -182,7 +180,7 @@ export default defineComponent({
 		}
 
 		function filterOptions(value = '') {
-			filter.value = value.trim();
+			filter.value = value;
 			void nextTick(() => focusFirstOption());
 		}
 


### PR DESCRIPTION
## Summary

The tag dropdown fails to create a tag if the same text with another casing exists.

## Related tickets and issues
https://linear.app/n8n/issue/ADO-2110/weird-error-when-trying-to-add-a-tag-to-the-wf

Before:

https://www.loom.com/share/096f16b52ea74b89bd83a50e5fcd7d6b

Now:

https://www.loom.com/share/5ceb16f9ae934708bf8e7d2013e3b62d


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 