### PR TITLE
feat(Anthropic Chat Model Node): Add support for Claude 3.5 Sonnet

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -110,8 +110,8 @@ export class LmChatAnthropic implements INodeType {
 				...modelField,
 				default: 'claude-3-sonnet-20240229',
 				displayOptions: {
-					hide: {
-						'@version': [{ _cnd: { gte: 1.2 } }, 1],
+					show: {
+						'@version': [1.1],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -1,4 +1,5 @@
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
+import type { INodePropertyOptions } from 'n8n-workflow';
 import {
 	NodeConnectionType,
 	type INodeProperties,
@@ -22,6 +23,10 @@ const modelField: INodeProperties = {
 		{
 			name: 'Claude 3 Opus(20240229)',
 			value: 'claude-3-opus-20240229',
+		},
+		{
+			name: 'Claude 3.5 Sonnet(20240620)',
+			value: 'claude-3-5-sonnet-20240620',
 		},
 		{
 			name: 'Claude 3 Sonnet(20240229)',
@@ -60,7 +65,8 @@ export class LmChatAnthropic implements INodeType {
 		name: 'lmChatAnthropic',
 		icon: 'file:anthropic.svg',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
+		defaultVersion: 1.2,
 		description: 'Language Model Anthropic',
 		defaults: {
 			name: 'Anthropic Chat Model',
@@ -105,7 +111,19 @@ export class LmChatAnthropic implements INodeType {
 				default: 'claude-3-sonnet-20240229',
 				displayOptions: {
 					hide: {
-						'@version': [1],
+						'@version': [{ _cnd: { gte: 1.2 } }, 1],
+					},
+				},
+			},
+			{
+				...modelField,
+				default: 'claude-3-5-sonnet-20240620',
+				options: (modelField.options ?? []).filter(
+					(o): o is INodePropertyOptions => 'name' in o && !o.name.toString().startsWith('LEGACY'),
+				),
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.2 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -1,7 +1,7 @@
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
-import type { INodePropertyOptions } from 'n8n-workflow';
 import {
 	NodeConnectionType,
+	type INodePropertyOptions,
 	type INodeProperties,
 	type IExecuteFunctions,
 	type INodeType,


### PR DESCRIPTION
## Summary
- Add support for Claude 3.5 Sonnet(20240620) model and make it default for latest version of the node
- Filter-out the legacy models from the latest version of the node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

## Links
https://community.n8n.io/t/claude-sonnet-3-5/48995