### PR TITLE
feat(core): Allow transfering/deleting workflows and credentials when resetting LDAP, instead of orphaning them

### DIFF
--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -58,7 +58,7 @@ export class ImportWorkflowsCommand extends BaseCommand {
 			description: 'The ID of the user to assign the imported workflows to',
 		}),
 		projectId: Flags.string({
-			description: 'The ID of the project to assign the imported credential to',
+			description: 'The ID of the project to assign the imported workflows to',
 		}),
 	};
 

--- a/packages/cli/src/commands/ldap/reset.ts
+++ b/packages/cli/src/commands/ldap/reset.ts
@@ -5,15 +5,111 @@ import { AuthProviderSyncHistoryRepository } from '@db/repositories/authProvider
 import { SettingsRepository } from '@db/repositories/settings.repository';
 import { UserRepository } from '@db/repositories/user.repository';
 import { BaseCommand } from '../BaseCommand';
+import { Flags } from '@oclif/core';
+import { ApplicationError } from 'n8n-workflow';
+import { ProjectRepository } from '@/databases/repositories/project.repository';
+import { WorkflowService } from '@/workflows/workflow.service';
+import { In } from '@n8n/typeorm';
+import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
+import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
+import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+import { CredentialsService } from '@/credentials/credentials.service';
+import { UM_FIX_INSTRUCTION } from '@/constants';
+
+const wrongFlagsError =
+	'You must use exactly one of `--userId`, `--projectId` or `--deleteWorkflowsAndCredentials`.';
 
 export class Reset extends BaseCommand {
-	static description = '\nResets the database to the default ldap state';
+	static description =
+		'\nResets the database to the default ldap state.\n\nTHIS DELETES ALL LDAP MANAGED USERS.';
+
+	static examples = [
+		'$ n8n ldap:reset --userId=1d64c3d2-85fe-4a83-a649-e446b07b3aae',
+		'$ n8n ldap:reset --projectId=Ox8O54VQrmBrb4qL',
+		'$ n8n ldap:reset --deleteWorkflowsAndCredentials',
+	];
+
+	static flags = {
+		help: Flags.help({ char: 'h' }),
+		userId: Flags.string({
+			description:
+				'The ID of the user to assign the workflows and credentials owned by the deleted LDAP users to',
+		}),
+		projectId: Flags.string({
+			description:
+				'The ID of the project to assign the workflows and credentials owned by the deleted LDAP users to',
+		}),
+		deleteWorkflowsAndCredentials: Flags.boolean({
+			description:
+				'Delete all workflows and credentials owned by the users that were created by the users managed via LDAP.',
+		}),
+	};
 
 	async run(): Promise<void> {
+		const { flags } = await this.parse(Reset);
+		const numberOfOptions =
+			Number(!!flags.userId) +
+			Number(!!flags.projectId) +
+			Number(!!flags.deleteWorkflowsAndCredentials);
+
+		if (numberOfOptions !== 1) {
+			throw new ApplicationError(wrongFlagsError);
+		}
+
+		const owner = await this.getOwner();
 		const ldapIdentities = await Container.get(AuthIdentityRepository).find({
 			where: { providerType: 'ldap' },
 			select: ['userId'],
 		});
+		const personalProjectIds = await Container.get(
+			ProjectRelationRepository,
+		).getPersonalProjectsForUsers(ldapIdentities.map((i) => i.userId));
+
+		// Migrate all workflows and credentials to another project.
+		if (flags.projectId ?? flags.userId) {
+			if (flags.userId && ldapIdentities.some((i) => i.userId === flags.userId)) {
+				throw new ApplicationError(
+					`Can't migrate workflows and credentials to the user with the ID ${flags.userId}. That user was created via LDAP and will be deleted as well.`,
+				);
+			}
+
+			if (flags.projectId && personalProjectIds.includes(flags.projectId)) {
+				throw new ApplicationError(
+					`Can't migrate workflows and credentials to the project with the ID ${flags.projectId}. That project is a personal project belonging to a user that was created via LDAP and will be deleted as well.`,
+				);
+			}
+
+			const project = await this.getProject(flags.userId, flags.projectId);
+
+			await Container.get(UserRepository).manager.transaction(async (trx) => {
+				for (const projectId of personalProjectIds) {
+					await Container.get(WorkflowService).transferAll(projectId, project.id, trx);
+					await Container.get(CredentialsService).transferAll(projectId, project.id, trx);
+				}
+			});
+		}
+
+		const [ownedSharedWorkflows, ownedSharedCredentials] = await Promise.all([
+			Container.get(SharedWorkflowRepository).find({
+				select: { workflowId: true },
+				where: { projectId: In(personalProjectIds), role: 'workflow:owner' },
+			}),
+			Container.get(SharedCredentialsRepository).find({
+				relations: { credentials: true },
+				where: { projectId: In(personalProjectIds), role: 'credential:owner' },
+			}),
+		]);
+
+		const ownedCredentials = ownedSharedCredentials.map(({ credentials }) => credentials);
+
+		for (const { workflowId } of ownedSharedWorkflows) {
+			await Container.get(WorkflowService).delete(owner, workflowId);
+		}
+
+		for (const credential of ownedCredentials) {
+			await Container.get(CredentialsService).delete(credential);
+		}
+
 		await Container.get(AuthProviderSyncHistoryRepository).delete({ providerType: 'ldap' });
 		await Container.get(AuthIdentityRepository).delete({ providerType: 'ldap' });
 		await Container.get(UserRepository).deleteMany(ldapIdentities.map((i) => i.userId));
@@ -27,8 +123,43 @@ export class Reset extends BaseCommand {
 		this.logger.info('Successfully reset the database to default ldap state.');
 	}
 
+	async getProject(userId?: string, projectId?: string) {
+		if (projectId) {
+			const project = await Container.get(ProjectRepository).findOneBy({ id: projectId });
+
+			if (project === null) {
+				throw new ApplicationError(`Could not find the project with the ID ${projectId}.`);
+			}
+
+			return project;
+		}
+
+		if (userId) {
+			const project = await Container.get(ProjectRepository).getPersonalProjectForUser(userId);
+
+			if (project === null) {
+				throw new ApplicationError(
+					`Could not find the user with the ID ${userId} or their personalProject.`,
+				);
+			}
+
+			return project;
+		}
+
+		throw new ApplicationError(wrongFlagsError);
+	}
+
 	async catch(error: Error): Promise<void> {
 		this.logger.error('Error resetting database. See log messages for details.');
 		this.logger.error(error.message);
+	}
+
+	private async getOwner() {
+		const owner = await Container.get(UserRepository).findOneBy({ role: 'global:owner' });
+		if (!owner) {
+			throw new ApplicationError(`Failed to find owner. ${UM_FIX_INSTRUCTION}`);
+		}
+
+		return owner;
 	}
 }

--- a/packages/cli/src/commands/ldap/reset.ts
+++ b/packages/cli/src/commands/ldap/reset.ts
@@ -113,6 +113,7 @@ export class Reset extends BaseCommand {
 		await Container.get(AuthProviderSyncHistoryRepository).delete({ providerType: 'ldap' });
 		await Container.get(AuthIdentityRepository).delete({ providerType: 'ldap' });
 		await Container.get(UserRepository).deleteMany(ldapIdentities.map((i) => i.userId));
+		await Container.get(ProjectRepository).delete({ id: In(personalProjectIds) });
 		await Container.get(SettingsRepository).delete({ key: LDAP_FEATURE_NAME });
 		await Container.get(SettingsRepository).insert({
 			key: LDAP_FEATURE_NAME,

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -2,8 +2,6 @@ import { plainToInstance } from 'class-transformer';
 
 import { AuthService } from '@/auth/auth.service';
 import { User } from '@db/entities/User';
-import { SharedCredentials } from '@db/entities/SharedCredentials';
-import { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import { GlobalScope, Delete, Get, RestController, Patch, Licensed } from '@/decorators';
 import {
 	ListQuery,
@@ -29,7 +27,6 @@ import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { Project } from '@/databases/entities/Project';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { CredentialsService } from '@/credentials/credentials.service';
-import { In } from '@n8n/typeorm';
 import { ProjectService } from '@/services/project.service';
 
 @RestController('/users')

--- a/packages/cli/src/databases/repositories/projectRelation.repository.ts
+++ b/packages/cli/src/databases/repositories/projectRelation.repository.ts
@@ -18,6 +18,17 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 		});
 	}
 
+	async getPersonalProjectsForUsers(userIds: string[]) {
+		const projectRelations = await this.find({
+			where: {
+				userId: In(userIds),
+				role: 'project:personalOwner',
+			},
+		});
+
+		return projectRelations.map((pr) => pr.projectId);
+	}
+
 	/**
 	 * Find the role of a user in a project.
 	 */

--- a/packages/cli/test/integration/commands/ldap/reset.test.ts
+++ b/packages/cli/test/integration/commands/ldap/reset.test.ts
@@ -46,10 +46,6 @@ beforeAll(async () => {
 	await testDb.init();
 });
 
-beforeEach(async () => {
-	await testDb.truncate([]);
-});
-
 afterAll(async () => {
 	await testDb.terminate();
 });

--- a/packages/cli/test/integration/commands/ldap/reset.test.ts
+++ b/packages/cli/test/integration/commands/ldap/reset.test.ts
@@ -17,7 +17,7 @@ import { EntityNotFoundError } from '@n8n/typeorm';
 import { Push } from '@/push';
 import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
-import { createTeamProject, getPersonalProject } from '../../shared/db/projects';
+import { createTeamProject, findProject, getPersonalProject } from '../../shared/db/projects';
 import { WaitTracker } from '@/WaitTracker';
 import { getLdapSynchronizations, saveLdapSynchronization } from '@/Ldap/helpers';
 import { createLdapConfig } from '../../shared/ldap';
@@ -82,6 +82,7 @@ describe('--deleteWorkflowsAndCredentials', () => {
 		// ARRANGE
 		//
 		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: member,
@@ -105,6 +106,7 @@ describe('--deleteWorkflowsAndCredentials', () => {
 		//
 		// LDAP user is deleted
 		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+		await expect(findProject(memberProject.id)).rejects.toThrowError(EntityNotFoundError);
 		await expect(
 			Container.get(WorkflowRepository).findOneBy({ id: workflow.id }),
 		).resolves.toBeNull();
@@ -196,6 +198,7 @@ describe('--userId', () => {
 		// ARRANGE
 		//
 		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: member,
@@ -220,6 +223,7 @@ describe('--userId', () => {
 		//
 		// LDAP user is deleted
 		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+		await expect(findProject(memberProject.id)).rejects.toThrowError(EntityNotFoundError);
 
 		// Their workflow and credential have been migrated to the normal user.
 		await expect(
@@ -271,6 +275,7 @@ describe('--projectId', () => {
 		// ARRANGE
 		//
 		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: member,
@@ -295,6 +300,7 @@ describe('--projectId', () => {
 		//
 		// LDAP user is deleted
 		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+		await expect(findProject(memberProject.id)).rejects.toThrowError(EntityNotFoundError);
 
 		// Their workflow and credential have been migrated to the normal user.
 		await expect(
@@ -325,6 +331,7 @@ describe('--projectId', () => {
 		// ARRANGE
 		//
 		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: member,
@@ -350,6 +357,7 @@ describe('--projectId', () => {
 		//
 		// LDAP user is deleted
 		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+		await expect(findProject(memberProject.id)).rejects.toThrowError(EntityNotFoundError);
 
 		// Their workflow and credential have been migrated to the team project.
 		await expect(

--- a/packages/cli/test/integration/commands/ldap/reset.test.ts
+++ b/packages/cli/test/integration/commands/ldap/reset.test.ts
@@ -2,7 +2,6 @@ import { Reset } from '@/commands/ldap/reset';
 import { Config } from '@oclif/core';
 
 import * as testDb from '../../shared/testDb';
-import { nanoid } from 'nanoid';
 import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
 import { mockInstance } from '../../../shared/mocking';
 import { InternalHooks } from '@/InternalHooks';
@@ -22,6 +21,7 @@ import { WaitTracker } from '@/WaitTracker';
 import { getLdapSynchronizations, saveLdapSynchronization } from '@/Ldap/helpers';
 import { createLdapConfig } from '../../shared/ldap';
 import { LdapService } from '@/Ldap/ldap.service';
+import { v4 as uuid } from 'uuid';
 
 const oclifConfig = new Config({ root: __dirname });
 
@@ -61,12 +61,12 @@ test('fails if neither `--userId` nor `--projectId` nor `--deleteWorkflowsAndCre
 });
 
 test.each([
-	[`--userId=${nanoid()}`, `--projectId=${nanoid()}`, '--deleteWorkflowsAndCredentials'],
+	[`--userId=${uuid()}`, `--projectId=${uuid()}`, '--deleteWorkflowsAndCredentials'],
 
-	[`--userId=${nanoid()}`, `--projectId=${nanoid()}`],
-	[`--userId=${nanoid()}`, '--deleteWorkflowsAndCredentials'],
+	[`--userId=${uuid()}`, `--projectId=${uuid()}`],
+	[`--userId=${uuid()}`, '--deleteWorkflowsAndCredentials'],
 
-	['--deleteWorkflowsAndCredentials', `--projectId=${nanoid()}`],
+	['--deleteWorkflowsAndCredentials', `--projectId=${uuid()}`],
 ])(
 	'fails if more than one of `--userId`, `--projectId`, `--deleteWorkflowsAndCredentials` are passed',
 	async (...argv) => {
@@ -81,7 +81,7 @@ describe('--deleteWorkflowsAndCredentials', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
@@ -176,7 +176,7 @@ describe('--deleteWorkflowsAndCredentials', () => {
 
 describe('--userId', () => {
 	test('fails if the user does not exist', async () => {
-		const userId = nanoid();
+		const userId = uuid();
 		await expect(resetLDAP([`--userId=${userId}`])).rejects.toThrowError(
 			`Could not find the user with the ID ${userId} or their personalProject.`,
 		);
@@ -186,7 +186,7 @@ describe('--userId', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 
 		await expect(resetLDAP([`--userId=${member.id}`])).rejects.toThrowError(
 			`Can't migrate workflows and credentials to the user with the ID ${member.id}. That user was created via LDAP and will be deleted as well.`,
@@ -197,7 +197,7 @@ describe('--userId', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
@@ -252,7 +252,7 @@ describe('--userId', () => {
 
 describe('--projectId', () => {
 	test('fails if the project does not exist', async () => {
-		const projectId = nanoid();
+		const projectId = uuid();
 		await expect(resetLDAP([`--projectId=${projectId}`])).rejects.toThrowError(
 			`Could not find the project with the ID ${projectId}.`,
 		);
@@ -262,7 +262,7 @@ describe('--projectId', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 		const memberProject = await getPersonalProject(member);
 
 		await expect(resetLDAP([`--projectId=${memberProject.id}`])).rejects.toThrowError(
@@ -274,7 +274,7 @@ describe('--projectId', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {
@@ -330,7 +330,7 @@ describe('--projectId', () => {
 		//
 		// ARRANGE
 		//
-		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const member = await createLdapUser({ role: 'global:member' }, uuid());
 		const memberProject = await getPersonalProject(member);
 		const workflow = await createWorkflow({}, member);
 		const credential = await saveCredential(randomCredentialPayload(), {

--- a/packages/cli/test/integration/commands/ldap/reset.test.ts
+++ b/packages/cli/test/integration/commands/ldap/reset.test.ts
@@ -1,0 +1,377 @@
+import { Reset } from '@/commands/ldap/reset';
+import { Config } from '@oclif/core';
+
+import * as testDb from '../../shared/testDb';
+import { nanoid } from 'nanoid';
+import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
+import { mockInstance } from '../../../shared/mocking';
+import { InternalHooks } from '@/InternalHooks';
+import { createLdapUser, createMember, getUserById } from '../../shared/db/users';
+import { createWorkflow } from '../../shared/db/workflows';
+import { randomCredentialPayload } from '../../shared/random';
+import { saveCredential } from '../../shared/db/credentials';
+import Container from 'typedi';
+import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
+import { EntityNotFoundError } from '@n8n/typeorm';
+import { Push } from '@/push';
+import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
+import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
+import { createTeamProject, getPersonalProject } from '../../shared/db/projects';
+import { WaitTracker } from '@/WaitTracker';
+import { getLdapSynchronizations, saveLdapSynchronization } from '@/Ldap/helpers';
+import { createLdapConfig } from '../../shared/ldap';
+import { LdapService } from '@/Ldap/ldap.service';
+
+const oclifConfig = new Config({ root: __dirname });
+
+async function resetLDAP(argv: string[]) {
+	const cmd = new Reset(argv, oclifConfig);
+	try {
+		await cmd.init();
+	} catch (error) {
+		console.error(error);
+		throw error;
+	}
+	await cmd.run();
+}
+
+beforeAll(async () => {
+	mockInstance(Push);
+	mockInstance(InternalHooks);
+	mockInstance(LoadNodesAndCredentials);
+	// This needs to be mocked, otherwise the time setInterval would prevent jest
+	// from exiting properly.
+	mockInstance(WaitTracker);
+	await testDb.init();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([]);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+test('fails if neither `--userId` nor `--projectId` nor `--deleteWorkflowsAndCredentials` is passed', async () => {
+	await expect(resetLDAP([])).rejects.toThrowError(
+		'You must use exactly one of `--userId`, `--projectId` or `--deleteWorkflowsAndCredentials`.',
+	);
+});
+
+test.each([
+	[`--userId=${nanoid()}`, `--projectId=${nanoid()}`, '--deleteWorkflowsAndCredentials'],
+
+	[`--userId=${nanoid()}`, `--projectId=${nanoid()}`],
+	[`--userId=${nanoid()}`, '--deleteWorkflowsAndCredentials'],
+
+	['--deleteWorkflowsAndCredentials', `--projectId=${nanoid()}`],
+])(
+	'fails if more than one of `--userId`, `--projectId`, `--deleteWorkflowsAndCredentials` are passed',
+	async (...argv) => {
+		await expect(resetLDAP(argv)).rejects.toThrowError(
+			'You must use exactly one of `--userId`, `--projectId` or `--deleteWorkflowsAndCredentials`.',
+		);
+	},
+);
+
+describe('--deleteWorkflowsAndCredentials', () => {
+	test('deletes personal projects, workflows and credentials owned by LDAP managed users', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const workflow = await createWorkflow({}, member);
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+			role: 'credential:owner',
+		});
+
+		const normalMember = await createMember();
+		const workflow2 = await createWorkflow({}, normalMember);
+		const credential2 = await saveCredential(randomCredentialPayload(), {
+			user: normalMember,
+			role: 'credential:owner',
+		});
+
+		//
+		// ACT
+		//
+		await resetLDAP(['--deleteWorkflowsAndCredentials']);
+
+		//
+		// ASSERT
+		//
+		// LDAP user is deleted
+		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+		await expect(
+			Container.get(WorkflowRepository).findOneBy({ id: workflow.id }),
+		).resolves.toBeNull();
+		await expect(
+			Container.get(CredentialsRepository).findOneBy({ id: credential.id }),
+		).resolves.toBeNull();
+
+		// Non LDAP user is not deleted
+		await expect(getUserById(normalMember.id)).resolves.not.toThrowError();
+		await expect(
+			Container.get(WorkflowRepository).findOneBy({ id: workflow2.id }),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(CredentialsRepository).findOneBy({ id: credential2.id }),
+		).resolves.not.toBeNull();
+	});
+
+	test('deletes the LDAP sync history', async () => {
+		//
+		// ARRANGE
+		//
+		await saveLdapSynchronization({
+			created: 1,
+			disabled: 1,
+			scanned: 1,
+			updated: 1,
+			endedAt: new Date(),
+			startedAt: new Date(),
+			error: '',
+			runMode: 'dry',
+			status: 'success',
+		});
+
+		//
+		// ACT
+		//
+		await resetLDAP(['--deleteWorkflowsAndCredentials']);
+
+		//
+		// ASSERT
+		//
+		await expect(getLdapSynchronizations(0, 10)).resolves.toHaveLength(0);
+	});
+
+	test('resets LDAP settings', async () => {
+		//
+		// ARRANGE
+		//
+		await createLdapConfig();
+		await expect(Container.get(LdapService).loadConfig()).resolves.toMatchObject({
+			loginEnabled: true,
+		});
+
+		//
+		// ACT
+		//
+		await resetLDAP(['--deleteWorkflowsAndCredentials']);
+
+		//
+		// ASSERT
+		//
+		await expect(Container.get(LdapService).loadConfig()).resolves.toMatchObject({
+			loginEnabled: false,
+		});
+	});
+});
+
+describe('--userId', () => {
+	test('fails if the user does not exist', async () => {
+		const userId = nanoid();
+		await expect(resetLDAP([`--userId=${userId}`])).rejects.toThrowError(
+			`Could not find the user with the ID ${userId} or their personalProject.`,
+		);
+	});
+
+	test('fails if the user to migrate to is also an LDAP user', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+
+		await expect(resetLDAP([`--userId=${member.id}`])).rejects.toThrowError(
+			`Can't migrate workflows and credentials to the user with the ID ${member.id}. That user was created via LDAP and will be deleted as well.`,
+		);
+	});
+
+	test("transfers all workflows and credentials to the user's personal project", async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const workflow = await createWorkflow({}, member);
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+			role: 'credential:owner',
+		});
+
+		const normalMember = await createMember();
+		const normalMemberProject = await getPersonalProject(normalMember);
+		const workflow2 = await createWorkflow({}, normalMember);
+		const credential2 = await saveCredential(randomCredentialPayload(), {
+			user: normalMember,
+			role: 'credential:owner',
+		});
+
+		//
+		// ACT
+		//
+		await resetLDAP([`--userId=${normalMember.id}`]);
+
+		//
+		// ASSERT
+		//
+		// LDAP user is deleted
+		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+
+		// Their workflow and credential have been migrated to the normal user.
+		await expect(
+			Container.get(SharedWorkflowRepository).findOneBy({
+				workflowId: workflow.id,
+				projectId: normalMemberProject.id,
+			}),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(SharedCredentialsRepository).findOneBy({
+				credentialsId: credential.id,
+				projectId: normalMemberProject.id,
+			}),
+		).resolves.not.toBeNull();
+
+		// Non LDAP user is not deleted
+		await expect(getUserById(normalMember.id)).resolves.not.toThrowError();
+		await expect(
+			Container.get(WorkflowRepository).findOneBy({ id: workflow2.id }),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(CredentialsRepository).findOneBy({ id: credential2.id }),
+		).resolves.not.toBeNull();
+	});
+});
+
+describe('--projectId', () => {
+	test('fails if the project does not exist', async () => {
+		const projectId = nanoid();
+		await expect(resetLDAP([`--projectId=${projectId}`])).rejects.toThrowError(
+			`Could not find the project with the ID ${projectId}.`,
+		);
+	});
+
+	test('fails if the user to migrate to is also an LDAP user', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const memberProject = await getPersonalProject(member);
+
+		await expect(resetLDAP([`--projectId=${memberProject.id}`])).rejects.toThrowError(
+			`Can't migrate workflows and credentials to the project with the ID ${memberProject.id}. That project is a personal project belonging to a user that was created via LDAP and will be deleted as well.`,
+		);
+	});
+
+	test('transfers all workflows and credentials to a personal project', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const workflow = await createWorkflow({}, member);
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+			role: 'credential:owner',
+		});
+
+		const normalMember = await createMember();
+		const normalMemberProject = await getPersonalProject(normalMember);
+		const workflow2 = await createWorkflow({}, normalMember);
+		const credential2 = await saveCredential(randomCredentialPayload(), {
+			user: normalMember,
+			role: 'credential:owner',
+		});
+
+		//
+		// ACT
+		//
+		await resetLDAP([`--projectId=${normalMemberProject.id}`]);
+
+		//
+		// ASSERT
+		//
+		// LDAP user is deleted
+		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+
+		// Their workflow and credential have been migrated to the normal user.
+		await expect(
+			Container.get(SharedWorkflowRepository).findOneBy({
+				workflowId: workflow.id,
+				projectId: normalMemberProject.id,
+			}),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(SharedCredentialsRepository).findOneBy({
+				credentialsId: credential.id,
+				projectId: normalMemberProject.id,
+			}),
+		).resolves.not.toBeNull();
+
+		// Non LDAP user is not deleted
+		await expect(getUserById(normalMember.id)).resolves.not.toThrowError();
+		await expect(
+			Container.get(WorkflowRepository).findOneBy({ id: workflow2.id }),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(CredentialsRepository).findOneBy({ id: credential2.id }),
+		).resolves.not.toBeNull();
+	});
+
+	test('transfers all workflows and credentials to a team project', async () => {
+		//
+		// ARRANGE
+		//
+		const member = await createLdapUser({ role: 'global:member' }, nanoid());
+		const workflow = await createWorkflow({}, member);
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+			role: 'credential:owner',
+		});
+
+		const normalMember = await createMember();
+		const workflow2 = await createWorkflow({}, normalMember);
+		const credential2 = await saveCredential(randomCredentialPayload(), {
+			user: normalMember,
+			role: 'credential:owner',
+		});
+
+		const teamProject = await createTeamProject();
+
+		//
+		// ACT
+		//
+		await resetLDAP([`--projectId=${teamProject.id}`]);
+
+		//
+		// ASSERT
+		//
+		// LDAP user is deleted
+		await expect(getUserById(member.id)).rejects.toThrowError(EntityNotFoundError);
+
+		// Their workflow and credential have been migrated to the team project.
+		await expect(
+			Container.get(SharedWorkflowRepository).findOneBy({
+				workflowId: workflow.id,
+				projectId: teamProject.id,
+			}),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(SharedCredentialsRepository).findOneBy({
+				credentialsId: credential.id,
+				projectId: teamProject.id,
+			}),
+		).resolves.not.toBeNull();
+
+		// Non LDAP user is not deleted
+		await expect(getUserById(normalMember.id)).resolves.not.toThrowError();
+		await expect(
+			Container.get(WorkflowRepository).findOneBy({ id: workflow2.id }),
+		).resolves.not.toBeNull();
+		await expect(
+			Container.get(CredentialsRepository).findOneBy({ id: credential2.id }),
+		).resolves.not.toBeNull();
+	});
+});

--- a/packages/cli/test/integration/ldap/ldap.api.test.ts
+++ b/packages/cli/test/integration/ldap/ldap.api.test.ts
@@ -2,15 +2,13 @@ import Container from 'typedi';
 import type { SuperAgentTest } from 'supertest';
 import type { Entry as LdapUser } from 'ldapts';
 import { Not } from '@n8n/typeorm';
-import { jsonParse } from 'n8n-workflow';
 import { Cipher } from 'n8n-core';
 
 import config from '@/config';
 import type { User } from '@db/entities/User';
-import { LDAP_DEFAULT_CONFIGURATION, LDAP_FEATURE_NAME } from '@/Ldap/constants';
+import { LDAP_DEFAULT_CONFIGURATION } from '@/Ldap/constants';
 import { LdapService } from '@/Ldap/ldap.service';
 import { saveLdapSynchronization } from '@/Ldap/helpers';
-import type { LdapConfig } from '@/Ldap/types';
 import { getCurrentAuthenticationMethod, setCurrentAuthenticationMethod } from '@/sso/ssoHelpers';
 
 import { randomEmail, randomName, uniqueId } from './../shared/random';
@@ -19,28 +17,14 @@ import * as utils from '../shared/utils/';
 
 import { createLdapUser, createUser, getAllUsers, getLdapIdentities } from '../shared/db/users';
 import { UserRepository } from '@db/repositories/user.repository';
-import { SettingsRepository } from '@db/repositories/settings.repository';
 import { AuthProviderSyncHistoryRepository } from '@db/repositories/authProviderSyncHistory.repository';
 import { getPersonalProject } from '../shared/db/projects';
+import { createLdapConfig, defaultLdapConfig } from '../shared/ldap';
 
 jest.mock('@/telemetry');
 
 let owner: User;
 let authOwnerAgent: SuperAgentTest;
-
-const defaultLdapConfig = {
-	...LDAP_DEFAULT_CONFIGURATION,
-	loginEnabled: true,
-	loginLabel: '',
-	ldapIdAttribute: 'uid',
-	firstNameAttribute: 'givenName',
-	lastNameAttribute: 'sn',
-	emailAttribute: 'mail',
-	loginIdAttribute: 'mail',
-	baseDn: 'baseDn',
-	bindingAdminDn: 'adminDn',
-	bindingAdminPassword: 'adminPassword',
-};
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['auth', 'ldap'],
@@ -74,18 +58,6 @@ beforeEach(async () => {
 
 	await setCurrentAuthenticationMethod('email');
 });
-
-const createLdapConfig = async (attributes: Partial<LdapConfig> = {}): Promise<LdapConfig> => {
-	const { value: ldapConfig } = await Container.get(SettingsRepository).save({
-		key: LDAP_FEATURE_NAME,
-		value: JSON.stringify({
-			...defaultLdapConfig,
-			...attributes,
-		}),
-		loadOnStartup: true,
-	});
-	return await jsonParse(ldapConfig);
-};
 
 test('Member role should not be able to access ldap routes', async () => {
 	const member = await createUser({ role: 'global:member' });

--- a/packages/cli/test/integration/shared/ldap.ts
+++ b/packages/cli/test/integration/shared/ldap.ts
@@ -1,0 +1,33 @@
+import { LDAP_DEFAULT_CONFIGURATION, LDAP_FEATURE_NAME } from '@/Ldap/constants';
+import type { LdapConfig } from '@/Ldap/types';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
+import { jsonParse } from 'n8n-workflow';
+import Container from 'typedi';
+
+export const defaultLdapConfig = {
+	...LDAP_DEFAULT_CONFIGURATION,
+	loginEnabled: true,
+	loginLabel: '',
+	ldapIdAttribute: 'uid',
+	firstNameAttribute: 'givenName',
+	lastNameAttribute: 'sn',
+	emailAttribute: 'mail',
+	loginIdAttribute: 'mail',
+	baseDn: 'baseDn',
+	bindingAdminDn: 'adminDn',
+	bindingAdminPassword: 'adminPassword',
+};
+
+export const createLdapConfig = async (
+	attributes: Partial<LdapConfig> = {},
+): Promise<LdapConfig> => {
+	const { value: ldapConfig } = await Container.get(SettingsRepository).save({
+		key: LDAP_FEATURE_NAME,
+		value: JSON.stringify({
+			...defaultLdapConfig,
+			...attributes,
+		}),
+		loadOnStartup: true,
+	});
+	return await jsonParse(ldapConfig);
+};


### PR DESCRIPTION
## Summary

It's best to review this commit by commit.

So far `n8n ldap:reset` just reset the LDAP configuration and deleted the users that use LDAP to authenticate.
That left their workflows and credentials orphaned.

This PR introduces 3 new flags:

1. `--deleteWorkflowsAndCredentials`: delete all workflows and credentials owned by the users that are deleted
2. `--userId=[ID]`: transfer all workflows and credentials to the user with said ID. The user must not use LDAP to authenticate.
3. `--projectId=[ID]`: transfer all workflows and credentials to the project with said ID. If the project is personal project, then the user owning it must not use LDAP to authenticate.

Additionally this contains to smaller refactors:

1. the credential and workflow transfer logic is extracted from the controller into a service function so it can be re-used (also keeping in mind that in soon we want to allow moving workflows and credentials from team project to team project)
2. the LDAP setup helpers are extracted out into a shared test module so they can be re-used by the integration tests for the LDAP command


## Related tickets and issues

https://linear.app/n8n/issue/PAY-1550/cli-command-ldapreset-deletes-users-but-not-their-personal-project

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Docs ticket: https://linear.app/n8n/issue/PAY-1112/create-docs-for-new-rbac-functionality
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

