### PR TITLE
fix(editor): Fix frontend project roles

### DIFF
--- a/packages/editor-ui/src/stores/roles.store.test.ts
+++ b/packages/editor-ui/src/stores/roles.store.test.ts
@@ -1,0 +1,108 @@
+import { useRolesStore } from '@/stores/roles.store';
+import * as rolesApi from '@/api/roles.api';
+import { createPinia, setActivePinia } from 'pinia';
+
+let rolesStore: ReturnType<typeof useRolesStore>;
+
+describe('roles store', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		rolesStore = useRolesStore();
+	});
+
+	it('should use project roles defined in the frontend in correct order', async () => {
+		vi.spyOn(rolesApi, 'getRoles').mockResolvedValue({
+			global: [],
+			credential: [],
+			workflow: [],
+			project: [
+				{
+					name: 'Project Admin',
+					role: 'project:admin',
+					scopes: [
+						'workflow:create',
+						'workflow:read',
+						'workflow:update',
+						'workflow:delete',
+						'workflow:list',
+						'workflow:execute',
+						'workflow:move',
+						'credential:create',
+						'credential:read',
+						'credential:update',
+						'credential:delete',
+						'credential:list',
+						'credential:move',
+						'project:list',
+						'project:read',
+						'project:update',
+						'project:delete',
+					],
+					licensed: true,
+				},
+				{
+					name: 'Project Owner',
+					role: 'project:personalOwner',
+					scopes: [
+						'workflow:create',
+						'workflow:read',
+						'workflow:update',
+						'workflow:delete',
+						'workflow:list',
+						'workflow:execute',
+						'workflow:share',
+						'workflow:move',
+						'credential:create',
+						'credential:read',
+						'credential:update',
+						'credential:delete',
+						'credential:list',
+						'credential:share',
+						'credential:move',
+						'project:list',
+						'project:read',
+					],
+					licensed: true,
+				},
+				{
+					name: 'Project Editor',
+					role: 'project:editor',
+					scopes: [
+						'workflow:create',
+						'workflow:read',
+						'workflow:update',
+						'workflow:delete',
+						'workflow:list',
+						'workflow:execute',
+						'credential:create',
+						'credential:read',
+						'credential:update',
+						'credential:delete',
+						'credential:list',
+						'project:list',
+						'project:read',
+					],
+					licensed: true,
+				},
+				{
+					name: 'Project Viewer',
+					role: 'project:viewer',
+					scopes: [
+						'credential:list',
+						'credential:read',
+						'project:list',
+						'project:read',
+						'workflow:list',
+						'workflow:read',
+					],
+					licensed: true,
+				},
+			],
+		});
+		await rolesStore.fetchRoles();
+		expect(rolesStore.processedProjectRoles.map(({ role }) => role)).toEqual([
+			'project:editor',
+			'project:admin',
+		]);
+	});
+});

--- a/packages/editor-ui/src/stores/roles.store.ts
+++ b/packages/editor-ui/src/stores/roles.store.ts
@@ -20,12 +20,12 @@ export const useRolesStore = defineStore('roles', () => {
 
 	const processedProjectRoles = computed<RoleMap['project']>(() =>
 		roles.value.project
+			.filter((role) => projectRoleOrderMap.value.has(role.role))
 			.sort(
 				(a, b) =>
 					(projectRoleOrderMap.value.get(a.role) ?? 0) -
 					(projectRoleOrderMap.value.get(b.role) ?? 0),
-			)
-			.filter((role) => role.role !== 'project:personalOwner'),
+			),
 	);
 
 	const processedCredentialRoles = computed<RoleMap['credential']>(() =>


### PR DESCRIPTION
## Summary
Frontend is not yet prepared to use the new project viewer role. Until fully implemented it should be hidden in the project settings.

## Related Linear tickets, Github issues, and Community forum posts
Ticket for fix: [PAY-1710](https://linear.app/n8n/issue/PAY-1710/empty-permission-field-in-project-members)
Ticket for implementation: [PAY-1659](https://linear.app/n8n/issue/PAY-1659/connect-up-new-project-viewer-role-to-the-fe)

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
