### PR TITLE
fix(HubSpot Trigger Node): Fix issue with ticketId not being set

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -447,6 +447,9 @@ export class HubspotTrigger implements INodeType {
 			if (subscriptionType.includes('deal')) {
 				bodyData[i].dealId = bodyData[i].objectId;
 			}
+			if (subscriptionType.includes('ticket')) {
+				bodyData[i].ticketId = bodyData[i].objectId;
+			}
 			delete bodyData[i].objectId;
 		}
 		return {


### PR DESCRIPTION
## Summary
When adding support for the ticket event setting `ticketId` to `objectId` was missed and for some reason we delete `objectId` if we do a v2 / overhaul of the trigger we should probably keep the original field names to make life easier.

![image](https://github.com/n8n-io/n8n/assets/4688521/5695dab6-4fd9-4ea3-b8c4-7a43cb5c06e9)

Test Payload from Hubspot
![image](https://github.com/n8n-io/n8n/assets/4688521/be000cf5-ca93-4e73-a0cb-31b2bd4708bb)


## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9400