### PR TITLE
fix(core): Prevent node param resolution from failing telemetry graph generation

### DIFF
--- a/packages/workflow/src/TelemetryHelpers.ts
+++ b/packages/workflow/src/TelemetryHelpers.ts
@@ -126,14 +126,20 @@ export function generateNodesGraph(
 			return;
 		}
 
-		const nodeParameters =
-			getNodeParameters(
-				stickyType.description.properties,
-				stickyNote.parameters,
-				true,
-				false,
-				stickyNote,
-			) ?? {};
+		let nodeParameters: IDataObject = {};
+
+		try {
+			nodeParameters =
+				getNodeParameters(
+					stickyType.description.properties,
+					stickyNote.parameters,
+					true,
+					false,
+					stickyNote,
+				) ?? {};
+		} catch {
+			// prevent node param resolution from failing graph generation
+		}
 
 		const height: number = typeof nodeParameters.height === 'number' ? nodeParameters.height : 0;
 		const width: number = typeof nodeParameters.width === 'number' ? nodeParameters.width : 0;

--- a/packages/workflow/test/TelemetryHelpers.test.ts
+++ b/packages/workflow/test/TelemetryHelpers.test.ts
@@ -5,7 +5,7 @@ import {
 	getDomainBase,
 	getDomainPath,
 } from '@/TelemetryHelpers';
-import { ApplicationError, type IWorkflowBase } from '@/index';
+import { ApplicationError, STICKY_NODE_TYPE, type IWorkflowBase } from '@/index';
 import { nodeTypes } from './ExpressionExtensions/Helpers';
 import { mock } from 'jest-mock-extended';
 import * as nodeHelpers from '@/NodeHelpers';
@@ -766,8 +766,8 @@ describe('generateNodesGraph', () => {
 		});
 	});
 
-	test('should not fail on error to resolve a node parameter', () => {
-		const workflow = mock<IWorkflowBase>({ nodes: [] });
+	test('should not fail on error to resolve a node parameter for sticky node type', () => {
+		const workflow = mock<IWorkflowBase>({ nodes: [{ type: STICKY_NODE_TYPE }] });
 
 		jest.spyOn(nodeHelpers, 'getNodeParameters').mockImplementationOnce(() => {
 			throw new ApplicationError('Could not find property option');

--- a/packages/workflow/test/TelemetryHelpers.test.ts
+++ b/packages/workflow/test/TelemetryHelpers.test.ts
@@ -5,8 +5,10 @@ import {
 	getDomainBase,
 	getDomainPath,
 } from '@/TelemetryHelpers';
-import type { IWorkflowBase } from '@/index';
+import { ApplicationError, type IWorkflowBase } from '@/index';
 import { nodeTypes } from './ExpressionExtensions/Helpers';
+import { mock } from 'jest-mock-extended';
+import * as nodeHelpers from '@/NodeHelpers';
 
 describe('getDomainBase should return protocol plus domain', () => {
 	test('in valid URLs', () => {
@@ -762,6 +764,16 @@ describe('generateNodesGraph', () => {
 			},
 			webhookNodeNames: [],
 		});
+	});
+
+	test('should not fail on error to resolve a node parameter', () => {
+		const workflow = mock<IWorkflowBase>({ nodes: [] });
+
+		jest.spyOn(nodeHelpers, 'getNodeParameters').mockImplementationOnce(() => {
+			throw new ApplicationError('Could not find property option');
+		});
+
+		expect(() => generateNodesGraph(workflow, nodeTypes)).not.toThrow();
 	});
 });
 


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1529/property-option-missing-when-creating-telemetry-payload