### PR TITLE
fix(Execute Workflow Node): Assign fallback pairedItem only if not present in output item and different length of input output 

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -260,11 +260,19 @@ export class ExecuteWorkflow implements INodeType {
 					items,
 				);
 
-				const pairedItem = generatePairedItemData(items.length);
+				const fallbackPairedItemData = generatePairedItemData(items.length);
 
 				for (const output of workflowResult) {
-					for (const item of output) {
-						item.pairedItem = pairedItem;
+					const sameLength = output.length === items.length;
+
+					for (const [itemIndex, item] of output.entries()) {
+						if (item.pairedItem) continue;
+
+						if (sameLength) {
+							item.pairedItem = { item: itemIndex };
+						} else {
+							item.pairedItem = fallbackPairedItemData;
+						}
 					}
 				}
 


### PR DESCRIPTION
## Summary
Execute workflow node: pairedItem breaks in 'run once with all items' mode



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1160/execute-workflow-node-paireditem-breaks-in-run-once-with-all-items