### PR TITLE
fix(core): Block Public API related REST calls when Public API is not enabled

### DIFF
--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -153,11 +153,6 @@ export const loadPublicApiVersions = async (
 	};
 };
 
-function isApiEnabledByLicense(): boolean {
-	const license = Container.get(License);
-	return !license.isAPIDisabled();
-}
-
 export function isApiEnabled(): boolean {
-	return !config.get('publicApi.disabled') && isApiEnabledByLicense();
+	return !config.get('publicApi.disabled') && !Container.get(License).isAPIDisabled();
 }

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -1,6 +1,6 @@
 import validator from 'validator';
 import { plainToInstance } from 'class-transformer';
-import { Response } from 'express';
+import { type RequestHandler, Response } from 'express';
 import { randomBytes } from 'crypto';
 
 import { AuthService } from '@/auth/auth.service';
@@ -22,6 +22,15 @@ import { ExternalHooks } from '@/ExternalHooks';
 import { InternalHooks } from '@/InternalHooks';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { UserRepository } from '@/databases/repositories/user.repository';
+import { isApiEnabled } from '@/PublicApi';
+
+export const isApiEnabledMiddleware: RequestHandler = (_, res, next) => {
+	if (isApiEnabled()) {
+		next();
+	} else {
+		res.status(404).end();
+	}
+};
 
 @RestController('/me')
 export class MeController {
@@ -185,7 +194,7 @@ export class MeController {
 	/**
 	 * Creates an API Key
 	 */
-	@Post('/api-key')
+	@Post('/api-key', { middlewares: [isApiEnabledMiddleware] })
 	async createAPIKey(req: AuthenticatedRequest) {
 		const apiKey = `n8n_api_${randomBytes(40).toString('hex')}`;
 
@@ -202,7 +211,7 @@ export class MeController {
 	/**
 	 * Get an API Key
 	 */
-	@Get('/api-key')
+	@Get('/api-key', { middlewares: [isApiEnabledMiddleware] })
 	async getAPIKey(req: AuthenticatedRequest) {
 		return { apiKey: req.user.apiKey };
 	}
@@ -210,7 +219,7 @@ export class MeController {
 	/**
 	 * Deletes an API Key
 	 */
-	@Delete('/api-key')
+	@Delete('/api-key', { middlewares: [isApiEnabledMiddleware] })
 	async deleteAPIKey(req: AuthenticatedRequest) {
 		await this.userService.update(req.user.id, { apiKey: null });
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -31,6 +31,7 @@ import type { CommunityPackagesService } from '@/services/communityPackages.serv
 import { Logger } from '@/Logger';
 import { UrlService } from './url.service';
 import { InternalHooks } from '@/InternalHooks';
+import { isApiEnabled } from '@/PublicApi';
 
 @Service()
 export class FrontendService {
@@ -143,7 +144,7 @@ export class FrontendService {
 				},
 			},
 			publicApi: {
-				enabled: !config.get('publicApi.disabled') && !this.license.isAPIDisabled(),
+				enabled: isApiEnabled(),
 				latestVersion: 1,
 				path: config.getEnv('publicApi.path'),
 				swaggerUi: {


### PR DESCRIPTION
When Public API is disabled via config, or unavailable because of licensing, the related rest endpoints to manage API keys should also be disabled.  

## Related tickets and issues
https://linear.app/n8n/issue/SEC-5

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included