### PR TITLE
fix: Fix type errors in community nodes components

### DIFF
--- a/packages/editor-ui/src/components/CommunityPackageCard.vue
+++ b/packages/editor-ui/src/components/CommunityPackageCard.vue
@@ -4,7 +4,7 @@
 			<n8n-loading :class="$style.loader" variant="p" :rows="1" />
 			<n8n-loading :class="$style.loader" variant="p" :rows="1" />
 		</div>
-		<div v-else :class="$style.packageCard">
+		<div v-else-if="communityPackage" :class="$style.packageCard">
 			<div :class="$style.cardInfoContainer">
 				<div :class="$style.cardTitle">
 					<n8n-text :bold="true" size="large">{{ communityPackage.packageName }}</n8n-text>
@@ -72,7 +72,9 @@ export default defineComponent({
 	name: 'CommunityPackageCard',
 	props: {
 		communityPackage: {
-			type: Object as () => PublicInstalledPackage,
+			type: Object as () => PublicInstalledPackage | null,
+			required: false,
+			default: null,
 		},
 		loading: {
 			type: Boolean,
@@ -99,6 +101,7 @@ export default defineComponent({
 	},
 	methods: {
 		async onAction(value: string) {
+			if (!this.communityPackage) return;
 			switch (value) {
 				case COMMUNITY_PACKAGE_MANAGE_ACTIONS.VIEW_DOCS:
 					this.$telemetry.track('user clicked to browse the cnr package documentation', {
@@ -115,6 +118,7 @@ export default defineComponent({
 			}
 		},
 		onUpdateClick() {
+			if (!this.communityPackage) return;
 			this.uiStore.openCommunityPackageUpdateConfirmModal(this.communityPackage.packageName);
 		},
 	},

--- a/packages/editor-ui/src/views/SettingsCommunityNodesView.vue
+++ b/packages/editor-ui/src/views/SettingsCommunityNodesView.vue
@@ -95,59 +95,6 @@ export default defineComponent({
 			loading: false,
 		};
 	},
-	beforeMount() {
-		this.pushConnection.initialize();
-		// The push connection is needed here to receive `reloadNodeType` and `removeNodeType` events when community nodes are installed, updated, or removed.
-		this.pushStore.pushConnect();
-	},
-	async mounted() {
-		try {
-			this.loading = true;
-			await this.communityNodesStore.fetchInstalledPackages();
-
-			const installedPackages: PublicInstalledPackage[] =
-				this.communityNodesStore.getInstalledPackages;
-			const packagesToUpdate: PublicInstalledPackage[] = installedPackages.filter(
-				(p) => p.updateAvailable,
-			);
-			this.$telemetry.track('user viewed cnr settings page', {
-				num_of_packages_installed: installedPackages.length,
-				installed_packages: installedPackages.map((p) => {
-					return {
-						package_name: p.packageName,
-						package_version: p.installedVersion,
-						package_nodes: p.installedNodes.map((node) => `${node.name}-v${node.latestVersion}`),
-						is_update_available: p.updateAvailable !== undefined,
-					};
-				}),
-				packages_to_update: packagesToUpdate.map((p) => {
-					return {
-						package_name: p.packageName,
-						package_version_current: p.installedVersion,
-						package_version_available: p.updateAvailable,
-					};
-				}),
-				number_of_updates_available: packagesToUpdate.length,
-			});
-		} catch (error) {
-			this.showError(
-				error,
-				this.$locale.baseText('settings.communityNodes.fetchError.title'),
-				this.$locale.baseText('settings.communityNodes.fetchError.message'),
-			);
-		} finally {
-			this.loading = false;
-		}
-		try {
-			await this.communityNodesStore.fetchAvailableCommunityPackageCount();
-		} finally {
-			this.loading = false;
-		}
-	},
-	beforeUnmount() {
-		this.pushStore.pushDisconnect();
-		this.pushConnection.terminate();
-	},
 	computed: {
 		...mapStores(useCommunityNodesStore, useSettingsStore, useUIStore, usePushConnectionStore),
 		getEmptyStateDescription(): string {
@@ -213,6 +160,59 @@ export default defineComponent({
 				hideButton: false,
 			};
 		},
+	},
+	beforeMount() {
+		this.pushConnection.initialize();
+		// The push connection is needed here to receive `reloadNodeType` and `removeNodeType` events when community nodes are installed, updated, or removed.
+		this.pushStore.pushConnect();
+	},
+	async mounted() {
+		try {
+			this.loading = true;
+			await this.communityNodesStore.fetchInstalledPackages();
+
+			const installedPackages: PublicInstalledPackage[] =
+				this.communityNodesStore.getInstalledPackages;
+			const packagesToUpdate: PublicInstalledPackage[] = installedPackages.filter(
+				(p) => p.updateAvailable,
+			);
+			this.$telemetry.track('user viewed cnr settings page', {
+				num_of_packages_installed: installedPackages.length,
+				installed_packages: installedPackages.map((p) => {
+					return {
+						package_name: p.packageName,
+						package_version: p.installedVersion,
+						package_nodes: p.installedNodes.map((node) => `${node.name}-v${node.latestVersion}`),
+						is_update_available: p.updateAvailable !== undefined,
+					};
+				}),
+				packages_to_update: packagesToUpdate.map((p) => {
+					return {
+						package_name: p.packageName,
+						package_version_current: p.installedVersion,
+						package_version_available: p.updateAvailable,
+					};
+				}),
+				number_of_updates_available: packagesToUpdate.length,
+			});
+		} catch (error) {
+			this.showError(
+				error,
+				this.$locale.baseText('settings.communityNodes.fetchError.title'),
+				this.$locale.baseText('settings.communityNodes.fetchError.message'),
+			);
+		} finally {
+			this.loading = false;
+		}
+		try {
+			await this.communityNodesStore.fetchAvailableCommunityPackageCount();
+		} finally {
+			this.loading = false;
+		}
+	},
+	beforeUnmount() {
+		this.pushStore.pushDisconnect();
+		this.pushConnection.terminate();
 	},
 	methods: {
 		onClickEmptyStateButton(): void {


### PR DESCRIPTION
## Summary
- Fixes error types in `CommunityPackageCard`
- Also fixes the Vue property order warning in the `SettingsCommunityNodesView` component
<img width="771" alt="image" src="https://github.com/n8n-io/n8n/assets/2598782/17b2fb24-482f-4804-8564-4cc54f3b16ee">


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 