### PR TITLE
feat(editor): Allow two-way connection for AI Nodes in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/handles/HandleRenderer.vue
+++ b/packages/editor-ui/src/components/canvas/elements/handles/HandleRenderer.vue
@@ -23,11 +23,11 @@ const $style = useCssModule();
 const handleType = computed(() => (props.mode === 'input' ? 'target' : 'source'));
 
 const isConnectableStart = computed(() => {
-	return props.mode === 'output';
+	return props.mode === 'output' || props.type !== NodeConnectionType.Main;
 });
 
 const isConnectableEnd = computed(() => {
-	return props.mode === 'input';
+	return props.mode === 'input' || props.type !== NodeConnectionType.Main;
 });
 
 const Render = (renderProps: { label?: string }) => {


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/assets/6179477/30684421-3afb-418b-bd1b-0b5822afff0f

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7451/allow-initiating-connection-from-ai-inputs

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
