### PR TITLE
fix(core): Create personal projects for users created via LDAP

### DIFF
--- a/packages/cli/src/Ldap/helpers.ts
+++ b/packages/cli/src/Ldap/helpers.ts
@@ -179,10 +179,15 @@ export const processUsers = async (
 	toUpdateUsers: Array<[string, User]>,
 	toDisableUsers: string[],
 ): Promise<void> => {
+	const userRepository = Container.get(UserRepository);
 	await Db.transaction(async (transactionManager) => {
 		return await Promise.all([
 			...toCreateUsers.map(async ([ldapId, user]) => {
-				const authIdentity = AuthIdentity.create(await transactionManager.save(user), ldapId);
+				const { user: savedUser } = await userRepository.createUserWithProject(
+					user,
+					transactionManager,
+				);
+				const authIdentity = AuthIdentity.create(savedUser, ldapId);
 				return await transactionManager.save(authIdentity);
 			}),
 			...toUpdateUsers.map(async ([ldapId, user]) => {

--- a/packages/cli/src/Ldap/ldap.service.ts
+++ b/packages/cli/src/Ldap/ldap.service.ts
@@ -349,7 +349,7 @@ export class LdapService {
 			localAdUsers,
 		);
 
-		this.logger.debug('LDAP - Users processed', {
+		this.logger.debug('LDAP - Users to process', {
 			created: usersToCreate.length,
 			updated: usersToUpdate.length,
 			disabled: usersToDisable.length,

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -367,6 +367,8 @@ describe('POST /ldap/sync', () => {
 			expect(memberUser.email).toBe(ldapUser.mail);
 			expect(memberUser.lastName).toBe(ldapUser.sn);
 			expect(memberUser.firstName).toBe(ldapUser.givenName);
+			const memberProject = getPersonalProject(memberUser);
+			expect(memberProject).toBeDefined();
 
 			const authIdentities = await getLdapIdentities();
 			expect(authIdentities.length).toBe(1);


### PR DESCRIPTION
## Summary

Before users created via LDAP would not have a personal project. Now they do.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1548/users-created-via-ldap-have-no-personal-project

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

