### PR TITLE
fix(Notion Node): Add itemIndex to API and operation errors

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -6,6 +6,7 @@ import type {
 	IHookFunctions,
 	IHttpRequestMethods,
 	ILoadOptionsFunctions,
+	INode,
 	INodeExecutionData,
 	INodeProperties,
 	IPairedItemData,
@@ -21,6 +22,7 @@ import moment from 'moment-timezone';
 
 import { validate as uuidValidate } from 'uuid';
 import { filters } from './descriptions/Filters';
+import set from 'lodash/set';
 
 function uuidValidateWithoutDashes(this: IExecuteFunctions, value: string) {
 	if (uuidValidate(value)) return true;
@@ -1170,3 +1172,17 @@ export function extractBlockId(this: IExecuteFunctions, nodeVersion: number, ite
 
 	return blockId;
 }
+
+export const prepareNotionError = (node: INode, error: Error, itemIndex: number) => {
+	if (error instanceof NodeApiError) {
+		set(error, 'context.itemIndex', itemIndex);
+		return error;
+	}
+
+	if (error instanceof NodeOperationError && error?.context?.itemIndex === undefined) {
+		set(error, 'context.itemIndex', itemIndex);
+		return error;
+	}
+
+	return new NodeOperationError(node, error, { itemIndex });
+};

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -23,6 +23,7 @@ import {
 	notionApiRequest,
 	notionApiRequestAllItems,
 	notionApiRequestGetBlockChildrens,
+	prepareNotionError,
 	simplifyBlocksOutput,
 	simplifyObjects,
 	validateJSON,
@@ -91,7 +92,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -166,7 +167,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -198,7 +199,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -241,7 +242,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -304,7 +305,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -391,7 +392,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -421,7 +422,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -459,9 +460,13 @@ export class NotionV2 implements INodeType {
 							if (validateJSON(filterJson) !== undefined) {
 								body.filter = jsonParse(filterJson);
 							} else {
-								throw new NodeApiError(this.getNode(), {
-									message: 'Filters (JSON) must be a valid json',
-								});
+								throw new NodeApiError(
+									this.getNode(),
+									{
+										message: 'Filters (JSON) must be a valid json',
+									},
+									{ itemIndex: i },
+								);
 							}
 						}
 
@@ -512,7 +517,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -564,7 +569,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -590,7 +595,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -619,7 +624,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -653,7 +658,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -705,7 +710,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}
@@ -767,7 +772,7 @@ export class NotionV2 implements INodeType {
 								pairedItem: { item: i },
 							});
 						} else {
-							throw error;
+							throw prepareNotionError(this.getNode(), error, i);
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
errors don't specify the item (i.e. [item N])



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1195/notion-errors-dont-specify-the-item-ie-%5Bitem-n%5D