### PR TITLE
fix: Cast boolean values in filter parameter

### DIFF
--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -36,13 +36,8 @@ function parseSingleFilterValue(
 		return { valid: true, newValue: value } as ValidationResult;
 	}
 
-	if (type === 'boolean') {
-		const result = validateFieldType('filter', value, type, { strict });
-		if (!result.valid && !strict) {
-			return { valid: true, newValue: Boolean(value) };
-		}
-
-		return result;
+	if (type === 'boolean' && !strict) {
+		return { valid: true, newValue: Boolean(value) };
 	}
 
 	return validateFieldType('filter', value, type, { strict, parseStrings: true });

--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -32,9 +32,20 @@ function parseSingleFilterValue(
 	type: FilterOperatorType,
 	strict = false,
 ): ValidationResult {
-	return type === 'any' || value === null || value === undefined
-		? ({ valid: true, newValue: value } as ValidationResult)
-		: validateFieldType('filter', value, type, { strict, parseStrings: true });
+	if (type === 'any' || value === null || value === undefined) {
+		return { valid: true, newValue: value } as ValidationResult;
+	}
+
+	if (type === 'boolean') {
+		const result = validateFieldType('filter', value, type, { strict });
+		if (!result.valid && !strict) {
+			return { valid: true, newValue: Boolean(value) };
+		}
+
+		return result;
+	}
+
+	return validateFieldType('filter', value, type, { strict, parseStrings: true });
 }
 
 const withIndefiniteArticle = (noun: string): string => {

--- a/packages/workflow/test/FilterParameter.test.ts
+++ b/packages/workflow/test/FilterParameter.test.ts
@@ -177,6 +177,27 @@ describe('FilterParameter', () => {
 									leftValue: 'true',
 									operator: { operation: 'true', type: 'boolean' },
 								},
+								{
+									id: '3',
+									leftValue: '',
+									operator: { operation: 'false', type: 'boolean' },
+								},
+
+								{
+									id: '4',
+									leftValue: 0,
+									operator: { operation: 'false', type: 'boolean' },
+								},
+								{
+									id: '5',
+									leftValue: 1,
+									operator: { operation: 'true', type: 'boolean' },
+								},
+								{
+									id: '6',
+									leftValue: 'a string',
+									operator: { operation: 'true', type: 'boolean' },
+								},
 							],
 							options: { typeValidation: 'loose' },
 						}),
@@ -194,14 +215,14 @@ describe('FilterParameter', () => {
 										id: '1',
 										leftValue: 'a string',
 										rightValue: 15,
-										operator: { operation: 'equals', type: 'boolean' },
+										operator: { operation: 'equals', type: 'number' },
 									},
 								],
 								options: { typeValidation: 'loose' },
 							}),
 						),
 					).toThrowError(
-						"Conversion error: the string 'a string' can't be converted to a boolean [condition 0, item 0]",
+						"Conversion error: the string 'a string' can't be converted to a number [condition 0, item 0]",
 					);
 				});
 			});


### PR DESCRIPTION
## Summary
- When typeValidation is set to loose, values should always be cast to boolean (similar to an if() in JS)

**Before**
<img width="1045" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/ac3c251b-a0c2-4faf-88e7-4343879eb0f7">

**After**
<img width="769" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/ecaa58c5-f95c-4bed-8a03-ace26b8717ba">

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1319/switch-node-condition-throws-error-when-it-should-not

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 