### PR TITLE
fix(editor): Fix type errors in the `SettingsLdapView.vue` (no-changelog)

### DIFF
--- a/packages/design-system/src/types/form.ts
+++ b/packages/design-system/src/types/form.ts
@@ -57,6 +57,7 @@ export type IFormInput = {
 		disabled?: boolean;
 		labelSize?: 'small' | 'medium' | 'large';
 		labelAlignment?: 'left' | 'right' | 'center';
+		tooltipText?: string;
 	};
 	shouldDisplay?: (values: { [key: string]: unknown }) => boolean;
 };

--- a/packages/editor-ui/src/v3-infinite-loading.d.ts
+++ b/packages/editor-ui/src/v3-infinite-loading.d.ts
@@ -1,0 +1,16 @@
+declare module 'v3-infinite-loading' {
+	import { Plugin, DefineComponent } from 'vue';
+
+	interface InfiniteLoadingProps {
+		target: string;
+	}
+
+	export interface Events {
+		infinite: (state: { loaded: () => void; complete: () => void }) => void;
+	}
+
+	const InfiniteLoading: DefineComponent<InfiniteLoadingProps, {}, {}, {}, {}, {}, {}, Events> &
+		Plugin;
+
+	export default InfiniteLoading;
+}


### PR DESCRIPTION
## Summary

This PR decreases the type errors in the FE from `1712` to `1688`. 

To test locally build n8n with `export ENABLE_TYPE_CHECKING=true`

## Related tickets and issues

https://linear.app/n8n/issue/ADO-2207/fix-type-errors-in-settingsldapviewvue

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))