### PR TITLE
fix(core): Handle credential in body for oauth2 refresh token

### DIFF
--- a/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
@@ -10,6 +10,7 @@ export interface ClientOAuth2TokenData extends Record<string, string | undefined
 	expires_in?: string;
 	scope?: string | undefined;
 }
+
 /**
  * General purpose client token generator.
  */
@@ -77,7 +78,7 @@ export class ClientOAuth2Token {
 		const clientId = options.clientId;
 		const clientSecret = options.clientSecret;
 		const headers = { ...DEFAULT_HEADERS };
-		const body: Record<string, any> = {
+		const body: Record<string, string> = {
 			refresh_token: this.refreshToken,
 			grant_type: 'refresh_token',
 		};
@@ -93,8 +94,8 @@ export class ClientOAuth2Token {
 			{
 				url: options.accessTokenUri,
 				method: 'POST',
-				headers: headers,
-				body: body,
+				headers,
+				body,
 			},
 			options,
 		);

--- a/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
@@ -74,18 +74,27 @@ export class ClientOAuth2Token {
 
 		if (!this.refreshToken) throw new Error('No refresh token');
 
+		const clientId = options.clientId;
+		const clientSecret = options.clientSecret;
+		const headers = { ...DEFAULT_HEADERS };
+		const body: Record<string, any> = {
+			refresh_token: this.refreshToken,
+			grant_type: 'refresh_token',
+		};
+
+		if (options.authentication === 'body') {
+			body.client_id = clientId;
+			body.client_secret = clientSecret;
+		} else {
+			headers.Authorization = auth(clientId, clientSecret);
+		}
+
 		const requestOptions = getRequestOptions(
 			{
 				url: options.accessTokenUri,
 				method: 'POST',
-				headers: {
-					...DEFAULT_HEADERS,
-					Authorization: auth(options.clientId, options.clientSecret),
-				},
-				body: {
-					refresh_token: this.refreshToken,
-					grant_type: 'refresh_token',
-				},
+				headers: headers,
+				body: body,
 			},
 			options,
 		);

--- a/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
+++ b/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
@@ -159,8 +159,10 @@ describe('CredentialsFlow', () => {
 				const token = await authClient.credentials.getToken();
 				expect(token.accessToken).toEqual(config.accessToken);
 
-				mockRefreshCall();
+				const requestPromise = mockRefreshCall();
 				const token1 = await token.refresh();
+				await requestPromise;
+
 				expect(token1).toBeInstanceOf(ClientOAuth2Token);
 				expect(token1.accessToken).toEqual(config.refreshedAccessToken);
 				expect(token1.tokenType).toEqual('bearer');
@@ -181,11 +183,16 @@ describe('CredentialsFlow', () => {
 				expect(token1.accessToken).toEqual(config.refreshedAccessToken);
 				expect(token1.tokenType).toEqual('bearer');
 				expect(headers?.authorization).toBe(undefined);
-				expect(body).toEqual('refresh_token=def456token&grant_type=refresh_token&client_id=abc&client_secret=123');
+				expect(body).toEqual(
+					'refresh_token=def456token&grant_type=refresh_token&client_id=abc&client_secret=123',
+				);
 			});
 
 			it('should make a request to get a new access token with authentication = "header"', async () => {
-				const authClient = createAuthClient({ scopes: ['notifications'], authentication: 'header' });
+				const authClient = createAuthClient({
+					scopes: ['notifications'],
+					authentication: 'header',
+				});
 				void mockTokenCall({ requestedScope: 'notifications' });
 
 				const token = await authClient.credentials.getToken();

--- a/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
+++ b/packages/@n8n/client-oauth2/test/CredentialsFlow.test.ts
@@ -130,8 +130,8 @@ describe('CredentialsFlow', () => {
 		});
 
 		describe('#refresh', () => {
-			const mockRefreshCall = () =>
-				nock(config.baseUrl)
+			const mockRefreshCall = async () => {
+				const nockScope = nock(config.baseUrl)
 					.post(
 						'/login/oauth/access_token',
 						({ refresh_token, grant_type }) =>
@@ -142,6 +142,15 @@ describe('CredentialsFlow', () => {
 						access_token: config.refreshedAccessToken,
 						refresh_token: config.refreshedRefreshToken,
 					});
+				return await new Promise<{ headers: Headers; body: unknown }>((resolve) => {
+					nockScope.once('request', (req) => {
+						resolve({
+							headers: req.headers,
+							body: req.requestBodyBuffers.toString('utf-8'),
+						});
+					});
+				});
+			};
 
 			it('should make a request to get a new access token', async () => {
 				const authClient = createAuthClient({ scopes: ['notifications'] });
@@ -155,6 +164,42 @@ describe('CredentialsFlow', () => {
 				expect(token1).toBeInstanceOf(ClientOAuth2Token);
 				expect(token1.accessToken).toEqual(config.refreshedAccessToken);
 				expect(token1.tokenType).toEqual('bearer');
+			});
+
+			it('should make a request to get a new access token with authentication = "body"', async () => {
+				const authClient = createAuthClient({ scopes: ['notifications'], authentication: 'body' });
+				void mockTokenCall({ requestedScope: 'notifications' });
+
+				const token = await authClient.credentials.getToken();
+				expect(token.accessToken).toEqual(config.accessToken);
+
+				const requestPromise = mockRefreshCall();
+				const token1 = await token.refresh();
+				const { headers, body } = await requestPromise;
+
+				expect(token1).toBeInstanceOf(ClientOAuth2Token);
+				expect(token1.accessToken).toEqual(config.refreshedAccessToken);
+				expect(token1.tokenType).toEqual('bearer');
+				expect(headers?.authorization).toBe(undefined);
+				expect(body).toEqual('refresh_token=def456token&grant_type=refresh_token&client_id=abc&client_secret=123');
+			});
+
+			it('should make a request to get a new access token with authentication = "header"', async () => {
+				const authClient = createAuthClient({ scopes: ['notifications'], authentication: 'header' });
+				void mockTokenCall({ requestedScope: 'notifications' });
+
+				const token = await authClient.credentials.getToken();
+				expect(token.accessToken).toEqual(config.accessToken);
+
+				const requestPromise = mockRefreshCall();
+				const token1 = await token.refresh();
+				const { headers, body } = await requestPromise;
+
+				expect(token1).toBeInstanceOf(ClientOAuth2Token);
+				expect(token1.accessToken).toEqual(config.refreshedAccessToken);
+				expect(token1.tokenType).toEqual('bearer');
+				expect(headers?.authorization).toBe('Basic YWJjOjEyMw==');
+				expect(body).toEqual('refresh_token=def456token&grant_type=refresh_token');
 			});
 		});
 	});


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.
Fix credentials in body when option is activated for oauth2.


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.

https://github.com/n8n-io/n8n/issues/9178

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 