### PR TITLE
fix(core): Add an option to add additional non-ui routes (no-changelog)

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -256,6 +256,7 @@ export class Server extends AbstractServer {
 			this.restEndpoint,
 			this.endpointPresetCredentials,
 			isApiEnabled() ? '' : publicApiEndpoint,
+			...config.getEnv('endpoints.additionalNonUIRoutes').split(':'),
 		].filter((u) => !!u);
 		const nonUIRoutesRegex = new RegExp(`^/(${nonUIRoutes.join('|')})/?.*$`);
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -727,6 +727,12 @@ export const schema = {
 			env: 'N8N_DISABLE_PRODUCTION_MAIN_PROCESS',
 			doc: 'Disable production webhooks from main process. This helps ensures no http traffic load to main process when using webhook-specific processes.',
 		},
+		additionalNonUIRoutes: {
+			doc: 'Additional endpoints to not open the UI on. Multiple endpoints can be separated by colon (":")',
+			format: String,
+			default: '',
+			env: 'N8N_ADDITIONAL_NON_UI_ROUTES',
+		},
 	},
 
 	publicApi: {


### PR DESCRIPTION
#9044 removed `N8N_AUTH_EXCLUDE_ENDPOINTS`, which is now causing `/cloud` urls on cloud instances to open in the UI. 
This PR fixes that by creating a new config variable to define additional set of endpoints that the UI can be skipped on.

Cloud PR https://github.com/n8n-io/n8n-cloud/pull/1124

## Review / Merge checklist
- [x] PR title and summary are descriptive