### PR TITLE
feat(editor): Temporarily disable AI error helper

### DIFF
--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -45,16 +45,6 @@ const isLoadingErrorDebugging = ref(false);
 const errorDebuggingMessage = ref('');
 const errorDebuggingFeedback = ref<'positive' | 'negative' | undefined>();
 
-const isErrorDebuggingEnabled = computed(() => {
-	return aiStore.isErrorDebuggingEnabled;
-});
-
-const showErrorDebuggingButton = computed(() => {
-	return (
-		isErrorDebuggingEnabled.value && !(isLoadingErrorDebugging.value || errorDebuggingMessage.value)
-	);
-});
-
 const displayCause = computed(() => {
 	return JSON.stringify(props.error.cause).length < MAX_DISPLAY_DATA_SIZE;
 });
@@ -428,17 +418,9 @@ function copySuccess() {
 	<div class="node-error-view">
 		<div class="node-error-view__header">
 			<div class="node-error-view__header-message">
-				<div :class="showErrorDebuggingButton ? 'mt-4xs' : ''">
+				<div>
 					{{ getErrorMessage() }}
 				</div>
-				<N8nButton
-					v-if="showErrorDebuggingButton"
-					type="tertiary"
-					size="small"
-					@click="onDebugError"
-				>
-					{{ i18n.baseText('nodeErrorView.debugError.button') }}
-				</N8nButton>
 			</div>
 			<div
 				v-if="error.description || error.context?.descriptionKey"


### PR DESCRIPTION
## Summary
This PR disables the `Ask AI` error helper feature. The proper cleanup will be conducted as part of ADO-2205, this is just quick disable for today's release.


## Related tickets and issues
ADO-2213


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 