### PR TITLE
fix(HelpScout Trigger Node): Change secret generation to not use math.random (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/HelpScout/HelpScoutTrigger.node.ts
+++ b/packages/nodes-base/nodes/HelpScout/HelpScoutTrigger.node.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac, randomBytes } from 'crypto';
 import type {
 	IHookFunctions,
 	IWebhookFunctions,
@@ -140,7 +140,7 @@ export class HelpScoutTrigger implements INodeType {
 				const body = {
 					url: webhookUrl,
 					events,
-					secret: Math.random().toString(36).substring(2, 15),
+					secret: randomBytes(15).toString('base64url'),
 				};
 
 				const responseData = await helpscoutApiRequest.call(


### PR DESCRIPTION
## Summary
Move from statistical prng to cyptographic prng, HelpScout can use a secret that is up to 40 characters long so this shouldn't break anything.

```
The secret key is a randomly generated (by you) 40-character or less string used to create signatures for each data request. Help Scout uses this secret key to generate a signature for each message. When the message is received at your callback url, you can calculate a signature and compare to the one Help Scout sends. If the signatures match, you know it’s from Help Scout.
```
https://developer.helpscout.com/apps/legacy-custom-apps/dynamic/