### PR TITLE
fix(Execute Workflow Node): Continue on fail behaviour not correctly implemented

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -231,7 +231,11 @@ export class ExecuteWorkflow implements INodeType {
 					}
 				} catch (error) {
 					if (this.continueOnFail(error)) {
-						return [[{ json: { error: error.message }, pairedItem: { item: i } }]];
+						if (returnData[i] === undefined) {
+							returnData[i] = [];
+						}
+						returnData[i].push({ json: { error: error.message }, pairedItem: { item: i } });
+						continue;
 					}
 					throw new NodeOperationError(this.getNode(), error, {
 						message: `Error executing workflow with item at index ${i}`,


### PR DESCRIPTION
## Summary

When using the Execute Workflow Node with multiple items and the following parameters/settings:

- Mode: Run once for each item
- On error: Continue

The expected behaviour is to run the sub-workflow for each item and return an error for the items that fail. However, there is a bug that causes the execution to stop once an item fails.

Fix:

This PR fixes the issue by adding the error to the output instead of throwing it and returning early. This allows the sub-workflow to continue running for the remaining items even if one item fails.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1447/execute-workflow-continue-on-fail-not-correctly-implemented

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
