### PR TITLE
fix(Google Sheets Node): Fix "Append or Update" on an empty sheet

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -19,6 +19,7 @@ import { fieldCannotBeDeleted, parseResourceMapperFieldName } from '@/utils/node
 import { isResourceMapperValue } from '@/utils/typeGuards';
 import { i18n as locale } from '@/plugins/i18n';
 import { useNDVStore } from '@/stores/ndv.store';
+import { useWorkflowsStore } from '@/stores/workflows.store';
 
 type Props = {
 	parameter: INodeProperties;
@@ -32,6 +33,7 @@ type Props = {
 
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
 
 const props = withDefaults(defineProps<Props>(), {
 	teleported: true,
@@ -67,6 +69,16 @@ watch(
 			emitValueChanged();
 			await initFetching();
 			setDefaultFieldValues(true);
+		}
+	},
+);
+
+// Reload fields to map when node is executed
+watch(
+	() => workflowsStore.getWorkflowExecution,
+	async (data) => {
+		if (data?.status === 'success') {
+			await initFetching();
 		}
 	},
 );

--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -77,8 +77,8 @@ watch(
 watch(
 	() => workflowsStore.getWorkflowExecution,
 	async (data) => {
-		if (data?.status === 'success') {
-			await initFetching();
+		if (data?.status === 'success' && state.paramValue.mappingMode === 'autoMapInputData') {
+			await initFetching(true);
 		}
 	},
 );
@@ -211,9 +211,9 @@ const pluralFieldWord = computed<string>(() => {
 	);
 });
 
-async function initFetching(inlineLading = false): Promise<void> {
+async function initFetching(inlineLoading = false): Promise<void> {
 	state.loadingError = false;
-	if (inlineLading) {
+	if (inlineLoading) {
 		state.refreshInProgress = true;
 	} else {
 		state.loading = true;

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -476,7 +476,7 @@ export class GoogleSheet {
 
 		const keyIndex = columnNames.indexOf(indexKey);
 
-		if (keyIndex === -1) {
+		if (keyIndex === -1 && !upsert) {
 			throw new NodeOperationError(
 				this.executeFunctions.getNode(),
 				`Could not find column for key "${indexKey}"`,


### PR DESCRIPTION
## Summary
- Fix "Append or Update" on an empty sheet
- Reload mappable columns after node executed


## Related tickets and issues
https://linear.app/n8n/issue/NODE-1253/google-sheets-node-append-or-update-row-does-not-work-with-empty-sheet

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 