### PR TITLE
fix(X (Formerly Twitter) Node): Change how tweet id is retrieved from quote URL

### DIFF
--- a/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
@@ -85,7 +85,7 @@ export function returnId(tweetId: INodeParameterResourceLocator) {
 	} else if (tweetId.mode === 'url') {
 		try {
 			const url = new URL(tweetId.value as string);
-			if (/{twitter|x}.com$/.test(url.hostname)) {
+			if (!/(twitter|x).com$/.test(url.hostname)) {
 				throw new ApplicationError('Invalid domain');
 			}
 			const parts = url.pathname.split('/');

--- a/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
@@ -85,8 +85,7 @@ export function returnId(tweetId: INodeParameterResourceLocator) {
 	} else if (tweetId.mode === 'url') {
 		const value = tweetId.value as string;
 		const urlParts = value.split('/');
-		const tweetIdPart = urlParts[urlParts.length - 1];
-		return tweetIdPart as string;
+		return urlParts[urlParts.length - 1];
 	} else {
 		throw new ApplicationError(`The mode ${tweetId.mode} is not valid!`, { level: 'warning' });
 	}

--- a/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Twitter/V2/GenericFunctions.ts
@@ -84,11 +84,9 @@ export function returnId(tweetId: INodeParameterResourceLocator) {
 		return tweetId.value as string;
 	} else if (tweetId.mode === 'url') {
 		const value = tweetId.value as string;
-		const tweetIdMatch = value.includes('lists')
-			? value.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/list(s)?\/(\d+)$/)
-			: value.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/);
-
-		return tweetIdMatch?.[3] as string;
+		const urlParts = value.split('/');
+		const tweetIdPart = urlParts[urlParts.length - 1];
+		return tweetIdPart as string;
 	} else {
 		throw new ApplicationError(`The mode ${tweetId.mode} is not valid!`, { level: 'warning' });
 	}

--- a/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
+++ b/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
@@ -1,4 +1,6 @@
 import nock from 'nock';
+import type { INodeParameterResourceLocator } from 'n8n-workflow';
+import { returnId } from '../V2/GenericFunctions';
 import { getWorkflowFilenames, testWorkflows } from '@test/nodes/Helpers';
 
 const searchResult = {
@@ -66,6 +68,7 @@ const searchResult = {
 const meResult = {
 	data: { id: '1285192200213626880', name: 'Integration-n8n', username: 'IntegrationN8n' },
 };
+
 describe('Test Twitter Request Node', () => {
 	beforeAll(() => {
 		const baseUrl = 'https://api.twitter.com/2';
@@ -84,4 +87,44 @@ describe('Test Twitter Request Node', () => {
 
 	const workflows = getWorkflowFilenames(__dirname);
 	testWorkflows(workflows);
+});
+
+describe('X / Twitter Node unit tests', () => {
+	describe('returnId', () => {
+		it('should return the id when mode is id', () => {
+			const tweetId: INodeParameterResourceLocator = {
+				__rl: true,
+				mode: 'id',
+				value: '12345',
+			};
+			expect(returnId(tweetId)).toBe('12345');
+		});
+
+		it('should return the last part of the URL when mode is url and domain is twitter.com', () => {
+			const tweetId: INodeParameterResourceLocator = {
+				__rl: true,
+				mode: 'url',
+				value: 'https://twitter.com/user/status/12345',
+			};
+			expect(returnId(tweetId)).toBe('12345');
+		});
+
+		it('should return the last part of the URL when mode is url and domain is x.com', () => {
+			const tweetId: INodeParameterResourceLocator = {
+				__rl: true,
+				mode: 'url',
+				value: 'https://x.com/user/status/12345',
+			};
+			expect(returnId(tweetId)).toBe('12345');
+		});
+
+		it('should throw an error when mode is not valid', () => {
+			const tweetId: INodeParameterResourceLocator = {
+				__rl: true,
+				mode: 'invalid',
+				value: 'https://twitter.com/user/status/12345',
+			};
+			expect(() => returnId(tweetId)).toThrow();
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
+++ b/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
@@ -100,20 +100,20 @@ describe('X / Twitter Node unit tests', () => {
 			expect(returnId(tweetId)).toBe('12345');
 		});
 
-		it('should return the last part of the URL when mode is url and domain is twitter.com', () => {
+		it('should extract the tweetId from url when the domain is twitter.com', () => {
 			const tweetId: INodeParameterResourceLocator = {
 				__rl: true,
 				mode: 'url',
-				value: 'https://twitter.com/user/status/12345',
+				value: 'https://twitter.com/user/status/12345?utm=6789',
 			};
 			expect(returnId(tweetId)).toBe('12345');
 		});
 
-		it('should return the last part of the URL when mode is url and domain is x.com', () => {
+		it('should extract the tweetId from url when the domain is x.com', () => {
 			const tweetId: INodeParameterResourceLocator = {
 				__rl: true,
 				mode: 'url',
-				value: 'https://x.com/user/status/12345',
+				value: 'https://x.com/user/status/12345?utm=6789',
 			};
 			expect(returnId(tweetId)).toBe('12345');
 		});
@@ -125,6 +125,23 @@ describe('X / Twitter Node unit tests', () => {
 				value: 'https://twitter.com/user/status/12345',
 			};
 			expect(() => returnId(tweetId)).toThrow();
+		});
+
+		describe('should throw an error when the URL is not valid', () => {
+			test.each([
+				'https://twitter.com/user/',
+				'https://twitter.com/user/status/',
+				'https://twitter.com/user/profile/12345',
+				'https://twitter.com/search?param=12345',
+			])('%s', (value) => {
+				expect(() =>
+					returnId({
+						__rl: true,
+						mode: 'url',
+						value,
+					}),
+				).toThrow();
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary
changed how we retrieve the tweet id from a url the user can paste into the `Quote a Tweet` option `by URL`. 

![image](https://github.com/n8n-io/n8n/assets/123465523/3f7610c2-d8fa-4221-8c51-0b21d10f0be4)

previously this was done through regex but that broke when _twitter.com_ re-branded to _x.com_

## Related tickets and issues

Linear: https://linear.app/n8n/issue/NODE-1386/x-twitter-returnid-method-still-uses-twittercom
Forum: https://community.n8n.io/t/quote-tweet-not-working-in-x-formerly-twitter-node/47317

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 