### PR TITLE
fix(editor): Skip disabled nodes when detecting workflow issues

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -6,6 +6,7 @@ import {
 	EDIT_FIELDS_SET_NODE_NAME,
 	INSTANCE_MEMBERS,
 	INSTANCE_OWNER,
+	NOTION_NODE_NAME,
 } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
 import { WorkflowsPage as WorkflowsPageClass } from '../pages/workflows';
@@ -49,6 +50,30 @@ describe('Workflow Actions', () => {
 	it('should be able to activate workflow', () => {
 		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.saveWorkflowOnButtonClick();
+		WorkflowPage.actions.activateWorkflow();
+		WorkflowPage.getters.isWorkflowActivated();
+	});
+
+	it('should not be be able to activate workflow when nodes have errors', () => {
+		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
+		WorkflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME);
+		WorkflowPage.actions.saveWorkflowOnButtonClick();
+		WorkflowPage.getters.successToast().should('exist');
+		WorkflowPage.actions.clickWorkflowActivator();
+		WorkflowPage.getters.errorToast().should('exist');
+	});
+
+	it('should be be able to activate workflow when nodes with errors are disabled', () => {
+		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
+		WorkflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME);
+		WorkflowPage.actions.saveWorkflowOnButtonClick();
+		WorkflowPage.getters.successToast().should('exist');
+		// First, try to activate the workflow with errors
+		WorkflowPage.actions.clickWorkflowActivator();
+		WorkflowPage.getters.errorToast().should('exist');
+		// Now, disable the node with errors
+		WorkflowPage.getters.canvasNodes().last().click();
+		WorkflowPage.actions.hitDisableNodeShortcut();
 		WorkflowPage.actions.activateWorkflow();
 		WorkflowPage.getters.isWorkflowActivated();
 	});

--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -187,45 +187,47 @@ describe('Workflow Actions', () => {
 
 	it('should update workflow settings', () => {
 		cy.visit(WorkflowPages.url);
-		WorkflowPages.getters.workflowCards().then((cards) => {
-			const totalWorkflows = cards.length;
+		cy.intercept('GET', '/rest/workflows', (req) => {
+			req.on('response', (res) => {
+				const totalWorkflows = res.body.count ?? 0;
 
-			WorkflowPage.actions.visit();
-			// Open settings dialog
-			WorkflowPage.actions.saveWorkflowOnButtonClick();
-			WorkflowPage.getters.workflowMenu().should('be.visible');
-			WorkflowPage.getters.workflowMenu().click();
-			WorkflowPage.getters.workflowMenuItemSettings().should('be.visible');
-			WorkflowPage.getters.workflowMenuItemSettings().click();
-			// Change all settings
-			// totalWorkflows + 1 (current workflow) + 1 (no workflow option)
-			WorkflowPage.getters.workflowSettingsErrorWorkflowSelect().click();
-			getVisibleSelect()
-				.find('li')
-				.should('have.length', totalWorkflows + 2);
-			getVisibleSelect().find('li').last().click({ force: true });
-			WorkflowPage.getters.workflowSettingsTimezoneSelect().click();
-			getVisibleSelect().find('li').should('exist');
-			getVisibleSelect().find('li').eq(1).click({ force: true });
-			WorkflowPage.getters.workflowSettingsSaveFiledExecutionsSelect().click();
-			getVisibleSelect().find('li').should('have.length', 3);
-			getVisibleSelect().find('li').last().click({ force: true });
-			WorkflowPage.getters.workflowSettingsSaveSuccessExecutionsSelect().click();
-			getVisibleSelect().find('li').should('have.length', 3);
-			getVisibleSelect().find('li').last().click({ force: true });
-			WorkflowPage.getters.workflowSettingsSaveManualExecutionsSelect().click();
-			getVisibleSelect().find('li').should('have.length', 3);
-			getVisibleSelect().find('li').last().click({ force: true });
-			WorkflowPage.getters.workflowSettingsSaveExecutionProgressSelect().click();
-			getVisibleSelect().find('li').should('have.length', 3);
-			getVisibleSelect().find('li').last().click({ force: true });
-			WorkflowPage.getters.workflowSettingsTimeoutWorkflowSwitch().click();
-			WorkflowPage.getters.workflowSettingsTimeoutForm().find('input').first().type('1');
-			// Save settings
-			WorkflowPage.getters.workflowSettingsSaveButton().click();
-			WorkflowPage.getters.workflowSettingsModal().should('not.exist');
-			WorkflowPage.getters.successToast().should('exist');
-		});
+				WorkflowPage.actions.visit();
+				// Open settings dialog
+				WorkflowPage.actions.saveWorkflowOnButtonClick();
+				WorkflowPage.getters.workflowMenu().should('be.visible');
+				WorkflowPage.getters.workflowMenu().click();
+				WorkflowPage.getters.workflowMenuItemSettings().should('be.visible');
+				WorkflowPage.getters.workflowMenuItemSettings().click();
+				// Change all settings
+				// totalWorkflows + 1 (current workflow) + 1 (no workflow option)
+				WorkflowPage.getters.workflowSettingsErrorWorkflowSelect().click();
+				getVisibleSelect()
+					.find('li')
+					.should('have.length', totalWorkflows + 2);
+				getVisibleSelect().find('li').last().click({ force: true });
+				WorkflowPage.getters.workflowSettingsTimezoneSelect().click();
+				getVisibleSelect().find('li').should('exist');
+				getVisibleSelect().find('li').eq(1).click({ force: true });
+				WorkflowPage.getters.workflowSettingsSaveFiledExecutionsSelect().click();
+				getVisibleSelect().find('li').should('have.length', 3);
+				getVisibleSelect().find('li').last().click({ force: true });
+				WorkflowPage.getters.workflowSettingsSaveSuccessExecutionsSelect().click();
+				getVisibleSelect().find('li').should('have.length', 3);
+				getVisibleSelect().find('li').last().click({ force: true });
+				WorkflowPage.getters.workflowSettingsSaveManualExecutionsSelect().click();
+				getVisibleSelect().find('li').should('have.length', 3);
+				getVisibleSelect().find('li').last().click({ force: true });
+				WorkflowPage.getters.workflowSettingsSaveExecutionProgressSelect().click();
+				getVisibleSelect().find('li').should('have.length', 3);
+				getVisibleSelect().find('li').last().click({ force: true });
+				WorkflowPage.getters.workflowSettingsTimeoutWorkflowSwitch().click();
+				WorkflowPage.getters.workflowSettingsTimeoutForm().find('input').first().type('1');
+				// Save settings
+				WorkflowPage.getters.workflowSettingsSaveButton().click();
+				WorkflowPage.getters.workflowSettingsModal().should('not.exist');
+				WorkflowPage.getters.successToast().should('exist');
+			});
+		}).as('loadWorkflows');
 	});
 
 	it('should not be able to delete unsaved workflow', () => {

--- a/cypress/pages/workflow.ts
+++ b/cypress/pages/workflow.ts
@@ -298,10 +298,13 @@ export class WorkflowPage extends BasePage {
 			this.getters.workflowNameInput().should('be.enabled');
 			this.getters.workflowNameInput().clear().type(name).type('{enter}');
 		},
-		activateWorkflow: () => {
-			cy.intercept('PATCH', '/rest/workflows/*').as('activateWorkflow');
+		clickWorkflowActivator: () => {
 			this.getters.activatorSwitch().find('input').first().should('be.enabled');
 			this.getters.activatorSwitch().click();
+		},
+		activateWorkflow: () => {
+			cy.intercept('PATCH', '/rest/workflows/*').as('activateWorkflow');
+			this.actions.clickWorkflowActivator();
 			cy.wait('@activateWorkflow');
 			cy.get('body').type('{esc}');
 		},

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -175,7 +175,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	const nodesIssuesExist = computed(() => {
 		for (const node of workflow.value.nodes) {
-			if (node.issues === undefined || Object.keys(node.issues).length === 0) {
+			const isNodeDisabled = node.disabled === true;
+			const noNodeIssues = node.issues === undefined || Object.keys(node.issues).length === 0;
+			if (isNodeDisabled || noNodeIssues) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary
Not counting disabled nodes when detecting workflow errors. This should fix a bug where workflows cannot be activated after nodes with errors are disabled.

EDIT: Starting from this PR, the workflow settings e2e tests started failing. Reason is that we are getting the total workflow count by counting workflow cards. Unfortunately, the recycler component will not render cards outside of viewport so that is not giving us accurate count. I've changed it to use response from `/workflows` endpoint.

## Related tickets and issues
Fixes ADO-1658



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 