### PR TITLE
fix(editor): Fix type errors in NodeCredentials (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/editor-ui/src/components/NodeCredentials.vue
@@ -10,7 +10,6 @@
 			<n8n-input-label
 				:label="getCredentialsFieldLabel(credentialTypeDescription)"
 				:bold="false"
-				:set="(issues = getIssues(credentialTypeDescription.name))"
 				size="small"
 				color="text-dark"
 				data-test-id="credentials-label"
@@ -25,12 +24,21 @@
 				</div>
 				<div
 					v-else
-					:class="issues.length && !hideIssues ? $style.hasIssues : $style.input"
+					:class="
+						getIssues(credentialTypeDescription.name).length && !hideIssues
+							? $style.hasIssues
+							: $style.input
+					"
 					data-test-id="node-credentials-select"
 				>
 					<n8n-select
 						:model-value="getSelectedId(credentialTypeDescription.name)"
-						:placeholder="getSelectPlaceholder(credentialTypeDescription.name, issues)"
+						:placeholder="
+							getSelectPlaceholder(
+								credentialTypeDescription.name,
+								getIssues(credentialTypeDescription.name),
+							)
+						"
 						size="small"
 						@update:model-value="
 							(value: string) =>
@@ -65,12 +73,15 @@
 						</n8n-option>
 					</n8n-select>
 
-					<div v-if="issues.length && !hideIssues" :class="$style.warning">
+					<div
+						v-if="getIssues(credentialTypeDescription.name).length && !hideIssues"
+						:class="$style.warning"
+					>
 						<n8n-tooltip placement="top">
 							<template #content>
 								<TitledList
 									:title="`${$locale.baseText('nodeCredentials.issues')}:`"
-									:items="issues"
+									:items="getIssues(credentialTypeDescription.name)"
 								/>
 							</template>
 							<font-awesome-icon icon="exclamation-triangle" />

--- a/packages/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/editor-ui/src/components/NodeCredentials.vue
@@ -179,7 +179,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	emits: { credentialSelected: null, valueChanged: null, 'blur': null },
+	emits: { credentialSelected: null, valueChanged: null, blur: null },
 	setup() {
 		const nodeHelpers = useNodeHelpers();
 

--- a/packages/editor-ui/src/components/NodeCredentials.vue
+++ b/packages/editor-ui/src/components/NodeCredentials.vue
@@ -146,6 +146,7 @@ import {
 	updateNodeAuthType,
 	isRequiredCredential,
 } from '@/utils/nodeTypesUtils';
+import { assert } from '@/utils/assert';
 
 interface CredentialDropdownOption extends ICredentialsResponse {
 	typeDisplayName: string;

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1103,8 +1103,6 @@
 	"nodeCredentials.showMessage.message": "Nodes that used credential \"{oldCredentialName}\" have been updated to use \"{newCredentialName}\"",
 	"nodeCredentials.showMessage.title": "Node credential updated",
 	"nodeCredentials.updateCredential": "Update Credential",
-	"nodeCredentials.editCredentialError.title": "Problem editing credential",
-	"nodeCredentials.editCredentialError.message": "Cannot find selected credential type \"{credentialType}\"",
 	"nodeErrorView.cause": "Cause",
 	"nodeErrorView.copyToClipboard": "Copy to Clipboard",
 	"nodeErrorView.copyToClipboard.tooltip": "Copy error details for debugging. Copied data may contain sensitive information. Proceed with caution when sharing.",

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1103,6 +1103,8 @@
 	"nodeCredentials.showMessage.message": "Nodes that used credential \"{oldCredentialName}\" have been updated to use \"{newCredentialName}\"",
 	"nodeCredentials.showMessage.title": "Node credential updated",
 	"nodeCredentials.updateCredential": "Update Credential",
+	"nodeCredentials.editCredentialError.title": "Problem editing credential",
+	"nodeCredentials.editCredentialError.message": "Cannot find selected credential type \"{credentialType}\"",
 	"nodeErrorView.cause": "Cause",
 	"nodeErrorView.copyToClipboard": "Copy to Clipboard",
 	"nodeErrorView.copyToClipboard.tooltip": "Copy error details for debugging. Copied data may contain sensitive information. Proceed with caution when sharing.",


### PR DESCRIPTION
## Summary
Typefixes for the `NodeCredentials` component.

**Note for reviewers**: In the 2nd commit, I substituted setting local template variable using `:set` and reverted back to calling a function. Please take a look if that makes sense (using dynamic props like this saves us some typing and function calling but it is a hacky, undocumented feat. Also typescript cannot infer types from such vars)




## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 