### PR TITLE
fix(Mattermost Node): Fix issue when fetching reactions

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/getAll/execute.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/actions/reaction/getAll/execute.ts
@@ -15,6 +15,9 @@ export async function getAll(
 	const body = {} as IDataObject;
 
 	let responseData = await apiRequest.call(this, requestMethod, endpoint, body, qs);
+	if (responseData === null) {
+		return [];
+	}
 	if (limit > 0) {
 		responseData = responseData.slice(0, limit);
 	}


### PR DESCRIPTION
## Summary
An API change resulted in the output changing if there was no reaction, We now return nothing if no reaction is found.

![image](https://github.com/n8n-io/n8n/assets/4688521/435fc5e8-6b33-462c-a00e-3def35468dd9)



## Related tickets and issues
https://github.com/n8n-io/n8n/issues/2740
https://linear.app/n8n/issue/NODE-41/