### PR TITLE
fix(core): Deadlock when sharing credentials and workflows when using sqlite pooled

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -26,6 +26,7 @@ import * as utils from '@/utils';
 import { listQueryMiddleware } from '@/middlewares';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
 import { In } from '@n8n/typeorm';
+import { SharedCredentials } from '@/databases/entities/SharedCredentials';
 
 @RestController('/credentials')
 export class CredentialsController {
@@ -275,7 +276,7 @@ export class CredentialsController {
 				[currentPersonalProjectIDs, (id) => id],
 			);
 
-			const deleteResult = await this.sharedCredentialsRepository.delete({
+			const deleteResult = await trx.delete(SharedCredentials, {
 				credentialsId: credentialId,
 				projectId: In(toUnshare),
 			});

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -8,7 +8,7 @@ import * as WorkflowHelpers from '@/WorkflowHelpers';
 import type { IWorkflowResponse } from '@/Interfaces';
 import config from '@/config';
 import { Delete, Get, Patch, Post, ProjectScope, Put, RestController } from '@/decorators';
-import type { SharedWorkflow } from '@db/entities/SharedWorkflow';
+import { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { TagRepository } from '@db/repositories/tag.repository';
@@ -432,7 +432,7 @@ export class WorkflowsController {
 				[currentPersonalProjectIDs, (id) => id],
 			);
 
-			await this.sharedWorkflowRepository.delete({
+			await trx.delete(SharedWorkflow, {
 				workflowId,
 				projectId: In(toUnshare),
 			});


### PR DESCRIPTION
## Summary

Trying to acquire a db writer inside a transaction will create a dead lock. So let's not do that.

I triggered a manual run: https://github.com/n8n-io/n8n/actions/runs/8999437172

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1570/sqlite-pooled-tests-failing

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

