### PR TITLE
refactor(core): Lint to restrict `@n8n/typeorm` to persistence layer (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/local-rules.js
+++ b/packages/@n8n_io/eslint-config/local-rules.js
@@ -422,6 +422,32 @@ module.exports = {
 			};
 		},
 	},
+
+	'misplaced-n8n-typeorm-import': {
+		meta: {
+			type: 'error',
+			docs: {
+				description:
+					'Ensure `@n8n/typeorm` is imported only from within the `packages/cli/src/databases` directory.',
+				recommended: 'error',
+			},
+			messages: {
+				moveImport: 'Move this import to `packages/cli/src/databases/**/*.ts`.',
+			},
+		},
+		create(context) {
+			return {
+				ImportDeclaration(node) {
+					if (
+						node.source.value === '@n8n/typeorm' &&
+						!context.getFilename().includes('packages/cli/src/databases/')
+					) {
+						context.report({ node, messageId: 'moveImport' });
+					}
+				},
+			};
+		},
+	},
 };
 
 const isJsonParseCall = (node) =>

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
 
 	rules: {
 		'n8n-local-rules/no-dynamic-import-template': 'error',
+		'n8n-local-rules/misplaced-n8n-typeorm-import': 'error',
 		complexity: 'error',
 
 		// TODO: Remove this
@@ -37,6 +38,12 @@ module.exports = {
 	},
 
 	overrides: [
+		{
+			files: ['./src/databases/**/*.ts', './test/**/*.ts'],
+			rules: {
+				'n8n-local-rules/misplaced-n8n-typeorm-import': 'off',
+			},
+		},
 		{
 			files: ['./src/decorators/**/*.ts'],
 			rules: {

--- a/packages/cli/src/CredentialsHelper.ts
+++ b/packages/cli/src/CredentialsHelper.ts
@@ -37,6 +37,7 @@ import { RESPONSE_ERROR_MESSAGES } from './constants';
 import { CredentialsRepository } from '@db/repositories/credentials.repository';
 import { SharedCredentialsRepository } from '@db/repositories/sharedCredentials.repository';
 import { CredentialNotFoundError } from './errors/credential-not-found.error';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { CacheService } from './services/cache/cache.service';
 

--- a/packages/cli/src/Db.ts
+++ b/packages/cli/src/Db.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Container } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { DataSource as Connection } from '@n8n/typeorm';
 import { ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
 

--- a/packages/cli/src/Ldap/ldap.service.ts
+++ b/packages/cli/src/Ldap/ldap.service.ts
@@ -1,4 +1,5 @@
 import { Service } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { QueryFailedError } from '@n8n/typeorm';
 import type { Entry as LdapUser, ClientOptions } from 'ldapts';
 import { Client } from 'ldapts';

--- a/packages/cli/src/PublicApi/v1/handlers/tags/tags.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/tags/tags.handler.ts
@@ -6,6 +6,7 @@ import type { TagRequest } from '../../../types';
 import { encodeNextCursor } from '../../shared/services/pagination.service';
 
 import { Container } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindManyOptions } from '@n8n/typeorm';
 import { TagRepository } from '@db/repositories/tag.repository';
 import { TagService } from '@/services/tag.service';

--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -1,7 +1,9 @@
 import type express from 'express';
 
 import { Container } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindOptionsWhere } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, Like, QueryFailedError } from '@n8n/typeorm';
 import { v4 as uuid } from 'uuid';
 

--- a/packages/cli/src/commands/db/revert.ts
+++ b/packages/cli/src/commands/db/revert.ts
@@ -1,5 +1,7 @@
 import { Command, Flags } from '@oclif/core';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { DataSourceOptions as ConnectionOptions } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { MigrationExecutor, DataSource as Connection } from '@n8n/typeorm';
 import { Container } from 'typedi';
 import { Logger } from '@/Logger';

--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -3,6 +3,7 @@ import { Flags } from '@oclif/core';
 import { Cipher } from 'n8n-core';
 import fs from 'fs';
 import glob from 'fast-glob';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
 
 import * as Db from '@/Db';

--- a/packages/cli/src/commands/ldap/reset.ts
+++ b/packages/cli/src/commands/ldap/reset.ts
@@ -9,6 +9,7 @@ import { Flags } from '@oclif/core';
 import { ApplicationError } from 'n8n-workflow';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { WorkflowService } from '@/workflows/workflow.service';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { SharedWorkflowRepository } from '@/databases/repositories/sharedWorkflow.repository';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -20,6 +20,7 @@ import { combineScopes } from '@n8n/permissions';
 import type { Scope } from '@n8n/permissions';
 import { RoleService } from '@/services/role.service';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, Not } from '@n8n/typeorm';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalHooks } from '@/InternalHooks';

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -25,6 +25,7 @@ import * as Db from '@/Db';
 import * as utils from '@/utils';
 import { listQueryMiddleware } from '@/middlewares';
 import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { SharedCredentials } from '@/databases/entities/SharedCredentials';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type EntityManager } from '@n8n/typeorm';
 import type { User } from '@db/entities/User';
 import { CredentialsService } from './credentials.service';

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -6,6 +6,7 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 import { ApplicationError, CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import {
 	In,
 	type EntityManager,

--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -18,6 +18,7 @@ import { SharedCredentials } from '@db/entities/SharedCredentials';
 import type { WorkflowTagMapping } from '@db/entities/WorkflowTagMapping';
 import type { TagEntity } from '@db/entities/TagEntity';
 import { ActiveWorkflowManager } from '@/ActiveWorkflowManager';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { isUniqueConstraintError } from '@/ResponseHelper';
 import type { SourceControlWorkflowVersionId } from './types/sourceControlWorkflowVersionId';

--- a/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
+++ b/packages/cli/src/eventbus/MessageEventBus/MessageEventBus.ts
@@ -1,5 +1,7 @@
 import { Service } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { DeleteResult } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import EventEmitter from 'events';
 import uniqby from 'lodash/uniqBy';

--- a/packages/cli/src/permissions/checkAccess.ts
+++ b/packages/cli/src/permissions/checkAccess.ts
@@ -1,4 +1,5 @@
 import { Container } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 
 import { RoleService } from '@/services/role.service';

--- a/packages/cli/src/services/hooks.service.ts
+++ b/packages/cli/src/services/hooks.service.ts
@@ -1,6 +1,7 @@
 import { Service } from 'typedi';
 import type { NextFunction, Response } from 'express';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindManyOptions, FindOneOptions, FindOptionsWhere } from '@n8n/typeorm';
 
 import { AuthService } from '@/auth/auth.service';

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -4,9 +4,11 @@ import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { User } from '@/databases/entities/User';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { FindOptionsWhere, EntityManager } from '@n8n/typeorm';
 import Container, { Service } from 'typedi';
 import { type Scope } from '@n8n/permissions';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, Not } from '@n8n/typeorm';
 import { RoleService } from './role.service';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';

