### PR TITLE
refactor: Migrate `FormInputs` to composition API (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nFormBox/FormBox.vue
+++ b/packages/design-system/src/components/N8nFormBox/FormBox.vue
@@ -56,6 +56,8 @@ interface FormBoxProps {
 	redirectLink?: string;
 }
 
+type Value = string | number | boolean | null | undefined;
+
 defineOptions({ name: 'N8nFormBox' });
 withDefaults(defineProps<FormBoxProps>(), {
 	title: '',
@@ -68,8 +70,8 @@ withDefaults(defineProps<FormBoxProps>(), {
 const formBus = createEventBus();
 const $emit = defineEmits(['submit', 'update', 'secondaryClick']);
 
-const onUpdateModelValue = (e: { name: string; value: string }) => $emit('update', e);
-const onSubmit = (e: { [key: string]: string }) => $emit('submit', e);
+const onUpdateModelValue = (e: { name: string; value: Value }) => $emit('update', e);
+const onSubmit = (e: { [key: string]: Value }) => $emit('submit', e);
 const onButtonClick = () => formBus.emit('submit');
 const onSecondaryButtonClick = (event: Event) => $emit('secondaryClick', event);
 </script>


### PR DESCRIPTION
## Summary

Migrate `FormInputs` to composition API

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
