### PR TITLE
refactor(editor): Migrate `SettingsView` to composition api (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/typeGuards.ts
+++ b/packages/editor-ui/src/utils/typeGuards.ts
@@ -8,6 +8,7 @@ import { nodeConnectionTypes } from 'n8n-workflow';
 import type { IExecutionResponse, ICredentialsResponse, NewCredentialsModal } from '@/Interface';
 import type { jsPlumbDOMElement } from '@jsplumb/browser-ui';
 import type { Connection } from '@jsplumb/core';
+import type { RouteLocationRaw } from 'vue-router';
 
 /*
 	Type guards used in editor-ui project
@@ -78,4 +79,11 @@ export function isFullExecutionResponse(
 	execution: IExecutionResponse | null,
 ): execution is IExecutionResponse {
 	return !!execution && 'status' in execution;
+}
+
+export function isRouteLocationRaw(value: unknown): value is RouteLocationRaw {
+	return (
+		typeof value === 'string' ||
+		(typeof value === 'object' && value !== null && ('name' in value || 'path' in value))
+	);
 }

--- a/packages/editor-ui/src/views/SettingsView.vue
+++ b/packages/editor-ui/src/views/SettingsView.vue
@@ -1,3 +1,26 @@
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue';
+import type { HistoryState } from 'vue-router';
+import { useRouter } from 'vue-router';
+import { VIEWS } from '@/constants';
+import SettingsSidebar from '@/components/SettingsSidebar.vue';
+import { isRouteLocationRaw } from '@/utils/typeGuards';
+
+const router = useRouter();
+
+const previousRoute = ref<HistoryState[string] | undefined>();
+
+function onReturn() {
+	void router.push(
+		isRouteLocationRaw(previousRoute.value) ? previousRoute.value : { name: VIEWS.HOMEPAGE },
+	);
+}
+
+onMounted(() => {
+	previousRoute.value = router.options.history.state.back;
+});
+</script>
+
 <template>
 	<div :class="$style.container">
 		<SettingsSidebar @return="onReturn" />
@@ -12,40 +35,6 @@
 		</div>
 	</div>
 </template>
-
-<script lang="ts">
-import { defineComponent } from 'vue';
-import type { RouteLocationPathRaw } from 'vue-router';
-
-import { VIEWS } from '@/constants';
-import SettingsSidebar from '@/components/SettingsSidebar.vue';
-
-const SettingsView = defineComponent({
-	name: 'SettingsView',
-	components: {
-		SettingsSidebar,
-	},
-	beforeRouteEnter(_to, from, next) {
-		next((vm) => {
-			(vm as unknown as InstanceType<typeof SettingsView>).previousRoute = from;
-		});
-	},
-	data() {
-		return {
-			previousRoute: null as RouteLocationPathRaw | null,
-		};
-	},
-	methods: {
-		onReturn() {
-			void this.$router.push(
-				this.previousRoute ? this.previousRoute.path : { name: VIEWS.HOMEPAGE },
-			);
-		},
-	},
-});
-
-export default SettingsView;
-</script>
 
 <style lang="scss" module>
 .container {


### PR DESCRIPTION
## Summary

Migrate `SettingsView` to composition api.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