--- a/packages/cli/src/services/userOnboarding.service.ts
+++ b/packages/cli/src/services/userOnboarding.service.ts
@@ -1,4 +1,5 @@
 import { Service } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 
 import type { User } from '@db/entities/User';

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -17,6 +17,7 @@ import type {
 	WorkflowWithSharingsMetaDataAndCredentials,
 } from './workflows.types';
 import { OwnershipService } from '@/services/ownership.service';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type EntityManager } from '@n8n/typeorm';
 import { Project } from '@/databases/entities/Project';
 import { ProjectService } from '@/services/project.service';

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -29,7 +29,9 @@ import { WorkflowSharingService } from './workflowSharing.service';
 import { ProjectService } from '@/services/project.service';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { Scope } from '@n8n/permissions';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 import { SharedWorkflow } from '@/databases/entities/SharedWorkflow';
 import { EventRelay } from '@/eventbus/event-relay.service';

--- a/packages/cli/src/workflows/workflowSharing.service.ts
+++ b/packages/cli/src/workflows/workflowSharing.service.ts
@@ -1,4 +1,5 @@
 import { Service } from 'typedi';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
 
 import type { User } from '@db/entities/User';

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -37,6 +37,7 @@ import { UserManagementMailer } from '@/UserManagement/email';
 import { ProjectRepository } from '@/databases/repositories/project.repository';
 import { ProjectService } from '@/services/project.service';
 import { ApplicationError } from 'n8n-workflow';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type FindOptionsRelations } from '@n8n/typeorm';
 import type { Project } from '@/databases/entities/Project';
 import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';


### PR DESCRIPTION
Some work was [done](https://github.com/n8n-io/n8n/pulls?q=is%3Apr+is%3Amerged+author%3Aivov+typeorm+operators+) last year to corral `typeorm` to `/databases`. Locking this down as it has been recently growing again.