### PR TITLE
fix: Init license properly with multi main (no-changelog)

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -61,8 +61,8 @@ export class License {
 		return autoRenewEnabled;
 	}
 
-	async init(instanceType: N8nInstanceType = 'main') {
-		if (this.manager) {
+	async init(instanceType: N8nInstanceType = 'main', forceRecreate = false) {
+		if (this.manager && !forceRecreate) {
 			this.logger.warn('License manager already initialized or shutting down');
 			return;
 		}
@@ -375,6 +375,6 @@ export class License {
 
 	async reinit() {
 		this.manager?.reset();
-		await this.init();
+		await this.init('main', true);
 	}
 }


### PR DESCRIPTION
## Summary
n8n initialization in multi main starts the license manager without auto renewal and it seems like this is also preventing the license loading completely



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] Tests included.