### PR TITLE
test: Add tests for license manager reinit method

### DIFF
--- a/packages/cli/test/unit/License.test.ts
+++ b/packages/cli/test/unit/License.test.ts
@@ -252,4 +252,16 @@ describe('License', () => {
 			});
 		});
 	});
+
+	describe('reinit', () => {
+		it('should reinitialize license manager', async () => {
+			const license = new License(mock(), mock(), mock(), mock(), mock());
+			await license.init();
+
+			await license.reinit();
+
+			expect(LicenseManager.prototype.reset).toHaveBeenCalled();
+			expect(LicenseManager.prototype.initialize).toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/test/unit/License.test.ts
+++ b/packages/cli/test/unit/License.test.ts
@@ -258,7 +258,11 @@ describe('License', () => {
 			const license = new License(mock(), mock(), mock(), mock(), mock());
 			await license.init();
 
+			const initSpy = jest.spyOn(license, 'init');
+
 			await license.reinit();
+
+			expect(initSpy).toHaveBeenCalledWith('main', true);
 
 			expect(LicenseManager.prototype.reset).toHaveBeenCalled();
 			expect(LicenseManager.prototype.initialize).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Adding tests to license manager reinit method


## Related tickets and issues
https://linear.app/n8n/issue/PAY-1595/test-license-reload-process-with-multi-main

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] Tests included.