### PR TITLE
fix: Fix sending pin data twice causing payload too large errors

### DIFF
--- a/cypress/e2e/19-execution.cy.ts
+++ b/cypress/e2e/19-execution.cy.ts
@@ -536,7 +536,6 @@ describe('Execution', () => {
 
 		cy.wait('@workflowRun').then((interception) => {
 			expect(interception.request.body).not.to.have.property('runData').that.is.an('object');
-			expect(interception.request.body).not.to.have.property('pinData').that.is.an('object');
 			expect(interception.request.body).to.have.property('workflowData').that.is.an('object');
 			expect(interception.request.body.workflowData)
 				.to.have.property('pinData')

--- a/cypress/e2e/19-execution.cy.ts
+++ b/cypress/e2e/19-execution.cy.ts
@@ -536,10 +536,14 @@ describe('Execution', () => {
 
 		cy.wait('@workflowRun').then((interception) => {
 			expect(interception.request.body).not.to.have.property('runData').that.is.an('object');
-			expect(interception.request.body).to.have.property('pinData').that.is.an('object');
+			expect(interception.request.body).not.to.have.property('pinData').that.is.an('object');
+			expect(interception.request.body).to.have.property('workflowData').that.is.an('object');
+			expect(interception.request.body.workflowData)
+				.to.have.property('pinData')
+				.that.is.an('object');
 			const expectedPinnedDataKeys = ['Webhook'];
 
-			const { pinData } = interception.request.body as Record<string, object>;
+			const { pinData } = interception.request.body.workflowData as Record<string, object>;
 			expect(Object.keys(pinData)).to.have.lengthOf(expectedPinnedDataKeys.length);
 			expect(pinData).to.include.all.keys(expectedPinnedDataKeys);
 		});
@@ -555,14 +559,18 @@ describe('Execution', () => {
 
 		cy.wait('@workflowRun').then((interception) => {
 			expect(interception.request.body).to.have.property('runData').that.is.an('object');
-			expect(interception.request.body).to.have.property('pinData').that.is.an('object');
+			expect(interception.request.body).to.have.property('workflowData').that.is.an('object');
+			expect(interception.request.body.workflowData)
+				.to.have.property('pinData')
+				.that.is.an('object');
 			const expectedPinnedDataKeys = ['Webhook'];
 			const expectedRunDataKeys = ['If', 'Webhook'];
 
-			const { pinData, runData } = interception.request.body as Record<string, object>;
+			const { pinData } = interception.request.body.workflowData as Record<string, object>;
 			expect(Object.keys(pinData)).to.have.lengthOf(expectedPinnedDataKeys.length);
 			expect(pinData).to.include.all.keys(expectedPinnedDataKeys);
 
+			const { runData } = interception.request.body as Record<string, object>;
 			expect(Object.keys(runData)).to.have.lengthOf(expectedRunDataKeys.length);
 			expect(runData).to.include.all.keys(expectedRunDataKeys);
 		});

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,13 +1,6 @@
 import type { IWorkflowDb } from '@/Interfaces';
 import type { AuthenticatedRequest, ListQuery } from '@/requests';
-import type {
-	INode,
-	IConnections,
-	IWorkflowSettings,
-	IRunData,
-	IPinData,
-	StartNodeData,
-} from 'n8n-workflow';
+import type { INode, IConnections, IWorkflowSettings, IRunData, StartNodeData } from 'n8n-workflow';
 
 export declare namespace WorkflowRequest {
 	type CreateUpdatePayload = Partial<{
@@ -26,7 +19,6 @@ export declare namespace WorkflowRequest {
 	type ManualRunPayload = {
 		workflowData: IWorkflowDb;
 		runData: IRunData;
-		pinData: IPinData;
 		startNodes?: StartNodeData[];
 		destinationNode?: string;
 	};

--- a/packages/cli/src/workflows/workflowExecution.service.ts
+++ b/packages/cli/src/workflows/workflowExecution.service.ts
@@ -92,16 +92,11 @@ export class WorkflowExecutionService {
 	}
 
 	async executeManually(
-		{
-			workflowData,
-			runData,
-			pinData,
-			startNodes,
-			destinationNode,
-		}: WorkflowRequest.ManualRunPayload,
+		{ workflowData, runData, startNodes, destinationNode }: WorkflowRequest.ManualRunPayload,
 		user: User,
 		pushRef?: string,
 	) {
+		const pinData = workflowData.pinData;
 		const pinnedTrigger = this.selectPinnedActivatorStarter(
 			workflowData,
 			startNodes?.map((nodeData) => nodeData.name),

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -200,7 +200,6 @@ export interface IStartRunData {
 	startNodes?: StartNodeData[];
 	destinationNode?: string;
 	runData?: IRunData;
-	pinData?: IPinData;
 }
 
 export interface ITableData {

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -219,7 +219,6 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			const startRunData: IStartRunData = {
 				workflowData,
 				runData: newRunData,
-				pinData: workflowData.pinData,
 				startNodes,
 			};
 			if ('destinationNode' in options) {


### PR DESCRIPTION
## Summary

For manual executions the pin data is sent to the backend in the execute request. At the moment it is included twice. Once in the `.pinData` and once in the `.workflowData.pinData`. The data is identical. This can cause 413 payload too large errors for workflows for which it is still possible to pin the data.

This change removes the `.pinData` parameter from the POST /:id/run endpoint, requiring the pin data to be defined in the `.workflowData.pinData` property. In the `IWorkflowExecutionDataProcess` interface the pin data is kept in both `.pinData` and `.workflowData.pinData` properties for backwards compatibility.

## Related tickets and issues

https://linear.app/n8n/issue/ADO-1731/bug-pinned-data-still-causing-413-errors


## Review / Merge checklist
- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
   > A feature is not complete without tests. 