### PR TITLE
fix: Return scopes on the personal the project endpoint

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -107,12 +107,21 @@ export class ProjectController {
 	}
 
 	@Get('/personal')
-	async getPersonalProject(req: ProjectRequest.GetPersonalProject): Promise<Project> {
+	async getPersonalProject(req: ProjectRequest.GetPersonalProject) {
 		const project = await this.projectsService.getPersonalProject(req.user);
 		if (!project) {
 			throw new NotFoundError('Could not find a personal project for this user');
 		}
-		return project;
+		const scopes: Scope[] = [
+			...combineScopes({
+				global: this.roleService.getRoleScopes(req.user.role),
+				project: this.roleService.getRoleScopes('project:personalOwner'),
+			}),
+		];
+		return {
+			...project,
+			scopes,
+		};
 	}
 
 	@Get('/:projectId')

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -34,6 +34,8 @@ const testServer = utils.setupTestServer({
 	enabledFeatures: ['feat:advancedPermissions'],
 });
 
+// The `ActiveWorkflowRunner` keeps the event loop alive, which in turn leads to jest not shutting down cleanly.
+// We don't need it for the tests here, so we can mock it and make the tests exit cleanly.
 mockInstance(ActiveWorkflowRunner);
 
 beforeEach(async () => {

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -26,11 +26,15 @@ import { SharedCredentialsRepository } from '@/databases/repositories/sharedCred
 import type { GlobalRole } from '@/databases/entities/User';
 import type { Scope } from '@n8n/permissions';
 import { CacheService } from '@/services/cache/cache.service';
+import { mockInstance } from '../shared/mocking';
+import { ActiveWorkflowRunner } from '@/ActiveWorkflowRunner';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['project'],
 	enabledFeatures: ['feat:advancedPermissions'],
 });
+
+mockInstance(ActiveWorkflowRunner);
 
 beforeEach(async () => {
 	await testDb.truncate(['User', 'Project']);
@@ -329,8 +333,9 @@ describe('GET /projects/personal', () => {
 
 		const resp = await memberAgent.get('/projects/personal');
 		expect(resp.status).toBe(200);
-		const respProject = resp.body.data as Project;
+		const respProject = resp.body.data as Project & { scopes: Scope[] };
 		expect(respProject.id).toEqual(project.id);
+		expect(respProject.scopes).not.toBeUndefined();
 	});
 
 	test("should return 404 if user doesn't have a personal project", async () => {


### PR DESCRIPTION
## Summary
Add scopes to the personal project API endpoint

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 