### PR TITLE
fix(editor): Shrink #node-view-background to viewport size (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -5213,8 +5213,8 @@ export default defineComponent({
 .node-view-background {
 	background-color: var(--color-canvas-background);
 	position: absolute;
-	width: 10000px;
-	height: 10000px;
+	width: 100vw;
+	height: 100vh;
 	z-index: -2;
 }
 


### PR DESCRIPTION
## Summary
Our `#node-view-background` is a `10Kpx` x `10Kpx` div that, by Chrome estimates, takes up about 400MB of memory. From what I've tested, this is completely unnecessary. This PR shrinks it down to viewport dimensions.

[Latest e2e run](https://github.com/n8n-io/n8n/actions/runs/9366423996)

Before (n8n workspace is a tiny rectange in the upper-left corner)
----
![SCR-20240604-imm](https://github.com/n8n-io/n8n/assets/2598782/787499fe-89a9-4b75-858b-a4cf902af5f1)

After
----
![SCR-20240604-iqx](https://github.com/n8n-io/n8n/assets/2598782/216e121f-56df-44e3-802d-7e62c9e5b6a0)


## Related tickets and issues
> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 