### PR TITLE
refactor(core): Make `PruningService.init` and `WaitTracker.init` consistent (no-changelog)

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -30,19 +30,19 @@ export class WaitTracker {
 		private readonly orchestrationService: OrchestrationService,
 	) {}
 
+	/**
+	 * @important Requires `OrchestrationService` to be initialized.
+	 */
 	init() {
-		const { isSingleMainSetup, isLeader, multiMainSetup } = this.orchestrationService;
-
-		if (isSingleMainSetup) {
-			this.startTracking();
-			return;
-		}
+		const { isLeader, isMultiMainSetupEnabled } = this.orchestrationService;
 
 		if (isLeader) this.startTracking();
 
-		multiMainSetup
-			.on('leader-takeover', () => this.startTracking())
-			.on('leader-stepdown', () => this.stopTracking());
+		if (isMultiMainSetupEnabled) {
+			this.orchestrationService.multiMainSetup
+				.on('leader-takeover', () => this.startTracking())
+				.on('leader-stepdown', () => this.stopTracking());
+		}
 	}
 
 	private startTracking() {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -290,7 +290,7 @@ export class Start extends BaseCommand {
 
 		await this.server.start();
 
-		await this.initPruning();
+		Container.get(PruningService).init();
 
 		if (config.getEnv('executions.mode') === 'regular') {
 			await this.runEnqueuedExecutions();
@@ -331,24 +331,6 @@ export class Start extends BaseCommand {
 				}
 			});
 		}
-	}
-
-	async initPruning() {
-		this.pruningService = Container.get(PruningService);
-
-		this.pruningService.startPruning();
-
-		if (config.getEnv('executions.mode') !== 'queue') return;
-
-		const orchestrationService = Container.get(OrchestrationService);
-
-		await orchestrationService.init();
-
-		if (!orchestrationService.isMultiMainSetupEnabled) return;
-
-		orchestrationService.multiMainSetup
-			.on('leader-stepdown', () => this.pruningService.stopPruning())
-			.on('leader-takeover', () => this.pruningService.startPruning());
 	}
 
 	async catch(error: Error) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -199,7 +199,10 @@ export class Start extends BaseCommand {
 	}
 
 	async initOrchestration() {
-		if (config.getEnv('executions.mode') !== 'queue') return;
+		if (config.getEnv('executions.mode') === 'regular') {
+			config.set('multiMainSetup.instanceType', 'leader');
+			return;
+		}
 
 		if (
 			config.getEnv('multiMainSetup.enabled') &&

--- a/packages/cli/test/integration/pruning.service.test.ts
+++ b/packages/cli/test/integration/pruning.service.test.ts
@@ -14,6 +14,8 @@ import { Logger } from '@/Logger';
 import { mockInstance } from '../shared/mocking';
 import { createWorkflow } from './shared/db/workflows';
 import { createExecution, createSuccessfulExecution } from './shared/db/executions';
+import { mock } from 'jest-mock-extended';
+import type { OrchestrationService } from '@/services/orchestration.service';
 
 describe('softDeleteOnPruningCycle()', () => {
 	let pruningService: PruningService;
@@ -29,6 +31,7 @@ describe('softDeleteOnPruningCycle()', () => {
 			mockInstance(Logger),
 			Container.get(ExecutionRepository),
 			mockInstance(BinaryDataService),
+			mock<OrchestrationService>(),
 		);
 
 		workflow = await createWorkflow();

--- a/packages/cli/test/unit/WaitTracker.test.ts
+++ b/packages/cli/test/unit/WaitTracker.test.ts
@@ -34,12 +34,21 @@ describe('WaitTracker', () => {
 	});
 
 	describe('init()', () => {
-		it('should query DB for waiting executions', async () => {
+		it('should query DB for waiting executions if leader', async () => {
+			jest.spyOn(orchestrationService, 'isLeader', 'get').mockReturnValue(true);
 			executionRepository.getWaitingExecutions.mockResolvedValue([execution]);
 
 			waitTracker.init();
 
 			expect(executionRepository.getWaitingExecutions).toHaveBeenCalledTimes(1);
+		});
+
+		it('if follower, should do nothing', () => {
+			executionRepository.getWaitingExecutions.mockResolvedValue([]);
+
+			waitTracker.init();
+
+			expect(executionRepository.findSingleExecution).not.toHaveBeenCalled();
 		});
 
 		it('if no executions to start, should do nothing', () => {


### PR DESCRIPTION
As discussed with @krynble 