### PR TITLE
feat(Zammad Node): Add reply_to and sender fields to article on ticket creation

### DIFF
--- a/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
@@ -177,6 +177,28 @@ export const ticketDescription: INodeProperties[] = [
 						],
 					},
 					{
+						displayName: 'Sender',
+						name: 'sender',
+						type: 'options',
+						// https://docs.zammad.org/en/latest/api/ticket/articles.html
+						options: [
+							{
+								name: 'Agent',
+								value: 'Agent',
+							},
+							{
+								name: 'Customer',
+								value: 'Customer',
+							},
+							{
+								name: 'System',
+								value: 'System',
+								description: 'Only subject will be displayed in Zammad',
+							},
+						],
+						default: 'Agent',
+					},
+					{
 						displayName: 'Article Type',
 						name: 'type',
 						type: 'options',
@@ -208,6 +230,12 @@ export const ticketDescription: INodeProperties[] = [
 							},
 						],
 						default: 'note',
+					},
+					{
+						displayName: 'Reply To',
+						name: 'reply_to',
+						type: 'string',
+						default: '',
 					},
 				],
 			},

--- a/packages/nodes-base/nodes/Zammad/types.ts
+++ b/packages/nodes-base/nodes/Zammad/types.ts
@@ -89,7 +89,9 @@ export declare namespace Zammad {
 			visibility: 'external' | 'internal';
 			subject: string;
 			body: string;
+			sender: 'Agent' | 'Customer' | 'System';
 			type: 'chat' | 'email' | 'fax' | 'note' | 'phone' | 'sms';
+			reply_to: string;
 		};
 	};
 }


### PR DESCRIPTION
## Summary

Add two new fields to Zammad articles during Zammad ticket creation:

![grafik](https://github.com/n8n-io/n8n/assets/241552/ea32e782-c595-4e3d-a692-a3fdc14279af)

The new `sender` field allows setting which side has created the article, which always defaulted to `Agent` previously.
The new `reply_to` field allows setting a email address for replies that is different from the email address of the user that created the article. This is needed when using a single account to create tickets and articles as otherwise that accounts email address is used for replies.

## Related Linear tickets, Github issues, and Community forum posts

This PR addresses the FR part of #9807 but not the bug reported in the ticket.

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
