### PR TITLE
ci: Add GH workflow to notify about PR status changes (no-changelog)

### DIFF
--- a/.github/workflows/notify-pr-status.yml
+++ b/.github/workflows/notify-pr-status.yml
@@ -1,0 +1,26 @@
+name: Notify PR status changed
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'dismissed') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == false && github.event.action == 'closed')
+    steps:
+      - uses: fjogeleit/http-request-action@dea46570591713c7de04a5b556bf2ff7bdf0aa9c # v1
+        name: Notify
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        with:
+          url: ${{ secrets.N8N_NOTIFY_PR_STATUS_CHANGED_URL }}
+          method: 'POST'
+          customHeaders: '{ "x-api-token": "${{ secrets.N8N_NOTIFY_PR_STATUS_CHANGED_TOKEN }}" }'
+          data: '{ "event_name": "${{ github.event_name }}", "pr_url": "${{ env.PR_URL }}",  "event": ${{ toJSON(github.event) }} }'


### PR DESCRIPTION

## Summary

Add a workflow that calls a webhook for specific PR status changes. This allows certain automations based on the event.

This could have also been implemented as a Github App or using a personal access token, but decided to use a workflow for transparency. The URL and access token are kept secret for security.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))