### PR TITLE
fix(editor): Load credentials for workflow before determining credentials errors

### DIFF
--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -3743,6 +3743,8 @@ export default defineComponent({
 			}
 		},
 		async initView(): Promise<void> {
+			await this.loadCredentialsForWorkflow();
+
 			if (this.$route.params.action === 'workflowSave') {
 				// In case the workflow got saved we do not have to run init
 				// as only the route changed but all the needed data is already loaded
@@ -3820,7 +3822,7 @@ export default defineComponent({
 					await this.newWorkflow();
 				}
 			}
-			await this.loadCredentials();
+
 			this.historyStore.reset();
 			this.uiStore.nodeViewInitialized = true;
 			document.addEventListener('keydown', this.keyDown);
@@ -4468,7 +4470,7 @@ export default defineComponent({
 		async loadCredentialTypes(): Promise<void> {
 			await this.credentialsStore.fetchCredentialTypes(true);
 		},
-		async loadCredentials(): Promise<void> {
+		async loadCredentialsForWorkflow(): Promise<void> {
 			const workflow = this.workflowsStore.getWorkflowById(this.currentWorkflow);
 			let options: { workflowId: string } | { projectId: string };
 
@@ -4801,7 +4803,7 @@ export default defineComponent({
 				await Promise.all([
 					this.loadVariables(),
 					this.tagsStore.fetchAll(),
-					this.loadCredentials(),
+					this.loadCredentialsForWorkflow(),
 				]);
 			} catch (error) {
 				console.error(error);

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4472,10 +4472,11 @@ export default defineComponent({
 		},
 		async loadCredentialsForWorkflow(): Promise<void> {
 			const workflow = this.workflowsStore.getWorkflowById(this.currentWorkflow);
+			const workflowId = workflow?.id ?? this.$route.params.name;
 			let options: { workflowId: string } | { projectId: string };
 
-			if (workflow) {
-				options = { workflowId: workflow.id };
+			if (workflowId) {
+				options = { workflowId };
 			} else {
 				const queryParam =
 					typeof this.$route.query?.projectId === 'string'


### PR DESCRIPTION
## Summary

We are attempting to get node credentials errors before we load the credentials in the store. This causes the UI to show "issues with the credentials" even though there are none. Loading the credentials as soon as we initiate the view seems to fix the issue.

Specifically, we are trying to get the credentials errors for `predefinedCredentialType` and [here](https://github.com/n8n-io/n8n/blob/e995309789c886f9203290e6973149ad96102fb2/packages/editor-ui/src/composables/useNodeHelpers.ts#L397), we attempt to get the type by calling `getCredentialsByType`, but that method depends on `allCredentialsByType` which at the same time depends on the state property `allCredentials`. At the time of calling the credentials have not been loaded in the store, so it returns `[]` even though it should have returned the credentials type. This empty array causes the logic to show an incorrect error. 

The execution does follow:

`Mounted` -> `ready (jsplumb)` -> `initView` - > `openWorkflow` ->  `addNodes` ->  `refreshNodeIssues` -> `getNodeIssue` ->` getNodeCredentialIssues` -> `credentialsStore.getCredentialsByType` (were we return [] because the store has not loaded yet.) -> at some point later we load the credentials for that workflow in the store (this should have happened before getNodeCredentialIssues)

@cstuncsik Can you please have a look? I'm not too familiar with this side of the code, so I'm not sure whether this would break something else or if it's the best approach to solve the issue. So far, it seems to fix the problem.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2280/http-request-shows-credentials-not-set-warning-in-ui-despite

## Before changes

https://www.loom.com/share/5c07e76288e84041b6b8abdf99a33b30?from_recorder=1&focus_title=1

## After the changes

https://www.loom.com/share/7ac13702dced4784bc1bb820a29ed5bc?from_recorder=1&focus_title=1

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
