### PR TITLE
feat(core): Make `project.name` required

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -28,9 +28,7 @@ export class ProjectController {
 
 	@Get('/')
 	async getAllProjects(req: ProjectRequest.GetAll): Promise<Project[]> {
-		const projects = await this.projectsService.getAccessibleProjects(req.user);
-
-		return await this.projectsService.guaranteeProjectNames(projects);
+		return await this.projectsService.getAccessibleProjects(req.user);
 	}
 
 	@Post('/')

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -16,7 +16,7 @@ export type ProjectType = 'personal' | 'team';
 @Entity()
 export class Project extends WithTimestampsAndStringId {
 	@Column({ length: 255, nullable: true })
-	name?: string;
+	name: string;
 
 	@Column({ length: 36 })
 	type: ProjectType;

--- a/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
+++ b/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
@@ -197,7 +197,7 @@ export class CreateProject1705928727784 implements IrreversibleMigration {
 				await Promise.all(
 					users.map(async (user) => {
 						const projectId = generateNanoId();
-						const name = `${user.firstName} ${user.lastName} <${user.email}>`;
+						const name = this.createPersonalProjectName(user.firstName, user.lastName, user.email);
 						await runQuery(
 							`INSERT INTO ${projectName} (id, type, name) VALUES (:projectId, 'personal', :name)`,
 							{
@@ -218,6 +218,20 @@ export class CreateProject1705928727784 implements IrreversibleMigration {
 				);
 			},
 		);
+	}
+
+	// Duplicated from packages/cli/src/databases/entities/User.ts
+	// Reason:
+	// This migration should work the same even if we refactor the function in
+	// `User.ts`.
+	createPersonalProjectName(firstName?: string, lastName?: string, email?: string) {
+		if (firstName && lastName && email) {
+			return `${firstName} ${lastName} <${email}>`;
+		} else if (email) {
+			return `<${email}>`;
+		} else {
+			return 'Unnamed Project';
+		}
 	}
 
 	async up(context: MigrationContext) {

--- a/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
+++ b/packages/cli/src/databases/migrations/common/1705928727784-CreateProject.ts
@@ -23,7 +23,7 @@ export class CreateProject1705928727784 implements IrreversibleMigration {
 	async setupTables({ schemaBuilder: { createTable, column } }: MigrationContext) {
 		await createTable(projectTable).withColumns(
 			column('id').varchar(36).primary.notNull,
-			column('name').varchar(255),
+			column('name').varchar(255).notNull,
 			column('type').varchar(36),
 		).withTimestamps;
 

--- a/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
@@ -133,8 +133,7 @@ export class SourceControlExportService {
 					owners[e.workflowId] = {
 						type: 'team',
 						teamId: project.id,
-						// TODO: remove when project name is not nullable
-						teamName: project.name!,
+						teamName: project.name,
 					};
 				} else {
 					throw new ApplicationError(
@@ -289,8 +288,7 @@ export class SourceControlExportService {
 						owner = {
 							type: 'team',
 							teamId: sharing.project.id,
-							// TODO: remove when project name is not nullable
-							teamName: sharing.project.name!,
+							teamName: sharing.project.name,
 						};
 					}
 

--- a/packages/cli/src/services/ownership.service.ts
+++ b/packages/cli/src/services/ownership.service.ts
@@ -88,15 +88,13 @@ export class OwnershipService {
 				entity.homeProject = {
 					id: project.id,
 					type: project.type,
-					// TODO: confirm name with product
-					name: project.name ?? 'My n8n',
+					name: project.name,
 				};
 			} else {
 				entity.sharedWithProjects.push({
 					id: project.id,
 					type: project.type,
-					// TODO: confirm name with product
-					name: project.name ?? 'My n8n',
+					name: project.name,
 				});
 			}
 		}

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -145,27 +145,6 @@ export class ProjectService {
 		return await this.projectRelationRepository.getPersonalProjectOwners(projectIds);
 	}
 
-	async guaranteeProjectNames(projects: Project[]): Promise<Array<Project & { name: string }>> {
-		const projectOwnerRelations = await this.getPersonalProjectOwners(projects.map((p) => p.id));
-
-		return projects.map((p) => {
-			if (p.name) {
-				return p;
-			}
-			const pr = projectOwnerRelations.find((r) => r.projectId === p.id);
-			let name = `Unclaimed Personal Project (${p.id})`;
-			if (pr && !pr.user.isPending) {
-				name = `${pr.user.firstName} ${pr.user.lastName}`;
-			} else if (pr) {
-				name = pr.user.email;
-			}
-			return this.projectRepository.create({
-				...p,
-				name,
-			});
-		}) as Array<Project & { name: string }>;
-	}
-
 	async createTeamProject(name: string, adminUser: User): Promise<Project> {
 		const project = await this.projectRepository.save(
 			this.projectRepository.create({

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -387,7 +387,6 @@ describe('GET /workflows', () => {
 			user: owner,
 			role: 'credential:owner',
 		});
-		const ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
 		const nodes: INode[] = [
 			{

--- a/packages/cli/test/unit/services/ownership.service.test.ts
+++ b/packages/cli/test/unit/services/ownership.service.test.ts
@@ -122,14 +122,14 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: ownerProject.id,
-				name: 'My n8n',
+				name: ownerProject.name,
 				type: ownerProject.type,
 			});
 
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: editorProject.id,
-					name: 'My n8n',
+					name: editorProject.name,
 					type: editorProject.type,
 				},
 			]);
@@ -151,13 +151,13 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: projectOwner.id,
-				name: 'My n8n',
+				name: projectOwner.name,
 				type: projectOwner.type,
 			});
 			expect(sharedWithProjects).toMatchObject([
 				{
 					id: projectEditor.id,
-					name: 'My n8n',
+					name: projectEditor.name,
 					type: projectEditor.type,
 				},
 			]);
@@ -175,7 +175,7 @@ describe('OwnershipService', () => {
 
 			expect(homeProject).toMatchObject({
 				id: project.id,
-				name: 'My n8n',
+				name: project.name,
 				type: project.type,
 			});
 

--- a/packages/cli/test/unit/shared/mockObjects.ts
+++ b/packages/cli/test/unit/shared/mockObjects.ts
@@ -25,4 +25,5 @@ export const mockProject = (): Project =>
 	Object.assign(new Project(), {
 		id: uniqueId(),
 		type: 'personal',
+		name: 'Nathan Fillion <nathan.fillion@n8n.io>',
 	});


### PR DESCRIPTION
## Summary

This marks `Project.name` as required/non-nullable.

Team projects always have names.
Personal projects always have a name since: https://github.com/n8n-io/n8n/pull/8995

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

