### PR TITLE
fix: Make cloud e2e tests less flaky (no-changelog)

### DIFF
--- a/cypress/e2e/27-cloud.cy.ts
+++ b/cypress/e2e/27-cloud.cy.ts
@@ -91,7 +91,7 @@ describe('Cloud', { disableAutoLogin: true }, () => {
 		});
 	});
 
-	describe('Public API', () => {
+	describe.only('Public API', () => {
 		it('Should show upgrade CTA for Public API if user is trialing', () => {
 			cy.intercept('GET', '/rest/admin/cloud-plan', {
 				body: planData,
@@ -112,6 +112,7 @@ describe('Cloud', { disableAutoLogin: true }, () => {
 			cy.signin({ email: INSTANCE_OWNER.email, password: INSTANCE_OWNER.password });
 
 			visitPublicApiPage();
+			cy.wait(['@loadSettings', '@getPlanData']);
 
 			getPublicApiUpgradeCTA().should('be.visible');
 		});

--- a/cypress/e2e/27-cloud.cy.ts
+++ b/cypress/e2e/27-cloud.cy.ts
@@ -91,7 +91,7 @@ describe('Cloud', { disableAutoLogin: true }, () => {
 		});
 	});
 
-	describe.only('Public API', () => {
+	describe('Public API', () => {
 		it('Should show upgrade CTA for Public API if user is trialing', () => {
 			cy.intercept('GET', '/rest/admin/cloud-plan', {
 				body: planData,

--- a/cypress/pages/settings-public-api.ts
+++ b/cypress/pages/settings-public-api.ts
@@ -2,6 +2,4 @@ export const getPublicApiUpgradeCTA = () => cy.getByTestId('public-api-upgrade-c
 
 export const visitPublicApiPage = () => {
 	cy.visit('/settings/api');
-
-	cy.waitForLoad();
 };

--- a/cypress/pages/settings-public-api.ts
+++ b/cypress/pages/settings-public-api.ts
@@ -2,4 +2,6 @@ export const getPublicApiUpgradeCTA = () => cy.getByTestId('public-api-upgrade-c
 
 export const visitPublicApiPage = () => {
 	cy.visit('/settings/api');
+
+	cy.waitForLoad();
 };


### PR DESCRIPTION
## Summary
Wait for page to load before checking elements, in order to reduce flakiness of tests


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 