### PR TITLE
fix: Source Control import creating project without specifying type

### DIFF
--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -508,6 +508,7 @@ export class SourceControlImportService {
 					projectRepository.create({
 						id: owner.teamId,
 						name: owner.teamName,
+						type: 'team',
 					}),
 				);
 			}
@@ -519,7 +520,9 @@ export class SourceControlImportService {
 
 		const errorOwner = owner as ResourceOwner;
 		throw new ApplicationError(
-			`Unknown resource owner type "${typeof errorOwner !== 'string' ? errorOwner.type : 'UNKNOWN'}" found when importing from source controller`,
+			`Unknown resource owner type "${
+				typeof errorOwner !== 'string' ? errorOwner.type : 'UNKNOWN'
+			}" found when importing from source controller`,
 		);
 	}
 }

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -249,6 +249,7 @@ describe('SourceControlImportService', () => {
 
 			expect(sharing?.project.id).toBe('1234-asdf');
 			expect(sharing?.project.name).toBe('Marketing');
+			expect(sharing?.project.type).toBe('team');
 
 			expect(sharing).toBeTruthy(); // original user missing, so importing user owns credential
 		});


### PR DESCRIPTION
## Summary
Lack of project type was creating null type projects from source control

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 