### PR TITLE
fix(HTTP Request Node): Tolerate header name being empty

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -1527,7 +1527,10 @@ export class HttpRequestV3 implements INodeType {
 			if (sendHeaders && headerParameters) {
 				let additionalHeaders: IDataObject = {};
 				if (specifyHeaders === 'keypair') {
-					additionalHeaders = await reduceAsync(headerParameters, parametersToKeyValue);
+					additionalHeaders = await reduceAsync(
+						headerParameters.filter((header) => header.name),
+						parametersToKeyValue,
+					);
 				} else if (specifyHeaders === 'json') {
 					// body is specified using JSON
 					try {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -59,6 +59,12 @@ describe('Test HTTP Request Node', () => {
 			completed: true,
 			userId: 26,
 		});
+		nock(baseUrl).get('/todos/1').reply(200, {
+			id: 1,
+			todo: 'Do something nice for someone I care about',
+			completed: true,
+			userId: 26,
+		});
 		nock(baseUrl).matchHeader('Authorization', 'Bearer 12345').get('/todos/3').reply(200, {
 			id: 3,
 			todo: 'Watch a classic movie',

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.get.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.get.json
@@ -1,144 +1,188 @@
 {
-	"name": "http request test",
+	"name": "HTTP Request test",
 	"nodes": [
-		{
-			"parameters": {},
-			"id": "12433cfb-74d9-4bf1-9afd-0ab9afc9ef19",
-			"name": "When clicking \"Execute Workflow\"",
-			"type": "n8n-nodes-base.manualTrigger",
-			"typeVersion": 1,
-			"position": [820, 360]
+	  {
+		"parameters": {},
+		"id": "3db51d12-a71b-4d0d-84db-1d4c46454c40",
+		"name": "When clicking \"Execute Workflow\"",
+		"type": "n8n-nodes-base.manualTrigger",
+		"typeVersion": 1,
+		"position": [
+		  160,
+		  720
+		]
+	  },
+	  {
+		"parameters": {
+		  "url": "https://dummyjson.com/todos/1",
+		  "options": {}
 		},
-		{
-			"parameters": {
-				"url": "https://dummyjson.com/todos/1",
-				"options": {}
-			},
-			"id": "07670093-862f-403f-96a5-ddf7fdb0d225",
-			"name": "HTTP Request",
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 3,
-			"position": [1120, 100]
+		"id": "96f38d87-0bdd-420c-b981-26fd55d11cb2",
+		"name": "HTTP Request",
+		"type": "n8n-nodes-base.httpRequest",
+		"typeVersion": 3,
+		"position": [
+		  460,
+		  460
+		]
+	  },
+	  {
+		"parameters": {
+		  "url": "https://dummyjson.com/todos/3",
+		  "sendHeaders": true,
+		  "headerParameters": {
+			"parameters": [
+			  {
+				"name": "Authorization",
+				"value": "Bearer 12345"
+			  }
+			]
+		  },
+		  "options": {}
 		},
-		{
-			"parameters": {
-				"url": "https://dummyjson.com/todos/3",
-				"sendHeaders": true,
-				"headerParameters": {
-					"parameters": [
-						{
-							"name": "Authorization",
-							"value": "Bearer 12345"
-						}
-					]
-				},
-				"options": {}
-			},
-			"id": "25cc4f31-9363-4247-a49d-7ac49f174d16",
-			"name": "HTTP Request fake header",
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 3,
-			"position": [1120, 440]
+		"id": "85ca0a5b-3ff4-491d-ba51-990fdf2b757f",
+		"name": "HTTP Request fake header",
+		"type": "n8n-nodes-base.httpRequest",
+		"typeVersion": 3,
+		"position": [
+		  460,
+		  800
+		]
+	  },
+	  {
+		"parameters": {
+		  "url": "https://dummyjson.com/todos",
+		  "sendQuery": true,
+		  "queryParameters": {
+			"parameters": [
+			  {
+				"name": "limit",
+				"value": "2"
+			  },
+			  {
+				"name": "skip",
+				"value": "10"
+			  }
+			]
+		  },
+		  "options": {}
 		},
-		{
-			"parameters": {
-				"url": "https://dummyjson.com/todos",
-				"sendQuery": true,
-				"queryParameters": {
-					"parameters": [
-						{
-							"name": "limit",
-							"value": "2"
-						},
-						{
-							"name": "skip",
-							"value": "10"
-						}
-					]
-				},
-				"options": {}
-			},
-			"id": "33c80933-b113-4eff-beb7-4a5b0bc30bcf",
-			"name": "HTTP Request with query",
-			"type": "n8n-nodes-base.httpRequest",
-			"typeVersion": 3,
-			"position": [1120, 620]
-		}
+		"id": "68d6e51a-66ea-45bf-928c-55efd2493cf0",
+		"name": "HTTP Request with query",
+		"type": "n8n-nodes-base.httpRequest",
+		"typeVersion": 3,
+		"position": [
+		  460,
+		  980
+		]
+	  },
+	  {
+		"parameters": {
+		  "url": "https://dummyjson.com/todos/1",
+		  "sendHeaders": true,
+		  "options": {}
+		},
+		"id": "38ec1a50-7f0e-4749-822d-f26370b00694",
+		"name": "HTTP Request empty header",
+		"type": "n8n-nodes-base.httpRequest",
+		"typeVersion": 3,
+		"position": [
+		  460,
+		  640
+		]
+	  }
 	],
 	"pinData": {
-		"HTTP Request": [
-			{
-				"json": {
-					"id": 1,
-					"todo": "Do something nice for someone I care about",
-					"completed": true,
-					"userId": 26
-				}
-			}
-		],
-		"HTTP Request with query": [
-			{
-				"json": {
-					"todos": [
-						{
-							"id": 11,
-							"todo": "Text a friend I haven't talked to in a long time",
-							"completed": false,
-							"userId": 39
-						},
-						{
-							"id": 12,
-							"todo": "Organize pantry",
-							"completed": true,
-							"userId": 39
-						}
-					],
-					"total": 150,
-					"skip": 10,
-					"limit": 2
-				}
-			}
-		],
-		"HTTP Request fake header": [
-			{
-				"json": {
-					"id": 3,
-					"todo": "Watch a classic movie",
-					"completed": false,
-					"userId": 4
-				}
-			}
-		]
+	  "HTTP Request": [
+		{
+		  "json": {
+			"id": 1,
+			"todo": "Do something nice for someone I care about",
+			"completed": true,
+			"userId": 26
+		  }
+		}
+	  ],
+	  "HTTP Request with query": [
+		{
+		  "json": {
+			"todos": [
+			  {
+				"id": 11,
+				"todo": "Text a friend I haven't talked to in a long time",
+				"completed": false,
+				"userId": 39
+			  },
+			  {
+				"id": 12,
+				"todo": "Organize pantry",
+				"completed": true,
+				"userId": 39
+			  }
+			],
+			"total": 150,
+			"skip": 10,
+			"limit": 2
+		  }
+		}
+	  ],
+	  "HTTP Request fake header": [
+		{
+		  "json": {
+			"id": 3,
+			"todo": "Watch a classic movie",
+			"completed": false,
+			"userId": 4
+		  }
+		}
+	  ],
+	  "HTTP Request empty header": [
+		{
+		  "json": {
+			"id": 1,
+			"todo": "Do something nice for someone I care about",
+			"completed": true,
+			"userId": 26
+		  }
+		}
+	  ]
 	},
 	"connections": {
-		"When clicking \"Execute Workflow\"": {
-			"main": [
-				[
-					{
-						"node": "HTTP Request",
-						"type": "main",
-						"index": 0
-					},
-					{
-						"node": "HTTP Request with query",
-						"type": "main",
-						"index": 0
-					},
-					{
-						"node": "HTTP Request fake header",
-						"type": "main",
-						"index": 0
-					}
-				]
-			]
-		}
+	  "When clicking \"Execute Workflow\"": {
+		"main": [
+		  [
+			{
+			  "node": "HTTP Request",
+			  "type": "main",
+			  "index": 0
+			},
+			{
+			  "node": "HTTP Request with query",
+			  "type": "main",
+			  "index": 0
+			},
+			{
+			  "node": "HTTP Request fake header",
+			  "type": "main",
+			  "index": 0
+			},
+			{
+			  "node": "HTTP Request empty header",
+			  "type": "main",
+			  "index": 0
+			}
+		  ]
+		]
+	  }
 	},
 	"active": false,
-	"settings": {},
-	"versionId": "0fb64565-22b3-4ff3-8ba4-354b2bcaf8a6",
-	"id": "108",
+	"settings": {
+	  "executionOrder": "v1"
+	},
+	"versionId": "",
 	"meta": {
-		"instanceId": "36203ea1ce3cef713fa25999bd9874ae26b9e4c2c3a90a365f2882a154d031d0"
+	  "templateCredsSetupCompleted": true,
+	  "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
 	},
 	"tags": []
-}
+  }


### PR DESCRIPTION
## Summary

Don't throw error when header name is empty in HTTP Request Node, just don't send header

<img width="1925" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/de0b8d2a-d248-4a26-826e-e65783747e95">


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1284/http-request-tolerate-headers-being-empty

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 