### PR TITLE
refactor(editor): Fix Types issues in @n8n/chat (no-changelog)

### DIFF
--- a/packages/@n8n/chat/src/components/Chat.vue
+++ b/packages/@n8n/chat/src/components/Chat.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// eslint-disable-next-line import/no-unresolved
 import Close from 'virtual:icons/mdi/close';
 import { computed, nextTick, onMounted } from 'vue';
 import Layout from '@n8n/chat/components/Layout.vue';

--- a/packages/@n8n/chat/src/components/ChatWindow.vue
+++ b/packages/@n8n/chat/src/components/ChatWindow.vue
@@ -1,7 +1,5 @@
 <script lang="ts" setup>
-// eslint-disable-next-line import/no-unresolved
 import IconChat from 'virtual:icons/mdi/chat';
-// eslint-disable-next-line import/no-unresolved
 import IconChevronDown from 'virtual:icons/mdi/chevron-down';
 import { nextTick, ref } from 'vue';
 import Chat from '@n8n/chat/components/Chat.vue';

--- a/packages/@n8n/chat/src/components/Input.vue
+++ b/packages/@n8n/chat/src/components/Input.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// eslint-disable-next-line import/no-unresolved
 import IconSend from 'virtual:icons/mdi/send';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n, useChat, useOptions } from '@n8n/chat/composables';

--- a/packages/@n8n/chat/src/types/icons.d.ts
+++ b/packages/@n8n/chat/src/types/icons.d.ts
@@ -1,0 +1,5 @@
+declare module 'virtual:icons/*' {
+	import { FunctionalComponent, SVGAttributes } from 'vue';
+	const component: FunctionalComponent<SVGAttributes>;
+	export default component;
+}

--- a/packages/@n8n/chat/vite.config.ts
+++ b/packages/@n8n/chat/vite.config.ts
@@ -14,6 +14,7 @@ const plugins = [
 	vue(),
 	icons({
 		compiler: 'vue3',
+		autoInstall: true,
 	}),
 	dts(),
 ];

--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -361,7 +361,7 @@ const config = (module.exports = {
 		/**
 		 * https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md
 		 */
-		'import/no-unresolved': 'error',
+		'import/no-unresolved': ['error', { ignore: ['^virtual:'] }],
 
 		/**
 		 * https://github.com/import-js/eslint-plugin-import/blob/master/docs/rules/order.md

--- a/packages/editor-ui/tsconfig.json
+++ b/packages/editor-ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"rootDir": ".",
+		"rootDirs": [".", "../design-system/src", "../@n8n/chat/src"],
 		"outDir": "dist",
 		"target": "esnext",
 		"module": "esnext",

--- a/packages/editor-ui/vite.config.mts
+++ b/packages/editor-ui/vite.config.mts
@@ -73,6 +73,7 @@ const alias = [
 const plugins = [
 	icons({
 		compiler: 'vue3',
+		autoInstall: true,
 	}),
 	vue(),
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4560,7 +4560,7 @@ packages:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.23.5
       '@babel/parser': 7.24.0
       '@babel/types': 7.24.0
 
@@ -8883,7 +8883,7 @@ packages:
       lodash: 4.17.21
       prettier: 3.2.5
       recast: 0.23.6
-      tiny-invariant: 1.3.1
+      tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9261,7 +9261,7 @@ packages:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.21(typescript@5.4.2)
-      vue-component-type-helpers: 2.0.18
+      vue-component-type-helpers: 2.0.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -24125,7 +24125,7 @@ packages:
       npm-run-path: 4.0.1
       semver: 7.6.0
       strip-ansi: 6.0.1
-      tiny-invariant: 1.3.1
+      tiny-invariant: 1.3.3
       typescript: 5.4.2
       vite: 5.1.6(sass@1.64.1)
       vscode-languageclient: 7.0.0
@@ -24344,8 +24344,8 @@ packages:
     resolution: {integrity: sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==}
     dev: true
 
-  /vue-component-type-helpers@2.0.18:
-    resolution: {integrity: sha512-zi1QaDBhSb3oeHJh55aTCrosFNKEQsOL9j3XCAjpF9dwxDUUtd85RkJVzO+YpJqy1LNoCWLU8gwuZ7HW2iDN/A==}
+  /vue-component-type-helpers@2.0.19:
+    resolution: {integrity: sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==}
     dev: true
 
   /vue-demi@0.14.5(vue@3.4.21):


### PR DESCRIPTION
## Summary
- Add both `@n8n/chat ` and `design-system` as root dirs
- Add shims for virtual icons & autoinstall them in vite config

For some reason, running `typecheck` from `editor-ui` still throws `error TS2307: Cannot find module 'virtual:icons/mdi/.....` even after adding the shims but to not loose too much time on this; I will move over to other issues now and will look into these as last.

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 