### PR TITLE
feat(Send Email Node): Add an option to customize client host-name on SMTP connections

### DIFF
--- a/packages/nodes-base/credentials/Smtp.credentials.ts
+++ b/packages/nodes-base/credentials/Smtp.credentials.ts
@@ -41,5 +41,13 @@ export class Smtp implements ICredentialType {
 			type: 'boolean',
 			default: true,
 		},
+		{
+			displayName: 'Client Host Name',
+			name: 'hostName',
+			type: 'string',
+			default: '',
+			placeholder: '',
+			description: 'The hostname of the client, used for identifying to the server',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
@@ -210,6 +210,10 @@ function configureTransport(credentials: IDataObject, options: EmailSendOptions)
 		secure: credentials.secure as boolean,
 	};
 
+	if (typeof credentials.hostName === 'string' && credentials.hostName) {
+		connectionOptions.name = credentials.hostName;
+	}
+
 	if (credentials.user || credentials.password) {
 		connectionOptions.auth = {
 			user: credentials.user as string,


### PR DESCRIPTION
By default nodemailer uses the hostname for in the `HELO` or `EHLO` greeting command.
Sometimes this can be a random hex string (like in the case of some containers), which some SMTP relay can reject.
This PR adds a new option in the SMTP credential to let the end user customize what hostname gets sent to a SMTP relay during the greeting. 

## Related tickets and issues
#9320

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included