### PR TITLE
fix(core): Send email again when a workflow or credential is shared

### DIFF
--- a/packages/cli/test/integration/credentials.ee.test.ts
+++ b/packages/cli/test/integration/credentials.ee.test.ts
@@ -422,6 +422,13 @@ describe('PUT /credentials/:id/share', () => {
 		});
 
 		expect(mailer.notifyCredentialsShared).toHaveBeenCalledTimes(1);
+		expect(mailer.notifyCredentialsShared).toHaveBeenCalledWith(
+			expect.objectContaining({
+				newShareeIds: expect.arrayContaining([member1.id, member2.id, member3.id]),
+				sharer: expect.objectContaining({ id: owner.id }),
+				credentialsName: savedCredential.name,
+			}),
+		);
 	});
 
 	test('should share the credential with the provided userIds', async () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -117,6 +117,13 @@ describe('PUT /workflows/:id', () => {
 		const sharedWorkflows = await getWorkflowSharing(workflow);
 		expect(sharedWorkflows).toHaveLength(2);
 		expect(mailer.notifyWorkflowShared).toHaveBeenCalledTimes(1);
+		expect(mailer.notifyWorkflowShared).toHaveBeenCalledWith(
+			expect.objectContaining({
+				newShareeIds: [member.id],
+				sharer: expect.objectContaining({ id: owner.id }),
+				workflow: expect.objectContaining({ id: workflow.id }),
+			}),
+		);
 	});
 
 	test('PUT /workflows/:id/share should succeed when sharing with invalid user-id', async () => {


### PR DESCRIPTION
## Summary

This fixes a regression the led to emails not being sent anymore when sharing credentials of workflows.

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

