### PR TITLE
refactor: Require project admin role for project creation

### DIFF
--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -45,7 +45,8 @@ export class ProjectController {
 
 	@Post('/')
 	@GlobalScope('project:create')
-	@Licensed('feat:advancedPermissions')
+	// Using admin as all plans that contain projects should allow admins at the very least
+	@Licensed('feat:projectRole:admin')
 	async createProject(req: ProjectRequest.Create): Promise<Project> {
 		try {
 			const project = await this.projectsService.createTeamProject(req.body.name, req.user);


### PR DESCRIPTION
## Summary
Change the required permission for RBAC - in order to create projects, we need at least one role to be available. At this time, let's link this to the admin role as it's the minimum necessary to create users within a project.

Linking the ability to create projects to advanced permissions is a major blocker as some cloud plans do not offer this feature (admin role) at this point.

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 