### PR TITLE
fix(editor): Fix initialize authenticated features

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -60,7 +60,6 @@ import { useUsageStore } from '@/stores/usage.store';
 import { useUsersStore } from '@/stores/users.store';
 import { useHistoryHelper } from '@/composables/useHistoryHelper';
 import { useRoute } from 'vue-router';
-import { initializeAuthenticatedFeatures } from '@/init';
 import { useAIStore } from './stores/ai.store';
 import AIAssistantChat from './components/AIAssistantChat/AIAssistantChat.vue';
 
@@ -103,26 +102,16 @@ export default defineComponent({
 	},
 	data() {
 		return {
-			onAfterAuthenticateInitialized: false,
 			loading: true,
 		};
 	},
 	watch: {
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		async 'usersStore.currentUser'(currentValue, previousValue) {
-			if (currentValue && !previousValue) {
-				await initializeAuthenticatedFeatures();
-			}
-		},
 		defaultLocale(newLocale) {
 			void loadLanguage(newLocale);
 		},
 	},
 	async mounted() {
 		this.logHiringBanner();
-
-		void initializeAuthenticatedFeatures();
-
 		void useExternalHooks().run('app.mount');
 		this.loading = false;
 	},

--- a/packages/editor-ui/src/__tests__/router.test.ts
+++ b/packages/editor-ui/src/__tests__/router.test.ts
@@ -7,6 +7,9 @@ import { useSettingsStore } from '@/stores/settings.store';
 import { useRBACStore } from '@/stores/rbac.store';
 import type { Scope } from '@n8n/permissions';
 import type { RouteRecordName } from 'vue-router';
+import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+import { useProjectsStore } from '@/stores/projects.store';
+import { useRolesStore } from '@/stores/roles.store';
 
 const App = {
 	template: '<div />',
@@ -21,6 +24,17 @@ describe('router', () => {
 
 		const pinia = createPinia();
 		setActivePinia(pinia);
+
+		const nodeTypesStore = useNodeTypesStore();
+		vi.spyOn(nodeTypesStore, 'getNodeTranslationHeaders').mockResolvedValue();
+
+		const projectsStore = useProjectsStore();
+		vi.spyOn(projectsStore, 'getMyProjects').mockResolvedValue();
+		vi.spyOn(projectsStore, 'getPersonalProject').mockResolvedValue();
+		vi.spyOn(projectsStore, 'getProjectsCount').mockResolvedValue();
+
+		const rolesStore = useRolesStore();
+		vi.spyOn(rolesStore, 'fetchRoles').mockResolvedValue();
 
 		renderComponent({ pinia });
 	});

--- a/packages/editor-ui/src/__tests__/router.test.ts
+++ b/packages/editor-ui/src/__tests__/router.test.ts
@@ -41,6 +41,7 @@ describe('router', () => {
 
 	afterAll(() => {
 		server.shutdown();
+		vi.restoreAllMocks();
 	});
 
 	test.each([

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -15,7 +15,7 @@ import { EnterpriseEditionFeature, VIEWS, EDITABLE_CANVAS_VIEWS } from '@/consta
 import { useTelemetry } from '@/composables/useTelemetry';
 import { middleware } from '@/utils/rbac/middleware';
 import type { RouterMiddleware } from '@/types/router';
-import { initializeCore } from '@/init';
+import { initializeAuthenticatedFeatures, initializeCore } from '@/init';
 import { tryToParseNumber } from '@/utils/typesUtils';
 import { projectsRoutes } from '@/routes/projects.routes';
 
@@ -777,6 +777,7 @@ router.beforeEach(async (to: RouteLocationNormalized, from, next) => {
 		 */
 
 		await initializeCore();
+		await initializeAuthenticatedFeatures();
 
 		/**
 		 * Redirect to setup page. User should be redirected to this only once

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4789,12 +4789,6 @@ export default defineComponent({
 			}
 
 			try {
-				await Promise.all([
-					this.loadVariables(),
-					this.tagsStore.fetchAll(),
-					this.loadCredentials(),
-				]);
-
 				if (workflowId !== null && !this.uiStore.stateIsDirty) {
 					const workflow: IWorkflowDb | undefined =
 						await this.workflowsStore.fetchWorkflow(workflowId);
@@ -4803,6 +4797,12 @@ export default defineComponent({
 						await this.openWorkflow(workflow);
 					}
 				}
+
+				await Promise.all([
+					this.loadVariables(),
+					this.tagsStore.fetchAll(),
+					this.loadCredentials(),
+				]);
 			} catch (error) {
 				console.error(error);
 			}


### PR DESCRIPTION
## Summary
The initial problem was that credentials were not loading when opening the editor.
The app didn't wait for the login process and initializing the authenticated features to finish

## Related Linear tickets, Github issues, and Community forum posts
[PAY-1704](https://linear.app/n8n/issue/PAY-1704/bug-executions-arent-loading-on-the-internal-instance-and-on-147)
[PAY-1706](https://linear.app/n8n/issue/PAY-1706/bug-when-i-open-a-new-workflow-on-cloud-i-get-this-error)

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
