### PR TITLE
fix(core): equals sign breaks the "Import from cURL" functionality for HTTP node

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -119,7 +119,7 @@
     "convict": "6.2.4",
     "cookie-parser": "1.4.6",
     "csrf": "3.1.0",
-    "curlconverter": "3.21.0",
+    "curlconverter": "4.10.1",
     "dotenv": "8.6.0",
     "express": "4.19.2",
     "express-async-errors": "3.1.1",

--- a/packages/cli/src/services/curl.service.ts
+++ b/packages/cli/src/services/curl.service.ts
@@ -1,5 +1,5 @@
 import { Service } from 'typedi';
-import curlconverter from 'curlconverter';
+import * as curlconverter from 'curlconverter';
 import get from 'lodash/get';
 import type { IDataObject } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';


### PR DESCRIPTION
## Summary
"Import from cURL" functionality for HTTP node is broken for some POSTed JSON data.
`=` sign is encoded incorrectly on JSON import due to outdated `curlconverter` dependency. I verified that newer `curlconverter` versions are working correctly. (I am new to n8n development so I apologize if I missed something in this PR) 

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/9768
