### PR TITLE
feat(core): Node version available in expression

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
@@ -85,16 +85,16 @@ export const baseCompletions = defineComponent({
 					info: this.$locale.baseText('codeNodeEditor.completer.$today'),
 				},
 				{
-					label: `${prefix}nodeVersion`,
-					info: this.$locale.baseText('codeNodeEditor.completer.$nodeVersion'),
-				},
-				{
 					label: `${prefix}jmespath()`,
 					info: this.$locale.baseText('codeNodeEditor.completer.$jmespath'),
 				},
 				{
 					label: `${prefix}runIndex`,
 					info: this.$locale.baseText('codeNodeEditor.completer.$runIndex'),
+				},
+				{
+					label: `${prefix}nodeVersion`,
+					info: this.$locale.baseText('codeNodeEditor.completer.$nodeVersion'),
 				},
 			];
 

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/base.completions.ts
@@ -85,6 +85,10 @@ export const baseCompletions = defineComponent({
 					info: this.$locale.baseText('codeNodeEditor.completer.$today'),
 				},
 				{
+					label: `${prefix}nodeVersion`,
+					info: this.$locale.baseText('codeNodeEditor.completer.$nodeVersion'),
+				},
+				{
 					label: `${prefix}jmespath()`,
 					info: this.$locale.baseText('codeNodeEditor.completer.$jmespath'),
 				},

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -516,9 +516,9 @@ export const MAPPING_PARAMS = [
 	'$resumeWebhookUrl',
 	'$runIndex',
 	'$today',
-	'$nodeVersion',
 	'$vars',
 	'$workflow',
+	'$nodeVersion',
 ];
 
 export const DEFAULT_STICKY_HEIGHT = 160;

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -516,6 +516,7 @@ export const MAPPING_PARAMS = [
 	'$resumeWebhookUrl',
 	'$runIndex',
 	'$today',
+	'$nodeVersion',
 	'$vars',
 	'$workflow',
 ];

--- a/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
@@ -109,11 +109,6 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 		info: i18n.rootVars.$today,
 	},
 	{
-		label: '$nodeVersion',
-		section: METADATA_SECTION,
-		info: i18n.rootVars.$nodeVersion,
-	},
-	{
 		label: '$vars',
 		section: METADATA_SECTION,
 		info: i18n.rootVars.$vars,
@@ -137,6 +132,11 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 		label: '$min()',
 		section: METHODS_SECTION,
 		info: i18n.rootVars.$min,
+	},
+	{
+		label: '$nodeVersion',
+		section: METADATA_SECTION,
+		info: i18n.rootVars.$nodeVersion,
 	},
 ];
 

--- a/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
@@ -109,6 +109,11 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 		info: i18n.rootVars.$today,
 	},
 	{
+		label: '$nodeVersion',
+		section: METADATA_SECTION,
+		info: i18n.rootVars.$nodeVersion,
+	},
+	{
 		label: '$vars',
 		section: METADATA_SECTION,
 		info: i18n.rootVars.$vars,

--- a/packages/editor-ui/src/plugins/i18n/index.ts
+++ b/packages/editor-ui/src/plugins/i18n/index.ts
@@ -373,6 +373,7 @@ export class I18nClass {
 		$min: this.baseText('codeNodeEditor.completer.$min'),
 		$runIndex: this.baseText('codeNodeEditor.completer.$runIndex'),
 		$today: this.baseText('codeNodeEditor.completer.$today'),
+		$nodeVersion: this.baseText('codeNodeEditor.completer.$nodeVersion'),
 		$vars: this.baseText('codeNodeEditor.completer.$vars'),
 		$workflow: this.baseText('codeNodeEditor.completer.$workflow'),
 		DateTime: this.baseText('codeNodeEditor.completer.dateTime'),

--- a/packages/editor-ui/src/plugins/i18n/index.ts
+++ b/packages/editor-ui/src/plugins/i18n/index.ts
@@ -373,13 +373,13 @@ export class I18nClass {
 		$min: this.baseText('codeNodeEditor.completer.$min'),
 		$runIndex: this.baseText('codeNodeEditor.completer.$runIndex'),
 		$today: this.baseText('codeNodeEditor.completer.$today'),
-		$nodeVersion: this.baseText('codeNodeEditor.completer.$nodeVersion'),
 		$vars: this.baseText('codeNodeEditor.completer.$vars'),
 		$workflow: this.baseText('codeNodeEditor.completer.$workflow'),
 		DateTime: this.baseText('codeNodeEditor.completer.dateTime'),
 		$request: this.baseText('codeNodeEditor.completer.$request'),
 		$response: this.baseText('codeNodeEditor.completer.$response'),
 		$pageCount: this.baseText('codeNodeEditor.completer.$pageCount'),
+		$nodeVersion: this.baseText('codeNodeEditor.completer.$nodeVersion'),
 	} as const satisfies Record<string, string | undefined>;
 
 	proxyVars: Record<string, string | undefined> = {

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -217,6 +217,7 @@
 	"codeNodeEditor.completer.$prevNode.runIndex": "The run of the node providing input data to the current one",
 	"codeNodeEditor.completer.$runIndex": "The index of the current run of this node",
 	"codeNodeEditor.completer.$today": "A timestamp representing the current day (at midnight, as a Luxon object)",
+	"codeNodeEditor.completer.$nodeVersion": "The type version of the current node",
 	"codeNodeEditor.completer.$vars": "The variables defined in your instance",
 	"codeNodeEditor.completer.$vars.varName": "Variable set on this n8n instance. All variables evaluate to strings.",
 	"codeNodeEditor.completer.$secrets": "The external secrets connected to your instance",

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -995,6 +995,7 @@ export class WorkflowDataProxy {
 								// Before resolving the pairedItem make sure that the requested node comes in the
 								// graph before the current one
 								const activeNode = that.workflow.getNode(that.activeNodeName);
+
 								let contextNode = that.contextNodeName;
 								if (activeNode) {
 									const parentMainInputNode = that.workflow.getParentMainInputNode(activeNode);
@@ -1281,6 +1282,7 @@ export class WorkflowDataProxy {
 			$thisItem: that.connectionInputData[that.itemIndex],
 			$thisItemIndex: this.itemIndex,
 			$thisRunIndex: this.runIndex,
+			$nodeVersion: that.workflow.getNode(that.activeNodeName)?.typeVersion,
 		};
 
 		return new Proxy(base, {


### PR DESCRIPTION
## Summary
Use `$nodeVersion` in expressions to get current node version

![image](https://github.com/n8n-io/n8n/assets/88898367/fcd2004e-9126-4ef1-82da-5c70bbaa840c)
![image](https://github.com/n8n-io/n8n/assets/88898367/87038d67-4464-40dc-b320-45d1641a661e)

## Related
would be needed for this ticket
https://linear.app/n8n/issue/NODE-1327/run-once-for-each-item-tooltip