### PR TITLE
feat(core): Return `homeProject` from `POST /workflow`

### DIFF
--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -186,6 +186,19 @@ describe('POST /workflows', () => {
 				workflowId: response.body.data.id,
 			},
 		});
+		expect(response.body.data).toMatchObject({
+			active: false,
+			id: expect.any(String),
+			name: workflow.name,
+			sharedWithProjects: [],
+			usedCredentials: [],
+			homeProject: {
+				id: personalProject.id,
+				name: personalProject.name,
+				type: personalProject.type,
+			},
+		});
+		expect(response.body.data.shared).toBeUndefined();
 	});
 
 	test('creates workflow in a specific project if the projectId is passed', async () => {
@@ -218,6 +231,19 @@ describe('POST /workflows', () => {
 				workflowId: response.body.data.id,
 			},
 		});
+		expect(response.body.data).toMatchObject({
+			active: false,
+			id: expect.any(String),
+			name: workflow.name,
+			sharedWithProjects: [],
+			usedCredentials: [],
+			homeProject: {
+				id: project.id,
+				name: project.name,
+				type: project.type,
+			},
+		});
+		expect(response.body.data.shared).toBeUndefined();
 	});
 
 	test('does not create the workflow in a specific project if the user is not part of the project', async () => {


### PR DESCRIPTION
## Summary

This is necessary so that the FE knows if the workflow was created in a personal or team project and thus can conditionally render the share button.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1536/front-end-fixes-for-project-settings-icons-and-cached-view-states

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

