### PR TITLE
fix(core): Fix regression, `POST /workflows` not returning tags anymore

### DIFF
--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -91,7 +91,7 @@ export class WorkflowsController {
 
 		if (this.license.isSharingEnabled()) {
 			// This is a new workflow, so we simply check if the user has access to
-			// all used workflows
+			// all used credentials
 
 			const allCredentials = await this.credentialsService.getMany(req.user);
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -144,7 +144,7 @@ export class WorkflowsController {
 				workflow.id,
 				req.user,
 				['workflow:read'],
-				{ em: transactionManager },
+				{ em: transactionManager, includeTags: true },
 			);
 		});
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -169,13 +169,17 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
+		const tag = await createTag({ name: 'A' });
 		const workflow = makeWorkflow();
 		const personalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
 		//
 		// ACT
 		//
-		const response = await authOwnerAgent.post('/workflows').send(workflow).expect(200);
+		const response = await authOwnerAgent
+			.post('/workflows')
+			.send({ ...workflow, tags: [tag.id] })
+			.expect(200);
 
 		//
 		// ASSERT
@@ -197,6 +201,7 @@ describe('POST /workflows', () => {
 				name: personalProject.name,
 				type: personalProject.type,
 			},
+			tags: [{ id: tag.id, name: tag.name }],
 		});
 		expect(response.body.data.shared).toBeUndefined();
 	});
@@ -205,6 +210,7 @@ describe('POST /workflows', () => {
 		//
 		// ARRANGE
 		//
+		const tag = await createTag({ name: 'A' });
 		const workflow = makeWorkflow();
 		const project = await projectRepository.save(
 			projectRepository.create({
@@ -219,7 +225,7 @@ describe('POST /workflows', () => {
 		//
 		const response = await authOwnerAgent
 			.post('/workflows')
-			.send({ ...workflow, projectId: project.id })
+			.send({ ...workflow, projectId: project.id, tags: [tag.id] })
 			.expect(200);
 
 		//
@@ -242,6 +248,7 @@ describe('POST /workflows', () => {
 				name: project.name,
 				type: project.type,
 			},
+			tags: [{ id: tag.id, name: tag.name }],
 		});
 		expect(response.body.data.shared).toBeUndefined();
 	});


### PR DESCRIPTION
## Summary

This fixes a regression introduced by https://github.com/n8n-io/n8n/pull/9242.
`POST /workflows` would not return tags anymore if the workflow was saved with tags.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

