### PR TITLE
fix(core): Make `project.type` type match in migration and entity

### DIFF
--- a/packages/cli/src/databases/migrations/common/1714133768519-CreateProject.ts
+++ b/packages/cli/src/databases/migrations/common/1714133768519-CreateProject.ts
@@ -48,7 +48,7 @@ export class CreateProject1714133768519 implements ReversibleMigration {
 		await createTable(table.project).withColumns(
 			column('id').varchar(36).primary.notNull,
 			column('name').varchar(255).notNull,
-			column('type').varchar(36),
+			column('type').varchar(36).notNull,
 		).withTimestamps;
 
 		await createTable(table.projectRelation)


### PR DESCRIPTION
## Summary

According to the entity `project.type` is already not nullable:

https://github.com/n8n-io/n8n/blob/afffa36416dac55ae3aceb0be05b73bc17f51a06/packages/cli/src/databases/entities/Project.ts#L21-L22

In the migration it was nullable which could lead to errors like the one here:
https://github.com/n8n-io/n8n/pull/9268

This PR marks the field as non-nullable in the db schema as well.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

