### PR TITLE
fix(editor): Fix expression preview when previous node is selected

### DIFF
--- a/cypress/e2e/14-mapping.cy.ts
+++ b/cypress/e2e/14-mapping.cy.ts
@@ -276,6 +276,33 @@ describe('Data mapping', () => {
 		ndv.actions.validateExpressionPreview('value', '0 [object Object]');
 	});
 
+	it('renders expression preview when a previous node is selected', () => {
+		cy.fixture('Test_workflow_3.json').then((data) => {
+			cy.get('body').paste(JSON.stringify(data));
+		});
+
+		workflowPage.actions.openNode('Set');
+		ndv.actions.typeIntoParameterInput('value', 'test_value');
+		ndv.actions.typeIntoParameterInput('name', '{selectall}test_name');
+		ndv.actions.close();
+
+		workflowPage.actions.openNode('Set1');
+		ndv.actions.executePrevious();
+		ndv.getters.executingLoader().should('not.exist');
+		ndv.getters.inputDataContainer().should('exist');
+		ndv.getters
+			.inputDataContainer()
+			.should('exist')
+			.find('span')
+			.contains('test_name')
+			.realMouseDown();
+		ndv.actions.mapToParameter('value');
+
+		ndv.actions.validateExpressionPreview('value', 'test_value');
+		ndv.actions.selectInputNode(SCHEDULE_TRIGGER_NODE_NAME);
+		ndv.actions.validateExpressionPreview('value', 'test_value');
+	});
+
 	it('shows you can drop to inputs, including booleans', () => {
 		cy.fixture('Test_workflow_3.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));

--- a/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -83,12 +83,18 @@ const hint = computed(() => {
 
 	let result: Result<unknown, Error>;
 	try {
-		const resolvedValue = resolveExpression(value, undefined, {
-			targetItem: ndvStore.hoveringItem ?? undefined,
-			inputNodeName: ndvStore.ndvInputNodeName,
-			inputRunIndex: ndvStore.ndvInputRunIndex,
-			inputBranchIndex: ndvStore.ndvInputBranchIndex,
-		}) as unknown;
+		const resolvedValue = resolveExpression(
+			value,
+			undefined,
+			ndvStore.isInputParentOfActiveNode
+				? {
+						targetItem: ndvStore.hoveringItem ?? undefined,
+						inputNodeName: ndvStore.ndvInputNodeName,
+						inputRunIndex: ndvStore.ndvInputRunIndex,
+						inputBranchIndex: ndvStore.ndvInputBranchIndex,
+					}
+				: {},
+		) as unknown;
 
 		result = { ok: true, result: resolvedValue };
 	} catch (error) {


### PR DESCRIPTION
## Summary

Inline expression preview would disappear when a previous node was selected

![image](https://github.com/n8n-io/n8n/assets/8850410/78272d58-d5ff-4619-ad6e-c549c3fdae95)



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1275/edit-fields-changing-to-a-node-further-down-the-chain-breaks-inline

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 