### PR TITLE
fix(editor): Update webhook paths when duplicating workflow

### DIFF
--- a/cypress/constants.ts
+++ b/cypress/constants.ts
@@ -57,6 +57,7 @@ export const AI_TOOL_CODE_NODE_NAME = 'Custom Code Tool';
 export const AI_TOOL_WIKIPEDIA_NODE_NAME = 'Wikipedia';
 export const AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME = 'OpenAI Chat Model';
 export const AI_OUTPUT_PARSER_AUTO_FIXING_NODE_NAME = 'Auto-fixing Output Parser';
+export const WEBHOOK_NODE_NAME = 'Webhook';
 
 export const META_KEY = Cypress.platform === 'darwin' ? '{meta}' : '{ctrl}';
 

--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -252,21 +252,6 @@ describe('Workflow Actions', () => {
 			WorkflowPage.actions.saveWorkflowOnButtonClick();
 			duplicateWorkflow();
 		});
-
-		it('should update webhook path when duplicating workflow', () => {
-			WorkflowPage.actions.addNodeToCanvas(WEBHOOK_NODE_NAME);
-			WorkflowPage.actions.addNodeToCanvas(WEBHOOK_NODE_NAME);
-			// Activate original workflow
-			WorkflowPage.actions.activateWorkflow();
-			WorkflowPage.getters.isWorkflowActivated();
-			duplicateWorkflow();
-			cy.visit(WorkflowPages.url);
-			WorkflowPages.getters.workflowCards().contains(DUPLICATE_WORKFLOW_NAME).click();
-			// Activate duplicated workflow
-			WorkflowPage.actions.activateWorkflow();
-			// If webhooks are properly updated, this should pass
-			WorkflowPage.getters.isWorkflowActivated();
-		});
 	});
 
 	it('should keep endpoint click working when switching between execution and editor tab', () => {

--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -6,6 +6,7 @@ import {
 	EDIT_FIELDS_SET_NODE_NAME,
 	INSTANCE_MEMBERS,
 	INSTANCE_OWNER,
+	WEBHOOK_NODE_NAME,
 } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
@@ -250,6 +251,21 @@ describe('Workflow Actions', () => {
 		it('should duplicate saved workflow', () => {
 			WorkflowPage.actions.saveWorkflowOnButtonClick();
 			duplicateWorkflow();
+		});
+
+		it('should update webhook path when duplicating workflow', () => {
+			WorkflowPage.actions.addNodeToCanvas(WEBHOOK_NODE_NAME);
+			WorkflowPage.actions.addNodeToCanvas(WEBHOOK_NODE_NAME);
+			// Activate original workflow
+			WorkflowPage.actions.activateWorkflow();
+			WorkflowPage.getters.isWorkflowActivated();
+			duplicateWorkflow();
+			cy.visit(WorkflowPages.url);
+			WorkflowPages.getters.workflowCards().contains(DUPLICATE_WORKFLOW_NAME).click();
+			// Activate duplicated workflow
+			WorkflowPage.actions.activateWorkflow();
+			// If webhooks are properly updated, this should pass
+			WorkflowPage.getters.isWorkflowActivated();
 		});
 	});
 

--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -162,7 +162,7 @@ export default defineComponent({
 					data: workflowToUpdate,
 					tags: this.currentTagIds,
 					resetWebhookUrls: true,
-					openInNewWindow: false,
+					openInNewWindow: true,
 					resetNodeIds: true,
 				});
 

--- a/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
+++ b/packages/editor-ui/src/components/DuplicateWorkflowDialog.vue
@@ -89,11 +89,6 @@ export default defineComponent({
 			prevTagIds: currentTagIds,
 		};
 	},
-	async mounted() {
-		this.name = await this.workflowsStore.getDuplicateCurrentWorkflowName(this.data.name);
-		await this.$nextTick();
-		this.focusOnNameInput();
-	},
 	computed: {
 		...mapStores(useCredentialsStore, useUsersStore, useSettingsStore, useWorkflowsStore),
 	},
@@ -103,6 +98,11 @@ export default defineComponent({
 				this.focusOnSelect();
 			}
 		},
+	},
+	async mounted() {
+		this.name = await this.workflowsStore.getDuplicateCurrentWorkflowName(this.data.name);
+		await this.$nextTick();
+		this.focusOnNameInput();
 	},
 	methods: {
 		focusOnSelect() {
@@ -162,7 +162,7 @@ export default defineComponent({
 					data: workflowToUpdate,
 					tags: this.currentTagIds,
 					resetWebhookUrls: true,
-					openInNewWindow: true,
+					openInNewWindow: false,
 					resetNodeIds: true,
 				});
 

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -32,6 +32,20 @@ const duplicateTestWorkflow: IWorkflowDataUpdate = {
 			position: [700, 40],
 			webhookId: 'aa5150d8-1d7d-4247-88d8-44c96fe3a37b',
 		},
+		{
+			parameters: {
+				resume: 'webhook',
+				options: {
+					webhookSuffix: '/test',
+				},
+			},
+			id: '979d8443-51b1-48e2-b239-acf399b66509',
+			name: 'Wait',
+			type: 'n8n-nodes-base.wait',
+			typeVersion: 1.1,
+			position: [900, 20],
+			webhookId: '5340ae49-2c96-4492-9073-7744d2e52b8a',
+		},
 	],
 	connections: {},
 };
@@ -69,6 +83,11 @@ describe('useWorkflowHelpers', () => {
 			const { saveAsNewWorkflow } = useWorkflowHelpers({ router });
 			const webHookIdsPreSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
 			const pathsPreSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webhookSuffixPreSave = duplicateTestWorkflow.nodes
+				.map((node) => node.parameters.options)
+				.filter((options): options is { webhookSuffix: string } => typeof options !== 'string')
+				.map((options) => options.webhookSuffix)
+				.filter((suffix) => suffix);
 
 			await saveAsNewWorkflow({
 				name: duplicateTestWorkflow.name,
@@ -76,11 +95,17 @@ describe('useWorkflowHelpers', () => {
 				data: duplicateTestWorkflow,
 			});
 
-			// Expect the webhookIds and paths to be different
 			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			expect(webHookIdsPreSave).not.toEqual(webHookIdsPostSave);
 			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webhookSuffixPostSave = duplicateTestWorkflow.nodes
+				.map((node) => node.parameters.options)
+				.filter((options): options is { webhookSuffix: string } => typeof options !== 'string')
+				.map((options) => options.webhookSuffix)
+				.filter((suffix) => suffix);
+			// Expect webhookIds, paths and suffix to be different
+			expect(webHookIdsPreSave).not.toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).not.toEqual(pathsPostSave);
+			expect(webhookSuffixPreSave).not.toEqual(webhookSuffixPostSave);
 		});
 
 		it('should respect `resetWebhookUrls` when duplicating workflows', async () => {
@@ -90,6 +115,11 @@ describe('useWorkflowHelpers', () => {
 			const { saveAsNewWorkflow } = useWorkflowHelpers({ router });
 			const webHookIdsPreSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
 			const pathsPreSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webhookSuffixPreSave = duplicateTestWorkflow.nodes
+				.map((node) => node.parameters.options)
+				.filter((options): options is { webhookSuffix: string } => typeof options !== 'string')
+				.map((options) => options.webhookSuffix)
+				.filter((suffix) => suffix);
 
 			await saveAsNewWorkflow({
 				name: duplicateTestWorkflow.name,
@@ -97,11 +127,17 @@ describe('useWorkflowHelpers', () => {
 				data: duplicateTestWorkflow,
 			});
 
-			// Now. webhookIds and paths should be the same
 			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			expect(webHookIdsPreSave).toEqual(webHookIdsPostSave);
 			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webhookSuffixPostSave = duplicateTestWorkflow.nodes
+				.map((node) => node.parameters.options)
+				.filter((options): options is { webhookSuffix: string } => typeof options !== 'string')
+				.map((options) => options.webhookSuffix)
+				.filter((suffix) => suffix);
+			// Now, webhookIds, paths and suffix should be the same
+			expect(webHookIdsPreSave).toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).toEqual(pathsPostSave);
+			expect(webhookSuffixPreSave).not.toEqual(webhookSuffixPostSave);
 		});
 	});
 });

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -5,8 +5,6 @@ import { createTestingPinia } from '@pinia/testing';
 import type { INode } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 
-const TEST_WEBHOOK_SUFFIX = '/test';
-
 const duplicateTestWorkflow: IWorkflowDataUpdate = {
 	name: 'Duplicate webhook test',
 	active: false,
@@ -39,7 +37,7 @@ const duplicateTestWorkflow: IWorkflowDataUpdate = {
 			parameters: {
 				resume: 'webhook',
 				options: {
-					webhookSuffix: TEST_WEBHOOK_SUFFIX,
+					webhookSuffix: '/test',
 				},
 			},
 			id: '979d8443-51b1-48e2-b239-acf399b66509',
@@ -51,22 +49,6 @@ const duplicateTestWorkflow: IWorkflowDataUpdate = {
 		},
 	],
 	connections: {},
-};
-
-/**
- * Extract webhook suffixes from nodes that have them
- * @param nodes List of nodes
- * @returns List of webhook suffixes found in the nodes
- */
-const extractWebhookSuffixes = (nodes: INode[]) => {
-	return nodes
-		.map((node) => node.parameters.options)
-		.filter(
-			(options): options is { webhookSuffix: string } =>
-				options !== null && typeof options === 'object' && 'webhookSuffix' in options,
-		)
-		.map((options) => options.webhookSuffix)
-		.filter((suffix) => suffix);
 };
 
 vi.mock('@/stores/workflows.store', () => ({
@@ -111,11 +93,9 @@ describe('useWorkflowHelpers', () => {
 
 			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
 			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
-			const webhookSuffixPostSave = extractWebhookSuffixes(duplicateTestWorkflow.nodes);
 			// Expect webhookIds, paths and suffix to be the same as in the original workflow
 			expect(webHookIdsPreSave).toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).toEqual(pathsPostSave);
-			expect(webhookSuffixPostSave).toEqual([TEST_WEBHOOK_SUFFIX]);
 		});
 
 		it('should respect `resetWebhookUrls: true` when duplicating workflows', async () => {
@@ -134,11 +114,9 @@ describe('useWorkflowHelpers', () => {
 
 			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
 			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
-			const webhookSuffixPostSave = extractWebhookSuffixes(duplicateTestWorkflow.nodes);
 			// Now, expect webhookIds, paths and suffix to be different
 			expect(webHookIdsPreSave).not.toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).not.toEqual(pathsPostSave);
-			expect(webhookSuffixPostSave).toEqual([`${TEST_WEBHOOK_SUFFIX}-copy`]);
 		});
 	});
 });

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -2,10 +2,9 @@ import type { IWorkflowDataUpdate } from '@/Interface';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import router from '@/router';
 import { createTestingPinia } from '@pinia/testing';
