### PR TITLE
refactor(core): Fix type errors in workflow, core, nodes-langchain, and nodes-base (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -46,7 +46,7 @@ function getInputs(
 			[NodeConnectionType.AiOutputParser]: 'Output Parser',
 		};
 
-		return inputs.map(({ type, filter, required }) => {
+		return inputs.map(({ type, filter }) => {
 			const input: INodeInputConfiguration = {
 				type,
 				displayName: type in displayNames ? displayNames[type] : undefined,
@@ -370,13 +370,13 @@ export class Agent implements INodeType {
 		if (agentType === 'conversationalAgent') {
 			return await conversationalAgentExecute.call(this, nodeVersion);
 		} else if (agentType === 'toolsAgent') {
-			return await toolsAgentExecute.call(this, nodeVersion);
+			return await toolsAgentExecute.call(this);
 		} else if (agentType === 'openAiFunctionsAgent') {
 			return await openAiFunctionsAgentExecute.call(this, nodeVersion);
 		} else if (agentType === 'reActAgent') {
 			return await reActAgentAgentExecute.call(this, nodeVersion);
 		} else if (agentType === 'sqlAgent') {
-			return await sqlAgentAgentExecute.call(this, nodeVersion);
+			return await sqlAgentAgentExecute.call(this);
 		} else if (agentType === 'planAndExecuteAgent') {
 			return await planAndExecuteAgentExecute.call(this, nodeVersion);
 		}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -120,5 +120,5 @@ export async function conversationalAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
@@ -125,5 +125,5 @@ export async function openAiFunctionsAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
@@ -100,5 +100,5 @@ export async function planAndExecuteAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -121,5 +121,5 @@ export async function reActAgentAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/execute.ts
@@ -28,7 +28,6 @@ const parseTablesString = (tablesString: string) =>
 
 export async function sqlAgentAgentExecute(
 	this: IExecuteFunctions,
-	nodeVersion: number,
 ): Promise<INodeExecutionData[][]> {
 	this.logger.verbose('Executing SQL Agent');
 
@@ -152,5 +151,5 @@ export async function sqlAgentAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -39,10 +39,7 @@ function getOutputParserSchema(outputParser: BaseOutputParser): ZodObject<any, a
 	return schema;
 }
 
-export async function toolsAgentExecute(
-	this: IExecuteFunctions,
-	nodeVersion: number,
-): Promise<INodeExecutionData[][]> {
+export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	this.logger.verbose('Executing Tools Agent');
 	const model = await this.getInputConnectionData(NodeConnectionType.AiLanguageModel, 0);
 
@@ -185,5 +182,5 @@ export async function toolsAgentExecute(
 		}
 	}
 
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -392,6 +392,6 @@ export class OpenAiAssistant implements INodeType {
 			}
 		}
 
-		return await this.prepareOutputData(returnData);
+		return [returnData];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -189,6 +189,6 @@ export class ChainRetrievalQa implements INodeType {
 				throw error;
 			}
 		}
-		return await this.prepareOutputData(returnData);
+		return [returnData];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
@@ -258,6 +258,6 @@ export class ChainSummarizationV1 implements INodeType {
 			returnData.push({ json: { response } });
 		}
 
-		return await this.prepareOutputData(returnData);
+		return [returnData];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -425,6 +425,6 @@ export class ChainSummarizationV2 implements INodeType {
 			}
 		}
 
-		return await this.prepareOutputData(returnData);
+		return [returnData];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
@@ -98,7 +98,7 @@ export class MemoryChatRetriever implements INodeType {
 		const messages = await memory?.chatHistory.getMessages();
 
 		if (simplifyOutput && messages) {
-			return await this.prepareOutputData(simplifyMessages(messages));
+			return [simplifyMessages(messages)];
 		}
 
 		const serializedMessages =
@@ -107,6 +107,6 @@ export class MemoryChatRetriever implements INodeType {
 				return { json: serializedMessage as unknown as IDataObject };
 			}) ?? [];
 
-		return await this.prepareOutputData(serializedMessages);
+		return [serializedMessages];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -1,4 +1,4 @@
-import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
+import type { IExecuteFunctions, INode, IWorkflowDataProxyData } from 'n8n-workflow';
 import { mock } from 'jest-mock-extended';
 import { normalizeItems } from 'n8n-core';
 import type { z } from 'zod';
@@ -12,7 +12,7 @@ describe('OutputParserStructured', () => {
 	});
 	const workflowDataProxy = mock<IWorkflowDataProxyData>({ $input: mock() });
 	thisArg.getWorkflowDataProxy.mockReturnValue(workflowDataProxy);
-	thisArg.getNode.mockReturnValue({ typeVersion: 1.1 });
+	thisArg.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.1 }));
 	thisArg.addInputData.mockReturnValue({ index: 0 });
 	thisArg.addOutputData.mockReturnValue();
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemoryInsert/VectorStoreInMemoryInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemoryInsert/VectorStoreInMemoryInsert.node.ts
@@ -108,6 +108,6 @@ export class VectorStoreInMemoryInsert implements INodeType {
 			clearStore,
 		);
 
-		return await this.prepareOutputData(serializedDocuments);
+		return [serializedDocuments];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
@@ -134,6 +134,6 @@ export class VectorStorePineconeInsert implements INodeType {
 			pineconeIndex,
 		});
 
