### PR TITLE
fix(Code Node): Bind helper methods to the correct context

### DIFF
--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -19,11 +19,16 @@ export interface SandboxContext extends IWorkflowDataProxyData {
 export const REQUIRED_N8N_ITEM_KEYS = new Set(['json', 'binary', 'pairedItem', 'error']);
 
 export function getSandboxContext(this: IExecuteFunctions, index: number): SandboxContext {
+	const helpers = {
+		...this.helpers,
+		httpRequestWithAuthentication: this.helpers.httpRequestWithAuthentication.bind(this),
+		requestWithAuthenticationPaginated: this.helpers.requestWithAuthenticationPaginated.bind(this),
+	};
 	return {
 		// from NodeExecuteFunctions
 		$getNodeParameter: this.getNodeParameter,
 		$getWorkflowStaticData: this.getWorkflowStaticData,
-		helpers: this.helpers,
+		helpers,
 
 		// to bring in all $-prefixed vars and methods from WorkflowDataProxy
 		// $node, $items(), $parameter, $json, $env, etc.


### PR DESCRIPTION
Since we pass in `this.helpers` into code sandbox, but not `this`, all calls to `helpers.httpRequestWithAuthentication` or `helpers.requestWithAuthenticationPaginated` fails at calls like `this.getCredentials()` and `this.getNode()`.


## Related tickets and issues
https://community.n8n.io/t/what-is-the-equivalent-http-request-with-auth-in-code-node


## Review / Merge checklist
- [x] PR title and summary are descriptive