### PR TITLE
fix: Members not being able to test credentials with external secrets

### DIFF
--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -190,7 +190,7 @@ export class CredentialsTester {
 					'internal' as WorkflowExecuteMode,
 					undefined,
 					undefined,
-					user.hasGlobalScope('externalSecret:use'),
+					await this.credentialsHelper.credentialCanUseExternalSecrets(credentialsDecrypted),
 				);
 			} catch (error) {
 				this.logger.debug('Credential test failed', error);


### PR DESCRIPTION
## Summary
When a instance member opens a credential in a project with an instance owner/admin that's using external secrets, the connection test would always show as failing. This fix allows the user to test the connection, but no see the secrets themselves.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 