### PR TITLE
ci: Keep n8n-workflow version in sync with the main version (no-changelog)

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -33,8 +33,10 @@ assert.ok(
 	'No changes found since the last release',
 );
 
-// Keep the monorepo version up to date with the released version
-packageMap['monorepo-root'].version = packageMap['n8n'].version;
+// Keep the monorepo and n8n-workflow version up to date with the released version
+const { version } = packageMap['n8n'];
+packageMap['monorepo-root'].version = version;
+packageMap['n8n-workflow'].version = version;
 
 for (const packageName in packageMap) {
 	const { path, version, isDirty } = packageMap[packageName];

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -28,6 +28,7 @@ jobs:
       - run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm dist-tag add n8n@${{ github.event.inputs.version }} ${{ github.event.inputs.release-channel }}
+          npm dist-tag add n8n-workflow@${{ github.event.inputs.version }} ${{ github.event.inputs.release-channel }}
 
   release-to-docker-hub:
     name: Release to DockerHub


### PR DESCRIPTION
Right now `n8n-workflow` package is released without the latest tag. This means that people developing custom nodes need to manually keep updating the version in their dependencies, which is cumbersome.

`n8n-workflow` should use the same version as `n8n` and when we tag `n8n`, we should also re-tag `n8n-workflow`.

## Related tickets and issues
ENG-114

## Review / Merge checklist
- [x] PR title and summary are descriptive