### PR TITLE
test(core): Re-enable and amend test for `n8n user-management:reset`

### DIFF
--- a/packages/cli/test/integration/commands/reset.cmd.test.ts
+++ b/packages/cli/test/integration/commands/reset.cmd.test.ts
@@ -7,7 +7,16 @@ import { UserRepository } from '@db/repositories/user.repository';
 
 import { mockInstance } from '../../shared/mocking';
 import * as testDb from '../shared/testDb';
-import { createUser } from '../shared/db/users';
+import { createMember, createUser } from '../shared/db/users';
+import { createWorkflow } from '../shared/db/workflows';
+import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
+import { getPersonalProject } from '../shared/db/projects';
+import { saveCredential } from '../shared/db/credentials';
+import { randomCredentialPayload } from '../shared/random';
+import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
+import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
+import { CredentialsEntity } from '@/databases/entities/CredentialsEntity';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
 
 beforeAll(async () => {
 	mockInstance(InternalHooks);
@@ -25,20 +34,75 @@ afterAll(async () => {
 });
 
 // eslint-disable-next-line n8n-local-rules/no-skipped-tests
-test.skip('user-management:reset should reset DB to default user state', async () => {
-	await createUser({ role: 'global:owner' });
+test('user-management:reset should reset DB to default user state', async () => {
+	//
+	// ARRANGE
+	//
+	const owner = await createUser({ role: 'global:owner' });
+	const ownerProject = await getPersonalProject(owner);
 
+	// should be deleted
+	const member = await createMember();
+
+	// should be re-owned
+	const workflow = await createWorkflow({}, member);
+	const credential = await saveCredential(randomCredentialPayload(), {
+		user: member,
+		role: 'credential:owner',
+	});
+
+	// dangling credentials should also be re-owned
+	const danglingCredential = await Container.get(CredentialsRepository).save(
+		Object.assign(new CredentialsEntity(), randomCredentialPayload()),
+	);
+
+	// mark instance as set up
+	await Container.get(SettingsRepository).update(
+		{ key: 'userManagement.isInstanceOwnerSetUp' },
+		{ value: 'true' },
+	);
+
+	//
+	// ACT
+	//
 	await Reset.run();
 
-	const user = await Container.get(UserRepository).findOneBy({ role: 'global:owner' });
+	//
+	// ASSERT
+	//
 
-	if (!user) {
-		fail('No owner found after DB reset to default user state');
-	}
+	// check if the owner account was reset:
+	await expect(
+		Container.get(UserRepository).findOneBy({ role: 'global:owner' }),
+	).resolves.toMatchObject({
+		email: null,
+		firstName: null,
+		lastName: null,
+		password: null,
+		personalizationAnswers: null,
+	});
 
-	expect(user.email).toBeNull();
-	expect(user.firstName).toBeNull();
-	expect(user.lastName).toBeNull();
-	expect(user.password).toBeNull();
-	expect(user.personalizationAnswers).toBeNull();
+	// all members were deleted:
+	const members = await Container.get(UserRepository).findOneBy({ role: 'global:member' });
+	expect(members).toBeNull();
+
+	// all workflows are owned by the owner:
+	await expect(
+		Container.get(SharedWorkflowRepository).findBy({ workflowId: workflow.id }),
+	).resolves.toMatchObject([{ projectId: ownerProject.id, role: 'workflow:owner' }]);
+
+	// all credentials are owned by the owner
+	await expect(
+		Container.get(SharedCredentialsRepository).findBy({ credentialsId: credential.id }),
+	).resolves.toMatchObject([{ projectId: ownerProject.id, role: 'credential:owner' }]);
+
+	// all dangling credentials are owned by the owner
+	await expect(
+		Container.get(SharedCredentialsRepository).findBy({ credentialsId: danglingCredential.id }),
+	).resolves.toMatchObject([{ projectId: ownerProject.id, role: 'credential:owner' }]);
+
+	// the instance is marked as not set up:
+	await expect(
+		Container.get(SettingsRepository).findBy({ key: 'userManagement.isInstanceOwnerSetUp' }),
+	).resolves.toMatchObject([{ value: 'false' }]);
 });


### PR DESCRIPTION
## Summary

This test was skipped in https://github.com/n8n-io/n8n/pull/5669 because it was timing out a lot.
It was supposed to be re-enabled with https://github.com/n8n-io/n8n/pull/5464 but was subsequently closed.

I re-enabled it and added more setup and assertions. It finishes within 700ms on my machine, which is not fast, but also well below our timeout of 10 seconds.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

