### PR TITLE
ci: Fix repository url for provenance checks (no-changelog)

### DIFF
--- a/packages/@n8n/client-oauth2/package.json
+++ b/packages/@n8n/client-oauth2/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@n8n/client-oauth2",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/n8n-io/n8n.git"
+  },
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/imap/package.json
+++ b/packages/@n8n/imap/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@n8n/imap",
   "version": "0.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/n8n-io/n8n.git"
+  },
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://n8n.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/n8n-io/n8n-nodes-langchain.git"
+    "url": "git+https://github.com/n8n-io/n8n.git"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/@n8n/permissions/package.json
+++ b/packages/@n8n/permissions/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@n8n/permissions",
   "version": "0.9.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/n8n-io/n8n.git"
+  },
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",


### PR DESCRIPTION
## Summary

For provenance to work, all published packages should have a valid `repository.url` in their `package.json`, and it should point to this repo. 

## Review / Merge checklist

- [x] PR title and summary are descriptive