### PR TITLE
ci: Update isbang/compose-action and postgres in DB tests (no-changelog)

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         hard: 46677
 
   postgres:
-    image: postgres:11
+    image: postgres:16
     restart: always
     environment:
       - POSTGRES_DB=n8n

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -84,7 +84,7 @@ jobs:
           key: ${{ github.sha }}:db-tests
 
       - name: Start MySQL
-        uses: isbang/compose-action@v1.5.1
+        uses: isbang/compose-action@v2.0.0
         with:
           compose-file: ./.github/docker-compose.yml
           services: |
@@ -117,7 +117,7 @@ jobs:
           key: ${{ github.sha }}:db-tests
 
       - name: Start Postgres
-        uses: isbang/compose-action@v1.5.1
+        uses: isbang/compose-action@v2.0.0
         with:
           compose-file: ./.github/docker-compose.yml
           services: |


### PR DESCRIPTION
This PR updates:
1. `isbang/compose-action` to a version that uses node 20, since node 16 is EOL
2. `postgres` docker image to 16, since 11 went EOL 5 months ago

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] [Tests included](https://github.com/n8n-io/n8n/actions/runs/8739306898)