### PR TITLE
fix(editor): Don't try to load credentials on the demo route

### DIFF
--- a/cypress/e2e/31-demo.cy.ts
+++ b/cypress/e2e/31-demo.cy.ts
@@ -1,23 +1,32 @@
 import workflow from '../fixtures/Manual_wait_set.json';
-import { importWorkflow, vistDemoPage } from '../pages/demo';
+import { importWorkflow, visitDemoPage } from '../pages/demo';
 import { WorkflowPage } from '../pages/workflow';
+import { errorToast } from '../pages/notifications';
 
 const workflowPage = new WorkflowPage();
 
 describe('Demo', () => {
+	beforeEach(() => {
+		cy.overrideSettings({ previewMode: true });
+		cy.signout();
+	});
+
 	it('can import template', () => {
-		vistDemoPage();
+		visitDemoPage();
+		errorToast().should('not.exist');
 		importWorkflow(workflow);
 		workflowPage.getters.canvasNodes().should('have.length', 3);
 	});
 
 	it('can override theme to dark', () => {
-		vistDemoPage('dark');
+		visitDemoPage('dark');
 		cy.get('body').should('have.attr', 'data-theme', 'dark');
+		errorToast().should('not.exist');
 	});
 
 	it('can override theme to light', () => {
-		vistDemoPage('light');
+		visitDemoPage('light');
 		cy.get('body').should('have.attr', 'data-theme', 'light');
+		errorToast().should('not.exist');
 	});
 });

--- a/cypress/pages/demo.ts
+++ b/cypress/pages/demo.ts
@@ -2,7 +2,7 @@
  * Actions
  */
 
-export function vistDemoPage(theme?: 'dark' | 'light') {
+export function visitDemoPage(theme?: 'dark' | 'light') {
 	const query = theme ? `?theme=${theme}` : '';
 	cy.visit('/workflows/demo' + query);
 	cy.waitForLoad();

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -4470,6 +4470,13 @@ export default defineComponent({
 			await this.credentialsStore.fetchCredentialTypes(true);
 		},
 		async loadCredentialsForWorkflow(): Promise<void> {
+			// In preview mode, we don't have to load the credentials. We actually
+			// can't load them because they depend on the project the workflow is in,
+			// but in preview mode there is no project.
+			if (this.settingsStore.isPreviewMode) {
+				return;
+			}
+
 			const workflow = this.workflowsStore.getWorkflowById(this.currentWorkflow);
 			const workflowId = workflow?.id ?? this.$route.params.name;
 			let options: { workflowId: string } | { projectId: string };


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Before this PR we tried to load the credentials on the preview route, which would fail, because there is no user and no personal project and team project. 
Now this short circuits and does not try to load the credentials.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1717/bug-preview-instance-on-1472-has-init-error

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
