### PR TITLE
test: Run cypress e2e tests in light mode by default (no-changelog)

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,6 +14,10 @@ beforeEach(() => {
 		cy.signin({ email: INSTANCE_OWNER.email, password: INSTANCE_OWNER.password });
 	}
 
+	cy.window().then((win): void => {
+		win.localStorage.setItem('N8N_THEME', 'light');
+	});
+
 	cy.intercept('GET', '/rest/settings').as('loadSettings');
 	cy.intercept('GET', '/types/nodes.json').as('loadNodeTypes');
 


### PR DESCRIPTION
## Summary

When running e2e tests, they currently follow the current device's light/dark mode setting. Some tests expect certain colors to be set, and fail in dark mode (in CI the tests always run in light mode). 

It's still possible to run tests in dark mode, or enable dark mode for certain tests (if we want to test dark mode styles for example)


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 