### PR TITLE
fix(core): Create a personal project if a user signs up via SAML

### DIFF
--- a/packages/cli/src/sso/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso/saml/saml.service.ee.ts
@@ -349,7 +349,8 @@ export class SamlService {
 		} catch (error) {
 			// throw error;
 			throw new AuthError(
-				`SAML Authentication failed. Could not parse SAML response. ${(error as Error).message}`,
+				// INFO: The error can be a string. Samlify rejects promises with strings.
+				`SAML Authentication failed. Could not parse SAML response. ${error instanceof Error ? error.message : error}`,
 			);
 		}
 		const { attributes, missingAttributes } = getMappedSamlAttributesFromFlowResult(

--- a/packages/cli/src/sso/saml/samlHelpers.ts
+++ b/packages/cli/src/sso/saml/samlHelpers.ts
@@ -1,7 +1,7 @@
 import { Container } from 'typedi';
 import config from '@/config';
 import { AuthIdentity } from '@db/entities/AuthIdentity';
-import { User } from '@db/entities/User';
+import type { User } from '@db/entities/User';
 import { License } from '@/License';
 import { PasswordUtility } from '@/services/password.utility';
 import type { SamlPreferences } from './types/samlPreferences';
@@ -97,24 +97,29 @@ export function generatePassword(): string {
 }
 
 export async function createUserFromSamlAttributes(attributes: SamlUserAttributes): Promise<User> {
-	const user = new User();
-	const authIdentity = new AuthIdentity();
-	const lowerCasedEmail = attributes.email?.toLowerCase() ?? '';
-	user.email = lowerCasedEmail;
-	user.firstName = attributes.firstName;
-	user.lastName = attributes.lastName;
-	user.role = 'global:member';
-	// generates a password that is not used or known to the user
-	user.password = await Container.get(PasswordUtility).hash(generatePassword());
-	authIdentity.providerId = attributes.userPrincipalName;
-	authIdentity.providerType = 'saml';
-	const resultAuthIdentity = await Container.get(AuthIdentityRepository).save(authIdentity, {
-		transaction: false,
+	return await Container.get(UserRepository).manager.transaction(async (trx) => {
+		const { user } = await Container.get(UserRepository).createUserWithProject(
+			{
+				email: attributes.email.toLowerCase(),
+				firstName: attributes.firstName,
+				lastName: attributes.lastName,
+				role: 'global:member',
+				// generates a password that is not used or known to the user
+				password: await Container.get(PasswordUtility).hash(generatePassword()),
+			},
+			trx,
+		);
+
+		await trx.save(
+			trx.create(AuthIdentity, {
+				providerId: attributes.userPrincipalName,
+				providerType: 'saml',
+				userId: user.id,
+			}),
+		);
+
+		return user;
 	});
-	if (!resultAuthIdentity) throw new AuthError('Could not create AuthIdentity');
-	const { user: resultUser } = await Container.get(UserRepository).createUserWithProject(user);
-	if (!resultUser) throw new AuthError('Could not create User');
-	return resultUser;
 }
 
 export async function updateUserFromSamlAttributes(

--- a/packages/cli/src/sso/saml/samlHelpers.ts
+++ b/packages/cli/src/sso/saml/samlHelpers.ts
@@ -108,13 +108,11 @@ export async function createUserFromSamlAttributes(attributes: SamlUserAttribute
 	user.password = await Container.get(PasswordUtility).hash(generatePassword());
 	authIdentity.providerId = attributes.userPrincipalName;
 	authIdentity.providerType = 'saml';
-	authIdentity.user = user;
 	const resultAuthIdentity = await Container.get(AuthIdentityRepository).save(authIdentity, {
 		transaction: false,
 	});
 	if (!resultAuthIdentity) throw new AuthError('Could not create AuthIdentity');
-	user.authIdentities = [authIdentity];
-	const resultUser = await Container.get(UserRepository).save(user, { transaction: false });
+	const { user: resultUser } = await Container.get(UserRepository).createUserWithProject(user);
 	if (!resultUser) throw new AuthError('Could not create User');
 	return resultUser;
 }

--- a/packages/cli/test/integration/saml/samlHelpers.test.ts
+++ b/packages/cli/test/integration/saml/samlHelpers.test.ts
@@ -1,0 +1,40 @@
+import * as helpers from '@/sso/saml/samlHelpers';
+import type { SamlUserAttributes } from '@/sso/saml/types/samlUserAttributes';
+import { getPersonalProject } from '../../integration/shared/db/projects';
+
+import * as testDb from '../shared/testDb';
+
+beforeAll(async () => {
+	await testDb.init();
+});
+
+describe('sso/saml/samlHelpers', () => {
+	describe('createUserFromSamlAttributes', () => {
+		test('Creates personal project for user', async () => {
+			//
+			// ARRANGE
+			//
+			const samlUserAttributes: SamlUserAttributes = {
+				firstName: 'Nathan',
+				lastName: 'Nathaniel',
+				email: 'n@8.n',
+				userPrincipalName: 'Huh?',
+			};
+
+			//
+			// ACT
+			//
+			const user = await helpers.createUserFromSamlAttributes(samlUserAttributes);
+
+			//
+			// ASSERT
+			//
+			expect(user).toMatchObject({
+				firstName: samlUserAttributes.firstName,
+				lastName: samlUserAttributes.lastName,
+				email: samlUserAttributes.email,
+			});
+			await expect(getPersonalProject(user)).resolves.not.toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

With this PR a personal project is also created for users that are created via SAML.

This is best reviewed commit by commit.

Additionally there is a small fix that makes sure that SAML errors contain the message from samlify, instead of just `undefined`.

I also refactored `createUserFromSamlAttributes` to run inside a transaction, so that either the user, project and auth identity are created, or nothing. I removed some code that was unnecessary according to the types.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