-		return await this.prepareOutputData(serializedDocuments);
+		return [serializedDocuments];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -46,7 +46,7 @@ export const VectorStoreQdrant = createVectorStoreNode({
 	methods: { listSearch: { qdrantCollectionsSearch } },
 	insertFields,
 	sharedFields,
-	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
+	async getVectorStoreClient(context, _, embeddings, itemIndex) {
 		const collection = context.getNodeParameter('qdrantCollection', itemIndex, '', {
 			extractValue: true,
 		}) as string;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabaseInsert/VectorStoreSupabaseInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabaseInsert/VectorStoreSupabaseInsert.node.ts
@@ -122,6 +122,6 @@ export class VectorStoreSupabaseInsert implements INodeType {
 			queryName,
 		});
 
-		return await this.prepareOutputData(serializedDocuments);
+		return [serializedDocuments];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZepInsert/VectorStoreZepInsert.node.ts
@@ -139,6 +139,6 @@ export class VectorStoreZepInsert implements INodeType {
 
 		await ZepVectorStore.fromDocuments(processedDocuments, embeddings, zepConfig);
 
-		return await this.prepareOutputData(serializedDocuments);
+		return [serializedDocuments];
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -240,7 +240,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					void logAiEvent(this, 'n8n.ai.vector.store.searched', { query: prompt });
 				}
 
-				return await this.prepareOutputData(resultData);
+				return [resultData];
 			}
 
 			if (mode === 'insert') {
@@ -270,7 +270,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 					}
 				}
 
