### PR TITLE
feat(core): Allow transferring credentials from any project to any team project

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -28,6 +28,7 @@ import { SharedCredentialsRepository } from '@/databases/repositories/sharedCred
 import { In } from '@n8n/typeorm';
 import { SharedCredentials } from '@/databases/entities/SharedCredentials';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+import { z } from 'zod';
 
 @RestController('/credentials')
 export class CredentialsController {
@@ -323,5 +324,17 @@ export class CredentialsController {
 			newShareeIds: projectsRelations.map((pr) => pr.userId),
 			credentialsName: credential.name,
 		});
+	}
+
+	@Put('/:credentialId/transfer')
+	@ProjectScope('credential:move')
+	async transfer(req: CredentialRequest.Transfer) {
+		const body = z.object({ destinationProjectId: z.string() }).parse(req.body);
+
+		return await this.enterpriseCredentialsService.transferOne(
+			req.user,
+			req.params.credentialId,
+			body.destinationProjectId,
+		);
 	}
 }

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -103,11 +103,17 @@ export class EnterpriseCredentialsService {
 			user,
 			['credential:move'],
 		);
-		NotFoundError.isDefinedAndNotNull(credential, '...');
+		NotFoundError.isDefinedAndNotNull(
+			credential,
+			`Could not find the credential with the id "${credentialId}". Make sure you have the permission to move it.`,
+		);
 
 		// 2. get owner-sharing
 		const ownerSharing = credential.shared.find((s) => s.role === 'credential:owner');
-		NotFoundError.isDefinedAndNotNull(ownerSharing, '...');
+		NotFoundError.isDefinedAndNotNull(
+			ownerSharing,
+			`Could not find owner for credential "${credential.id}"`,
+		);
 
 		// 3. get source project
 		const sourceProject = ownerSharing.project;
@@ -118,17 +124,24 @@ export class EnterpriseCredentialsService {
 			destinationProjectId,
 			['credential:create'],
 		);
