### PR TITLE
fix(Gmail Node): Remove duplicate options when creating drafts

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/DraftDescription.ts
@@ -117,49 +117,6 @@ export const draftFields: INodeProperties[] = [
 		default: {},
 		options: [
 			{
-				displayName: 'To Email',
-				name: 'sendTo',
-				type: 'string',
-				default: '',
-				placeholder: 'info@example.com',
-				description:
-					'The email addresses of the recipients. Multiple addresses can be separated by a comma. e.g. jay@getsby.com, jon@smith.com.',
-			},
-			{
-				displayName: 'BCC',
-				name: 'bccList',
-				type: 'string',
-				description:
-					'The email addresses of the blind copy recipients. Multiple addresses can be separated by a comma. e.g. jay@getsby.com, jon@smith.com.',
-				placeholder: 'info@example.com',
-				default: '',
-			},
-			{
-				displayName: 'CC',
-				name: 'ccList',
-				type: 'string',
-				description:
-					'The email addresses of the copy recipients. Multiple addresses can be separated by a comma. e.g. jay@getsby.com, jon@smith.com.',
-				placeholder: 'info@example.com',
-				default: '',
-			},
-			{
-				displayName: 'Send Replies To',
-				name: 'replyTo',
-				type: 'string',
-				placeholder: 'reply@example.com',
-				default: '',
-				description: 'The email address that the reply message is sent to',
-			},
-			{
-				displayName: 'Thread ID',
-				name: 'threadId',
-				type: 'string',
-				placeholder: '18cc573e2431878f',
-				default: '',
-				description: 'The identifier of the thread to attach the draft',
-			},
-			{
 				displayName: 'Attachments',
 				name: 'attachmentsUi',
 				placeholder: 'Add Attachment',
@@ -222,6 +179,14 @@ export const draftFields: INodeProperties[] = [
 				placeholder: 'reply@example.com',
 				default: '',
 				description: 'The email address that the reply message is sent to',
+			},
+			{
+				displayName: 'Thread ID',
+				name: 'threadId',
+				type: 'string',
+				placeholder: '18cc573e2431878f',
+				default: '',
+				description: 'The identifier of the thread to attach the draft',
 			},
 			{
 				displayName: 'To Email',


### PR DESCRIPTION
## Summary
Removes duplicate options from the Draft options



## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9293
