### PR TITLE
fix(editor): Fix unwanted side effects from tailwind components (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -519,7 +519,7 @@ function goToUpgrade() {
 </script>
 
 <template>
-	<div class="container">
+	<div :class="$style.container">
 		<BreakpointsObserver :value-x-s="15" :value-s-m="25" :value-m-d="50" class="name-container">
 			<template #default="{ value }">
 				<ShortenName
@@ -665,14 +665,6 @@ function goToUpgrade() {
 $--text-line-height: 24px;
 $--header-spacing: 20px;
 
-.container {
-	position: relative;
-	top: -1px;
-	width: 100%;
-	display: flex;
-	align-items: center;
-}
-
 .name-container {
 	margin-right: $--header-spacing;
 }
@@ -729,6 +721,14 @@ $--header-spacing: 20px;
 </style>
 
 <style module lang="scss">
+.container {
+	position: relative;
+	top: -1px;
+	width: 100%;
+	display: flex;
+	align-items: center;
+}
+
 .group {
 	display: flex;
 	gap: var(--spacing-xs);

--- a/packages/editor-ui/src/components/TagsManager/NoTagsView.vue
+++ b/packages/editor-ui/src/components/TagsManager/NoTagsView.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="container">
+	<div :class="$style.container">
 		<el-col class="notags" :span="16">
 			<div class="icon">🗄️</div>
 			<div>
@@ -25,7 +25,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss" module>
 $--footer-spacing: 45px;
 
 .container {
@@ -34,7 +34,9 @@ $--footer-spacing: 45px;
 	align-items: center;
 	margin-top: $--footer-spacing;
 }
+</style>
 
+<style lang="scss" scoped>
 .notags {
 	word-break: normal;
 	text-align: center;


### PR DESCRIPTION
## Summary
Tailwind `@tailwind components` directive adds `max-width` css for the `.container` class. This PR makes sure the `.container` class names are not affected by tailwind.

<img width="2158" alt="image" src="https://github.com/n8n-io/n8n/assets/6179477/bea31f54-2926-4701-aab7-612dbf580c84">


## Related tickets and issues

https://linear.app/n8n/issue/N8N-7406/bug-header-extra-spacing#comment-f401894e


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. N/A
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 