### PR TITLE
fix(editor): Fix parameter reset on credential change in Discord node

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -635,7 +635,7 @@ describe('NDV', () => {
 		ndv.getters.nodeRunErrorIndicator().should('exist');
 	});
 
-	it.only('Should clear mismatched collection parameters', () => {
+	it('Should clear mismatched collection parameters', () => {
 		workflowPage.actions.addInitialNodeToCanvas('LDAP', {
 			keepNdvOpen: true,
 			action: 'Create a new entry',
@@ -647,7 +647,7 @@ describe('NDV', () => {
 		cy.getByTestId('parameter-item').contains('Currently no items exist').should('exist');
 	});
 
-	it.only('Should keep RLC values after operation change', () => {
+	it('Should keep RLC values after operation change', () => {
 		const TEST_DOC_ID = '1111';
 		workflowPage.actions.addInitialNodeToCanvas('Google Sheets', {
 			keepNdvOpen: true,
@@ -658,7 +658,7 @@ describe('NDV', () => {
 		ndv.getters.resourceLocatorInput('documentId').find('input').should('have.value', TEST_DOC_ID);
 	});
 
-	it.only('Should not clear resource/operation after credential change', () => {
+	it('Should not clear resource/operation after credential change', () => {
 		workflowPage.actions.addInitialNodeToCanvas('Discord', {
 			keepNdvOpen: true,
 			action: 'Send a message',

--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -635,7 +635,7 @@ describe('NDV', () => {
 		ndv.getters.nodeRunErrorIndicator().should('exist');
 	});
 
-	it('Should clear mismatched collection parameters', () => {
+	it.only('Should clear mismatched collection parameters', () => {
 		workflowPage.actions.addInitialNodeToCanvas('LDAP', {
 			keepNdvOpen: true,
 			action: 'Create a new entry',
@@ -647,7 +647,7 @@ describe('NDV', () => {
 		cy.getByTestId('parameter-item').contains('Currently no items exist').should('exist');
 	});
 
-	it('Should keep RLC values after operation change', () => {
+	it.only('Should keep RLC values after operation change', () => {
 		const TEST_DOC_ID = '1111';
 		workflowPage.actions.addInitialNodeToCanvas('Google Sheets', {
 			keepNdvOpen: true,
@@ -658,10 +658,10 @@ describe('NDV', () => {
 		ndv.getters.resourceLocatorInput('documentId').find('input').should('have.value', TEST_DOC_ID);
 	});
 
-	it('Should not clear resource/operation after credential change', () => {
+	it.only('Should not clear resource/operation after credential change', () => {
 		workflowPage.actions.addInitialNodeToCanvas('Discord', {
 			keepNdvOpen: true,
-			action: 'Send a message',
+			action: 'Delete a message',
 		});
 
 		clickCreateNewCredential();
@@ -670,7 +670,7 @@ describe('NDV', () => {
 		});
 
 		ndv.getters.parameterInput('resource').find('input').should('have.value', 'Message');
-		ndv.getters.parameterInput('operation').find('input').should('have.value', 'Send');
+		ndv.getters.parameterInput('operation').find('input').should('have.value', 'Delete');
 	});
 
 	it('Should open appropriate node creator after clicking on connection hint link', () => {

--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -3,6 +3,8 @@ import { getVisibleSelect } from '../utils';
 import { MANUAL_TRIGGER_NODE_DISPLAY_NAME } from '../constants';
 import { NDV, WorkflowPage } from '../pages';
 import { NodeCreator } from '../pages/features/node-creator';
+import { clickCreateNewCredential } from '../composables/ndv';
+import { setCredentialValues } from '../composables/modals/credential-modal';
 
 const workflowPage = new WorkflowPage();
 const ndv = new NDV();
@@ -633,7 +635,7 @@ describe('NDV', () => {
 		ndv.getters.nodeRunErrorIndicator().should('exist');
 	});
 
-	it('Should handle mismatched option attributes', () => {
+	it.only('Should clear mismatched collection parameters', () => {
 		workflowPage.actions.addInitialNodeToCanvas('LDAP', {
 			keepNdvOpen: true,
 			action: 'Create a new entry',
@@ -645,7 +647,7 @@ describe('NDV', () => {
 		cy.getByTestId('parameter-item').contains('Currently no items exist').should('exist');
 	});
 
-	it('Should keep RLC values after operation change', () => {
+	it.only('Should keep RLC values after operation change', () => {
 		const TEST_DOC_ID = '1111';
 		workflowPage.actions.addInitialNodeToCanvas('Google Sheets', {
 			keepNdvOpen: true,
@@ -654,6 +656,21 @@ describe('NDV', () => {
 		ndv.actions.setRLCValue('documentId', TEST_DOC_ID);
 		ndv.actions.changeNodeOperation('Update Row');
 		ndv.getters.resourceLocatorInput('documentId').find('input').should('have.value', TEST_DOC_ID);
+	});
+
+	it.only('Should not clear resource/operation after credential change', () => {
+		workflowPage.actions.addInitialNodeToCanvas('Discord', {
+			keepNdvOpen: true,
+			action: 'Send a message',
+		});
+
+		clickCreateNewCredential();
+		setCredentialValues({
+			botToken: 'sk_test_123',
+		});
+
+		ndv.getters.parameterInput('resource').find('input').should('have.value', 'Message');
+		ndv.getters.parameterInput('operation').find('input').should('have.value', 'Send');
 	});
 
 	it('Should open appropriate node creator after clicking on connection hint link', () => {

--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -635,7 +635,7 @@ describe('NDV', () => {
 		ndv.getters.nodeRunErrorIndicator().should('exist');
 	});
 
-	it.only('Should clear mismatched collection parameters', () => {
+	it('Should clear mismatched collection parameters', () => {
 		workflowPage.actions.addInitialNodeToCanvas('LDAP', {
 			keepNdvOpen: true,
 			action: 'Create a new entry',
@@ -647,7 +647,7 @@ describe('NDV', () => {
 		cy.getByTestId('parameter-item').contains('Currently no items exist').should('exist');
 	});
 
-	it.only('Should keep RLC values after operation change', () => {
+	it('Should keep RLC values after operation change', () => {
 		const TEST_DOC_ID = '1111';
 		workflowPage.actions.addInitialNodeToCanvas('Google Sheets', {
 			keepNdvOpen: true,
@@ -658,7 +658,7 @@ describe('NDV', () => {
 		ndv.getters.resourceLocatorInput('documentId').find('input').should('have.value', TEST_DOC_ID);
 	});
 
-	it.only('Should not clear resource/operation after credential change', () => {
+	it('Should not clear resource/operation after credential change', () => {
 		workflowPage.actions.addInitialNodeToCanvas('Discord', {
 			keepNdvOpen: true,
 			action: 'Delete a message',

--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -194,6 +194,7 @@ import {
 	isINodePropertyCollectionList,
 	isINodePropertiesList,
 	isINodePropertyOptionsList,
+	displayParameter,
 } from 'n8n-workflow';
 import type {
 	INodeUi,
@@ -997,15 +998,16 @@ export default defineComponent({
 				if (!nodeParameterValues?.hasOwnProperty(prop.name) || !displayOptions || !prop.options) {
 					return;
 				}
-				// Only process the parameters that should be hidden
+				// Only process the parameters that depend on the updated parameter
 				const showCondition = displayOptions.show?.[updatedParameter.name];
 				const hideCondition = displayOptions.hide?.[updatedParameter.name];
 				if (showCondition === undefined && hideCondition === undefined) {
 					return;
 				}
-				// Every value should be a possible option
+
 				let hasValidOptions = true;
 
+				// Every value should be a possible option
 				if (isINodePropertyCollectionList(prop.options) || isINodePropertiesList(prop.options)) {
 					hasValidOptions = Object.keys(nodeParameterValues).every(
 						(key) => (prop.options ?? []).find((option) => option.name === key) !== undefined,
@@ -1016,11 +1018,7 @@ export default defineComponent({
 					);
 				}
 
-				if (
-					!hasValidOptions ||
-					(showCondition && !showCondition.includes(updatedParameter.value)) ||
-					(hideCondition && hideCondition.includes(updatedParameter.value))
-				) {
+				if (!hasValidOptions && displayParameter(nodeParameterValues, prop, this.node)) {
 					unset(nodeParameterValues as object, prop.name);
 				}
 			});


### PR DESCRIPTION
## Summary

Resource and operation parameters should not reset when credentials is changed.

The code that is looking for mismatched collection parameter options was also resetting options parameters.

Related to https://github.com/n8n-io/n8n/pull/8114

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1089/discord-actions-not-being-seleted-after-selecting-them-in-nodes-panel



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 