### PR TITLE
fix(core): Fix optional chaining in continue on fail check

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -1067,7 +1067,7 @@ export class WorkflowExecute {
 
 								nodeSuccessData = runNodeData.data;
 
-								const didContinueOnFail = nodeSuccessData?.at(0)?.at(0)?.json.error !== undefined;
+								const didContinueOnFail = nodeSuccessData?.at(0)?.at(0)?.json?.error !== undefined;
 
 								while (didContinueOnFail && tryIndex !== maxTries - 1) {
 									await sleep(waitBetweenTries);


### PR DESCRIPTION
https://linear.app/n8n/issue/N8N-7437
https://github.com/n8n-io/n8n/issues/9665
https://community.n8n.io/t/getting-cannot-read-properties-of-undefined-reading-error-after-upgrading-to-1-45-0/48028