### PR TITLE
fix(core): Prevent expression modifying other node's data

### DIFF
--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -64,7 +64,15 @@ describe('WorkflowDataProxy', () => {
 			expect(proxy.$('Rename').all().length).toEqual(5);
 		});
 		test('$("NodeName").item', () => {
-			expect(proxy.$('Rename').item).toEqual({ json: { data: 105 }, pairedItem: { item: 0 } });
+			expect(proxy.$('Rename').item).toEqual({
+				json: {
+					data: 105,
+					nested: {
+						data: 106,
+					},
+				},
+				pairedItem: { item: 0 },
+			});
 		});
 		test('$("NodeNameEarlier").item', () => {
 			expect(proxy.$('Function').item).toEqual({
@@ -282,5 +290,30 @@ describe('WorkflowDataProxy', () => {
 				done();
 			}
 		});
+	});
+
+	test('is read-only', () => {
+		const fixture = loadFixture('base');
+		const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'End');
+
+		expect(() => (proxy.$json.data = 2)).toThrow(TypeError);
+		expect(proxy.$json.data).toEqual(105);
+
+		expect(() => {
+			if (proxy.$binary) {
+				proxy.$binary.data = { data: 'foo', mimeType: 'text/plain' };
+			}
+		}).toThrow(TypeError);
+		expect(proxy.$binary).toEqual({});
+
+		expect(() => (proxy.$('Rename').item.json.data = 2)).toThrow(TypeError);
+		expect(() => (proxy.$('Rename').item.json.nested.data = 2)).toThrow(TypeError);
+		expect(proxy.$('Rename').item.json).toEqual({ data: 105, nested: { data: 106 } });
+
+		expect(() => (proxy.$parameter.value2 = 'foo')).toThrow(TypeError);
+		expect(proxy.$parameter.value2).toEqual('default-value2');
+
+		expect(() => (proxy.$('Rename').all()[1].json.data = 2)).toThrow(TypeError);
+		expect(proxy.$('Rename').all()[1].json).toEqual({ data: 160 });
 	});
 });

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/base_run.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/base_run.json
@@ -64,7 +64,7 @@
 							"main": [
 								[
 									{
-										"json": { "data": 105 },
+										"json": { "data": 105, "nested": { "data": 106 } },
 										"pairedItem": { "item": 0 }
 									},
 									{


### PR DESCRIPTION
## Summary

Expressions could modify the output data of other nodes by using an expression like:

```js
{{ $json.foo = 'bar' }}
```

This was also possible for a lot of other data exposed in expressions

## Related tickets and issues
https://linear.app/n8n/issue/NODE-1328/set-node-expressions-null-is-changed-to-bool-when-using-string

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 