### PR TITLE
refactor(core): Support writing tests in `cli/src` (no-changelog)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,9 +24,11 @@ const config = {
 	// This resolve the path mappings from the tsconfig relative to each jest.config.js
 	moduleNameMapper: Object.entries(paths || {}).reduce((acc, [path, [mapping]]) => {
 		path = `^${path.replace(/\/\*$/, '/(.*)$')}`;
-		mapping = mapping.replace(/^\.\/(?:(.*)\/)?\*$/, '$1');
+		mapping = mapping.replace(/^\.?\.\/(?:(.*)\/)?\*$/, '$1');
 		mapping = mapping ? `/${mapping}` : '';
-		acc[path] = '<rootDir>' + (baseUrl ? `/${baseUrl.replace(/^\.\//, '')}` : '') + mapping + '/$1';
+		acc[path] = mapping.startsWith('/test')
+			? '<rootDir>' + mapping + '/$1'
+			: '<rootDir>' + (baseUrl ? `/${baseUrl.replace(/^\.\//, '')}` : '') + mapping + '/$1';
 		return acc;
 	}, {}),
 	setupFilesAfterEnv: ['jest-expect-message'],

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -6,5 +6,5 @@
 		"tsBuildInfoFile": "dist/build.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["test/**"]
+	"exclude": ["test/**", "src/**/__tests__/**"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,7 +8,9 @@
 		"baseUrl": "src",
 		"paths": {
 			"@/*": ["./*"],
-			"@db/*": ["./databases/*"]
+			"@db/*": ["./databases/*"],
+			"@test/*": ["../test/shared/*"],
+			"@test-integration/*": ["../test/integration/shared/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		// TODO: remove all options below this line


### PR DESCRIPTION
This PR allows us to start writing tests in `packages/cli/src/**/__tests__` for better organization and visibility of coverage.

Extracted from: https://github.com/n8n-io/n8n/pull/9453