### PR TITLE
ci: Skip the flaky test in SettingsSso.test.ts (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/__tests__/SettingsSso.test.ts
+++ b/packages/editor-ui/src/views/__tests__/SettingsSso.test.ts
@@ -88,7 +88,7 @@ describe('SettingsSso', () => {
 		expect(getByTestId('sso-test')).toBeEnabled();
 	});
 
-	it('should enable activation checkbox after data is saved', async () => {
+	it.skip('should enable activation checkbox after data is saved', async () => {
 		await ssoStore.saveSamlConfig({ metadata: '' });
 
 		settingsStore.settings.enterprise[EnterpriseEditionFeature.Saml] = true;

--- a/packages/editor-ui/src/views/__tests__/SettingsSso.test.ts
+++ b/packages/editor-ui/src/views/__tests__/SettingsSso.test.ts
@@ -88,6 +88,7 @@ describe('SettingsSso', () => {
 		expect(getByTestId('sso-test')).toBeEnabled();
 	});
 
+	// eslint-disable-next-line n8n-local-rules/no-skipped-tests
 	it.skip('should enable activation checkbox after data is saved', async () => {
 		await ssoStore.saveSamlConfig({ metadata: '' });
 


### PR DESCRIPTION
This one test is behind majority of all CI failures on `master` in the last month.
So, until someone else has time to fix this, I suggest that we disable it.


## Review / Merge checklist
- [x] PR title and summary are descriptive