### PR TITLE
feat: Add a project count API

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -36,6 +36,11 @@ export class ProjectController {
 		return await this.projectsService.getAccessibleProjects(req.user);
 	}
 
+	@Get('/count')
+	async getProjectCounts() {
+		return await this.projectsService.getProjectCounts();
+	}
+
 	@Post('/')
 	@GlobalScope('project:create')
 	@Licensed('feat:advancedPermissions')

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -1,4 +1,4 @@
-import { Project, ProjectType } from '@/databases/entities/Project';
+import { Project, type ProjectType } from '@/databases/entities/Project';
 import { ProjectRelation } from '@/databases/entities/ProjectRelation';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { User } from '@/databases/entities/User';

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -1,4 +1,4 @@
-import { Project } from '@/databases/entities/Project';
+import { Project, ProjectType } from '@/databases/entities/Project';
 import { ProjectRelation } from '@/databases/entities/ProjectRelation';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { User } from '@/databases/entities/User';
@@ -335,5 +335,12 @@ export class ProjectService {
 				},
 			},
 		});
+	}
+
+	async getProjectCounts(): Promise<Record<ProjectType, number>> {
+		return {
+			personal: await this.projectRepository.count({ where: { type: 'personal' } }),
+			team: await this.projectRepository.count({ where: { type: 'team' } }),
+		};
 	}
 }

--- a/packages/cli/test/integration/project.api.test.ts
+++ b/packages/cli/test/integration/project.api.test.ts
@@ -131,6 +131,25 @@ describe('GET /projects/', () => {
 	});
 });
 
+describe('GET /projects/count', () => {
+	test('should return correct number of projects', async () => {
+		const [firstUser] = await Promise.all([
+			createUser(),
+			createUser(),
+			createUser(),
+			createUser(),
+			createTeamProject(),
+			createTeamProject(),
+			createTeamProject(),
+		]);
+
+		const resp = await testServer.authAgentFor(firstUser).get('/projects/count');
+
+		expect(resp.body.data.personal).toBe(4);
+		expect(resp.body.data.team).toBe(3);
+	});
+});
+
 describe('GET /projects/my-projects', () => {
 	test('member should get all projects they are apart of', async () => {
 		//


### PR DESCRIPTION
## Summary
Adds an API to get the total number of projects that exists. This lets us check if we've hit our projects quota on the frontend.



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 