### PR TITLE
fix(core): Don't execute 'workflowExecuteBefore' hook on execution continuations

### DIFF
--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -146,7 +146,7 @@ export class WorkflowRunner {
 			// frontend would not be possible
 			await this.enqueueExecution(executionId, data, loadStaticData, realtime);
 		} else {
-			await this.runMainProcess(executionId, data, loadStaticData, executionId);
+			await this.runMainProcess(executionId, data, loadStaticData, restartExecutionId);
 			this.eventRelay.emit('workflow-pre-execute', { executionId, data });
 		}
 
@@ -273,7 +273,6 @@ export class WorkflowRunner {
 				pushRef: data.pushRef,
 			});
 
-			await additionalData.hooks.executeHookFunctions('workflowExecuteBefore', []);
 			if (data.executionData !== undefined) {
 				this.logger.debug(`Execution ID ${executionId} had Execution data. Running with payload.`, {
 					executionId,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Since version 1.29.0 n8n executes the `workflow.preExecute` hook whenever an execution transitions from `waiting` to `running`.
`workflow.preExecute` should only be called once per execution.

This was introduced by a combination of https://github.com/n8n-io/n8n/pull/8487 and https://github.com/n8n-io/n8n/pull/8601.
The former refactored the WorkflowRunner class. It passes the executionId to `runMainProcess`, in the position where the `restartExecutionId` is expected.
This leads eventually to this code never executing:

https://github.com/n8n-io/n8n/blob/16b1a094b19e5f803a460b99c6062a1175bec153/packages/core/src/WorkflowExecute.ts#L851-L853

The latter PR attempted to fix this by calling `additionalData.hooks.executeHookFunctions('workflowExecuteBefore', []);` directly in `runMainProcess`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1712/executions-counted-multiple-times-if-there-is-a-wait-node-on-cloud

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
