### PR TITLE
feat(Postgres Node): Add option IS NOT NULL and hide value input fields

### DIFF
--- a/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
@@ -279,6 +279,10 @@ export const selectRowsFixedCollection: INodeProperties = {
 							name: 'Is Null',
 							value: 'IS NULL',
 						},
+						{
+							name: 'Is Not Null',
+							value: 'IS NOT NULL',
+						},
 					],
 					default: 'equal',
 				},
@@ -286,6 +290,11 @@ export const selectRowsFixedCollection: INodeProperties = {
 					displayName: 'Value',
 					name: 'value',
 					type: 'string',
+					displayOptions: {
+						hide: {
+							condition: ['IS NULL', 'IS NOT NULL'],
+						},
+					},
 					default: '',
 				},
 			],

--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -413,7 +413,7 @@ export function addWhereClauses(
 		}
 
 		let valueReplacement = ' ';
-		if (clause.condition !== 'IS NULL') {
+		if (clause.condition !== 'IS NULL' && clause.condition !== 'IS NOT NULL'){
 			valueReplacement = ' ?';
 			values.push(clause.value);
 		}

--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -413,7 +413,7 @@ export function addWhereClauses(
 		}
 
 		let valueReplacement = ' ';
-		if (clause.condition !== 'IS NULL' && clause.condition !== 'IS NOT NULL'){
+		if (clause.condition !== 'IS NULL' && clause.condition !== 'IS NOT NULL') {
 			valueReplacement = ' ?';
 			values.push(clause.value);
 		}

--- a/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/common.descriptions.ts
@@ -263,6 +263,10 @@ export const whereFixedCollection: INodeProperties = {
 							name: 'Is Null',
 							value: 'IS NULL',
 						},
+						{
+							name: 'Is Not Null',
+							value: 'IS NOT NULL',
+						},
 					],
 					default: 'equal',
 				},
@@ -270,6 +274,11 @@ export const whereFixedCollection: INodeProperties = {
 					displayName: 'Value',
 					name: 'value',
 					type: 'string',
+					displayOptions: {
+						hide: {
+							condition: ['IS NULL', 'IS NOT NULL'],
+						},
+					},
 					default: '',
 				},
 			],

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -147,7 +147,7 @@ export function addWhereClauses(
 		replacementIndex = replacementIndex + 1;
 
 		let valueReplacement = '';
-		if (clause.condition !== 'IS NULL') {
+		if (clause.condition !== 'IS NULL' && clause.condition !== 'IS NOT NULL') {
 			valueReplacement = ` $${replacementIndex}`;
 			values.push(clause.value);
 			replacementIndex = replacementIndex + 1;


### PR DESCRIPTION
## Summary
- Add `IS NOT NULL` operator in options for Postgres and MySql
- Hide value input field for options `IS NULL` and `IS NOT NULL` as no values should be assigned

## Related tickets and issues
Community: [Postgres Is Null condition should honor false for Is Not Null](https://community.n8n.io/t/postgres-is-null-condition-should-honor-false-for-is-not-null/44491)

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 