### PR TITLE
feat(GitHub Node): Add support for state reasons when editing an issue

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -903,11 +903,23 @@ export class Github implements INodeType {
 				default: {},
 				options: [
 					{
-						displayName: 'Title',
-						name: 'title',
-						type: 'string',
-						default: '',
-						description: 'The title of the issue',
+						displayName: 'Assignees',
+						name: 'assignees',
+						type: 'collection',
+						typeOptions: {
+							multipleValues: true,
+							multipleValueButtonText: 'Add Assignee',
+						},
+						default: { assignee: '' },
+						options: [
+							{
+								displayName: 'Assignees',
+								name: 'assignee',
+								type: 'string',
+								default: '',
+								description: 'User to assign issue to',
+							},
+						],
 					},
 					{
 						displayName: 'Body',
@@ -918,25 +930,6 @@ export class Github implements INodeType {
 						},
 						default: '',
 						description: 'The body of the issue',
-					},
-					{
-						displayName: 'State',
-						name: 'state',
-						type: 'options',
-						options: [
-							{
-								name: 'Closed',
-								value: 'closed',
-								description: 'Set the state to "closed"',
-							},
-							{
-								name: 'Open',
-								value: 'open',
-								description: 'Set the state to "open"',
-							},
-						],
-						default: 'open',
-						description: 'The state to set',
 					},
 					{
 						displayName: 'Labels',
@@ -958,27 +951,57 @@ export class Github implements INodeType {
 						],
 					},
 					{
-						displayName: 'Assignees',
-						name: 'assignees',
-						type: 'collection',
-						typeOptions: {
-							multipleValues: true,
-							multipleValueButtonText: 'Add Assignee',
-						},
-						default: { assignee: '' },
+						displayName: 'State',
+						name: 'state',
+						type: 'options',
 						options: [
 							{
-								displayName: 'Assignees',
-								name: 'assignee',
-								type: 'string',
-								default: '',
-								description: 'User to assign issue to',
+								name: 'Closed',
+								value: 'closed',
+								description: 'Set the state to "closed"',
+							},
+							{
+								name: 'Open',
+								value: 'open',
+								description: 'Set the state to "open"',
 							},
 						],
+						default: 'open',
+						description: 'The state to set',
+					},
+					{
+						displayName: 'State Reason',
+						name: 'state_reason',
+						type: 'options',
+						options: [
+							{
+								name: 'Completed',
+								value: 'completed',
+								description: 'Issue is completed',
+							},
+							{
+								name: 'Not Planned',
+								value: 'not_planned',
+								description: 'Issue is not planned',
+							},
+							{
+								name: 'Reopened',
+								value: 'reopened',
+								description: 'Issue is reopened',
+							},
+						],
+						default: 'completed',
+						description: 'The reason for the state change',
+					},
+					{
+						displayName: 'Title',
+						name: 'title',
+						type: 'string',
+						default: '',
+						description: 'The title of the issue',
 					},
 				],
 			},
-
 			// ----------------------------------
 			//         issue:get
 			// ----------------------------------


### PR DESCRIPTION
## Summary
Found on the forum and it is a quick win. Adds State Reason which lets you set closed as completed, closed as not planned and reopened.

<img width="544" alt="image" src="https://github.com/n8n-io/n8n/assets/4688521/6664e22a-6acc-4424-a479-2e40a25a1e92">


## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/github-node-close-issue-as-not-planned/48801