### PR TITLE
fix: Source Control import failing due to creating multiple of a project

### DIFF
--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -504,13 +504,22 @@ export class SourceControlImportService {
 				where: { id: owner.teamId },
 			});
 			if (!teamProject) {
-				teamProject = await projectRepository.save(
-					projectRepository.create({
-						id: owner.teamId,
-						name: owner.teamName,
-						type: 'team',
-					}),
-				);
+				try {
+					teamProject = await projectRepository.save(
+						projectRepository.create({
+							id: owner.teamId,
+							name: owner.teamName,
+							type: 'team',
+						}),
+					);
+				} catch (e) {
+					teamProject = await projectRepository.findOne({
+						where: { id: owner.teamId },
+					});
+					if (!teamProject) {
+						throw e;
+					}
+				}
 			}
 
 			return teamProject;


### PR DESCRIPTION
## Summary
Due to doing a `Promise.all` the backend would attempt to create the same project multiple times, and this would usually cause all other workflows/credentials using that project to fail.



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 