### PR TITLE
refactor: Allow admins and instance owners to use any credentials in their workflows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,12 +57,7 @@
 			"name": "Debug CLI tests",
 			"cwd": "${workspaceFolder}/packages/cli",
 			"runtimeExecutable": "npm",
-			"args": [
-				"run",
-				"test"
-				// "--",
-				// "ActiveExecutions"
-			],
+			"args": ["run", "test", "--", "credentials.controller"],
 			"type": "node",
 			"request": "launch"
 		}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,12 @@
 			"name": "Debug CLI tests",
 			"cwd": "${workspaceFolder}/packages/cli",
 			"runtimeExecutable": "npm",
-			"args": ["run", "test", "--", "credentials.controller"],
+			"args": [
+				"run",
+				"test"
+				// "--",
+				// "ActiveExecutions"
+			],
 			"type": "node",
 			"request": "launch"
 		}

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -77,6 +77,7 @@ export class CredentialsService {
 					(relation) => relation.projectId === options.listQueryOptions?.filter?.projectId,
 				);
 				if (projectRelation?.role === 'project:personalOwner') {
+					// Will not affect team projects as these have admins, not owners.
 					delete options.listQueryOptions?.filter?.projectId;
 				}
 			}
@@ -103,6 +104,16 @@ export class CredentialsService {
 			});
 
 			return credentials;
