### PR TITLE
fix(editor): Render credentials editable when opening them from the node view

### DIFF
--- a/cypress/e2e/2-credentials.cy.ts
+++ b/cypress/e2e/2-credentials.cy.ts
@@ -21,6 +21,7 @@ const workflowPage = new WorkflowPage();
 const nodeDetailsView = new NDV();
 
 const NEW_CREDENTIAL_NAME = 'Something else';
+const NEW_CREDENTIAL_NAME2 = 'Something else entirely';
 
 describe('Credentials', () => {
 	beforeEach(() => {
@@ -180,6 +181,24 @@ describe('Credentials', () => {
 			.nodeCredentialsSelect()
 			.find('input')
 			.should('have.value', NEW_CREDENTIAL_NAME);
+
+		// Reload page to make sure this also works when the credential hasn't been
+		// just created.
+		nodeDetailsView.actions.close();
+		workflowPage.actions.saveWorkflowOnButtonClick();
+		cy.reload();
+		workflowPage.getters.canvasNodes().last().click();
+		cy.get('body').type('{enter}');
+		workflowPage.getters.nodeCredentialsEditButton().click();
+		credentialsModal.getters.credentialsEditModal().should('be.visible');
+		credentialsModal.getters.name().click();
+		credentialsModal.actions.renameCredential(NEW_CREDENTIAL_NAME2);
+		credentialsModal.getters.saveButton().click();
+		credentialsModal.getters.closeButton().click();
+		workflowPage.getters
+			.nodeCredentialsSelect()
+			.find('input')
+			.should('have.value', NEW_CREDENTIAL_NAME2);
 	});
 
 	it('should setup generic authentication for HTTP node', () => {

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -118,7 +118,7 @@
 import { mapStores } from 'pinia';
 import { defineComponent, type PropType } from 'vue';
 
-import type { ICredentialsResponse, IUser } from '@/Interface';
+import type { ICredentialsDecryptedResponse, ICredentialsResponse, IUser } from '@/Interface';
 
 import type {
 	CredentialInformation,
@@ -215,6 +215,7 @@ export default defineComponent({
 			credentialId: '',
 			credentialName: '',
 			credentialData: {} as ICredentialDataDecryptedObject,
+			currentCredential: null as ICredentialsResponse | ICredentialsDecryptedResponse | null,
 			modalBus: createEventBus(),
 			isDeleting: false,
 			isSaving: false,
@@ -276,13 +277,6 @@ export default defineComponent({
 		},
 		currentUser(): IUser | null {
 			return this.usersStore.currentUser;
-		},
-		currentCredential(): ICredentialsResponse | null {
-			if (!this.credentialId) {
-				return null;
-			}
-
-			return this.credentialsStore.getCredentialById(this.credentialId);
 		},
 		credentialTypeName(): string | null {
 			if (this.mode === 'edit') {
@@ -643,9 +637,9 @@ export default defineComponent({
 			this.credentialId = (this.activeId ?? '') as string;
 
 			try {
-				const currentCredentials = (await this.credentialsStore.getCredentialData({
+				const currentCredentials = await this.credentialsStore.getCredentialData({
 					id: this.credentialId,
-				})) as unknown as ICredentialDataDecryptedObject;
+				});
 
 				if (!currentCredentials) {
 					throw new Error(
@@ -654,6 +648,8 @@ export default defineComponent({
 							this.credentialId,
 					);
 				}
+
+				this.currentCredential = currentCredentials;
 
 				this.credentialData = (currentCredentials.data as ICredentialDataDecryptedObject) || {};
 				if (currentCredentials.sharedWithProjects) {
@@ -875,6 +871,7 @@ export default defineComponent({
 			this.isSaving = false;
 			if (credential) {
 				this.credentialId = credential.id;
+				this.currentCredential = credential;
 
 				if (this.isCredentialTestable) {
 					this.isTesting = true;

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialSharing.ee.vue
@@ -72,7 +72,11 @@
 </template>
 
 <script lang="ts">
-import type { ICredentialsResponse, IUserListAction } from '@/Interface';
+import type {
+	ICredentialsResponse,
+	ICredentialsDecryptedResponse,
+	IUserListAction,
+} from '@/Interface';
 import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
 import { useMessage } from '@/composables/useMessage';
@@ -101,7 +105,7 @@ export default defineComponent({
 	},
 	props: {
 		credential: {
-			type: Object as PropType<ICredentialsResponse | null>,
+			type: Object as PropType<ICredentialsResponse | ICredentialsDecryptedResponse | null>,
 			default: null,
 		},
 		credentialId: {


### PR DESCRIPTION
## Summary

The modal is already fetching the up to date credential to get the data.
But then it wants to use the credential from the store for everything else.

I changed this so that it uses the fetched credential for everything.

TODO:

- [x] Add tests

## Related tickets and issues

https://linear.app/n8n/issue/PAY-1664/credentials-cant-be-accessed-from-workflows

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
  > A bug is not considered fixed, unless a test is added to prevent it from happening again.
  > A feature is not complete without tests.

