### PR TITLE
fix(editor): Send only execution id in postMessage when previewing an execution

### DIFF
--- a/packages/editor-ui/src/components/WorkflowPreview.vue
+++ b/packages/editor-ui/src/components/WorkflowPreview.vue
@@ -119,7 +119,7 @@ const loadExecution = () => {
 			iframeRef.value?.contentWindow?.postMessage?.(
 				JSON.stringify({
 					command: 'setActiveExecution',
-					execution: executionsStore.activeExecution,
+					executionId: executionsStore.activeExecution.id,
 				}),
 				'*',
 			);

--- a/packages/editor-ui/src/components/__tests__/WorkflowPreview.test.ts
+++ b/packages/editor-ui/src/components/__tests__/WorkflowPreview.test.ts
@@ -179,7 +179,7 @@ describe('WorkflowPreview', () => {
 			expect(postMessageSpy).toHaveBeenCalledWith(
 				JSON.stringify({
 					command: 'setActiveExecution',
-					execution: { id: 'abc' },
+					executionId: 'abc',
 				}),
 				'*',
 			);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4765,7 +4765,9 @@ export default defineComponent({
 						});
 					}
 				} else if (json?.command === 'setActiveExecution') {
-					this.executionsStore.activeExecution = json.execution;
+					this.executionsStore.activeExecution = (await this.executionsStore.fetchExecution(
+						json.executionId,
+					)) as ExecutionSummary;
 				}
 			} catch (e) {}
 		},


### PR DESCRIPTION
## Summary
Execution preview showing error toast message if the workflow contains binary data



## Related tickets and issues
[PAY-1589](https://linear.app/n8n/issue/PAY-1589/bug-http-node-throws-preview-error-in-execution)



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.