### PR TITLE
fix(core): Fix `RangeError: Maximum call stack size exceeded` under certain circumstances

### DIFF
--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -50,9 +50,10 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
 					fields.includes('email')
 				) {
 					const oldUser = event.databaseEntity;
-					const name = Container.get(UserRepository)
-						.create(newUserData)
-						.createPersonalProjectName();
+					const name =
+						newUserData instanceof User
+							? newUserData.createPersonalProjectName()
+							: Container.get(UserRepository).create(newUserData).createPersonalProjectName();
 
 					const project = await Container.get(ProjectRepository).getPersonalProjectForUser(
 						oldUser.id,


### PR DESCRIPTION
## Summary

TypeORM enters an infinite loop if you create entities with circular references and pass this to the `Repository.create` function.

This actually happened in combination with SAML:

`samlHelpers.updateUserFromSamlAttributes` and `samlHelpers.createUserFromSamlAttributes` would create a User and an AuthIdentity and assign them to one another:

https://github.com/n8n-io/n8n/blob/afffa36416dac55ae3aceb0be05b73bc17f51a06/packages/cli/src/sso/saml/samlHelpers.ts#L133

https://github.com/n8n-io/n8n/blob/afffa36416dac55ae3aceb0be05b73bc17f51a06/packages/cli/src/sso/saml/samlHelpers.ts#L137

Then it would call `UserRepository.save(user)`.

https://github.com/n8n-io/n8n/blob/afffa36416dac55ae3aceb0be05b73bc17f51a06/packages/cli/src/sso/saml/samlHelpers.ts#L144

This would then call the UserSubscriber in `database/entities/Project.ts` which would pass the circular User into `UserRepository.create` and cause the infinite loop.

https://github.com/n8n-io/n8n/blob/afffa36416dac55ae3aceb0be05b73bc17f51a06/packages/cli/src/databases/entities/Project.ts#L53-L55

The test simulates that behavior and makes sure the UserSubscriber checks if the entity is already a user and does not pass it into `UserRepository.create` in that case.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

