### PR TITLE
fix(editor): Fix sessionId for manual chat trigger execution

### DIFF
--- a/packages/editor-ui/src/components/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat.vue
@@ -465,7 +465,7 @@ export default defineComponent({
 						[
 							{
 								json: {
-									pushRef: `test-${currentUser.id || 'unknown'}`,
+									sessionId: `test-${currentUser.id || 'unknown'}`,
 									action: 'sendMessage',
 									[inputKey]: message,
 								},


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

Due to renaming done in #8905, the manual chat trigger would incorrectly send `pushRef` instead of the expected `sessionId`. This PR reverts those changes for `WorkflowLMChat` component which trigger manual chat trigger execution

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 