### PR TITLE
fix(core): Don't revert irreversibble migrations

### DIFF
--- a/packages/cli/src/databases/utils/migrationHelpers.ts
+++ b/packages/cli/src/databases/utils/migrationHelpers.ts
@@ -189,6 +189,10 @@ export const wrapMigration = (migration: Migration) => {
 				logMigrationEnd(migration.name);
 			},
 		});
+	} else {
+		throw new ApplicationError(
+			'At least on migration is missing the method `up`. Make sure all migrations are valid.',
+		);
 	}
 	if (down) {
 		Object.assign(migration.prototype, {

--- a/packages/cli/src/databases/utils/migrationHelpers.ts
+++ b/packages/cli/src/databases/utils/migrationHelpers.ts
@@ -193,7 +193,6 @@ export const wrapMigration = (migration: Migration) => {
 	if (down) {
 		Object.assign(migration.prototype, {
 			async down(this: BaseMigration, queryRunner: QueryRunner) {
-				console.log('down');
 				const context = createContext(queryRunner, migration);
 				if (this.transaction === false) {
 					await runDisablingForeignKeys(this, context, down);

--- a/packages/cli/src/databases/utils/migrationHelpers.ts
+++ b/packages/cli/src/databases/utils/migrationHelpers.ts
@@ -176,26 +176,31 @@ const createContext = (queryRunner: QueryRunner, migration: Migration): Migratio
 
 export const wrapMigration = (migration: Migration) => {
 	const { up, down } = migration.prototype;
-	Object.assign(migration.prototype, {
-		async up(this: BaseMigration, queryRunner: QueryRunner) {
-			logMigrationStart(migration.name);
-			const context = createContext(queryRunner, migration);
-			if (this.transaction === false) {
-				await runDisablingForeignKeys(this, context, up);
-			} else {
-				await up.call(this, context);
-			}
-			logMigrationEnd(migration.name);
-		},
-		async down(this: BaseMigration, queryRunner: QueryRunner) {
-			if (down) {
+	if (up) {
+		Object.assign(migration.prototype, {
+			async up(this: BaseMigration, queryRunner: QueryRunner) {
+				logMigrationStart(migration.name);
+				const context = createContext(queryRunner, migration);
+				if (this.transaction === false) {
+					await runDisablingForeignKeys(this, context, up);
+				} else {
+					await up.call(this, context);
+				}
+				logMigrationEnd(migration.name);
+			},
+		});
+	}
+	if (down) {
+		Object.assign(migration.prototype, {
+			async down(this: BaseMigration, queryRunner: QueryRunner) {
+				console.log('down');
 				const context = createContext(queryRunner, migration);
 				if (this.transaction === false) {
 					await runDisablingForeignKeys(this, context, down);
 				} else {
 					await down.call(this, context);
 				}
-			}
-		},
-	});
+			},
+		});
+	}
 };

--- a/packages/cli/test/unit/commands/db/revert.test.ts
+++ b/packages/cli/test/unit/commands/db/revert.test.ts
@@ -1,0 +1,105 @@
+import { main } from '@/commands/db/revert';
+import { mockInstance } from '../../../shared/mocking';
+import { Logger } from '@/Logger';
+import * as DbConfig from '@db/config';
+import type { IrreversibleMigration, ReversibleMigration } from '@/databases/types';
+import type { DataSource } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+
+const logger = mockInstance(Logger);
+
+afterEach(() => {
+	jest.resetAllMocks();
+});
+
+test("don't revert migrations if there is no migration", async () => {
+	//
+	// ARRANGE
+	//
+	const connectionOptions = DbConfig.getConnectionOptions();
+	// @ts-expect-error property is readonly
+	connectionOptions.migrations = [];
+	const dataSource = mock<DataSource>({ migrations: [] });
+
+	//
+	// ACT
+	//
+	await main(connectionOptions, logger, function () {
+		return dataSource;
+	} as never);
+
+	//
+	// ASSERT
+	//
+	expect(logger.error).toHaveBeenCalledTimes(1);
+	expect(logger.error).toHaveBeenCalledWith('There is no migration to reverse.');
+	expect(dataSource.undoLastMigration).not.toHaveBeenCalled();
+	expect(dataSource.destroy).not.toHaveBeenCalled();
+});
+
+test("don't revert the last migration if it had no down migration", async () => {
+	//
+	// ARRANGE
+	//
+	class TestMigration implements IrreversibleMigration {
+		async up() {}
+	}
+
+	const connectionOptions = DbConfig.getConnectionOptions();
+	const migrations = [TestMigration];
+	// @ts-expect-error property is readonly
+	connectionOptions.migrations = migrations;
+	const dataSource = mock<DataSource>();
+	// @ts-expect-error property is readonly, and I can't pass them the `mock`
+	// because `mock` will mock the down method and thus defeat the purpose
+	// of this test, because the tested code will assume that the migration has a
+	// down method.
+	dataSource.migrations = migrations.map((M) => new M());
+
+	//
+	// ACT
+	//
+	await main(connectionOptions, logger, function () {
+		return dataSource;
+	} as never);
+
+	//
+	// ASSERT
+	//
+	expect(logger.error).toHaveBeenCalledTimes(1);
+	expect(logger.error).toHaveBeenCalledWith(
+		'The last migration was irreversible and cannot be reverted.',
+	);
+	expect(dataSource.undoLastMigration).not.toHaveBeenCalled();
+	expect(dataSource.destroy).not.toHaveBeenCalled();
+});
+
+test('revert the last migration if it has a down migration', async () => {
+	//
+	// ARRANGE
+	//
+	class TestMigration implements ReversibleMigration {
+		async up() {}
+
+		async down() {}
+	}
+
+	const connectionOptions = DbConfig.getConnectionOptions();
+	// @ts-expect-error property is readonly
+	connectionOptions.migrations = [TestMigration];
+	const dataSource = mock<DataSource>({ migrations: [new TestMigration()] });
+
+	//
+	// ACT
+	//
+	await main(connectionOptions, logger, function () {
+		return dataSource;
+	} as never);
+
+	//
+	// ASSERT
+	//
+	expect(logger.error).not.toHaveBeenCalled();
+	expect(dataSource.undoLastMigration).toHaveBeenCalled();
+	expect(dataSource.destroy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

`n8n db:revert` would revert irreversible migrations. It would not call `down`,
because it does not exist, but it would remove the migration from the migrations table.

Next time you'd start n8n it would try to run the migration again and most
likely fail because it tries to create tables and columns that exit.

With this PR it will
1. log out an error if the last migration is irreversible and stop,
2. log out an error if there are no migrations and stop.

Note: this could be fixed in typeorm in the `undoLastMigration` function, but typeorm assumes all migrations to be reversible. Typeorm's types force you to have a down migration. We just use our own types for migrations that allow you to not have a down migration. I didn't want to refactor typeorm to fix this.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

