### PR TITLE
refactor(core)!: Switch default Postgres user from `root` to `postgres`

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: always
     environment:
       - POSTGRES_DB=n8n
-      - POSTGRES_USER=root
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
     ports:
       - 5432:5432

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.39.0
+
+### What changed?
+
+The default value for the `DB_POSTGRESDB_USER` environment variable was switched from `root` to `postgres`.
+
+### When is action necessary?
+
+If your Postgres connection is relying on the old default value `root` for the `DB_POSTGRESDB_USER` environment variable, you must now explicitly set `DB_POSTGRESDB_USER` to `root` in your environment.
+
 ## 1.37.0
 
 ### What changed?

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,7 +2,7 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
-## 1.39.0
+## 1.40.0
 
 ### What changed?
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -82,7 +82,7 @@ export const schema = {
 			user: {
 				doc: 'PostgresDB User',
 				format: String,
-				default: 'root',
+				default: 'postgres',
 				env: 'DB_POSTGRESDB_USER',
 			},
 			schema: {


### PR DESCRIPTION
Switch the legacy value `root` for the `DB_POSTGRESDB_USER` env var to `postgres` in line with PG's actual default.