### PR TITLE
fix(core): Exclude oAuth callback urls from browser-id checks

### DIFF
--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -42,6 +42,10 @@ const skipBrowserIdCheckEndpoints = [
 
 	// We need to exclude binary-data downloading endpoint because we can't send custom headers on `<embed>` tags
 	`/${restEndpoint}/binary-data`,
+
+	// oAuth callback urls aren't called by the frontend. therefore we can't send custom header on these requests
+	`/${restEndpoint}/oauth1-credential/callback`,
+	`/${restEndpoint}/oauth2-credential/callback`,
 ];
 
 @Service()


### PR DESCRIPTION
oAuth callback URLs aren't called by the frontend. therefore we can't send custom header on these requests, and need to exclude these from browser-id checks. 

fixes #9151

## Review / Merge checklist
- [x] PR title and summary are descriptive