### PR TITLE
fix(core): Add an option to disable STARTTLS for SMTP connections

### DIFF
--- a/packages/cli/src/UserManagement/email/NodeMailer.ts
+++ b/packages/cli/src/UserManagement/email/NodeMailer.ts
@@ -19,6 +19,7 @@ export class NodeMailer {
 			host: config.getEnv('userManagement.emails.smtp.host'),
 			port: config.getEnv('userManagement.emails.smtp.port'),
 			secure: config.getEnv('userManagement.emails.smtp.secure'),
+			ignoreTLS: !config.getEnv('userManagement.emails.smtp.startTLS'),
 		};
 
 		if (

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -816,6 +816,12 @@ export const schema = {
 					default: true,
 					env: 'N8N_SMTP_SSL',
 				},
+				startTLS: {
+					doc: 'Whether or not to use STARTTLS for SMTP when SSL is disabled',
+					format: Boolean,
+					default: true,
+					env: 'N8N_SMTP_STARTTLS',
+				},
 				auth: {
 					user: {
 						doc: 'SMTP login username',


### PR DESCRIPTION
When `secure` is set to `false` for nodemailer, it still tries to use STARTTLS to upgrade the connection. 
This PR adds an additional flag to completely disable STARTTLS.

## Related tickets and issues
https://community.n8n.io/t/user-management-need-help-fixing-smtp-error/14274
https://community.n8n.io/t/user-management-how-to-invite-users-with-ssl-less-unauthenticated-smtp-server/12940
https://community.n8n.io/t/any-idea-why-the-smtp-mailer-would-error-on-ssl/21264



## Review / Merge checklist
- [x] PR title and summary are descriptive