### PR TITLE
feat(editor): Add object keys that need bracket access to autocomplete

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
@@ -552,12 +552,32 @@ describe('Resolution-based completions', () => {
 
 			const found = completions('{{ $json.| }}');
 			if (!found) throw new Error('Expected to find completions');
-			expect(
-				found.find((completion) => completion.label === 'Key with spaces'),
-			).not.toBeUndefined();
-			expect(
-				found.find((completion) => completion.label === 'Key with spaces and \'quotes"'),
-			).not.toBeUndefined();
+			expect(found).toContainEqual(
+				expect.objectContaining({
+					label: 'Key with spaces',
+					apply: utils.applyBracketAccessCompletion,
+				}),
+			);
+			expect(found).toContainEqual(
+				expect.objectContaining({
+					label: 'Key with spaces and \'quotes"',
+					apply: utils.applyBracketAccessCompletion,
+				}),
+			);
+		});
+
+		test('should escape keys with quotes', () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockReturnValue({
+				'Key with spaces and \'quotes"': 1,
+			});
+
+			const found = completions('{{ $json[| }}');
+			if (!found) throw new Error('Expected to find completions');
+			expect(found).toContainEqual(
+				expect.objectContaining({
+					label: "'Key with spaces and \\'quotes\"']",
+				}),
+			);
 		});
 	});
 

--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
@@ -542,6 +542,23 @@ describe('Resolution-based completions', () => {
 				expect(found.map((c) => c.label).every((l) => l.endsWith(']')));
 			});
 		});
+
+		test('should give completions for keys that need bracket access', () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockReturnValue({
+				foo: 'bar',
+				'Key with spaces': 1,
+				'Key with spaces and \'quotes"': 1,
+			});
+
+			const found = completions('{{ $json.| }}');
+			if (!found) throw new Error('Expected to find completions');
+			expect(
+				found.find((completion) => completion.label === 'Key with spaces'),
+			).not.toBeUndefined();
+			expect(
+				found.find((completion) => completion.label === 'Key with spaces and \'quotes"'),
+			).not.toBeUndefined();
+		});
 	});
 
 	describe('recommended completions', () => {

--- a/packages/editor-ui/src/plugins/codemirror/completions/bracketAccess.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/bracketAccess.completions.ts
@@ -3,6 +3,7 @@ import { prefixMatch, longestCommonPrefix } from './utils';
 import type { IDataObject } from 'n8n-workflow';
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import type { Resolved } from './types';
+import { escapeMappingString } from '@/utils/mappingUtils';
 
 /**
  * Resolution-based completions offered at the start of bracket access notation.
@@ -67,7 +68,7 @@ function bracketAccessOptions(resolved: IDataObject) {
 			const isNumber = !isNaN(parseInt(key)); // array or string index
 
 			return {
-				label: isNumber ? `${key}]` : `'${key}']`,
+				label: isNumber ? `${key}]` : `'${escapeMappingString(key)}']`,
 				type: 'keyword',
 			};
 		});

--- a/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
@@ -19,6 +19,8 @@ import {
 	hasRequiredArgs,
 	getDefaultArgs,
 	insertDefaultArgs,
+	applyBracketAccessCompletion,
+	applyBracketAccess,
 } from './utils';
 import type {
 	Completion,
@@ -58,6 +60,7 @@ import {
 } from './constants';
 import { VALID_EMAIL_REGEX } from '@/constants';
 import { uniqBy } from 'lodash-es';
+import { escapeMappingString } from '../../../utils/mappingUtils';
 
 /**
  * Resolution-based completions offered according to datatype.
@@ -354,7 +357,11 @@ const createPropHeader = (typeName: string, property: { doc?: DocMetadata | unde
 	const header = document.createElement('div');
 	if (property.doc) {
 		const typeNameSpan = document.createElement('span');
-		typeNameSpan.innerHTML = typeName.slice(0, 1).toUpperCase() + typeName.slice(1) + '.';
+		typeNameSpan.innerHTML = typeName.charAt(0).toUpperCase() + typeName.slice(1);
+
+		if (!property.doc.name.startsWith("['")) {
+			typeNameSpan.innerHTML += '.';
+		}
 
 		const propNameSpan = document.createElement('span');
 		propNameSpan.classList.add('autocomplete-info-name');
@@ -371,7 +378,7 @@ const createPropHeader = (typeName: string, property: { doc?: DocMetadata | unde
 };
 
 const objectOptions = (input: AutocompleteInput<IDataObject>): Completion[] => {
-	const { base, resolved, transformLabel } = input;
+	const { base, resolved, transformLabel = (label) => label } = input;
 	const rank = setRank(['item', 'all', 'first', 'last']);
 	const SKIP = new Set(['__ob__', 'pairedItem']);
 
@@ -393,9 +400,10 @@ const objectOptions = (input: AutocompleteInput<IDataObject>): Completion[] => {
 	}
 
 	const localKeys = rank(rawKeys)
-		.filter((key) => !SKIP.has(key) && isAllowedInDotNotation(key) && !isPseudoParam(key))
+		.filter((key) => !SKIP.has(key) && !isPseudoParam(key))
 		.map((key) => {
 			ensureKeyCanBeResolved(resolved, key);
+			const needsBracketAccess = !isAllowedInDotNotation(key);
 			const resolvedProp = resolved[key];
 
 			const isFunction = typeof resolvedProp === 'function';
@@ -403,20 +411,25 @@ const objectOptions = (input: AutocompleteInput<IDataObject>): Completion[] => {
 
 			const option: Completion = {
 				label: isFunction ? key + '()' : key,
-				type: isFunction ? 'function' : 'keyword',
 				section: getObjectPropertySection({ name, key, isFunction }),
-				apply: applyCompletion({ hasArgs, transformLabel }),
+				apply: needsBracketAccess
+					? applyBracketAccessCompletion
+					: applyCompletion({
+							hasArgs,
+							transformLabel,
+						}),
 				detail: getDetail(name, resolvedProp),
 			};
 
 			const infoKey = [name, key].join('.');
+			const infoName = needsBracketAccess ? applyBracketAccess(key) : key;
 			option.info = createCompletionOption(
 				'',
-				key,
+				infoName,
 				isFunction ? 'native-function' : 'keyword',
 				{
 					doc: {
-						name: key,
+						name: infoName,
 						returnType: getType(resolvedProp),
 						description: i18n.proxyVars[infoKey],
 					},

--- a/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
@@ -60,7 +60,6 @@ import {
 } from './constants';
 import { VALID_EMAIL_REGEX } from '@/constants';
 import { uniqBy } from 'lodash-es';
-import { escapeMappingString } from '../../../utils/mappingUtils';
 
 /**
  * Resolution-based completions offered according to datatype.


### PR DESCRIPTION
## Summary
<img width="698" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/6b05b2f6-3ef3-4d62-8272-4548d1a9f091">
<img width="698" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/f55c7c1c-026f-4bdc-81bf-bc13dad1bd40">



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1479/auto-suggest-is-not-working-properly-when-[]-syntax-is-needed

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 