### PR TITLE
fix(core): Fix license autorenewal disabled warning

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -87,16 +87,6 @@ export class License {
 
 		const renewalEnabled = this.renewalEnabled(instanceType);
 
-		if (
-			!config.getEnv('license.autoRenewEnabled') &&
-			isMainInstance &&
-			config.getEnv('multiMainSetup.instanceType') === 'leader'
-		) {
-			this.logger.warn(
-				'Automatic license renewal is disabled. The license will not renew automatically, and access to licensed features may be lost!',
-			);
-		}
-
 		try {
 			this.manager = new LicenseManager({
 				server,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -177,6 +177,16 @@ export class Start extends BaseCommand {
 
 		await this.initOrchestration();
 		this.logger.debug('Orchestration init complete');
+
+		if (
+			!config.getEnv('license.autoRenewEnabled') &&
+			config.getEnv('multiMainSetup.instanceType') === 'leader'
+		) {
+			this.logger.warn(
+				'Automatic license renewal is disabled. The license will not renew automatically, and access to licensed features may be lost!',
+			);
+		}
+
 		await this.initBinaryDataService();
 		this.logger.debug('Binary data service init complete');
 		await this.initExternalHooks();
@@ -192,7 +202,10 @@ export class Start extends BaseCommand {
 	}
 
 	async initOrchestration() {
-		if (config.getEnv('executions.mode') !== 'queue') return;
+		if (config.getEnv('executions.mode') === 'regular') {
+			config.set('multiMainSetup.instanceType', 'leader');
+			return;
+		}
 
 		if (
 			config.getEnv('multiMainSetup.enabled') &&


### PR DESCRIPTION
Ensure warning is shown always in single-main setup and only for leader in multi-main setup.