### PR TITLE
feat(S3 Node): Add support for self signed SSL certificates

### DIFF
--- a/packages/nodes-base/credentials/S3.credentials.ts
+++ b/packages/nodes-base/credentials/S3.credentials.ts
@@ -41,5 +41,12 @@ export class S3 implements ICredentialType {
 			type: 'boolean',
 			default: false,
 		},
+		{
+			displayName: 'Ignore SSL Issues',
+			name: 'ignoreSSLIssues',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to connect even if SSL certificate validation is not possible',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/S3/GenericFunctions.ts
@@ -83,6 +83,7 @@ export async function s3ApiRequest(
 		qs: query,
 		uri: endpoint.toString(),
 		body: signOpts.body,
+		rejectUnauthorized: !credentials.ignoreSSLIssues as boolean,
 	};
 
 	if (Object.keys(option).length !== 0) {


### PR DESCRIPTION
## Summary
In the S3 Node Credentials add a toggle for ignoring SSL issues (similar to other Nodes like the Gotify Node) for users selfhosting s3 compatible storage providers who may be using self signed certificates.

![image](https://github.com/n8n-io/n8n/assets/123465523/f5f07e72-58fd-48f7-a41f-306c58707fec)

## Related tickets and issues

Github Issue: 
https://github.com/n8n-io/n8n/issues/7239

Linear Ticket: 
https://linear.app/n8n/issue/NODE-801/add-ignoresslissues-to-s3-not-aws-node

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests run using `pnpm build` and `pnpm start`