### PR TITLE
refactor: Migrate `ResizeObserver` to composition API (no-changelog)

### DIFF
--- a/packages/design-system/src/components/ResizeObserver/ResizeObserver.vue
+++ b/packages/design-system/src/components/ResizeObserver/ResizeObserver.vue
@@ -1,9 +1,3 @@
-<template>
-	<div ref="root">
-		<slot :bp="breakpoint"></slot>
-	</div>
-</template>
-
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, computed } from 'vue';
 
@@ -61,3 +55,9 @@ onBeforeUnmount(() => {
 	}
 });
 </script>
+
+<template>
+	<div ref="root">
+		<slot :bp="breakpoint"></slot>
+	</div>
+</template>

--- a/packages/design-system/src/components/ResizeObserver/ResizeObserver.vue
+++ b/packages/design-system/src/components/ResizeObserver/ResizeObserver.vue
@@ -1,86 +1,63 @@
 <template>
 	<div ref="root">
-		<slot :bp="bp"></slot>
+		<slot :bp="breakpoint"></slot>
 	</div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue';
 
-export default defineComponent({
-	name: 'ResizeObserver',
-	props: {
-		enabled: {
-			type: Boolean,
-			default: true,
-		},
-		breakpoints: {
-			type: Array,
-			validator: (bps: Array<{ bp: string; width: number }>) => {
-				return (
-					Array.isArray(bps) &&
-					bps.reduce(
-						(accu, { width, bp }) => accu && typeof width === 'number' && typeof bp === 'string',
-						true,
-					)
-				);
-			},
-		},
+export type BreakpointDefinition = { bp: string; width: number };
+
+const props = defineProps({
+	enabled: {
+		type: Boolean,
+		default: true,
 	},
-	data(): { observer: ResizeObserver | null; bp: string } {
-		return {
-			observer: null,
-			bp: '',
-		};
+	breakpoints: {
+		type: Array as () => BreakpointDefinition[],
+		validator: (breakpoints: BreakpointDefinition[]) => {
+			if (breakpoints.length === 0) return true;
+
+			return breakpoints.every((bp) => typeof bp.width === 'number' && typeof bp.bp === 'string');
+		},
+		default: () => [],
 	},
-	mounted() {
-		if (!this.enabled) {
-			return;
-		}
+});
 
-		const root = this.$refs.root as HTMLDivElement;
+const observer = ref<ResizeObserver | null>(null);
+const breakpoint = ref('');
+const root = ref<HTMLDivElement | null>(null);
 
-		if (!root) {
-			return;
-		}
+const sortedBreakpoints = computed(() => [...props.breakpoints].sort((a, b) => a.width - b.width));
 
-		this.bp = this.getBreakpointFromWidth(root.offsetWidth);
+const getBreakpointFromWidth = (width: number): string => {
+	return (
+		sortedBreakpoints.value.find((sortedBreakpoint) => width < sortedBreakpoint.width)?.bp ??
+		'default'
+	);
+};
 
-		const observer = new ResizeObserver((entries) => {
-			entries.forEach((entry) => {
-				// We wrap it in requestAnimationFrame to avoid this error - ResizeObserver loop limit exceeded
-				requestAnimationFrame(() => {
-					this.bp = this.getBreakpointFromWidth(entry.contentRect.width);
-				});
+onMounted(() => {
+	if (!props.enabled) return;
+	if (!root.value) return;
+
+	breakpoint.value = getBreakpointFromWidth(root.value.offsetWidth);
+
+	observer.value = new ResizeObserver((entries) => {
+		entries.forEach((entry) => {
+			requestAnimationFrame(() => {
+				breakpoint.value = getBreakpointFromWidth(entry.contentRect.width);
 			});
 		});
+	});
 
-		this.observer = observer;
-		observer.observe(root);
-	},
-	beforeUnmount() {
-		if (this.enabled) {
-			this.observer?.disconnect();
-		}
-	},
-	methods: {
-		getBreakpointFromWidth(width: number): string {
-			let newBP = 'default';
-			const unsortedBreakpoints = [...(this.breakpoints || [])] as Array<{
-				width: number;
-				bp: string;
-			}>;
+	observer.value.observe(root.value);
+});
 
-			const bps = unsortedBreakpoints.sort((a, b) => a.width - b.width);
-			for (let i = 0; i < bps.length; i++) {
-				if (width < bps[i].width) {
-					newBP = bps[i].bp;
-					break;
-				}
-			}
-
-			return newBP;
-		},
-	},
+onBeforeUnmount(() => {
+	if (observer.value) {
+		observer.value.disconnect();
+	}
 });
 </script>


### PR DESCRIPTION
## Summary

Migrate `ResizeObserver` to composition API 

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
