### PR TITLE
fix(HTML Node): Fix typo preventing row attributes from being set in tables

### DIFF
--- a/packages/nodes-base/nodes/Html/Html.node.ts
+++ b/packages/nodes-base/nodes/Html/Html.node.ts
@@ -427,7 +427,7 @@ export class Html implements INodeType {
 			table += '<tbody>';
 			itemsData.forEach((entry, entryIndex) => {
 				const rowsAttributes = this.getNodeParameter(
-					'options.rowsAttributes',
+					'options.rowAttributes',
 					entryIndex,
 					'',
 				) as string;


### PR DESCRIPTION
## Summary
There was a typo that meant the row atrribute changes were never being applied.


## Related tickets and issues
https://github.com/n8n-io/n8n/issues/9428