### PR TITLE
fix(core): Add a WebCrypto Polyfill for older versions of Node.js 18

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -57,13 +57,7 @@ require('net').setDefaultAutoSelectFamily?.(false);
 
 // WebCrypto Polyfill for older versions of Node.js 18
 if (!globalThis.crypto?.getRandomValues) {
-	const picocolors = require('picocolors');
-	console.warn(
-		picocolors.red(`Your Node.js version does not support WebCrypto.
-Please upgrade to the latest version of Node.js.`),
-	);
-	const { webcrypto } = require('node:crypto');
-	globalThis.crypto = webcrypto;
+	globalThis.crypto = require('node:crypto').webcrypto;
 }
 
 (async () => {

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -63,7 +63,7 @@ if (!globalThis.crypto?.getRandomValues) {
 Please upgrade to the latest version of Node.js ${major(nodeVersion)}.`),
 	);
 	const { webcrypto } = require('node:crypto');
-	globalThis.crypto = { ...webcrypto };
+	globalThis.crypto = webcrypto;
 }
 
 (async () => {

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -55,6 +55,17 @@ if (process.env.NODEJS_PREFER_IPV4 === 'true') {
 // More details: https://github.com/nodejs/node/issues/48145
 require('net').setDefaultAutoSelectFamily?.(false);
 
+// WebCrypto Polyfill for older versions of Node.js 18
+if (!globalThis.crypto?.getRandomValues) {
+	const picocolors = require('picocolors');
+	console.warn(
+		picocolors.red(`Your Node.js version does not support WebCrypto.
+Please upgrade to the latest version of Node.js ${major(nodeVersion)}.`),
+	);
+	const { webcrypto } = require('node:crypto');
+	globalThis.crypto = { ...webcrypto };
+}
+
 (async () => {
 	const oclif = await import('@oclif/core');
 	await oclif.execute({ dir: __dirname });

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -60,7 +60,7 @@ if (!globalThis.crypto?.getRandomValues) {
 	const picocolors = require('picocolors');
 	console.warn(
 		picocolors.red(`Your Node.js version does not support WebCrypto.
-Please upgrade to the latest version of Node.js ${major(nodeVersion)}.`),
+Please upgrade to the latest version of Node.js.`),
 	);
 	const { webcrypto } = require('node:crypto');
 	globalThis.crypto = webcrypto;


### PR DESCRIPTION
## Summary
Some older versions of node.js are missing `global.crypto` even when `require('node:crypto').webrypto` is available.
This PR shims the missing global object until we drop support for node.js 18 next year.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/all-workflows-deactivated/49352
https://github.com/n8n-io/n8n/issues/9873
https://github.com/n8n-io/n8n/issues/9884

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] PR Labeled with `release/backport`