### PR TITLE
fix(editor): Prevent running workflows using keyboard shortcuts if execution is disabled

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -312,6 +312,33 @@ describe('Workflow Actions', () => {
 		WorkflowPage.getters.canvasNodePlusEndpointByName(EDIT_FIELDS_SET_NODE_NAME).click();
 		WorkflowPage.getters.nodeCreatorSearchBar().should('be.visible');
 	});
+
+	it('should run workflow on button click', () => {
+		WorkflowPage.actions.addInitialNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
+		WorkflowPage.actions.saveWorkflowOnButtonClick();
+		WorkflowPage.getters.executeWorkflowButton().click();
+		WorkflowPage.getters.successToast().should('contain.text', 'Workflow executed successfully');
+	});
+
+	it('should run workflow using keyboard shortcut', () => {
+		WorkflowPage.actions.addInitialNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);
+		WorkflowPage.actions.saveWorkflowOnButtonClick();
+		cy.get('body').type(META_KEY, { delay: 500, release: false }).type('{enter}');
+		WorkflowPage.getters.successToast().should('contain.text', 'Workflow executed successfully');
+	});
+
+	it('should not run empty workflows', () => {
+		// Clear the canvas
+		cy.get('body').type(META_KEY, { delay: 500, release: false }).type('a');
+		cy.get('body').type('{backspace}');
+		WorkflowPage.getters.canvasNodes().should('have.length', 0);
+		// Button should be disabled
+		WorkflowPage.getters.executeWorkflowButton().should('be.disabled');
+		// Keyboard shortcut should not work
+		cy.get('body').type(META_KEY, { delay: 500, release: false }).type('{enter}');
+		WorkflowPage.getters.successToast().should('not.exist');
+	});
+
 });
 
 describe('Menu entry Push To Git', () => {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1643,7 +1643,7 @@ export default defineComponent({
 					source: NODE_CREATOR_OPEN_SOURCES.TAB,
 					createNodeActive: !this.createNodeActive && !this.isReadOnlyRoute && !this.readOnlyEnv,
 				});
-			} else if (e.key === 'Enter' && ctrlModifier && !readOnly) {
+			} else if (e.key === 'Enter' && ctrlModifier && !readOnly && !this.isExecutionDisabled) {
 				void this.onRunWorkflow();
 			} else if (e.key === 'S' && shiftModifier && !readOnly) {
 				void this.onAddNodes({ nodes: [{ type: STICKY_NODE_TYPE }], connections: [] });


### PR DESCRIPTION
## Summary
Preventing workflow execution via keyboard shortcut by enforcing the same condition used for the button.

## Related tickets and issues
Fixes ADO-2188
Fixes #9133 


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 