### PR TITLE
ci: Fix a flaky test (no-changelog)

### DIFF
--- a/packages/nodes-base/test/utils/utilities.test.ts
+++ b/packages/nodes-base/test/utils/utilities.test.ts
@@ -148,7 +148,7 @@ describe('Test getResolvables', () => {
 
 describe('shuffleArray', () => {
 	it('should shuffle array', () => {
-		const array = [1, 2, 3, 4, 5];
+		const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 		const toShuffle = [...array];
 		shuffleArray(toShuffle);
 		expect(toShuffle).not.toEqual(array);


### PR DESCRIPTION
## Summary

The unit tests for `shuffleArray` were using a 5 element array, which meant there was a probability of 1 in 120 (5!), that the test would fail. Increasing the array size to 10 decreases this probability to 1 in 3.6 million (10!).

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
