### PR TITLE
fix(editor): Use segments/graphemes when creating the compact sidebar entries

### DIFF
--- a/packages/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -151,12 +151,12 @@ const isItemActive = (item: IMenuItem): boolean => {
 };
 
 const getInitials = (label: string): string => {
-	const words = label.split(' ');
+	const words = label.split(' ').map((word) => [...new Intl.Segmenter().segment(word)]);
 
 	if (words.length === 1) {
-		return words[0].substring(0, 2);
+		return words[0][0].segment + words[0][1].segment;
 	} else {
-		return words[0].charAt(0) + words[1].charAt(0);
+		return words[0][0].segment + words[1][0].segment;
 	}
 };
 </script>

--- a/packages/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -97,6 +97,7 @@ import N8nIcon from '../N8nIcon';
 import ConditionalRouterLink from '../ConditionalRouterLink';
 import type { IMenuItem } from '../../types';
 import { doesMenuItemMatchCurrentRoute } from './routerUtil';
+import { getInitials } from './labelUtil';
 
 interface MenuItemProps {
 	item: IMenuItem;
@@ -148,16 +149,6 @@ const isItemActive = (item: IMenuItem): boolean => {
 	const hasActiveChild =
 		Array.isArray(item.children) && item.children.some((child) => isActive(child));
 	return isActive(item) || hasActiveChild;
-};
-
-const getInitials = (label: string): string => {
-	const words = label.split(' ').map((word) => [...new Intl.Segmenter().segment(word)]);
-
-	if (words.length === 1) {
-		return words[0][0].segment + words[0][1].segment;
-	} else {
-		return words[0][0].segment + words[1][0].segment;
-	}
 };
 </script>
 

--- a/packages/design-system/src/components/N8nMenuItem/__tests__/labelUtil.spec.ts
+++ b/packages/design-system/src/components/N8nMenuItem/__tests__/labelUtil.spec.ts
@@ -1,0 +1,29 @@
+import { getInitials } from '../labelUtil';
+
+describe('labelUtil.getInitials', () => {
+	it.each([
+		['', ''],
+
+		// simple words
+		['Hello', 'He'],
+		['Hello World', 'HW'],
+		['H', 'H'],
+
+		// multiple spaces
+		['Double  Space', 'DS'],
+		['        ', ''],
+
+		// simple emoji
+		['👋 Hello', '👋H'],
+		['👋Hello', '👋H'],
+		['Hello 👋', 'H👋'],
+		['Hello👋', 'He'],
+
+		// combined emojis
+		['1️⃣ 1️⃣', '1️⃣1️⃣'],
+		['1️⃣', '1️⃣'],
+		['👩‍⚕️D 👩‍⚕️D', '👩‍⚕️👩‍⚕️'],
+	])('turns "%s" into "%s"', (input, output) => {
+		expect(getInitials(input)).toBe(output);
+	});
+});

--- a/packages/design-system/src/components/N8nMenuItem/labelUtil.ts
+++ b/packages/design-system/src/components/N8nMenuItem/labelUtil.ts
@@ -1,0 +1,25 @@
+export const getInitials = (label: string): string => {
+	const words = label
+		.split(' ')
+		.filter((word) => word !== '')
+		.map((word) => [...new Intl.Segmenter().segment(word)]);
+
+	if (words.length === 0) {
+		return '';
+	} else if (words.length === 1) {
+		// first two segments of the first word
+		return (
+			words
+				.at(0)
+				?.slice(0, 2)
+				.map((grapheme) => grapheme.segment)
+				.join('') ?? ''
+		);
+	} else {
+		// first segment ok the first two words
+		return words
+			.slice(0, 2)
+			.map((word) => word.at(0)?.segment ?? '')
+			.join('');
+	}
+};


### PR DESCRIPTION
## Summary

Before

![image](https://github.com/n8n-io/n8n/assets/927609/df1359b5-3de7-46b0-b6c4-69497a49e66d)


After

![image](https://github.com/n8n-io/n8n/assets/927609/722740e4-a070-4e81-9251-279ee6109d60)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1637/ux-improvements-to-rbac-feature-set

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
             **Remember, the title automatically goes into the changelog.
             Use `(no-changelog)` otherwise.**
          -->
- [ ] Tests included. <!--
             A bug is not considered fixed, unless a test is added to prevent it from happening again.
             A feature is not complete without tests.
          -->
