### PR TITLE
fix(Invoice Ninja Node): Fix assigning an invoice to a payment

### DIFF
--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -675,7 +675,7 @@ export class InvoiceNinja implements INodeType {
 						else if (apiVersion === 'v5') {
 							body.invoices = {
 								invoice_id: invoice as string,
-								amount
+								amount,
 							}
 					}
 						if (additionalFields.paymentType) {

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -673,10 +673,12 @@ export class InvoiceNinja implements INodeType {
 							body.invoice_id = invoice as number;
 						}
 						else if (apiVersion === 'v5') {
-							body.invoices = {
-								invoice_id: invoice as string,
-								amount,
-							};
+							body.invoices = [
+								{
+									invoice_id: invoice as string,
+									amount,
+								},
+							];
 						}
 						if (additionalFields.paymentType) {
 							body.payment_type_id = additionalFields.paymentType as number;

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -680,7 +680,11 @@ export class InvoiceNinja implements INodeType {
 							];
 						}
 						if (additionalFields.paymentType) {
-							body.payment_type_id = additionalFields.paymentType as number;
+							if (apiVersion === 'v4') {
+								body.payment_type_id = additionalFields.paymentType as number;
+							} else if(apiVersion == 'v5') {
+								body.type_id = additionalFields.paymentType as number;
+							}
 						}
 						if (additionalFields.transferReference) {
 							body.transaction_reference = additionalFields.transferReference as string;

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -671,8 +671,7 @@ export class InvoiceNinja implements INodeType {
 						};
 						if (apiVersion === 'v4') {
 							body.invoice_id = invoice as number;
-						}
-						else if (apiVersion === 'v5') {
+						} else if (apiVersion === 'v5') {
 							body.invoices = [
 								{
 									invoice_id: invoice as string,

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -660,16 +660,24 @@ export class InvoiceNinja implements INodeType {
 				if (resource === 'payment') {
 					if (operation === 'create') {
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						const invoice = this.getNodeParameter('invoice', i) as number;
+						const invoice = this.getNodeParameter('invoice', i) as number | string;
 						const client = (
 							await invoiceNinjaApiRequest.call(this, 'GET', `/invoices/${invoice}`, {}, qs)
 						).data?.client_id as string;
 						const amount = this.getNodeParameter('amount', i) as number;
 						const body: IPayment = {
-							invoice_id: invoice,
 							amount,
 							client_id: client,
 						};
+						if (apiVersion === 'v4') {
+							body.invoice_id = invoice as number;
+						}
+						else if (apiVersion === 'v5') {
+							body.invoices = {
+								invoice_id: invoice as string,
+								amount
+							}
+					}
 						if (additionalFields.paymentType) {
 							body.payment_type_id = additionalFields.paymentType as number;
 						}

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -676,8 +676,8 @@ export class InvoiceNinja implements INodeType {
 							body.invoices = {
 								invoice_id: invoice as string,
 								amount,
-							}
-					}
+							};
+						}
 						if (additionalFields.paymentType) {
 							body.payment_type_id = additionalFields.paymentType as number;
 						}

--- a/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/InvoiceNinja.node.ts
@@ -682,7 +682,7 @@ export class InvoiceNinja implements INodeType {
 						if (additionalFields.paymentType) {
 							if (apiVersion === 'v4') {
 								body.payment_type_id = additionalFields.paymentType as number;
-							} else if(apiVersion == 'v5') {
+							} else if (apiVersion == 'v5') {
 								body.type_id = additionalFields.paymentType as number;
 							}
 						}

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
@@ -6,7 +6,7 @@ export interface IPayment {
 	private_notes?: string;
 	client_id?: string;
 	invoices?: {
-		invoice_id?: string
-		amount?: number
-	}
+		invoice_id?: string;
+		amount?: number;
+	};
 }

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
@@ -5,4 +5,8 @@ export interface IPayment {
 	transaction_reference?: string;
 	private_notes?: string;
 	client_id?: string;
+	invoices?: {
+		invoice_id?: string
+		amount?: number
+	}
 }

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
@@ -5,8 +5,10 @@ export interface IPayment {
 	transaction_reference?: string;
 	private_notes?: string;
 	client_id?: string;
-	invoices?: {
-		invoice_id?: string;
-		amount?: number;
-	};
+	invoices?: IInvoice[];
+}
+
+export interface IInvoice {
+	invoice_id: string;
+	amount: number;
 }

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentInterface.ts
@@ -2,6 +2,7 @@ export interface IPayment {
 	invoice_id?: number;
 	amount?: number;
 	payment_type_id?: number;
+	type_id?: number;
 	transaction_reference?: string;
 	private_notes?: string;
 	client_id?: string;


### PR DESCRIPTION
## Summary
> Describe what the PR does and how to test. Photos and videos are recommended.

Currently, when creating a payment and specifying an invoice ID for it, the invoice isn't assigned to the payment. Instead, an unapplied payment is created in InvoiceNinja. This is because the body for the payment create request has changed in API v5, see https://api-docs.invoicing.co/#post-/api/v1/payments.

This PR fixes this by keeping the current request body for API version 4 and changes adds an invoices array to the request body for API version 5.

```json
{
  <OLD_PAYMENT_CREATE_REQUEST_BODY>
  "invoices": [
    {
      "invoice_id": "{{INVOICE_ID}}",
      "amount": "{{AMOUNT}}"
    }
  ]
}
```

## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.

None available. I just used the Invoice Ninja API node and figured that a payment is never assigned to an invoice although an `invoice_id` has been specified.

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 