### PR TITLE
fix(editor): Fix multi-select parameters with load options getting cleared

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -415,7 +415,7 @@
 				:disabled="isReadOnly || remoteParameterOptionsLoading"
 				:title="displayTitle"
 				:placeholder="i18n.baseText('parameterInput.select')"
-				@update:model-value="valueChanged"
+				@update:model-value="valueChangedMultiOptions"
 				@keydown.stop
 				@focus="setFocus"
 				@blur="onBlur"
@@ -1184,6 +1184,14 @@ function valueChangedDebounced(value: NodeParameterValueType | {} | Date) {
 function onUpdateTextInput(value: string) {
 	valueChanged(value);
 	onTextInputChange(value);
+}
+
+function valueChangedMultiOptions(value: string[]): void {
+	if (remoteParameterOptionsLoading.value) {
+		return;
+	}
+
+	valueChanged(value);
 }
 
 function valueChanged(value: NodeParameterValueType | {} | Date) {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -415,7 +415,7 @@
 				:disabled="isReadOnly || remoteParameterOptionsLoading"
 				:title="displayTitle"
 				:placeholder="i18n.baseText('parameterInput.select')"
-				@update:model-value="valueChangedMultiOptions"
+				@update:model-value="valueChanged"
 				@keydown.stop
 				@focus="setFocus"
 				@blur="onBlur"
@@ -1186,15 +1186,11 @@ function onUpdateTextInput(value: string) {
 	onTextInputChange(value);
 }
 
-function valueChangedMultiOptions(value: string[]): void {
+function valueChanged(value: NodeParameterValueType | {} | Date) {
 	if (remoteParameterOptionsLoading.value) {
 		return;
 	}
 
-	valueChanged(value);
-}
-
-function valueChanged(value: NodeParameterValueType | {} | Date) {
 	if (props.parameter.name === 'nodeCredentialType') {
 		activeCredentialType.value = value as string;
 	}

--- a/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
@@ -4,13 +4,13 @@ import type { useNDVStore } from '@/stores/ndv.store';
 import type { CompletionResult } from '@codemirror/autocomplete';
 import { createTestingPinia } from '@pinia/testing';
 import { faker } from '@faker-js/faker';
+import { waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import type { useNodeTypesStore } from '../../stores/nodeTypes.store';
 
 let mockNdvState: Partial<ReturnType<typeof useNDVStore>>;
 let mockNodeTypesState: Partial<ReturnType<typeof useNodeTypesStore>>;
 let mockCompletionResult: Partial<CompletionResult>;
-import { waitFor } from '@testing-library/vue';
-import userEvent from '@testing-library/user-event';
-import { useNodeTypesStore } from '../../stores/nodeTypes.store';
 
 vi.mock('@/stores/ndv.store', () => {
 	return {

--- a/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
@@ -6,13 +6,21 @@ import { createTestingPinia } from '@pinia/testing';
 import { faker } from '@faker-js/faker';
 
 let mockNdvState: Partial<ReturnType<typeof useNDVStore>>;
+let mockNodeTypesState: Partial<ReturnType<typeof useNodeTypesStore>>;
 let mockCompletionResult: Partial<CompletionResult>;
 import { waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { useNodeTypesStore } from '../../stores/nodeTypes.store';
 
 vi.mock('@/stores/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
+	};
+});
+
+vi.mock('@/stores/nodeTypes.store', () => {
+	return {
+		useNodeTypesStore: vi.fn(() => mockNodeTypesState),
 	};
 });
 
@@ -44,6 +52,9 @@ describe('ParameterInput.vue', () => {
 				type: 'test',
 				typeVersion: 1,
 			},
+		};
+		mockNodeTypesState = {
+			allNodeTypes: [],
 		};
 	});
 
@@ -120,5 +131,33 @@ describe('ParameterInput.vue', () => {
 		await userEvent.type(input, 'foo');
 
 		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 'foo' })]);
+	});
+
+	test('should not reset the value of a multi-select with loadOptionsMethod on load', async () => {
+		mockNodeTypesState.getNodeParameterOptions = vi.fn(async () => [
+			{ name: 'ID', value: 'id' },
+			{ name: 'Title', value: 'title' },
+			{ name: 'Description', value: 'description' },
+		]);
+
+		const { emitted, container } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'columns',
+				parameter: {
+					displayName: 'Columns',
+					name: 'columns',
+					type: 'multiOptions',
+					typeOptions: { loadOptionsMethod: 'getColumnsMultiOptions' },
+				},
+				modelValue: ['id', 'title'],
+			},
+		});
+
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+
+		// Nothing should be emitted
+		expect(emitted('update')).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
The select component sends out a `model-value:update` event while the options are still loading.
Prevent this event from resetting the parameter value.

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1326/multi-select-loadoptions-are-cleared-when-you-open-the-node

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 