### PR TITLE
fix(core): Fix MySQL tests timeout issues

### DIFF
--- a/packages/cli/test/integration/CredentialsHelper.test.ts
+++ b/packages/cli/test/integration/CredentialsHelper.test.ts
@@ -22,6 +22,10 @@ beforeAll(async () => {
 	member = await createMember();
 });
 
+afterAll(async () => {
+	await testDb.terminate();
+});
+
 describe('CredentialsHelper', () => {
 	describe('credentialOwnedBySuperUsers', () => {
 		test.each([

--- a/packages/cli/test/integration/commands/reset.cmd.test.ts
+++ b/packages/cli/test/integration/commands/reset.cmd.test.ts
@@ -11,7 +11,7 @@ import { createMember, createUser } from '../shared/db/users';
 import { createWorkflow } from '../shared/db/workflows';
 import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 import { getPersonalProject } from '../shared/db/projects';
-import { saveCredential } from '../shared/db/credentials';
+import { encryptCredentialData, saveCredential } from '../shared/db/credentials';
 import { randomCredentialPayload } from '../shared/random';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
 import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
@@ -53,7 +53,7 @@ test('user-management:reset should reset DB to default user state', async () => 
 
 	// dangling credentials should also be re-owned
 	const danglingCredential = await Container.get(CredentialsRepository).save(
-		Object.assign(new CredentialsEntity(), randomCredentialPayload()),
+		await encryptCredentialData(Object.assign(new CredentialsEntity(), randomCredentialPayload())),
 	);
 
 	// mark instance as set up

--- a/packages/cli/test/integration/environments/SourceControl.test.ts
+++ b/packages/cli/test/integration/environments/SourceControl.test.ts
@@ -9,9 +9,14 @@ import type { SourceControlledFile } from '@/environments/sourceControl/types/so
 
 import * as utils from '../shared/utils/';
 import { createUser } from '../shared/db/users';
+import { mockInstance } from '../../shared/mocking';
+import { WaitTracker } from '@/WaitTracker';
 
 let authOwnerAgent: SuperAgentTest;
 let owner: User;
+
+// This is necessary for the tests to shutdown cleanly.
+mockInstance(WaitTracker);
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['sourceControl', 'license', 'auth'],

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -5,11 +5,16 @@ import { createMember, createOwner } from './shared/db/users';
 import { createWorkflow, shareWorkflowWithUsers } from './shared/db/workflows';
 import * as testDb from './shared/testDb';
 import { setupTestServer } from './shared/utils';
+import { mockInstance } from '../shared/mocking';
+import { WaitTracker } from '@/WaitTracker';
 
 const testServer = setupTestServer({ endpointGroups: ['executions'] });
 
 let owner: User;
 let member: User;
+
+// This is necessary for the tests to shutdown cleanly.
+mockInstance(WaitTracker);
 
 const saveExecution = async ({ belongingTo }: { belongingTo: User }) => {
 	const workflow = await createWorkflow({}, belongingTo);

--- a/packages/cli/test/integration/saml/samlHelpers.test.ts
+++ b/packages/cli/test/integration/saml/samlHelpers.test.ts
@@ -8,6 +8,10 @@ beforeAll(async () => {
 	await testDb.init();
 });
 
+afterAll(async () => {
+	await testDb.terminate();
+});
+
 describe('sso/saml/samlHelpers', () => {
 	describe('createUserFromSamlAttributes', () => {
 		test('Creates personal project for user', async () => {

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -9,14 +9,16 @@ import type { CredentialPayload } from '../types';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import type { Project } from '@/databases/entities/Project';
 
-async function encryptCredentialData(credential: CredentialsEntity) {
+export async function encryptCredentialData(
+	credential: CredentialsEntity,
+): Promise<ICredentialsDb> {
 	const { createCredentialsFromCredentialsEntity } = await import('@/CredentialsHelper');
 	const coreCredential = createCredentialsFromCredentialsEntity(credential, true);
 
 	// @ts-ignore
 	coreCredential.setData(credential.data);
 
-	return coreCredential.getDataToSave() as ICredentialsDb;
+	return Object.assign(credential, coreCredential.getDataToSave());
 }
 
 const emptyAttributes = {
@@ -60,9 +62,7 @@ export async function saveCredential(
 
 	Object.assign(newCredential, credentialPayload);
 
-	const encryptedData = await encryptCredentialData(newCredential);
-
-	Object.assign(newCredential, encryptedData);
+	await encryptCredentialData(newCredential);
 
 	const savedCredential = await Container.get(CredentialsRepository).save(newCredential);
 

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -443,10 +443,12 @@ describe('DELETE /users/:id', () => {
 		// ASSERT
 		//
 
-		expect(deleteSpy).toBeCalledWith([
-			`credential-can-use-secrets:${sharedByTransfereeCredential.id}`,
-			`credential-can-use-secrets:${ownedCredential.id}`,
-		]);
+		expect(deleteSpy).toBeCalledWith(
+			expect.arrayContaining([
+				`credential-can-use-secrets:${sharedByTransfereeCredential.id}`,
+				`credential-can-use-secrets:${ownedCredential.id}`,
+			]),
+		);
 		deleteSpy.mockClear();
 
 		const userRepository = Container.get(UserRepository);

--- a/packages/cli/test/integration/workflowHistoryManager.test.ts
+++ b/packages/cli/test/integration/workflowHistoryManager.test.ts
@@ -34,6 +34,10 @@ describe('Workflow History Manager', () => {
 		license.getWorkflowHistoryPruneLimit.mockReturnValue(-1);
 	});
 
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
 	test('should prune on interval', () => {
 		const pruneSpy = jest.spyOn(manager, 'prune');
 		const currentCount = pruneSpy.mock.calls.length;

--- a/packages/cli/test/integration/workflows/workflowSharing.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflowSharing.service.test.ts
@@ -34,6 +34,10 @@ beforeEach(async () => {
 	await testDb.truncate(['Workflow', 'SharedWorkflow', 'WorkflowHistory']);
 });
 
+afterAll(async () => {
+	await testDb.terminate();
+});
+
 describe('WorkflowSharingService', () => {
 	describe('getSharedWorkflowIds', () => {
 		it('should show all workflows to owners', async () => {


### PR DESCRIPTION
## Summary

This fixes the remaining MySQL test failing.

Additionally I identified some tests that would not shut down properly, mainly because they don't close the connection to the db, while others depend on the WaitTracker which does is not terminated implicitly and so will keep the event loop busy.

For the test db it would be nice to have this work implicitly like the test server does it:
https://github.com/n8n-io/n8n/blob/57c95dcf2d0d2af208fe5f59ba14cd09678466cf/packages/cli/test/integration/shared/utils/testServer.ts#L70-L285

But that would be a bigger refactor which I don't want to include into feature/rbac, nor want to do it on master now for the fear or conflicts with feature/rbac.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1569/mysql-tests-failing

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

