### PR TITLE
fix(core): Allow owner and admin to edit nodes with credentials that haven't been shared with them explicitly

### DIFF
--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -135,7 +135,11 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 		workflowsPage.getters.workflowCards().should('have.length', 2);
 		workflowsPage.getters.workflowCard('Workflow W1').click();
 		workflowPage.actions.openNode('Notion');
-		ndv.getters.credentialInput().should('have.value', 'Credential C1').should('be.disabled');
+		ndv.getters
+			.credentialInput()
+			.find('input')
+			.should('have.value', 'Credential C1')
+			.should('be.enabled');
 		ndv.actions.close();
 
 		cy.waitForLoad();

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -63,11 +63,10 @@ export class CredentialsService {
 		user: User,
 		options: {
 			listQueryOptions?: ListQuery.Options;
-			onlyOwn?: boolean;
 			includeScopes?: string;
 		} = {},
 	) {
-		const returnAll = user.hasGlobalScope('credential:list') && !options.onlyOwn;
+		const returnAll = user.hasGlobalScope('credential:list');
 		const isDefaultSelect = !options.listQueryOptions?.select;
 
 		let projectRelations: ProjectRelation[] | undefined = undefined;

--- a/packages/cli/src/workflows/workflow.service.ee.ts
+++ b/packages/cli/src/workflows/workflow.service.ee.ts
@@ -80,7 +80,10 @@ export class EnterpriseWorkflowService {
 		currentUser: User,
 	): Promise<void> {
 		workflow.usedCredentials = [];
-		const userCredentials = await this.credentialsService.getMany(currentUser, { onlyOwn: true });
+		const userCredentials = await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
+			currentUser,
+			{ workflowId: workflow.id },
+		);
 		const credentialIdsUsedByWorkflow = new Set<string>();
 		workflow.nodes.forEach((node) => {
 			if (!node.credentials) {

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -428,28 +428,38 @@ describe('GET /workflows/:workflowId', () => {
 		expect(responseWorkflow.sharedWithProjects).toHaveLength(0);
 	});
 
-	test('should return workflow with credentials saying owner does not have access when not shared', async () => {
-		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
+	test.each([
+		['owner', () => owner],
+		['admin', () => admin],
+	])(
+		'should return workflow with credentials saying %s does have access event when not shared',
+		async (_description, getActor) => {
+			const actor = getActor();
+			const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });
 
-		const workflowPayload = makeWorkflow({
-			withPinData: false,
-			withCredential: { id: savedCredential.id, name: savedCredential.name },
-		});
-		const workflow = await createWorkflow(workflowPayload, owner);
+			const workflowPayload = makeWorkflow({
+				withPinData: false,
+				withCredential: { id: savedCredential.id, name: savedCredential.name },
+			});
+			const workflow = await createWorkflow(workflowPayload, actor);
 
-		const response = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
-		const responseWorkflow: WorkflowWithSharingsMetaDataAndCredentials = response.body.data;
+			const response = await testServer
+				.authAgentFor(actor)
+				.get(`/workflows/${workflow.id}`)
+				.expect(200);
+			const responseWorkflow: WorkflowWithSharingsMetaDataAndCredentials = response.body.data;
 
-		expect(responseWorkflow.usedCredentials).toMatchObject([
-			{
-				id: savedCredential.id,
-				name: savedCredential.name,
-				currentUserHasAccess: false, // although owner can see, they do not have access
-			},
-		]);
+			expect(responseWorkflow.usedCredentials).toMatchObject([
+				{
+					id: savedCredential.id,
+					name: savedCredential.name,
+					currentUserHasAccess: true,
+				},
+			]);
 
-		expect(responseWorkflow.sharedWithProjects).toHaveLength(0);
-	});
+			expect(responseWorkflow.sharedWithProjects).toHaveLength(0);
+		},
+	);
 
 	test('should return workflow with credentials for all users with or without access', async () => {
 		const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });

--- a/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.ee.test.ts
@@ -432,7 +432,7 @@ describe('GET /workflows/:workflowId', () => {
 		['owner', () => owner],
 		['admin', () => admin],
 	])(
-		'should return workflow with credentials saying %s does have access event when not shared',
+		'should return workflow with credentials saying %s does have access even when not shared',
 		async (_description, getActor) => {
 			const actor = getActor();
 			const savedCredential = await saveCredential(randomCredentialPayload(), { user: member });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Previously, the owners and admins were not allowed to use credentials in workflows that they did not own. They first had to share them with themselves, and then they could use them in workflows.

With https://github.com/n8n-io/n8n/pull/9718 we started showing credentials in the dropdown that they did not own and haven't been shared with them, but when choosing them the node edit view would turn read only. 

With this PR the node edit view now stays editable.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1296/bug-owner-user-cant-edit-workflow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
