### PR TITLE
ci: Update codecov setup (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -44,6 +44,8 @@ jobs:
       nodeVersion: ${{ matrix.node-version }}
       cacheKey: ${{ github.sha }}-base:build
       collectCoverage: ${{ matrix.node-version == '20.x' }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -43,7 +43,7 @@ jobs:
       ref: ${{ inputs.branch }}
       nodeVersion: ${{ matrix.node-version }}
       cacheKey: ${{ github.sha }}-base:build
-      collectCoverage: true
+      collectCoverage: ${{ matrix.node-version == '20.x' }}
 
   lint:
     name: Lint

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -22,6 +22,10 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Codecov upload token.'
+        required: false
 
 jobs:
   unit-test:
@@ -67,6 +71,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: inputs.collectCoverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4.5.0
         with:
-          files: packages/@n8n/chat/coverage/cobertura-coverage.xml,packages/@n8n/nodes-langchain/coverage/cobertura-coverage.xml,packages/@n8n/permissions/coverage/cobertura-coverage.xml,packages/@n8n/client-oauth2/coverage/cobertura-coverage.xml,packages/cli/coverage/cobertura-coverage.xml,packages/core/coverage/cobertura-coverage.xml,packages/design-system/coverage/cobertura-coverage.xml,packages/@n8n/codemirror-lang/coverage/cobertura-coverage.xml,packages/editor-ui/coverage/cobertura-coverage.xml,packages/nodes-base/coverage/cobertura-coverage.xml,packages/workflow/coverage/cobertura-coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/@n8n/nodes-langchain/jest.config.js
+++ b/packages/@n8n/nodes-langchain/jest.config.js
@@ -1,2 +1,5 @@
 /** @type {import('jest').Config} */
-module.exports = require('../../../jest.config');
+module.exports = {
+	...require('../../../jest.config'),
+	collectCoverageFrom: ['credentials/**/*.ts', 'nodes/**/*.ts', 'utils/**/*.ts'],
+};


### PR DESCRIPTION
## Summary
This PR updates our codecov setup to 
1. Update the github action for code coverage collection
2. Collect coverage for all packages, without having to maintain an explicit list
3. Generate valid coverage for `@n8n/n8n-nodes-langchain` 
4. Collect coverage on `master` CI only on node.js 20, to prevent hitting rate-limits

## Review / Merge checklist

- [x] PR title and summary are descriptive