### PR TITLE
feat(TelegramTrigger Node): Replace allowedUpdates value for '*' option with full range of possible update types

### DIFF
--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -191,7 +191,14 @@ export class TelegramTrigger implements INodeType {
 				let allowedUpdates = this.getNodeParameter('updates') as string[];
 
 				if ((allowedUpdates || []).includes('*')) {
-					allowedUpdates = [];
+					allowedUpdates = [
+						"update_id", "message", "edited_message", "channel_post", "edited_channel_post",
+						"business_connection", "business_message", "edited_business_message",
+						"deleted_business_messages", "message_reaction", "message_reaction_count",
+						"inline_query", "chosen_inline_result", "callback_query", "shipping_query",
+						"pre_checkout_query", "poll", "poll_answer", "my_chat_member", "chat_member",
+						"chat_join_request", "chat_boost", "removed_chat_boost"
+					];
 				}
 
 				const endpoint = 'setWebhook';


### PR DESCRIPTION
Current value of allowedUpdates for '*' option is set to an empty array, which enables "all update types except chat_member, message_reaction, and message_reaction_count (default)". More details can be found in the [Telegram Bot API documentation](https://core.telegram.org/bots/api#setwebhook)

It causes not receiving updates about new channel subscriber for example.


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 