### PR TITLE
fix(editor): Set default value for `isProductionExecutionPreview` in `NodeDetaillsView.vue` (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -187,11 +187,16 @@ const emit = defineEmits([
 	'stopExecution',
 ]);
 
-const props = defineProps<{
-	readOnly: boolean;
-	renaming: boolean;
-	isProductionExecutionPreview: boolean;
-}>();
+const props = withDefaults(
+	defineProps<{
+		readOnly?: boolean;
+		renaming?: boolean;
+		isProductionExecutionPreview?: boolean;
+	}>(),
+	{
+		isProductionExecutionPreview: false,
+	},
+);
 
 const ndvStore = useNDVStore();
 const externalHooks = useExternalHooks();


### PR DESCRIPTION
## Summary

It was missed when migrating this component to the composition API [here](https://github.com/n8n-io/n8n/pull/9762/files).


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