-import type { INode } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 
-const duplicateTestWorkflow: IWorkflowDataUpdate = {
+const getDuplicateTestWorkflow = (): IWorkflowDataUpdate => ({
 	name: 'Duplicate webhook test',
 	active: false,
 	nodes: [
@@ -49,7 +48,7 @@ const duplicateTestWorkflow: IWorkflowDataUpdate = {
 		},
 	],
 	connections: {},
-};
+});
 
 vi.mock('@/stores/workflows.store', () => ({
 	useWorkflowsStore: vi.fn(() => ({
@@ -78,42 +77,44 @@ describe('useWorkflowHelpers', () => {
 		});
 
 		it('should respect `resetWebhookUrls: false` when duplicating workflows', async () => {
-			if (!duplicateTestWorkflow.nodes) {
+			const workflow = getDuplicateTestWorkflow();
+			if (!workflow.nodes) {
 				throw new Error('Missing nodes in test workflow');
 			}
 			const { saveAsNewWorkflow } = useWorkflowHelpers({ router });
-			const webHookIdsPreSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			const pathsPreSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webHookIdsPreSave = workflow.nodes.map((node) => node.webhookId);
+			const pathsPreSave = workflow.nodes.map((node) => node.parameters.path);
 
 			await saveAsNewWorkflow({
-				name: duplicateTestWorkflow.name,
+				name: workflow.name,
 				resetWebhookUrls: false,
-				data: duplicateTestWorkflow,
+				data: workflow,
 			});
 
-			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webHookIdsPostSave = workflow.nodes.map((node) => node.webhookId);
+			const pathsPostSave = workflow.nodes.map((node) => node.parameters.path);
 			// Expect webhookIds, paths and suffix to be the same as in the original workflow
 			expect(webHookIdsPreSave).toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).toEqual(pathsPostSave);
 		});
 
 		it('should respect `resetWebhookUrls: true` when duplicating workflows', async () => {
-			if (!duplicateTestWorkflow.nodes) {
+			const workflow = getDuplicateTestWorkflow();
+			if (!workflow.nodes) {
 				throw new Error('Missing nodes in test workflow');
 			}
 			const { saveAsNewWorkflow } = useWorkflowHelpers({ router });
-			const webHookIdsPreSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			const pathsPreSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webHookIdsPreSave = workflow.nodes.map((node) => node.webhookId);
+			const pathsPreSave = workflow.nodes.map((node) => node.parameters.path);
 
 			await saveAsNewWorkflow({
-				name: duplicateTestWorkflow.name,
+				name: workflow.name,
 				resetWebhookUrls: true,
-				data: duplicateTestWorkflow,
+				data: workflow,
 			});
 
-			const webHookIdsPostSave = duplicateTestWorkflow.nodes.map((node) => node.webhookId);
-			const pathsPostSave = duplicateTestWorkflow.nodes.map((node) => node.parameters.path);
+			const webHookIdsPostSave = workflow.nodes.map((node) => node.webhookId);
+			const pathsPostSave = workflow.nodes.map((node) => node.parameters.path);
 			// Now, expect webhookIds, paths and suffix to be different
 			expect(webHookIdsPreSave).not.toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).not.toEqual(pathsPostSave);

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -93,7 +93,7 @@ describe('useWorkflowHelpers', () => {
 
 			const webHookIdsPostSave = workflow.nodes.map((node) => node.webhookId);
 			const pathsPostSave = workflow.nodes.map((node) => node.parameters.path);
-			// Expect webhookIds, paths and suffix to be the same as in the original workflow
+			// Expect webhookIds and paths to be the same as in the original workflow
 			expect(webHookIdsPreSave).toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).toEqual(pathsPostSave);
 		});
@@ -115,7 +115,7 @@ describe('useWorkflowHelpers', () => {
 
 			const webHookIdsPostSave = workflow.nodes.map((node) => node.webhookId);
 			const pathsPostSave = workflow.nodes.map((node) => node.parameters.path);
-			// Now, expect webhookIds, paths and suffix to be different
+			// Now, expect webhookIds and paths to be different
 			expect(webHookIdsPreSave).not.toEqual(webHookIdsPostSave);
 			expect(pathsPreSave).not.toEqual(pathsPostSave);
 		});

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.test.ts
@@ -1,0 +1,119 @@
+import type { IWorkflowDataUpdate, IWorkflowDb } from '@/Interface';
+import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
+import router from '@/router';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+const inputWorkflowData: IWorkflowDataUpdate = {
+	name: 'My workflow 9 copy',
+	active: false,
+	nodes: [
+		{
+			parameters: {
+				path: '5340ae49-2c96-4492-9073-7744d2e52b8a',
+				options: {},
+			},
+			id: 'c1e1b6e7-df13-41b1-95f6-42903b85e438',
+			name: 'Webhook',
+			type: 'n8n-nodes-base.webhook',
+			typeVersion: 2,
+			position: [680, 20],
+			webhookId: '5340ae49-2c96-4492-9073-7744d2e52b8a',
+		},
+	],
+	connections: {},
+	settings: {
+		executionOrder: 'v1',
+	},
+	meta: {
+		templateCredsSetupCompleted: true,
+	},
+	pinData: {},
+	versionId: '20c24e55-5756-4b55-b63e-c18c0cf56537',
+	tags: [],
+};
+
+const newWorkflowData: IWorkflowDb = {
+	createdAt: '2024-05-27T14:20:51.177Z',
+	updatedAt: '2024-05-27T14:20:51.177Z',
+	id: 'HQ9KIBzVl5FvHfB2',
+	name: 'My workflow 9 copy',
+	active: false,
+	nodes: [
+		{
+			parameters: {
+				path: '5340ae49-2c96-4492-9073-7744d2e52b8a',
+				options: {},
+			},
+			id: 'c1e1b6e7-df13-41b1-95f6-42903b85e438',
+			name: 'Webhook',
+			type: 'n8n-nodes-base.webhook',
+			typeVersion: 2,
+			position: [680, 20],
+			webhookId: '5340ae49-2c96-4492-9073-7744d2e52b8a',
+		},
+	],
+	connections: {},
+	settings: {
+		executionOrder: 'v1',
+	},
+	meta: {
+		templateCredsSetupCompleted: true,
+	},
+	pinData: {},
+	versionId: '1d601560-b15f-42d1-84ac-9b572262dfff',
+	tags: [],
+	sharedWithProjects: [],
+	usedCredentials: [],
+	scopes: [
+		'workflow:create',
+		'workflow:delete',
+		'workflow:execute',
+		'workflow:list',
+		'workflow:read',
+		'workflow:share',
+		'workflow:update',
+	],
+};
+
+vi.mock('@/stores/workflows.store', () => ({
+	useWorkflowsStore: vi.fn(() => ({
+		workflowsById: {},
+		createNewWorkflow: vi.fn((workflowData: IWorkflowDataUpdate) => {
+			return newWorkflowData;
+		}),
+		addWorkflow: vi.fn((workflow: IWorkflowDb) => {}),
+		setActive: vi.fn(() => {}),
+		setWorkflowId: vi.fn(() => {}),
+		setWorkflowVersionId: vi.fn(() => {}),
+		setWorkflowName: vi.fn(() => {}),
+		setWorkflowSettings: vi.fn(() => {}),
+		setNodeValue: vi.fn(() => {}),
+		setWorkflowTagIds: vi.fn(() => {}),
+		getCurrentWorkflow: vi.fn(() => ({})),
+	})),
+}));
+
+describe('useWorkflowHelpers', () => {
+	describe('saveAsNewWorkflow', () => {
+		beforeAll(() => {
+			setActivePinia(createTestingPinia());
+		});
+
+		afterEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should save the current workflow as a new workflow', async () => {
+			const { saveAsNewWorkflow } = useWorkflowHelpers({ router });
+
+			const saved = await saveAsNewWorkflow({
+				name: inputWorkflowData.name,
+				resetWebhookUrls: true,
+				data: inputWorkflowData,
+			});
+
+			expect(saved).toEqual(true);
+		});
+	});
+});

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -1004,7 +1004,9 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 			if (resetWebhookUrls) {
 				workflowDataRequest.nodes = workflowDataRequest.nodes!.map((node) => {
 					if (node.webhookId) {
-						node.webhookId = uuid();
+						const newId = uuid();
+						node.webhookId = newId;
+						node.parameters.path = newId;
 						changedNodes[node.name] = node.webhookId;
 					}
 					return node;

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -1009,6 +1009,14 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 						node.parameters.path = newId;
 						changedNodes[node.name] = node.webhookId;
 					}
+					// Also update the webhookSuffix if it exists in wait nodes
+					if (
+						node.parameters.options &&
+						typeof node.parameters.options === 'object' &&
+						'webhookSuffix' in node.parameters.options
+					) {
+						node.parameters.options.webhookSuffix = `${node.parameters.options.webhookSuffix}-copy`;
+					}
 					return node;
 				});
 			}

--- a/packages/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -1009,14 +1009,6 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 						node.parameters.path = newId;
 						changedNodes[node.name] = node.webhookId;
 					}
-					// Also update the webhookSuffix if it exists in wait nodes
-					if (
-						node.parameters.options &&
-						typeof node.parameters.options === 'object' &&
-						'webhookSuffix' in node.parameters.options
-					) {
-						node.parameters.options.webhookSuffix = `${node.parameters.options.webhookSuffix}-copy`;
-					}
 					return node;
 				});
 			}


### PR DESCRIPTION
## Summary
When duplicating workflows, we are updating webhook ids but not the paths, this PR fixes that.
Also fixing Vue options order in duplicate dialog, so `eslint` is not complaining anymore:
<img width="866" alt="image" src="https://github.com/n8n-io/n8n/assets/2598782/f8d18d11-46f9-422e-b5e3-6a5db170820d">


## Related tickets and issues
ADO-2149


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 