### PR TITLE
ci: Increase timeout of MySQL tests

### DIFF
--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysql
+        run: pnpm test:mysql --testTimeout 20000
 
   postgres:
     name: Postgres

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - packages/cli/src/databases/**
+      - .github/workflows/ci-postgres-mysql.yml
 
 concurrency:
   group: db-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Mainly this fixes the MySQL timeout issues by, drum roll, increasing the timeout.

Additionally this executes the workflow if the workflow has been changed.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1569/mysql-tests-failing

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

