### PR TITLE
fix(LangChain Code Node): Fix icon in dark mode (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -120,6 +120,7 @@ export class Code implements INodeType {
 		displayName: 'LangChain Code',
 		name: 'code',
 		icon: 'fa:code',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'LangChain Code Node',

--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -79,16 +79,19 @@
 	--color-sticky-border-7: var(--prim-gray-670);
 
 	// NodeIcon
-	--color-node-icon-gray: var(--prim-gray-200);
-	--color-node-icon-black: var(--prim-gray-70);
-	--color-node-icon-blue: #766dfb;
-	--color-node-icon-dark-blue: #6275ad;
+	--color-node-icon-gray: var(--prim-gray-120);
+	--color-node-icon-black: var(--prim-gray-10);
+	--color-node-icon-blue: #898fff;
+	--color-node-icon-light-blue: #58abff;
+	--color-node-icon-dark-blue: #7ba7ff;
 	--color-node-icon-orange-red: var(--prim-color-primary);
+	--color-node-icon-pink-red: #f85d82;
 	--color-node-icon-red: var(--prim-color-alt-k);
 	--color-node-icon-light-green: #20b69e;
+	--color-node-icon-green: #38cb7a;
 	--color-node-icon-dark-green: #86decc;
 	--color-node-icon-purple: #9b6dd5;
-	--color-node-icon-crimson: #d05876;
+	--color-node-icon-crimson: #f188a2;
 
 	// Expressions, autocomplete, infobox
 	--color-valid-resolvable-foreground: var(--prim-color-alt-a-tint-300);

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -67,6 +67,7 @@ const versionDescription: INodeTypeDescription = {
 	displayName: 'Email Trigger (IMAP)',
 	name: 'emailReadImap',
 	icon: 'fa:inbox',
+	iconColor: 'green',
 	group: ['trigger'],
 	version: 2,
 	description: 'Triggers the workflow when a new email is received',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -310,7 +310,7 @@ type ICredentialHttpRequestNode = {
 export interface ICredentialType {
 	name: string;
 	displayName: string;
-	icon?: Themed<Icon>;
+	icon?: Icon;
 	iconUrl?: Themed<string>;
 	extends?: string[];
 	properties: INodeProperties[];
@@ -1571,13 +1571,15 @@ export type NodeIconColor =
 	| 'azure'
 	| 'purple'
 	| 'crimson';
-export type Icon = `fa:${string}` | `file:${string}` | `node:${string}`;
 export type Themed<T> = T | { light: T; dark: T };
+export type IconRef = `fa:${string}` | `node:${string}.${string}`;
+export type IconFile = `file:${string}.png` | `file:${string}.svg`;
+export type Icon = IconRef | Themed<IconFile>;
 
 export interface INodeTypeBaseDescription {
 	displayName: string;
 	name: string;
-	icon?: Themed<Icon>;
+	icon?: Icon;
 	iconColor?: NodeIconColor;
 	iconUrl?: Themed<string>;
 	badgeIconUrl?: Themed<string>;


### PR DESCRIPTION
## Summary
This PR:
1. Improves the type-safety in how icons are defined
2. fixes the icon for the Langchain Code node in dark mode

Before 
![image](https://github.com/n8n-io/n8n/assets/196144/4017cf24-ca62-46d7-84f9-5b0a1531cd14)

After
![image](https://github.com/n8n-io/n8n/assets/196144/640a72c4-864d-4ede-9565-04819c0cc5e2)


## Review / Merge checklist

- [x] PR title and summary are descriptive