### PR TITLE
feat(Zammad Node): Make it possible for Zammad to lookup and create users during ticket creation

### DIFF
--- a/packages/nodes-base/nodes/Zammad/Zammad.node.ts
+++ b/packages/nodes-base/nodes/Zammad/Zammad.node.ts
@@ -662,13 +662,6 @@ export class Zammad implements INodeType {
 
 						// https://docs.zammad.org/en/latest/api/ticket/index.html#create
 
-						const body = {
-							article: {},
-							title: this.getNodeParameter('title', i) as string,
-							group: this.getNodeParameter('group', i) as string,
-							customer: this.getNodeParameter('customer', i) as string,
-						};
-
 						const article = this.getNodeParameter('article', i) as ZammadTypes.Article;
 
 						if (!Object.keys(article).length) {
@@ -679,10 +672,29 @@ export class Zammad implements INodeType {
 							articleDetails: { visibility, ...rest },
 						} = article;
 
-						body.article = {
-							...rest,
-							internal: visibility === 'internal',
+						const base = {
+							article: {
+								...rest,
+								internal: visibility === 'internal',
+							},
+							title: this.getNodeParameter('title', i) as string,
+							group: this.getNodeParameter('group', i) as string,
 						};
+
+						const createCustomerIfNotExists = this.getNodeParameter(
+							'createCustomerIfNotExists',
+							i,
+						) as boolean;
+
+						const body = createCustomerIfNotExists
+							? {
+									...base,
+									customer_id: 'guess:' + (this.getNodeParameter('customer', i) as string),
+								}
+							: {
+									...base,
+									customer: this.getNodeParameter('customer', i) as string,
+								};
 
 						responseData = await zammadApiRequest.call(this, 'POST', '/tickets', body);
 

--- a/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
+++ b/packages/nodes-base/nodes/Zammad/descriptions/TicketDescription.ts
@@ -99,6 +99,20 @@ export const ticketDescription: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Create Customer if They Do Not Exist',
+		name: 'createCustomerIfNotExists',
+		description:
+			'Whether you want Zammad to find out the user ID or, if there is no user for the email address, create the user for you during ticket creation',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['ticket'],
+				operation: ['create'],
+			},
+		},
+	},
+	{
 		displayName: 'Ticket ID',
 		name: 'id',
 		type: 'string',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

During ticket creation, Zammad normally requires that the associated customer already exists in Zammad.
Zammad also allows "guessing" the customer which will create the customer at the time of ticket creation, saving an API roundtrip and logic on the caller side. This PR implements a switch to enable this guessing mode.

![grafik](https://github.com/n8n-io/n8n/assets/241552/33b1988c-ecd9-4fc1-9148-d6a2acc09881)

## Related Linear tickets, Github issues, and Community forum posts

Could not find any

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
