### PR TITLE
fix: When editing nodes only show the credentials in the dropdown that the user is allowed to use in that workflow

### DIFF
--- a/cypress/composables/projects.ts
+++ b/cypress/composables/projects.ts
@@ -17,15 +17,15 @@ export const getProjectSettingsCancelButton = () =>
 export const getProjectSettingsDeleteButton = () =>
 	cy.getByTestId('project-settings-delete-button');
 export const getProjectMembersSelect = () => cy.getByTestId('project-members-select');
+export const addProjectMember = (email: string) => {
+	getProjectMembersSelect().click();
+	getProjectMembersSelect().get('.el-select-dropdown__item').contains(email.toLowerCase()).click();
+};
 export const getProjectNameInput = () => cy.get('#projectName');
 export const getResourceMoveModal = () => cy.getByTestId('project-move-resource-modal');
 export const getResourceMoveConfirmModal = () =>
 	cy.getByTestId('project-move-resource-confirm-modal');
 export const getProjectMoveSelect = () => cy.getByTestId('project-move-resource-modal-select');
-export const addProjectMember = (email: string) => {
-	getProjectMembersSelect().click();
-	getProjectMembersSelect().get('.el-select-dropdown__item').contains(email.toLowerCase()).click();
-};
 
 export function createProject(name: string) {
 	getAddProjectButton().should('be.visible').click();

--- a/cypress/composables/projects.ts
+++ b/cypress/composables/projects.ts
@@ -10,21 +10,22 @@ export const getProjectTabs = () => cy.getByTestId('project-tabs').find('a');
 export const getProjectTabWorkflows = () => getProjectTabs().filter('a[href$="/workflows"]');
 export const getProjectTabCredentials = () => getProjectTabs().filter('a[href$="/credentials"]');
 export const getProjectTabSettings = () => getProjectTabs().filter('a[href$="/settings"]');
+export const getProjectSettingsNameInput = () => cy.getByTestId('project-settings-name-input');
 export const getProjectSettingsSaveButton = () => cy.getByTestId('project-settings-save-button');
 export const getProjectSettingsCancelButton = () =>
 	cy.getByTestId('project-settings-cancel-button');
 export const getProjectSettingsDeleteButton = () =>
 	cy.getByTestId('project-settings-delete-button');
 export const getProjectMembersSelect = () => cy.getByTestId('project-members-select');
-export const addProjectMember = (email: string) => {
-	getProjectMembersSelect().click();
-	getProjectMembersSelect().get('.el-select-dropdown__item').contains(email.toLowerCase()).click();
-};
 export const getProjectNameInput = () => cy.get('#projectName');
 export const getResourceMoveModal = () => cy.getByTestId('project-move-resource-modal');
 export const getResourceMoveConfirmModal = () =>
 	cy.getByTestId('project-move-resource-confirm-modal');
 export const getProjectMoveSelect = () => cy.getByTestId('project-move-resource-modal-select');
+export const addProjectMember = (email: string) => {
+	getProjectMembersSelect().click();
+	getProjectMembersSelect().get('.el-select-dropdown__item').contains(email.toLowerCase()).click();
+};
 
 export function createProject(name: string) {
 	getAddProjectButton().should('be.visible').click();
@@ -55,3 +56,11 @@ export function createCredential(name: string) {
 	credentialsModal.actions.save();
 	credentialsModal.actions.close();
 }
+
+export const actions = {
+	createProject: (name: string) => {
+		getAddProjectButton().click();
+		getProjectSettingsNameInput().type(name);
+		getProjectSettingsSaveButton().click();
+	},
+};

--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -1,4 +1,4 @@
-import { INSTANCE_MEMBERS, INSTANCE_OWNER, INSTANCE_ADMIN } from '../constants';
+import { INSTANCE_MEMBERS, INSTANCE_OWNER, INSTANCE_ADMIN, NOTION_NODE_NAME } from '../constants';
 import {
 	CredentialsModal,
 	CredentialsPage,
@@ -8,6 +8,7 @@ import {
 	WorkflowsPage,
 } from '../pages';
 import { getVisibleSelect } from '../utils';
+import * as projects from '../composables/projects';
 
 /**
  * User U1 - Instance owner
@@ -186,5 +187,179 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		credentialsModal.actions.addUser(INSTANCE_ADMIN.email);
 		credentialsModal.actions.saveSharing();
 		credentialsModal.actions.close();
+	});
+});
+
+describe('Credential Usage in Cross Shared Workflows', () => {
+	beforeEach(() => {
+		cy.resetDatabase();
+		cy.enableFeature('advancedPermissions');
+		cy.enableFeature('projectRole:admin');
+		cy.enableFeature('projectRole:editor');
+		cy.changeQuota('maxTeamProjects', -1);
+		cy.reload();
+		cy.signinAsOwner();
+		cy.visit(credentialsPage.url);
+	});
+
+	it('should only show credentials from the same team project', () => {
+		cy.enableFeature('advancedPermissions');
+		cy.enableFeature('projectRole:admin');
+		cy.enableFeature('projectRole:editor');
+		cy.changeQuota('maxTeamProjects', -1);
+
+		// Create a notion credential in the home project
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// Create a notion credential in one project
+		projects.actions.createProject('Development');
+		projects.getProjectTabCredentials().click();
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// Create a notion credential in another project
+		projects.actions.createProject('Test');
+		projects.getProjectTabCredentials().click();
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		// Create a workflow with a notion node in the same project
+		projects.getProjectTabWorkflows().click();
+		workflowsPage.actions.createWorkflowFromCard();
+		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
+
+		// Only the credential in this project (+ the 'Create new' option) should
+		// be in the dropdown
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').should('have.length', 2);
+	});
+
+	it('should only show credentials in their personal project for members', () => {
+		cy.enableFeature('sharing');
+		cy.reload();
+
+		// Create a notion credential as the owner
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// Create another notion credential as the owner, but share it with member
+		// 0
+		credentialsPage.getters.createCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API', false);
+		credentialsModal.actions.changeTab('Sharing');
+		credentialsModal.actions.addUser(INSTANCE_MEMBERS[0].email);
+		credentialsModal.actions.saveSharing();
+
+		// As the member, create a new notion credential and a workflow
+		cy.signinAsMember();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.createCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		cy.visit(workflowsPage.url);
+		workflowsPage.actions.createWorkflowFromCard();
+		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
+
+		// Only the own credential the shared one (+ the 'Create new' option)
+		// should be in the dropdown
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').should('have.length', 3);
+	});
+
+	it('should only show credentials in their personal project for members if the workflow was shared with them', () => {
+		const workflowName = 'Test workflow';
+		cy.enableFeature('sharing');
+		cy.reload();
+
+		// Create a notion credential as the owner and a workflow that is shared
+		// with member 0
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		//cy.visit(workflowsPage.url);
+		projects.getProjectTabWorkflows().click();
+		workflowsPage.actions.createWorkflowFromCard();
+		workflowPage.actions.setWorkflowName(workflowName);
+		workflowPage.actions.openShareModal();
+		workflowSharingModal.actions.addUser(INSTANCE_MEMBERS[0].email);
+		workflowSharingModal.actions.save();
+
+		// As the member, create a new notion credential
+		cy.signinAsMember();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		cy.visit(workflowsPage.url);
+		workflowsPage.getters.workflowCard(workflowName).click();
+		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
+
+		// Only the own credential the shared one (+ the 'Create new' option)
+		// should be in the dropdown
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').should('have.length', 2);
+	});
+
+	it("should show all credentials from all personal projects the workflow's been shared into for the global owner", () => {
+		const workflowName = 'Test workflow';
+		cy.enableFeature('sharing');
+
+		// As member 1, create a new notion credential. This should not show up.
+		cy.signinAsMember(1);
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// As admin, create a new notion credential. This should show up.
+		cy.signinAsAdmin();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.createCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// As member 0, create a new notion credential and a workflow and share it
+		// with the global owner and the admin.
+		cy.signinAsMember();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		cy.visit(workflowsPage.url);
+		workflowsPage.actions.createWorkflowFromCard();
+		workflowPage.actions.setWorkflowName(workflowName);
+		workflowPage.actions.openShareModal();
+		workflowSharingModal.actions.addUser(INSTANCE_OWNER.email);
+		workflowSharingModal.actions.addUser(INSTANCE_ADMIN.email);
+		workflowSharingModal.actions.save();
+
+		// As the global owner, create a new notion credential and open the shared
+		// workflow
+		cy.signinAsOwner();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.createCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+		cy.visit(workflowsPage.url);
+		workflowsPage.getters.workflowCard(workflowName).click();
+		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
+
+		// Only the personal credentials of the workflow owner and the global owner
+		// should show up.
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').should('have.length', 4);
+	});
+
+	it('should show all personal credentials if the global owner owns the workflow', () => {
+		cy.enableFeature('sharing');
+
+		// As member 0, create a new notion credential.
+		cy.signinAsMember();
+		cy.visit(credentialsPage.url);
+		credentialsPage.getters.emptyListCreateCredentialButton().click();
+		credentialsModal.actions.createNewCredential('Notion API');
+
+		// As the global owner, create a workflow and add a notion node
+		cy.signinAsOwner();
+		cy.visit(workflowsPage.url);
+		workflowsPage.actions.createWorkflowFromCard();
+		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
+
+		// Show all personal credentials
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').should('have.have.length', 2);
 	});
 });

--- a/cypress/e2e/30-editor-after-route-changes.cy.ts
+++ b/cypress/e2e/30-editor-after-route-changes.cy.ts
@@ -102,7 +102,7 @@ const switchBetweenEditorAndHistory = () => {
 
 const switchBetweenEditorAndWorkflowlist = () => {
 	cy.getByTestId('menu-item').first().click();
-	cy.wait(['@getUsers', '@getWorkflows', '@getActiveWorkflows', '@getCredentials']);
+	cy.wait(['@getUsers', '@getWorkflows', '@getActiveWorkflows', '@getProjects']);
 
 	cy.getByTestId('resources-list-item').first().click();
 
@@ -197,7 +197,7 @@ describe('Editor zoom should work after route changes', () => {
 		cy.intercept('GET', '/rest/users').as('getUsers');
 		cy.intercept('GET', '/rest/workflows?*').as('getWorkflows');
 		cy.intercept('GET', '/rest/active-workflows').as('getActiveWorkflows');
-		cy.intercept('GET', '/rest/credentials?*').as('getCredentials');
+		cy.intercept('GET', '/rest/projects').as('getProjects');
 
 		switchBetweenEditorAndHistory();
 		zoomInAndCheckNodes();

--- a/cypress/pages/modals/credentials-modal.ts
+++ b/cypress/pages/modals/credentials-modal.ts
@@ -55,7 +55,7 @@ export class CredentialsModal extends BasePage {
 		close: () => {
 			this.getters.closeButton().click();
 		},
-		fillCredentialsForm: () => {
+		fillCredentialsForm: (closeModal = true) => {
 			this.getters.credentialsEditModal().should('be.visible');
 			this.getters.credentialInputs().should('have.length.greaterThan', 0);
 			this.getters
@@ -65,14 +65,23 @@ export class CredentialsModal extends BasePage {
 					cy.wrap($el).type('test');
 				});
 			this.getters.saveButton().click();
-			this.getters.closeButton().click();
+			if (closeModal) {
+				this.getters.closeButton().click();
+			}
+		},
+		createNewCredential: (type: string, closeModal = true) => {
+			this.getters.newCredentialModal().should('be.visible');
+			this.getters.newCredentialTypeSelect().should('be.visible');
+			this.getters.newCredentialTypeOption(type).click();
+			this.getters.newCredentialTypeButton().click();
+			this.actions.fillCredentialsForm(closeModal);
 		},
 		renameCredential: (newName: string) => {
 			this.getters.nameInput().type('{selectall}');
 			this.getters.nameInput().type(newName);
 			this.getters.nameInput().type('{enter}');
 		},
-		changeTab: (tabName: string) => {
+		changeTab: (tabName: 'Sharing') => {
 			this.getters.menuItem(tabName).click();
 		},
 	};

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -32,8 +32,6 @@ declare global {
 			 * @param [workflowName] Optional name for the workflow. A random nanoid is used if not given
 			 */
 			createFixtureWorkflow(fixtureKey: string, workflowName?: string): void;
-			/** @deprecated */
-			createFixtureWorkflow(fixtureKey: string, workflowName: string): void;
 			/** @deprecated use signinAsOwner, signinAsAdmin or signinAsMember instead */
 			signin(payload: SigninPayload): void;
 			signinAsOwner(): void;

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -33,9 +33,14 @@ declare global {
 			 */
 			createFixtureWorkflow(fixtureKey: string, workflowName?: string): void;
 			/** @deprecated */
+			createFixtureWorkflow(fixtureKey: string, workflowName: string): void;
+			/** @deprecated use signinAsOwner, signinAsAdmin or signinAsMember instead */
 			signin(payload: SigninPayload): void;
 			signinAsOwner(): void;
 			signinAsAdmin(): void;
+			/**
+			 * Omitting the index will default to index 0.
+			 */
 			signinAsMember(index?: number): void;
 			signout(): void;
 			overrideSettings(value: Partial<IN8nUISettings>): void;

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -52,6 +52,14 @@ export class CredentialsController {
 		});
 	}
 
+	@Get('/for-workflow')
+	async getProjectCredentials(req: CredentialRequest.ForWorkflow) {
+		const options = z
+			.union([z.object({ workflowId: z.string() }), z.object({ projectId: z.string() })])
+			.parse(req.query);
+		return await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(req.user, options);
+	}
+
 	@Get('/new')
 	async generateUniqueName(req: CredentialRequest.NewName) {
 		const requestedName = req.query.name ?? config.getEnv('credentials.defaultName');

--- a/packages/cli/src/databases/repositories/credentials.repository.ts
+++ b/packages/cli/src/databases/repositories/credentials.repository.ts
@@ -1,12 +1,18 @@
 import { Service } from 'typedi';
 import { DataSource, In, Repository, Like } from '@n8n/typeorm';
-import type { FindManyOptions } from '@n8n/typeorm';
+import type { FindManyOptions, FindOptionsWhere } from '@n8n/typeorm';
 import { CredentialsEntity } from '../entities/CredentialsEntity';
 import type { ListQuery } from '@/requests';
+import type { User } from '../entities/User';
+import type { Scope } from '@n8n/permissions';
+import { RoleService } from '@/services/role.service';
 
 @Service()
 export class CredentialsRepository extends Repository<CredentialsEntity> {
-	constructor(dataSource: DataSource) {
+	constructor(
+		dataSource: DataSource,
+		readonly roleService: RoleService,
+	) {
 		super(CredentialsEntity, dataSource.manager);
 	}
 
@@ -81,5 +87,65 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		}
 
 		return await this.find(findManyOptions);
+	}
+
+	/**
+	 * Find all credentials that are owned by a personal project.
+	 */
+	async findAllPersonalCredentials(): Promise<CredentialsEntity[]> {
+		return await this.findBy({ shared: { project: { type: 'personal' } } });
+	}
+
+	/**
+	 * Find all credentials that are part of any project that the workflow is
+	 * part of.
+	 *
+	 * This is useful to for finding credentials that can be used in the
+	 * workflow.
+	 */
+	async findAllCredentialsForWorkflow(workflowId: string): Promise<CredentialsEntity[]> {
+		return await this.findBy({
+			shared: { project: { sharedWorkflows: { workflowId } } },
+		});
+	}
+
+	/**
+	 * Find all credentials that are part of that project.
+	 *
+	 * This is useful for finding credentials that can be used in workflows that
+	 * are part of this project.
+	 */
+	async findAllCredentialsForProject(projectId: string): Promise<CredentialsEntity[]> {
+		return await this.findBy({ shared: { projectId } });
+	}
+
+	/**
+	 * Find all credentials that the user has access to taking the scopes into
+	 * account.
+	 *
+	 * This also returns `credentials.shared` which is useful for constructing
+	 * all scopes the user has for the credential using `RoleService.addScopes`.
+	 **/
+	async findCredentialsForUser(user: User, scopes: Scope[]) {
+		let where: FindOptionsWhere<CredentialsEntity> = {};
+
+		if (!user.hasGlobalScope(scopes, { mode: 'allOf' })) {
+			const projectRoles = this.roleService.rolesWithScope('project', scopes);
+			const credentialRoles = this.roleService.rolesWithScope('credential', scopes);
+			where = {
+				...where,
+				shared: {
+					role: In(credentialRoles),
+					project: {
+						projectRelations: {
+							role: In(projectRoles),
+							userId: user.id,
+						},
+					},
+				},
+			};
+		}
+
+		return await this.find({ where, relations: { shared: true } });
 	}
 }

--- a/packages/cli/src/databases/repositories/user.repository.ts
+++ b/packages/cli/src/databases/repositories/user.repository.ts
@@ -150,4 +150,36 @@ export class UserRepository extends Repository<User> {
 		// This is blocked by TypeORM having concurrency issues with transactions
 		return await createInner(this.manager);
 	}
+
+	/**
+	 * Find the user that owns the personal project that owns the workflow.
+	 *
+	 * Returns null if the workflow does not exist or is owned by a team project.
+	 */
+	async findPersonalOwnerForWorkflow(workflowId: string): Promise<User | null> {
+		return await this.findOne({
+			where: {
+				projectRelations: {
+					role: 'project:personalOwner',
+					project: { sharedWorkflows: { workflowId, role: 'workflow:owner' } },
+				},
+			},
+		});
+	}
+
+	/**
+	 * Find the user that owns the personal project.
+	 *
+	 * Returns null if the project does not exist or is not a personal project.
+	 */
+	async findPersonalOwnerForProject(projectId: string): Promise<User | null> {
+		return await this.findOne({
+			where: {
+				projectRelations: {
+					role: 'project:personalOwner',
+					projectId,
+				},
+			},
+		});
+	}
 }

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -24,6 +24,7 @@ import type { WorkflowHistory } from '@db/entities/WorkflowHistory';
 import type { Project, ProjectType } from '@db/entities/Project';
 import type { ProjectRole } from './databases/entities/ProjectRelation';
 import type { Scope } from '@n8n/permissions';
+import type { ScopesField } from './services/role.service';
 
 export class UserUpdatePayload implements Pick<User, 'email' | 'firstName' | 'lastName'> {
 	@Expose()
@@ -125,8 +126,6 @@ export namespace ListQuery {
 
 		type OwnedByField = { ownedBy: SlimUser | null; homeProject: SlimProject | null };
 
-		type ScopesField = { scopes: Scope[] };
-
 		export type Plain = BaseFields;
 
 		export type WithSharing = BaseFields & SharedField;
@@ -149,8 +148,6 @@ export namespace ListQuery {
 		type SharedField = Partial<Pick<CredentialsEntity, 'shared'>>;
 
 		type SharedWithField = { sharedWithProjects: SlimProject[] };
-
-		type ScopesField = { scopes: Scope[] };
 
 		export type WithSharing = CredentialsEntity & SharedField;
 
@@ -222,6 +219,13 @@ export declare namespace CredentialRequest {
 		{ credentialId: string },
 		{},
 		{ destinationProjectId: string }
+	>;
+
+	type ForWorkflow = AuthenticatedRequest<
+		{},
+		{},
+		{},
+		{ workflowId: string } | { projectId: string }
 	>;
 }
 

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -27,6 +27,7 @@ import { combineScopes, type Resource, type Scope } from '@n8n/permissions';
 import { Service } from 'typedi';
 import { ApplicationError } from 'n8n-workflow';
 import { License } from '@/License';
+import type { CredentialsEntity } from '@/databases/entities/CredentialsEntity';
 
 export type RoleNamespace = 'global' | 'project' | 'credential' | 'workflow';
 
@@ -96,6 +97,8 @@ const ROLE_NAMES: Record<
 	'workflow:editor': 'Workflow Editor',
 };
 
+export type ScopesField = { scopes: Scope[] };
+
 @Service()
 export class RoleService {
 	constructor(private readonly license: License) {}
@@ -158,6 +161,11 @@ export class RoleService {
 		userProjectRelations: ProjectRelation[],
 	): ListQuery.Workflow.WithScopes;
 	addScopes(
+		rawCredential: CredentialsEntity,
+		user: User,
+		userProjectRelations: ProjectRelation[],
+	): CredentialsEntity & ScopesField;
+	addScopes(
 		rawCredential:
 			| ListQuery.Credentials.WithSharing
 			| ListQuery.Credentials.WithOwnedByAndSharedWith,
@@ -166,13 +174,17 @@ export class RoleService {
 	): ListQuery.Credentials.WithScopes;
 	addScopes(
 		rawEntity:
+			| CredentialsEntity
 			| ListQuery.Workflow.WithSharing
 			| ListQuery.Credentials.WithOwnedByAndSharedWith
 			| ListQuery.Credentials.WithSharing
 			| ListQuery.Workflow.WithOwnedByAndSharedWith,
 		user: User,
 		userProjectRelations: ProjectRelation[],
-	): ListQuery.Workflow.WithScopes | ListQuery.Credentials.WithScopes {
+	):
+		| (CredentialsEntity & ScopesField)
+		| ListQuery.Workflow.WithScopes
+		| ListQuery.Credentials.WithScopes {
 		const shared = rawEntity.shared;
 		const entity = rawEntity as ListQuery.Workflow.WithScopes | ListQuery.Credentials.WithScopes;
 

--- a/packages/editor-ui/src/api/credentials.ts
+++ b/packages/editor-ui/src/api/credentials.ts
@@ -36,6 +36,15 @@ export async function getAllCredentials(
 	});
 }
 
+export async function getAllCredentialsForWorkflow(
+	context: IRestApiContext,
+	options: { workflowId: string } | { projectId: string },
+): Promise<ICredentialsResponse[]> {
+	return await makeRestApiRequest(context, 'GET', '/credentials/for-workflow', {
+		...options,
+	});
+}
+
 export async function createNewCredential(
 	context: IRestApiContext,
 	data: ICredentialsDecrypted,

--- a/packages/editor-ui/src/api/projects.api.ts
+++ b/packages/editor-ui/src/api/projects.api.ts
@@ -1,4 +1,4 @@
-import type { IRestApiContext } from '@/Interface';
+import type { ICredentialsResponse, IRestApiContext } from '@/Interface';
 import { makeRestApiRequest } from '@/utils/apiUtils';
 import type {
 	Project,
@@ -25,6 +25,13 @@ export const getPersonalProject = async (context: IRestApiContext): Promise<Proj
 export const getProject = async (context: IRestApiContext, id: string): Promise<Project> => {
 	return await makeRestApiRequest(context, 'GET', `/projects/${id}`);
 };
+
+export async function getAllCredentialsAUserCanUseInAWorkflow(
+	context: IRestApiContext,
+	projectId: string,
+): Promise<Array<Pick<ICredentialsResponse, 'id' | 'name'>>> {
+	return await makeRestApiRequest(context, 'GET', `/projects/${projectId}/credentials`);
+}
 
 export const createProject = async (
 	context: IRestApiContext,

--- a/packages/editor-ui/src/api/projects.api.ts
+++ b/packages/editor-ui/src/api/projects.api.ts
@@ -1,4 +1,4 @@
-import type { ICredentialsResponse, IRestApiContext } from '@/Interface';
+import type { IRestApiContext } from '@/Interface';
 import { makeRestApiRequest } from '@/utils/apiUtils';
 import type {
 	Project,
@@ -25,13 +25,6 @@ export const getPersonalProject = async (context: IRestApiContext): Promise<Proj
 export const getProject = async (context: IRestApiContext, id: string): Promise<Project> => {
 	return await makeRestApiRequest(context, 'GET', `/projects/${id}`);
 };
-
-export async function getAllCredentialsAUserCanUseInAWorkflow(
-	context: IRestApiContext,
-	projectId: string,
-): Promise<Array<Pick<ICredentialsResponse, 'id' | 'name'>>> {
-	return await makeRestApiRequest(context, 'GET', `/projects/${projectId}/credentials`);
-}
 
 export const createProject = async (
 	context: IRestApiContext,

--- a/packages/editor-ui/src/components/Projects/ProjectSettings.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectSettings.vue
@@ -262,6 +262,7 @@ onBeforeMount(async () => {
 					v-model="formData.name"
 					type="text"
 					name="name"
+					data-test-id="project-settings-name-input"
 					@input="onNameInput"
 				/>
 			</fieldset>

--- a/packages/editor-ui/src/stores/credentials.store.ts
+++ b/packages/editor-ui/src/stores/credentials.store.ts
@@ -11,6 +11,7 @@ import {
 	createNewCredential,
 	deleteCredential,
 	getAllCredentials,
+	getAllCredentialsForWorkflow,
 	getCredentialData,
 	getCredentialsNewName,
 	getCredentialTypes,
@@ -259,6 +260,15 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, {
 				isEmpty(filter) ? undefined : filter,
 				includeScopes,
 			);
+			this.setCredentials(credentials);
+			return credentials;
+		},
+		async fetchAllCredentialsForWorkflow(
+			options: { workflowId: string } | { projectId: string },
+		): Promise<ICredentialsResponse[]> {
+			const rootStore = useRootStore();
+
+			const credentials = await getAllCredentialsForWorkflow(rootStore.getRestApiContext, options);
 			this.setCredentials(credentials);
 			return credentials;
 		},

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -398,7 +398,6 @@ import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { useRunWorkflow } from '@/composables/useRunWorkflow';
 import { useProjectsStore } from '@/stores/projects.store';
 import type { ProjectSharingData } from '@/types/projects.types';
-import { ProjectTypes } from '@/types/projects.types';
 import { useAIStore } from '@/stores/ai.store';
 import { useStorage } from '@/composables/useStorage';
 import { isJSPlumbEndpointElement, isJSPlumbConnection } from '@/utils/typeGuards';
@@ -4815,7 +4814,7 @@ export default defineComponent({
 					);
 				}
 
-				options = { projectId: projectId };
+				options = { projectId };
 			}
 			await this.credentialsStore.fetchAllCredentialsForWorkflow(options);
 		},

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4798,20 +4798,26 @@ export default defineComponent({
 		},
 		async loadCredentials(): Promise<void> {
 			const workflow = this.workflowsStore.getWorkflowById(this.currentWorkflow);
-			let projectId: string | undefined;
+			let options: { workflowId: string } | { projectId: string };
+
 			if (workflow) {
-				projectId =
-					workflow.homeProject?.type === ProjectTypes.Personal
-						? this.projectsStore.personalProject?.id
-						: workflow?.homeProject?.id ?? this.projectsStore.currentProjectId;
+				options = { workflowId: workflow.id };
 			} else {
 				const queryParam =
 					typeof this.$route.query?.projectId === 'string'
 						? this.$route.query?.projectId
 						: undefined;
-				projectId = queryParam ?? this.projectsStore.personalProject?.id;
+				const projectId = queryParam ?? this.projectsStore.personalProject?.id;
+
+				if (projectId === undefined) {
+					throw new Error(
+						'Could not find projectId in the query nor could I find the personal project in the project store',
+					);
+				}
+
+				options = { projectId: projectId };
 			}
-			await this.credentialsStore.fetchAllCredentials(projectId, false);
+			await this.credentialsStore.fetchAllCredentialsForWorkflow(options);
 		},
 		async loadVariables(): Promise<void> {
 			await this.environmentsStore.fetchAllVariables();


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

With the introduction of projects and RBAC we've been having issues with rendering the correct list of credentials for nodes in workflows in personal projects. We've patched `GET /credentials` multiple times to get it right and each time broke some edge case:
https://github.com/n8n-io/n8n/pull/9396
https://github.com/n8n-io/n8n/pull/9615
https://github.com/n8n-io/n8n/pull/9678

This PR introduces a new route that returns all credentials a user can use is a
specific workflow or project.

This route is used by the Node View and Node Credentials drop down.
They are not using the `GET /credentials` endpoint anymore, because they return

- either all credentials a user have access to,
- or all credentials a user have access to filtered by project.

But the credentials that a user can add to nodes in a workflow have further restrictions.
The new endpoint returns all credentials that the workflow can use when executing AND to which the user has access to.

For workflows in team project that's simple: It's only the credentials that exist in that project. Even having global read permissions does not circumvent this.

For workflows in personal projects it becomes more complex due to point to point sharing:
![Untitled-2024-01-25-1160](https://github.com/n8n-io/n8n/assets/927609/2c9a86e3-7c48-40e2-b763-3c2e249fc719)
The y axis is the global role of the user, the x axis describes their relation ship to the workflow, either they have no relationship, the workflow was shared with them, or they own the workflow.

The new endpoint first gets all credentials the user has access to, then all the credentials the workflow can use and then returns the intersection of both.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1661/bug-cant-choose-the-right-credentials-in-a-personal-wf-as-an-owner-or

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
             **Remember, the title automatically goes into the changelog.
             Use `(no-changelog)` otherwise.**
          -->
- [x] Tests included. <!--
             A bug is not considered fixed, unless a test is added to prevent it from happening again.
             A feature is not complete without tests.
          -->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
