### PR TITLE
fix(editor): Indent on tabs in expression fields

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -49,7 +49,7 @@ const ndvStore = useNDVStore();
 const root = ref<HTMLElement>();
 const extensions = computed(() => [
 	Prec.highest(
-		keymap.of([...tabKeyMap(true), ...enterKeyMap, ...autocompleteKeyMap, ...historyKeyMap]),
+		keymap.of([...tabKeyMap(false), ...enterKeyMap, ...autocompleteKeyMap, ...historyKeyMap]),
 	),
 	n8nLang(),
 	n8nAutocompletion(),

--- a/packages/editor-ui/src/plugins/codemirror/keymap.ts
+++ b/packages/editor-ui/src/plugins/codemirror/keymap.ts
@@ -7,7 +7,7 @@ import {
 import { indentLess, indentMore, insertNewlineAndIndent, redo, undo } from '@codemirror/commands';
 import type { EditorView, KeyBinding } from '@codemirror/view';
 
-export const tabKeyMap = (singleLine = false): KeyBinding[] => [
+export const tabKeyMap = (blurOnTab = false): KeyBinding[] => [
 	{
 		any(view, event) {
 			if (
@@ -27,7 +27,7 @@ export const tabKeyMap = (singleLine = false): KeyBinding[] => [
 				return acceptCompletion(view);
 			}
 
-			if (!singleLine) return indentMore(view);
+			if (!blurOnTab) return indentMore(view);
 			return false;
 		},
 	},


### PR DESCRIPTION
## Summary
- Adding tab indentation to inline expression fields
- Renaming keymap parameter from `singleLine` -> `blurOnTab` to match the new purpose



## Related tickets and issues
Fixes ADO-1920



## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 