### PR TITLE
fix(editor): Fix read-only mode in inline expression editor

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -25,14 +25,14 @@ type Props = {
 	modelValue: string;
 	path: string;
 	rows?: number;
-	isReadonly?: boolean;
+	isReadOnly?: boolean;
 	additionalData?: IDataObject;
 	eventBus?: EventBus;
 };
 
 const props = withDefaults(defineProps<Props>(), {
 	rows: 5,
-	isReadonly: false,
+	isReadOnly: false,
 	additionalData: () => ({}),
 	eventBus: () => createEventBus(),
 });
@@ -70,7 +70,7 @@ const {
 	editorRef: root,
 	editorValue,
 	extensions,
-	isReadOnly: props.isReadonly,
+	isReadOnly: props.isReadOnly,
 	autocompleteTelemetry: { enabled: true, parameterPath: props.path },
 	additionalData: props.additionalData,
 });

--- a/packages/editor-ui/src/components/ParameterOptions.vue
+++ b/packages/editor-ui/src/components/ParameterOptions.vue
@@ -203,6 +203,7 @@ export default defineComponent({
 <style lang="scss" module>
 .container {
 	display: flex;
+	min-height: 22px;
 }
 
 .loader {

--- a/packages/editor-ui/src/components/__tests__/ExpressionParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ExpressionParameterInput.test.ts
@@ -47,4 +47,20 @@ describe('ExpressionParameterInput', () => {
 		await userEvent.click(baseElement);
 		expect(emitted('blur')).toHaveLength(1);
 	});
+
+	describe('in read-only mode', () => {
+		test('it should render a read-only expression input', async () => {
+			const { container } = renderComponent({
+				props: {
+					modelValue: '={{$json.foo}}',
+					isReadOnly: true,
+				},
+			});
+
+			const editor = container.querySelector('.cm-content') as HTMLDivElement;
+			expect(editor).toBeInTheDocument();
+			expect(editor.getAttribute('contenteditable')).toEqual('false');
+			expect(editor.getAttribute('aria-readonly')).toEqual('true');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Expressions should not be editable in executions view:

<img width="644" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/e0740751-34ef-45b2-8c2b-7a61fc60f3ed">

Typo caused read only prop to not be used

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1321/bug-able-to-edit-a-node-from-past-execution

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 