### PR TITLE
fix: Get workflow API sending shared data to the frontend

### DIFF
--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -66,6 +66,9 @@ export class WorkflowsController {
 	@Post('/')
 	async create(req: WorkflowRequest.Create) {
 		delete req.body.id; // delete if sent
+		// @ts-expect-error: We shouldn't accept this because it can
+		// mess with relations of other workflows
+		delete req.body.shared;
 
 		const newWorkflow = new WorkflowEntity();
 
@@ -258,6 +261,10 @@ export class WorkflowsController {
 			const workflowWithMetaData = enterpriseWorkflowService.addOwnerAndSharings(workflow);
 
 			await enterpriseWorkflowService.addCredentialsToWorkflow(workflowWithMetaData, req.user);
+
+			// @ts-expect-error: This is added as part of addOwnerAndSharings but
+			// shouldn't be returned to the frontend
+			delete workflowWithMetaData.shared;
 
 			return workflowWithMetaData;
 		}

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -302,6 +302,8 @@ describe('GET /workflows/:id', () => {
 		});
 
 		expect(responseWorkflow.sharedWithProjects).toHaveLength(0);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((responseWorkflow as any).shared).toBeUndefined();
 	});
 
 	test('GET should return shared workflow with user data', async () => {


### PR DESCRIPTION
## Summary
The GET endpoint for individual workflows was returning shared data. This was causing issue with duplicating workflows from the canvas view.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 