### PR TITLE
feat(Extract from File Node): Add option to set encoding for CSV files

### DIFF
--- a/packages/nodes-base/nodes/Files/ExtractFromFile/actions/spreadsheet.operation.ts
+++ b/packages/nodes-base/nodes/Files/ExtractFromFile/actions/spreadsheet.operation.ts
@@ -17,7 +17,9 @@ export const description: INodeProperties[] = fromFile.description
 		if (newProperty.name === 'options') {
 			newProperty.options = (newProperty.options as INodeProperties[]).map((option) => {
 				let newOption = option;
-				if (['delimiter', 'fromLine', 'maxRowCount', 'enableBOM'].includes(option.name)) {
+				if (
+					['delimiter', 'encoding', 'fromLine', 'maxRowCount', 'enableBOM'].includes(option.name)
+				) {
 					newOption = { ...option, displayOptions: { show: { '/operation': ['csv'] } } };
 				}
 				if (option.name === 'sheetName') {

--- a/packages/nodes-base/nodes/SpreadsheetFile/description.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/description.ts
@@ -178,6 +178,26 @@ export const fromFileOptions: INodeProperties = {
 			description: 'Set the field delimiter, usually a comma',
 		},
 		{
+			displayName: 'Encoding',
+			name: 'encoding',
+			type: 'options',
+			displayOptions: {
+				show: {
+					'/fileFormat': ['csv'],
+				},
+			},
+			options: [
+				{ name: 'ASCII', value: 'ascii' },
+				{ name: 'Latin1', value: 'latin1' },
+				{ name: 'UCS-2', value: 'ucs-2' },
+				{ name: 'UCS2', value: 'ucs2' },
+				{ name: 'UTF-8', value: 'utf-8' },
+				{ name: 'UTF16LE', value: 'utf16le' },
+				{ name: 'UTF8', value: 'utf8' },
+			],
+			default: 'utf-8',
+		},
+		{
 			displayName: 'Exclude Byte Order Mark (BOM)',
 			name: 'enableBOM',
 			type: 'boolean',

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -92,6 +92,7 @@ export async function execute(
 				const parser = createCSVParser({
 					delimiter: options.delimiter as string,
 					fromLine: options.fromLine as number,
+					encoding: options.encoding as BufferEncoding,
 					bom: options.enableBOM as boolean,
 					to: maxRowCount > -1 ? maxRowCount : undefined,
 					columns: options.headerRow !== false,


### PR DESCRIPTION
## Summary
Adds Encoding option when reading CSV files, Uses some of the options from the Node `BufferEncoding` list. Tested with `default` and `filesystem` binary data defaults.

![image](https://github.com/n8n-io/n8n/assets/4688521/496c6639-7b82-429c-bcfa-65c9811d1465)

![image](https://github.com/n8n-io/n8n/assets/4688521/2c44c166-d0b8-4aab-9657-3de53edfa7f3)



## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9365
