### PR TITLE
fix(core): Stop relying on filesystem for SSH keys

### DIFF
--- a/packages/cli/src/environments/sourceControl/sourceControlPreferences.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlPreferences.service.ee.ts
@@ -4,12 +4,8 @@ import Container, { Service } from 'typedi';
 import { SourceControlPreferences } from './types/sourceControlPreferences';
 import type { ValidationError } from 'class-validator';
 import { validate } from 'class-validator';
-import { writeFile as fsWriteFile, rm as fsRm } from 'fs/promises';
-import {
-	generateSshKeyPair,
-	isSourceControlLicensed,
-	sourceControlFoldersExistCheck,
-} from './sourceControlHelper.ee';
+import { rm as fsRm } from 'fs/promises';
+import { generateSshKeyPair, isSourceControlLicensed } from './sourceControlHelper.ee';
 import { Cipher, InstanceSettings } from 'n8n-core';
 import { ApplicationError, jsonParse } from 'n8n-workflow';
 import {
@@ -82,7 +78,7 @@ export class SourceControlPreferencesService {
 	private async getPrivateKeyFromDatabase() {
 		const dbKeyPair = await this.getKeyPairFromDatabase();
 
-		if (!dbKeyPair) return null;
+		if (!dbKeyPair) throw new ApplicationError('Failed to find key pair in database');
 
 		return this.cipher.decrypt(dbKeyPair.encryptedPrivateKey);
 	}
@@ -90,7 +86,7 @@ export class SourceControlPreferencesService {
 	private async getPublicKeyFromDatabase() {
 		const dbKeyPair = await this.getKeyPairFromDatabase();
 
-		if (!dbKeyPair) return null;
+		if (!dbKeyPair) throw new ApplicationError('Failed to find key pair in database');
 
 		return dbKeyPair.publicKey;
 	}
@@ -98,17 +94,13 @@ export class SourceControlPreferencesService {
 	async getPrivateKeyPath() {
 		const dbPrivateKey = await this.getPrivateKeyFromDatabase();
 
-		if (dbPrivateKey) {
-			const tempFilePath = path.join(os.tmpdir(), 'ssh_private_key_temp');
+		const tempFilePath = path.join(os.tmpdir(), 'ssh_private_key_temp');
 
-			await writeFile(tempFilePath, dbPrivateKey);
+		await writeFile(tempFilePath, dbPrivateKey);
 
-			await chmod(tempFilePath, 0o600);
+		await chmod(tempFilePath, 0o600);
 
-			return tempFilePath;
-		}
-
-		return this.sshKeyName; // fall back to key in filesystem
+		return tempFilePath;
 	}
 
 	async getPublicKey() {
@@ -136,11 +128,9 @@ export class SourceControlPreferencesService {
 	}
 
 	/**
-	 * Will generate an ed25519 key pair and save it to the database and the file system
-	 * Note: this will overwrite any existing key pair
+	 * Generate an SSH key pair and write it to the database, overwriting any existing key pair.
 	 */
 	async generateAndSaveKeyPair(keyPairType?: KeyPairType): Promise<SourceControlPreferences> {
-		sourceControlFoldersExistCheck([this.gitFolder, this.sshFolder]);
 		if (!keyPairType) {
 			keyPairType =
 				this.getPreferences().keyGeneratorType ??
@@ -148,21 +138,6 @@ export class SourceControlPreferencesService {
 				'ed25519';
 		}
 		const keyPair = await generateSshKeyPair(keyPairType);
-		if (keyPair.publicKey && keyPair.privateKey) {
-			try {
-				await fsWriteFile(this.sshKeyName + '.pub', keyPair.publicKey, {
-					encoding: 'utf8',
-					mode: 0o666,
-				});
-				await fsWriteFile(this.sshKeyName, keyPair.privateKey, { encoding: 'utf8', mode: 0o600 });
-			} catch (error) {
-				throw new ApplicationError('Failed to save key pair to disk', { cause: error });
-			}
-		}
-		// update preferences only after generating key pair to prevent endless loop
-		if (keyPairType !== this.getPreferences().keyGeneratorType) {
-			await this.setPreferences({ keyGeneratorType: keyPairType });
-		}
 
 		try {
 			await Container.get(SettingsRepository).save({
@@ -175,6 +150,11 @@ export class SourceControlPreferencesService {
 			});
 		} catch (error) {
 			throw new ApplicationError('Failed to write key pair to database', { cause: error });
+		}
+
+		// update preferences only after generating key pair to prevent endless loop
+		if (keyPairType !== this.getPreferences().keyGeneratorType) {
+			await this.setPreferences({ keyGeneratorType: keyPairType });
 		}
 
 		return this.getPreferences();
@@ -223,6 +203,10 @@ export class SourceControlPreferencesService {
 		preferences: Partial<SourceControlPreferences>,
 		saveToDb = true,
 	): Promise<SourceControlPreferences> {
+		const noKeyPair = (await this.getKeyPairFromDatabase()) === null;
+
+		if (noKeyPair) await this.generateAndSaveKeyPair();
+
 		this.sourceControlPreferences = preferences;
 		if (saveToDb) {
 			const settingsValue = JSON.stringify(this._sourceControlPreferences);

--- a/packages/cli/src/environments/sourceControl/sourceControlPreferences.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlPreferences.service.ee.ts
@@ -1,4 +1,3 @@
-import os from 'node:os';
 import { writeFile, chmod, readFile } from 'node:fs/promises';
 import Container, { Service } from 'typedi';
 import { SourceControlPreferences } from './types/sourceControlPreferences';
@@ -31,7 +30,7 @@ export class SourceControlPreferencesService {
 	readonly gitFolder: string;
 
 	constructor(
-		instanceSettings: InstanceSettings,
+		private readonly instanceSettings: InstanceSettings,
 		private readonly logger: Logger,
 		private readonly cipher: Cipher,
 	) {
@@ -94,7 +93,7 @@ export class SourceControlPreferencesService {
 	async getPrivateKeyPath() {
 		const dbPrivateKey = await this.getPrivateKeyFromDatabase();
 
-		const tempFilePath = path.join(os.tmpdir(), 'ssh_private_key_temp');
+		const tempFilePath = path.join(this.instanceSettings.n8nFolder, 'ssh_private_key_temp');
 
 		await writeFile(tempFilePath, dbPrivateKey);
 


### PR DESCRIPTION
- On startup, if no SSH key pair in DB, generate SSH key pair and persist in DB.
- On request to `/generate-key-pair`, generate SSH key pair and persist in DB.
- Before push, pull and fetch, set key pair from DB in in-memory settings.

Follow-up: https://linear.app/n8n/issue/PAY-1534