### PR TITLE
ci: Do not hoist workspace packages in custom builds (no-changelog)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -7,4 +7,5 @@ prefer-workspace-packages = true
 link-workspace-packages = deep
 hoist = true
 shamefully-hoist = true
+hoist-workspace-packages = false
 loglevel = warn

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
     "test:e2e:dev": "scripts/run-e2e.js dev",
     "test:e2e:all": "scripts/run-e2e.js all"
   },
-  "dependencies": {
-    "n8n": "workspace:*"
-  },
   "devDependencies": {
     "@n8n_io/eslint-config": "workspace:*",
     "@ngneat/falso": "^6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,10 +44,6 @@ patchedDependencies:
 importers:
 
   .:
-    dependencies:
-      n8n:
-        specifier: workspace:*
-        version: link:packages/cli
     devDependencies:
       '@n8n_io/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
When workspace packages are hoisted in custom docker builds, we end up with a duplicate copy of the `n8n` package, which messes with external hooks because we then have two separate DI container instances.


## Review / Merge checklist
- [x] PR title and summary are descriptive