### PR TITLE
fix: Update sales templates card content (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -95,13 +95,9 @@
 							data-test-id="browse-sales-templates-card"
 							@click="trackCategoryLinkClick('Sales')"
 						>
-							<n8n-icon :class="$style.emptyStateCardIcon" icon="handshake" />
+							<n8n-icon :class="$style.emptyStateCardIcon" icon="box-open" />
 							<n8n-text size="large" class="mt-xs" color="text-base">
-								{{
-									$locale.baseText('workflows.empty.browseTemplates', {
-										interpolate: { category: 'Sales' },
-									})
-								}}
+								{{ $locale.baseText('workflows.empty.browseTemplates') }}
 							</n8n-text>
 						</n8n-card>
 					</a>
@@ -268,6 +264,9 @@ const WorkflowsView = defineComponent({
 			return userRole;
 		},
 		isSalesUser() {
+			if (!this.userRole) {
+				return false;
+			}
 			return ['Sales', 'sales-and-marketing'].includes(this.userRole);
 		},
 	},


### PR DESCRIPTION
## Summary
Updating content (copy + icon) of the `Browse Sales templates` card in an empty workflows page.

<img width="459" alt="image" src="https://github.com/n8n-io/n8n/assets/2598782/a4496afb-1798-46e3-bbf3-72228037d27d">


## Related tickets and issues
Fixes ADO-2169



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 