### PR TITLE
fix(Pipedrive Node): Improve type-safety in custom-property handling

### DIFF
--- a/packages/nodes-base/nodes/Pipedrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Pipedrive/GenericFunctions.ts
@@ -236,14 +236,14 @@ export function pipedriveResolveCustomProperties(
 	const json = item.json as IDataObject;
 
 	// Iterate over all keys and replace the custom ones
-	for (const key of Object.keys(json)) {
+	for (const [key, value] of Object.entries(json)) {
 		if (customProperties[key] !== undefined) {
 			// Is a custom property
 			customPropertyData = customProperties[key];
 
 			// value is not set, so nothing to resolve
-			if (json[key] === null) {
-				json[customPropertyData.name] = json[key];
+			if (value === null) {
+				json[customPropertyData.name] = value;
 				delete json[key];
 				continue;
 			}
@@ -267,7 +267,7 @@ export function pipedriveResolveCustomProperties(
 					'timerange',
 				].includes(customPropertyData.field_type)
 			) {
-				json[customPropertyData.name] = json[key];
+				json[customPropertyData.name] = value;
 				delete json[key];
 				// type options
 			} else if (
@@ -275,15 +275,19 @@ export function pipedriveResolveCustomProperties(
 				customPropertyData.options
 			) {
 				const propertyOption = customPropertyData.options.find(
-					(option) => option.id.toString() === json[key]!.toString(),
+					(option) => option.id.toString() === value?.toString(),
 				);
 				if (propertyOption !== undefined) {
 					json[customPropertyData.name] = propertyOption.label;
 					delete json[key];
 				}
 				// type multioptions
-			} else if (['set'].includes(customPropertyData.field_type) && customPropertyData.options) {
-				const selectedIds = (json[key] as string).split(',');
+			} else if (
+				['set'].includes(customPropertyData.field_type) &&
+				customPropertyData.options &&
+				typeof value === 'string'
+			) {
+				const selectedIds = value.split(',');
 				const selectedLabels = customPropertyData.options
 					.filter((option) => selectedIds.includes(option.id.toString()))
 					.map((option) => option.label);


### PR DESCRIPTION
Code like `(json[key] as string).split(',')` assumes that `json[key]` will always be a string, which in this case seems like not to be the case.
This is a general issue with forced type-assertions, where we tell the TS compiler that we know more about types than it does, and it should stop complaining. While this might be a valid scenario a lot of the times, a few times this is simply wrong.
To avoid bugs like this we should assert types instead of force-typing them.


## Related tickets and issues
N8N-7391



## Review / Merge checklist
- [x] PR title and summary are descriptive