### PR TITLE
feat(Google Cloud Firestore Node): Add support for service account and document creation with id

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
@@ -110,6 +110,19 @@ export const documentFields: INodeProperties[] = [
 		required: true,
 	},
 	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['document'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		required: false,
+	},
+	{
 		displayName: 'Columns / Attributes',
 		name: 'columns',
 		type: 'string',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
@@ -120,7 +120,6 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		required: false,
 	},
 	{
 		displayName: 'Columns / Attributes',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -9,7 +9,7 @@ import type {
 import { NodeApiError } from 'n8n-workflow';
 
 import moment from 'moment-timezone';
-import { getGoogleAccessToken } from "../../GenericFunctions";
+import { getGoogleAccessToken } from '../../GenericFunctions';
 
 export async function googleApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
@@ -50,11 +50,7 @@ export async function googleApiRequest(
 		}
 
 		//@ts-ignore
-		return await this.helpers.requestWithAuthentication.call(
-			this,
-			credentialType,
-			options,
-		);
+		return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -188,6 +188,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 					items.map(async (item: IDataObject, i: number) => {
 						const collection = this.getNodeParameter('collection', i) as string;
 						const columns = this.getNodeParameter('columns', i) as string;
+						const documentId = this.getNodeParameter('documentId', i) as string;
 						const columnList = columns.split(',').map((column) => column.trim());
 						const document = { fields: {} };
 						columnList.map((column) => {
@@ -205,6 +206,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 							'POST',
 							`/${projectId}/databases/${database}/documents/${collection}`,
 							document,
+							{ documentId },
 						);
 
 						responseData.id = (responseData.name as string).split('/').pop();

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -40,9 +40,40 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 			{
 				name: 'googleFirebaseCloudFirestoreOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['googleFirebaseCloudFirestoreOAuth2Api'],
+					},
+				},
 			},
+			{
+				name: 'googleApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['serviceAccount'],
+					},
+				},
+			}
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'OAuth2 (recommended)',
+						value: 'googleFirebaseCloudFirestoreOAuth2Api',
+					},
+					{
+						name: 'Service Account',
+						value: 'serviceAccount',
+					},
+				],
+				default: 'googleFirebaseCloudFirestoreOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -54,7 +54,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 						authentication: ['serviceAccount'],
 					},
 				},
-			}
+			},
 		],
 		properties: [
 			{

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -52,6 +52,10 @@ const googleServiceAccountScopes = {
 		'https://www.googleapis.com/auth/cloud-translation',
 		'https://www.googleapis.com/auth/cloud-platform',
 	],
+	firestore: [
+		'https://www.googleapis.com/auth/datastore',
+		'https://www.googleapis.com/auth/firebase',
+	]
 };
 
 type GoogleServiceAccount = keyof typeof googleServiceAccountScopes;

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -55,7 +55,7 @@ const googleServiceAccountScopes = {
 	firestore: [
 		'https://www.googleapis.com/auth/datastore',
 		'https://www.googleapis.com/auth/firebase',
-	]
+	],
 };
 
 type GoogleServiceAccount = keyof typeof googleServiceAccountScopes;


### PR DESCRIPTION
## Summary

This PR adds two features:
- Allows to use Google Service Accounts for Firestore nodes authentication.
- Allows to create Firestore documents with specific ids (optionally).

## Details

While its possible to use Firestore using a service account, it is currently not supported by n8n, as noted at https://docs.n8n.io/integrations/builtin/credentials/google/#compatible-nodes. Allowing to use a service account in this node allows not depending on a personal account, and provides a reliable way to connect to Firestore.

In this way, proposed changes are backwards compatible, and offer the possibility of using either Oauth2 or Service Account authentication, and optionally, supply a document id, as it is possible while calling API or creating the document manually through the UI:

<img width="929" alt="Captura de pantalla 2024-06-12 a las 12 43 00" src="https://github.com/n8n-io/n8n/assets/162105928/93418042-485b-4433-adcf-8b4e7690e480">

<img width="923" alt="Captura de pantalla 2024-06-12 a las 12 43 34" src="https://github.com/n8n-io/n8n/assets/162105928/13ea9b30-83f4-42d0-85f5-068f704ceb90">

<img width="915" alt="Captura de pantalla 2024-06-12 a las 12 47 35" src="https://github.com/n8n-io/n8n/assets/162105928/531b418f-4705-4c90-a76b-452588793861">

<img width="556" alt="Captura de pantalla 2024-06-12 a las 12 53 57" src="https://github.com/n8n-io/n8n/assets/162105928/d8e3b28f-137d-4a95-8863-9cb1fe4f891d">

<img width="1412" alt="Captura de pantalla 2024-06-12 a las 12 56 35" src="https://github.com/n8n-io/n8n/assets/162105928/2f5b4838-242f-42e9-ba72-68e8c898d097">

<img width="666" alt="Captura de pantalla 2024-06-12 a las 13 03 32" src="https://github.com/n8n-io/n8n/assets/162105928/084091f6-04c8-47e9-a491-07014ee8dd55">

<img width="701" alt="Captura de pantalla 2024-06-12 a las 13 03 49" src="https://github.com/n8n-io/n8n/assets/162105928/d7e54ba0-ab61-4fe7-b220-53cbdb1f336f">

