### PR TITLE
refactor(editor): Migrate ErrorView component to Vue 3 (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/ErrorView.vue
+++ b/packages/editor-ui/src/views/ErrorView.vue
@@ -17,34 +17,22 @@
 	</div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import type { BaseTextKey } from '@/plugins/i18n';
-import { type PropType, defineComponent } from 'vue';
+import { useRouter } from 'vue-router';
+import { VIEWS } from '@/constants';
+const router = useRouter();
 
-export default defineComponent({
-	name: 'ErrorView',
-	props: {
-		messageKey: {
-			type: String as PropType<BaseTextKey>,
-			required: true,
-		},
-		errorCode: {
-			type: Number,
-		},
-		redirectTextKey: {
-			type: String as PropType<BaseTextKey>,
-			required: true,
-		},
-		redirectPage: {
-			type: String,
-		},
-	},
-	methods: {
-		onButtonClick() {
-			void this.$router.push({ name: this.redirectPage });
-		},
-	},
-});
+const props = defineProps<{
+	messageKey: BaseTextKey;
+	errorCode: number;
+	redirectTextKey: BaseTextKey;
+	redirectPage?: keyof typeof VIEWS;
+}>();
+
+function onButtonClick() {
+	void router.push({ name: props.redirectPage ?? VIEWS.HOMEPAGE });
+}
 </script>
 
 <style lang="scss" module>


### PR DESCRIPTION
## Summary
Migrate ErrroVewi.vue to Vue 3 script setup syntax. 

## Related Linear tickets, Github issues, and Community forum posts
- https://www.notion.so/n8n/WIP-Move-to-only-Composition-API-5915b347b1a242789cec01be53e222cf#89c8aa083e88423cbd50d0058ee0b6fe

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
