### PR TITLE
fix(SalesforceTrigger Node): Add missing codex (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/SalesforceTrigger.node.json
+++ b/packages/nodes-base/nodes/Salesforce/SalesforceTrigger.node.json
@@ -1,0 +1,18 @@
+{
+	"node": "n8n-nodes-base.salesforceTrigger",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["Sales", "Communication"],
+	"resources": {
+		"credentialDocumentation": [
+			{
+				"url": "https://docs.n8n.io/credentials/salesforce"
+			}
+		],
+		"primaryDocumentation": [
+			{
+				"url": "https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.salesforcetrigger/"
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary
Every node should have a valid codex, either as a separate `.node.json` file, or in the node description. 
But looks like [we forgot to add one for this node](https://github.com/n8n-io/n8n/pull/8920).

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1233/salesforce-trigger-node-new-node

## Review / Merge checklist

- [x] PR title and summary are descriptive
