### PR TITLE
fix(core)!: `$(...).[last,first,all]()` defaulting to the first output instead of the output that connects the nodes

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,7 +2,7 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
-## 1.46.0
+## 1.47.0
 
 ### What changed?
 

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,18 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.46.0
+
+### What changed?
+
+Calling `$(...).last()` (or `$(...).first()` or `$(...).all()` respectively) without arguments is returning the the last item (or first or all items) of the output that connects the two nodes. Before it was returning the item/items of the first output of that node.
+
+### When is action necessary?
+
+If you are using `$(...).last()` (or `$(...).first()` or `$(...)all()` respectively) without arguments for nodes that have multiple outputs (e.g. `If`, `Switch`, `Compare Datasets`, etc.) and you want it to default to the first output. In that case change it to `$(...).last(0)` (or `first` or `all` respectively).
+
+This does not affect the Array functions `[].last()`, `[].first()`.
+
 ## 1.40.0
 
 ### What changed?

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -619,18 +619,9 @@ export class WorkflowDataProxy {
 	getDataProxy(): IWorkflowDataProxyData {
 		const that = this;
 
-		const getNodeOutput = (nodeName?: string, branchIndex?: number, runIndex?: number) => {
-			let executionData: INodeExecutionData[];
-
-			if (nodeName === undefined) {
-				executionData = that.connectionInputData;
-			} else {
-				branchIndex = branchIndex || 0;
-				runIndex = runIndex === undefined ? -1 : runIndex;
-				executionData = that.getNodeExecutionData(nodeName, false, branchIndex, runIndex);
-			}
-
-			return executionData;
+		const getNodeOutput = (nodeName: string, branchIndex: number, runIndex?: number) => {
+			runIndex = runIndex === undefined ? -1 : runIndex;
+			return that.getNodeExecutionData(nodeName, false, branchIndex, runIndex);
 		};
 
 		// replacing proxies with the actual data.
@@ -1073,6 +1064,12 @@ export class WorkflowDataProxy {
 							if (property === 'first') {
 								ensureNodeExecutionData();
 								return (branchIndex?: number, runIndex?: number) => {
+									branchIndex =
+										branchIndex ??
+										// default to the output the active node is connected to
+										that.workflow.getNodeConnectionIndexes(that.activeNodeName, nodeName)
+											?.sourceIndex ??
+										0;
 									const executionData = getNodeOutput(nodeName, branchIndex, runIndex);
 									if (executionData[0]) return executionData[0];
 									return undefined;
@@ -1081,6 +1078,12 @@ export class WorkflowDataProxy {
 							if (property === 'last') {
 								ensureNodeExecutionData();
 								return (branchIndex?: number, runIndex?: number) => {
+									branchIndex =
+										branchIndex ??
+										// default to the output the active node is connected to
+										that.workflow.getNodeConnectionIndexes(that.activeNodeName, nodeName)
+											?.sourceIndex ??
+										0;
 									const executionData = getNodeOutput(nodeName, branchIndex, runIndex);
 									if (!executionData.length) return undefined;
 									if (executionData[executionData.length - 1]) {
@@ -1091,8 +1094,15 @@ export class WorkflowDataProxy {
 							}
 							if (property === 'all') {
 								ensureNodeExecutionData();
-								return (branchIndex?: number, runIndex?: number) =>
-									getNodeOutput(nodeName, branchIndex, runIndex);
+								return (branchIndex?: number, runIndex?: number) => {
+									branchIndex =
+										branchIndex ??
+										// default to the output the active node is connected to
+										that.workflow.getNodeConnectionIndexes(that.activeNodeName, nodeName)
+											?.sourceIndex ??
+										0;
+									return getNodeOutput(nodeName, branchIndex, runIndex);
+								};
 							}
 							if (property === 'context') {
 								return that.nodeContextGetter(nodeName);

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -53,6 +53,46 @@ const getProxyFromFixture = (workflow: IWorkflowBase, run: IRun | null, activeNo
 };
 
 describe('WorkflowDataProxy', () => {
+	describe('$(If))', () => {
+		const fixture = loadFixture('multiple_outputs');
+		const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'Edit Fields');
+
+		test('last() should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').last().json.code).toEqual(2);
+		});
+
+		test('last(0) should use the first output', () => {
+			expect(proxy.$('If').last(0)).toBeUndefined();
+		});
+
+		test('last(1) should use the second output', () => {
+			expect(proxy.$('If').last(1).json.code).toEqual(2);
+		});
+
+		test('first() should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').first().json.code).toEqual(1);
+		});
+		test('first(0) should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').first(0)).toBeUndefined();
+		});
+		test('first(1) should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').first(1).json.code).toEqual(1);
+		});
+
+		test('all() should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').all()[0].json.code).toEqual(1);
+			expect(proxy.$('If').all()[1].json.code).toEqual(2);
+		});
+		test('all(0) should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').all(0)[0]).toBeUndefined();
+			expect(proxy.$('If').all(0)[1]).toBeUndefined();
+		});
+		test('all(1) should use the output the node is connected to by default', () => {
+			expect(proxy.$('If').all(1)[0].json.code).toEqual(1);
+			expect(proxy.$('If').all(1)[1].json.code).toEqual(2);
+		});
+	});
+
 	describe('Base', () => {
 		const fixture = loadFixture('base');
 		const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'End');

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/multiple_outputs_run.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/multiple_outputs_run.json
@@ -1,0 +1,84 @@
+{
+	"data": {
+		"startData": {},
+		"resultData": {
+			"runData": {
+				"When clicking ‘Test workflow’": [
+					{
+						"hints": [],
+						"startTime": 1718369813697,
+						"executionTime": 0,
+						"source": [],
+						"executionStatus": "success",
+						"data": {
+							"main": [
+								[
+									{
+										"json": {
+											"name": "First item",
+											"code": 1
+										},
+										"pairedItem": {
+											"item": 0
+										}
+									},
+									{
+										"json": {
+											"name": "Second item",
+											"code": 2
+										},
+										"pairedItem": {
+											"item": 0
+										}
+									}
+								]
+							]
+						}
+					}
+				],
+				"If": [
+					{
+						"hints": [],
+						"startTime": 1718369813698,
+						"executionTime": 1,
+						"source": [
+							{
+								"previousNode": "When clicking ‘Test workflow’"
+							}
+						],
+						"executionStatus": "success",
+						"data": {
+							"main": [
+								[],
+								[
+									{
+										"json": {
+											"name": "First item",
+											"code": 1
+										},
+										"pairedItem": {
+											"item": 0
+										}
+									},
+									{
+										"json": {
+											"name": "Second item",
+											"code": 2
+										},
+										"pairedItem": {
+											"item": 1
+										}
+									}
+								]
+							]
+						}
+					}
+				]
+			}
+		}
+	},
+	"mode": "manual",
+	"startedAt": "2024-02-08T15:45:18.848Z",
+	"stoppedAt": "2024-02-08T15:45:18.862Z",
+	"status": "running"
+}

--- a/packages/workflow/test/fixtures/WorkflowDataProxy/multiple_outputs_workflow.json
+++ b/packages/workflow/test/fixtures/WorkflowDataProxy/multiple_outputs_workflow.json
@@ -1,0 +1,84 @@
+{
+	"meta": {
+		"instanceId": "060d2be233778dc6349e0f3fa8d972652e8dff467638325ffc56812c6b66ef1a"
+	},
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "656d6d8d-1af6-4af7-ab53-7c4e495ee51c",
+			"name": "When clicking ‘Test workflow’",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-300, 1880]
+		},
+		{
+			"parameters": {
+				"conditions": {
+					"options": {
+						"caseSensitive": true,
+						"leftValue": "",
+						"typeValidation": "strict"
+					},
+					"conditions": [
+						{
+							"id": "1fff886f-3d13-4fbf-b0fb-7e2f845937c0",
+							"leftValue": "={{ false }}",
+							"rightValue": "",
+							"operator": {
+								"type": "boolean",
+								"operation": "true",
+								"singleValue": true
+							}
+						}
+					],
+					"combinator": "and"
+				},
+				"options": {}
+			},
+			"id": "204feab7-f5e9-458f-8fdb-4b762b184147",
+			"name": "If",
+			"type": "n8n-nodes-base.if",
+			"typeVersion": 2,
+			"position": [40, 1880]
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": []
+				},
+				"options": {}
+			},
+			"id": "ab122060-f8da-475e-b6c6-d9e486289e1f",
+			"name": "Edit Fields",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.3,
+			"position": [360, 2080]
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "If",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"If": {
+			"main": [
+				[],
+				[
+					{
+						"node": "Edit Fields",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}


### PR DESCRIPTION
## Summary

This PR makes `$(...).[last|first|all]()` default to the the output the node was connected to.

Before it would default to the first output.

<details><summary>Example Workflow</summary>
<p>

```json
{
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "6944c3a4f9d5af1d486eb3bd76ceeae78d947e96a0d9e6c404bb1bcec6a36054"
  },
  "nodes": [
    {
      "parameters": {
        "path": "e9586c98-e50e-43fb-9c6b-2ff1deaaa0c9",
        "options": {}
      },
      "id": "669a68fd-cc30-45ff-88f4-6a5455bcf66a",
      "name": "Webhook1",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2,
      "position": [
        180,
        700
      ],
      "webhookId": "e9586c98-e50e-43fb-9c6b-2ff1deaaa0c9"
    },
    {
      "parameters": {
        "conditions": {
          "options": {
            "caseSensitive": true,
            "leftValue": "",
            "typeValidation": "strict"
          },
          "conditions": [
            {
              "id": "1fff886f-3d13-4fbf-b0fb-7e2f845937c0",
              "leftValue": "={{ true }}",
              "rightValue": "",
              "operator": {
                "type": "boolean",
                "operation": "true",
                "singleValue": true
              }
            }
          ],
          "combinator": "and"
        },
        "options": {}
      },
      "id": "588e25bd-940c-498b-91e3-d768f45cc616",
      "name": "true",
      "type": "n8n-nodes-base.if",
      "typeVersion": 2,
      "position": [
        460,
        460
      ]
    },
    {
      "parameters": {
        "conditions": {
          "options": {
            "caseSensitive": true,
            "leftValue": "",
            "typeValidation": "strict"
          },
          "conditions": [
            {
              "id": "1fff886f-3d13-4fbf-b0fb-7e2f845937c0",
              "leftValue": "={{ false }}",
              "rightValue": "",
              "operator": {
                "type": "boolean",
                "operation": "true",
                "singleValue": true
              }
            }
          ],
          "combinator": "and"
        },
        "options": {}
      },
      "id": "dddc1d50-495c-403e-a17a-5305a3b277a8",
      "name": "false",
      "type": "n8n-nodes-base.if",
      "typeVersion": 2,
      "position": [
        460,
        660
      ]
    },
    {
      "parameters": {
        "conditions": {
          "options": {
            "caseSensitive": true,
            "leftValue": "",
            "typeValidation": "strict"
          },
          "conditions": [
            {
              "id": "1fff886f-3d13-4fbf-b0fb-7e2f845937c0",
              "leftValue": "={{ true }}",
              "rightValue": "",
              "operator": {
                "type": "boolean",
                "operation": "true",
                "singleValue": true
              }
            }
          ],
          "combinator": "and"
        },
        "options": {}
      },
      "id": "b794c9be-7d16-47fb-9a5d-d3816c44e247",
      "name": "false1",
      "type": "n8n-nodes-base.if",
      "typeVersion": 2,
      "position": [
        460,
        860
      ]
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "41531ffa-e84c-4843-a401-45b93d520f97",
              "name": "test",
              "value": "={{ $('false').last().json.code }}",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "id": "56928338-14d7-4e70-8979-d091fc8da23e",
      "name": "Edit fields 2",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.3,
      "position": [
        840,
        660
      ]
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "41531ffa-e84c-4843-a401-45b93d520f97",
              "name": "test",
              "value": "={{ $('true').last().json.code }}",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "id": "c71938b7-fe93-4a6a-8c90-10ef02f1d56f",
      "name": "Edit fields 1",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.3,
      "position": [
        840,
        460
      ]
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "41531ffa-e84c-4843-a401-45b93d520f97",
              "name": "test",
              "value": "={{ $('false1').last().json.code }}",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "id": "aab4f1c7-465b-474b-b769-4afd10232f1a",
      "name": "Edit fields 3",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.3,
      "position": [
        840,
        860
      ]
    }
  ],
  "connections": {
    "Webhook1": {
      "main": [
        [
          {
            "node": "true",
            "type": "main",
            "index": 0
          },
          {
            "node": "false",
            "type": "main",
            "index": 0
          },
          {
            "node": "false1",
            "type": "main",
            "index": 0
          },
          {
            "node": "Edit fields 3",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "true": {
      "main": [
        [
          {
            "node": "Edit fields 1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "false": {
      "main": [
        null,
        [
          {
            "node": "Edit fields 2",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "false1": {
      "main": [
        null,
        [
          {
            "node": "Edit fields 3",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {
    "Webhook1": [
      {
        "name": "First item",
        "code": 1
      },
      {
        "name": "Second item",
        "code": 2
      }
    ]
  }
}
```

</p>
</details> 

Before it would always evaluate output 0 (true branch) 
![image](https://github.com/n8n-io/n8n/assets/927609/658e2cb0-8f05-4f28-b8ad-7ae73db2ed50)

Now it will take the output that connects the nodes. If the user wants another output they'd have to specify if like `$(...).last(1)`
![image](https://github.com/n8n-io/n8n/assets/927609/8b1baaa6-7f7a-4faa-ae7f-a3ed04403c81)

Workflows that rely on something like the third example will break with this change.
Workflows that rely on `last`, `first` and `all` always returning the first output will also break.

The ticket is marked as a bug, meaning this was never the intended behavior. I marked this as a breaking change regardless. 

We'd also want to update the docs to make it clear how those functions work: https://docs.n8n.io/code/builtin/output-other-nodes/


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1400/bug-dollarlast-uses-wrong-branch
https://github.com/n8n-io/n8n-docs/pull/2167

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
         **Remember, the title automatically goes into the changelog.
         Use `(no-changelog)` otherwise.**
      -->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
         A bug is not considered fixed, unless a test is added to prevent it from happening again.
         A feature is not complete without tests.
      -->
- [ ] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
