### PR TITLE
feat: Add RS client to hooks service

### DIFF
--- a/packages/cli/src/services/hooks.service.ts
+++ b/packages/cli/src/services/hooks.service.ts
@@ -17,6 +17,7 @@ import type { Settings } from '@db/entities/Settings';
 import { UserService } from '@/services/user.service';
 import type { AuthenticatedRequest } from '@/requests';
 import type { Invitation } from '@/Interfaces';
+import RudderStack, { type constructorOptions } from '@rudderstack/rudder-sdk-node';
 
 /**
  * Exposes functionality to be used by the cloud BE hooks.
@@ -103,6 +104,10 @@ export class HooksService {
 	 */
 	async authMiddleware(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		return await this.authService.authMiddleware(req, res, next);
+	}
+
+	getRudderStackClient(key: string, options: constructorOptions): RudderStack {
+		return new RudderStack(key, options);
 	}
 
 	/**

--- a/packages/cli/test/unit/services/hooks.service.test.ts
+++ b/packages/cli/test/unit/services/hooks.service.test.ts
@@ -12,6 +12,9 @@ import { HooksService } from '@/services/hooks.service';
 import type { Invitation } from '@/Interfaces';
 import type { AuthenticatedRequest } from '@/requests';
 import type { AuthUserRepository } from '@/databases/repositories/authUser.repository';
+import RudderStack from '@rudderstack/rudder-sdk-node';
+
+jest.mock('@rudderstack/rudder-sdk-node');
 
 describe('HooksService', () => {
 	const mockedUser = mock<AuthUser>();
@@ -147,5 +150,15 @@ describe('HooksService', () => {
 		expect(collections).toHaveProperty('Settings');
 		expect(collections).toHaveProperty('Credentials');
 		expect(collections).toHaveProperty('Workflow');
+	});
+
+	it('hooksService.getRudderStackClient', async () => {
+		// ACT
+		const key = 'TEST';
+		const opts = { dataPlaneUrl: 'test.com' };
+		const client = hooksService.getRudderStackClient(key, opts);
+
+		expect(client instanceof RudderStack).toBeTruthy();
+		expect(RudderStack).toHaveBeenCalledWith(key, opts);
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Adds support for creating a RS client from internal hooks. This client will be used to trigger events from the Cloud hooks
(related PR here https://github.com/n8n-io/n8n-cloud/pull/1325/)
We cannot use same client as n8n backend because the user id and write key are different. 
So we need a different client every time. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
