### PR TITLE
ci: Update pull_request_template.md (no-changelog)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,26 @@
 ## Summary
-> Describe what the PR does and how to test. Photos and videos are recommended.
 
+<!--
+Describe what the PR does and how to test.
+Photos and videos are recommended.
+-->
 
+## Related Linear tickets, Github issues, and Community forum posts
 
-## Related tickets and issues
-> Include links to **Linear ticket** or Github issue or Community forum post. Important in order to close *automatically* and provide context to reviewers.
-
-
+<!--
+Include links to **Linear ticket** or Github issue or Community forum post.
+Important in order to close *automatically* and provide context to reviewers.
+-->
 
 ## Review / Merge checklist
-- [ ] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
+
+- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
+   **Remember, the title automatically goes into the changelog.
+   Use `(no-changelog)` otherwise.**
+-->
 - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
-- [ ] Tests included.
-   > A bug is not considered fixed, unless a test is added to prevent it from happening again.
-   > A feature is not complete without tests. 
+- [ ] Tests included. <!--
+   A bug is not considered fixed, unless a test is added to prevent it from happening again.
+   A feature is not complete without tests.
+-->
+- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


### PR DESCRIPTION
## Summary
This PR
1. Adds an additional item to the checklist for labeling fixes that need backporting
2. Fixes the link to `pull_request_title_conventions.md`
3. Moves the comments into `<!-- ... --->` blocks, so that when people don't fill out the template, we have less noise in the PR description.

### Screenshot
![image](https://github.com/n8n-io/n8n/assets/196144/3fbfc46a-f664-49a8-b060-93c117138abe)


## Review / Merge checklist

- [x] PR title and summary are descriptive