### PR TITLE
fix(core): Add `view engine` to webhook server to support forms

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -7,12 +7,7 @@ import compression from 'compression';
 import isbot from 'isbot';
 
 import config from '@/config';
-import {
-	N8N_VERSION,
-	TEMPLATES_DIR,
-	inDevelopment,
-	inTest,
-} from '@/constants';
+import { N8N_VERSION, TEMPLATES_DIR, inDevelopment, inTest } from '@/constants';
 import * as Db from '@/Db';
 import { N8nInstanceType } from '@/Interfaces';
 import { ExternalHooks } from '@/ExternalHooks';

--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -2,11 +2,17 @@ import { Container, Service } from 'typedi';
 import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import express from 'express';
+import { engine as expressHandlebars } from 'express-handlebars';
 import compression from 'compression';
 import isbot from 'isbot';
 
 import config from '@/config';
-import { N8N_VERSION, inDevelopment, inTest } from '@/constants';
+import {
+	N8N_VERSION,
+	TEMPLATES_DIR,
+	inDevelopment,
+	inTest,
+} from '@/constants';
 import * as Db from '@/Db';
 import { N8nInstanceType } from '@/Interfaces';
 import { ExternalHooks } from '@/ExternalHooks';
@@ -61,6 +67,10 @@ export abstract class AbstractServer {
 	constructor(instanceType: N8nInstanceType = 'main') {
 		this.app = express();
 		this.app.disable('x-powered-by');
+
+		this.app.engine('handlebars', expressHandlebars({ defaultLayout: false }));
+		this.app.set('view engine', 'handlebars');
+		this.app.set('views', TEMPLATES_DIR);
 
 		const proxyHops = config.getEnv('proxy_hops');
 		if (proxyHops > 0) this.app.set('trust proxy', proxyHops);

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -10,7 +10,6 @@ import { promisify } from 'util';
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import helmet from 'helmet';
-import { engine as expressHandlebars } from 'express-handlebars';
 import { type Class, InstanceSettings } from 'n8n-core';
 import type { IN8nUISettings } from 'n8n-workflow';
 
@@ -26,7 +25,6 @@ import {
 	inDevelopment,
 	inE2ETests,
 	N8N_VERSION,
-	TEMPLATES_DIR,
 	Time,
 } from '@/constants';
 import { CredentialsController } from '@/credentials/credentials.controller';
@@ -94,10 +92,6 @@ export class Server extends AbstractServer {
 
 	constructor() {
 		super('main');
-
-		this.app.engine('handlebars', expressHandlebars({ defaultLayout: false }));
-		this.app.set('view engine', 'handlebars');
-		this.app.set('views', TEMPLATES_DIR);
 
 		this.testWebhooksEnabled = true;
 		this.webhooksEnabled = !config.getEnv('endpoints.disableProductionWebhooksOnMainProcess');

--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -20,13 +20,7 @@ import config from '@/config';
 import { Queue } from '@/Queue';
 
 import { WorkflowsController } from '@/workflows/workflows.controller';
-import {
-	EDITOR_UI_DIST_DIR,
-	inDevelopment,
-	inE2ETests,
-	N8N_VERSION,
-	Time,
-} from '@/constants';
+import { EDITOR_UI_DIST_DIR, inDevelopment, inE2ETests, N8N_VERSION, Time } from '@/constants';
 import { CredentialsController } from '@/credentials/credentials.controller';
 import type { APIRequest, CurlHelper } from '@/requests';
 import { registerController } from '@/decorators';


### PR DESCRIPTION
## Summary
Fix view engine missing in webhook server

## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9223
https://github.com/n8n-io/n8n/issues/7538


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 