### PR TITLE
fix: Delete duplicate properties in Structured Output Parser Node (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -129,8 +129,6 @@ export class OutputParserStructured implements INodeType {
 			},
 			{
 				...inputSchemaField,
-				displayName: 'JSON Schema',
-				description: 'JSON Schema to structure and validate the output against',
 				default: `{
 	"type": "object",
 	"properties": {
@@ -145,79 +143,6 @@ export class OutputParserStructured implements INodeType {
 		}
 	}
 }`,
-			},
-			{
-				displayName: 'Schema Type',
-				name: 'schemaType',
-				type: 'options',
-				noDataExpression: true,
-				options: [
-					{
-						name: 'Generate From JSON Example',
-						value: 'fromJson',
-						description: 'Generate a schema from an example JSON object',
-					},
-					{
-						name: 'Define Below',
-						value: 'manual',
-						description: 'Define the JSON schema manually',
-					},
-				],
-				default: 'fromJson',
-				description: 'How to specify the schema for the function',
-				displayOptions: {
-					show: {
-						'@version': [{ _cnd: { gte: 1.2 } }],
-					},
-				},
-			},
-			{
-				displayName: 'JSON Example',
-				name: 'jsonSchemaExample',
-				type: 'json',
-				default: `{
-	"state": "California",
-	"cities": ["Los Angeles", "San Francisco", "San Diego"]
-}`,
-				noDataExpression: true,
-				typeOptions: {
-					rows: 10,
-				},
-				displayOptions: {
-					show: {
-						schemaType: ['fromJson'],
-					},
-				},
-				description: 'Example JSON object to use to generate the schema',
-			},
-			{
-				displayName: 'Input Schema',
-				name: 'inputSchema',
-				type: 'json',
-				default: `{
-	"type": "object",
-	"properties": {
-		"state": {
-			"type": "string"
-		},
-		"cities": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		}
-	}
-}`,
-				noDataExpression: true,
-				typeOptions: {
-					rows: 10,
-				},
-				displayOptions: {
-					show: {
-						schemaType: ['manual'],
-					},
-				},
-				description: 'Schema to use for the function',
 			},
 			{
 				displayName: 'JSON Schema',


### PR DESCRIPTION
## Summary

These duplicate properties were introduced in an accidental bad merge [here](https://github.com/n8n-io/n8n/pull/9484/files#diff-76afc25d81dbfea47a75d0ae4b1555db59b162ade6c650e6ff9baabb320a8ae6R149).

## Related Linear tickets, Github issues, and Community forum posts

#9771
https://linear.app/n8n/issue/AI-198

## Review / Merge checklist

- [x] PR title and summary are descriptive