### PR TITLE
ci: Update release-push-to-channel.yml (no-changelog)

### DIFF
--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -28,6 +28,9 @@ jobs:
       - run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm dist-tag add n8n@${{ github.event.inputs.version }} ${{ github.event.inputs.release-channel }}
+      - name: Update latest and next in the docs
+        continue-on-error: true
+        run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
 
   release-to-docker-hub:
     name: Release to DockerHub
@@ -53,3 +56,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.release-channel }} ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.version }}
+
+  
+    

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -28,9 +28,6 @@ jobs:
       - run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm dist-tag add n8n@${{ github.event.inputs.version }} ${{ github.event.inputs.release-channel }}
-      - name: Update latest and next in the docs
-        continue-on-error: true
-        run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
 
   release-to-docker-hub:
     name: Release to DockerHub
@@ -56,3 +53,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.release-channel }} ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.version }}
+
+  update-docs:
+    name: Update latest and next in the docs
+    runs-on: ubuntu-latest
+    needs: [release-to-npm, release-to-docker-hub]
+    steps:
+      - continue-on-error: true
+        run: curl -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -56,6 +56,3 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.release-channel }} ghcr.io/${{ github.repository_owner }}/n8n:${{ github.event.inputs.version }}
-
-  
-    


### PR DESCRIPTION
Update the release publication to include an automatic call to the lates/next docs update workflow. I've edited the workflow to trigger on webhook.

Workflow: https://internal.users.n8n.cloud/workflow/684

If this is accepted, I think we can modify https://www.notion.so/n8n/Release-Process-fce65faea3d5403a85210f7e7a60d0f8 to remove step 5 in 3.2

