### PR TITLE
fix(editor): Show owner email in the owner badge if the resource owner is a pending user

### DIFF
--- a/packages/editor-ui/src/features/projects/components/ProjectCardBadge.vue
+++ b/packages/editor-ui/src/features/projects/components/ProjectCardBadge.vue
@@ -23,8 +23,8 @@ const badgeText = computed(() => {
 	) {
 		return locale.baseText('generic.ownedByMe');
 	} else {
-		const { firstName, lastName } = splitName(props.resource.homeProject?.name ?? '');
-		return `${firstName}${lastName ? ' ' + lastName : ''}`;
+		const { firstName, lastName, email } = splitName(props.resource.homeProject?.name ?? '');
+		return !firstName ? email : `${firstName}${lastName ? ' ' + lastName : ''}`;
 	}
 });
 

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectCardBadge.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectCardBadge.test.ts
@@ -40,7 +40,7 @@ describe('ProjectCardBadge', () => {
 		[' <email@domain.com>', 'email@domain.com'],
 		['My project', 'My project'],
 		['MyProject', 'MyProject'],
-	])('should split a name in the format "First Last <email@domain.com>"', (name, result) => {
+	])('should show the correct owner badge for project name: "%s"', (name, result) => {
 		const { getByText } = renderComponent({
 			props: {
 				resource: {

--- a/packages/editor-ui/src/features/projects/components/__tests__/ProjectCardBadge.test.ts
+++ b/packages/editor-ui/src/features/projects/components/__tests__/ProjectCardBadge.test.ts
@@ -1,0 +1,59 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import ProjectCardBadge from '@/features/projects/components/ProjectCardBadge.vue';
+
+const renderComponent = createComponentRenderer(ProjectCardBadge);
+
+describe('ProjectCardBadge', () => {
+	it('should show "Owned by me" badge if there is no homeProject', () => {
+		const { getByText } = renderComponent({
+			props: {
+				resource: {},
+				personalProject: {},
+			},
+		});
+
+		expect(getByText('Owned by me')).toBeVisible();
+	});
+
+	it('should show "Owned by me" badge if homeProject ID equals personalProject ID', () => {
+		const { getByText } = renderComponent({
+			props: {
+				resource: {
+					homeProject: {
+						id: '1',
+					},
+				},
+				personalProject: {
+					id: '1',
+				},
+			},
+		});
+
+		expect(getByText('Owned by me')).toBeVisible();
+	});
+
+	test.each([
+		['First Last <email@domain.com>', 'First Last'],
+		['First Last Third <email@domain.com>', 'First Last Third'],
+		['First Last Third Fourth <email@domain.com>', 'First Last Third Fourth'],
+		['<email@domain.com>', 'email@domain.com'],
+		[' <email@domain.com>', 'email@domain.com'],
+		['My project', 'My project'],
+		['MyProject', 'MyProject'],
+	])('should split a name in the format "First Last <email@domain.com>"', (name, result) => {
+		const { getByText } = renderComponent({
+			props: {
+				resource: {
+					homeProject: {
+						id: '1',
+						name,
+					},
+				},
+				personalProject: {
+					id: '2',
+				},
+			},
+		});
+		expect(getByText(result)).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary
`undefined` is displayed in the owner badge on workflow and credential cards.

![image](https://github.com/n8n-io/n8n/assets/5410822/04f12878-c2ac-4b88-ab6b-3622e425063a)


## Related tickets and issues
[PAY-1633](https://linear.app/n8n/issue/PAY-1633/undefined-badge-shows-up-on-workflow-card)



## Review / Merge checklist
- [x] PR title and summary are descriptive.
- [x] Tests included.