### PR TITLE
fix(editor): Make sure auto loading and auto scrolling works in executions tab

### DIFF
--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
@@ -110,6 +110,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
+	emits: ['retryExecution', 'mounted'],
 	setup() {
 		const executionHelpers = useExecutionHelpers();
 
@@ -146,6 +147,9 @@ export default defineComponent({
 		executionPreviewViewName() {
 			return VIEWS.EXECUTION_PREVIEW;
 		},
+	},
+	mounted() {
+		this.$emit('mounted', this.execution.id);
 	},
 	methods: {
 		onRetryMenuItemSelect(action: string): void {

--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
@@ -81,6 +81,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import type { ExecutionFilterType } from '@/Interface';
 
 type WorkflowExecutionsCardRef = InstanceType<typeof WorkflowExecutionsCard>;
+type AutoScrollDeps = { activeExecutionSet: boolean; cardsMounted: boolean; scroll: boolean };
 
 export default defineComponent({
 	name: 'WorkflowExecutionsSidebar',
@@ -123,7 +124,7 @@ export default defineComponent({
 				activeExecutionSet: false,
 				cardsMounted: false,
 				scroll: true,
-			} as { activeExecutionSet: boolean; cardsMounted: boolean; scroll: boolean },
+			} as AutoScrollDeps,
 		};
 	},
 	computed: {
@@ -145,11 +146,7 @@ export default defineComponent({
 			}
 		},
 		autoScrollDeps: {
-			handler(updatedDeps: {
-				activeExecutionSet: boolean;
-				cardsMounted: boolean;
-				scroll: boolean;
-			}) {
+			handler(updatedDeps: AutoScrollDeps) {
 				if (Object.values(updatedDeps).every(Boolean)) {
 					this.scrollToActiveCard();
 				}


### PR DESCRIPTION
## Summary
Auto loading more items and auto scrolling on the execution tab wasn't working on very tall screen size


## Related tickets and issues
[PAY-1584](https://linear.app/n8n/issue/PAY-1584/executions-view-on-single-workflow-limited-to-10)



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.