### PR TITLE
fix(editor): Set `browser-id` on all relative urls (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -78,8 +78,11 @@ export async function request(config: {
 		method,
 		url: endpoint,
 		baseURL,
-		headers,
+		headers: headers ?? {},
 	};
+	if (baseURL.startsWith('/') && browserId) {
+		options.headers!['browser-id'] = browserId;
+	}
 	if (
 		import.meta.env.NODE_ENV !== 'production' &&
 		!baseURL.includes('api.n8n.io') &&
@@ -128,15 +131,11 @@ export async function makeRestApiRequest<T>(
 	endpoint: string,
 	data?: IDataObject | IDataObject[],
 ) {
-	const headers: RawAxiosRequestHeaders = { 'push-ref': context.pushRef };
-	if (browserId) {
-		headers['browser-id'] = browserId;
-	}
 	const response = await request({
 		method,
 		baseURL: context.baseUrl,
 		endpoint,
-		headers,
+		headers: { 'push-ref': context.pushRef },
 		data,
 	});
 


### PR DESCRIPTION
We have quite a lot of API calls in the editor code that do not use `makeRestApiRequest`. 
This hasn't been in an issue in the past as the cookie gets automatically set for these urls.

However, since #9057 these requests also need to send the `Browser-Id` header, otherwise these requests return a 401, and invalidate the session.

In the long term, we should clearly distinguish between internal api calls vs requests to external domains. But, until that is addressed, this PR moves the `Browser-Id` header to all relative requests.

## Review / Merge checklist
- [x] PR title and summary are descriptive