### PR TITLE
refactor: Fix TypeScript errors workflow package

### DIFF
--- a/packages/editor-ui/tsconfig.json
+++ b/packages/editor-ui/tsconfig.json
@@ -11,7 +11,7 @@
 		"allowSyntheticDefaultImports": true,
 		"resolveJsonModule": true,
 		"baseUrl": ".",
-		"types": ["vitest/globals"],
+		"types": ["vitest/globals", "../workflow/src/types.d.ts"],
 		"paths": {
 			"@/*": ["src/*"],
 			"n8n-design-system/*": ["../design-system/src/*"],

--- a/packages/workflow/src/AugmentObject.ts
+++ b/packages/workflow/src/AugmentObject.ts
@@ -29,7 +29,7 @@ export function augmentArray<T>(data: T[]): T[] {
 	}
 
 	const proxy = new Proxy(data, {
-		deleteProperty(target, key: string) {
+		deleteProperty(_target, key: string) {
 			return Reflect.deleteProperty(getData(), key);
 		},
 		get(target, key: string, receiver): unknown {
@@ -59,7 +59,7 @@ export function augmentArray<T>(data: T[]): T[] {
 		ownKeys(target) {
 			return Reflect.ownKeys(newData ?? target);
 		},
-		set(target, key: string, newValue: unknown) {
+		set(_target, key: string, newValue: unknown) {
 			// Always proxy all objects. Like that we can check in get simply if it
 			// is a proxy and it does then not matter if it was already there from the
 			// beginning and it got proxied at some point or set later and so theoretically
@@ -143,7 +143,7 @@ export function augmentObject<T extends object>(data: T): T {
 			);
 		},
 
-		getOwnPropertyDescriptor(target, key) {
+		getOwnPropertyDescriptor(_target, key) {
 			if (deletedProperties.has(key)) return undefined;
 			return Object.getOwnPropertyDescriptor(key in newData ? newData : data, key);
 		},

--- a/packages/workflow/src/NativeMethods/Array.methods.ts
+++ b/packages/workflow/src/NativeMethods/Array.methods.ts
@@ -1,4 +1,4 @@
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 
 export const arrayMethods: NativeDoc = {
 	typeName: 'Array',

--- a/packages/workflow/src/NativeMethods/Boolean.methods.ts
+++ b/packages/workflow/src/NativeMethods/Boolean.methods.ts
@@ -1,4 +1,4 @@
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 
 export const booleanMethods: NativeDoc = {
 	typeName: 'Boolean',

--- a/packages/workflow/src/NativeMethods/Number.methods.ts
+++ b/packages/workflow/src/NativeMethods/Number.methods.ts
@@ -1,4 +1,4 @@
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 
 export const numberMethods: NativeDoc = {
 	typeName: 'Number',

--- a/packages/workflow/src/NativeMethods/Object.Methods.ts
+++ b/packages/workflow/src/NativeMethods/Object.Methods.ts
@@ -1,4 +1,4 @@
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 
 export const objectMethods: NativeDoc = {
 	typeName: 'Object',

--- a/packages/workflow/src/NativeMethods/String.methods.ts
+++ b/packages/workflow/src/NativeMethods/String.methods.ts
@@ -1,4 +1,4 @@
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 
 export const stringMethods: NativeDoc = {
 	typeName: 'String',

--- a/packages/workflow/src/NativeMethods/index.ts
+++ b/packages/workflow/src/NativeMethods/index.ts
@@ -2,7 +2,7 @@ import { stringMethods } from './String.methods';
 import { arrayMethods } from './Array.methods';
 import { numberMethods } from './Number.methods';
 import { objectMethods } from './Object.Methods';
-import type { NativeDoc } from '@/Extensions/Extensions';
+import type { NativeDoc } from '../Extensions/Extensions';
 import { booleanMethods } from './Boolean.methods';
 
 const NATIVE_METHODS: NativeDoc[] = [

--- a/packages/workflow/src/errors/credential-access-error.ts
+++ b/packages/workflow/src/errors/credential-access-error.ts
@@ -1,4 +1,4 @@
-import type { INode } from '@/Interfaces';
+import type { INode } from '../Interfaces';
 import { ExecutionBaseError } from './abstract/execution-base.error';
 
 export class CredentialAccessError extends ExecutionBaseError {

--- a/packages/workflow/src/errors/node-operation.error.ts
+++ b/packages/workflow/src/errors/node-operation.error.ts
@@ -6,8 +6,6 @@ import { NodeError } from './abstract/node.error';
  * Class for instantiating an operational error, e.g. an invalid credentials error.
  */
 export class NodeOperationError extends NodeError {
-	lineNumber: number | undefined;
-
 	type: string | undefined;
 
 	constructor(

--- a/packages/workflow/src/errors/workflow-operation.error.ts
+++ b/packages/workflow/src/errors/workflow-operation.error.ts
@@ -9,10 +9,6 @@ export class WorkflowOperationError extends ExecutionBaseError {
 
 	timestamp: number;
 
-	lineNumber: number | undefined;
-
-	description: string | undefined;
-
 	constructor(message: string, node?: INode, description?: string) {
 		super(message, { cause: undefined });
 		this.level = 'warning';


### PR DESCRIPTION
## Summary
- Replaced `@/` imports in workflow package with relative imports (they conflict with `@/` imports in editor-ui
  - Tried changing the tsconfig and using https://www.npmjs.com/package/vite-tsconfig-paths, but it doesn't work. Long thread about it here: https://github.com/vercel/turbo/discussions/620
  - Potentially we could use globally unique aliases `@` -> `@editor-ui`, `@` -> `@workflow` but it would be a bigger refactor

## Related tickets and issues
https://www.notion.so/n8n/TS-Spring-Cleaning-b41b52e5e79042449b92fabd37b6f77d

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 