### PR TITLE
fix(editor): Render checkboxes in markdown

### DIFF
--- a/packages/design-system/src/components/N8nMarkdown/Markdown.stories.ts
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.stories.ts
@@ -51,3 +51,18 @@ Markdown.args = {
 		},
 	],
 };
+
+const TemplateWithCheckboxes: StoryFn = (args, { argTypes }) => ({
+	setup: () => ({ args }),
+	props: Object.keys(argTypes),
+	components: {
+		N8nMarkdown,
+	},
+	template: '<n8n-markdown v-bind="args"></n8n-markdown>',
+});
+
+export const WithCheckboxes = TemplateWithCheckboxes.bind({});
+WithCheckboxes.args = {
+	content: `__TODO__\n- [ ] Buy milk\n- [X] Buy socks\n`,
+	loading: false,
+};

--- a/packages/design-system/src/components/N8nMarkdown/Markdown.stories.ts
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.stories.ts
@@ -63,6 +63,6 @@ const TemplateWithCheckboxes: StoryFn = (args, { argTypes }) => ({
 
 export const WithCheckboxes = TemplateWithCheckboxes.bind({});
 WithCheckboxes.args = {
-	content: `__TODO__\n- [ ] Buy milk\n- [X] Buy socks\n`,
+	content: '__TODO__\n- [ ] Buy milk\n- [X] Buy socks\n',
 	loading: false,
 };

--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -27,7 +27,6 @@ import xss, { friendlyAttrValue, whiteList } from 'xss';
 
 import N8nLoading from '../N8nLoading';
 import { escapeMarkdown } from '../../utils/markdown';
-import { input } from '@testing-library/user-event/dist/types/event';
 
 interface IImage {
 	id: string;

--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -23,10 +23,11 @@ import Markdown from 'markdown-it';
 import markdownLink from 'markdown-it-link-attributes';
 import markdownEmoji from 'markdown-it-emoji';
 import markdownTaskLists from 'markdown-it-task-lists';
-import xss, { friendlyAttrValue } from 'xss';
+import xss, { friendlyAttrValue, whiteList } from 'xss';
 
 import N8nLoading from '../N8nLoading';
 import { escapeMarkdown } from '../../utils/markdown';
+import { input } from '@testing-library/user-event/dist/types/event';
 
 interface IImage {
 	id: string;
@@ -72,6 +73,7 @@ const props = withDefaults(defineProps<MarkdownProps>(), {
 			},
 		},
 		tasklists: {
+			enabled: true,
 			label: true,
 			labelAfter: true,
 		},
@@ -83,6 +85,11 @@ const md = new Markdown(options.markdown)
 	.use(markdownLink, options.linkAttributes)
 	.use(markdownEmoji)
 	.use(markdownTaskLists, options.tasklists);
+
+const xssWhiteList = {
+	...whiteList,
+	label: ['class', 'for'],
+};
 
 const htmlContent = computed(() => {
 	if (!props.content) {
@@ -130,6 +137,13 @@ const htmlContent = computed(() => {
 			}
 			// return nothing, keep tag
 		},
+		onIgnoreTag(tag, tagHTML) {
+			// Allow checkboxes
+			if (tag === 'input' && tagHTML.includes('type="checkbox"')) {
+				return tagHTML;
+			}
+		},
+		whiteList: xssWhiteList,
 	});
 
 	return safeHtml;

--- a/packages/design-system/src/components/N8nMarkdown/__tests__/Markdown.spec.ts
+++ b/packages/design-system/src/components/N8nMarkdown/__tests__/Markdown.spec.ts
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/vue';
+import N8nMarkdown from '../Markdown.vue';
+
+describe('components', () => {
+	describe('N8nMarkdown', () => {
+		it('should render unchecked checkboxes', () => {
+			const wrapper = render(N8nMarkdown, {
+				props: {
+					content: '__TODO__\n- [ ] Buy milk\n- [ ] Buy socks\n',
+				},
+			});
+			const checkboxes = wrapper.getAllByRole('checkbox');
+			expect(checkboxes).toHaveLength(2);
+			checkboxes.forEach((checkbox) => {
+				expect(checkbox).not.toBeChecked();
+			});
+		});
+		it('should render checked checkboxes', () => {
+			const wrapper = render(N8nMarkdown, {
+				props: {
+					content: '__TODO__\n- [X] Buy milk\n- [X] Buy socks\n',
+				},
+			});
+			const checkboxes = wrapper.getAllByRole('checkbox');
+			expect(checkboxes).toHaveLength(2);
+			checkboxes.forEach((checkbox) => {
+				expect(checkbox).toBeChecked();
+			});
+		});
+		it('should render inputs as plain text', () => {
+			const wrapper = render(N8nMarkdown, {
+				props: {
+					content:
+						'__TODO__\n- [X] Buy milk\n- <input type="text" data-testid="text-input" value="Something"/>\n',
+				},
+			});
+			const checkboxes = wrapper.getAllByRole('checkbox');
+			expect(checkboxes).toHaveLength(1);
+			expect(wrapper.queryByTestId('text-input')).toBeNull();
+			expect(wrapper.html()).toContain(
+				'&lt;input type=“text” data-testid=“text-input” value=“Something”/&gt;',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Allows rendering checkboxes in markdown
![image](https://github.com/n8n-io/n8n/assets/2598782/54c8f824-228e-47e7-8e33-6bf1d5c6056a)

## Related tickets and issues
Fixes ADO-1988
https://github.com/n8n-io/n8n/issues/3616

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 