### PR TITLE
fix(editor): Fix node connection showing incorrect item count during …

### DIFF
--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -658,12 +658,15 @@ export default defineComponent({
 				this.showTriggerNodeTooltip = false;
 			}
 		},
-		nodeRunData(newValue) {
-			if (!this.data) {
-				return;
-			}
+		nodeRunData: {
+			deep: true,
+			handler(newValue) {
+				if (!this.data) {
+					return;
+				}
 
-			this.$emit('run', { name: this.data.name, data: newValue, waiting: !!this.waiting });
+				this.$emit('run', { name: this.data.name, data: newValue, waiting: !!this.waiting });
+			},
 		},
 	},
 	created() {


### PR DESCRIPTION

## Summary

Fix node connection showing incorrect item count during execution in certain cases

I tried adding a test case for the `Node.vue` component, but there is so much going on in that component that it got very complex to set it up. Hence no test. LMK if you have a good idea how this could be tested (need to either simulate run data passing via webhook or pause the execution after first loop iteration)

Before:

https://github.com/n8n-io/n8n/assets/10324676/e48768d4-c1a2-4ec7-a239-9c2caa529f2d

After:


https://github.com/n8n-io/n8n/assets/10324676/c17e14e4-fb5c-45f2-8bfa-15e1ae6bd7da




## Related tickets and issues

https://linear.app/n8n/issue/ADO-2031/bug-connector-item-counts-are-incorrect-items-total-has-disappeared

## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 