### PR TITLE
fix(core): Map NodeOperationErrors to BadRequestError in /resource-locator-results

### DIFF
--- a/packages/cli/test/unit/controllers/dynamicNodeParameters.controller.test.ts
+++ b/packages/cli/test/unit/controllers/dynamicNodeParameters.controller.test.ts
@@ -1,0 +1,87 @@
+import { DynamicNodeParametersController } from '@/controllers/dynamicNodeParameters.controller';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import type { DynamicNodeParametersRequest } from '@/requests';
+import type { DynamicNodeParametersService } from '@/services/dynamicNodeParameters.service';
+import { mock } from 'jest-mock-extended';
+import type { INode } from 'n8n-workflow';
+import {
+	NodeOperationError,
+	type INodeCredentials,
+	type INodeParameters,
+	type INodeTypeNameVersion,
+} from 'n8n-workflow';
+import { mockInstance } from '../../shared/mocking';
+import { CredentialsHelper } from '@/CredentialsHelper';
+import { SecretsHelper } from '@/SecretsHelpers';
+import { MessageEventBus } from '@/eventbus/MessageEventBus/MessageEventBus';
+import { VariablesService } from '@/environments/variables/variables.service.ee';
+
+describe('DynamicNodeParametersController', () => {
+	mockInstance(CredentialsHelper);
+	mockInstance(SecretsHelper);
+	mockInstance(MessageEventBus);
+	mockInstance(VariablesService, {
+		getAllCached: async () => [],
+	});
+
+	const service = mock<DynamicNodeParametersService>();
+	const controller = new DynamicNodeParametersController(service);
+
+	describe('getResourceLocatorResults', () => {
+		it('should call the service method with the correct parameters', async () => {
+			// Arrange
+			const mockCredentials = mock<INodeCredentials>();
+			const mockNodeParams = mock<INodeParameters>();
+			const mockNodeTypeAndVersion = mock<INodeTypeNameVersion>();
+
+			const req = mock<DynamicNodeParametersRequest.ResourceLocatorResults>({
+				query: {
+					methodName: 'testMethodName',
+					path: 'testPath',
+					filter: 'testFilter',
+					paginationToken: 'testPaginationToken',
+				},
+				params: {
+					nodeTypeAndVersion: mockNodeTypeAndVersion,
+					currentNodeParameters: mockNodeParams,
+					credentials: mockCredentials,
+				},
+				user: {
+					id: 'testUserId',
+				},
+			});
+
+			// Act
+			await controller.getResourceLocatorResults(req);
+
+			// Assert
+			expect(service.getResourceLocatorResults).toHaveBeenCalledWith(
+				'testMethodName',
+				'testPath',
+				expect.anything(),
+				mockNodeTypeAndVersion,
+				mockNodeParams,
+				mockCredentials,
+				'testFilter',
+				'testPaginationToken',
+			);
+		});
+
+		it('should throw BadRequestError if service throws NodeOperationError', async () => {
+			// Arrange
+			const req = mock<DynamicNodeParametersRequest.ResourceLocatorResults>({
+				user: {
+					id: 'testUserId',
+				},
+			});
+			service.getResourceLocatorResults.mockRejectedValue(
+				new NodeOperationError(mock<INode>(), 'test error'),
+			);
+
+			// Act & Assert
+			await expect(async () => await controller.getResourceLocatorResults(req)).rejects.toThrow(
+				new BadRequestError('test error'),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

While investigating https://linear.app/n8n/issue/ADO-1361/dynamic-options-fail-to-load-if-the-node-contains-an-expression-in-an I noticed this:

UI calls the /dynamic-node-parameters/resource-locator-results endpoint to resolve resources to show in the NDV resource picker. For example the user can select an n8n workflow from a list in the n8n node. However, if the credentials are invalid or missing, the resolution will throw a NodeOperationError. This results in HTTP 500 response from the endpoint. Since this is an expected error due to invalid configuration, it makes more sense to respond with 400 Bad Request.


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1361/dynamic-options-fail-to-load-if-the-node-contains-an-expression-in-an


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 