### PR TITLE
refactor(editor): Enable @typescript-eslint/no-base-to-string lint rule, fix errors (no-changelog)

### DIFF
--- a/packages/editor-ui/.eslintrc.js
+++ b/packages/editor-ui/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
 		'@typescript-eslint/restrict-plus-operands': 'warn',
 		'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
 		'@typescript-eslint/no-redundant-type-constituents': 'warn',
-		'@typescript-eslint/no-base-to-string': 'warn',
 		'@typescript-eslint/no-unsafe-enum-comparison': 'warn',
 	},
 };

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -887,8 +887,9 @@ export default defineComponent({
 					this.testedSuccessfully = false;
 				}
 
-				const usesExternalSecrets = Object.entries(credentialDetails.data || {}).some(([, value]) =>
-					/=.*\{\{[^}]*\$secrets\.[^}]+}}.*/.test(`${value}`),
+				const usesExternalSecrets = Object.entries(credentialDetails.data || {}).some(
+					([, value]) =>
+						typeof value !== 'object' && /=.*\{\{[^}]*\$secrets\.[^}]+}}.*/.test(`${value}`),
 				);
 
 				const trackProperties: ITelemetryTrackProperties = {

--- a/packages/editor-ui/src/components/NodeIcon.vue
+++ b/packages/editor-ui/src/components/NodeIcon.vue
@@ -19,7 +19,12 @@
 import type { IVersionNode, SimplifiedNodeType } from '@/Interface';
 import { useRootStore } from '@/stores/n8nRoot.store';
 import { useUIStore } from '@/stores/ui.store';
-import { getBadgeIconUrl, getNodeIcon, getNodeIconUrl } from '@/utils/nodeTypesUtils';
+import {
+	getBadgeIconUrl,
+	getNodeIcon,
+	getNodeIconColor,
+	getNodeIconUrl,
+} from '@/utils/nodeTypesUtils';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { computed } from 'vue';
 
@@ -75,14 +80,7 @@ const iconType = computed(() => {
 	return 'unknown';
 });
 
-const color = computed(() => {
-	const nodeType = props.nodeType;
-
-	if (nodeType && 'iconColor' in nodeType && nodeType.iconColor) {
-		return `var(--color-node-icon-${nodeType.iconColor})`;
-	}
-	return nodeType?.defaults?.color?.toString() ?? props.colorDefault ?? '';
-});
+const color = computed(() => getNodeIconColor(props.nodeType) ?? props.colorDefault ?? '');
 
 const iconSource = computed<NodeIconSource>(() => {
 	const nodeType = props.nodeType;

--- a/packages/editor-ui/src/components/NodeIcon.vue
+++ b/packages/editor-ui/src/components/NodeIcon.vue
@@ -19,12 +19,7 @@
 import type { IVersionNode, SimplifiedNodeType } from '@/Interface';
 import { useRootStore } from '@/stores/n8nRoot.store';
 import { useUIStore } from '@/stores/ui.store';
-import {
-	getBadgeIconUrl,
-	getNodeIcon,
-	getNodeIconColor,
-	getNodeIconUrl,
-} from '@/utils/nodeTypesUtils';
+import { getBadgeIconUrl, getNodeIcon, getNodeIconUrl } from '@/utils/nodeTypesUtils';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { computed } from 'vue';
 
@@ -80,7 +75,14 @@ const iconType = computed(() => {
 	return 'unknown';
 });
 
-const color = computed(() => getNodeIconColor(props.nodeType) ?? props.colorDefault ?? '');
+const color = computed(() => {
+	const nodeType = props.nodeType;
+
+	if (nodeType && 'iconColor' in nodeType && nodeType.iconColor) {
+		return `var(--color-node-icon-${nodeType.iconColor})`;
+	}
+	return nodeType?.defaults?.color?.toString() ?? props.colorDefault ?? '';
+});
 
 const iconSource = computed<NodeIconSource>(() => {
 	const nodeType = props.nodeType;

--- a/packages/editor-ui/src/components/RunDataAi/useAiContentParsers.ts
+++ b/packages/editor-ui/src/components/RunDataAi/useAiContentParsers.ts
@@ -132,7 +132,11 @@ const outputTypeParsers: {
 						} else if (content.id.includes('SystemMessage')) {
 							message = `**System Message:** ${message}`;
 						}
-						if (execData.action && execData.action !== 'getMessages') {
+						if (
+							execData.action &&
+							typeof execData.action !== 'object' &&
+							execData.action !== 'getMessages'
+						) {
 							message = `## Action: ${execData.action}\n\n${message}`;
 						}
 

--- a/packages/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
+++ b/packages/editor-ui/src/components/SettingsLogStreaming/EventDestinationSettingsModal.ee.vue
@@ -459,7 +459,7 @@ export default defineComponent({
 		onModalClose() {
 			if (!this.hasOnceBeenSaved) {
 				this.workflowsStore.removeNode(this.node);
-				if (this.nodeParameters.id) {
+				if (this.nodeParameters.id && typeof this.nodeParameters.id !== 'object') {
 					this.logStreamingStore.removeDestination(this.nodeParameters.id.toString());
 				}
 			}
@@ -480,7 +480,9 @@ export default defineComponent({
 				this.uiStore.stateIsDirty = false;
 
 				const destinationType = (
-					this.nodeParameters.__type ? `${this.nodeParameters.__type}` : 'unknown'
+					this.nodeParameters.__type && typeof this.nodeParameters.__type !== 'object'
+						? `${this.nodeParameters.__type}`
+						: 'unknown'
 				)
 					.replace('$$MessageEventBusDestination', '')
 					.toLowerCase();

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -306,7 +306,8 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 						if (!showForm) continue;
 
 						const { webhookSuffix } = (node.parameters.options ?? {}) as IDataObject;
-						const suffix = webhookSuffix ? `/${webhookSuffix}` : '';
+						const suffix =
+							webhookSuffix && typeof webhookSuffix !== 'object' ? `/${webhookSuffix}` : '';
 						testUrl = `${rootStore.getFormWaitingUrl}/${runWorkflowApiResponse.executionId}${suffix}`;
 					}
 

--- a/packages/editor-ui/src/utils/mappingUtils.ts
+++ b/packages/editor-ui/src/utils/mappingUtils.ts
@@ -97,7 +97,9 @@ export function getMappedResult(
 	} else if (typeof prevValue === 'string' && isExpression(prevValue) && prevValue.length > 1) {
 		return `${prevValue} ${newParamValue}`;
 	} else if (prevValue && ['string', 'json'].includes(parameter.type)) {
-		return prevValue === '=' ? `=${newParamValue}` : `=${prevValue} ${newParamValue}`;
+		return prevValue === '=' || typeof prevValue === 'object'
+			? `=${newParamValue}`
+			: `=${prevValue} ${newParamValue}`;
 	}
 
 	return `=${newParamValue}`;


### PR DESCRIPTION
## Summary

Enable @typescript-eslint/no-base-to-string lint rule, fix errors

Recently a bug: https://github.com/n8n-io/n8n/pull/9782 could have been prevented by this rule

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
