### PR TITLE
fix(core): Don't fail when asking for an execution with sharing enabled

### DIFF
--- a/packages/cli/src/executions/execution.service.ee.ts
+++ b/packages/cli/src/executions/execution.service.ee.ts
@@ -22,12 +22,9 @@ export class EnterpriseExecutionsService {
 
 		if (!execution) return;
 
-		const relations = ['shared', 'shared.user'];
-
-		const workflow = (await this.workflowRepository.get(
-			{ id: execution.workflowId },
-			{ relations },
-		)) as WorkflowWithSharingsAndCredentials;
+		const workflow = (await this.workflowRepository.get({
+			id: execution.workflowId,
+		})) as WorkflowWithSharingsAndCredentials;
 
 		if (!workflow) return;
 


### PR DESCRIPTION
## Summary

Using `GET /executions/:id` started failing after we removed the user from the sharings because it still tried to load that relation.
There was no test for that endpoint, so I added a test as well as fixing the issue.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

