### PR TITLE
feat(core): Extract UserSubscriber into it's own module breaking dependency cycles

### DIFF
--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -10,7 +10,8 @@ import { InstanceSettings } from 'n8n-core';
 import { ApplicationError } from 'n8n-workflow';
 
 import config from '@/config';
-import { entities, subscribers } from './entities';
+import { entities } from './entities';
+import { subscribers } from './subscribers';
 import { mysqlMigrations } from './migrations/mysqldb';
 import { postgresMigrations } from './migrations/postgresdb';
 import { sqliteMigrations } from './migrations/sqlite';

--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -1,15 +1,8 @@
-import type { EntitySubscriberInterface, UpdateEvent } from '@n8n/typeorm';
-import { Column, Entity, EventSubscriber, OneToMany } from '@n8n/typeorm';
+import { Column, Entity, OneToMany } from '@n8n/typeorm';
 import { WithTimestampsAndStringId } from './AbstractEntity';
 import type { ProjectRelation } from './ProjectRelation';
 import type { SharedCredentials } from './SharedCredentials';
 import type { SharedWorkflow } from './SharedWorkflow';
-import { User } from './User';
-import Container from 'typedi';
-import { ProjectRepository } from '../repositories/project.repository';
-import { ApplicationError, ErrorReporterProxy } from 'n8n-workflow';
-import { Logger } from '@/Logger';
-import { UserRepository } from '../repositories/user.repository';
 
 export type ProjectType = 'personal' | 'team';
 
@@ -29,68 +22,4 @@ export class Project extends WithTimestampsAndStringId {
 
 	@OneToMany('SharedWorkflow', 'project')
 	sharedWorkflows: SharedWorkflow[];
-}
-
-@EventSubscriber()
-export class UserSubscriber implements EntitySubscriberInterface<User> {
-	listenTo() {
-		return User;
-	}
-
-	async afterUpdate(event: UpdateEvent<User>): Promise<void> {
-		if (event.entity) {
-			const newUserData = event.entity;
-
-			if (event.databaseEntity) {
-				const fields = event.updatedColumns.map((c) => c.propertyName);
-
-				if (
-					fields.includes('firstName') ||
-					fields.includes('lastName') ||
-					fields.includes('email')
-				) {
-					const oldUser = event.databaseEntity;
-					const name =
-						newUserData instanceof User
-							? newUserData.createPersonalProjectName()
-							: Container.get(UserRepository).create(newUserData).createPersonalProjectName();
-
-					const project = await Container.get(ProjectRepository).getPersonalProjectForUser(
-						oldUser.id,
-					);
-
-					if (!project) {
-						// Since this is benign we're not throwing the exception. We don't
-						// know if we're running inside a transaction and thus there is a risk
-						// that this could cause further data inconsistencies.
-						const message = "Could not update the personal project's name";
-						Container.get(Logger).warn(message, event.entity);
-						const exception = new ApplicationError(message);
-						ErrorReporterProxy.warn(exception, event.entity);
-						return;
-					}
-
-					project.name = name;
-
-					await event.manager.save(Project, project);
-				}
-			} else {
-				// This means the user was updated using `Repository.update`. In this
-				// case we're missing the user's id and cannot update their project.
-				//
-				// When updating the user's firstName, lastName or email we must use
-				// `Repository.save`, so this is a bug and we should report it to sentry.
-				//
-				if (event.entity.firstName || event.entity.lastName || event.entity.email) {
-					// Since this is benign we're not throwing the exception. We don't
-					// know if we're running inside a transaction and thus there is a risk
-					// that this could cause further data inconsistencies.
-					const message = "Could not update the personal project's name";
-					Container.get(Logger).warn(message, event.entity);
-					const exception = new ApplicationError(message);
-					ErrorReporterProxy.warn(exception, event.entity);
-				}
-			}
-		}
-	}
 }

--- a/packages/cli/src/databases/entities/index.ts
+++ b/packages/cli/src/databases/entities/index.ts
@@ -19,7 +19,7 @@ import { WorkflowStatistics } from './WorkflowStatistics';
 import { ExecutionMetadata } from './ExecutionMetadata';
 import { ExecutionData } from './ExecutionData';
 import { WorkflowHistory } from './WorkflowHistory';
