### PR TITLE
Support for business_connection messages in Telegram Bot API

### DIFF
--- a/packages/editor-ui/src/utils/testData/nodeTypeTestData.ts
+++ b/packages/editor-ui/src/utils/testData/nodeTypeTestData.ts
@@ -4005,6 +4005,18 @@ export const nodeTypeTelegramV1_1 = {
 					displayOptions: { show: { '/operation': ['sendMessage'] } },
 				},
 				{
+					displayName: 'Business Connection ID',
+					name: 'business_connection_id',
+					type: 'number',
+					displayOptions: {
+						hide: {
+							'/operation': ['editMessageText'],
+						},
+					},
+					default: 0,
+					description: 'If the message is sent to a business connection, ID of the connection',
+				},
+				{
 					displayName: 'Caption',
 					name: 'caption',
 					type: 'string',

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1482,6 +1482,18 @@ export class Telegram implements INodeType {
 						},
 					},
 					{
+						displayName: 'Business Connection ID',
+						name: 'business_connection_id',
+						type: 'number',
+						displayOptions: {
+							hide: {
+								'/operation': ['editMessageText'],
+							},
+						},
+						default: 0,
+						description: 'If the message is sent to a business connection, ID of the connection',
+					},
+					{
 						displayName: 'Caption',
 						name: 'caption',
 						type: 'string',


### PR DESCRIPTION
## Summary
Since the March of 2024, Telegram Bot API allows bots to read & send messages on behalf of a user, who's a premium user and had configured business connection of his account with a bot. 

Relevant docs:
- https://core.telegram.org/bots#manage-your-business
- https://core.telegram.org/bots/api#businessconnection
- https://core.telegram.org/bots/api#update
- https://core.telegram.org/bots/api#sendmessage

This PR adds a business_connection_id property to be available for send* operations (such as sendMessage or sendVideo). 

This is enough to be able to send those message on behalf on user. 

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))