### PR TITLE
feat(editor): Add canvas edge toolbar hover show/hide support (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
@@ -1,0 +1,42 @@
+import { fireEvent } from '@testing-library/vue';
+import CanvasEdge from './CanvasEdge.vue';
+import { createComponentRenderer } from '@/__tests__/render';
+
+const renderComponent = createComponentRenderer(CanvasEdge, {
+	props: {
+		sourceX: 0,
+		sourceY: 0,
+		sourcePosition: 'top',
+		targetX: 100,
+		targetY: 100,
+		targetPosition: 'bottom',
+	},
+});
+
+describe('CanvasEdge', () => {
+	it('should emit delete event when toolbar delete is clicked', async () => {
+		const { emitted, getByTestId } = renderComponent();
+		const deleteButton = getByTestId('delete-connection-button');
+
+		await fireEvent.click(deleteButton);
+
+		expect(emitted()).toHaveProperty('delete');
+	});
+
+	it('should compute edgeStyle correctly', () => {
+		const { container } = renderComponent({
+			props: {
+				style: {
+					stroke: 'red',
+				},
+			},
+		});
+
+		const edge = container.querySelector('.vue-flow__edge-path');
+
+		expect(edge).toHaveStyle({
+			stroke: 'red',
+			strokeWidth: 2,
+		});
+	});
+});

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -2,16 +2,19 @@
 /* eslint-disable vue/no-multiple-template-root */
 import type { Connection, EdgeProps } from '@vue-flow/core';
 import { BaseEdge, EdgeLabelRenderer, getBezierPath } from '@vue-flow/core';
+import CanvasEdgeToolbar from './CanvasEdgeToolbar.vue';
 import { computed, useCssModule } from 'vue';
-import { useI18n } from '@/composables/useI18n';
 
 const emit = defineEmits<{
 	delete: [connection: Connection];
 }>();
 
-const props = defineProps<EdgeProps>();
+const props = defineProps<
+	EdgeProps & {
+		hovered?: boolean;
+	}
+>();
 
-const i18n = useI18n();
 const $style = useCssModule();
 
 const edgeStyle = computed(() => ({
@@ -19,8 +22,19 @@ const edgeStyle = computed(() => ({
 	...props.style,
 }));
 
-const edgeLabelStyle = computed(() => ({
-	transform: `translate(-50%, -50%) translate(${path.value[1]}px,${path.value[2]}px)`,
+const isEdgeToolbarVisible = computed(() => props.selected || props.hovered);
+
+const edgeToolbarStyle = computed(() => {
+	return {
+		transform: `translate(-50%, -50%) translate(${path.value[1]}px,${path.value[2]}px)`,
+	};
+});
+
+const edgeToolbarClasses = computed(() => ({
+	[$style.edgeToolbar]: true,
+	[$style.edgeToolbarVisible]: isEdgeToolbarVisible.value,
+	nodrag: true,
+	nopan: true,
 }));
 
 const path = computed(() =>
@@ -60,24 +74,24 @@ function onDelete() {
 		:label-bg-style="{ fill: 'red' }"
 		:label-bg-padding="[2, 4]"
 		:label-bg-border-radius="2"
+		:class="$style.edge"
 	/>
 	<EdgeLabelRenderer>
-		<div :class="[$style.edgeToolbar, 'nodrag', 'nopan']" :style="edgeLabelStyle">
-			<N8nIconButton
-				data-test-id="delete-connection-button"
-				type="tertiary"
-				size="small"
-				icon="trash"
-				:title="i18n.baseText('node.delete')"
-				@click="onDelete"
-			/>
-		</div>
+		<CanvasEdgeToolbar :class="edgeToolbarClasses" :style="edgeToolbarStyle" @delete="onDelete" />
 	</EdgeLabelRenderer>
 </template>
 
 <style lang="scss" module>
 .edgeToolbar {
-	pointer-events: all;
 	position: absolute;
+	opacity: 0;
+
+	&.edgeToolbarVisible {
+		opacity: 1;
+	}
+
+	&:hover {
+		opacity: 1;
+	}
 }
 </style>

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.spec.ts
@@ -1,0 +1,16 @@
+import { fireEvent } from '@testing-library/vue';
+import CanvasEdgeToolbar from './CanvasEdgeToolbar.vue';
+import { createComponentRenderer } from '@/__tests__/render';
+
+const renderComponent = createComponentRenderer(CanvasEdgeToolbar);
+
+describe('CanvasEdgeToolbar', () => {
+	it('should emit delete event when delete button is clicked', async () => {
+		const { getByTestId, emitted } = renderComponent();
+		const deleteButton = getByTestId('delete-connection-button');
+
+		await fireEvent.click(deleteButton);
+
+		expect(emitted()).toHaveProperty('delete');
+	});
+});

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -1,0 +1,42 @@
+<script lang="ts" setup>
+import { useI18n } from '@/composables/useI18n';
+import { computed, useCssModule } from 'vue';
+
+const emit = defineEmits<{
+	delete: [];
+}>();
+
+const $style = useCssModule();
+
+const i18n = useI18n();
+
+const classes = computed(() => ({
+	[$style.canvasEdgeToolbar]: true,
+}));
+
+function onDelete() {
+	emit('delete');
+}
+</script>
+
+<template>
+	<div :class="classes" data-test-id="canvas-edge-toolbar">
+		<N8nIconButton
+			data-test-id="delete-connection-button"
+			type="tertiary"
+			size="small"
+			icon="trash"
+			:title="i18n.baseText('node.delete')"
+			@click="onDelete"
+		/>
+	</div>
+</template>
+
+<style lang="scss" module>
+.canvasEdgeToolbar {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	pointer-events: all;
+}
+</style>


### PR DESCRIPTION
## Summary
Add canvas edge toolbar show/hide when hovering the edge.


https://github.com/n8n-io/n8n/assets/6179477/e8ea364c-9162-4629-ba71-20d5c646c4e2



## Related tickets and issues
https://linear.app/n8n/issue/N8N-7427/hideshow-edge-actions-on-hover

## Review / Merge checklist
- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 