### PR TITLE
fix(Jira Software Node): Fix comments limit and add sorting

### DIFF
--- a/packages/nodes-base/nodes/Jira/IssueCommentDescription.ts
+++ b/packages/nodes-base/nodes/Jira/IssueCommentDescription.ts
@@ -286,6 +286,23 @@ export const issueCommentFields: INodeProperties[] = [
 				description:
 					'Use expand to include additional information about comments in the response. This parameter accepts Rendered Body, which returns the comment body rendered in HTML.',
 			},
+			{
+				displayName: 'Order By',
+				name: 'orderBy',
+				type: 'options',
+				options: [
+					{
+						name: 'Created Ascending',
+						value: '+created',
+					},
+					{
+						name: 'Created Descending',
+						value: '-created',
+					},
+				],
+				default: 'created_asc',
+				description: 'Order comments by the created date',
+			},
 		],
 	},
 

--- a/packages/nodes-base/nodes/Jira/Jira.node.ts
+++ b/packages/nodes-base/nodes/Jira/Jira.node.ts
@@ -1280,7 +1280,7 @@ export class Jira implements INodeType {
 						);
 					} else {
 						const limit = this.getNodeParameter('limit', i);
-						body.maxResults = limit;
+						qs.maxResults = limit;
 						responseData = await jiraSoftwareCloudApiRequest.call(
 							this,
 							`/api/${apiVersion}/issue/${issueKey}/comment`,


### PR DESCRIPTION
## Summary
This PR fixes the comments limit which doesn't currently work. It appears it was borrowed from the Issue getAll which uses a POST request with `maxResults` in the body. The comments endpoint is GET only, changing maxResults to a query param works correctly.
The other change is to add the ability to sort by created ascending/descending (the only sort option for this endpoint). It maintains the default sort order (ascending).

## Related tickets and issues
- None



## Review / Merge checklist
- [X] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 