+		}
+
+		if (typeof options.listQueryOptions?.filter?.projectId === 'string') {
+			const project = await this.projectService.getProject(
+				options.listQueryOptions.filter.projectId,
+			);
+			if (project?.type === 'personal') {
+				const currentUsersPersonalProject = await this.projectService.getPersonalProject(user);
+				options.listQueryOptions.filter.projectId = currentUsersPersonalProject?.id;
+			}
 		}
 
 		const ids = await this.sharedCredentialsRepository.getCredentialIdsByUserAndRole([user.id], {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -73,6 +73,7 @@ export class CredentialsService {
 			if (options.listQueryOptions?.filter?.projectId && user.hasGlobalScope('credential:list')) {
 				// Only instance owners and admins have the credential:list scope
 				// Those users should be able to use _all_ credentials within their workflows.
+				// TODO: Change this so we filter by `workflowId` in this case. Require a slight FE change
 				const projectRelation = projectRelations.find(
 					(relation) => relation.projectId === options.listQueryOptions?.filter?.projectId,
 				);

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -70,6 +70,16 @@ export class CredentialsService {
 		let projectRelations: ProjectRelation[] | undefined = undefined;
 		if (options.includeScopes) {
 			projectRelations = await this.projectService.getProjectRelationsForUser(user);
+			if (options.listQueryOptions?.filter?.projectId && user.hasGlobalScope('credential:list')) {
+				// Only instance owners and admins have the credential:list scope
+				// Those users should be able to use _all_ credentials within their workflows.
+				const projectRelation = projectRelations.find(
+					(relation) => relation.projectId === options.listQueryOptions?.filter?.projectId,
+				);
+				if (projectRelation?.role === 'project:personalOwner') {
+					delete options.listQueryOptions?.filter?.projectId;
+				}
+			}
 		}
 
 		if (returnAll) {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -107,6 +107,7 @@ export class CredentialsService {
 			return credentials;
 		}
 
+		// If the workflow is part of a personal project we want to show the credentials the user making the request has access to, not the credentials the user owning the workflow has access to.
 		if (typeof options.listQueryOptions?.filter?.projectId === 'string') {
 			const project = await this.projectService.getProject(
 				options.listQueryOptions.filter.projectId,

--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -269,6 +269,27 @@ describe('GET /credentials', () => {
 			expect(response.body.data.map((credential) => credential.id)).toContain(ownerCredential.id);
 			expect(response.body.data.map((credential) => credential.id)).toContain(memberCredential.id);
 		});
+
+		test('should return all credentials to instance owners when working on their own personal project', async () => {
+			const ownerCredential = await saveCredential(payload(), {
+				user: owner,
+				role: 'credential:owner',
+			});
+			const memberCredential = await saveCredential(payload(), {
+				user: member,
+				role: 'credential:owner',
+			});
+
+			const response: GetAllResponse = await testServer
+				.authAgentFor(owner)
+				.get('/credentials')
+				.query(`filter={ "projectId": "${ownerPersonalProject.id}" }&includeScopes=true`)
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(2);
+			expect(response.body.data.map((credential) => credential.id)).toContain(ownerCredential.id);
+			expect(response.body.data.map((credential) => credential.id)).toContain(memberCredential.id);
+		});
 	});
 
 	describe('select', () => {

--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -260,7 +260,7 @@ describe('GET /credentials', () => {
 
 			// Simulate editing a workflow owned by `owner` so request credentials to their personal project
 			const response: GetAllResponse = await testServer
-				.authAgentFor(owner)
+				.authAgentFor(member)
 				.get('/credentials')
 				.query(`filter={ "projectId": "${ownerPersonalProject.id}" }`)
 				.expect(200);

--- a/packages/cli/test/integration/credentials.controller.test.ts
+++ b/packages/cli/test/integration/credentials.controller.test.ts
@@ -3,10 +3,12 @@ import type { User } from '@db/entities/User';
 import * as testDb from './shared/testDb';
 import { setupTestServer } from './shared/utils/';
 import { randomCredentialPayload as payload } from './shared/random';
-import { saveCredential } from './shared/db/credentials';
+import { saveCredential, shareCredentialWithUsers } from './shared/db/credentials';
 import { createMember, createOwner } from './shared/db/users';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import Container from 'typedi';
+import type { Project } from '@/databases/entities/Project';
+import { createTeamProject, linkUserToProject } from './shared/db/projects';
 
 const { any } = expect;
 
@@ -15,11 +17,19 @@ const testServer = setupTestServer({ endpointGroups: ['credentials'] });
 let owner: User;
 let member: User;
 
+let ownerPersonalProject: Project;
+let memberPersonalProject: Project;
 beforeEach(async () => {
 	await testDb.truncate(['SharedCredentials', 'Credentials']);
 
 	owner = await createOwner();
 	member = await createMember();
+	ownerPersonalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+		owner.id,
+	);
+	memberPersonalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+		member.id,
+	);
 });
 
 type GetAllResponse = { body: { data: ListQuery.Credentials.WithOwnedByAndSharedWith[] } };
@@ -176,12 +186,11 @@ describe('GET /credentials', () => {
 
 		test('should filter credentials by projectId', async () => {
 			const credential = await saveCredential(payload(), { user: owner, role: 'credential:owner' });
-			const pp = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(owner.id);
 
 			const response1: GetAllResponse = await testServer
 				.authAgentFor(owner)
 				.get('/credentials')
-				.query(`filter={ "projectId": "${pp.id}" }`)
+				.query(`filter={ "projectId": "${ownerPersonalProject.id}" }`)
 				.expect(200);
 
 			expect(response1.body.data).toHaveLength(1);
@@ -194,6 +203,71 @@ describe('GET /credentials', () => {
 				.expect(200);
 
 			expect(response2.body.data).toHaveLength(0);
+		});
+
+		test('should return all credentials in a team project that member is part of', async () => {
+			const teamProjectWithMember = await createTeamProject('Team Project With member', owner);
+			void (await linkUserToProject(member, teamProjectWithMember, 'project:editor'));
+			await saveCredential(payload(), {
+				project: teamProjectWithMember,
+				role: 'credential:owner',
+			});
+			await saveCredential(payload(), {
+				project: teamProjectWithMember,
+				role: 'credential:owner',
+			});
+			const response: GetAllResponse = await testServer
+				.authAgentFor(member)
+				.get('/credentials')
+				.query(`filter={ "projectId": "${teamProjectWithMember.id}" }`)
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(2);
+		});
+
+		test('should return no credentials in a team project that member not is part of', async () => {
+			const teamProjectWithoutMember = await createTeamProject(
+				'Team Project Without member',
+				owner,
+			);
+
+			await saveCredential(payload(), {
+				project: teamProjectWithoutMember,
+				role: 'credential:owner',
+			});
+
+			const response = await testServer
+				.authAgentFor(member)
+				.get('/credentials')
+				.query(`filter={ "projectId": "${teamProjectWithoutMember.id}" }`)
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(0);
+		});
+
+		test('should return only owned and explicitly shared credentials when filtering by any personal project id', async () => {
+			// Create credential owned by `owner` and share it to `member`
+			const ownerCredential = await saveCredential(payload(), {
+				user: owner,
+				role: 'credential:owner',
+			});
+			await shareCredentialWithUsers(ownerCredential, [member]);
+			// Create credential owned by `member`
+			const memberCredential = await saveCredential(payload(), {
+				user: member,
+				role: 'credential:owner',
+			});
+
+			// Simulate editing a workflow owned by `owner` so request credentials to their personal project
+			const response: GetAllResponse = await testServer
+				.authAgentFor(owner)
+				.get('/credentials')
+				.query(`filter={ "projectId": "${ownerPersonalProject.id}" }`)
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(2);
+			expect(response.body.data.map((credential) => credential.id)).toContain(ownerCredential.id);
+			expect(response.body.data.map((credential) => credential.id)).toContain(memberCredential.id);
 		});
 	});
 


### PR DESCRIPTION
## Summary
With the introduction of projects within RBAC we broke part of the functionality which is about allowing instance owners and admins to use any credentials within their workflows.

This PR fixes this.



## Related tickets and issues
https://linear.app/n8n/issue/PAY-1581


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.