### PR TITLE
fix(editor): Node background for executing nodes in dark mode

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -47,9 +47,13 @@
 	--color-canvas-background-l: 18%;
 	--color-canvas-dot: var(--prim-gray-670);
 	--color-canvas-read-only-line: var(--prim-gray-800);
-	--color-canvas-node-background: var(--prim-gray-740);
-	--color-canvas-node-pinned-border: var(--prim-color-secondary-tint-100);
 	--color-canvas-selected: var(--prim-gray-0-alpha-025);
+
+	// Nodes
+	--color-node-background: var(--prim-gray-740);
+	--color-node-executing-background: var(--prim-gray-670);
+	--color-node-executing-other-background: var(--prim-gray-670);
+	--color-node-pinned-border: var(--prim-color-secondary-tint-100);
 	--node-type-main-color: var(--prim-gray-420);
 
 	// Sticky

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -79,9 +79,13 @@
 	--color-canvas-background-l: 99%;
 	--color-canvas-dot: var(--prim-gray-120);
 	--color-canvas-read-only-line: var(--prim-gray-30);
-	--color-canvas-node-background: var(--color-background-xlight);
-	--color-canvas-node-pinned-border: var(--color-secondary);
 	--color-canvas-selected: var(--prim-gray-70);
+
+	// Nodes
+	--color-node-background: var(--color-background-xlight);
+	--color-node-executing-background: var(--color-primary-tint-3);
+	--color-node-executing-other-background: var(--color-primary-tint-3);
+	--color-node-pinned-border: var(--color-secondary);
 	--node-type-main-color: var(--prim-gray-490);
 
 	// Sticky

--- a/packages/editor-ui/src/components/NDVFloatingNodes.vue
+++ b/packages/editor-ui/src/components/NDVFloatingNodes.vue
@@ -202,7 +202,7 @@ defineExpose({
 }
 .connectedNode {
 	border: var(--border-base);
-	background-color: var(--color-canvas-node-background);
+	background-color: var(--color-node-background);
 	border-radius: 100%;
 	padding: var(--spacing-s);
 	cursor: pointer;

--- a/packages/editor-ui/src/components/NDVSubConnections.vue
+++ b/packages/editor-ui/src/components/NDVSubConnections.vue
@@ -406,7 +406,7 @@ defineExpose({
 }
 .connectedNode {
 	border: var(--border-base);
-	background-color: var(--color-canvas-node-background);
+	background-color: var(--color-node-background);
 	border-radius: 100%;
 	padding: var(--spacing-xs);
 	cursor: pointer;

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -563,7 +563,7 @@ export default defineComponent({
 						returnStyles['border-style'] = 'solid';
 					}
 				} else if (!!this.waiting || this.showPinnedDataInfo) {
-					borderColor = '--color-canvas-node-pinned-border';
+					borderColor = '--color-node-pinned-border';
 				} else if (this.nodeExecutionStatus === 'unknown') {
 					borderColor = '--color-foreground-xdark';
 				} else if (this.workflowDataItems) {
@@ -906,10 +906,10 @@ export default defineComponent({
 			height: 100%;
 			border: 2px solid var(--color-foreground-xdark);
 			border-radius: var(--border-radius-large);
-			background-color: var(--color-canvas-node-background);
-			--color-background-node-icon-badge: var(--color-canvas-node-background);
+			background-color: var(--color-node-background);
+			--color-background-node-icon-badge: var(--color-node-background);
 			&.executing {
-				background-color: $node-background-executing !important;
+				background-color: var(--color-node-executing-background) !important;
 
 				.node-executing-info {
 					display: inline-block;
@@ -990,7 +990,7 @@ export default defineComponent({
 				border-radius: 50px;
 
 				&.executing {
-					background-color: $node-background-executing-other !important;
+					background-color: var(--color-node-executing-other-background) !important;
 				}
 
 				.node-executing-info {

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeConfigurable.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeConfigurable.vue
@@ -63,7 +63,7 @@ const styles = computed(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: var(--canvas-node--background, var(--color-canvas-node-background));
+	background: var(--canvas-node--background, var(--color-node-background));
 	border: 2px solid var(--canvas-node--border-color, var(--color-foreground-xdark));
 	border-radius: var(--border-radius-large);
 }

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -44,7 +44,7 @@ const styles = computed(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: var(--canvas-node--background, var(--color-canvas-node-background));
+	background: var(--canvas-node--background, var(--color-node-background));
 	border: 2px solid var(--canvas-node--border-color, var(--color-foreground-xdark));
 	border-radius: var(--border-radius-large);
 }

--- a/packages/editor-ui/src/n8n-theme-variables.scss
+++ b/packages/editor-ui/src/n8n-theme-variables.scss
@@ -62,13 +62,6 @@ $tag-text-color: var(--color-text-dark);
 $tag-close-background-color: var(--color-text-light);
 $tag-close-background-hover-color: var(--color-text-dark);
 
-// nodes
-$node-background-default: var(--color-background-xlight);
-$node-background-executing: var(--color-primary-tint-3);
-$node-background-executing-other: #ede9ff;
-// TODO: Define that differently
-$node-background-type-other: #ede9ff;
-
 // Node creator
 $node-creator-width: 385px;
 $node-creator-text-color: var(--color-text-dark);


### PR DESCRIPTION
## Summary

Fixed the color of the execution nodes (previously white).


## Related tickets and issues

https://linear.app/n8n/issue/NODE-1402/dark-mode-node-background-for-executing-nodes

![Google Chrome 2024-06-10 14 37 16](https://github.com/n8n-io/n8n/assets/66951/4e65cbbe-2dbc-4664-89d8-1a5f563f0914)

<img width="1426" alt="image" src="https://github.com/n8n-io/n8n/assets/66951/331c1787-1f0a-40b9-83f6-2cd6239d12c8">


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 