### PR TITLE
fix: Fix empty page for Sales Cloud users 

### DIFF
--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -72,7 +72,7 @@
 			</div>
 			<div v-if="!readOnlyEnv" :class="['text-center', 'mt-2xl', $style.actionsContainer]">
 				<a
-					v-if="isSalesUser && templateRepositoryURL"
+					v-if="isSalesUser"
 					:href="templateRepositoryURL"
 					:class="$style.emptyStateCard"
 					target="_blank"

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -72,8 +72,8 @@
 			</div>
 			<div v-if="!readOnlyEnv" :class="['text-center', 'mt-2xl', $style.actionsContainer]">
 				<a
-					v-if="isSalesUser"
-					:href="getTemplateRepositoryURL()"
+					v-if="isSalesUser && templateRepositoryURL"
+					:href="templateRepositoryURL"
 					:class="$style.emptyStateCard"
 					target="_blank"
 				>
@@ -267,6 +267,9 @@ const WorkflowsView = defineComponent({
 				? this.$locale.baseText('workflows.project.add')
 				: this.$locale.baseText('workflows.add');
 		},
+		templateRepositoryURL() {
+			return this.templatesStore.websiteTemplateRepositoryURL;
+		},
 	},
 	watch: {
 		'filters.tags'() {
@@ -307,9 +310,6 @@ const WorkflowsView = defineComponent({
 			this.$telemetry.track('User clicked add workflow button', {
 				source: 'Workflows list',
 			});
-		},
-		getTemplateRepositoryURL() {
-			return this.templatesStore.websiteTemplateRepositoryURL;
 		},
 		trackCategoryLinkClick(category: string) {
 			this.$telemetry.track(`User clicked Browse ${category} Templates`, {


### PR DESCRIPTION
## Summary
Fix empty page for Sales Cloud users. Show button that redirects to templates


## Related tickets and issues
https://community.n8n.io/t/cloud-hosted-workflow-editor-only-shows-blank-space/48054
https://community.n8n.io/t/bug-cant-use-n8n-at-all/48265


## Review / Merge checklist
- [X] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 