### PR TITLE
fix: Remove scope filter on projects APIs

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -66,8 +66,8 @@ export class ProjectController {
 			if (result.scopes) {
 				result.scopes.push(
 					...combineScopes({
-						global: this.roleService.getRoleScopes(req.user.role, ['project']),
-						project: this.roleService.getRoleScopes(pr.role, ['project']),
+						global: this.roleService.getRoleScopes(req.user.role),
+						project: this.roleService.getRoleScopes(pr.role),
 					}),
 				);
 			}
@@ -89,7 +89,7 @@ export class ProjectController {
 
 			if (result.scopes) {
 				result.scopes.push(
-					...combineScopes({ global: this.roleService.getRoleScopes(req.user.role, ['project']) }),
+					...combineScopes({ global: this.roleService.getRoleScopes(req.user.role) }),
 				);
 			}
 
@@ -137,10 +137,8 @@ export class ProjectController {
 			})),
 			scopes: [
 				...combineScopes({
-					global: this.roleService.getRoleScopes(req.user.role, ['project']),
-					...(myRelation
-						? { project: this.roleService.getRoleScopes(myRelation.role, ['project']) }
-						: {}),
+					global: this.roleService.getRoleScopes(req.user.role),
+					...(myRelation ? { project: this.roleService.getRoleScopes(myRelation.role) } : {}),
 				}),
 			],
 		};

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -152,15 +152,35 @@ describe('GET /projects/my-projects', () => {
 		//
 		expect(respProjects.length).toBe(2);
 
-		expect(respProjects.find((p) => p.id === personalProject1.id)).toMatchObject({
-			role: 'project:personalOwner',
-			scopes: ['project:list', 'project:read'].sort(),
-		});
+		const projectsExpected = [
+			[
+				personalProject1,
+				{
+					role: 'project:personalOwner',
+					scopes: ['project:list', 'project:read', 'credential:create'],
+				},
+			],
+			[
+				teamProject1,
+				{
+					role: 'project:admin',
+					scopes: [
+						'project:list',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+		] as const;
 
-		expect(respProjects.find((p) => p.id === teamProject1.id)).toMatchObject({
-			role: 'project:admin',
-			scopes: ['project:list', 'project:read', 'project:update', 'project:delete'].sort(),
-		});
+		for (const [project, expected] of projectsExpected) {
+			const p = respProjects.find((p) => p.id === project.id)!;
+
+			expect(p.role).toBe(expected.role);
+			expect(expected.scopes.every((s) => p.scopes?.includes(s as Scope))).toBe(true);
+		}
 
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject3.id }));
@@ -213,57 +233,85 @@ describe('GET /projects/my-projects', () => {
 		//
 		expect(respProjects.length).toBe(5);
 
-		expect(respProjects.find((p) => p.id === ownerProject.id)).toMatchObject({
-			role: 'project:personalOwner',
-			scopes: [
-				'project:list',
-				'project:create',
-				'project:read',
-				'project:update',
-				'project:delete',
-			].sort(),
-		});
+		const projectsExpected = [
+			[
+				ownerProject,
+				{
+					role: 'project:personalOwner',
+					scopes: [
+						'project:list',
+						'project:create',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+			[
+				teamProject1,
+				{
+					role: 'global:owner',
+					scopes: [
+						'project:list',
+						'project:create',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+			[
+				teamProject2,
+				{
+					role: 'project:admin',
+					scopes: [
+						'project:list',
+						'project:create',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+			[
+				teamProject3,
+				{
+					role: 'project:viewer',
+					scopes: [
+						'project:list',
+						'project:create',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+			[
+				teamProject4,
+				{
+					role: 'global:owner',
+					scopes: [
+						'project:list',
+						'project:create',
+						'project:read',
+						'project:update',
+						'project:delete',
+						'credential:create',
+					],
+				},
+			],
+		] as const;
 
-		expect(respProjects.find((p) => p.id === teamProject1.id)).toMatchObject({
-			role: 'global:owner',
-			scopes: [
-				'project:list',
-				'project:create',
-				'project:read',
-				'project:update',
-				'project:delete',
-			].sort(),
-		});
-		expect(respProjects.find((p) => p.id === teamProject2.id)).toMatchObject({
-			role: 'project:admin',
-			scopes: [
-				'project:list',
-				'project:create',
-				'project:read',
-				'project:update',
-				'project:delete',
-			].sort(),
-		});
-		expect(respProjects.find((p) => p.id === teamProject3.id)).toMatchObject({
-			role: 'project:viewer',
-			scopes: [
-				'project:list',
-				'project:create',
-				'project:read',
-				'project:update',
-				'project:delete',
-			].sort(),
-		});
-		expect(respProjects.find((p) => p.id === teamProject4.id)).toMatchObject({
-			role: 'global:owner',
-			scopes: [
-				'project:list',
-				'project:create',
-				'project:read',
-				'project:update',
-				'project:delete',
-			].sort(),
-		});
+		for (const [project, expected] of projectsExpected) {
+			const p = respProjects.find((p) => p.id === project.id)!;
+
+			expect(p.role).toBe(expected.role);
+			expect(expected.scopes.every((s) => p.scopes?.includes(s as Scope))).toBe(true);
+		}
 
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject1.id }));
 		expect(respProjects).not.toContainEqual(expect.objectContaining({ id: personalProject2.id }));


### PR DESCRIPTION
## Summary
Return all scopes that a use has on a project, rather than filtering it to just project scopes.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 