### PR TITLE
fix(nodes-base): display scope as text for xero auth credentials

### DIFF
--- a/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/XeroOAuth2Api.credentials.ts
@@ -38,7 +38,7 @@ export class XeroOAuth2Api implements ICredentialType {
 		{
 			displayName: 'Scope',
 			name: 'scope',
-			type: 'hidden',
+			type: 'text',
 			default: scopes.join(' '),
 		},
 		{


### PR DESCRIPTION
display scope as text in order to be able to add more scopes to my xero credential

## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.
The PR updates the Xero Credentials node to allow for scopes to be added.


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 