### PR TITLE
ci: Remove unused WaitTracker mocking (no-changelog)

### DIFF
--- a/packages/cli/test/integration/commands/ldap/reset.test.ts
+++ b/packages/cli/test/integration/commands/ldap/reset.test.ts
@@ -17,7 +17,6 @@ import { Push } from '@/push';
 import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
 import { createTeamProject, findProject, getPersonalProject } from '../../shared/db/projects';
-import { WaitTracker } from '@/WaitTracker';
 import { getLdapSynchronizations, saveLdapSynchronization } from '@/Ldap/helpers';
 import { createLdapConfig } from '../../shared/ldap';
 import { LdapService } from '@/Ldap/ldap.service';
@@ -40,9 +39,6 @@ beforeAll(async () => {
 	mockInstance(Push);
 	mockInstance(InternalHooks);
 	mockInstance(LoadNodesAndCredentials);
-	// This needs to be mocked, otherwise the time setInterval would prevent jest
-	// from exiting properly.
-	mockInstance(WaitTracker);
 	await testDb.init();
 	await oclifConfig.load();
 });

--- a/packages/cli/test/integration/environments/SourceControl.test.ts
+++ b/packages/cli/test/integration/environments/SourceControl.test.ts
@@ -5,18 +5,13 @@ import config from '@/config';
 import { SourceControlPreferencesService } from '@/environments/sourceControl/sourceControlPreferences.service.ee';
 import { SourceControlService } from '@/environments/sourceControl/sourceControl.service.ee';
 import type { SourceControlledFile } from '@/environments/sourceControl/types/sourceControlledFile';
-import { WaitTracker } from '@/WaitTracker';
 
 import * as utils from '../shared/utils/';
 import { createUser } from '../shared/db/users';
-import { mockInstance } from '../../shared/mocking';
 import type { SuperAgentTest } from '../shared/types';
 
 let authOwnerAgent: SuperAgentTest;
 let owner: User;
-
-// This is necessary for the tests to shutdown cleanly.
-mockInstance(WaitTracker);
 
 const testServer = utils.setupTestServer({
 	endpointGroups: ['sourceControl', 'license', 'auth'],

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -5,17 +5,12 @@ import { createMember, createOwner } from './shared/db/users';
 import { createWorkflow, shareWorkflowWithUsers } from './shared/db/workflows';
 import * as testDb from './shared/testDb';
 import { setupTestServer } from './shared/utils';
-import { mockInstance } from '../shared/mocking';
-import { WaitTracker } from '@/WaitTracker';
 import { createTeamProject, linkUserToProject } from './shared/db/projects';
 
 const testServer = setupTestServer({ endpointGroups: ['executions'] });
 
 let owner: User;
 let member: User;
-
-// This is necessary for the tests to shutdown cleanly.
-mockInstance(WaitTracker);
 
 const saveExecution = async ({ belongingTo }: { belongingTo: User }) => {
 	const workflow = await createWorkflow({}, belongingTo);

--- a/packages/cli/test/integration/workflows/workflows.controller-with-active-workflow-manager.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller-with-active-workflow-manager.ee.test.ts
@@ -5,8 +5,6 @@ import * as testDb from '../shared/testDb';
 import { createUser } from '../shared/db/users';
 import { createWorkflowWithTrigger } from '../shared/db/workflows';
 import { createTeamProject } from '../shared/db/projects';
-import { mockInstance } from '../../shared/mocking';
-import { WaitTracker } from '@/WaitTracker';
 
 let member: User;
 let anotherMember: User;
@@ -15,9 +13,6 @@ const testServer = utils.setupTestServer({
 	endpointGroups: ['workflows'],
 	enabledFeatures: ['feat:sharing', 'feat:advancedPermissions'],
 });
-
-// This is necessary for the tests to shutdown cleanly.
-mockInstance(WaitTracker);
 
 beforeAll(async () => {
 	member = await createUser({ role: 'global:member' });


### PR DESCRIPTION
We changed WaitTracker to not start the timer in the constructor in #9600. So we don't need to mock it anymore.

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests included