### PR TITLE
fix: Fix issue with Crowdstrike credential not working correctly

### DIFF
--- a/packages/nodes-base/credentials/CrowdStrikeOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/CrowdStrikeOAuth2Api.credentials.ts
@@ -63,9 +63,11 @@ export class CrowdStrikeOAuth2Api implements ICredentialType {
 		const url = credentials.url as string;
 		const { access_token } = (await this.helpers.httpRequest({
 			method: 'POST',
-			url: `${url.endsWith('/') ? url.slice(0, -1) : url}/oauth2/token?client_id=${
-				credentials.clientId
-			}&client_secret=${credentials.clientSecret}`,
+			url: `${url.endsWith('/') ? url.slice(0, -1) : url}/oauth2/token`,
+			body: {
+				client_id: credentials.clientId,
+				client_secret: credentials.clientSecret,
+			},
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},


### PR DESCRIPTION
## Summary
This changes the credential to send the id and secret in the body rather than URI params following the Crowdstrike API docs.


## Related tickets and issues
https://community.n8n.io/t/crowdstrike-oauth2-api-token-not-refreshing/34159