### PR TITLE
fix(Code Node): Replace tab character with spaces in placeholder (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/constants.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/constants.ts
@@ -56,7 +56,7 @@ return $input.item;`.trim(),
 		runOnceForAllItems: `
 # Loop over input items and add a new field called 'myNewField' to the JSON of each one
 for item in _input.all():
-	item.json.myNewField = 1
+  item.json.myNewField = 1
 return _input.all()`.trim(),
 		runOnceForEachItem: `
 # Add a new field called 'myNewField' to the JSON of the item


### PR DESCRIPTION
## Summary
Code node: error if create new line in the pre-populated example
![image](https://github.com/n8n-io/n8n/assets/88898367/0cbbd6e4-72fc-4c8e-932e-393c448f1445)



## Related tickets and issues
https://linear.app/n8n/issue/NODE-1371/code-node-error-if-create-new-line-in-the-pre-populated-example