### PR TITLE
refactor(core): Stop reporting to Sentry invalid credentials on workflow activation (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/workflow-activation.error.ts
+++ b/packages/workflow/src/errors/workflow-activation.error.ts
@@ -47,6 +47,7 @@ export class WorkflowActivationError extends ExecutionBaseError {
 				'econnrefused', // Node.js
 				'eauth', // OAuth
 				'temporary authentication failure', // IMAP server
+				'invalid credentials',
 			].some((str) => this.message.toLowerCase().includes(str))
 		) {
 			this.level = 'warning';

--- a/packages/workflow/test/errors/workflow-activation.error.test.ts
+++ b/packages/workflow/test/errors/workflow-activation.error.test.ts
@@ -18,12 +18,15 @@ describe('WorkflowActivationError', () => {
 		expect(secondError.level).toBe('error');
 	});
 
-	test.each(['ETIMEDOUT', 'ECONNREFUSED', 'EAUTH', 'Temporary authentication failure'])(
-		'should set `level` to `warning` for `%s`',
-		(code) => {
-			const error = new WorkflowActivationError(code, { cause });
+	test.each([
+		'ETIMEDOUT',
+		'ECONNREFUSED',
+		'EAUTH',
+		'Temporary authentication failure',
+		'Invalid credentials',
+	])('should set `level` to `warning` for `%s`', (code) => {
+		const error = new WorkflowActivationError(code, { cause });
 
-			expect(error.level).toBe('warning');
-		},
-	);
+		expect(error.level).toBe('warning');
+	});
 });


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-1632

Ideally we should not expand this check too much until we streamline errors, but for now this is the quickest way to stop reporting high frequency non-issues to Sentry.