-				return await this.prepareOutputData(resultData);
+				return [resultData];
 			}
 
 			throw new NodeOperationError(

--- a/packages/core/src/Secrets.ts
+++ b/packages/core/src/Secrets.ts
@@ -3,7 +3,7 @@ import { ExpressionError } from 'n8n-workflow';
 
 function buildSecretsValueProxy(value: IDataObject): unknown {
 	return new Proxy(value, {
-		get(target, valueName) {
+		get(_target, valueName) {
 			if (typeof valueName !== 'string') {
 				return;
 			}
@@ -27,7 +27,7 @@ export function getSecretsProxy(additionalData: IWorkflowExecuteAdditionalData):
 	return new Proxy(
 		{},
 		{
-			get(target, providerName) {
+			get(_target, providerName) {
 				if (typeof providerName !== 'string') {
 					return {};
 				}
@@ -35,7 +35,7 @@ export function getSecretsProxy(additionalData: IWorkflowExecuteAdditionalData):
 					return new Proxy(
 						{},
 						{
-							get(target2, secretName) {
+							get(_target2, secretName) {
 								if (typeof secretName !== 'string') {
 									return;
 								}

--- a/packages/core/test/ObjectStore.manager.test.ts
+++ b/packages/core/test/ObjectStore.manager.test.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs/promises';
+import { mock } from 'jest-mock-extended';
 import { ObjectStoreManager } from '@/BinaryData/ObjectStore.manager';
 import { ObjectStoreService } from '@/ObjectStore/ObjectStore.service.ee';
 import { isStream } from '@/ObjectStore/utils';
+import type { MetadataResponseHeaders } from '@/ObjectStore/types';
 import { mockInstance, toFileId, toStream } from './utils';
 
 jest.mock('fs/promises');
@@ -74,11 +76,13 @@ describe('getMetadata()', () => {
 		const mimeType = 'text/plain';
 		const fileName = 'file.txt';
 
-		objectStoreService.getMetadata.mockResolvedValue({
-			'content-length': '1',
-			'content-type': mimeType,
-			'x-amz-meta-filename': fileName,
-		});
+		objectStoreService.getMetadata.mockResolvedValue(
+			mock<MetadataResponseHeaders>({
+				'content-length': '1',
+				'content-type': mimeType,
+				'x-amz-meta-filename': fileName,
+			}),
+		);
 
 		const metadata = await objectStoreManager.getMetadata(fileId);
 

--- a/packages/nodes-base/nodes/AgileCrm/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/AgileCrm/GenericFunctions.ts
@@ -96,7 +96,7 @@ export async function agileCrmApiRequestAllItems(
 export async function agileCrmApiRequestUpdate(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods = 'PUT',
-	endpoint?: string,
+	_endpoint?: string,
 	body: any = {},
 	_query: IDataObject = {},
 	uri?: string,

--- a/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
@@ -14,7 +14,7 @@ export async function clockifyApiRequest(
 
 	body: any = {},
 	qs: IDataObject = {},
-	uri?: string,
+	_uri?: string,
 	_option: IDataObject = {},
 ): Promise<any> {
 	const BASE_URL = 'https://api.clockify.me/api/v1';

--- a/packages/nodes-base/nodes/Cloudflare/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Cloudflare/GenericFunctions.ts
@@ -15,7 +15,7 @@ export async function cloudflareApiRequest(
 	resource: string,
 	body = {},
 	qs: IDataObject = {},
-	uri?: string,
+	_uri?: string,
 	headers: IDataObject = {},
 ): Promise<any> {
 	const options: IRequestOptions = {

--- a/packages/nodes-base/nodes/Code/test/Code.node.test.ts
+++ b/packages/nodes-base/nodes/Code/test/Code.node.test.ts
@@ -1,7 +1,7 @@
 import { anyNumber, mock } from 'jest-mock-extended';
 import { NodeVM } from '@n8n/vm2';
 import type { IExecuteFunctions, IWorkflowDataProxyData } from 'n8n-workflow';
-import { ApplicationError, NodeHelpers } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
 import { normalizeItems } from 'n8n-core';
 import { Code } from '../Code.node';
 import { ValidationError } from '../ValidationError';
@@ -22,7 +22,6 @@ describe('Code Node unit test', () => {
 	const thisArg = mock<IExecuteFunctions>({
 		getNode: () => mock(),
 		helpers: { normalizeItems },
-		prepareOutputData: NodeHelpers.prepareOutputData,
 	});
 	const workflowDataProxy = mock<IWorkflowDataProxyData>({ $input: mock() });
 	thisArg.getWorkflowDataProxy.mockReturnValue(workflowDataProxy);

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'POST') {
 		return {
 			id: '1168528323006181417',

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'DELETE') {
 		return {
 			id: '1168528323006181417',

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
@@ -5,10 +5,11 @@ import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 import type { WorkflowTestData } from '@test/nodes/types';
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
+// TODO: use nock
 const requestApiSpy = jest.spyOn(transport, 'requestApi');
 
 requestApiSpy.mockImplementation(
-	async (options: IRequestOptions, credentialType: string, endpoint: string) => {
+	async (_options: IRequestOptions, _credentialType: string, endpoint: string) => {
 		if (endpoint === '/users/@me/guilds') {
 			return {
 				headers: {},

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'GET') {
 		return [
 			{

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string, _) => {
 	if (method === 'PATCH') {
 		return {
 			id: '1168516240332034067',

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'GET') {
 		return [
 			{

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'PUT') {
 		return {
 			success: true,

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'DELETE') {
 		return {
 			success: true,

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'DELETE') {
 		return {
 			success: true,

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'GET') {
 		return {
 			id: '1168777380144369718',

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'GET') {
 		return [
 			{

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'PUT') {
 		return {
 			success: true,

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'POST') {
 		return {
 			id: '1168784010269433998',

--- a/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
@@ -7,7 +7,7 @@ import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 
 const discordApiRequestSpy = jest.spyOn(transport, 'discordApiRequest');
 
-discordApiRequestSpy.mockImplementation(async (method: string, endpoint) => {
+discordApiRequestSpy.mockImplementation(async (method: string) => {
 	if (method === 'POST') {
 		return {
 			id: '1168768986385747999',

--- a/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/GoToWebinar/GenericFunctions.ts
@@ -14,7 +14,7 @@ import moment from 'moment-timezone';
 
 import * as losslessJSON from 'lossless-json';
 
-function convertLosslessNumber(key: any, value: any) {
+function convertLosslessNumber(_: any, value: any) {
 	if (value?.isLosslessNumber) {
 		return value.toString();
 	} else {

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../v2/transport';

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../v2/transport';

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../v2/transport';

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
@@ -36,7 +36,7 @@ describe('test GoogleDriveV2: drive create', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			name: 'newDrive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: drive deleteDrive', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			operation: 'deleteDrive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: drive get', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			operation: 'get',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 import * as list from '../../../../v2/actions/drive/list.operation';
 
@@ -33,7 +34,7 @@ describe('test GoogleDriveV2: drive list', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with limit', async () => {
+	it('should be called with limit', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			operation: 'list',
@@ -54,7 +55,7 @@ describe('test GoogleDriveV2: drive list', () => {
 		);
 	});
 
-	it('shuold be called with returnAll true', async () => {
+	it('should be called with returnAll true', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			operation: 'list',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: drive update', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',
 			operation: 'update',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 import * as move from '../../../../v2/actions/file/move.operation';
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 import * as upload from '../../../../v2/actions/file/upload.operation';
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 import * as search from '../../../../v2/actions/fileFolder/search.operation';
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: folder create', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'folder',
 			name: 'testFolder 2',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: folder deleteFolder', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with PATCH', async () => {
+	it('should be called with PATCH', async () => {
 		const nodeParameters = {
 			resource: 'folder',
 			operation: 'deleteFolder',
@@ -52,7 +52,7 @@ describe('test GoogleDriveV2: folder deleteFolder', () => {
 		);
 	});
 
-	it('shuold be called with DELETE', async () => {
+	it('should be called with DELETE', async () => {
 		const nodeParameters = {
 			resource: 'folder',
 			operation: 'deleteFolder',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
@@ -26,7 +26,7 @@ describe('test GoogleDriveV2: folder share', () => {
 		jest.unmock('../../../../v2/transport');
 	});
 
-	it('shuold be called with', async () => {
+	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'folder',
 			operation: 'share',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -102,7 +102,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 				const projectId = this.getNodeParameter('projectId', 0) as string;
 				const database = this.getNodeParameter('database', 0) as string;
 				const simple = this.getNodeParameter('simple', 0) as boolean;
-				const documentList = items.map((item: IDataObject, i: number) => {
+				const documentList = items.map((_: IDataObject, i: number) => {
 					const collection = this.getNodeParameter('collection', i) as string;
 					const documentId = this.getNodeParameter('documentId', i) as string;
 					return `projects/${projectId}/databases/${database}/documents/${collection}/${documentId}`;
@@ -221,7 +221,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 				returnData.push(...executionData);
 			} else if (operation === 'delete') {
 				await Promise.all(
-					items.map(async (item: IDataObject, i: number) => {
+					items.map(async (_: IDataObject, i: number) => {
 						const projectId = this.getNodeParameter('projectId', i) as string;
 						const database = this.getNodeParameter('database', i) as string;
 						const collection = this.getNodeParameter('collection', i) as string;
@@ -332,7 +332,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 				const simple = this.getNodeParameter('simple', 0) as boolean;
 
 				await Promise.all(
-					items.map(async (item: IDataObject, i: number) => {
+					items.map(async (_: IDataObject, i: number) => {
 						const query = this.getNodeParameter('query', i) as string;
 						responseData = await googleApiRequest.call(
 							this,

--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -477,7 +477,6 @@ export function prepareEmailBody(
 export async function prepareEmailAttachments(
 	this: IExecuteFunctions,
 	options: IDataObject,
-	items: INodeExecutionData[],
 	itemIndex: number,
 ) {
 	const attachmentsList: IDataObject[] = [];
@@ -536,7 +535,6 @@ export function unescapeSnippets(items: INodeExecutionData[]) {
 
 export async function replyToEmail(
 	this: IExecuteFunctions,
-	items: INodeExecutionData[],
 	gmailId: string,
 	options: IDataObject,
 	itemIndex: number,
@@ -558,7 +556,6 @@ export async function replyToEmail(
 		attachments = await prepareEmailAttachments.call(
 			this,
 			options.attachmentsUi as IDataObject,
-			items,
 			itemIndex,
 		);
 		if (attachments.length) {

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -325,7 +325,6 @@ export class GmailV2 implements INodeType {
 							attachments = await prepareEmailAttachments.call(
 								this,
 								options.attachmentsUi as IDataObject,
-								items,
 								i,
 							);
 							if (attachments.length) {
@@ -374,7 +373,7 @@ export class GmailV2 implements INodeType {
 						const messageIdGmail = this.getNodeParameter('messageId', i) as string;
 						const options = this.getNodeParameter('options', i);
 
-						responseData = await replyToEmail.call(this, items, messageIdGmail, options, i);
+						responseData = await replyToEmail.call(this, messageIdGmail, options, i);
 					}
 					if (operation === 'get') {
 						//https://developers.google.com/gmail/api/v1/reference/users/messages/get
@@ -581,7 +580,6 @@ export class GmailV2 implements INodeType {
 							attachments = await prepareEmailAttachments.call(
 								this,
 								options.attachmentsUi as IDataObject,
-								items,
 								i,
 							);
 							if (attachments.length) {
@@ -793,7 +791,7 @@ export class GmailV2 implements INodeType {
 						const messageIdGmail = this.getNodeParameter('messageId', i) as string;
 						const options = this.getNodeParameter('options', i);
 
-						responseData = await replyToEmail.call(this, items, messageIdGmail, options, i);
+						responseData = await replyToEmail.call(this, messageIdGmail, options, i);
 					}
 					if (operation === 'trash') {
 						//https://developers.google.com/gmail/api/reference/rest/v1/users.threads/trash

--- a/packages/nodes-base/nodes/Google/Sheet/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v1/GenericFunctions.ts
@@ -95,7 +95,7 @@ export async function googleApiRequestAllItems(
 export function hexToRgb(hex: string) {
 	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 	const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-	hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+	hex = hex.replace(shorthandRegex, (_, r, g, b) => {
 		return r + r + g + g + b + b;
 	});
 

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
@@ -77,7 +77,7 @@ export function getColumnNumber(colPosition: string): number {
 export function hexToRgb(hex: string) {
 	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
 	const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-	hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+	hex = hex.replace(shorthandRegex, (_, r, g, b) => {
 		return r + r + g + g + b + b;
 	});
 

--- a/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
@@ -78,7 +78,7 @@ export async function hubspotApiRequest(
  */
 export async function hubspotApiRequestAllItems(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
-	propertyName: string,
+	_propertyName: string,
 	method: IHttpRequestMethods,
 	endpoint: string,
 	// tslint:disable-next-line:no-any

--- a/packages/nodes-base/nodes/Line/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Line/GenericFunctions.ts
@@ -12,7 +12,7 @@ import { NodeApiError } from 'n8n-workflow';
 export async function lineApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 	method: IHttpRequestMethods,
-	resource: string,
+	_resource: string,
 
 	body: any = {},
 	qs: IDataObject = {},

--- a/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Matrix/GenericFunctions.ts
@@ -57,7 +57,6 @@ export async function matrixApiRequest(
 
 export async function handleMatrixCall(
 	this: IExecuteFunctions,
-	item: IDataObject,
 	index: number,
 	resource: string,
 	operation: string,

--- a/packages/nodes-base/nodes/Matrix/Matrix.node.ts
+++ b/packages/nodes-base/nodes/Matrix/Matrix.node.ts
@@ -143,7 +143,7 @@ export class Matrix implements INodeType {
 
 		for (let i = 0; i < items.length; i++) {
 			try {
-				const responseData = await handleMatrixCall.call(this, items[i], i, resource, operation);
+				const responseData = await handleMatrixCall.call(this, i, resource, operation);
 				const executionData = this.helpers.constructExecutionMetaData(
 					this.helpers.returnJsonArray(responseData as IDataObject[]),
 					{ itemData: { item: i } },

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
@@ -1,4 +1,4 @@
-import type { INodeTypes } from 'n8n-workflow';
+import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
 
 import nock from 'nock';
 import * as transport from '../../../../v2/transport';

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
+import type { IHttpRequestMethods } from 'n8n-workflow';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');
 	return {
 		...originalModule,
-		microsoftApiRequestAllItems: jest.fn(async function (method: string) {
+		microsoftApiRequestAllItems: jest.fn(async function () {
 			return [
 				{
 					'@odata.etag': 'W/"CQAAABYAAABZf4De/LkrSqpPI8eyjUmAAAFW3CAj"',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/GenericFunctions.ts
@@ -7,7 +7,7 @@ import type {
 	IRequestOptions,
 	JsonObject,
 } from 'n8n-workflow';
-import { BINARY_ENCODING, NodeApiError } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
@@ -221,24 +221,4 @@ export async function downloadAttachments(
 		elements.push(element);
 	}
 	return elements;
-}
-
-export async function binaryToAttachments(
-	this: IExecuteFunctions,
-	attachments: IDataObject[],
-	items: INodeExecutionData[],
-	i: number,
-) {
-	return await Promise.all(
-		attachments.map(async (attachment) => {
-			const binaryPropertyName = attachment.binaryPropertyName as string;
-			const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-			const dataBuffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
-			return {
-				'@odata.type': '#microsoft.graph.fileAttachment',
-				name: binaryData.fileName,
-				contentBytes: dataBuffer.toString(BINARY_ENCODING),
-			};
-		}),
-	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/MicrosoftSql.node.ts
@@ -275,7 +275,7 @@ export class MicrosoftSql implements INodeType {
 				responseData = items;
 			} else if (operation === 'update') {
 				const updateKeys = items.map(
-					(item, index) => this.getNodeParameter('updateKey', index) as string,
+					(_, index) => this.getNodeParameter('updateKey', index) as string,
 				);
 
 				const tables = createTableStruct(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
@@ -64,12 +64,7 @@ const displayOptions = {
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
-export async function execute(
-	this: IExecuteFunctions,
-	i: number,
-	nodeVersion: number,
-	instanceId: string,
-) {
+export async function execute(this: IExecuteFunctions, i: number, instanceId: string) {
 	// https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http
 
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/router.ts
@@ -46,7 +46,6 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 					responseData = await chatMessage[microsoftTeamsTypeData.operation].execute.call(
 						this,
 						i,
-						nodeVersion,
 						instanceId,
 					);
 					break;

--- a/packages/nodes-base/nodes/MySql/test/v2/runQueries.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v2/runQueries.test.ts
@@ -48,6 +48,7 @@ describe('Test MySql V2, runQueries', () => {
 			const pool = createFakePool(fakeConnection);
 			const mockExecuteFns = createMockExecuteFunction({}, mySqlMockNode);
 
+			// @ts-expect-error
 			pool.query = jest.fn(async () => [
 				[[{ finishedAt: '2023-12-30' }], [{ finishedAt: '2023-12-31' }]],
 			]);

--- a/packages/nodes-base/nodes/Peekalink/test/Peekalink.node.test.ts
+++ b/packages/nodes-base/nodes/Peekalink/test/Peekalink.node.test.ts
@@ -44,7 +44,10 @@ describe('Peekalink Node', () => {
 							typeVersion: 1,
 							position: [960, 380],
 							credentials: {
-								peekalinkApi: 'token',
+								peekalinkApi: {
+									id: '1',
+									name: 'peekalink',
+								},
 							},
 						},
 					],
@@ -113,7 +116,10 @@ describe('Peekalink Node', () => {
 							typeVersion: 1,
 							position: [960, 380],
 							credentials: {
-								peekalinkApi: 'token',
+								peekalinkApi: {
+									id: '1',
+									name: 'peekalink',
+								},
 							},
 						},
 					],

--- a/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/QuickBooks/GenericFunctions.ts
@@ -296,12 +296,7 @@ export async function loadResource(this: ILoadOptionsFunctions, resource: string
 /**
  * Populate the `Line` property in a request body.
  */
-export function processLines(
-	this: IExecuteFunctions,
-	body: IDataObject,
-	lines: IDataObject[],
-	resource: string,
-) {
+export function processLines(this: IExecuteFunctions, lines: IDataObject[], resource: string) {
 	lines.forEach((line) => {
 		if (resource === 'bill') {
 			if (line.DetailType === 'AccountBasedExpenseLineDetail') {

--- a/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
+++ b/packages/nodes-base/nodes/QuickBooks/QuickBooks.node.ts
@@ -263,7 +263,7 @@ export class QuickBooks implements INodeType {
 							},
 						} as IDataObject;
 
-						body.Line = processLines.call(this, body, lines, resource);
+						body.Line = processLines.call(this, lines, resource);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
@@ -528,7 +528,7 @@ export class QuickBooks implements INodeType {
 							},
 						} as IDataObject;
 
-						body.Line = processLines.call(this, body, lines, resource);
+						body.Line = processLines.call(this, lines, resource);
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						body = populateFields.call(this, body, additionalFields, resource);
@@ -688,7 +688,7 @@ export class QuickBooks implements INodeType {
 							},
 						} as IDataObject;
 
-						body.Line = processLines.call(this, body, lines, resource);
+						body.Line = processLines.call(this, lines, resource);
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 

--- a/packages/nodes-base/nodes/SeaTable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/SeaTable/GenericFunctions.ts
@@ -67,7 +67,7 @@ function endpointCtxExpr(ctx: ICtx, endpoint: string): string {
 
 	return endpoint.replace(
 		/({{ *(access_token|dtable_uuid|server) *}})/g,
-		(match: string, expr: string, name: TEndpointVariableName) => {
+		(match: string, _: string, name: TEndpointVariableName) => {
 			return endpointVariables[name] || match;
 		},
 	);
@@ -228,7 +228,7 @@ export const split = (subject: string): string[] =>
 	normalize(subject)
 		.split(/\s*((?:[^\\,]*?(?:\\[\s\S])*)*?)\s*(?:,|$)/)
 		.filter((s) => s.length)
-		.map((s) => s.replace(/\\([\s\S])/gm, ($0, $1) => $1));
+		.map((s) => s.replace(/\\([\s\S])/gm, (_, $1) => $1));
 
 export function columnNamesToArray(columnNames: string): string[] {
 	return columnNames ? split(columnNames).filter(nonInternalPredicate).filter(uniquePredicate) : [];

--- a/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Snowflake/GenericFunctions.ts
@@ -21,7 +21,7 @@ export async function execute(
 		conn.execute({
 			sqlText,
 			binds,
-			complete: (error, stmt, rows) => (error ? reject(error) : resolve(rows)),
+			complete: (error, _, rows) => (error ? reject(error) : resolve(rows)),
 		});
 	});
 }

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -66,7 +66,6 @@ export function getFilters(
 		filterTypeDisplayName = 'Filter',
 		filterFixedCollectionDisplayName = 'Filters',
 
-		filterStringDisplayName = 'Filters (String)',
 		mustMatchOptions = [
 			{
 				name: 'Any Filter',

--- a/packages/nodes-base/nodes/Supabase/RowDescription.ts
+++ b/packages/nodes-base/nodes/Supabase/RowDescription.ts
@@ -74,7 +74,6 @@ export const rowFields: INodeProperties[] = [
 	...getFilters(['row'], ['update'], {
 		includeNoneOption: false,
 		filterTypeDisplayName: 'Select Type',
-		filterStringDisplayName: 'Select Condition (String)',
 		filterFixedCollectionDisplayName: 'Select Conditions',
 		mustMatchOptions: [
 			{
@@ -177,7 +176,6 @@ export const rowFields: INodeProperties[] = [
 	...getFilters(['row'], ['delete'], {
 		includeNoneOption: false,
 		filterTypeDisplayName: 'Select Type',
-		filterStringDisplayName: 'Select Condition (String)',
 		filterFixedCollectionDisplayName: 'Select Conditions',
 		mustMatchOptions: [
 			{

--- a/packages/nodes-base/nodes/TheHive/QueryFunctions.ts
+++ b/packages/nodes-base/nodes/TheHive/QueryFunctions.ts
@@ -29,19 +29,19 @@ export function Eq(field: string, value: any): IQueryObject {
 	return { _field: field, _value: value };
 }
 
-export function Gt(field: string, value: any): IQueryObject {
+export function Gt(_field: string, value: any): IQueryObject {
 	return { _gt: { field: value } };
 }
 
-export function Gte(field: string, value: any): IQueryObject {
+export function Gte(_field: string, value: any): IQueryObject {
 	return { _gte: { field: value } };
 }
 
-export function Lt(field: string, value: any): IQueryObject {
+export function Lt(_field: string, value: any): IQueryObject {
 	return { _lt: { field: value } };
 }
 
-export function Lte(field: string, value: any): IQueryObject {
+export function Lte(_field: string, value: any): IQueryObject {
 	return { _lte: { field: value } };
 }
 export function And(...criteria: IQueryObject[]): IQueryObject {

--- a/packages/nodes-base/nodes/TheHiveProject/actions/router.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/actions/router.ts
@@ -76,5 +76,5 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 			throw error;
 		}
 	}
-	return await this.prepareOutputData(returnData);
+	return [returnData];
 }

--- a/packages/nodes-base/nodes/UProc/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UProc/GenericFunctions.ts
@@ -14,7 +14,6 @@ export async function uprocApiRequest(
 	method: IHttpRequestMethods,
 	body: any = {},
 	qs: IDataObject = {},
-	uri?: string,
 	_option: IDataObject = {},
 ): Promise<any> {
 	const options: IHttpRequestOptions = {

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/GenericFunctions.ts
@@ -19,7 +19,6 @@ export async function venafiApiRequest(
 	resource: string,
 	body = {},
 	qs: IDataObject = {},
-	uri?: string,
 	option: IDataObject = {},
 ): Promise<any> {
 	const operation = this.getNodeParameter('operation', 0);

--- a/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
+++ b/packages/nodes-base/nodes/Venafi/ProtectCloud/VenafiTlsProtectCloud.node.ts
@@ -301,7 +301,6 @@ export class VenafiTlsProtectCloud implements INodeType {
 								`/outagedetection/v1/certificates/${certificateId}/contents`,
 								{},
 								qs,
-								undefined,
 								{ encoding: null, json: false, resolveWithFullResponse: true, cert: true },
 							);
 						} else {
@@ -342,7 +341,6 @@ export class VenafiTlsProtectCloud implements INodeType {
 								`/outagedetection/v1/certificates/${certificateId}/keystore`,
 								body,
 								{},
-								undefined,
 								{ encoding: null, json: false, resolveWithFullResponse: true },
 							);
 						}

--- a/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wufoo/GenericFunctions.ts
@@ -14,7 +14,6 @@ export async function wufooApiRequest(
 
 	body: any = {},
 	qs: IDataObject = {},
-	uri?: string,
 	option: IDataObject = {},
 ): Promise<any> {
 	const credentials = await this.getCredentials('wufooApi');

--- a/packages/nodes-base/test/nodes/Postgres/Postgres.node.functions.test.ts
+++ b/packages/nodes-base/test/nodes/Postgres/Postgres.node.functions.test.ts
@@ -53,7 +53,7 @@ describe('pgUpdate', () => {
 			},
 		];
 
-		const results = await PostgresFun.pgUpdate(getNodeParam, pgp, db, items);
+		await PostgresFun.pgUpdate(getNodeParam, pgp, db, items);
 
 		expect(db.any).toHaveBeenCalledWith(
 			'update "myschema"."mytable" as t set "id"=v."id","name"=v."name" from (values(1234,\'test\')) as v("id","name") WHERE v."id" = t."id" RETURNING *',

--- a/packages/workflow/test/AugmentObject.test.ts
+++ b/packages/workflow/test/AugmentObject.test.ts
@@ -290,7 +290,7 @@ describe('AugmentObject', () => {
 		});
 
 		test('should work with complex values on first level', () => {
-			const originalObject = {
+			const originalObject: any = {
 				a: {
 					b: {
 						cc: '3',
@@ -483,7 +483,7 @@ describe('AugmentObject', () => {
 
 		test('should be faster than doing a deepCopy', () => {
 			const iterations = 100;
-			const originalObject: IDataObject = {
+			const originalObject: any = {
 				a: {
 					b: {
 						c: {
@@ -530,7 +530,7 @@ describe('AugmentObject', () => {
 		});
 
 		test('should return property descriptors', () => {
-			const originalObject = {
+			const originalObject: any = {
 				x: {
 					y: {},
 					z: {},
@@ -559,7 +559,7 @@ describe('AugmentObject', () => {
 		});
 
 		test('should return valid values on `has` calls', () => {
-			const originalObject = {
+			const originalObject: any = {
 				x: {
 					y: {},
 				},


### PR DESCRIPTION
In the spirit of today's cleanup sessions, this PR cleans up type errors on a couple of backend packages, and also deletes a lot of old dead code in tests.

## Review / Merge checklist
- [x] PR title and summary are descriptive