### PR TITLE
fix(core): Disable Fast Fallback for network connections (no-changelog)

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -47,6 +47,9 @@ if (process.env.NODEJS_PREFER_IPV4 === 'true') {
 	require('dns').setDefaultResultOrder('ipv4first');
 }
 
+// set Socket `autoSelectFamily` defaults to pre v20 behavior
+require('net').setDefaultAutoSelectFamily?.(false);
+
 (async () => {
 	const oclif = await import('@oclif/core');
 	await oclif.execute({ dir: __dirname });

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -47,7 +47,12 @@ if (process.env.NODEJS_PREFER_IPV4 === 'true') {
 	require('dns').setDefaultResultOrder('ipv4first');
 }
 
-// set Socket `autoSelectFamily` defaults to pre v20 behavior
+// Node.js 20 enabled a Happy Eyeballs algorithm which enables support
+// for both IPv6 and IPv4 at the same time, favoring IPv6 when possible.
+// However there are some issues in the algorithm implementation that is causing
+// issues to our users with services like Telegram or Airtable. This restores the
+// behavior to pre v20
+// More details: https://github.com/nodejs/node/issues/48145
 require('net').setDefaultAutoSelectFamily?.(false);
 
 (async () => {


### PR DESCRIPTION
## Summary
Node.js 20 enabled [Happy Eyeballs algorithm](https://en.wikipedia.org/wiki/Happy_Eyeballs) for all dual-stack network calls by default. 
This has turned out to be an issue with certain services like Telegram and Airtable, that are not responding to their IPv6 addresses in a timely manner.
There have been a couple of fixes to Node's implementation of this algorithm, but there seem to be still some bugs present for our users.
Until one of us understand this issue a bit more, and can track the issues on Node.js, I suggest that we disable socket `autoSelectFamily` by default, like it used to be on Node.js 18.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/errors-since-last-n8n-update-1-44-1/48238
https://github.com/n8n-io/n8n/issues/9824

## Review / Merge checklist

- [x] PR title and summary are descriptive