### PR TITLE
fix(core): Do not allow admins to delete the instance owner

### DIFF
--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -164,6 +164,10 @@ export class UsersController {
 			);
 		}
 
+		if (userToDelete.role === 'global:owner') {
+			throw new ForbiddenError('Instance owner cannot be deleted.');
+		}
+
 		const personalProjectToDelete = await this.projectRepository.getPersonalProjectForUserOrFail(
 			userToDelete.id,
 		);

--- a/packages/cli/test/integration/users.api.test.ts
+++ b/packages/cli/test/integration/users.api.test.ts
@@ -555,6 +555,15 @@ describe('DELETE /users/:id', () => {
 		expect(user).toBeDefined();
 	});
 
+	test('should fail to delete the instance owner', async () => {
+		const admin = await createAdmin();
+		const adminAgent = testServer.authAgentFor(admin);
+		await adminAgent.delete(`/users/${owner.id}`).expect(403);
+
+		const user = await getUserById(owner.id);
+		expect(user).toBeDefined();
+	});
+
 	test('should fail to delete a user that does not exist', async () => {
 		await ownerAgent.delete(`/users/${uuid()}`).query({ transferId: '' }).expect(404);
 	});


### PR DESCRIPTION
Admins should not be able to delete the instance owners, because that can be used to take-over the entire instance.


## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included