### PR TITLE
docs: Update executions.id.yml to fix typo

### DIFF
--- a/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.id.yml
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/spec/paths/executions.id.yml
@@ -4,7 +4,7 @@ get:
   tags:
     - Execution
   summary: Retrieve an execution
-  description: Retrieve an execution from you instance.
+  description: Retrieve an execution from your instance.
   parameters:
     - $ref: '../schemas/parameters/executionId.yml'
     - $ref: '../schemas/parameters/includeData.yml'


### PR DESCRIPTION
Fix a typo in the API spec descriptions

## Fixes a typo based on user feedback