### PR TITLE
fix: continueOnFail when inserting multiple documents in MongoDB

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -325,7 +325,7 @@ export class MongoDb implements INodeType {
 
 				const { insertedIds } = await mdb
 					.collection(this.getNodeParameter('collection', 0) as string)
-					.insertMany(insertItems);
+					.insertMany(insertItems, { ordered: !this.continueOnFail() });
 
 				// Add the id to the data
 				for (const i of Object.keys(insertedIds)) {


### PR DESCRIPTION
## Summary
When inserting multiple documents in MongoDB, the whole batch will fail even with only one error.
The `ordered` parameter in MongoDB allows to continue on error (with the added benefit of allowing parallel insert, speeding up the operation).



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.


## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))