-import { Project, UserSubscriber } from './Project';
+import { Project } from './Project';
 import { ProjectRelation } from './ProjectRelation';
 
 export const entities = {
@@ -45,8 +45,4 @@ export const entities = {
 	WorkflowHistory,
 	Project,
 	ProjectRelation,
-};
-
-export const subscribers = {
-	UserSubscriber,
 };

--- a/packages/cli/src/databases/subscribers/UserSubscriber.ts
+++ b/packages/cli/src/databases/subscribers/UserSubscriber.ts
@@ -1,0 +1,73 @@
+import type { EntitySubscriberInterface, UpdateEvent } from '@n8n/typeorm';
+import { EventSubscriber } from '@n8n/typeorm';
+import { User } from '../entities/User';
+import Container from 'typedi';
+import { ProjectRepository } from '../repositories/project.repository';
+import { ApplicationError, ErrorReporterProxy } from 'n8n-workflow';
+import { Logger } from '@/Logger';
+import { UserRepository } from '../repositories/user.repository';
+import { Project } from '../entities/Project';
+
+@EventSubscriber()
+export class UserSubscriber implements EntitySubscriberInterface<User> {
+	listenTo() {
+		return User;
+	}
+
+	async afterUpdate(event: UpdateEvent<User>): Promise<void> {
+		if (event.entity) {
+			const newUserData = event.entity;
+
+			if (event.databaseEntity) {
+				const fields = event.updatedColumns.map((c) => c.propertyName);
+
+				if (
+					fields.includes('firstName') ||
+					fields.includes('lastName') ||
+					fields.includes('email')
+				) {
+					const oldUser = event.databaseEntity;
+					const name =
+						newUserData instanceof User
+							? newUserData.createPersonalProjectName()
+							: Container.get(UserRepository).create(newUserData).createPersonalProjectName();
+
+					const project = await Container.get(ProjectRepository).getPersonalProjectForUser(
+						oldUser.id,
+					);
+
+					if (!project) {
+						// Since this is benign we're not throwing the exception. We don't
+						// know if we're running inside a transaction and thus there is a risk
+						// that this could cause further data inconsistencies.
+						const message = "Could not update the personal project's name";
+						Container.get(Logger).warn(message, event.entity);
+						const exception = new ApplicationError(message);
+						ErrorReporterProxy.warn(exception, event.entity);
+						return;
+					}
+
+					project.name = name;
+
+					await event.manager.save(Project, project);
+				}
+			} else {
+				// This means the user was updated using `Repository.update`. In this
+				// case we're missing the user's id and cannot update their project.
+				//
+				// When updating the user's firstName, lastName or email we must use
+				// `Repository.save`, so this is a bug and we should report it to sentry.
+				//
+				if (event.entity.firstName || event.entity.lastName || event.entity.email) {
+					// Since this is benign we're not throwing the exception. We don't
+					// know if we're running inside a transaction and thus there is a risk
+					// that this could cause further data inconsistencies.
+					const message = "Could not update the personal project's name";
+					Container.get(Logger).warn(message, event.entity);
+					const exception = new ApplicationError(message);
+					ErrorReporterProxy.warn(exception, event.entity);
+				}
+			}
+		}
+	}
+}

--- a/packages/cli/src/databases/subscribers/index.ts
+++ b/packages/cli/src/databases/subscribers/index.ts
@@ -1,0 +1,5 @@
+import { UserSubscriber } from './UserSubscriber';
+
+export const subscribers = {
+	UserSubscriber,
+};


### PR DESCRIPTION
## Summary

Breaking the cycles between the project entity and the project repo.

Before:
```mermaid
flowchart TD
    PE[Project Entity] --imports--> PR[Project Repo]
    PR --imports--> PE
```

After:
```mermaid
flowchart TD
    PR[Project Repo] --imports--> PE[Project Entity]
    US[User Subscriber] --imports--> PE
    US[User Subscriber] --imports--> PR
```

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

