### PR TITLE
fix(editor): Un-skip workflow save test (no-changelog)

### DIFF
--- a/cypress/e2e/7-workflow-actions.cy.ts
+++ b/cypress/e2e/7-workflow-actions.cy.ts
@@ -37,7 +37,7 @@ describe('Workflow Actions', () => {
 		WorkflowPage.getters.isWorkflowSaved();
 	});
 
-	it.skip('should not save already saved workflow', () => {
+	it('should not save already saved workflow', () => {
 		cy.intercept('PATCH', '/rest/workflows/*').as('saveWorkflow');
 		WorkflowPage.actions.saveWorkflowOnButtonClick();
 		WorkflowPage.actions.addNodeToCanvas(MANUAL_TRIGGER_NODE_NAME);


### PR DESCRIPTION
## Summary
Removes `.skip` from recently added workflow save e2e tests. Tests are working fine locally so want to test them again on CI

[Latest e2e test run against the branch](https://github.com/n8n-io/n8n/actions/runs/9462368094)

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 