### PR TITLE
fix(Telegram Node): Revert typo introduced in #8437 (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -2067,7 +2067,7 @@ export class Telegram implements INodeType {
 							{
 								json: false,
 								encoding: null,
-								uri: `${credentials.baseUrl}/bot${credentials.accessToken}/${filePath}`,
+								uri: `${credentials.baseUrl}/file/bot${credentials.accessToken}/${filePath}`,
 								resolveWithFullResponse: true,
 								useStream: true,
 							},


### PR DESCRIPTION
This url was replaced incorrectly in https://github.com/n8n-io/n8n/pull/8437

Incorrect change here https://github.com/n8n-io/n8n/commit/87f965e9055904486f5fd815c060abb4376296a0#diff-5938e9ee844c0a52711740e047ee6d69e95d0a272b86f43bbece03012b4bb861