### PR TITLE
fix: Partial Executions respecting runData from previous runs with nodes with multiple inputs

### DIFF
--- a/cypress/e2e/852-pay-partial-execution-with-multiple-input-nodes.cy.ts
+++ b/cypress/e2e/852-pay-partial-execution-with-multiple-input-nodes.cy.ts
@@ -1,0 +1,34 @@
+import { v4 as uuid } from 'uuid';
+import { NDV, WorkflowPage as WorkflowPageClass } from '../pages';
+
+const workflowPage = new WorkflowPageClass();
+const ndv = new NDV();
+
+describe('pay-852-partial-workflow-executions-with-run-data-and-merge-node', () => {
+	beforeEach(() => {
+		workflowPage.actions.visit();
+	});
+
+	it('it should combine old and new run data during partial executions for nodes with multiple inputs', () => {
+		cy.createFixtureWorkflow('Test_pay_852.json', uuid());
+
+		// Execute the workflow
+		workflowPage.getters.zoomToFitButton().click();
+		workflowPage.actions.deselectAll();
+
+		// execute input 1 first then the rest
+		workflowPage.actions.executeNode('Set Input 1');
+		workflowPage.actions.executeNode('Set Output');
+		workflowPage.actions.openNode('Merge');
+		ndv.getters.nodeRunErrorIndicator().should('not.exist');
+		ndv.getters.nodeRunSuccessIndicator().should('be.visible');
+		ndv.actions.close();
+
+		// execute input 2 first then the rest
+		workflowPage.actions.executeNode('Set Input 2');
+		workflowPage.actions.executeNode('Set Output');
+		workflowPage.actions.openNode('Merge');
+		ndv.getters.nodeRunErrorIndicator().should('not.exist');
+		ndv.getters.nodeRunSuccessIndicator().should('be.visible');
+	});
+});

--- a/cypress/fixtures/Test_pay_852.json
+++ b/cypress/fixtures/Test_pay_852.json
@@ -1,0 +1,123 @@
+{
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "cb484ba7b742928a2048bf8829668bed5b5ad9787579adea888f05980292a4a7"
+  },
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "bcd3c9b2-bbba-4070-a7b3-d6a8afd3013a",
+      "name": "When clicking \"Execute Workflow\"",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [280, 780]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "mergeByFields": {
+          "values": [
+            {
+              "field1": "test",
+              "field2": "test"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "bba1639f-4f0d-4d73-b9ba-3429ab0c9398",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 2,
+      "position": [900, 860]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "871813af-958a-4b96-bd73-6a23dadde35c",
+      "name": "Set Input 1",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [480, 780]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "57bb71ae-ea8e-4110-add6-7c265de7284b",
+      "name": "Set Input 2",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [480, 940]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "f8f9abe9-3362-4047-96aa-de63a0735d1d",
+      "name": "Set Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [1060, 860]
+    }
+  ],
+  "connections": {
+    "When clicking \"Execute Workflow\"": {
+      "main": [
+        [
+          {
+            "node": "Set Input 2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Set Input 1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge": {
+      "main": [
+        [
+          {
+            "node": "Set Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Input 1": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Input 2": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {
+    "When clicking \"Execute Workflow\"": [
+      {
+        "test": 123
+      }
+    ]
+  }
+}

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -470,7 +470,7 @@ export class WorkflowExecute {
 			// Check if all data exists now
 			let thisExecutionData: INodeExecutionData[] | null;
 			let allDataFound = true;
-			for (
+			outer: for (
 				let i = 0;
 				i <
 				this.runExecutionData.executionData!.waitingExecution[connectionData.node][waitingNodeIndex]
@@ -481,7 +481,43 @@ export class WorkflowExecute {
 					this.runExecutionData.executionData!.waitingExecution[connectionData.node][
 						waitingNodeIndex
 					].main[i];
+
 				if (thisExecutionData === null) {
+					// If this is a manual execution it may be a partial execution and we
+					// may find the data in the runData that was passed in.
+					if (this.mode === 'manual') {
+						const connections = workflow.connectionsByDestinationNode[connectionData.node].main[i];
+
+						for (const connection of connections) {
+							const runData = this.runExecutionData.resultData.runData[connection.node];
+
+							if (runData) {
+								const executionData = runData[runIndex].data?.main[connection.index];
+
+								if (executionData) {
+									// We found a node that is connected to the input i that
+									// already has executionData in the runData.
+									// Let's use this.
+									this.runExecutionData.executionData!.waitingExecution[connectionData.node][
+										waitingNodeIndex
+									].main[i] = executionData;
+
+									this.runExecutionData.executionData!.waitingExecutionSource[connectionData.node][
+										waitingNodeIndex
+									].main[i] = {
+										previousNode: connection.node,
+										previousNodeOutput: connection.index,
+										previousNodeRun: runIndex,
+									};
+
+									continue outer;
+								}
+							}
+						}
+					}
+
+					// If we end up here then the node is still missing input data.
+					// Let's move on.
 					allDataFound = false;
 					break;
 				}
@@ -681,6 +717,7 @@ export class WorkflowExecute {
 						if (addEmptyItem) {
 							// Add only node if it does not have any inputs because else it will
 							// be added by its input node later anyway.
+							// so now we add the `Merge` node to the execution stack
 							this.runExecutionData.executionData!.nodeExecutionStack[enqueueFn]({
 								node: workflow.getNode(nodeToAdd) as INode,
 								data: {
@@ -711,6 +748,7 @@ export class WorkflowExecute {
 		// Make sure the array has all the values
 		const connectionDataArray: Array<INodeExecutionData[] | null> = [];
 		for (let i: number = connectionData.index; i >= 0; i--) {
+			// TODO: merge run data in here?
 			connectionDataArray[i] = null;
 		}
 


### PR DESCRIPTION
## Summary

Nodes with multiple inputs would not see the input of a previous execution during a partial execution:

https://github.com/n8n-io/n8n/assets/927609/a696c5c5-1a48-4661-9d6b-d0b040182c54

The code that handles nodes with multiple inputs did not check the run data when deciding if a node has all data it needs to be put on the execution stack. 

Now it behaves as expected:

https://github.com/n8n-io/n8n/assets/927609/bae981e3-a631-4cb9-8c93-175812847671

The change only applies to manual executions. All other executions don't start with runData.

If you're wondering why one of the nodes always executed twice, that's another bug. The editor sends more start nodes than are necessary and it sends one of them twice. That will be fixed in another PR. Some variation of that behavior is tracked here: https://linear.app/n8n/issue/PAY-1385/partial-execution-uses-wrong-branch-to-start-execution

## Related tickets and issues

https://linear.app/n8n/issue/PAY-852/partial-workflow-executions-with-run-data-and-merge-node-incorrectly

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

