### PR TITLE
refactor: Migrate sizes to composition api (no-changelog)

### DIFF
--- a/packages/design-system/src/styleguide/Sizes.vue
+++ b/packages/design-system/src/styleguide/Sizes.vue
@@ -1,22 +1,3 @@
-<template>
-	<table :class="$style.table">
-		<tr>
-			<th :class="$style.row">Name</th>
-			<th :class="$style.row">rem</th>
-			<th :class="$style.row">px</th>
-		</tr>
-		<tr
-			v-for="variable in variables"
-			:key="variable"
-			:style="attr ? { [attr]: `var(${variable})` } : {}"
-		>
-			<td>{{ variable }}</td>
-			<td>{{ sizes[variable].rem }}</td>
-			<td>{{ sizes[variable].px }}</td>
-		</tr>
-	</table>
-</template>
-
 <script lang="ts">
 import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
@@ -75,6 +56,25 @@ export default defineComponent({
 	},
 });
 </script>
+
+<template>
+	<table :class="$style.table">
+		<tr>
+			<th :class="$style.row">Name</th>
+			<th :class="$style.row">rem</th>
+			<th :class="$style.row">px</th>
+		</tr>
+		<tr
+			v-for="variable in variables"
+			:key="variable"
+			:style="attr ? { [attr]: `var(${variable})` } : {}"
+		>
+			<td>{{ variable }}</td>
+			<td>{{ sizes[variable].rem }}</td>
+			<td>{{ sizes[variable].px }}</td>
+		</tr>
+	</table>
+</template>
 
 <style lang="scss" module>
 .table {


### PR DESCRIPTION
## Summary

Migrate `Sizes` to composition API

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
