### PR TITLE
fix(Postgres Node): Convert js arrays to postgres type, if column type is ARRAY

### DIFF
--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -11,7 +11,7 @@ export class Postgres extends VersionedNodeType {
 			name: 'postgres',
 			icon: 'file:postgres.svg',
 			group: ['input'],
-			defaultVersion: 2.3,
+			defaultVersion: 2.4,
 			description: 'Get, add and update data in Postgres',
 			parameterPane: 'wide',
 		};
@@ -22,6 +22,7 @@ export class Postgres extends VersionedNodeType {
 			2.1: new PostgresV2(baseDescription),
 			2.2: new PostgresV2(baseDescription),
 			2.3: new PostgresV2(baseDescription),
+			2.4: new PostgresV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -136,7 +136,7 @@ const properties: INodeProperties[] = [
 		},
 		displayOptions: {
 			show: {
-				'@version': [2.2, 2.3],
+				'@version': [{ _cnd: { gte: 2.2 } }],
 			},
 		},
 	},
@@ -225,7 +225,9 @@ export async function execute(
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
-		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		if (nodeVersion >= 2.4) {
+			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		}
 
 		values.push(checkItemAgainstSchema(this.getNode(), item, tableSchema, i));
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/insert.operation.ts
@@ -19,6 +19,7 @@ import {
 	configureTableSchemaUpdater,
 	getTableSchema,
 	prepareItem,
+	convertArraysToPostgresFormat,
 	replaceEmptyStringsByNulls,
 } from '../../helpers/utils';
 
@@ -223,6 +224,8 @@ export async function execute(
 		}
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
+
+		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 
 		values.push(checkItemAgainstSchema(this.getNode(), item, tableSchema, i));
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
@@ -173,7 +173,7 @@ const properties: INodeProperties[] = [
 		},
 		displayOptions: {
 			show: {
-				'@version': [2.2, 2.3],
+				'@version': [{ _cnd: { gte: 2.2 } }],
 			},
 		},
 	},
@@ -302,7 +302,9 @@ export async function execute(
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
-		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		if (nodeVersion >= 2.4) {
+			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		}
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/update.operation.ts
@@ -21,6 +21,7 @@ import {
 	doesRowExist,
 	getTableSchema,
 	prepareItem,
+	convertArraysToPostgresFormat,
 	replaceEmptyStringsByNulls,
 } from '../../helpers/utils';
 
@@ -300,6 +301,8 @@ export async function execute(
 		}
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
+
+		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -21,6 +21,7 @@ import {
 	prepareItem,
 	replaceEmptyStringsByNulls,
 	configureTableSchemaUpdater,
+	convertArraysToPostgresFormat,
 } from '../../helpers/utils';
 
 import { optionsCollection } from '../common.descriptions';
@@ -269,6 +270,8 @@ export async function execute(
 		}
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
+
+		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -172,7 +172,7 @@ const properties: INodeProperties[] = [
 		},
 		displayOptions: {
 			show: {
-				'@version': [2.2, 2.3],
+				'@version': [{ _cnd: { gte: 2.2 } }],
 			},
 		},
 	},
@@ -271,7 +271,9 @@ export async function execute(
 
 		tableSchema = await updateTableSchema(db, tableSchema, schema, table);
 
-		convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		if (nodeVersion >= 2.4) {
+			convertArraysToPostgresFormat(item, tableSchema, this.getNode(), i);
+		}
 
 		item = checkItemAgainstSchema(this.getNode(), item, tableSchema, i);
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
@@ -8,7 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'postgres',
 	icon: 'file:postgres.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2, 2.3],
+	version: [2, 2.1, 2.2, 2.3, 2.4],
 	subtitle: '={{ $parameter["operation"] }}',
 	description: 'Get, add and update data in Postgres',
 	defaults: {

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -16,7 +16,7 @@ export type ColumnInfo = {
 	data_type: string;
 	is_nullable: string;
 	udt_name?: string;
-	column_default?: string;
+	column_default?: string | null;
 	is_generated?: 'ALWAYS' | 'NEVER';
 	identity_generation?: 'ALWAYS' | 'NEVER';
 };

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -5,7 +5,7 @@ import type {
 	INodeExecutionData,
 	INodePropertyOptions,
 } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, jsonParse } from 'n8n-workflow';
 
 import { generatePairedItemData } from '../../../../utils/utilities';
 import type {
@@ -509,4 +509,55 @@ export const configureTableSchemaUpdater = (initialSchema: string, initialTable:
 		}
 		return tableSchema;
 	};
+};
+
+/**
+ * If postgress column type is array we need to convert it to fornmat that postgres understands, original object data would be modified
+ * @param data the object with keys representing column names and values
+ * @param schema table schema
+ * @param node INode
+ * @param itemIndex the index of the current item
+ */
+export const convertArraysToPostgresFormat = (
+	data: IDataObject,
+	schema: ColumnInfo[],
+	node: INode,
+	itemIndex = 0,
+) => {
+	for (const columnInfo of schema) {
+		//in case column type is array we need to convert it to fornmat that postgres understands
+		if (columnInfo.data_type.toUpperCase() === 'ARRAY') {
+			let columnValue = data[columnInfo.column_name];
+
+			if (typeof columnValue === 'string') {
+				columnValue = jsonParse(columnValue);
+			}
+
+			if (Array.isArray(columnValue)) {
+				const arrayEntries = columnValue.map((entry) => {
+					if (typeof entry === 'number') {
+						return entry;
+					}
+
+					if (typeof entry === 'object') {
+						entry = JSON.stringify(entry);
+					}
+
+					//escape double quotes
+					return `"${entry.replace(/"/g, '\\"')}"`;
+				});
+
+				//wrap in {} instead of [] as postgres does and join with ,
+				data[columnInfo.column_name] = `{${arrayEntries.join(',')}}`;
+			} else {
+				throw new NodeOperationError(
+					node,
+					`Column '${columnInfo.column_name}' has to be an array`,
+					{
+						itemIndex,
+					},
+				);
+			}
+		}
+	}
 };

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -539,24 +539,33 @@ export const convertArraysToPostgresFormat = (
 						return entry;
 					}
 
+					if (typeof entry === 'boolean') {
+						entry = String(entry);
+					}
+
 					if (typeof entry === 'object') {
 						entry = JSON.stringify(entry);
 					}
 
-					//escape double quotes
-					return `"${entry.replace(/"/g, '\\"')}"`;
+					if (typeof entry === 'string') {
+						return `"${entry.replace(/"/g, '\\"')}"`; //escape double quotes
+					}
+
+					return entry;
 				});
 
 				//wrap in {} instead of [] as postgres does and join with ,
 				data[columnInfo.column_name] = `{${arrayEntries.join(',')}}`;
 			} else {
-				throw new NodeOperationError(
-					node,
-					`Column '${columnInfo.column_name}' has to be an array`,
-					{
-						itemIndex,
-					},
-				);
+				if (columnInfo.is_nullable === 'NO') {
+					throw new NodeOperationError(
+						node,
+						`Column '${columnInfo.column_name}' has to be an array`,
+						{
+							itemIndex,
+						},
+					);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
The postgres node doesn't allow inserting an array as jsonb(and other type), We may need to add a type option for values to send.

this PR adds utility that converts js arrays to postgres format 


## Related tickets and issues
GH Issue: https://github.com/n8n-io/n8n/issues/8957
https://linear.app/n8n/issue/NODE-1263/postgres-add-support-for-jsonb