### PR TITLE
fix(core)!: Enforce a sandbox CSP on webhook endpoints

### DIFF
--- a/packages/cli/src/AbstractServer.ts
+++ b/packages/cli/src/AbstractServer.ts
@@ -183,7 +183,7 @@ export abstract class AbstractServer {
 			const activeWebhooks = Container.get(ActiveWebhooks);
 
 			// Register a handler for active forms
-			this.app.all(`/${this.endpointForm}/:path(*)`, webhookRequestHandler(activeWebhooks));
+			this.app.all(`/${this.endpointForm}/:path(*)`, webhookRequestHandler(activeWebhooks, false));
 
 			// Register a handler for active webhooks
 			this.app.all(`/${this.endpointWebhook}/:path(*)`, webhookRequestHandler(activeWebhooks));
@@ -205,7 +205,10 @@ export abstract class AbstractServer {
 			const testWebhooks = Container.get(TestWebhooks);
 
 			// Register a handler
-			this.app.all(`/${this.endpointFormTest}/:path(*)`, webhookRequestHandler(testWebhooks));
+			this.app.all(
+				`/${this.endpointFormTest}/:path(*)`,
+				webhookRequestHandler(testWebhooks, false),
+			);
 			this.app.all(`/${this.endpointWebhookTest}/:path(*)`, webhookRequestHandler(testWebhooks));
 		}
 

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -138,15 +138,15 @@ export const webhookRequestHandler =
 			return ResponseHelper.sendSuccessResponse(res, {}, true, 204);
 		}
 
-		if (cspSandbox) {
-			res.header('Content-Security-Policy', 'sandbox');
-		}
-
 		let response;
 		try {
 			response = await webhookManager.executeWebhook(req, res);
 		} catch (error) {
 			return ResponseHelper.sendErrorResponse(res, error as Error);
+		}
+
+		if (cspSandbox) {
+			res.header('Content-Security-Policy', 'sandbox');
 		}
 
 		// Don't respond, if already responded

--- a/packages/cli/src/WebhookHelpers.ts
+++ b/packages/cli/src/WebhookHelpers.ts
@@ -75,7 +75,8 @@ export const WEBHOOK_METHODS: IHttpRequestMethods[] = [
 ];
 
 export const webhookRequestHandler =
-	(webhookManager: IWebhookManager) =>
+	(webhookManager: IWebhookManager, cspSandbox = true) =>
+	// eslint-disable-next-line complexity
 	async (req: WebhookRequest | WebhookCORSRequest, res: express.Response) => {
 		const { path } = req.params;
 		const method = req.method;
@@ -135,6 +136,10 @@ export const webhookRequestHandler =
 
 		if (method === 'OPTIONS') {
 			return ResponseHelper.sendSuccessResponse(res, {}, true, 204);
+		}
+
+		if (cspSandbox) {
+			res.header('Content-Security-Policy', 'sandbox');
 		}
 
 		let response;


### PR DESCRIPTION
## Summary

If a webhook endpoint is used to serve an HTML file, it could be used for XSS.
This is not a supported feature, and to prevent this exploit, we should set CSP header to [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox) the entire page.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SEC-54

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included
