### PR TITLE
fix(core): Fix project quota not being applied correctly

### DIFF
--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -166,7 +166,7 @@ export class ProjectService {
 		const limit = this.license.getTeamProjectLimit();
 		if (
 			limit !== UNLIMITED_LICENSE_QUOTA &&
-			limit >= (await this.projectRepository.count({ where: { type: 'team' } }))
+			limit <= (await this.projectRepository.count({ where: { type: 'team' } }))
 		) {
 			throw new TeamProjectOverQuotaError(limit);
 		}

--- a/packages/cli/test/integration/credentials.test.ts
+++ b/packages/cli/test/integration/credentials.test.ts
@@ -279,7 +279,7 @@ describe('POST /credentials', () => {
 		//
 		// ARRANGE
 		//
-		const project = await Container.get(ProjectService).createTeamProject('Team Project', owner);
+		const project = await createTeamProject('Team Project', owner);
 
 		//
 		// ACT


### PR DESCRIPTION
## Summary

There is a mix up with the comparison operators.
I added 2 more tests for the transition from below quota to above quota.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

