### PR TITLE
fix(core): Fix browser session refreshes not working

### DIFF
--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -150,7 +150,7 @@ export class AuthService {
 
 		if (jwtPayload.exp * 1000 - Date.now() < this.jwtRefreshTimeout) {
 			this.logger.debug('JWT about to expire. Will be refreshed');
-			this.issueCookie(res, user, jwtPayload.browserId);
+			this.issueCookie(res, user, req.browserId);
 		}
 
 		return user;

--- a/packages/cli/test/unit/auth/auth.service.test.ts
+++ b/packages/cli/test/unit/auth/auth.service.test.ts
@@ -206,6 +206,9 @@ describe('AuthService', () => {
 			const newToken = res.cookie.mock.calls[0].at(1);
 			expect(newToken).not.toBe(validToken);
 			expect(await authService.resolveJwt(newToken, req, res)).toEqual(user);
+			expect((jwt.decode(newToken) as jwt.JwtPayload).browserId).toEqual(
+				(jwt.decode(validToken) as jwt.JwtPayload).browserId,
+			);
 		});
 
 		it('should refresh the cookie only if less than 1/4th of time is left', async () => {

--- a/packages/cli/test/unit/auth/auth.service.test.ts
+++ b/packages/cli/test/unit/auth/auth.service.test.ts
@@ -202,6 +202,10 @@ describe('AuthService', () => {
 				sameSite: 'lax',
 				secure: false,
 			});
+
+			const newToken = res.cookie.mock.calls[0].at(1);
+			expect(newToken).not.toBe(validToken);
+			expect(await authService.resolveJwt(newToken, req, res)).toEqual(user);
 		});
 
 		it('should refresh the cookie only if less than 1/4th of time is left', async () => {


### PR DESCRIPTION
## Summary

When refreshing a JWT, we'd create a new JWT and pass in the hashed browser ID. The hash would be hashed again and with the next request the check `hash(req.browserId) === JWT.browserId` would fail. `hash(hash(req.browserId)) === JWT.browserId` would succeed.

I fixed that by passing the un-hashed browserId to the `issueCookie` function.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included