### PR TITLE
fix(editor): Replace more variants of BASE_PATH in static assets

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -141,6 +141,7 @@ export class Start extends BaseCommand {
 					createReadStream(filePath, 'utf-8'),
 					replaceStream('/{{BASE_PATH}}/', n8nPath, { ignoreCase: false }),
 					replaceStream('/%7B%7BBASE_PATH%7D%7D/', n8nPath, { ignoreCase: false }),
+					replaceStream('/%257B%257BBASE_PATH%257D%257D/', n8nPath, { ignoreCase: false }),
 					replaceStream('/static/', n8nPath + 'static/', { ignoreCase: false }),
 				];
 				if (filePath.endsWith('index.html')) {


### PR DESCRIPTION
Vite upgrade in https://github.com/n8n-io/n8n/pull/9545 has started escaping `{{BASE_PATH}}` twice for a couple of places. Until we update vite config to escape these strings more reliably, adding this additional replacement on server startup fixes the issue.

## Related tickets and issues
https://linear.app/n8n/issue/ADO-2251
https://github.com/n8n-io/n8n/issues/9559

## Review / Merge checklist
- [x] PR title and summary are descriptive