### PR TITLE
 feat(editor): Remove cloud deployment check from settings route middlewareOptions (no-changelog)

### DIFF
--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -478,10 +478,7 @@ export const routes = [
 					middlewareOptions: {
 						custom: () => {
 							const settingsStore = useSettingsStore();
-							return !(
-								settingsStore.settings.hideUsagePage ||
-								settingsStore.settings.deployment?.type === 'cloud'
-							);
+							return !settingsStore.settings.hideUsagePage;
 						},
 					},
 					telemetry: {


### PR DESCRIPTION
## Summary
Remove cloud deployment check from middlewareOptions in settings route. This allows the "plan & usage" page to be disabled/enabled using the `N8N_HIDE_USAGE_PAGE` with cloud deployment type.

### To test
On cloud, set `N8N_HIDE_USAGE_PAGE` to `false` and the page should show up


## Related tickets and issues
[CP-1035](https://linear.app/n8n/issue/CP-1035)


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))