### PR TITLE
fix(editor): Show correct schema for output with falsy keys

### DIFF
--- a/packages/editor-ui/src/components/__tests__/RunDataSchema.test.ts
+++ b/packages/editor-ui/src/components/__tests__/RunDataSchema.test.ts
@@ -84,4 +84,27 @@ describe('RunDataJsonSchema.vue', () => {
 		});
 		expect(container).toMatchSnapshot();
 	});
+
+	it('renders no data to show for data empty objects', () => {
+		const renderResult = renderComponent({
+			props: {
+				data: [{}, {}],
+			},
+		});
+
+		expect(renderResult.getByText(/No data to show/)).toBeInTheDocument();
+	});
+
+	test.each([[[{ tx: false }, { tx: false }]], [[{ tx: '' }, { tx: '' }]], [[{ tx: [] }]]])(
+		'renders schema instead of showing no data for %o',
+		(data) => {
+			const renderResult = renderComponent({
+				props: {
+					data,
+				},
+			});
+
+			expect(renderResult.queryByText(/No data to show/)).not.toBeInTheDocument();
+		},
+	);
 });


### PR DESCRIPTION
## Summary

If the output data contains objects that have properties with falsy values, the schema would incorrectly be hidden. This fixes the empty data check to show the schema in these cases.

Before:

![image](https://github.com/n8n-io/n8n/assets/10324676/493a9336-19d6-47ec-af92-c24bcedb7f49)


After:

![image](https://github.com/n8n-io/n8n/assets/10324676/fc7497a8-9601-4dbd-80a9-f3f92ae64ecc)


## Related tickets and issues

https://linear.app/n8n/issue/ADO-1648/bug-schema-view-does-not-render-when-only-boolean-item

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 