### PR TITLE
fix(core): Report missing SAML attributes early with an actionable error message

### DIFF
--- a/packages/cli/src/sso/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso/saml/saml.service.ee.ts
@@ -359,7 +359,7 @@ export class SamlService {
 		if (!attributes) {
 			throw new AuthError('SAML Authentication failed. Invalid SAML response.');
 		}
-		if (!attributes.email && missingAttributes.length > 0) {
+		if (missingAttributes.length > 0) {
 			throw new AuthError(
 				`SAML Authentication failed. Invalid SAML response (missing attributes: ${missingAttributes.join(
 					', ',

--- a/packages/cli/test/unit/sso/saml/saml.service.ee.test.ts
+++ b/packages/cli/test/unit/sso/saml/saml.service.ee.test.ts
@@ -1,0 +1,53 @@
+import { mock } from 'jest-mock-extended';
+import type express from 'express';
+import { SamlService } from '@/sso/saml/saml.service.ee';
+import { mockInstance } from '../../../shared/mocking';
+import { UrlService } from '@/services/url.service';
+import { Logger } from '@/Logger';
+import type { IdentityProviderInstance, ServiceProviderInstance } from 'samlify';
+import * as samlHelpers from '@/sso/saml/samlHelpers';
+
+describe('SamlService', () => {
+	const logger = mockInstance(Logger);
+	const urlService = mockInstance(UrlService);
+	const samlService = new SamlService(logger, urlService);
+
+	describe('getAttributesFromLoginResponse', () => {
+		test('throws when any attribute is missing', async () => {
+			//
+			// ARRANGE
+			//
+			jest
+				.spyOn(samlService, 'getIdentityProviderInstance')
+				.mockReturnValue(mock<IdentityProviderInstance>());
+
+			const serviceProviderInstance = mock<ServiceProviderInstance>();
+			serviceProviderInstance.parseLoginResponse.mockResolvedValue({
+				samlContent: '',
+				extract: {},
+			});
+			jest
+				.spyOn(samlService, 'getServiceProviderInstance')
+				.mockReturnValue(serviceProviderInstance);
+
+			jest.spyOn(samlHelpers, 'getMappedSamlAttributesFromFlowResult').mockReturnValue({
+				attributes: {} as never,
+				missingAttributes: [
+					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/firstname',
+					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/lastname',
+					'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn',
+				],
+			});
+
+			//
+			// ACT & ASSERT
+			//
+			await expect(
+				samlService.getAttributesFromLoginResponse(mock<express.Request>(), 'post'),
+			).rejects.toThrowError(
+				'SAML Authentication failed. Invalid SAML response (missing attributes: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/firstname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/lastname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn).',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Before
![image (10)](https://github.com/n8n-io/n8n/assets/927609/c9875c99-0929-4298-873d-8c02ccd2824f)

After
![swappy-20240506_114537](https://github.com/n8n-io/n8n/assets/927609/e1e0c428-a802-4fb6-b864-4c13ab75d08b)

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1543/saml-test-connection-fails-with-weird-errors-when-mapping-is-wrong

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

