### PR TITLE
fix(HTTP Request Node): Proxy IPv6 hostname fix (no-changelog)

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -518,8 +518,9 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 		if (typeof requestObject.proxy === 'string') {
 			try {
 				const url = new URL(requestObject.proxy);
+				const host = url.hostname.startsWith('[') ? url.hostname.slice(1, -1) : url.hostname;
 				axiosConfig.proxy = {
-					host: url.hostname,
+					host,
 					port: parseInt(url.port, 10),
 					protocol: url.protocol,
 				};
@@ -544,8 +545,9 @@ export async function parseRequestObject(requestObject: IRequestOptions) {
 					const [userpass, hostport] = requestObject.proxy.split('@');
 					const [username, password] = userpass.split(':');
 					const [hostname, port] = hostport.split(':');
+					const host = hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
 					axiosConfig.proxy = {
-						host: hostname,
+						host,
 						port: parseInt(port, 10),
 						protocol: 'http',
 						auth: {


### PR DESCRIPTION
## Summary
 IPv6 Proxies not working as expected



## Related tickets and issues
https://community.n8n.io/t/cant-use-ipv6-proxy-with-http-request/40844
https://linear.app/n8n/issue/NODE-1175/http-request-node-ipv6-proxies-not-working-as-expected