### PR TITLE
feat: Release floating entitlements on license:clear command (no-changelog)

### DIFF
--- a/packages/cli/src/commands/license/clear.ts
+++ b/packages/cli/src/commands/license/clear.ts
@@ -2,6 +2,7 @@ import { Container } from 'typedi';
 import { SETTINGS_LICENSE_CERT_KEY } from '@/constants';
 import { BaseCommand } from '../BaseCommand';
 import { SettingsRepository } from '@db/repositories/settings.repository';
+import { License } from '@/License';
 
 export class ClearLicenseCommand extends BaseCommand {
 	static description = 'Clear license';
@@ -10,6 +11,12 @@ export class ClearLicenseCommand extends BaseCommand {
 
 	async run() {
 		this.logger.info('Clearing license from database.');
+
+		// Invoke shutdown() to force any floating entitlements to be released
+		const license = Container.get(License);
+		await license.init();
+		await license.shutdown();
+
 		await Container.get(SettingsRepository).delete({
 			key: SETTINGS_LICENSE_CERT_KEY,
 		});

--- a/packages/cli/test/integration/commands/license.cmd.test.ts
+++ b/packages/cli/test/integration/commands/license.cmd.test.ts
@@ -3,7 +3,6 @@ import { License } from '@/License';
 import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
 import { ClearLicenseCommand } from '@/commands/license/clear';
 import { Config } from '@oclif/core';
-import Container from 'typedi';
 import { mockInstance } from '../../shared/mocking';
 
 const oclifConfig = new Config({ root: __dirname });

--- a/packages/cli/test/integration/commands/license.cmd.test.ts
+++ b/packages/cli/test/integration/commands/license.cmd.test.ts
@@ -18,10 +18,7 @@ test('license:clear invokes shutdown() to release any floating entitlements', as
 	const cmd = new ClearLicenseCommand([], oclifConfig);
 	await cmd.init();
 
-	const license = Container.get(License);
-
-	jest.spyOn(license, 'init');
-	jest.spyOn(license, 'shutdown');
+	const license = mockInstance(License);
 
 	await cmd.run();
 

--- a/packages/cli/test/integration/commands/license.cmd.test.ts
+++ b/packages/cli/test/integration/commands/license.cmd.test.ts
@@ -1,0 +1,32 @@
+import { InternalHooks } from '@/InternalHooks';
+import { License } from '@/License';
+import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
+import { ClearLicenseCommand } from '@/commands/license/clear';
+import { Config } from '@oclif/core';
+import Container from 'typedi';
+import { mockInstance } from '../../shared/mocking';
+
+const oclifConfig = new Config({ root: __dirname });
+
+beforeAll(async () => {
+	mockInstance(InternalHooks);
+	mockInstance(LoadNodesAndCredentials);
+	await oclifConfig.load();
+});
+
+test('license:clear invokes shutdown() to release any floating entitlements', async () => {
+	const cmd = new ClearLicenseCommand([], oclifConfig);
+	await cmd.init();
+
+	const license = Container.get(License);
+
+	jest.spyOn(license, 'init');
+	jest.spyOn(license, 'shutdown');
+
+	await cmd.run();
+
+	expect(license.init).toHaveBeenCalledTimes(1);
+	expect(license.shutdown).toHaveBeenCalledTimes(1);
+
+	jest.restoreAllMocks();
+});


### PR DESCRIPTION
## Summary
The license:clear CLI command deletes the license information from the database. If the license contains any floating entitlements, these entitlements would be 'burned' and no longer attachable by other instances. This PR addresses that issue by ensuring floating entitlements are released before the license is deleted from the database.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included