### PR TITLE
fix(Microsoft OneDrive Trigger Node): Fix issue with test run failing

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
@@ -148,11 +148,7 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 				}));
 			}
 
-			if (this.getMode() === 'manual') {
-				return [this.helpers.returnJsonArray(responseData)];
-			} else {
-				return [this.helpers.returnJsonArray(responseData)];
-			}
+			return [this.helpers.returnJsonArray(responseData)];
 		} catch (error) {
 			if (this.getMode() === 'manual' || !workflowData.lastTimeChecked) {
 				throw error;

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
@@ -123,9 +123,11 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 					}) as string
 				).replace('%21', '!');
 				const folderPath = await getPath.call(this, folderId);
-				responseData = responseData.filter((item: IDataObject) =>
-					((item.parentReference as IDataObject).path as string).startsWith(folderPath),
-				);
+
+				responseData = responseData.filter((item: IDataObject) => {
+					const path = (item.parentReference as IDataObject)?.path as string;
+					return typeof path === 'string' && path.startsWith(folderPath);
+				});
 			}
 			responseData = responseData.filter((item: IDataObject) => item[eventResource]);
 			if (!responseData?.length) {
@@ -147,7 +149,7 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 			}
 
 			if (this.getMode() === 'manual') {
-				return [this.helpers.returnJsonArray(responseData[0])];
+				return [this.helpers.returnJsonArray(responseData)];
 			} else {
 				return [this.helpers.returnJsonArray(responseData)];
 			}


### PR DESCRIPTION
## Summary
The test run would fail when using the `Nested Folders` option as the parentReference path was sometimes undefined. Also removed showing the first item which is normally the first item added to the folder and can cause confusion.

## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9328