### PR TITLE
fix(MongoDB Node): Correct typo in MongoDbProperties (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDbProperties.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDbProperties.ts
@@ -248,7 +248,7 @@ export const nodeProperties: INodeProperties[] = [
 				name: 'dateFields',
 				type: 'string',
 				default: '',
-				description: 'Comma separeted list of fields that will be parse as Mongo Date type',
+				description: 'Comma separeted list of fields that will be parsed as Mongo Date type',
 			},
 			{
 				displayName: 'Use Dot Notation',


### PR DESCRIPTION
## Summary
Corrected typo: "... will be parse as Mongo Date type" -> "... will be parsed as Mongo Date type"



## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 