### PR TITLE
fix(Elasticsearch Node): Fix issue with self signed certificates

### DIFF
--- a/packages/nodes-base/credentials/ElasticsearchApi.credentials.ts
+++ b/packages/nodes-base/credentials/ElasticsearchApi.credentials.ts
@@ -51,7 +51,6 @@ export class ElasticsearchApi implements ICredentialType {
 				username: '={{$credentials.username}}',
 				password: '={{$credentials.password}}',
 			},
-			skipSslCertificateValidation: '={{$credentials.ignoreSSLIssues}}',
 		},
 	};
 
@@ -59,6 +58,7 @@ export class ElasticsearchApi implements ICredentialType {
 		request: {
 			baseURL: '={{$credentials.baseUrl}}',
 			url: '/_xpack?human=false',
+			skipSslCertificateValidation: '={{$credentials.ignoreSSLIssues}}',
 		},
 	};
 }


### PR DESCRIPTION
## Summary
The credential test was failing because we don't use the `skipSslCertificateValidation` from the `authenticate` and it needed to be added to the cred test instead.

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/9677