### PR TITLE
refactor(core): Decouple projects telemetry from internal hooks (no-changelog)

### DIFF
--- a/packages/cli/src/Interfaces.ts
+++ b/packages/cli/src/Interfaces.ts
@@ -268,7 +268,6 @@ export interface IWebhookManager {
 }
 
 export interface ITelemetryUserDeletionData {
-	user_id: string;
 	target_user_old_status: 'active' | 'invited';
 	migration_strategy?: 'transfer_data' | 'delete_data';
 	target_user_id?: string;

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -15,7 +15,7 @@ import { InstanceSettings } from 'n8n-core';
 import config from '@/config';
 import { N8N_VERSION } from '@/constants';
 import type { AuthProviderType } from '@db/entities/AuthIdentity';
-import type { GlobalRole, User } from '@db/entities/User';
+import type { User } from '@db/entities/User';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
 import { determineFinalExecutionStatus } from '@/executionLifecycleHooks/shared/sharedHookFunctions';
@@ -29,7 +29,6 @@ import { EventsService } from '@/services/events.service';
 import { NodeTypes } from '@/NodeTypes';
 import { Telemetry } from '@/telemetry';
 import type { Project } from '@db/entities/Project';
-import type { ProjectRole } from '@db/entities/ProjectRelation';
 import { ProjectRelationRepository } from './databases/repositories/projectRelation.repository';
 import { SharedCredentialsRepository } from './databases/repositories/sharedCredentials.repository';
 import { MessageEventBus } from './eventbus/MessageEventBus/MessageEventBus';
@@ -831,32 +830,5 @@ export class InternalHooks {
 		error_message?: string | undefined;
 	}): Promise<void> {
 		return await this.telemetry.track('User updated external secrets settings', saveData);
-	}
-
-	async onTeamProjectCreated(data: { user_id: string; role: GlobalRole }) {
-		return await this.telemetry.track('User created project', data);
-	}
-
-	async onTeamProjectDeleted(data: {
-		user_id: string;
-		role: GlobalRole;
-		project_id: string;
-		removal_type: 'delete' | 'transfer';
-		target_project_id?: string;
-	}) {
-		return await this.telemetry.track('User deleted project', data);
-	}
-
-	async onTeamProjectUpdated(data: {
-		user_id: string;
-		role: GlobalRole;
-		project_id: string;
-		members: Array<{ user_id: string; role: ProjectRole }>;
-	}) {
-		return await this.telemetry.track('Project settings updated', data);
-	}
-
-	async onConcurrencyLimitHit({ threshold }: { threshold: number }) {
-		await this.telemetry.track('User hit concurrency limit', { threshold });
 	}
 }

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -373,28 +373,6 @@ export class InternalHooks {
 		return await this.telemetry.track('User updated workflow sharing', properties);
 	}
 
