### PR TITLE
fix(core): Mark `Project.name` as non nullable (no-changelog)

### DIFF
--- a/packages/cli/src/databases/entities/Project.ts
+++ b/packages/cli/src/databases/entities/Project.ts
@@ -8,7 +8,7 @@ export type ProjectType = 'personal' | 'team';
 
 @Entity()
 export class Project extends WithTimestampsAndStringId {
-	@Column({ length: 255, nullable: true })
+	@Column({ length: 255 })
 	name: string;
 
 	@Column({ length: 36 })


### PR DESCRIPTION
## Summary

It's actually not nullable according to the db schemas:
https://github.com/n8n-io/n8n/blob/6ce18ccda11e40d7871f65c66af365b0da72bcb5/packages/cli/src/databases/migrations/common/1714133768519-CreateProject.ts#L50-L50

## Related tickets and issues

none

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))

