### PR TITLE
feat(core): Allow customizing rate limits on a per-route basis, and add rate limiting to more endpoints

### DIFF
--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -39,7 +39,7 @@ export class AuthController {
 	) {}
 
 	/** Log in a user */
-	@Post('/login', { skipAuth: true, rateLimit: true })
+	@Post('/login', { skipAuth: true, rateLimit: {} })
 	async login(req: LoginRequest, res: Response): Promise<PublicUser | undefined> {
 		const { email, password, mfaToken, mfaRecoveryCode } = req.body;
 		if (!email) throw new ApplicationError('Email is required to log in');

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -37,7 +37,7 @@ export class InvitationController {
 	 * Send email invite(s) to one or multiple users and create user shell(s).
 	 */
 
-	@Post('/')
+	@Post('/', { rateLimit: { limit: 10 } })
 	@GlobalScope('user:create')
 	async inviteUser(req: UserRequest.Invite) {
 		const isWithinUsersLimit = this.license.isWithinUsersLimit();

--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -41,7 +41,7 @@ export class PasswordResetController {
 	/**
 	 * Send a password reset email.
 	 */
-	@Post('/forgot-password', { skipAuth: true, rateLimit: true })
+	@Post('/forgot-password', { skipAuth: true, rateLimit: { limit: 3 } })
 	async forgotPassword(req: PasswordResetRequest.Email) {
 		if (!this.mailer.isEmailSetUp) {
 			this.logger.debug(

--- a/packages/cli/src/decorators/Route.ts
+++ b/packages/cli/src/decorators/Route.ts
@@ -1,14 +1,14 @@
 import type { RequestHandler } from 'express';
 import { CONTROLLER_ROUTES } from './constants';
-import type { Method, RouteMetadata } from './types';
+import type { Method, RateLimit, RouteMetadata } from './types';
 
 interface RouteOptions {
 	middlewares?: RequestHandler[];
 	usesTemplates?: boolean;
 	/** When this flag is set to true, auth cookie isn't validated, and req.user will not be set */
 	skipAuth?: boolean;
-	/** When this flag is set to true, calls to this endpoint is rate limited to a max of 5 over a window of 5 minutes **/
-	rateLimit?: boolean;
+	/** When these options are set, calls to this endpoint is rate limited using the options */
+	rateLimit?: RateLimit;
 }
 
 const RouteFactory =
@@ -25,7 +25,7 @@ const RouteFactory =
 			handlerName: String(handlerName),
 			usesTemplates: options.usesTemplates ?? false,
 			skipAuth: options.skipAuth ?? false,
-			rateLimit: options.rateLimit ?? false,
+			rateLimit: options.rateLimit,
 		});
 		Reflect.defineMetadata(CONTROLLER_ROUTES, routes, controllerClass);
 	};

--- a/packages/cli/src/decorators/Route.ts
+++ b/packages/cli/src/decorators/Route.ts
@@ -7,7 +7,7 @@ interface RouteOptions {
 	usesTemplates?: boolean;
 	/** When this flag is set to true, auth cookie isn't validated, and req.user will not be set */
 	skipAuth?: boolean;
-	/** When these options are set, calls to this endpoint is rate limited using the options */
+	/** When these options are set, calls to this endpoint are rate limited using the options */
 	rateLimit?: RateLimit;
 }
 

--- a/packages/cli/src/decorators/types.ts
+++ b/packages/cli/src/decorators/types.ts
@@ -17,6 +17,19 @@ export interface MiddlewareMetadata {
 	handlerName: string;
 }
 
+export interface RateLimit {
+	/**
+	 * The maximum number of requests to allow during the `window` before rate limiting the client.
+	 * @default 5
+	 */
+	limit?: number;
+	/**
+	 * How long we should remember the requests.
+	 * @default 300_000 (5 minutes)
+	 */
+	windowMs?: number;
+}
+
 export interface RouteMetadata {
 	method: Method;
 	path: string;
@@ -24,7 +37,7 @@ export interface RouteMetadata {
 	middlewares: RequestHandler[];
 	usesTemplates: boolean;
 	skipAuth: boolean;
-	rateLimit: boolean;
+	rateLimit?: RateLimit;
 }
 
 export type Controller = Record<

--- a/packages/cli/test/unit/decorators/registerController.test.ts
+++ b/packages/cli/test/unit/decorators/registerController.test.ts
@@ -1,6 +1,5 @@
 jest.mock('@/constants', () => ({
-	inE2ETests: false,
-	inTest: false,
+	inProduction: true,
 }));
 
 import express from 'express';
@@ -14,7 +13,7 @@ describe('registerController', () => {
 	@RestController('/test')
 	class TestController {
 		@Get('/unlimited', { skipAuth: true })
-		@Get('/rate-limited', { skipAuth: true, rateLimit: true })
+		@Get('/rate-limited', { skipAuth: true, rateLimit: {} })
 		endpoint() {
 			return { ok: true };
 		}


### PR DESCRIPTION
Without rate-limiting the user invitation endpoint can be used to spam via email.
This PR updated that endpoint to limit the number of requests to 10 over a 5 minute window for all non-owner users.


## Related tickets and issues
https://linear.app/n8n/issue/SEC-8/


## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included