### PR TITLE
fix(n8n Form Trigger Node): Fix missing options when using respond to webhook

### DIFF
--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -76,11 +76,6 @@ const descriptionV2: INodeTypeDescription = {
 			type: 'collection',
 			placeholder: 'Add Option',
 			default: {},
-			displayOptions: {
-				hide: {
-					responseMode: ['responseNode'],
-				},
-			},
 			options: [
 				{
 					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
@@ -91,29 +86,13 @@ const descriptionV2: INodeTypeDescription = {
 					description:
 						'Whether to include the link “Form automated with n8n” at the bottom of the form',
 				},
-				respondWithOptions,
-			],
-		},
-		{
-			displayName: 'Options',
-			name: 'options',
-			type: 'collection',
-			placeholder: 'Add Option',
-			default: {},
-			displayOptions: {
-				show: {
-					responseMode: ['responseNode'],
-				},
-			},
-			options: [
 				{
-					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-					displayName: 'Append n8n Attribution',
-					name: 'appendAttribution',
-					type: 'boolean',
-					default: true,
-					description:
-						'Whether to include the link “Form automated with n8n” at the bottom of the form',
+					...respondWithOptions,
+					displayOptions: {
+						hide: {
+							'/responseMode': ['responseNode'],
+						},
+					},
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -94,6 +94,29 @@ const descriptionV2: INodeTypeDescription = {
 				respondWithOptions,
 			],
 		},
+		{
+			displayName: 'Options',
+			name: 'options',
+			type: 'collection',
+			placeholder: 'Add Option',
+			default: {},
+			displayOptions: {
+				show: {
+					responseMode: ['responseNode'],
+				},
+			},
+			options: [
+				{
+					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+					displayName: 'Append n8n Attribution',
+					name: 'appendAttribution',
+					type: 'boolean',
+					default: true,
+					description:
+						'Whether to include the link “Form automated with n8n” at the bottom of the form',
+				},
+			],
+		},
 	],
 };
 


### PR DESCRIPTION
## Summary
Adds the option to remove the n8n attribution when using respond to webhook as the response type

## Related tickets and issues
https://community.n8n.io/t/n8n-form-trigger-append-n8n-attribution-option-is-missing/45126/5