### PR TITLE
fix(RabbitMQ Node): Revert breaking change and add option to assert queue / exchange

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -75,7 +75,7 @@ export async function rabbitmqConnectQueue(
 
 	return await new Promise(async (resolve, reject) => {
 		try {
-			if (options.assertQueue) {
+			if (options.assertQueue === true || options.assertQueue === undefined) {
 				await channel.assertQueue(queue, options);
 			} else {
 				await channel.checkQueue(queue);
@@ -110,7 +110,7 @@ export async function rabbitmqConnectExchange(
 
 	return await new Promise(async (resolve, reject) => {
 		try {
-			if (options.assertExchange) {
+			if (options.assertExchange === true || options.assertExchange === undefined) {
 				await channel.assertExchange(exchange, type, options);
 			} else {
 				await channel.checkExchange(exchange);

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -263,6 +263,30 @@ export class RabbitMQ implements INodeType {
 							'An exchange to send messages to if this exchange can’t route them to any queues',
 					},
 					{
+						displayName: 'Assert Exchange',
+						name: 'assertExchange',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to assert the exchange exists before sending',
+						displayOptions: {
+							show: {
+								'/mode': ['exchange'],
+							},
+						},
+					},
+					{
+						displayName: 'Assert Queue',
+						name: 'assertQueue',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to assert the queue exists before sending',
+						displayOptions: {
+							show: {
+								'/mode': ['queue'],
+							},
+						},
+					},
+					{
 						displayName: 'Arguments',
 						name: 'arguments',
 						placeholder: 'Add Argument',


### PR DESCRIPTION
## Summary

This adds the assert queue and exchange options to the standard node which was broken in this PR: https://github.com/n8n-io/n8n/pull/8430

By disabling Assert Queue / Exchange the node will not automatically create the queue / exchange

## Related tickets and issues

https://github.com/n8n-io/n8n/issues/8871