-		NotFoundError.isDefinedAndNotNull(destinationProject, '...');
+		NotFoundError.isDefinedAndNotNull(
+			destinationProject,
+			`Could not find project with the id "${destinationProjectId}". Make sure you have the permission to create credentials in it.`,
+		);
 
 		// 5. checks
 		if (sourceProject.id === destinationProject.id) {
-			throw new TransferCredentialError('...');
+			throw new TransferCredentialError(
+				"You can't transfer a credential into the project that's already owning it.",
+			);
 		}
 		if (sourceProject.type !== 'team' && sourceProject.type !== 'personal') {
-			throw new TransferCredentialError('...');
+			throw new TransferCredentialError(
+				'You can only transfer credentials out of personal or team projects.',
+			);
 		}
 		if (destinationProject.type !== 'team') {
-			throw new TransferCredentialError('...');
+			throw new TransferCredentialError('You can only transfer credentials into team projects.');
 		}
 
 		await this.sharedCredentialsRepository.manager.transaction(async (trx) => {

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -8,6 +8,9 @@ import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { OwnershipService } from '@/services/ownership.service';
 import { Project } from '@/databases/entities/Project';
+import { ProjectService } from '@/services/project.service';
+import { TransferCredentialError } from '@/errors/response-errors/transfer-credential.error';
+import { SharedCredentials } from '@/databases/entities/SharedCredentials';
 
 @Service()
 export class EnterpriseCredentialsService {
@@ -15,6 +18,7 @@ export class EnterpriseCredentialsService {
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
 		private readonly ownershipService: OwnershipService,
 		private readonly credentialsService: CredentialsService,
+		private readonly projectService: ProjectService,
 	) {}
 
 	async shareWithProjects(
@@ -90,5 +94,56 @@ export class EnterpriseCredentialsService {
 		}
 
 		return { ...rest };
+	}
+
+	async transferOne(user: User, credentialId: string, destinationProjectId: string) {
+		// 1. get credential
+		const credential = await this.sharedCredentialsRepository.findCredentialForUser(
+			credentialId,
+			user,
+			['credential:move'],
+		);
+		NotFoundError.isDefinedAndNotNull(credential, '...');
+
+		// 2. get owner-sharing
+		const ownerSharing = credential.shared.find((s) => s.role === 'credential:owner');
+		NotFoundError.isDefinedAndNotNull(ownerSharing, '...');
+
+		// 3. get source project
+		const sourceProject = ownerSharing.project;
+
+		// 4. get destination project
+		const destinationProject = await this.projectService.getProjectWithScope(
+			user,
+			destinationProjectId,
+			['credential:create'],
+		);
+		NotFoundError.isDefinedAndNotNull(destinationProject, '...');
+
+		// 5. checks
+		if (sourceProject.id === destinationProject.id) {
+			throw new TransferCredentialError('...');
+		}
+		if (sourceProject.type !== 'team' && sourceProject.type !== 'personal') {
+			throw new TransferCredentialError('...');
+		}
+		if (destinationProject.type !== 'team') {
+			throw new TransferCredentialError('...');
+		}
+
+		await this.sharedCredentialsRepository.manager.transaction(async (trx) => {
+			// 6. transfer the credential
+			// remove all sharings
+			await trx.remove(credential.shared);
+
+			// create new owner-sharing
+			await trx.save(
+				trx.create(SharedCredentials, {
+					credentialsId: credential.id,
+					projectId: destinationProject.id,
+					role: 'credential:owner',
+				}),
+			);
+		});
 	}
 }

--- a/packages/cli/src/errors/response-errors/transfer-credential.error.ts
+++ b/packages/cli/src/errors/response-errors/transfer-credential.error.ts
@@ -1,0 +1,7 @@
+import { ResponseError } from './abstract/response.error';
+
+export class TransferCredentialError extends ResponseError {
+	constructor(message: string) {
+		super(message, 400, 400);
+	}
+}

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -217,6 +217,12 @@ export declare namespace CredentialRequest {
 	type Test = AuthenticatedRequest<{}, {}, INodeCredentialTestRequest>;
 
 	type Share = AuthenticatedRequest<{ credentialId: string }, {}, { shareWithIds: string[] }>;
+
+	type Transfer = AuthenticatedRequest<
+		{ credentialId: string },
+		{},
+		{ destinationProjectId: string }
+	>;
 }
 
 // ----------------------------------

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -249,14 +249,14 @@ export class EnterpriseWorkflowService {
 		]);
 		NotFoundError.isDefinedAndNotNull(
 			workflow,
-			`Could not find workflow with the id "${workflowId}". Make sure you have the permission to delete it.`,
+			`Could not find workflow with the id "${workflowId}". Make sure you have the permission to move it.`,
 		);
 
 		// 2. get owner-sharing
 		const ownerSharing = workflow.shared.find((s) => s.role === 'workflow:owner')!;
 		NotFoundError.isDefinedAndNotNull(
 			ownerSharing,
-			`Could not find owner for workflow ${workflow.id}`,
+			`Could not find owner for workflow "${workflow.id}"`,
 		);
 
 		// 3. get source project

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -16,12 +16,21 @@ import type { SaveCredentialFunction } from '../shared/types';
 import * as utils from '../shared/utils';
 import {
 	affixRoleToSaveCredential,
+	getCredentialSharings,
 	shareCredentialWithProjects,
 	shareCredentialWithUsers,
 } from '../shared/db/credentials';
-import { createManyUsers, createUser, createUserShell } from '../shared/db/users';
+import {
+	createAdmin,
+	createManyUsers,
+	createOwner,
+	createUser,
+	createUserShell,
+} from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { mockInstance } from '../../shared/mocking';
+
+import { createTeamProject, linkUserToProject } from '../shared/db/projects';
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['credentials'],
@@ -32,6 +41,7 @@ const testServer = utils.setupTestServer({
 });
 
 let owner: User;
+let admin: User;
 let ownerPersonalProject: Project;
 let member: User;
 let memberPersonalProject: Project;
@@ -50,7 +60,8 @@ beforeEach(async () => {
 	projectRepository = Container.get(ProjectRepository);
 	projectService = Container.get(ProjectService);
 
-	owner = await createUser({ role: 'global:owner' });
+	owner = await createOwner();
+	admin = await createAdmin();
 	ownerPersonalProject = await projectRepository.getPersonalProjectForUserOrFail(owner.id);
 
 	member = await createUser({ role: 'global:member' });
@@ -645,6 +656,241 @@ describe('PUT /credentials/:id/share', () => {
 		expect(response.statusCode).toBe(200);
 
 		config.set('userManagement.emails.mode', 'smtp');
+	});
+});
+
+describe('PUT /:credentialId/transfer', () => {
+	test('cannot transfer into the same project', async () => {
+		const destinationProject = await createTeamProject('Team Project', member);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			project: destinationProject,
+		});
+
+		await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(400);
+	});
+
+	test('cannot transfer into a personal project', async () => {
+		const destinationProject = await createTeamProject('Team Project', member);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			project: destinationProject,
+		});
+
+		await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: memberPersonalProject.id })
+			.expect(400);
+	});
+
+	test('cannot transfer somebody elses credential', async () => {
+		const destinationProject = await createTeamProject('Team Project', member);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: anotherMember,
+		});
+
+		await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(403);
+	});
+
+	test('cannot transfer if youre not member in the source project', async () => {
+		const sourceProject = await createTeamProject('Source Project');
+		await linkUserToProject(member, sourceProject, 'project:editor');
+
+		const destinationProject = await createTeamProject('Destination Project', member);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			project: sourceProject,
+		});
+
+		await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(403);
+	});
+
+	test('cannot transfer without credential:create scope for the destination project', async () => {
+		const destinationProject = await createTeamProject('Team Project', anotherMember);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+		});
+
+		await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(404);
+	});
+
+	test('can transfer from personal to team project', async () => {
+		//
+		// ARRANGE
+		//
+		const credential = await saveCredential(randomCredentialPayload(), {
+			user: member,
+		});
+
+		const destinationProject = await createTeamProject('Destination Project', member);
+
+		// all other sharings should be deleted by the transfer
+		await shareCredentialWithUsers(credential, [anotherMember]);
+
+		//
+		// ACT
+		//
+		const response = await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(200);
+
+		//
+		// ASSERT
+		//
+		expect(response.body).toEqual({});
+
+		const allSharings = await getCredentialSharings(credential);
+		expect(allSharings).toHaveLength(1);
+		expect(allSharings[0]).toMatchObject({
+			projectId: destinationProject.id,
+			credentialsId: credential.id,
+			role: 'credential:owner',
+		});
+	});
+
+	test('can transfer from team to another team project', async () => {
+		//
+		// ARRANGE
+		//
+		const sourceProject = await createTeamProject('Team Project 1', member);
+
+		const credential = await saveCredential(randomCredentialPayload(), {
+			project: sourceProject,
+		});
+
+		const destinationProject = await createTeamProject('Team Project 2', member);
+
+		//
+		// ACT
+		//
+		const response = await testServer
+			.authAgentFor(member)
+			.put(`/credentials/${credential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(200);
+
+		//
+		// ASSERT
+		//
+		expect(response.body).toEqual({});
+
+		const allSharings = await getCredentialSharings(credential);
+		expect(allSharings).toHaveLength(1);
+		expect(allSharings[0]).toMatchObject({
+			projectId: destinationProject.id,
+			credentialsId: credential.id,
+			role: 'credential:owner',
+		});
+	});
+
+	test.each([
+		['owners', () => owner],
+		['admins', () => admin],
+	])(
+		'%s can always transfer from any personal or team project into any team project',
+		async (_name, actor) => {
+			//
+			// ARRANGE
+			//
+			const sourceProject = await createTeamProject('Source Project', member);
+			const destinationProject = await createTeamProject('Destination Project', member);
+
+			const teamCredential = await saveCredential(randomCredentialPayload(), {
+				project: sourceProject,
+			});
+			const personalCredential = await saveCredential(randomCredentialPayload(), { user: member });
+
+			//
+			// ACT
+			//
+			const response1 = await testServer
+				.authAgentFor(actor())
+				.put(`/credentials/${teamCredential.id}/transfer`)
+				.send({ destinationProjectId: destinationProject.id })
+				.expect(200);
+			const response2 = await testServer
+				.authAgentFor(actor())
+				.put(`/credentials/${personalCredential.id}/transfer`)
+				.send({ destinationProjectId: destinationProject.id })
+				.expect(200);
+
+			//
+			// ASSERT
+			//
+			expect(response1.body).toEqual({});
+			expect(response2.body).toEqual({});
+
+			{
+				const allSharings = await getCredentialSharings(teamCredential);
+				expect(allSharings).toHaveLength(1);
+				expect(allSharings[0]).toMatchObject({
+					projectId: destinationProject.id,
+					credentialsId: teamCredential.id,
+					role: 'credential:owner',
+				});
+			}
+
+			{
+				const allSharings = await getCredentialSharings(personalCredential);
+				expect(allSharings).toHaveLength(1);
+				expect(allSharings[0]).toMatchObject({
+					projectId: destinationProject.id,
+					credentialsId: personalCredential.id,
+					role: 'credential:owner',
+				});
+			}
+		},
+	);
+
+	test.each([
+		['owners', () => owner],
+		['admins', () => admin],
+	])('%s cannot transfer into personal projects', async (_name, actor) => {
+		//
+		// ARRANGE
+		//
+		const sourceProject = await createTeamProject('Source Project', member);
+		const destinationProject = anotherMemberPersonalProject;
+
+		const teamCredential = await saveCredential(randomCredentialPayload(), {
+			project: sourceProject,
+		});
+		const personalCredential = await saveCredential(randomCredentialPayload(), { user: member });
+
+		//
+		// ACT & ASSERT
+		//
+		await testServer
+			.authAgentFor(actor())
+			.put(`/credentials/${teamCredential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(400);
+		await testServer
+			.authAgentFor(actor())
+			.put(`/credentials/${personalCredential.id}/transfer`)
+			.send({ destinationProjectId: destinationProject.id })
+			.expect(400);
 	});
 });
 

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -661,7 +661,7 @@ describe('PUT /credentials/:id/share', () => {
 
 describe('PUT /:credentialId/transfer', () => {
 	test('cannot transfer into the same project', async () => {
-		const destinationProject = await createTeamProject('Team Project', member);
+		const destinationProject = await createTeamProject('Destination Project', member);
 
 		const credential = await saveCredential(randomCredentialPayload(), {
 			project: destinationProject,
@@ -675,10 +675,8 @@ describe('PUT /:credentialId/transfer', () => {
 	});
 
 	test('cannot transfer into a personal project', async () => {
-		const destinationProject = await createTeamProject('Team Project', member);
-
 		const credential = await saveCredential(randomCredentialPayload(), {
-			project: destinationProject,
+			user: member,
 		});
 
 		await testServer
@@ -689,7 +687,7 @@ describe('PUT /:credentialId/transfer', () => {
 	});
 
 	test('cannot transfer somebody elses credential', async () => {
-		const destinationProject = await createTeamProject('Team Project', member);
+		const destinationProject = await createTeamProject('Destination Project', member);
 
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: anotherMember,
@@ -702,15 +700,14 @@ describe('PUT /:credentialId/transfer', () => {
 			.expect(403);
 	});
 
-	test('cannot transfer if youre not member in the source project', async () => {
+	test("cannot transfer if you're not an admin in the source project", async () => {
 		const sourceProject = await createTeamProject('Source Project');
 		await linkUserToProject(member, sourceProject, 'project:editor');
-
-		const destinationProject = await createTeamProject('Destination Project', member);
-
 		const credential = await saveCredential(randomCredentialPayload(), {
 			project: sourceProject,
 		});
+
+		const destinationProject = await createTeamProject('Destination Project', member);
 
 		await testServer
 			.authAgentFor(member)
@@ -719,12 +716,12 @@ describe('PUT /:credentialId/transfer', () => {
 			.expect(403);
 	});
 
-	test('cannot transfer without credential:create scope for the destination project', async () => {
-		const destinationProject = await createTeamProject('Team Project', anotherMember);
-
+	test("cannot transfer if you're not a member of the destination project", async () => {
 		const credential = await saveCredential(randomCredentialPayload(), {
 			user: member,
 		});
+
+		const destinationProject = await createTeamProject('Team Project');
 
 		await testServer
 			.authAgentFor(member)
@@ -741,10 +738,10 @@ describe('PUT /:credentialId/transfer', () => {
 			user: member,
 		});
 
-		const destinationProject = await createTeamProject('Destination Project', member);
-
 		// all other sharings should be deleted by the transfer
 		await shareCredentialWithUsers(credential, [anotherMember]);
+
+		const destinationProject = await createTeamProject('Destination Project', member);
 
 		//
 		// ACT
@@ -774,7 +771,6 @@ describe('PUT /:credentialId/transfer', () => {
 		// ARRANGE
 		//
 		const sourceProject = await createTeamProject('Team Project 1', member);
-
 		const credential = await saveCredential(randomCredentialPayload(), {
 			project: sourceProject,
 		});
@@ -814,12 +810,13 @@ describe('PUT /:credentialId/transfer', () => {
 			// ARRANGE
 			//
 			const sourceProject = await createTeamProject('Source Project', member);
-			const destinationProject = await createTeamProject('Destination Project', member);
-
 			const teamCredential = await saveCredential(randomCredentialPayload(), {
 				project: sourceProject,
 			});
+
 			const personalCredential = await saveCredential(randomCredentialPayload(), { user: member });
+
+			const destinationProject = await createTeamProject('Destination Project', member);
 
 			//
 			// ACT
@@ -871,12 +868,13 @@ describe('PUT /:credentialId/transfer', () => {
 		// ARRANGE
 		//
 		const sourceProject = await createTeamProject('Source Project', member);
-		const destinationProject = anotherMemberPersonalProject;
-
 		const teamCredential = await saveCredential(randomCredentialPayload(), {
 			project: sourceProject,
 		});
+
 		const personalCredential = await saveCredential(randomCredentialPayload(), { user: member });
+
+		const destinationProject = anotherMemberPersonalProject;
 
 		//
 		// ACT & ASSERT

--- a/packages/cli/test/integration/shared/db/credentials.ts
+++ b/packages/cli/test/integration/shared/db/credentials.ts
@@ -145,3 +145,9 @@ export const getCredentialById = async (id: string) =>
 export async function getAllSharedCredentials() {
 	return await Container.get(SharedCredentialsRepository).find();
 }
+
+export async function getCredentialSharings(credential: CredentialsEntity) {
+	return await Container.get(SharedCredentialsRepository).findBy({
+		credentialsId: credential.id,
+	});
+}

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -1257,9 +1257,9 @@ describe('PUT /:workflowId/transfer', () => {
 	});
 
 	test('cannot transfer into a personal project', async () => {
-		const destinationProject = await createTeamProject('Team Project', member);
+		const sourceProject = await createTeamProject('Team Project', member);
 
-		const workflow = await createWorkflow({}, destinationProject);
+		const workflow = await createWorkflow({}, sourceProject);
 
 		await testServer
 			.authAgentFor(member)
@@ -1268,7 +1268,7 @@ describe('PUT /:workflowId/transfer', () => {
 			.expect(400);
 	});
 
-	test('cannot transfer without workflow:move scope for the workflow', async () => {
+	test('cannot transfer somebody elses workflow', async () => {
 		const destinationProject = await createTeamProject('Team Project', member);
 
 		const workflow = await createWorkflow({}, anotherMember);
@@ -1280,7 +1280,7 @@ describe('PUT /:workflowId/transfer', () => {
 			.expect(403);
 	});
 
-	test('cannot transfer without workflow:create scope in destination project', async () => {
+	test("cannot transfer if you're not a member of the destination project", async () => {
 		const destinationProject = await createTeamProject('Team Project', anotherMember);
 
 		const workflow = await createWorkflow({}, member);
@@ -1296,12 +1296,13 @@ describe('PUT /:workflowId/transfer', () => {
 		//
 		// ARRANGE
 		//
-		const sourceProject = await createTeamProject('Team Project 1');
+		const sourceProject = await createTeamProject();
 		await linkUserToProject(member, sourceProject, 'project:editor');
-		const destinationProject = await createTeamProject();
-		await linkUserToProject(member, destinationProject, 'project:admin');
 
 		const workflow = await createWorkflow({}, sourceProject);
+
+		const destinationProject = await createTeamProject();
+		await linkUserToProject(member, destinationProject, 'project:admin');
 
 		//
 		// ACT & ASSERT
@@ -1319,7 +1320,7 @@ describe('PUT /:workflowId/transfer', () => {
 		//
 		const workflow = await createWorkflow({}, member);
 
-		// this sharing should be deleted by the transfer
+		// these sharings should be deleted by the transfer
 		await shareWorkflowWithUsers(workflow, [anotherMember, owner]);
 
 		const destinationProject = await createTeamProject('Team Project', member);
@@ -1340,7 +1341,7 @@ describe('PUT /:workflowId/transfer', () => {
 
 		const allSharings = await getWorkflowSharing(workflow);
 		expect(allSharings).toHaveLength(1);
-		expect(allSharings).not.toContainEqual({
+		expect(allSharings[0]).toMatchObject({
 			projectId: destinationProject.id,
 			workflowId: workflow.id,
 			role: 'workflow:owner',
@@ -1352,9 +1353,9 @@ describe('PUT /:workflowId/transfer', () => {
 		// ARRANGE
 		//
 		const sourceProject = await createTeamProject('Team Project 1', member);
-		const destinationProject = await createTeamProject('Team Project 2', member);
-
 		const workflow = await createWorkflow({}, sourceProject);
+
+		const destinationProject = await createTeamProject('Team Project 2', member);
 
 		//
 		// ACT
@@ -1389,10 +1390,11 @@ describe('PUT /:workflowId/transfer', () => {
 			// ARRANGE
 			//
 			const sourceProject = await createTeamProject('Source Project', member);
-			const destinationProject = await createTeamProject('Destination Project', member);
-
 			const teamWorkflow = await createWorkflow({}, sourceProject);
+
 			const personalWorkflow = await createWorkflow({}, member);
+
+			const destinationProject = await createTeamProject('Destination Project', member);
 
 			//
 			// ACT
@@ -1444,10 +1446,11 @@ describe('PUT /:workflowId/transfer', () => {
 		// ARRANGE
 		//
 		const sourceProject = await createTeamProject('Source Project', member);
-		const destinationProject = anotherMemberPersonalProject;
-
 		const teamWorkflow = await createWorkflow({}, sourceProject);
+
 		const personalWorkflow = await createWorkflow({}, member);
+
+		const destinationProject = anotherMemberPersonalProject;
 
 		//
 		// ACT & ASSERT


### PR DESCRIPTION
## Summary

This allows transferring credentials from any personal or team project to any other team project.

The user needs to have the permissions/scopes of `credential:move` for the credential and `credential:create` for the destination project.

Credentials cannot be moved into their current home project.
Credentials cannot be moved into any personal project.
Credentials can only be moved out of personal and team projects. (For now there are only personal and team projects, but there are plans for other kinds of projects.)

## Related tickets and issues

https://www.notion.so/n8n/Move-resources-workflow-credentials-between-projects-e737365c6ff446ce9e396df03e7a1255
https://linear.app/n8n/issue/DOC-886/feature-transfer-workflows-and-credentials-from-project-to-project
https://linear.app/n8n/issue/PAY-1428/move-resources-between-projects

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

