### PR TITLE
fix: Do not show [object Object] in error message when validating type (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -9,6 +9,7 @@ import {
 	ApplicationError,
 	NodeOperationError,
 	deepCopy,
+	getValueDescription,
 	jsonParse,
 	validateFieldType,
 } from 'n8n-workflow';
@@ -184,7 +185,7 @@ export const validateEntry = (
 			} else {
 				throw new NodeOperationError(
 					node,
-					`'${name}' expects a ${type} but we got '${String(value)}' [item ${itemIndex}]`,
+					`'${name}' expects a ${type} but we got ${getValueDescription(value)} [item ${itemIndex}]`,
 					{ description },
 				);
 			}

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -145,6 +145,17 @@ export const tryToParseObject = (value: unknown): object => {
 	}
 };
 
+export const getValueDescription = <T>(value: T, stringify = false): string => {
+	if (typeof value === 'object') {
+		if (value === null) return "'null'";
+		if (stringify) return JSON.stringify(value);
+		if (Array.isArray(value)) return 'array';
+		return 'object';
+	}
+
+	return `'${String(value)}'`;
+};
+
 export const tryToParseUrl = (value: unknown): string => {
 	if (typeof value === 'string' && !value.includes('://')) {
 		value = `http://${value}`;
@@ -196,7 +207,8 @@ export function validateFieldType(
 	const strict = options.strict ?? false;
 	const valueOptions = options.valueOptions ?? [];
 	const parseStrings = options.parseStrings ?? false;
-	const defaultErrorMessage = `'${fieldName}' expects a ${type} but we got '${String(value)}'`;
+
+	const defaultErrorMessage = `'${fieldName}' expects a ${type} but we got ${getValueDescription(value)}`;
 	switch (type.toLowerCase()) {
 		case 'string': {
 			if (!parseStrings) return { valid: true, newValue: value };
@@ -256,7 +268,7 @@ export function validateFieldType(
 			} catch (e) {
 				return {
 					valid: false,
-					errorMessage: `'${fieldName}' expects time (hh:mm:(:ss)) but we got '${String(value)}'.`,
+					errorMessage: `'${fieldName}' expects time (hh:mm:(:ss)) but we got ${getValueDescription(value)}.`,
 				};
 			}
 		}
@@ -287,9 +299,9 @@ export function validateFieldType(
 			if (!isValidOption) {
 				return {
 					valid: false,
-					errorMessage: `'${fieldName}' expects one of the following values: [${validOptions}] but we got '${String(
+					errorMessage: `'${fieldName}' expects one of the following values: [${validOptions}] but we got ${getValueDescription(
 						value,
-					)}'`,
+					)}`,
 				};
 			}
 			return { valid: true, newValue: value };

--- a/packages/workflow/src/TypeValidation.ts
+++ b/packages/workflow/src/TypeValidation.ts
@@ -145,10 +145,9 @@ export const tryToParseObject = (value: unknown): object => {
 	}
 };
 
-export const getValueDescription = <T>(value: T, stringify = false): string => {
+export const getValueDescription = <T>(value: T): string => {
 	if (typeof value === 'object') {
 		if (value === null) return "'null'";
-		if (stringify) return JSON.stringify(value);
 		if (Array.isArray(value)) return 'array';
 		return 'object';
 	}

--- a/packages/workflow/test/TypeValidation.test.ts
+++ b/packages/workflow/test/TypeValidation.test.ts
@@ -1,4 +1,4 @@
-import { validateFieldType } from '@/TypeValidation';
+import { getValueDescription, validateFieldType } from '@/TypeValidation';
 import { DateTime } from 'luxon';
 
 const VALID_ISO_DATES = [
@@ -228,6 +228,17 @@ describe('Type Validation', () => {
 				expect(validateFieldType('test', 42, 'string', options).newValue).toBe('42');
 				expect(validateFieldType('test', true, 'string', options).newValue).toBe('true');
 			});
+		});
+	});
+	describe('getValueDescription util function', () => {
+		it('should return correct description', () => {
+			expect(getValueDescription('foo')).toBe("'foo'");
+			expect(getValueDescription(42)).toBe("'42'");
+			expect(getValueDescription(true)).toBe("'true'");
+			expect(getValueDescription(null)).toBe("'null'");
+			expect(getValueDescription(undefined)).toBe("'undefined'");
+			expect(getValueDescription([{}])).toBe('array');
+			expect(getValueDescription({})).toBe('object');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
in case a value is an object show 'object' or 'array' accordingly instead of '[object Object]'
![image](https://github.com/n8n-io/n8n/assets/88898367/2c615867-ccbd-4733-af1e-62671d63a808)




## Related tickets and issues
https://linear.app/n8n/issue/NODE-1349/type-errors-in-filter-component-dont-work-when-value-is-array-or