### PR TITLE
fix: Get workflow not returning home project and shared projects (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -13,7 +13,6 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { Logger } from '@/Logger';
 import type {
-	CredentialUsedByWorkflow,
 	WorkflowWithSharingsAndCredentials,
 	WorkflowWithSharingsMetaDataAndCredentials,
 } from './workflows.types';
@@ -101,16 +100,15 @@ export class EnterpriseWorkflowService {
 		const userCredentialIds = userCredentials.map((credential) => credential.id);
 		workflowCredentials.forEach((credential) => {
 			const credentialId = credential.id;
-			const workflowCredential: CredentialUsedByWorkflow = {
+			const filledCred = this.ownershipService.addOwnedByAndSharedWith(credential);
+			workflow.usedCredentials?.push({
 				id: credentialId,
 				name: credential.name,
 				type: credential.type,
 				currentUserHasAccess: userCredentialIds.includes(credentialId),
-				sharedWith: [],
-				ownedBy: null,
-			};
-			credential = this.ownershipService.addOwnedByAndSharedWith(credential);
-			workflow.usedCredentials?.push(workflowCredential);
+				homeProject: filledCred.homeProject,
+				sharedWithProjects: filledCred.sharedWithProjects,
+			});
 		});
 	}
 

--- a/packages/cli/src/workflows/workflows.types.ts
+++ b/packages/cli/src/workflows/workflows.types.ts
@@ -1,4 +1,3 @@
-import type { IUser } from 'n8n-workflow';
 import type { SharedWorkflow } from '@db/entities/SharedWorkflow';
 import type { WorkflowEntity } from '@db/entities/WorkflowEntity';
 import type { SlimProject } from '@/requests';
@@ -21,6 +20,6 @@ export interface CredentialUsedByWorkflow {
 	name: string;
 	type?: string;
 	currentUserHasAccess: boolean;
-	ownedBy?: IUser | null;
-	sharedWith?: IUser[];
+	homeProject: SlimProject | null;
+	sharedWithProjects: SlimProject[];
 }


### PR DESCRIPTION
## Summary

When we moved to RBAC, we stopped returning the `ownedBy` and `sharedWith` properties on `usedCredentials`, and when doing so, we failed to return the new `homeProject` and `sharedWithProjects` properties instead.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
