### PR TITLE
fix(editor): Redirect to workflows list after deleting a workflow

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -6,7 +6,6 @@ import {
 	EDIT_FIELDS_SET_NODE_NAME,
 	INSTANCE_MEMBERS,
 	INSTANCE_OWNER,
-	WEBHOOK_NODE_NAME,
 } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
@@ -205,7 +204,7 @@ describe('Workflow Actions', () => {
 		cy.get('div[role=dialog][aria-modal=true]').should('be.visible');
 		cy.get('button.btn--confirm').should('be.visible').click();
 		WorkflowPage.getters.successToast().should('exist');
-		cy.url().should('include', '/workflow/new');
+		cy.url().should('include', WorkflowPages.url);
 	});
 
 	describe('duplicate workflow', () => {

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -519,7 +519,7 @@ async function onWorkflowMenuSelect(action: string): Promise<void> {
 				type: 'success',
 			});
 
-			await router.push({ name: VIEWS.NEW_WORKFLOW });
+			await router.push({ name: VIEWS.WORKFLOWS });
 			break;
 		}
 		default:


### PR DESCRIPTION
## Summary
Redirecting users to workflow list, instead of an empty canvas, after deleting a workflow.

## Related tickets and issues
Fixes ADO-2108


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 