### PR TITLE
build: Bump license-sdk to v2.12.0 (no-changelog)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,7 +99,7 @@
     "@n8n/n8n-nodes-langchain": "workspace:*",
     "@n8n/permissions": "workspace:*",
     "@n8n/typeorm": "0.3.20-9",
-    "@n8n_io/license-sdk": "2.10.0",
+    "@n8n_io/license-sdk": "2.12.0",
     "@oclif/core": "3.18.1",
     "@pinecone-database/pinecone": "2.1.0",
     "@rudderstack/rudder-sdk-node": "2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,8 +523,8 @@ importers:
         specifier: 0.3.20-9
         version: 0.3.20-9(@sentry/node@7.87.0)(ioredis@5.3.2)(mysql2@3.9.7)(pg@8.11.3)(sqlite3@5.1.7)
       '@n8n_io/license-sdk':
-        specifier: 2.10.0
-        version: 2.10.0
+        specifier: 2.12.0
+        version: 2.12.0
       '@oclif/core':
         specifier: 3.18.1
         version: 3.18.1
@@ -7067,14 +7067,14 @@ packages:
       acorn-walk: 8.2.0
     dev: false
 
-  /@n8n_io/license-sdk@2.10.0:
-    resolution: {integrity: sha512-o6jJSQJ80uGGgGCaSr0NPVGpJd3ePR+fGBQ7MtnNKxxQy3m4iX8reKGoLAphANNzQHnXVFHqo7U2zXlI8h4ZvA==}
-    engines: {node: '>=18.12.1', npm: '>=8.19.2'}
+  /@n8n_io/license-sdk@2.12.0:
+    resolution: {integrity: sha512-hxXdaFlzd1moR5NWPCdGiKHyIuDTuiM8AYcH5qo2/Cbu93C8za8a0x19q5gZ1ahADRPfO48k9eYMTjxGhqNkBg==}
+    engines: {node: '>=18.12.1'}
     dependencies:
       crypto-js: 4.2.0
       node-machine-id: 1.1.12
       node-rsa: 1.1.1
-      undici: 6.4.0
+      undici: 6.18.1
     dev: false
 
   /@n8n_io/riot-tmpl@4.0.0:
@@ -23986,11 +23986,9 @@ packages:
       '@fastify/busboy': 2.0.0
     dev: false
 
-  /undici@6.4.0:
-    resolution: {integrity: sha512-wYaKgftNqf6Je7JQ51YzkEkEevzOgM7at5JytKO7BjaURQpERW8edQSMrr2xb+Yv4U8Yg47J24+lc9+NbeXMFA==}
-    engines: {node: '>=18.0'}
-    dependencies:
-      '@fastify/busboy': 2.0.0
+  /undici@6.18.1:
+    resolution: {integrity: sha512-/0BWqR8rJNRysS5lqVmfc7eeOErcOP4tZpATVjJOojjHZ71gSYVAtFhEmadcIjwMIUehh5NFyKGsXCnXIajtbA==}
+    engines: {node: '>=18.17'}
     dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:


### PR DESCRIPTION
## Summary
update license-sdk to v2.12.0, which
- bumps internal dependencies
- adds information about autoRenewal to the `n8n license:info` CLI command

## Review / Merge checklist
- [X] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - n/a
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 
  - tests were added in `license-management` repo