### PR TITLE
fix: Return scopes on more resource APIs

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -60,8 +60,9 @@ export class CredentialsController {
 	@Get('/:credentialId')
 	@ProjectScope('credential:read')
 	async getOne(req: CredentialRequest.Get) {
+		debugger;
 		if (this.license.isSharingEnabled()) {
-			return await this.enterpriseCredentialsService.getOne(
+			const credentials = await this.enterpriseCredentialsService.getOne(
 				req.user,
 				req.params.credentialId,
 				// TODO: editor-ui is always sending this, maybe we can just rely on the
@@ -69,15 +70,29 @@ export class CredentialsController {
 				// to do so.
 				req.query.includeData === 'true',
 			);
+
+			const scopes = await this.credentialsService.getCredentialScopes(
+				req.user,
+				req.params.credentialId,
+			);
+
+			return { ...credentials, scopes };
 		}
 
 		// non-enterprise
 
-		return await this.credentialsService.getOne(
+		const credentials = await this.credentialsService.getOne(
 			req.user,
 			req.params.credentialId,
 			req.query.includeData === 'true',
 		);
+
+		const scopes = await this.credentialsService.getCredentialScopes(
+			req.user,
+			req.params.credentialId,
+		);
+
+		return { ...credentials, scopes };
 	}
 
 	// TODO: Write at least test cases for the failure paths.
@@ -127,7 +142,9 @@ export class CredentialsController {
 			public_api: false,
 		});
 
-		return credential;
+		const scopes = await this.credentialsService.getCredentialScopes(req.user, credential.id);
+
+		return { ...credential, scopes };
 	}
 
 	@Patch('/:credentialId')
@@ -179,7 +196,9 @@ export class CredentialsController {
 			credential_id: credential.id,
 		});
 
-		return { ...rest };
+		const scopes = await this.credentialsService.getCredentialScopes(req.user, credential.id);
+
+		return { ...rest, scopes };
 	}
 
 	@Delete('/:credentialId')

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -171,7 +171,9 @@ export class WorkflowsController {
 		await this.externalHooks.run('workflow.afterCreate', [savedWorkflow]);
 		void this.internalHooks.onWorkflowCreated(req.user, newWorkflow, false);
 
-		return savedWorkflowWithMetaData;
+		const scopes = await this.workflowService.getWorkflowScopes(req.user, savedWorkflow.id);
+
+		return { ...savedWorkflowWithMetaData, scopes };
 	}
 
 	@Get('/', { middlewares: listQueryMiddleware })
@@ -277,7 +279,9 @@ export class WorkflowsController {
 			// shouldn't be returned to the frontend
 			delete workflowWithMetaData.shared;
 
-			return workflowWithMetaData;
+			const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);
+
+			return { ...workflowWithMetaData, scopes };
 		}
 
 		// sharing disabled
@@ -299,7 +303,9 @@ export class WorkflowsController {
 			);
 		}
 
-		return workflow;
+		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);
+
+		return { ...workflow, scopes };
 	}
 
 	@Patch('/:workflowId')
@@ -329,7 +335,9 @@ export class WorkflowsController {
 			isSharingEnabled ? forceSave : true,
 		);
 
-		return updatedWorkflow;
+		const scopes = await this.workflowService.getWorkflowScopes(req.user, workflowId);
+
+		return { ...updatedWorkflow, scopes };
 	}
 
 	@Delete('/:workflowId')


### PR DESCRIPTION
## Summary
The frontend needs the scopes on new workflows and credentials, so we return them.


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 