### PR TITLE
fix(OpenAI Node): Allow to pass files ids as comma separated string in expressions (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/create.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/create.operation.ts
@@ -62,7 +62,7 @@ const properties: INodeProperties[] = [
 		type: 'multiOptions',
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 		description:
-			'The files to be used by the assistant, there can be a maximum of 20 files attached to the assistant',
+			'The files to be used by the assistant, there can be a maximum of 20 files attached to the assistant. You can use expression to pass file IDs as an array or comma-separated string.',
 		typeOptions: {
 			loadOptionsMethod: 'getFiles',
 		},
@@ -161,7 +161,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const instructions = this.getNodeParameter('instructions', i) as string;
 	const codeInterpreter = this.getNodeParameter('codeInterpreter', i) as boolean;
 	const knowledgeRetrieval = this.getNodeParameter('knowledgeRetrieval', i) as boolean;
-	const file_ids = this.getNodeParameter('file_ids', i, []) as string[];
+	let file_ids = this.getNodeParameter('file_ids', i, []) as string[] | string;
+	if (typeof file_ids === 'string') {
+		file_ids = file_ids.split(',').map((file_id) => file_id.trim());
+	}
 	const options = this.getNodeParameter('options', i, {});
 
 	if (options.failIfExists) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/update.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/update.operation.ts
@@ -41,7 +41,7 @@ const properties: INodeProperties[] = [
 				type: 'multiOptions',
 				// eslint-disable-next-line n8n-nodes-base/node-param-description-wrong-for-dynamic-multi-options
 				description:
-					'The files to be used by the assistant, there can be a maximum of 20 files attached to the assistant',
+					'The files to be used by the assistant, there can be a maximum of 20 files attached to the assistant. You can use expression to pass file IDs as an array or comma-separated string.',
 				typeOptions: {
 					loadOptionsMethod: 'getFiles',
 				},
@@ -116,6 +116,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const body: IDataObject = {};
 
 	if (file_ids) {
+		let files = file_ids;
+		if (typeof files === 'string') {
+			files = files.split(',').map((file_id) => file_id.trim());
+		}
 		if ((file_ids as IDataObject[]).length > 20) {
 			throw new NodeOperationError(
 				this.getNode(),
@@ -124,7 +128,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			);
 		}
 
-		body.file_ids = file_ids;
+		body.file_ids = files;
 	}
 
 	if (modelId) {


### PR DESCRIPTION
## Summary
if `files_ids` parameter is a string split it by `,` trim and send as an array



## Related tickets and issues
https://linear.app/n8n/issue/AI-173/openai-assistant-allow-to-pass-files-ids-as-comma-separated-string-in