### PR TITLE
fix(editor): Make sticky node content parameter non require to support empty stickies

### DIFF
--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -244,7 +244,7 @@ describe('Canvas Actions', () => {
 			});
 	});
 
-	it('Empty sticky should not generate error when activating workflow', () => {
+	it('Empty sticky should not error when activating workflow', () => {
 		workflowPage.actions.addSticky();
 
 		workflowPage.getters.stickies().should('have.length', 1);

--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -243,6 +243,20 @@ describe('Canvas Actions', () => {
 				expect($el).to.have.css('z-index', '-158');
 			});
 	});
+
+	it('Empty sticky should generate error when activating workflow', () => {
+		workflowPage.actions.addSticky();
+
+		workflowPage.getters.stickies().should('have.length', 1);
+
+		workflowPage.getters.stickies().dblclick();
+
+		workflowPage.actions.clearSticky();
+
+		workflowPage.actions.addNodeToCanvas('Schedule Trigger');
+
+		workflowPage.actions.activateWorkflow();
+	});
 });
 
 type Position = {

--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -244,7 +244,7 @@ describe('Canvas Actions', () => {
 			});
 	});
 
-	it('Empty sticky should generate error when activating workflow', () => {
+	it('Empty sticky should not generate error when activating workflow', () => {
 		workflowPage.actions.addSticky();
 
 		workflowPage.getters.stickies().should('have.length', 1);

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -419,6 +419,9 @@ export class WorkflowPage extends BasePage {
 		editSticky: (content: string) => {
 			this.getters.stickies().dblclick().find('textarea').clear().type(content).type('{esc}');
 		},
+		clearSticky: () => {
+			this.getters.stickies().dblclick().find('textarea').clear().type('{esc}');
+		},
 		shouldHaveWorkflowName: (name: string) => {
 			this.getters.workflowNameInputContainer().invoke('attr', 'title').should('include', name);
 		},

--- a/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
+++ b/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
@@ -26,7 +26,6 @@ export class StickyNote implements INodeType {
 				displayName: 'Content',
 				name: 'content',
 				type: 'string',
-				required: true,
 				default:
 					"## I'm a note \n**Double click** to edit me. [Guide](https://docs.n8n.io/workflows/sticky-notes/)",
 			},


### PR DESCRIPTION
## Summary

When we create a workflow with an empty sticky and try to active it, get we `Please resolve outstanding issues before you activate it`. This happens because the `content` property is required. Making the `content` property non required allows to have empty sticky notes.


## Related tickets and issues
https://linear.app/n8n/issue/ADO-2186/unabel-to-activate-workflow-from-template


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 