### PR TITLE
feat(OpenAI Node): Use v2 assistants API and add support for memory

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/deleteAssistant.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/deleteAssistant.operation.ts
@@ -19,7 +19,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 	const response = await apiRequest.call(this, 'DELETE', `/assistants/${assistantId}`, {
 		headers: {
-			'OpenAI-Beta': 'assistants=v1',
+			'OpenAI-Beta': 'assistants=v2',
 		},
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/list.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/list.operation.ts
@@ -30,7 +30,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	do {
 		const response = await apiRequest.call(this, 'GET', '/assistants', {
 			headers: {
-				'OpenAI-Beta': 'assistants=v1',
+				'OpenAI-Beta': 'assistants=v2',
 			},
 			qs: {
 				limit: 100,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -212,12 +212,14 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		// Construct a new thread from the chat history to map the memory
 		if (chatMessages.length) {
 			const first32Messages = chatMessages.slice(0, 32);
+			// There is a undocumented limit of 32 messages per thread when creating a thread with messages
 			const mappedMessages: OpenAIClient.Beta.Threads.ThreadCreateParams.Message[] =
 				first32Messages.map(mapChatMessageToThreadMessage);
 
 			thread = await client.beta.threads.create({ messages: mappedMessages });
 			const overLimitMessages = chatMessages.slice(32).map(mapChatMessageToThreadMessage);
 
+			// Send the remaining messages that exceed the limit of 32 sequentially
 			for (const message of overLimitMessages) {
 				await client.beta.threads.messages.create(thread.id, message);
 			}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -4,9 +4,17 @@ import { OpenAIAssistantRunnable } from 'langchain/experimental/openai_assistant
 import type { OpenAIToolType } from 'langchain/dist/experimental/openai_assistant/schema';
 import { OpenAI as OpenAIClient } from 'openai';
 
-import { NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
-import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
 
+import type { BufferWindowMemory } from 'langchain/memory';
+import omit from 'lodash/omit';
+import type { BaseMessage } from '@langchain/core/messages';
 import { formatToOpenAIAssistantTool } from '../../helpers/utils';
 import { assistantRLC } from '../descriptions';
 
@@ -110,6 +118,12 @@ const displayOptions = {
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
+const mapChatMessageToThreadMessage = (
+	message: BaseMessage,
+): OpenAIClient.Beta.Threads.ThreadCreateParams.Message => ({
+	role: message._getType() === 'ai' ? 'assistant' : 'user',
+	content: message.content.toString(),
+});
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
 	const credentials = await this.getCredentials('openAiApi');
@@ -182,11 +196,45 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		tools: tools ?? [],
 	});
 
-	const response = await agentExecutor.withConfig(getTracingConfig(this)).invoke({
+	const memory = (await this.getInputConnectionData(NodeConnectionType.AiMemory, 0)) as
+		| BufferWindowMemory
+		| undefined;
+
+	const chainValues: IDataObject = {
 		content: input,
 		signal: this.getExecutionCancelSignal(),
 		timeout: options.timeout ?? 10000,
-	});
+	};
+	let thread: OpenAIClient.Beta.Threads.Thread;
+	if (memory) {
+		const chatMessages = await memory.chatHistory.getMessages();
+
+		// Construct a new thread from the chat history to map the memory
+		if (chatMessages.length) {
+			const first32Messages = chatMessages.slice(0, 32);
+			const mappedMessages: OpenAIClient.Beta.Threads.ThreadCreateParams.Message[] =
+				first32Messages.map(mapChatMessageToThreadMessage);
+
+			thread = await client.beta.threads.create({ messages: mappedMessages });
+			const overLimitMessages = chatMessages.slice(32).map(mapChatMessageToThreadMessage);
+
+			for (const message of overLimitMessages) {
+				await client.beta.threads.messages.create(thread.id, message);
+			}
+
+			chainValues.threadId = thread.id;
+		}
+	}
+
+	const response = await agentExecutor.withConfig(getTracingConfig(this)).invoke(chainValues);
+	if (memory) {
+		await memory.saveContext({ input }, { output: response.output });
+
+		if (response.threadId && response.runId) {
+			const threadRun = await client.beta.threads.runs.retrieve(response.threadId, response.runId);
+			response.usage = threadRun.usage;
+		}
+	}
 
 	if (
 		options.preserveOriginalTools !== false &&
@@ -197,6 +245,6 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			tools: assistantTools,
 		});
 	}
-
-	return [{ json: response, pairedItem: { item: i } }];
+	const filteredResponse = omit(response, ['signal', 'timeout']);
+	return [{ json: filteredResponse, pairedItem: { item: i } }];
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
@@ -46,6 +46,7 @@ const configureNodeInputs = (resource: string, operation: string, hideTools: str
 	if (resource === 'assistant' && operation === 'message') {
 		return [
 			{ type: NodeConnectionType.Main },
+			{ type: NodeConnectionType.AiMemory, displayName: 'Memory', maxConnections: 1 },
 			{ type: NodeConnectionType.AiTool, displayName: 'Tools' },
 		];
 	}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
@@ -78,7 +78,7 @@ export async function assistantSearch(
 ): Promise<INodeListSearchResult> {
 	const { data, has_more, last_id } = await apiRequest.call(this, 'GET', '/assistants', {
 		headers: {
-			'OpenAI-Beta': 'assistants=v1',
+			'OpenAI-Beta': 'assistants=v2',
 		},
 		qs: {
 			limit: 100,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/OpenAi.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/OpenAi.node.test.ts
@@ -84,13 +84,24 @@ describe('OpenAi, Assistant resource', () => {
 		expect(transport.apiRequest).toHaveBeenCalledWith('POST', '/assistants', {
 			body: {
 				description: 'description',
-				file_ids: [],
 				instructions: 'some instructions',
 				model: 'gpt-model',
 				name: 'name',
-				tools: [{ type: 'code_interpreter' }, { type: 'retrieval' }],
+				tool_resources: {
+					code_interpreter: {
+						file_ids: [],
+					},
+					file_search: {
+						vector_stores: [
+							{
+								file_ids: [],
+							},
+						],
+					},
+				},
+				tools: [{ type: 'code_interpreter' }, { type: 'file_search' }],
 			},
-			headers: { 'OpenAI-Beta': 'assistants=v1' },
+			headers: { 'OpenAI-Beta': 'assistants=v2' },
 		});
 	});
 
@@ -124,7 +135,7 @@ describe('OpenAi, Assistant resource', () => {
 		);
 
 		expect(transport.apiRequest).toHaveBeenCalledWith('DELETE', '/assistants/assistant-id', {
-			headers: { 'OpenAI-Beta': 'assistants=v1' },
+			headers: { 'OpenAI-Beta': 'assistants=v2' },
 		});
 	});
 
@@ -185,17 +196,28 @@ describe('OpenAi, Assistant resource', () => {
 
 		expect(transport.apiRequest).toHaveBeenCalledTimes(2);
 		expect(transport.apiRequest).toHaveBeenCalledWith('GET', '/assistants/assistant-id', {
-			headers: { 'OpenAI-Beta': 'assistants=v1' },
+			headers: { 'OpenAI-Beta': 'assistants=v2' },
 		});
 		expect(transport.apiRequest).toHaveBeenCalledWith('POST', '/assistants/assistant-id', {
 			body: {
-				file_ids: [],
 				instructions: 'some instructions',
 				model: 'gpt-model',
 				name: 'name',
-				tools: [{ type: 'existing_tool' }, { type: 'code_interpreter' }, { type: 'retrieval' }],
+				tool_resources: {
+					code_interpreter: {
+						file_ids: [],
+					},
+					file_search: {
+						vector_stores: [
+							{
+								file_ids: [],
+							},
+						],
+					},
+				},
+				tools: [{ type: 'existing_tool' }, { type: 'code_interpreter' }, { type: 'file_search' }],
 			},
-			headers: { 'OpenAI-Beta': 'assistants=v1' },
+			headers: { 'OpenAI-Beta': 'assistants=v2' },
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Update the raw OpenAI assistant API calls to use v2 assistant API
- Added support for temperature & topP parameters for assistant create/update operation
- Remapped `file_ids` to the new API interface
- Add support for assistant message memory connector
- Include toke `usage` in the response


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
- https://github.com/n8n-io/n8n/issues/9398
- https://community.n8n.io/t/n8n-upgrade-for-chatgpt-assistant/45560/6
- https://community.n8n.io/t/enhanced-openai-assistant-node/34291/3


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 