### PR TITLE
fix(RabbitMQ Trigger Node): Fix issue where queue was not created

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
@@ -66,6 +66,20 @@ export class RabbitMQTrigger implements INodeType {
 				placeholder: 'Add Option',
 				options: [
 					{
+						displayName: 'Assert Exchange',
+						name: 'assertExchange',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to assert the exchange exists before sending',
+					},
+					{
+						displayName: 'Assert Queue',
+						name: 'assertQueue',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to assert the queue exists before sending',
+					},
+					{
 						displayName: 'Content Is Binary',
 						name: 'contentIsBinary',
 						type: 'boolean',


### PR DESCRIPTION
## Summary
This adds the assert queue and exchange options to the trigger node which was broken in this PR: https://github.com/n8n-io/n8n/pull/8430 

By setting the `Assert Queue` the node will automatically create the queue if it doesn't exist already.

## Related tickets and issues
https://github.com/n8n-io/n8n/issues/8871