### PR TITLE
fix(editor): Remove template creds setup from workflow when copied (no-changelog)

### DIFF
--- a/cypress/e2e/34-template-credentials-setup.cy.ts
+++ b/cypress/e2e/34-template-credentials-setup.cy.ts
@@ -34,7 +34,7 @@ describe('Template credentials setup', () => {
 		});
 		cy.intercept('GET', '**/rest/settings', (req) => {
 			// Disable cache
-			delete req.headers['if-none-match']
+			delete req.headers['if-none-match'];
 			req.reply((res) => {
 				if (res.body.data) {
 					// Disable custom templates host if it has been overridden by another intercept
@@ -117,6 +117,7 @@ describe('Template credentials setup', () => {
 			const workflow = JSON.parse(workflowJSON);
 
 			expect(workflow.meta).to.haveOwnProperty('templateId', testTemplate.id.toString());
+			expect(workflow.meta).not.to.haveOwnProperty('templateCredsSetupCompleted');
 			workflow.nodes.forEach((node: any) => {
 				expect(Object.keys(node.credentials ?? {})).to.have.lengthOf(1);
 			});

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -260,7 +260,7 @@ export interface IWorkflowDataUpdate {
 }
 
 export interface IWorkflowToShare extends IWorkflowDataUpdate {
-	meta?: WorkflowMetadata;
+	meta: WorkflowMetadata;
 }
 
 export interface NewWorkflowResponse {

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -403,7 +403,7 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 			const exportData: IWorkflowToShare = {
 				...data,
 				meta: {
-					...(props.workflow.meta ?? {}),
+					...props.workflow.meta,
 					instanceId: rootStore.instanceId,
 				},
 				tags: (tags ?? []).map((tagId) => {

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -1997,11 +1997,13 @@ export default defineComponent({
 			void this.getNodesToSave(nodes).then((data) => {
 				const workflowToCopy: IWorkflowToShare = {
 					meta: {
-						...(this.workflowsStore.workflow.meta ?? {}),
+						...this.workflowsStore.workflow.meta,
 						instanceId: this.rootStore.instanceId,
 					},
 					...data,
 				};
+
+				delete workflowToCopy.meta.templateCredsSetupCompleted;
 
 				this.workflowHelpers.removeForeignCredentialsFromWorkflow(
 					workflowToCopy,


### PR DESCRIPTION
## Summary

Don't copy the templateCredsSetupCompleted field when copying a workflow. This ensures that when it's pasted to another instance or a template is created from it, the template setup is not ignored.

Leaving this out from the changelog as it's pretty technical detail

## Related tickets and issues

https://linear.app/n8n/issue/ADO-1899/bug-ensure-templates-setup-flow-shows-when-templates-are-imported


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 