### PR TITLE
fix(core): Return tags from `GET /workflows/:id`

### DIFF
--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -265,6 +265,7 @@ export class WorkflowsController {
 				workflowId,
 				req.user,
 				['workflow:read'],
+				{ includeTags: !config.getEnv('workflowTagsDisabled') },
 			);
 
 			if (!workflow) {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -371,6 +371,17 @@ describe('GET /workflows/:id', () => {
 		const { pinData } = workflowRetrievalResponse.body.data as { pinData: IPinData };
 		expect(pinData).toMatchObject(MOCK_PINDATA);
 	});
+
+	test('should return tags', async () => {
+		const tag = await createTag({ name: 'A' });
+		const workflow = await createWorkflow({ tags: [tag] }, owner);
+
+		const response = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
+
+		expect(response.body.data).toMatchObject({
+			tags: [expect.objectContaining({ id: tag.id, name: tag.name })],
+		});
+	});
 });
 
 describe('GET /workflows', () => {


### PR DESCRIPTION
## Summary

There is a regression on the feature/rbac branch. `GET /workflows/:id` would not return tags anymore if sharing is enabled.

This PR fixes that.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1583/bug-rbac-tags

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

