### PR TITLE
fix(core): Prevent occassional 429s on license init in multi-main setup

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -41,6 +41,27 @@ export class License {
 		private readonly usageMetricsService: UsageMetricsService,
 	) {}
 
+	/**
+	 * Whether this instance should renew the license - on init and periodically.
+	 */
+	private renewalEnabled() {
+		const isSingleMain = !config.getEnv('multiMainSetup.enabled');
+
+		if (isSingleMain) {
+			return (
+				config.getEnv('generic.instanceType') === 'main' &&
+				config.getEnv('license.autoRenewEnabled')
+			);
+		}
+
+		/**
+		 * In multi-main setup, all mains start off with `unset` status and renewal disabled.
+		 * On becoming leader or follower, each will enable or disable renewal, respectively.
+		 * This ensures the mains do not cause a 429 (too many requests) on license init.
+		 */
+		return config.getEnv('multiMainSetup.instanceType') === 'leader';
+	}
+
 	async init(instanceType: N8nInstanceType = 'main') {
 		if (this.manager) {
 			this.logger.warn('License manager already initialized or shutting down');
@@ -53,7 +74,6 @@ export class License {
 
 		const isMainInstance = instanceType === 'main';
 		const server = config.getEnv('license.serverUrl');
-		const autoRenewEnabled = isMainInstance && config.getEnv('license.autoRenewEnabled');
 		const offlineMode = !isMainInstance;
 		const autoRenewOffset = config.getEnv('license.autoRenewOffset');
 		const saveCertStr = isMainInstance
@@ -66,13 +86,15 @@ export class License {
 			? async () => await this.usageMetricsService.collectUsageMetrics()
 			: async () => [];
 
+		const renewalEnabled = this.renewalEnabled();
+
 		try {
 			this.manager = new LicenseManager({
 				server,
 				tenantId: config.getEnv('license.tenantId'),
 				productIdentifier: `n8n-${N8N_VERSION}`,
-				autoRenewEnabled,
-				renewOnInit: autoRenewEnabled,
+				autoRenewEnabled: renewalEnabled,
+				renewOnInit: renewalEnabled,
 				autoRenewOffset,
 				offlineMode,
 				logger: this.logger,
@@ -126,7 +148,7 @@ export class License {
 
 			if (this.orchestrationService.isMultiMainSetupEnabled && !isMultiMainLicensed) {
 				this.logger.debug(
-					'[Multi-main setup] License changed with no support for multi-main setup - no new followers will be allowed to init. To restore multi-main setup, please upgrade to a license that supporst this feature.',
+					'[Multi-main setup] License changed with no support for multi-main setup - no new followers will be allowed to init. To restore multi-main setup, please upgrade to a license that supports this feature.',
 				);
 			}
 		}
@@ -334,5 +356,10 @@ export class License {
 
 	isWithinUsersLimit() {
 		return this.getUsersLimit() === UNLIMITED_LICENSE_QUOTA;
+	}
+
+	async reinit() {
+		this.manager?.reset();
+		await this.init();
 	}
 }

--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -47,16 +47,18 @@ export class License {
 	private renewalEnabled(instanceType: N8nInstanceType) {
 		if (instanceType !== 'main') return false;
 
+		const autoRenewEnabled = config.getEnv('license.autoRenewEnabled');
+
 		/**
 		 * In multi-main setup, all mains start off with `unset` status and so renewal disabled.
 		 * On becoming leader or follower, each will enable or disable renewal, respectively.
 		 * This ensures the mains do not cause a 429 (too many requests) on license init.
 		 */
 		if (config.getEnv('multiMainSetup.enabled')) {
-			return config.getEnv('multiMainSetup.instanceType') === 'leader';
+			return autoRenewEnabled && config.getEnv('multiMainSetup.instanceType') === 'leader';
 		}
 
-		return config.getEnv('license.autoRenewEnabled');
+		return autoRenewEnabled;
 	}
 
 	async init(instanceType: N8nInstanceType = 'main') {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -41,6 +41,8 @@ export abstract class BaseCommand extends Command {
 
 	protected shutdownService: ShutdownService = Container.get(ShutdownService);
 
+	protected license: License;
+
 	/**
 	 * How long to wait for graceful shutdown before force killing the process.
 	 */
@@ -269,13 +271,13 @@ export abstract class BaseCommand extends Command {
 	}
 
 	async initLicense(): Promise<void> {
-		const license = Container.get(License);
-		await license.init(this.instanceType ?? 'main');
+		this.license = Container.get(License);
+		await this.license.init(this.instanceType ?? 'main');
 
 		const activationKey = config.getEnv('license.activationKey');
 
 		if (activationKey) {
-			const hasCert = (await license.loadCertStr()).length > 0;
+			const hasCert = (await this.license.loadCertStr()).length > 0;
 
 			if (hasCert) {
 				return this.logger.debug('Skipping license activation');
@@ -283,7 +285,7 @@ export abstract class BaseCommand extends Command {
 
 			try {
 				this.logger.debug('Attempting license activation');
-				await license.activate(activationKey);
+				await this.license.activate(activationKey);
 				this.logger.debug('License init complete');
 			} catch (e) {
 				this.logger.error('Could not activate license', e as Error);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -211,9 +211,11 @@ export class Start extends BaseCommand {
 
 		orchestrationService.multiMainSetup
 			.on('leader-stepdown', async () => {
+				await this.license.reinit(); // to disable renewal
 				await this.activeWorkflowRunner.removeAllTriggerAndPollerBasedWorkflows();
 			})
 			.on('leader-takeover', async () => {
+				await this.license.reinit(); // to enable renewal
 				await this.activeWorkflowRunner.addAllTriggerAndPollerBasedWorkflows();
 			});
 	}

--- a/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
+++ b/packages/cli/src/services/orchestration/main/MultiMainSetup.ee.ts
@@ -77,7 +77,10 @@ export class MultiMainSetup extends EventEmitter {
 
 			config.set('multiMainSetup.instanceType', 'follower');
 
-			this.emit('leader-stepdown'); // lost leadership - stop triggers, pollers, pruning
+			/**
+			 * Lost leadership - stop triggers, pollers, pruning, wait tracking, license renewal
+			 */
+			this.emit('leader-stepdown');
 
 			await this.tryBecomeLeader();
 		}
@@ -97,7 +100,10 @@ export class MultiMainSetup extends EventEmitter {
 
 			await this.redisPublisher.setExpiration(this.leaderKey, this.leaderKeyTtl);
 
-			this.emit('leader-takeover'); // gained leadership - start triggers, pollers, pruning, wait-tracking
+			/**
+			 * Gained leadership - start triggers, pollers, pruning, wait-tracking, license renewal
+			 */
+			this.emit('leader-takeover');
 		} else {
 			config.set('multiMainSetup.instanceType', 'follower');
 		}

--- a/packages/cli/test/unit/License.test.ts
+++ b/packages/cli/test/unit/License.test.ts
@@ -175,3 +175,54 @@ describe('License', () => {
 		expect(mainPlan).toBeUndefined();
 	});
 });
+
+describe('License', () => {
+	beforeEach(() => {
+		config.load(config.default);
+	});
+
+	describe('init', () => {
+		test('in single-main setup, should enable renewal', async () => {
+			config.set('multiMainSetup.enabled', false);
+
+			await new License(mock(), mock(), mock(), mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: true, renewOnInit: true }),
+			);
+		});
+
+		test('in multi-main setup, should disable renewal if unset', async () => {
+			config.set('multiMainSetup.enabled', true);
+			config.set('multiMainSetup.instanceType', 'unset');
+
+			await new License(mock(), mock(), mock(), mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: false, renewOnInit: false }),
+			);
+		});
+
+		test('in multi-main setup, should enable renewal if leader', async () => {
+			config.set('multiMainSetup.enabled', true);
+			config.set('multiMainSetup.instanceType', 'leader');
+
+			await new License(mock(), mock(), mock(), mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: true, renewOnInit: true }),
+			);
+		});
+
+		test('in multi-main setup, should disable renewal if follower', async () => {
+			config.set('multiMainSetup.enabled', true);
+			config.set('multiMainSetup.instanceType', 'follower');
+
+			await new License(mock(), mock(), mock(), mock(), mock()).init();
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: false, renewOnInit: false }),
+			);
+		});
+	});
+});


### PR DESCRIPTION
This PR fixes occassional 429s caused by multiple mains renewing the license on init.

In single-main setup, we keep initial and periodic renewals untouched. In multi-main setup, all instances start off with initial and periodic renewals disabled and, on leadership transition, the leader re-inits the license to enable them and followers re-init the license to disable them.

https://linear.app/n8n/issue/PAY-1517

Fixes https://github.com/n8n-io/n8n/issues/9164