### PR TITLE
fix(Airtable Node): Make multipleRecordLinks editable in fields

### DIFF
--- a/packages/nodes-base/nodes/Airtable/v2/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/methods/resourceMapping.ts
@@ -31,7 +31,6 @@ const airtableReadOnlyFields = [
 	'rollup',
 	'externalSyncSource',
 	'multipleLookupValues',
-	'multipleRecordLinks',
 ];
 
 const airtableTypesMap: TypesMap = {
@@ -42,7 +41,7 @@ const airtableTypesMap: TypesMap = {
 	time: [],
 	object: [],
 	options: ['singleSelect'],
-	array: ['multipleSelects', 'multipleAttachments'],
+	array: ['multipleSelects', 'multipleRecordLinks', 'multipleAttachments'],
 };
 
 function mapForeignType(foreignType: string, typesMap: TypesMap): FieldType {


### PR DESCRIPTION
- Removed multipleRecordLinks from read-only fields
- Ensured multipleRecordLinks is correctly mapped in types map
- Updated field mapping logic to reflect changes

## Summary
This PR makes the multipleRecordLinks field editable in Airtable fields. Previously, it was incorrectly marked as read-only. To test, ensure that multipleRecordLinks fields are now editable and correctly mapped when integrating with Airtable in n8n.

## Related tickets and issues
> https://community.n8n.io/t/airtable-linked-record/15462/6