### PR TITLE
fix: Sharing credentials and workflows with pending users

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -25,15 +25,12 @@ export class EnterpriseCredentialsService {
 		const em = entityManager ?? this.sharedCredentialsRepository.manager;
 
 		const projects = await em.find(Project, {
-			select: { projectRelations: { userId: true } },
-			where: { id: In(shareWithIds), projectRelations: { role: 'project:personalOwner' } },
-			relations: { projectRelations: { user: true } },
+			where: { id: In(shareWithIds), type: 'personal' },
 		});
 
 		const newSharedCredentials = projects
 			// We filter by role === 'project:personalOwner' above and there should
 			// always only be one owner.
-			.filter((project) => !project.projectRelations[0].user.isPending)
 			.map((project) =>
 				this.sharedCredentialsRepository.create({
 					credentialsId: credential.id,

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -40,15 +40,12 @@ export class EnterpriseWorkflowService {
 		const em = entityManager ?? this.sharedWorkflowRepository.manager;
 
 		const projects = await em.find(Project, {
-			select: { projectRelations: { userId: true } },
-			where: { id: In(shareWithIds), projectRelations: { role: 'project:personalOwner' } },
-			relations: { projectRelations: { user: true } },
+			where: { id: In(shareWithIds), type: 'personal' },
 		});
 
 		const newSharedWorkflows = projects
 			// We filter by role === 'project:personalOwner' above and there should
 			// always only be one owner.
-			.filter((project) => !project.projectRelations[0].user.isPending)
 			.map((project) =>
 				this.sharedWorkflowRepository.create({
 					workflowId: workflow.id,

--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -539,7 +539,7 @@ describe('PUT /credentials/:id/share', () => {
 		expect(mailer.notifyCredentialsShared).toHaveBeenCalledTimes(1);
 	});
 
-	test('should ignore pending sharee', async () => {
+	test('should not ignore pending sharee', async () => {
 		const memberShell = await createUserShell('global:member');
 		const memberShellPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(
 			memberShell.id,
@@ -555,8 +555,13 @@ describe('PUT /credentials/:id/share', () => {
 			where: { credentialsId: savedCredential.id },
 		});
 
-		expect(sharedCredentials).toHaveLength(1);
-		expect(sharedCredentials[0].projectId).toBe(ownerPersonalProject.id);
+		expect(sharedCredentials).toHaveLength(2);
+		expect(
+			sharedCredentials.find((c) => c.projectId === ownerPersonalProject.id),
+		).not.toBeUndefined();
+		expect(
+			sharedCredentials.find((c) => c.projectId === memberShellPersonalProject.id),
+		).not.toBeUndefined();
 	});
 
 	test('should ignore non-existing sharee', async () => {


### PR DESCRIPTION
## Summary
At some point we decided to allow this, but it was still being filtered out on the backend.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 