### PR TITLE
fix(core): Fix typos in common error messages (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -9,11 +9,11 @@ const COMMON_ERRORS: IDataObject = {
 	// nodeJS errors
 	ECONNREFUSED: 'The service refused the connection - perhaps it is offline',
 	ECONNRESET:
-		'The connection to the server wes closed unexpectedly, perhaps it is offline. You can retry request immidiately or wait and retry later.',
+		'The connection to the server was closed unexpectedly, perhaps it is offline. You can retry the request immediately or wait and retry later.',
 	ENOTFOUND:
-		'The connection cannot be established, this usually occurs due to an incorrect host(domain) value',
+		'The connection cannot be established, this usually occurs due to an incorrect host (domain) value',
 	ETIMEDOUT:
-		"The connection timed out, consider setting 'Retry on Fail' option in the node settings",
+		"The connection timed out, consider setting the 'Retry on Fail' option in the node settings",
 	ERRADDRINUSE:
 		'The port is already occupied by some other application, if possible change the port or kill the application that is using it',
 	EADDRNOTAVAIL: 'The address is not available, ensure that you have the right IP address',
@@ -21,8 +21,8 @@ const COMMON_ERRORS: IDataObject = {
 	EHOSTUNREACH: 'The host is unreachable, perhaps the server is offline',
 	EAI_AGAIN: 'The DNS server returned an error, perhaps the server is offline',
 	ENOENT: 'The file or directory does not exist',
-	EISDIR: 'The file path expected but a given path is a directory',
-	ENOTDIR: 'The directory path expected but a given path is a file',
+	EISDIR: 'The file path was expected but the given path is a directory',
+	ENOTDIR: 'The directory path was expected but the given path is a file',
 	EACCES: 'Forbidden by access permissions, make sure you have the right permissions',
 	EEXIST: 'The file or directory already exists',
 	EPERM: 'Operation not permitted, make sure you have the right permissions',

--- a/packages/workflow/test/NodeErrors.test.ts
+++ b/packages/workflow/test/NodeErrors.test.ts
@@ -81,7 +81,7 @@ describe('NodeErrors tests', () => {
 		const nodeOperationError = new NodeOperationError(node, 'ENOTFOUND test error message');
 
 		expect(nodeOperationError.message).toEqual(
-			'The connection cannot be established, this usually occurs due to an incorrect host(domain) value',
+			'The connection cannot be established, this usually occurs due to an incorrect host (domain) value',
 		);
 	});
 
@@ -89,7 +89,7 @@ describe('NodeErrors tests', () => {
 		const nodeApiError = new NodeApiError(node, { message: 'ENOTFOUND test error message' });
 
 		expect(nodeApiError.message).toEqual(
-			'The connection cannot be established, this usually occurs due to an incorrect host(domain) value',
+			'The connection cannot be established, this usually occurs due to an incorrect host (domain) value',
 		);
 	});
 


### PR DESCRIPTION
## Summary
Fix typos in common error messages:

<img width="826" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/406e8de3-61cd-4da7-91fe-44d27c074509">

## Review / Merge checklist
- [X] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 