### PR TITLE
fix(core): Ensure only the leader's license manager handles renewal

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -51,18 +51,19 @@ export class License {
 			return;
 		}
 
-		const isMainInstance = instanceType === 'main';
+		const isLeaderMain = instanceType === 'main' && this.orchestrationService.isLeader;
+
 		const server = config.getEnv('license.serverUrl');
-		const autoRenewEnabled = isMainInstance && config.getEnv('license.autoRenewEnabled');
-		const offlineMode = !isMainInstance;
+		const autoRenewEnabled = isLeaderMain && config.getEnv('license.autoRenewEnabled');
+		const offlineMode = !isLeaderMain;
 		const autoRenewOffset = config.getEnv('license.autoRenewOffset');
-		const saveCertStr = isMainInstance
+		const saveCertStr = isLeaderMain
 			? async (value: TLicenseBlock) => await this.saveCertStr(value)
 			: async () => {};
-		const onFeatureChange = isMainInstance
+		const onFeatureChange = isLeaderMain
 			? async (features: TFeatures) => await this.onFeatureChange(features)
 			: async () => {};
-		const collectUsageMetrics = isMainInstance
+		const collectUsageMetrics = isLeaderMain
 			? async () => await this.usageMetricsService.collectUsageMetrics()
 			: async () => [];
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -203,6 +203,8 @@ export class Start extends BaseCommand {
 
 		await orchestrationService.init();
 
+		if (config.getEnv('executions.mode') !== 'queue') return;
+
 		await Container.get(OrchestrationHandlerMainService).init();
 
 		if (!orchestrationService.isMultiMainSetupEnabled) return;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -174,9 +174,9 @@ export class Start extends BaseCommand {
 		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
 		await this.initOrchestration();
-		console.log('Orchestration init complete');
+		this.logger.debug('Orchestration init complete');
 		await this.initLicense();
-		console.log('License init complete');
+		this.logger.debug('License init complete');
 		await this.initBinaryDataService();
 		this.logger.debug('Binary data service init complete');
 		await this.initExternalHooks();

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -173,10 +173,10 @@ export class Start extends BaseCommand {
 		await super.init();
 		this.activeWorkflowRunner = Container.get(ActiveWorkflowRunner);
 
-		await this.initLicense();
-
 		await this.initOrchestration();
-		this.logger.debug('Orchestration init complete');
+		console.log('Orchestration init complete');
+		await this.initLicense();
+		console.log('License init complete');
 		await this.initBinaryDataService();
 		this.logger.debug('Binary data service init complete');
 		await this.initExternalHooks();
@@ -192,8 +192,6 @@ export class Start extends BaseCommand {
 	}
 
 	async initOrchestration() {
-		if (config.getEnv('executions.mode') !== 'queue') return;
-
 		if (
 			config.getEnv('multiMainSetup.enabled') &&
 			!Container.get(License).isMultipleMainInstancesLicensed()

--- a/packages/cli/src/services/orchestration.service.ts
+++ b/packages/cli/src/services/orchestration.service.ts
@@ -44,7 +44,8 @@ export class OrchestrationService {
 	}
 
 	/**
-	 * Whether this instance is the leader in a multi-main setup. Always `false` in single-main setup.
+	 * Whether this instance is the leader. This is always `true` in single-main setup,
+	 * once `OrchestrationService` has been initialized.
 	 */
 	get isLeader() {
 		return config.getEnv('multiMainSetup.instanceType') === 'leader';

--- a/packages/cli/test/unit/License.test.ts
+++ b/packages/cli/test/unit/License.test.ts
@@ -175,3 +175,27 @@ describe('License', () => {
 		expect(mainPlan).toBeUndefined();
 	});
 });
+
+describe('License', () => {
+	describe('init', () => {
+		test('should auto-renew if leader', async () => {
+			const orchestrationService = mock<OrchestrationService>({ isLeader: true });
+
+			await new License(mock(), mock(), orchestrationService, mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: true }),
+			);
+		});
+
+		test('should not auto-renew if follower', async () => {
+			const orchestrationService = mock<OrchestrationService>({ isLeader: false });
+
+			await new License(mock(), mock(), orchestrationService, mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: false }),
+			);
+		});
+	});
+});


### PR DESCRIPTION
Ensure only the leader's license manager handles renewal, in both single- and multi-main setup.

Fixes:
- https://github.com/n8n-io/n8n/issues/9164
- https://linear.app/n8n/issue/PAY-1517