### PR TITLE
feat(Wise Node): Add XML as supported format in getStatement operation

### DIFF
--- a/packages/nodes-base/nodes/Wise/Wise.node.ts
+++ b/packages/nodes-base/nodes/Wise/Wise.node.ts
@@ -213,7 +213,7 @@ export class Wise implements INodeType {
 
 						const profileId = this.getNodeParameter('profileId', i);
 						const borderlessAccountId = this.getNodeParameter('borderlessAccountId', i);
-						const format = this.getNodeParameter('format', i) as 'json' | 'csv' | 'pdf';
+						const format = this.getNodeParameter('format', i) as 'json' | 'csv' | 'pdf' | 'xml';
 						const endpoint = `v3/profiles/${profileId}/borderless-accounts/${borderlessAccountId}/statement.${format}`;
 
 						const qs = {

--- a/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
+++ b/packages/nodes-base/nodes/Wise/descriptions/AccountDescription.ts
@@ -136,6 +136,10 @@ export const accountFields: INodeProperties[] = [
 				name: 'PDF',
 				value: 'pdf',
 			},
+			{
+				name: 'XML (CAMT.053)',
+				value: 'xml',
+			},
 		],
 	},
 	{
@@ -149,7 +153,7 @@ export const accountFields: INodeProperties[] = [
 			show: {
 				resource: ['account'],
 				operation: ['getStatement'],
-				format: ['csv', 'pdf'],
+				format: ['csv', 'pdf', 'xml'],
 			},
 		},
 	},
@@ -165,7 +169,7 @@ export const accountFields: INodeProperties[] = [
 			show: {
 				resource: ['account'],
 				operation: ['getStatement'],
-				format: ['csv', 'pdf'],
+				format: ['csv', 'pdf', 'xml'],
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

Wise added XML (CAMT.053) as supported format to generate statements through their API.
Related docs from Wise:
https://docs.wise.com/api-docs/api-reference/balance-statement#get

This PR simply adds XML as supported format as option in the UI (as binary type, same as with already present options CSV and PDF) as well as to the backend code where the chosen format is appended to the request url.

![wise-node-xml-format](https://github.com/n8n-io/n8n/assets/11754639/94263939-73e9-4d10-97ac-12fbe412bc6e)

n8n docs are not affected since supported formats are not mentioned:
https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.wise/

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.

None available.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests.