### PR TITLE
feat(core): Implement `project:viewer` role

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -275,7 +275,7 @@ export class CredentialsService {
 
 			if (typeof projectId === 'string' && project === null) {
 				throw new BadRequestError(
-					"You don't have the permissions to save the workflow in this project.",
+					"You don't have the permissions to save the credential in this project.",
 				);
 			}
 

--- a/packages/cli/src/databases/entities/ProjectRelation.ts
+++ b/packages/cli/src/databases/entities/ProjectRelation.ts
@@ -4,7 +4,11 @@ import { WithTimestamps } from './AbstractEntity';
 import { Project } from './Project';
 
 // personalOwner is only used for personal projects
-export type ProjectRole = 'project:personalOwner' | 'project:admin' | 'project:editor';
+export type ProjectRole =
+	| 'project:personalOwner'
+	| 'project:admin'
+	| 'project:editor'
+	| 'project:viewer';
 
 @Entity()
 export class ProjectRelation extends WithTimestamps {

--- a/packages/cli/src/permissions/project-roles.ts
+++ b/packages/cli/src/permissions/project-roles.ts
@@ -61,3 +61,12 @@ export const PROJECT_EDITOR_SCOPES: Scope[] = [
 	'project:list',
 	'project:read',
 ];
+
+export const PROJECT_VIEWER_SCOPES: Scope[] = [
+	'credential:list',
+	'credential:read',
+	'project:list',
+	'project:read',
+	'workflow:list',
+	'workflow:read',
+];

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -13,6 +13,7 @@ import {
 import {
 	PERSONAL_PROJECT_OWNER_SCOPES,
 	PROJECT_EDITOR_SCOPES,
+	PROJECT_VIEWER_SCOPES,
 	REGULAR_PROJECT_ADMIN_SCOPES,
 } from '@/permissions/project-roles';
 import {
@@ -39,6 +40,7 @@ const PROJECT_SCOPE_MAP: Record<ProjectRole, Scope[]> = {
 	'project:admin': REGULAR_PROJECT_ADMIN_SCOPES,
 	'project:personalOwner': PERSONAL_PROJECT_OWNER_SCOPES,
 	'project:editor': PROJECT_EDITOR_SCOPES,
+	'project:viewer': PROJECT_VIEWER_SCOPES,
 };
 
 const CREDENTIALS_SHARING_SCOPE_MAP: Record<CredentialSharingRole, Scope[]> = {
@@ -87,6 +89,7 @@ const ROLE_NAMES: Record<
 	'project:personalOwner': 'Project Owner',
 	'project:admin': 'Project Admin',
 	'project:editor': 'Project Editor',
+	'project:viewer': 'Project Viewer',
 	'credential:user': 'Credential User',
 	'credential:owner': 'Credential Owner',
 	'workflow:owner': 'Workflow Owner',
@@ -230,6 +233,8 @@ export class RoleService {
 				return this.license.isProjectRoleAdminLicensed();
 			case 'project:editor':
 				return this.license.isProjectRoleEditorLicensed();
+			case 'project:viewer':
+				return this.license.isProjectRoleViewerLicensed();
 			case 'global:admin':
 				return this.license.isAdvancedPermissionsLicensed();
 			default:

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import { mockInstance } from '../../shared/mocking';
+import { createTeamProject, linkUserToProject } from '../shared/db/projects';
 
 import { createTeamProject, linkUserToProject } from '../shared/db/projects';
 
@@ -80,6 +81,23 @@ beforeEach(async () => {
 
 afterEach(() => {
 	jest.clearAllMocks();
+});
+
+describe('POST /credentials', () => {
+	test('project viewers cannot create credentials', async () => {
+		const teamProject = await createTeamProject();
+		await linkUserToProject(member, teamProject, 'project:viewer');
+
+		const response = await testServer
+			.authAgentFor(member)
+			.post('/credentials')
+			.send({ ...randomCredentialPayload(), projectId: teamProject.id });
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body.message).toBe(
+			"You don't have the permissions to save the credential in this project.",
+		);
+	});
 });
 
 // ----------------------------------------
@@ -231,6 +249,22 @@ describe('GET /credentials', () => {
 // GET /credentials/:id - fetch a certain credential
 // ----------------------------------------
 describe('GET /credentials/:id', () => {
+	test('project viewers can view credentials', async () => {
+		const teamProject = await createTeamProject();
+		await linkUserToProject(member, teamProject, 'project:viewer');
+
+		const savedCredential = await saveCredential(randomCredentialPayload(), {
+			project: teamProject,
+		});
+
+		const response = await testServer
+			.authAgentFor(member)
+			.get(`/credentials/${savedCredential.id}`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toBeDefined();
+	});
+
 	test('should retrieve owned cred for owner', async () => {
 		const savedCredential = await saveCredential(randomCredentialPayload(), { user: owner });
 
@@ -384,6 +418,35 @@ describe('GET /credentials/:id', () => {
 		// because EE router has precedence, check if forwards this route
 		const responseNew = await authOwnerAgent.get('/credentials/new');
 		expect(responseNew.statusCode).toBe(200);
+	});
+});
+
+describe('PATCH /credentials/:id', () => {
+	test('project viewer cannot update credentials', async () => {
+		//
+		// ARRANGE
+		//
+		const teamProject = await createTeamProject('', member);
+		await linkUserToProject(member, teamProject, 'project:viewer');
+
+		const savedCredential = await saveCredential(randomCredentialPayload(), {
+			project: teamProject,
+		});
+
+		//
+		// ACT
+		//
+		const response = await testServer
+			.authAgentFor(member)
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ ...randomCredentialPayload() });
+
+		//
+		// ASSERT
+		//
+
+		expect(response.statusCode).toBe(403);
+		expect(response.body.message).toBe('User is missing a scope required to perform this action');
 	});
 });
 

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -31,8 +31,6 @@ import type { SuperAgentTest } from '../shared/types';
 import { mockInstance } from '../../shared/mocking';
 import { createTeamProject, linkUserToProject } from '../shared/db/projects';
 
-import { createTeamProject, linkUserToProject } from '../shared/db/projects';
-
 const testServer = utils.setupTestServer({
 	endpointGroups: ['credentials'],
 	enabledFeatures: ['feat:sharing'],

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -260,7 +260,16 @@ describe('GET /credentials/:id', () => {
 			.get(`/credentials/${savedCredential.id}`);
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data).toBeDefined();
+		expect(response.body.data).toMatchObject({
+			id: savedCredential.id,
+			shared: [{ projectId: teamProject.id, role: 'credential:owner' }],
+			homeProject: {
+				id: teamProject.id,
+			},
+			sharedWithProjects: [],
+			scopes: ['credential:read'],
+		});
+		expect(response.body.data.data).toBeUndefined();
 	});
 
 	test('should retrieve owned cred for owner', async () => {

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -685,7 +685,7 @@ describe('POST /credentials', () => {
 			//
 			.expect(400, {
 				code: 400,
-				message: "You don't have the permissions to save the workflow in this project.",
+				message: "You don't have the permissions to save the credential in this project.",
 			});
 	});
 });

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -7,6 +7,7 @@ import * as testDb from './shared/testDb';
 import { setupTestServer } from './shared/utils';
 import { mockInstance } from '../shared/mocking';
 import { WaitTracker } from '@/WaitTracker';
+import { createTeamProject, linkUserToProject } from './shared/db/projects';
 
 const testServer = setupTestServer({ endpointGroups: ['executions'] });
 
@@ -45,6 +46,23 @@ describe('GET /executions', () => {
 });
 
 describe('GET /executions/:id', () => {
+	test('project viewers can view executions for workflows in the project', async () => {
+		// if sharing is not enabled, we're only returning the executions of
+		// personal workflows
+		testServer.license.enable('feat:sharing');
+
+		const teamProject = await createTeamProject();
+		await linkUserToProject(member, teamProject, 'project:viewer');
+
+		const workflow = await createWorkflow({}, teamProject);
+		const execution = await createSuccessfulExecution(workflow);
+
+		const response = await testServer.authAgentFor(member).get(`/executions/${execution.id}`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toBeDefined();
+	});
+
 	test('only returns executions of shared workflows if sharing is enabled', async () => {
 		const workflow = await createWorkflow({}, owner);
 		await shareWorkflowWithUsers(workflow, [member]);

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -665,18 +665,162 @@ describe('POST /workflows', () => {
 	});
 });
 
-describe('PATCH /workflows/:workflowId - validate credential permissions to user', () => {
-	it('Should succeed when saving unchanged workflow nodes', async () => {
-		const savedCredential = await saveCredential(randomCredentialPayload(), { user: owner });
-		const workflow = {
-			name: 'test',
-			active: false,
-			connections: {},
-			nodes: [
+describe('PATCH /workflows/:workflowId', () => {
+	describe('validate credential permissions to user', () => {
+		it('Should succeed when saving unchanged workflow nodes', async () => {
+			const savedCredential = await saveCredential(randomCredentialPayload(), { user: owner });
+			const workflow = {
+				name: 'test',
+				active: false,
+				connections: {},
+				nodes: [
+					{
+						id: 'uuid-1234',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {
+							default: {
+								id: savedCredential.id,
+								name: savedCredential.name,
+							},
+						},
+					},
+				],
+			};
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
+			const { id, versionId } = createResponse.body.data;
+
+			const response = await authOwnerAgent.patch(`/workflows/${id}`).send({
+				name: 'new name',
+				versionId,
+			});
+
+			expect(response.statusCode).toBe(200);
+		});
+
+		it('Should allow owner to add node containing credential not shared with the owner', async () => {
+			const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
+			const workflow = {
+				name: 'test',
+				active: false,
+				connections: {},
+				nodes: [
+					{
+						id: 'uuid-1234',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {
+							default: {
+								id: savedCredential.id,
+								name: savedCredential.name,
+							},
+						},
+					},
+				],
+			};
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
+			const { id, versionId } = createResponse.body.data;
+
+			const response = await authOwnerAgent.patch(`/workflows/${id}`).send({
+				versionId,
+				nodes: [
+					{
+						id: 'uuid-1234',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {
+							default: {
+								id: savedCredential.id,
+								name: savedCredential.name,
+							},
+						},
+					},
+				],
+			});
+
+			expect(response.statusCode).toBe(200);
+		});
+
+		it('Should prevent member from adding node containing credential inaccessible to member', async () => {
+			const savedCredential = await saveCredential(randomCredentialPayload(), { user: owner });
+
+			const workflow = {
+				name: 'test',
+				active: false,
+				connections: {},
+				nodes: [
+					{
+						id: 'uuid-1234',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {
+							default: {
+								id: savedCredential.id,
+								name: savedCredential.name,
+							},
+						},
+					},
+				],
+			};
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
+			const { id, versionId } = createResponse.body.data;
+
+			const response = await authMemberAgent.patch(`/workflows/${id}`).send({
+				versionId,
+				nodes: [
+					{
+						id: 'uuid-1234',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {},
+					},
+					{
+						id: 'uuid-12345',
+						name: 'Start',
+						parameters: {},
+						position: [-20, 260],
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						credentials: {
+							default: {
+								id: savedCredential.id,
+								name: savedCredential.name,
+							},
+						},
+					},
+				],
+			});
+			expect(response.statusCode).toBe(403);
+		});
+
+		it('Should succeed but prevent modifying node attributes other than position, name and disabled', async () => {
+			const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
+
+			const originalNodes: INode[] = [
 				{
 					id: 'uuid-1234',
 					name: 'Start',
-					parameters: {},
+					parameters: {
+						firstParam: 123,
+					},
 					position: [-20, 260],
 					type: 'n8n-nodes-base.start',
 					typeVersion: 1,
@@ -687,32 +831,36 @@ describe('PATCH /workflows/:workflowId - validate credential permissions to user
 						},
 					},
 				},
-			],
-		};
+			];
 
-		const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
-		const { id, versionId } = createResponse.body.data;
-
-		const response = await authOwnerAgent.patch(`/workflows/${id}`).send({
-			name: 'new name',
-			versionId,
-		});
-
-		expect(response.statusCode).toBe(200);
-	});
-
-	it('Should allow owner to add node containing credential not shared with the owner', async () => {
-		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
-		const workflow = {
-			name: 'test',
-			active: false,
-			connections: {},
-			nodes: [
+			const changedNodes: INode[] = [
 				{
 					id: 'uuid-1234',
-					name: 'Start',
-					parameters: {},
-					position: [-20, 260],
+					name: 'End',
+					parameters: {
+						firstParam: 456,
+					},
+					position: [-20, 555],
+					type: 'n8n-nodes-base.no-op',
+					typeVersion: 1,
+					credentials: {
+						default: {
+							id: '200',
+							name: 'fake credential',
+						},
+					},
+					disabled: true,
+				},
+			];
+
+			const expectedNodes: INode[] = [
+				{
+					id: 'uuid-1234',
+					name: 'End',
+					parameters: {
+						firstParam: 123,
+					},
+					position: [-20, 555],
 					type: 'n8n-nodes-base.start',
 					typeVersion: 1,
 					credentials: {
@@ -721,525 +869,379 @@ describe('PATCH /workflows/:workflowId - validate credential permissions to user
 							name: savedCredential.name,
 						},
 					},
+					disabled: true,
 				},
-			],
-		};
+			];
 
-		const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
-		const { id, versionId } = createResponse.body.data;
+			const workflow = {
+				name: 'test',
+				active: false,
+				connections: {},
+				nodes: originalNodes,
+			};
 
-		const response = await authOwnerAgent.patch(`/workflows/${id}`).send({
-			versionId,
-			nodes: [
-				{
-					id: 'uuid-1234',
-					name: 'Start',
-					parameters: {},
-					position: [-20, 260],
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					credentials: {
-						default: {
-							id: savedCredential.id,
-							name: savedCredential.name,
-						},
-					},
-				},
-			],
+			const createResponse = await authMemberAgent.post('/workflows').send(workflow);
+			const { id, versionId } = createResponse.body.data;
+
+			await authMemberAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [anotherMemberPersonalProject.id] })
+				.expect(200);
+
+			const response = await authAnotherMemberAgent.patch(`/workflows/${id}`).send({
+				versionId,
+				nodes: changedNodes,
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.nodes).toMatchObject(expectedNodes);
+		});
+	});
+
+	describe('validate interim updates', () => {
+		it('should block owner updating workflow nodes on interim update by member', async () => {
+			// owner creates and shares workflow
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerVersionId } = createResponse.body.data;
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
+
+			// member accesses and updates workflow name
+
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
+
+			await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ name: 'Update by member', versionId: memberVersionId });
+
+			// owner blocked from updating workflow nodes
+
+			const updateAttemptResponse = await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ nodes: [], versionId: ownerVersionId });
+
+			expect(updateAttemptResponse.status).toBe(400);
+			expect(updateAttemptResponse.body.code).toBe(100);
 		});
 
-		expect(response.statusCode).toBe(200);
-	});
+		it('should block member updating workflow nodes on interim update by owner', async () => {
+			// owner creates, updates and shares workflow
 
-	it('Should prevent member from adding node containing credential inaccessible to member', async () => {
-		const savedCredential = await saveCredential(randomCredentialPayload(), { user: owner });
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerFirstVersionId } = createResponse.body.data;
 
-		const workflow = {
-			name: 'test',
-			active: false,
-			connections: {},
-			nodes: [
-				{
-					id: 'uuid-1234',
-					name: 'Start',
-					parameters: {},
-					position: [-20, 260],
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					credentials: {
-						default: {
-							id: savedCredential.id,
-							name: savedCredential.name,
-						},
-					},
-				},
-			],
-		};
+			const updateResponse = await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ name: 'Update by owner', versionId: ownerFirstVersionId });
 
-		const createResponse = await authOwnerAgent.post('/workflows').send(workflow);
-		const { id, versionId } = createResponse.body.data;
+			const { versionId: ownerSecondVersionId } = updateResponse.body.data;
 
-		const response = await authMemberAgent.patch(`/workflows/${id}`).send({
-			versionId,
-			nodes: [
-				{
-					id: 'uuid-1234',
-					name: 'Start',
-					parameters: {},
-					position: [-20, 260],
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					credentials: {},
-				},
-				{
-					id: 'uuid-12345',
-					name: 'Start',
-					parameters: {},
-					position: [-20, 260],
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					credentials: {
-						default: {
-							id: savedCredential.id,
-							name: savedCredential.name,
-						},
-					},
-				},
-			],
-		});
-		expect(response.statusCode).toBe(403);
-	});
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
 
-	it('Should succeed but prevent modifying node attributes other than position, name and disabled', async () => {
-		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
+			// member accesses workflow
 
-		const originalNodes: INode[] = [
-			{
-				id: 'uuid-1234',
-				name: 'Start',
-				parameters: {
-					firstParam: 123,
-				},
-				position: [-20, 260],
-				type: 'n8n-nodes-base.start',
-				typeVersion: 1,
-				credentials: {
-					default: {
-						id: savedCredential.id,
-						name: savedCredential.name,
-					},
-				},
-			},
-		];
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
 
-		const changedNodes: INode[] = [
-			{
-				id: 'uuid-1234',
-				name: 'End',
-				parameters: {
-					firstParam: 456,
-				},
-				position: [-20, 555],
-				type: 'n8n-nodes-base.no-op',
-				typeVersion: 1,
-				credentials: {
-					default: {
-						id: '200',
-						name: 'fake credential',
-					},
-				},
-				disabled: true,
-			},
-		];
+			// owner re-updates workflow
 
-		const expectedNodes: INode[] = [
-			{
-				id: 'uuid-1234',
-				name: 'End',
-				parameters: {
-					firstParam: 123,
-				},
-				position: [-20, 555],
-				type: 'n8n-nodes-base.start',
-				typeVersion: 1,
-				credentials: {
-					default: {
-						id: savedCredential.id,
-						name: savedCredential.name,
-					},
-				},
-				disabled: true,
-			},
-		];
+			await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ name: 'Owner update again', versionId: ownerSecondVersionId });
 
-		const workflow = {
-			name: 'test',
-			active: false,
-			connections: {},
-			nodes: originalNodes,
-		};
+			// member blocked from updating workflow
 
-		const createResponse = await authMemberAgent.post('/workflows').send(workflow);
-		const { id, versionId } = createResponse.body.data;
+			const updateAttemptResponse = await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ nodes: [], versionId: memberVersionId });
 
-		await authMemberAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [anotherMemberPersonalProject.id] })
-			.expect(200);
-
-		const response = await authAnotherMemberAgent.patch(`/workflows/${id}`).send({
-			versionId,
-			nodes: changedNodes,
+			expect(updateAttemptResponse.status).toBe(400);
+			expect(updateAttemptResponse.body.code).toBe(100);
 		});
 
-		expect(response.statusCode).toBe(200);
-		expect(response.body.data.nodes).toMatchObject(expectedNodes);
-	});
-});
+		it('should block owner activation on interim activation by member', async () => {
+			// owner creates and shares workflow
 
-describe('PATCH /workflows/:workflowId - validate interim updates', () => {
-	it('should block owner updating workflow nodes on interim update by member', async () => {
-		// owner creates and shares workflow
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerVersionId } = createResponse.body.data;
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
 
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerVersionId } = createResponse.body.data;
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
+			// member accesses and activates workflow
 
-		// member accesses and updates workflow name
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
+			await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ active: true, versionId: memberVersionId, name: 'Update by member' });
+			// owner blocked from activating workflow
 
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
+			const activationAttemptResponse = await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ active: true, versionId: ownerVersionId, name: 'Update by owner' });
 
-		await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ name: 'Update by member', versionId: memberVersionId });
-
-		// owner blocked from updating workflow nodes
-
-		const updateAttemptResponse = await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ nodes: [], versionId: ownerVersionId });
-
-		expect(updateAttemptResponse.status).toBe(400);
-		expect(updateAttemptResponse.body.code).toBe(100);
-	});
-
-	it('should block member updating workflow nodes on interim update by owner', async () => {
-		// owner creates, updates and shares workflow
-
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerFirstVersionId } = createResponse.body.data;
-
-		const updateResponse = await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ name: 'Update by owner', versionId: ownerFirstVersionId });
-
-		const { versionId: ownerSecondVersionId } = updateResponse.body.data;
-
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
-
-		// member accesses workflow
-
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
-
-		// owner re-updates workflow
-
-		await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ name: 'Owner update again', versionId: ownerSecondVersionId });
-
-		// member blocked from updating workflow
-
-		const updateAttemptResponse = await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ nodes: [], versionId: memberVersionId });
-
-		expect(updateAttemptResponse.status).toBe(400);
-		expect(updateAttemptResponse.body.code).toBe(100);
-	});
-
-	it('should block owner activation on interim activation by member', async () => {
-		// owner creates and shares workflow
-
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerVersionId } = createResponse.body.data;
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
-
-		// member accesses and activates workflow
-
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
-		await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ active: true, versionId: memberVersionId, name: 'Update by member' });
-		// owner blocked from activating workflow
-
-		const activationAttemptResponse = await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ active: true, versionId: ownerVersionId, name: 'Update by owner' });
-
-		expect(activationAttemptResponse.status).toBe(400);
-		expect(activationAttemptResponse.body.code).toBe(100);
-	});
-
-	it('should block member activation on interim activation by owner', async () => {
-		// owner creates, updates and shares workflow
-
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerFirstVersionId } = createResponse.body.data;
-
-		const updateResponse = await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ name: 'Update by owner', versionId: ownerFirstVersionId });
-		const { versionId: ownerSecondVersionId } = updateResponse.body.data;
-
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
-
-		// member accesses workflow
-
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
-
-		// owner activates workflow
-
-		await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ active: true, versionId: ownerSecondVersionId, name: 'Owner update again' });
-
-		// member blocked from activating workflow
-
-		const updateAttemptResponse = await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ active: true, versionId: memberVersionId, name: 'Update by member' });
-
-		expect(updateAttemptResponse.status).toBe(400);
-		expect(updateAttemptResponse.body.code).toBe(100);
-	});
-
-	it('should block member updating workflow settings on interim update by owner', async () => {
-		// owner creates and shares workflow
-
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerVersionId } = createResponse.body.data;
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
-
-		// member accesses workflow
-
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
-
-		// owner updates workflow name
-
-		await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ name: 'Another name', versionId: ownerVersionId });
-
-		// member blocked from updating workflow settings
-
-		const updateAttemptResponse = await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ settings: { saveManualExecutions: true }, versionId: memberVersionId });
-
-		expect(updateAttemptResponse.status).toBe(400);
-		expect(updateAttemptResponse.body.code).toBe(100);
-	});
-
-	it('should block member updating workflow name on interim update by owner', async () => {
-		// owner creates and shares workflow
-
-		const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
-		const { id, versionId: ownerVersionId } = createResponse.body.data;
-		await authOwnerAgent
-			.put(`/workflows/${id}/share`)
-			.send({ shareWithIds: [memberPersonalProject.id] });
-
-		// member accesses workflow
-
-		const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`).expect(200);
-		const { versionId: memberVersionId } = memberGetResponse.body.data;
-
-		// owner updates workflow settings
-
-		await authOwnerAgent
-			.patch(`/workflows/${id}`)
-			.send({ settings: { saveManualExecutions: true }, versionId: ownerVersionId });
-
-		// member blocked from updating workflow name
-
-		const updateAttemptResponse = await authMemberAgent
-			.patch(`/workflows/${id}`)
-			.send({ settings: { saveManualExecutions: true }, versionId: memberVersionId });
-
-		expect(updateAttemptResponse.status).toBe(400);
-		expect(updateAttemptResponse.body.code).toBe(100);
-	});
-});
-
-describe('PATCH /workflows/:workflowId - workflow history', () => {
-	test('Should create workflow history version when licensed', async () => {
-		license.enable('feat:workflowHistory');
-		const workflow = await createWorkflow({}, owner);
-		const payload = {
-			name: 'name updated',
-			versionId: workflow.versionId,
-			nodes: [
-				{
-					id: 'uuid-1234',
-					parameters: {},
-					name: 'Start',
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					position: [240, 300],
-				},
-				{
-					id: 'uuid-1234',
-					parameters: {},
-					name: 'Cron',
-					type: 'n8n-nodes-base.cron',
-					typeVersion: 1,
-					position: [400, 300],
-				},
-			],
-			connections: {},
-			staticData: '{"id":1}',
-			settings: {
-				saveExecutionProgress: false,
-				saveManualExecutions: false,
-				saveDataErrorExecution: 'all',
-				saveDataSuccessExecution: 'all',
-				executionTimeout: 3600,
-				timezone: 'America/New_York',
-			},
-		};
-
-		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
-
-		const {
-			data: { id },
-		} = response.body;
-
-		expect(response.statusCode).toBe(200);
-
-		expect(id).toBe(workflow.id);
-		expect(
-			await Container.get(WorkflowHistoryRepository).count({ where: { workflowId: id } }),
-		).toBe(1);
-		const historyVersion = await Container.get(WorkflowHistoryRepository).findOne({
-			where: {
-				workflowId: id,
-			},
+			expect(activationAttemptResponse.status).toBe(400);
+			expect(activationAttemptResponse.body.code).toBe(100);
 		});
-		expect(historyVersion).not.toBeNull();
-		expect(historyVersion!.connections).toEqual(payload.connections);
-		expect(historyVersion!.nodes).toEqual(payload.nodes);
+
+		it('should block member activation on interim activation by owner', async () => {
+			// owner creates, updates and shares workflow
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerFirstVersionId } = createResponse.body.data;
+
+			const updateResponse = await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ name: 'Update by owner', versionId: ownerFirstVersionId });
+			const { versionId: ownerSecondVersionId } = updateResponse.body.data;
+
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
+
+			// member accesses workflow
+
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
+
+			// owner activates workflow
+
+			await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ active: true, versionId: ownerSecondVersionId, name: 'Owner update again' });
+
+			// member blocked from activating workflow
+
+			const updateAttemptResponse = await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ active: true, versionId: memberVersionId, name: 'Update by member' });
+
+			expect(updateAttemptResponse.status).toBe(400);
+			expect(updateAttemptResponse.body.code).toBe(100);
+		});
+
+		it('should block member updating workflow settings on interim update by owner', async () => {
+			// owner creates and shares workflow
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerVersionId } = createResponse.body.data;
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
+
+			// member accesses workflow
+
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
+
+			// owner updates workflow name
+
+			await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ name: 'Another name', versionId: ownerVersionId });
+
+			// member blocked from updating workflow settings
+
+			const updateAttemptResponse = await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ settings: { saveManualExecutions: true }, versionId: memberVersionId });
+
+			expect(updateAttemptResponse.status).toBe(400);
+			expect(updateAttemptResponse.body.code).toBe(100);
+		});
+
+		it('should block member updating workflow name on interim update by owner', async () => {
+			// owner creates and shares workflow
+
+			const createResponse = await authOwnerAgent.post('/workflows').send(makeWorkflow());
+			const { id, versionId: ownerVersionId } = createResponse.body.data;
+			await authOwnerAgent
+				.put(`/workflows/${id}/share`)
+				.send({ shareWithIds: [memberPersonalProject.id] });
+
+			// member accesses workflow
+
+			const memberGetResponse = await authMemberAgent.get(`/workflows/${id}`).expect(200);
+			const { versionId: memberVersionId } = memberGetResponse.body.data;
+
+			// owner updates workflow settings
+
+			await authOwnerAgent
+				.patch(`/workflows/${id}`)
+				.send({ settings: { saveManualExecutions: true }, versionId: ownerVersionId });
+
+			// member blocked from updating workflow name
+
+			const updateAttemptResponse = await authMemberAgent
+				.patch(`/workflows/${id}`)
+				.send({ settings: { saveManualExecutions: true }, versionId: memberVersionId });
+
+			expect(updateAttemptResponse.status).toBe(400);
+			expect(updateAttemptResponse.body.code).toBe(100);
+		});
 	});
 
-	test('Should not create workflow history version when not licensed', async () => {
-		license.disable('feat:workflowHistory');
-		const workflow = await createWorkflow({}, owner);
-		const payload = {
-			name: 'name updated',
-			versionId: workflow.versionId,
-			nodes: [
-				{
-					id: 'uuid-1234',
-					parameters: {},
-					name: 'Start',
-					type: 'n8n-nodes-base.start',
-					typeVersion: 1,
-					position: [240, 300],
+	describe('workflow history', () => {
+		test('Should create workflow history version when licensed', async () => {
+			license.enable('feat:workflowHistory');
+			const workflow = await createWorkflow({}, owner);
+			const payload = {
+				name: 'name updated',
+				versionId: workflow.versionId,
+				nodes: [
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Start',
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						position: [240, 300],
+					},
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Cron',
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+						position: [400, 300],
+					},
+				],
+				connections: {},
+				staticData: '{"id":1}',
+				settings: {
+					saveExecutionProgress: false,
+					saveManualExecutions: false,
+					saveDataErrorExecution: 'all',
+					saveDataSuccessExecution: 'all',
+					executionTimeout: 3600,
+					timezone: 'America/New_York',
 				},
-				{
-					id: 'uuid-1234',
-					parameters: {},
-					name: 'Cron',
-					type: 'n8n-nodes-base.cron',
-					typeVersion: 1,
-					position: [400, 300],
+			};
+
+			const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+
+			const {
+				data: { id },
+			} = response.body;
+
+			expect(response.statusCode).toBe(200);
+
+			expect(id).toBe(workflow.id);
+			expect(
+				await Container.get(WorkflowHistoryRepository).count({ where: { workflowId: id } }),
+			).toBe(1);
+			const historyVersion = await Container.get(WorkflowHistoryRepository).findOne({
+				where: {
+					workflowId: id,
 				},
-			],
-			connections: {},
-			staticData: '{"id":1}',
-			settings: {
-				saveExecutionProgress: false,
-				saveManualExecutions: false,
-				saveDataErrorExecution: 'all',
-				saveDataSuccessExecution: 'all',
-				executionTimeout: 3600,
-				timezone: 'America/New_York',
-			},
-		};
+			});
+			expect(historyVersion).not.toBeNull();
+			expect(historyVersion!.connections).toEqual(payload.connections);
+			expect(historyVersion!.nodes).toEqual(payload.nodes);
+		});
 
-		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+		test('Should not create workflow history version when not licensed', async () => {
+			license.disable('feat:workflowHistory');
+			const workflow = await createWorkflow({}, owner);
+			const payload = {
+				name: 'name updated',
+				versionId: workflow.versionId,
+				nodes: [
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Start',
+						type: 'n8n-nodes-base.start',
+						typeVersion: 1,
+						position: [240, 300],
+					},
+					{
+						id: 'uuid-1234',
+						parameters: {},
+						name: 'Cron',
+						type: 'n8n-nodes-base.cron',
+						typeVersion: 1,
+						position: [400, 300],
+					},
+				],
+				connections: {},
+				staticData: '{"id":1}',
+				settings: {
+					saveExecutionProgress: false,
+					saveManualExecutions: false,
+					saveDataErrorExecution: 'all',
+					saveDataSuccessExecution: 'all',
+					executionTimeout: 3600,
+					timezone: 'America/New_York',
+				},
+			};
 
-		const {
-			data: { id },
-		} = response.body;
+			const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
-		expect(response.statusCode).toBe(200);
+			const {
+				data: { id },
+			} = response.body;
 
-		expect(id).toBe(workflow.id);
-		expect(
-			await Container.get(WorkflowHistoryRepository).count({ where: { workflowId: id } }),
-		).toBe(0);
+			expect(response.statusCode).toBe(200);
+
+			expect(id).toBe(workflow.id);
+			expect(
+				await Container.get(WorkflowHistoryRepository).count({ where: { workflowId: id } }),
+			).toBe(0);
+		});
 	});
-});
 
-describe('PATCH /workflows/:workflowId - activate workflow', () => {
-	test('should activate workflow without changing version ID', async () => {
-		license.disable('feat:workflowHistory');
-		const workflow = await createWorkflow({}, owner);
-		const payload = {
-			versionId: workflow.versionId,
-			active: true,
-		};
+	describe('activate workflow', () => {
+		test('should activate workflow without changing version ID', async () => {
+			license.disable('feat:workflowHistory');
+			const workflow = await createWorkflow({}, owner);
+			const payload = {
+				versionId: workflow.versionId,
+				active: true,
+			};
 
-		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+			const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
-		expect(response.statusCode).toBe(200);
-		expect(activeWorkflowManager.add).toBeCalled();
+			expect(response.statusCode).toBe(200);
+			expect(activeWorkflowManager.add).toBeCalled();
 
-		const {
-			data: { id, versionId, active },
-		} = response.body;
+			const {
+				data: { id, versionId, active },
+			} = response.body;
 
-		expect(id).toBe(workflow.id);
-		expect(versionId).toBe(workflow.versionId);
-		expect(active).toBe(true);
-	});
+			expect(id).toBe(workflow.id);
+			expect(versionId).toBe(workflow.versionId);
+			expect(active).toBe(true);
+		});
 
-	test('should deactivate workflow without changing version ID', async () => {
-		license.disable('feat:workflowHistory');
-		const workflow = await createWorkflow({ active: true }, owner);
-		const payload = {
-			versionId: workflow.versionId,
-			active: false,
-		};
+		test('should deactivate workflow without changing version ID', async () => {
+			license.disable('feat:workflowHistory');
+			const workflow = await createWorkflow({ active: true }, owner);
+			const payload = {
+				versionId: workflow.versionId,
+				active: false,
+			};
 
-		const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
+			const response = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send(payload);
 
-		expect(response.statusCode).toBe(200);
-		expect(activeWorkflowManager.add).not.toBeCalled();
-		expect(activeWorkflowManager.remove).toBeCalled();
+			expect(response.statusCode).toBe(200);
+			expect(activeWorkflowManager.add).not.toBeCalled();
+			expect(activeWorkflowManager.remove).toBeCalled();
 
-		const {
-			data: { id, versionId, active },
-		} = response.body;
+			const {
+				data: { id, versionId, active },
+			} = response.body;
 
-		expect(id).toBe(workflow.id);
-		expect(versionId).toBe(workflow.versionId);
-		expect(active).toBe(false);
+			expect(id).toBe(workflow.id);
+			expect(versionId).toBe(workflow.versionId);
+			expect(active).toBe(false);
+		});
 	});
 });
 

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -261,6 +261,7 @@ describe('POST /workflows', () => {
 		//
 		const tag = await createTag({ name: 'A' });
 		const workflow = makeWorkflow();
+		// TODO: use helpers instead
 		const project = await projectRepository.save(
 			projectRepository.create({
 				name: 'Team Project',

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -261,7 +261,6 @@ describe('POST /workflows', () => {
 		//
 		const tag = await createTag({ name: 'A' });
 		const workflow = makeWorkflow();
-		// TODO: use helpers instead
 		const project = await projectRepository.save(
 			projectRepository.create({
 				name: 'Team Project',

--- a/packages/cli/test/unit/repositories/sharedCredentials.repository.test.ts
+++ b/packages/cli/test/unit/repositories/sharedCredentials.repository.test.ts
@@ -62,7 +62,12 @@ describe('SharedCredentialsRepository', () => {
 					role: In(['credential:owner', 'credential:user']),
 					project: {
 						projectRelations: {
-							role: In(['project:admin', 'project:personalOwner', 'project:editor']),
+							role: In([
+								'project:admin',
+								'project:personalOwner',
+								'project:editor',
+								'project:viewer',
+							]),
 							userId: member.id,
 						},
 					},
@@ -83,7 +88,12 @@ describe('SharedCredentialsRepository', () => {
 					role: In(['credential:owner', 'credential:user']),
 					project: {
 						projectRelations: {
-							role: In(['project:admin', 'project:personalOwner', 'project:editor']),
+							role: In([
+								'project:admin',
+								'project:personalOwner',
+								'project:editor',
+								'project:viewer',
+							]),
 							userId: member.id,
 						},
 					},


### PR DESCRIPTION
## Summary

Add a project viewer role.

This role only allows the user to view workflows, credentials and executions within a project, but not to create or modify them.

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1423/add-new-project-viewer-role

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

