### PR TITLE
refactor(core): Increase minimum supported Node.js version to 18.17

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -19,12 +19,17 @@ if (process.argv.length === 2) {
 }
 
 const nodeVersion = process.versions.node;
-const nodeVersionMajor = require('semver').major(nodeVersion);
+const { major, gte } = require('semver');
 
-if (![18, 20, 22].includes(nodeVersionMajor)) {
+const MINIMUM_SUPPORTED_NODE_VERSION = '18.17.0';
+
+if (
+	!gte(nodeVersion, MINIMUM_SUPPORTED_NODE_VERSION) ||
+	![18, 20, 22].includes(major(nodeVersion))
+) {
 	console.log(`
-	Your Node.js version (${nodeVersion}) is currently not supported by n8n.
-	Please use Node.js v18 (recommended), v20, or v22 instead!
+	Your Node.js version ${nodeVersion} is currently not supported by n8n.
+	Please use Node.js v${MINIMUM_SUPPORTED_NODE_VERSION} (recommended), v20, or v22 instead!
 	`);
 	process.exit(1);
 }

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -22,9 +22,10 @@ const nodeVersion = process.versions.node;
 const { major, gte } = require('semver');
 
 const MINIMUM_SUPPORTED_NODE_VERSION = '18.17.0';
+const ENFORCE_MIN_NODE_VERSION = process.env.E2E_TESTS !== 'true';
 
 if (
-	!gte(nodeVersion, MINIMUM_SUPPORTED_NODE_VERSION) ||
+	(ENFORCE_MIN_NODE_VERSION && !gte(nodeVersion, MINIMUM_SUPPORTED_NODE_VERSION)) ||
 	![18, 20, 22].includes(major(nodeVersion))
 ) {
 	console.log(`


### PR DESCRIPTION
We need to increase the Node.js minor for the [`undici` upgrade](https://github.com/n8n-io/n8n/pull/9510/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23991) in the license SDK.

Ref: https://github.com/nodejs/undici/issues/3123