### PR TITLE
refactor(editor): Translate sidebar "Help" label (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -270,7 +270,7 @@ export default defineComponent({
 				{
 					id: 'help',
 					icon: 'question',
-					label: 'Help',
+					label: this.$locale.baseText('mainSidebar.help'),
 					position: 'bottom',
 					children: [
 						{


### PR DESCRIPTION
## Summary

This PR translates one more item from the Main Sidebar, the "Help" label. It was in hard-coded English, but the "Help" item for the sidebar is in the translations file, so it was changed to make It ready for future translations (when n8n supports it broadly).

## Related Linear tickets, Github issues, and Community forum posts

No, I struggled with it in personal translations and thought it would be nice to be translation-ready.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
