### PR TITLE
fix(core): Start WaitTracker only in the main container

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -27,9 +27,11 @@ export class WaitTracker {
 		private readonly executionRepository: ExecutionRepository,
 		private readonly ownershipService: OwnershipService,
 		private readonly workflowRunner: WorkflowRunner,
-		readonly orchestrationService: OrchestrationService,
-	) {
-		const { isSingleMainSetup, isLeader, multiMainSetup } = orchestrationService;
+		private readonly orchestrationService: OrchestrationService,
+	) {}
+
+	init() {
+		const { isSingleMainSetup, isLeader, multiMainSetup } = this.orchestrationService;
 
 		if (isSingleMainSetup) {
 			this.startTracking();
@@ -43,7 +45,7 @@ export class WaitTracker {
 			.on('leader-stepdown', () => this.stopTracking());
 	}
 
-	startTracking() {
+	private startTracking() {
 		this.logger.debug('Wait tracker started tracking waiting executions');
 
 		// Poll every 60 seconds a list of upcoming executions

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -178,6 +178,8 @@ export class Start extends BaseCommand {
 
 		await this.initOrchestration();
 		this.logger.debug('Orchestration init complete');
+		Container.get(WaitTracker).init();
+		this.logger.debug('Wait tracker init complete');
 		await this.initBinaryDataService();
 		this.logger.debug('Binary data service init complete');
 		await this.initExternalHooks();


### PR DESCRIPTION
`WaitTracker` initialization in the constructor means that as soon as this class enters the DI dependency tree, we start tracking for waiting executions, causing `getWaitingExecutions` queries to run even before the `execution_entity` table might be available.
This can be verified by using any of the [import commands](https://github.com/n8n-io/n8n/actions/runs/9349335419/job/25730405977#step:8:7) on a new DB on any of the last releases.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [ ] Tests included