### PR TITLE
feat(Telegram Node): Add support to Keyboard Button Mini Apps

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1289,6 +1289,26 @@ export class Telegram implements INodeType {
 														default: '',
 														description: 'HTTP or tg:// URL to be opened when button is pressed',
 													},
+													{
+														displayName: 'Web App',
+														name: 'web_app',
+														type: 'collection',
+														placeholder: 'Set Telegram Web App URL',
+														typeOptions: {
+															multipleValues: false,
+														},
+														default: {},
+														options: [
+															{
+																displayName: 'URL',
+																name: 'url',
+																type: 'string',
+																default: '',
+																description: 'An HTTPS URL of a Web App to be opened',
+															},
+														],
+														description: 'Launch the Telegram Web App',
+													},
 												],
 											},
 										],
@@ -1364,6 +1384,26 @@ export class Telegram implements INodeType {
 														type: 'boolean',
 														default: false,
 														description: "Whether the user's request_location",
+													},
+													{
+														displayName: 'Web App',
+														name: 'web_app',
+														type: 'collection',
+														placeholder: 'Set Telegram Web App URL',
+														typeOptions: {
+															multipleValues: false,
+														},
+														default: {},
+														options: [
+															{
+																displayName: 'URL',
+																name: 'url',
+																type: 'string',
+																default: '',
+																description: 'An HTTPS URL of a Web App to be opened',
+															},
+														],
+														description: 'Launch the Telegram Web App',
 													},
 												],
 											},


### PR DESCRIPTION
## Summary
Currently, Telegram Node does not support [Keyboard Button Mini Apps](https://core.telegram.org/bots/webapps#keyboard-button-mini-apps).
This PR aims to enable the use of Mini App features in [Reply Keyboard](https://core.telegram.org/bots/api#keyboardbutton) and [Inline Reply Keyboard](https://core.telegram.org/bots/api#inlinekeyboardmarkup).

### Reply Keyboard

![image](https://github.com/n8n-io/n8n/assets/5655745/f8a7736b-a547-420d-922d-d6e6e5294fb7)

https://github.com/n8n-io/n8n/assets/5655745/ddfa199d-49f6-49c7-a10c-803dcd195337


### Inline Reply Keyboard
![image](https://github.com/n8n-io/n8n/assets/5655745/0638596a-a0e8-451c-8547-ad927621efc6)

https://github.com/n8n-io/n8n/assets/5655745/77c9f2b0-d92b-47af-864e-fd5e2b698774

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 