### PR TITLE
fix(editor): Do not show overlapping trash icon in the node's settings

### DIFF
--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -49,7 +49,7 @@
 				class="multi-parameter"
 			>
 				<n8n-icon-button
-					v-if="hideDelete !== true && !isReadOnly"
+					v-if="hideDelete !== true && !isReadOnly && !parameter.isNodeSetting"
 					type="tertiary"
 					text
 					size="mini"
@@ -131,7 +131,7 @@
 				class="parameter-item"
 			>
 				<n8n-icon-button
-					v-if="hideDelete !== true && !isReadOnly"
+					v-if="hideDelete !== true && !isReadOnly && !parameter.isNodeSetting"
 					type="tertiary"
 					text
 					size="mini"


### PR DESCRIPTION
## Summary
![image](https://github.com/n8n-io/n8n/assets/88898367/0311fc5f-4671-44c4-abba-38f68f193389)




## Related tickets and issues
