### PR TITLE
fix(core): Some more browser-id related fixes (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -41,7 +41,7 @@ export function createPage({
 		? loadPreviousSession
 		: 'notSupported';
 
-	return `<doctype html>
+	return `<!doctype html>
 	<html lang="en">
 		<head>
 			<meta charset="utf-8">
@@ -60,7 +60,8 @@ export function createPage({
 					if (authentication === 'n8nUserAuth') {
 						try {
 							const response = await fetch('/rest/login', {
-									method: 'GET'
+									method: 'GET',
+									headers: { 'browser-id': localStorage.getItem('n8n-browserId') }
 							});
 
 							if (response.status !== 200) {

--- a/packages/cli/test/integration/shared/utils/testServer.ts
+++ b/packages/cli/test/integration/shared/utils/testServer.ts
@@ -22,6 +22,7 @@ import { PUBLIC_API_REST_PATH_SEGMENT, REST_PATH_SEGMENT } from '../constants';
 import type { SetupProps, TestServer } from '../types';
 import { LicenseMocker } from '../license';
 import { AuthService } from '@/auth/auth.service';
+import type { APIRequest } from '@/requests';
 
 /**
  * Plugin to prefix a path segment into a request URL pathname.
@@ -43,11 +44,12 @@ function prefix(pathSegment: string) {
 	};
 }
 
+const browserId = 'test-browser-id';
 function createAgent(app: express.Application, options?: { auth: boolean; user: User }) {
 	const agent = request.agent(app);
 	void agent.use(prefix(REST_PATH_SEGMENT));
 	if (options?.auth && options?.user) {
-		const token = Container.get(AuthService).issueJWT(options.user);
+		const token = Container.get(AuthService).issueJWT(options.user, browserId);
 		agent.jar.setCookie(`${AUTH_COOKIE_NAME}=${token}`);
 	}
 	return agent;
@@ -73,6 +75,10 @@ export const setupTestServer = ({
 	const app = express();
 	app.use(rawBodyReader);
 	app.use(cookieParser());
+	app.use((req: APIRequest, _, next) => {
+		req.browserId = browserId;
+		next();
+	});
 
 	// Mock all telemetry and logging
 	mockInstance(Logger);


### PR DESCRIPTION
1. Hosted chat trigger UI sends a `GET /rest/login` request when the auth mode is `n8nUserAuth`. In this case a missing `browser-id` header breaks the UI, because the server always returns a 401. This PR adds the missing header.
2. Just like the push endpoint, the binary-data downloading endpoint can't always sent custom headers and needs to be excluded from the check in `AuthService`.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included