### PR TITLE
fix(core): Fix `level` in `warn` method of error reporter (no-changelog)

### DIFF
--- a/packages/workflow/src/ErrorReporterProxy.ts
+++ b/packages/workflow/src/ErrorReporterProxy.ts
@@ -39,4 +39,4 @@ export const info = (msg: string, options?: ReportingOptions) => {
 };
 
 export const warn = (warning: Error | string, options?: ReportingOptions) =>
-	error(warning, { level: 'warning', ...options });
+	error(warning, { ...options, level: 'warning' });


### PR DESCRIPTION
Passing an `error`-level error to the `warn` method of the error reporter causes it to be reported as an `error`-level error instead of as a warning, because the `level` is overridden. This is affecting some reports like `Expression difference`, errors reported by `UserSubscriber`, etc.

Ref: https://n8nio.slack.com/archives/C062YRE7EG4/p1716480235754399?thread_ts=1716474072.409529&cid=C062YRE7EG4