-	async onN8nStop(): Promise<void> {
-		const timeoutPromise = new Promise<void>((resolve) => {
-			setTimeout(() => {
-				resolve();
-			}, 3000);
-		});
-
-		return await Promise.race([timeoutPromise, this.telemetry.trackN8nStop()]);
-	}
-
-	async onUserDeletion(userDeletionData: {
-		user: User;
-		telemetryData: ITelemetryUserDeletionData;
-		publicApi: boolean;
-	}): Promise<void> {
-		void this.telemetry.track('User deleted user', {
-			...userDeletionData.telemetryData,
-			user_id: userDeletionData.user.id,
-			public_api: userDeletionData.publicApi,
-		});
-	}
-
 	async onUserInvite(userInviteData: {
 		user: User;
 		target_user_id: string[];
@@ -422,48 +400,6 @@ export class InternalHooks {
 		void this.telemetry.track('User changed role', { user_id: user.id, ...rest });
 	}
 
-	async onUserRetrievedUser(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved user', userRetrievedData);
-	}
-
-	async onUserRetrievedAllUsers(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved all users', userRetrievedData);
-	}
-
-	async onUserRetrievedExecution(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved execution', userRetrievedData);
-	}
-
-	async onUserRetrievedAllExecutions(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved all executions', userRetrievedData);
-	}
-
-	async onUserRetrievedWorkflow(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved workflow', userRetrievedData);
-	}
-
-	async onUserRetrievedAllWorkflows(userRetrievedData: {
-		user_id: string;
-		public_api: boolean;
-	}): Promise<void> {
-		return await this.telemetry.track('User retrieved all workflows', userRetrievedData);
-	}
-
 	async onUserUpdate(userUpdateData: { user: User; fields_changed: string[] }): Promise<void> {
 		void this.telemetry.track('User changed personal settings', {
 			user_id: userUpdateData.user.id,
@@ -477,12 +413,6 @@ export class InternalHooks {
 	}): Promise<void> {
 		void this.telemetry.track('User clicked invite link from email', {
 			user_id: userInviteClickData.invitee.id,
-		});
-	}
-
-	async onUserPasswordResetEmailClick(userPasswordResetData: { user: User }): Promise<void> {
-		void this.telemetry.track('User clicked password reset link from email', {
-			user_id: userPasswordResetData.user.id,
 		});
 	}
 
@@ -502,49 +432,9 @@ export class InternalHooks {
 		);
 	}
 
-	async onUserInvokedApi(userInvokedApiData: {
-		user_id: string;
-		path: string;
-		method: string;
-		api_version: string;
-	}): Promise<void> {
-		return await this.telemetry.track('User invoked API', userInvokedApiData);
-	}
-
-	async onApiKeyDeleted(apiKeyDeletedData: { user: User; public_api: boolean }): Promise<void> {
-		void this.telemetry.track('API key deleted', {
-			user_id: apiKeyDeletedData.user.id,
-			public_api: apiKeyDeletedData.public_api,
-		});
-	}
-
-	async onApiKeyCreated(apiKeyCreatedData: { user: User; public_api: boolean }): Promise<void> {
-		void this.telemetry.track('API key created', {
-			user_id: apiKeyCreatedData.user.id,
-			public_api: apiKeyCreatedData.public_api,
-		});
-	}
-
 	async onUserPasswordResetRequestClick(userPasswordResetData: { user: User }): Promise<void> {
 		void this.telemetry.track('User requested password reset while logged out', {
 			user_id: userPasswordResetData.user.id,
-		});
-	}
-
-	async onInstanceOwnerSetup(instanceOwnerSetupData: { user_id: string }): Promise<void> {
-		return await this.telemetry.track('Owner finished instance setup', instanceOwnerSetupData);
-	}
-
-	async onUserSignup(
-		user: User,
-		userSignupData: {
-			user_type: AuthProviderType;
-			was_disabled_ldap_user: boolean;
-		},
-	): Promise<void> {
-		void this.telemetry.track('User signed up', {
-			user_id: user.id,
-			...userSignupData,
 		});
 	}
 
@@ -753,13 +643,6 @@ export class InternalHooks {
 		credential_id?: string;
 	}): Promise<void> {
 		return await this.telemetry.track('Workflow first data fetched', data);
-	}
-
-	/**
-	 * License
-	 */
-	async onLicenseRenewAttempt(data: { success: boolean }): Promise<void> {
-		await this.telemetry.track('Instance attempted to refresh license', data);
 	}
 
 	/**

--- a/packages/cli/src/PublicApi/index.ts
+++ b/packages/cli/src/PublicApi/index.ts
@@ -17,6 +17,7 @@ import { License } from '@/License';
 import { UserRepository } from '@db/repositories/user.repository';
 import { UrlService } from '@/services/url.service';
 import type { AuthenticatedRequest } from '@/requests';
+import { EventRelay } from '@/eventbus/event-relay.service';
 
 async function createApiRouter(
 	version: string,
@@ -99,12 +100,14 @@ async function createApiRouter(
 
 						if (!user) return false;
 
-						void Container.get(InternalHooks).onUserInvokedApi({
-							user_id: user.id,
+						const invokedApiMetadata = {
+							user: user,
 							path: req.path,
 							method: req.method,
 							api_version: version,
-						});
+						};
+
+						void Container.get(EventRelay).emit('user-invoked-api', invokedApiMetadata);
 
 						req.user = user;
 

--- a/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/executions/executions.handler.ts
@@ -10,6 +10,7 @@ import { encodeNextCursor } from '../../shared/services/pagination.service';
 import { InternalHooks } from '@/InternalHooks';
 import { ExecutionRepository } from '@db/repositories/execution.repository';
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
+import { EventRelay } from '@/eventbus/event-relay.service';
 
 export = {
 	deleteExecution: [
@@ -78,9 +79,8 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
-			void Container.get(InternalHooks).onUserRetrievedExecution({
-				user_id: req.user.id,
-				public_api: true,
+			void Container.get(EventRelay).emit('user-retrieved-execution', {
+				user: req.user,
 			});
 
 			return res.json(replaceCircularReferences(execution));
@@ -129,10 +129,7 @@ export = {
 			const count =
 				await Container.get(ExecutionRepository).getExecutionsCountForPublicApi(filters);
 
-			void Container.get(InternalHooks).onUserRetrievedAllExecutions({
-				user_id: req.user.id,
-				public_api: true,
-			});
+			void Container.get(EventRelay).emit('user-retrieved-all-executions', { user: req.user });
 
 			return res.json({
 				data: replaceCircularReferences(executions),

--- a/packages/cli/src/PublicApi/v1/handlers/users/users.handler.ee.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/users/users.handler.ee.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/middlewares/global.middleware';
 import type { UserRequest } from '@/requests';
 import { InternalHooks } from '@/InternalHooks';
+import { EventRelay } from '@/eventbus/event-relay.service';
 
 export = {
 	getUser: [
@@ -28,12 +29,7 @@ export = {
 				});
 			}
 
-			const telemetryData = {
-				user_id: req.user.id,
-				public_api: true,
-			};
-
-			void Container.get(InternalHooks).onUserRetrievedUser(telemetryData);
+			void Container.get(EventRelay).emit('user-retrieved-user', { user });
 
 			return res.json(clean(user, { includeRole }));
 		},
@@ -51,12 +47,7 @@ export = {
 				offset,
 			});
 
-			const telemetryData = {
-				user_id: req.user.id,
-				public_api: true,
-			};
-
-			void Container.get(InternalHooks).onUserRetrievedAllUsers(telemetryData);
+			void Container.get(EventRelay).emit('user-retrieved-all-users', { user: req.user });
 
 			return res.json({
 				data: clean(users, { includeRole }),

--- a/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/PublicApi/v1/handlers/workflows/workflows.handler.ts
@@ -101,10 +101,7 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
-			void Container.get(InternalHooks).onUserRetrievedWorkflow({
-				user_id: req.user.id,
-				public_api: true,
-			});
+			void Container.get(EventRelay).emit('user-retrieved-workflow', { user: req.user });
 
 			return res.json(workflow);
 		},
@@ -163,10 +160,7 @@ export = {
 				...(!config.getEnv('workflowTagsDisabled') && { relations: ['tags'] }),
 			});
 
-			void Container.get(InternalHooks).onUserRetrievedAllWorkflows({
-				user_id: req.user.id,
-				public_api: true,
-			});
+			void Container.get(EventRelay).emit('user-retrieved-all-workflows', { user: req.user });
 
 			return res.json({
 				data: workflows,

--- a/packages/cli/src/auth/methods/ldap.ts
+++ b/packages/cli/src/auth/methods/ldap.ts
@@ -51,11 +51,13 @@ export const handleLdapLogin = async (
 			await updateLdapUserOnLocalDb(identity, ldapAttributesValues);
 		} else {
 			const user = await createLdapUserOnLocalDb(ldapAttributesValues, ldapId);
-			void Container.get(InternalHooks).onUserSignup(user, {
+
+			const signUpMetadata = {
 				user_type: 'ldap',
 				was_disabled_ldap_user: false,
-			});
-			Container.get(EventRelay).emit('user-signed-up', { user });
+			};
+
+			Container.get(EventRelay).emit('user-signed-up', { user, signUpMetadata });
 			return user;
 		}
 	} else {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -23,6 +23,7 @@ import { initExpressionEvaluator } from '@/ExpressionEvaluator';
 import { generateHostInstanceId } from '@db/utils/generators';
 import { WorkflowHistoryManager } from '@/workflows/workflowHistory/workflowHistoryManager.ee';
 import { ShutdownService } from '@/shutdown/Shutdown.service';
+import { TelemetryEventRelay } from '@/telemetry/telemetry-event-relay.service';
 
 export abstract class BaseCommand extends Command {
 	protected logger = Container.get(Logger);
@@ -110,6 +111,7 @@ export abstract class BaseCommand extends Command {
 
 		await Container.get(PostHogClient).init();
 		await Container.get(InternalHooks).init();
+		Container.get(TelemetryEventRelay).init();
 	}
 
 	protected setInstanceType(instanceType: N8nInstanceType) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -32,6 +32,7 @@ import { ExecutionService } from '@/executions/execution.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowRunner } from '@/WorkflowRunner';
 import { ExecutionRecoveryService } from '@/executions/execution-recovery.service';
+import { EventRelay } from '@/eventbus/event-relay.service';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
 const open = require('open');
@@ -107,7 +108,7 @@ export class Start extends BaseCommand {
 				await Container.get(OrchestrationService).shutdown();
 			}
 
-			await Container.get(InternalHooks).onN8nStop();
+			await Container.get(EventRelay).emit('n8n-stopped', {});
 
 			await Container.get(ActiveExecutions).shutdown();
 

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -168,11 +168,12 @@ export class InvitationController {
 
 		this.authService.issueCookie(res, updatedUser, req.browserId);
 
-		void this.internalHooks.onUserSignup(updatedUser, {
+		const signUpMetadata = {
 			user_type: 'email',
 			was_disabled_ldap_user: false,
-		});
-		this.eventRelay.emit('user-signed-up', { user: updatedUser });
+		};
+
+		this.eventRelay.emit('user-signed-up', { user: updatedUser, signUpMetadata });
 
 		const publicInvitee = await this.userService.toPublic(invitee);
 

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -198,7 +198,6 @@ export class MeController {
 
 		await this.userService.update(req.user.id, { apiKey });
 
-		void this.internalHooks.onApiKeyCreated({ user: req.user, public_api: false });
 		this.eventRelay.emit('api-key-created', { user: req.user });
 
 		return { apiKey };
@@ -219,7 +218,6 @@ export class MeController {
 	async deleteAPIKey(req: AuthenticatedRequest) {
 		await this.userService.update(req.user.id, { apiKey: null });
 
-		void this.internalHooks.onApiKeyDeleted({ user: req.user, public_api: false });
 		this.eventRelay.emit('api-key-deleted', { user: req.user });
 
 		return { success: true };

--- a/packages/cli/src/controllers/owner.controller.ts
+++ b/packages/cli/src/controllers/owner.controller.ts
@@ -14,12 +14,13 @@ import { UserService } from '@/services/user.service';
 import { Logger } from '@/Logger';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InternalHooks } from '@/InternalHooks';
+import { EventRelay } from '@/eventbus/event-relay.service';
 
 @RestController('/owner')
 export class OwnerController {
 	constructor(
 		private readonly logger: Logger,
-		private readonly internalHooks: InternalHooks,
+		private readonly eventRelay: EventRelay,
 		private readonly settingsRepository: SettingsRepository,
 		private readonly authService: AuthService,
 		private readonly userService: UserService,
@@ -85,7 +86,7 @@ export class OwnerController {
 
 		this.authService.issueCookie(res, owner, req.browserId);
 
-		void this.internalHooks.onInstanceOwnerSetup({ user_id: owner.id });
+		this.eventRelay.emit('user-owner-setup', { user: owner });
 
 		return await this.userService.toPublic(owner, { posthog: this.postHog, withScopes: true });
 	}

--- a/packages/cli/src/controllers/passwordReset.controller.ts
+++ b/packages/cli/src/controllers/passwordReset.controller.ts
@@ -171,8 +171,7 @@ export class PasswordResetController {
 		}
 
 		this.logger.info('Reset-password token resolved successfully', { userId: user.id });
-		void this.internalHooks.onUserPasswordResetEmailClick({ user });
-		this.eventRelay.emit('user-password-reset-email-click', { user });
+		this.eventRelay.emit('user-clicked-password-reset-email', { user });
 	}
 
 	/**
@@ -221,11 +220,11 @@ export class PasswordResetController {
 		// if this user used to be an LDAP users
 		const ldapIdentity = user?.authIdentities?.find((i) => i.providerType === 'ldap');
 		if (ldapIdentity) {
-			void this.internalHooks.onUserSignup(user, {
+			const signUpMetadata = {
 				user_type: 'email',
 				was_disabled_ldap_user: true,
-			});
-			this.eventRelay.emit('user-signed-up', { user });
+			};
+			this.eventRelay.emit('user-signed-up', { user, signUpMetadata });
 		}
 
 		await this.externalHooks.run('user.password.update', [user.email, passwordHash]);

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -253,12 +253,7 @@ export class UsersController {
 			await trx.delete(User, { id: userToDelete.id });
 		});
 
-		void this.internalHooks.onUserDeletion({
-			user: req.user,
-			telemetryData,
-			publicApi: false,
-		});
-		this.eventRelay.emit('user-deleted', { user: req.user });
+		this.eventRelay.emit('user-deleted', { user: req.user, ...telemetryData, public_api: true });
 
 		await this.externalHooks.run('user.deleted', [await this.userService.toPublic(userToDelete)]);
 

--- a/packages/cli/src/eventbus/audit-event-relay.service.ts
+++ b/packages/cli/src/eventbus/audit-event-relay.service.ts
@@ -35,7 +35,7 @@ export class AuditEventRelay {
 		this.eventRelay.on('user-password-reset-email-click', (event) =>
 			this.userPasswordResetEmailClick(event),
 		);
-		this.eventRelay.on('user-password-reset-request-click', (event) =>
+		this.eventRelay.on('user-clicked-password-reset-email', (event) =>
 			this.userPasswordResetRequestClick(event),
 		);
 		this.eventRelay.on('api-key-created', (event) => this.apiKeyCreated(event));

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -60,6 +60,11 @@ export type Event = {
 
 	'user-deleted': {
 		user: UserLike;
+		target_user_old_status: string;
+		target_user_id?: string;
+		migration_strategy?: string;
+		migration_user_id?: string;
+		public_api: boolean;
 	};
 
 	'user-invited': {
@@ -77,7 +82,46 @@ export type Event = {
 		fieldsChanged: string[];
 	};
 
+	'user-invoked-api': {
+		user: UserLike;
+		path: string;
+		method: string;
+		api_version: string;
+	};
+
 	'user-signed-up': {
+		user: UserLike;
+		signUpMetadata?: {
+			user_type: string;
+			was_disabled_ldap_user: boolean;
+		};
+	};
+
+	'user-retrieved-user': {
+		user: UserLike;
+	};
+
+	'user-retrieved-all-users': {
+		user: UserLike;
+	};
+
+	'user-retrieved-execution': {
+		user: UserLike;
+	};
+
+	'user-retrieved-all-executions': {
+		user: UserLike;
+	};
+
+	'user-retrieved-all-workflows': {
+		user: UserLike;
+	};
+
+	'user-retrieved-workflow': {
+		user: UserLike;
+	};
+
+	'user-owner-setup': {
 		user: UserLike;
 	};
 
@@ -97,20 +141,20 @@ export type Event = {
 		invitee: UserLike;
 	};
 
-	'user-password-reset-email-click': {
+	'user-clicked-password-reset-email': {
 		user: UserLike;
 	};
 
-	'user-password-reset-request-click': {
-		user: UserLike;
-	};
+	'n8n-stopped': {};
 
 	'api-key-created': {
 		user: UserLike;
+		public_api?: boolean;
 	};
 
 	'api-key-deleted': {
 		user: UserLike;
+		public_api?: boolean;
 	};
 
 	'email-failed': {
@@ -206,5 +250,9 @@ export type Event = {
 	'team-project-created': {
 		userId: string;
 		role: GlobalRole;
+	};
+
+	'license-renew-attempted': {
+		success: boolean;
 	};
 };

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -1,5 +1,7 @@
 import type { AuthenticationMethod, IWorkflowBase } from 'n8n-workflow';
 import type { IWorkflowExecutionDataProcess } from '@/Interfaces';
+import type { ProjectRole } from '@/databases/entities/ProjectRelation';
+import type { GlobalRole } from '@/databases/entities/User';
 
 export type UserLike = {
 	id: string;
@@ -10,7 +12,7 @@ export type UserLike = {
 };
 
 /**
- * Events sent by services and consumed by relays, e.g. `AuditEventRelay`.
+ * Events sent by services and consumed by relays, e.g. `AuditEventRelay` and `TelemetryEventRelay`.
  */
 export type Event = {
 	'workflow-created': {
@@ -181,5 +183,28 @@ export type Event = {
 		packageNodeNames: string[];
 		packageAuthor?: string;
 		packageAuthorEmail?: string;
+	};
+
+	'team-project-updated': {
+		userId: string;
+		role: GlobalRole;
+		members: Array<{
+			userId: string;
+			role: ProjectRole;
+		}>;
+		projectId: string;
+	};
+
+	'team-project-deleted': {
+		userId: string;
+		role: GlobalRole;
+		projectId: string;
+		removalType: 'transfer' | 'delete';
+		targetProjectId?: string;
+	};
+
+	'team-project-created': {
+		userId: string;
+		role: GlobalRole;
 	};
 };

--- a/packages/cli/src/telemetry/telemetry-event-relay.service.ts
+++ b/packages/cli/src/telemetry/telemetry-event-relay.service.ts
@@ -21,7 +21,32 @@ export class TelemetryEventRelay {
 		this.eventRelay.on('team-project-updated', (event) => this.teamProjectUpdated(event));
 		this.eventRelay.on('team-project-deleted', (event) => this.teamProjectDeleted(event));
 		this.eventRelay.on('team-project-created', (event) => this.teamProjectCreated(event));
+		this.eventRelay.on('api-key-deleted', (event) => this.apiKeyDeleted(event));
+		this.eventRelay.on('api-key-created', (event) => this.apiKeyCreated(event));
+		this.eventRelay.on('user-signed-up', (event) => this.userSignedUp(event));
+		this.eventRelay.on('user-invoked-api', (event) => this.userInvokedApi(event));
+		this.eventRelay.on('user-retrieved-user', (event) => this.userRetrievedUser(event));
+		this.eventRelay.on('user-retrieved-all-users', (event) => this.userRetrievedAllUsers(event));
+		this.eventRelay.on('user-retrieved-execution', (event) => this.userRetrievedExecution(event));
+		this.eventRelay.on('user-retrieved-all-executions', (event) =>
+			this.userRetrievedAllExecution(event),
+		);
+		this.eventRelay.on('user-retrieved-workflow', (event) => this.userRetrievedWorkflow(event));
+		this.eventRelay.on('user-retrieved-all-workflows', (event) =>
+			this.userRetrievedAllWorkflows(event),
+		);
+		this.eventRelay.on('user-deleted', (event) => this.userDeleted(event));
+		this.eventRelay.on('user-clicked-password-reset-email', (event) =>
+			this.userClickedPasswordResetEmail(event),
+		);
+		this.eventRelay.on('n8n-stopped', (_) => this.onN8nStopped());
+		this.eventRelay.on('user-owner-setup', (event) => this.userOwnerSetup(event));
+		this.eventRelay.on('license-renew-attempted', (event) => this.licenseRenewAttempted(event));
 	}
+
+	/**
+	 * Projects
+	 */
 
 	private teamProjectUpdated({ userId, role, members, projectId }: Event['team-project-updated']) {
 		void this.telemetry.track('Project settings updated', {
@@ -54,5 +79,115 @@ export class TelemetryEventRelay {
 			user_id: userId,
 			role,
 		});
+	}
+
+	/**
+	 * API Keys
+	 */
+
+	private apiKeyDeleted({ user, public_api }: Event['api-key-deleted']) {
+		void this.telemetry.track('User invited new user', {
+			user_id: user.id,
+			public_api: public_api ?? false,
+		});
+	}
+
+	private apiKeyCreated({ user, public_api }: Event['api-key-created']) {
+		void this.telemetry.track('User invited new user', {
+			user_id: user.id,
+			public_api: public_api ?? false,
+		});
+	}
+
+	/**
+	 * Users
+	 */
+
+	private userInvokedApi({ user, ...rest }: Event['user-invoked-api']) {
+		void this.telemetry.track('User invoked API', {
+			user_id: user.id,
+			...rest,
+		});
+	}
+
+	private userSignedUp({ user, signUpMetadata }: Event['user-signed-up']) {
+		void this.telemetry.track('User signed up', {
+			user_id: user.id,
+			...signUpMetadata,
+		});
+	}
+
+	private userRetrievedUser({ user }: Event['user-retrieved-user']) {
+		void this.telemetry.track('User retrieved user', {
+			user_id: user.id,
+			public_api: true,
+		});
+	}
+
+	private userRetrievedAllUsers({ user }: Event['user-retrieved-all-users']) {
+		void this.telemetry.track('User retrieved all users', {
+			user_id: user.id,
+			public_api: true,
+		});
+	}
+
+	private userRetrievedExecution({ user }: Event['user-retrieved-execution']) {
+		void this.telemetry.track('User retrieved execution', {
+			user_id: user.id,
+			public_api: true,
+		});
+	}
+
+	private userRetrievedAllExecution({ user }: Event['user-retrieved-all-executions']) {
+		void this.telemetry.track('User retrieved all executions', {
+			user_id: user.id,
+			public_api: true,
+		});
+	}
+
+	private userRetrievedWorkflow({ user }: Event['user-retrieved-workflow']) {
+		void this.telemetry.track('User retrieved workflow', { user_id: user.id, public_api: true });
+	}
+
+	private userRetrievedAllWorkflows({ user }: Event['user-retrieved-all-workflows']) {
+		void this.telemetry.track('User retrieved all workflows', {
+			user_id: user.id,
+			public_api: true,
+		});
+	}
+
+	private userDeleted({ user, public_api, ...rest }: Event['user-deleted']) {
+		void this.telemetry.track('User deleted', { user_id: user.id, public_api, ...rest });
+	}
+
+	private userClickedPasswordResetEmail({ user }: Event['user-clicked-password-reset-email']) {
+		void this.telemetry.track('User clicked password reset link from email', {
+			user_id: user.id,
+		});
+	}
+
+	private userOwnerSetup({ user }: Event['user-owner-setup']) {
+		void this.telemetry.track('Owner finished instance setup', { user_id: user.id });
+	}
+
+	/**
+	 * n8n
+	 */
+
+	private onN8nStopped() {
+		const timeoutPromise = new Promise<void>((resolve) => {
+			setTimeout(() => {
+				resolve();
+			}, 3000);
+		});
+
+		return Promise.race([timeoutPromise, this.telemetry.trackN8nStop()]);
+	}
+
+	/**
+	 * License
+	 */
+	async licenseRenewAttempted({ success }: Event['license-renew-attempted']) {
+		await this.telemetry.track('Instance attempted to refresh license', { success });
 	}
 }

--- a/packages/cli/src/telemetry/telemetry-event-relay.service.ts
+++ b/packages/cli/src/telemetry/telemetry-event-relay.service.ts
@@ -1,0 +1,58 @@
+import { Service } from 'typedi';
+import { EventRelay } from '@/eventbus/event-relay.service';
+import type { Event } from '@/eventbus/event.types';
+import { Telemetry } from '.';
+import config from '@/config';
+
+@Service()
+export class TelemetryEventRelay {
+	constructor(
+		private readonly eventRelay: EventRelay,
+		private readonly telemetry: Telemetry,
+	) {}
+
+	init() {
+		if (!config.getEnv('diagnostics.enabled')) return;
+
+		this.setupHandlers();
+	}
+
+	private setupHandlers() {
+		this.eventRelay.on('team-project-updated', (event) => this.teamProjectUpdated(event));
+		this.eventRelay.on('team-project-deleted', (event) => this.teamProjectDeleted(event));
+		this.eventRelay.on('team-project-created', (event) => this.teamProjectCreated(event));
+	}
+
+	private teamProjectUpdated({ userId, role, members, projectId }: Event['team-project-updated']) {
+		void this.telemetry.track('Project settings updated', {
+			user_id: userId,
+			role,
+			// eslint-disable-next-line @typescript-eslint/no-shadow
+			members: members.map(({ userId: user_id, role }) => ({ user_id, role })),
+			project_id: projectId,
+		});
+	}
+
+	private teamProjectDeleted({
+		userId,
+		role,
+		projectId,
+		removalType,
+		targetProjectId,
+	}: Event['team-project-deleted']) {
+		void this.telemetry.track('User deleted project', {
+			user_id: userId,
+			role,
+			project_id: projectId,
+			removal_type: removalType,
+			target_project_id: targetProjectId,
+		});
+	}
+
+	private teamProjectCreated({ userId, role }: Event['team-project-created']) {
+		void this.telemetry.track('User created project', {
+			user_id: userId,
+			role,
+		});
+	}
+}

--- a/packages/cli/test/integration/shared/utils/testCommand.ts
+++ b/packages/cli/test/integration/shared/utils/testCommand.ts
@@ -4,6 +4,8 @@ import { mock } from 'jest-mock-extended';
 
 import type { BaseCommand } from '@/commands/BaseCommand';
 import * as testDb from '../testDb';
+import { TelemetryEventRelay } from '@/telemetry/telemetry-event-relay.service';
+import { mockInstance } from '@test/mocking';
 
 export const setupTestCommand = <T extends BaseCommand>(Command: Class<T>) => {
 	const config = mock<Config>();
@@ -18,6 +20,7 @@ export const setupTestCommand = <T extends BaseCommand>(Command: Class<T>) => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		mockInstance(TelemetryEventRelay);
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
This PR kicks off decoupling telemetry from internal hooks, starting with projects: 

- set up `TelemetryEventRelay`
- migrate telemetry events for project created, updated, deleted 
- remove blocking on migrated telemetry events
- remove unused hook `onConcurrencyLimitHit`

As example for @RicardoE105
