### PR TITLE
fix(core): Do not report to Sentry trigger activation errors from `ETIMEDOUT` or `ECONNREFUSED` (no-changelog)

### DIFF
--- a/packages/core/src/ActiveWorkflows.ts
+++ b/packages/core/src/ActiveWorkflows.ts
@@ -92,7 +92,13 @@ export class ActiveWorkflows {
 
 				throw new WorkflowActivationError(
 					`There was a problem activating the workflow: "${error.message}"`,
-					{ cause: error, node: triggerNode },
+					{
+						cause: error,
+						node: triggerNode,
+						level: ['ETIMEDOUT', 'ECONNREFUSED'].some((code) => error.message.includes(code))
+							? 'warning'
+							: 'error',
+					},
 				);
 			}
 		}


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1553/error-connect-econnrefused-180