### PR TITLE
feat(editor): Add telemetry event 'User clicked AI error helper button' (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -129,6 +129,15 @@ const prepareRawMessages = computed(() => {
 async function onDebugError() {
 	try {
 		isLoadingErrorDebugging.value = true;
+		telemetry.track(
+			'User clicked AI error helper button',
+			{
+				node_type: props.error.node?.type,
+				error_title: props.error.message,
+			},
+			{ withPostHog: true },
+		);
+
 		const { message } = await aiStore.debugError({ error: props.error });
 		errorDebuggingMessage.value = message;
 	} catch (error) {


### PR DESCRIPTION
## Summary

Add telemetry event 'User clicked AI error helper button'


## Related tickets and issues

https://linear.app/n8n/issue/ADO-2138/feature-add-telemetry-for-the-ai-error-helper

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 