### PR TITLE
fix(editor): Executions view popup in dark mode

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -154,8 +154,11 @@
 	// Notification
 	--color-notification-background: var(--prim-gray-740);
 
-	// Execution card
+	// Execution
 	--execution-card-background-hover: var(--color-foreground-base);
+	--execution-selector-background: var(--prim-gray-740);
+	--execution-selector-text: var(--color-text-base);
+	--execution-select-all-text: var(--color-text-base);
 
 	// NDV
 	--color-run-data-background: var(--prim-gray-800);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -201,13 +201,16 @@
 	// Notification
 	--color-notification-background: var(--color-background-xlight);
 
-	// Execution card
+	// Execution
 	--execution-card-border-success: var(--prim-color-alt-a-tint-300);
 	--execution-card-border-error: var(--prim-color-alt-c-tint-250);
 	--execution-card-border-waiting: var(--prim-color-secondary-tint-300);
 	--execution-card-border-running: var(--prim-color-alt-b-tint-250);
 	--execution-card-border-unknown: var(--prim-gray-120);
 	--execution-card-background-hover: var(--color-foreground-light);
+	--execution-selector-background: var(--color-background-dark);
+	--execution-selector-text: var(--color-text-xlight);
+	--execution-select-all-text: var(--color-danger);
 
 	// NDV
 	--color-run-data-background: var(--color-background-base);

--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
@@ -454,9 +454,9 @@ async function onAutoRefreshToggle(value: boolean) {
 	left: 50%;
 	transform: translateX(-50%);
 	bottom: var(--spacing-3xl);
-	background: var(--color-background-dark);
+	background: var(--execution-selector-background);
 	border-radius: var(--border-radius-base);
-	color: var(--color-text-xlight);
+	color: var(--execution-selector-text);
 	font-size: var(--font-size-2xs);
 
 	button {
@@ -534,7 +534,7 @@ async function onAutoRefreshToggle(value: boolean) {
 .selectAll {
 	display: inline-block;
 	margin: 0 0 var(--spacing-s) var(--spacing-s);
-	color: var(--color-danger);
+	color: var(--execution-select-all-text);
 }
 
 .filterLoader {


### PR DESCRIPTION
## Summary

 Global executions view popup buttons invisible in dark mode

Before:

<img width="1198" alt="image" src="https://github.com/n8n-io/n8n/assets/66951/64b7526a-d874-4bc5-b1ab-b5212392f3b1">

after:

<img width="1813" alt="image" src="https://github.com/n8n-io/n8n/assets/66951/28e2f765-1a09-4b74-9462-2b8f9bc18139">


## Related tickets and issues

- https://linear.app/n8n/issue/NODE-1373/bug-global-executions-view-popup-buttons-invisible-in-dark-mode


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 