### PR TITLE
feat(Jenkins Node): Add support for self signed certificates

### DIFF
--- a/packages/nodes-base/credentials/JenkinsApi.credentials.ts
+++ b/packages/nodes-base/credentials/JenkinsApi.credentials.ts
@@ -9,7 +9,7 @@ export class JenkinsApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'Jenking Username',
+			displayName: 'Jenkins Username',
 			name: 'username',
 			type: 'string',
 			default: '',

--- a/packages/nodes-base/credentials/JenkinsApi.credentials.ts
+++ b/packages/nodes-base/credentials/JenkinsApi.credentials.ts
@@ -27,5 +27,12 @@ export class JenkinsApi implements ICredentialType {
 			type: 'string',
 			default: '',
 		},
+		{
+			displayName: 'Ignore SSL Issues',
+			name: 'ignoreSSLIssues',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to connect even if SSL certificate validation is not possible',
+		},
 	];
 }

--- a/packages/nodes-base/nodes/Jenkins/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Jenkins/GenericFunctions.ts
@@ -36,6 +36,7 @@ export async function jenkinsApiRequest(
 		json: true,
 		qs,
 		body,
+		rejectUnauthorized: !credentials.ignoreSSLIssues as boolean,
 	};
 	options = Object.assign({}, options, option);
 	try {

--- a/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
+++ b/packages/nodes-base/nodes/Jenkins/Jenkins.node.ts
@@ -19,6 +19,7 @@ export type JenkinsApiCredentials = {
 	username: string;
 	apiKey: string;
 	baseUrl: string;
+	ignoreSSLIssues: boolean;
 };
 
 export class Jenkins implements INodeType {
@@ -394,7 +395,8 @@ export class Jenkins implements INodeType {
 				this: ICredentialTestFunctions,
 				credential: ICredentialsDecrypted,
 			): Promise<INodeCredentialTestResult> {
-				const { baseUrl, username, apiKey } = credential.data as JenkinsApiCredentials;
+				const { baseUrl, username, apiKey, ignoreSSLIssues } =
+					credential.data as JenkinsApiCredentials;
 
 				const url = tolerateTrailingSlash(baseUrl);
 				const endpoint = '/api/json';
@@ -409,6 +411,7 @@ export class Jenkins implements INodeType {
 					qs: {},
 					uri: `${url}${endpoint}`,
 					json: true,
+					rejectUnauthorized: !ignoreSSLIssues,
 				};
 
 				try {


### PR DESCRIPTION
## Summary
Adds option to support self signed certificates with Jenkins, Also fixes a typo.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/jenkins-ignore-ssl-option/49027
