### PR TITLE
fix(Mattermost Node): Change loadOptions to fetch all items

### DIFF
--- a/packages/nodes-base/nodes/Mattermost/v1/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Mattermost/v1/methods/loadOptions.ts
@@ -1,12 +1,12 @@
 import type { IDataObject, ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
-import { apiRequest } from '../transport';
+import { apiRequestAllItems } from '../transport';
 
 // Get all the available channels
 export async function getChannels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const endpoint = 'channels';
-	const responseData = await apiRequest.call(this, 'GET', endpoint, {});
+	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {});
 
 	if (responseData === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No data got returned');
@@ -25,7 +25,7 @@ export async function getChannels(this: ILoadOptionsFunctions): Promise<INodePro
 
 		returnData.push({
 			name,
-			value: data.id,
+			value: data.id as string,
 		});
 	}
 
@@ -48,7 +48,7 @@ export async function getChannelsInTeam(
 ): Promise<INodePropertyOptions[]> {
 	const teamId = this.getCurrentNodeParameter('teamId');
 	const endpoint = `users/me/teams/${teamId}/channels`;
-	const responseData = await apiRequest.call(this, 'GET', endpoint, {});
+	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {});
 
 	if (responseData === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No data got returned');
@@ -72,7 +72,7 @@ export async function getChannelsInTeam(
 
 		returnData.push({
 			name,
-			value: data.id,
+			value: data.id as string,
 		});
 	}
 
@@ -91,7 +91,7 @@ export async function getChannelsInTeam(
 
 export async function getTeams(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const endpoint = 'users/me/teams';
-	const responseData = await apiRequest.call(this, 'GET', endpoint, {});
+	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {});
 
 	if (responseData === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No data got returned');
@@ -108,7 +108,7 @@ export async function getTeams(this: ILoadOptionsFunctions): Promise<INodeProper
 
 		returnData.push({
 			name,
-			value: data.id,
+			value: data.id as string,
 		});
 	}
 
@@ -127,7 +127,7 @@ export async function getTeams(this: ILoadOptionsFunctions): Promise<INodeProper
 
 export async function getUsers(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	const endpoint = 'users';
-	const responseData = await apiRequest.call(this, 'GET', endpoint, {});
+	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {});
 
 	if (responseData === undefined) {
 		throw new NodeOperationError(this.getNode(), 'No data got returned');
@@ -140,8 +140,8 @@ export async function getUsers(this: ILoadOptionsFunctions): Promise<INodeProper
 		}
 
 		returnData.push({
-			name: data.username,
-			value: data.id,
+			name: data.username as string,
+			value: data.id as string,
 		});
 	}
 


### PR DESCRIPTION
## Summary
LoadOptions were using `apiRequest` instead of `apiRequestAllItems` which implements pagination.

On an instance with 100 items it would only show the first 60, In the future if we do an overhaul on this node we should consider adding the RLC for User / Channel / Team selections.


## Related tickets and issues
https://github.com/n8n-io/n8n/issues/7344
https://linear.app/n8n/issue/NODE-869