### PR TITLE
fix(core): Disconnect Redis after pausing queue during worker shutdown

### DIFF
--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -9,6 +9,7 @@ import {
 } from 'n8n-workflow';
 import { ActiveExecutions } from '@/ActiveExecutions';
 import config from '@/config';
+import { HIGHEST_PRIORITY, OnShutdown } from './decorators/OnShutdown';
 
 export type JobId = Bull.JobId;
 export type Job = Bull.Job<JobData>;
@@ -108,6 +109,7 @@ export class Queue {
 		return await this.jobQueue.client.ping();
 	}
 
+	@OnShutdown(HIGHEST_PRIORITY)
 	async pause({
 		isLocal,
 		doNotWaitActive,

--- a/packages/cli/src/Queue.ts
+++ b/packages/cli/src/Queue.ts
@@ -110,11 +110,9 @@ export class Queue {
 	}
 
 	@OnShutdown(HIGHEST_PRIORITY)
-	async pause({
-		isLocal,
-		doNotWaitActive,
-	}: { isLocal?: boolean; doNotWaitActive?: boolean } = {}): Promise<void> {
-		return await this.jobQueue.pause(isLocal, doNotWaitActive);
+	// Stop accepting new jobs, `doNotWaitActive` allows reporting progress
+	async pause(): Promise<void> {
+		return await this.jobQueue?.pause(true, true);
 	}
 
 	getBullObjectInstance(): JobQueue {

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -64,9 +64,6 @@ export class Worker extends BaseCommand {
 	async stopProcess() {
 		this.logger.info('Stopping n8n...');
 
-		// Stop accepting new jobs, `doNotWaitActive` allows reporting progress
-		await Worker.jobQueue.pause({ isLocal: true, doNotWaitActive: true });
-
 		try {
 			await this.externalHooks?.run('n8n.stop', []);
 

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -30,6 +30,7 @@ import { ServiceUnavailableError } from '@/errors/response-errors/service-unavai
 import { BaseCommand } from './BaseCommand';
 import { MaxStalledCountError } from '@/errors/max-stalled-count.error';
 import { AuditEventRelay } from '@/eventbus/audit-event-relay.service';
+import { RedisClientService } from '@/services/redis/redis-client.service';
 
 export class Worker extends BaseCommand {
 	static description = '\nStarts a n8n worker';
@@ -89,6 +90,8 @@ export class Worker extends BaseCommand {
 		} catch (error) {
 			await this.exitWithCrash('There was an error shutting down n8n.', error);
 		}
+
+		Container.get(RedisClientService).disconnectClients();
 
 		await this.exitSuccessFully();
 	}

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -30,7 +30,6 @@ import { ServiceUnavailableError } from '@/errors/response-errors/service-unavai
 import { BaseCommand } from './BaseCommand';
 import { MaxStalledCountError } from '@/errors/max-stalled-count.error';
 import { AuditEventRelay } from '@/eventbus/audit-event-relay.service';
-import { RedisClientService } from '@/services/redis/redis-client.service';
 
 export class Worker extends BaseCommand {
 	static description = '\nStarts a n8n worker';
@@ -90,8 +89,6 @@ export class Worker extends BaseCommand {
 		} catch (error) {
 			await this.exitWithCrash('There was an error shutting down n8n.', error);
 		}
-
-		Container.get(RedisClientService).disconnectClients();
 
 		await this.exitSuccessFully();
 	}

--- a/packages/cli/src/decorators/OnShutdown.ts
+++ b/packages/cli/src/decorators/OnShutdown.ts
@@ -2,6 +2,10 @@ import { Container } from 'typedi';
 import { ApplicationError } from 'n8n-workflow';
 import { type ServiceClass, ShutdownService } from '@/shutdown/Shutdown.service';
 
+export const LOWEST_PRIORITY = 0;
+export const DEFAULT_PRIORITY = 100;
+export const HIGHEST_PRIORITY = 200;
+
 /**
  * Decorator that registers a method as a shutdown hook. The method will
  * be called when the application is shutting down.
@@ -22,7 +26,7 @@ import { type ServiceClass, ShutdownService } from '@/shutdown/Shutdown.service'
  * ```
  */
 export const OnShutdown =
-	(priority = 100): MethodDecorator =>
+	(priority = DEFAULT_PRIORITY): MethodDecorator =>
 	(prototype, propertyKey, descriptor) => {
 		const serviceClass = prototype.constructor as ServiceClass;
 		const methodName = String(propertyKey);

--- a/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
+++ b/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
@@ -40,10 +40,6 @@ class RedisServiceBase {
 		}
 		this.redisClient = this.redisClientService.createClient({ type });
 
-		this.redisClient.on('close', () => {
-			this.logger.warn('Redis unavailable - trying to reconnect...');
-		});
-
 		this.redisClient.on('error', (error) => {
 			if (!String(error).includes('ECONNREFUSED')) {
 				this.logger.warn('Error with Redis: ', error);

--- a/packages/cli/src/services/redis/redis-client.service.ts
+++ b/packages/cli/src/services/redis/redis-client.service.ts
@@ -4,7 +4,6 @@ import { Logger } from '@/Logger';
 import ioRedis from 'ioredis';
 import type { Cluster, RedisOptions } from 'ioredis';
 import type { RedisClientType } from './RedisServiceBaseClasses';
-import { OnShutdown } from '@/decorators/OnShutdown';
 
 @Service()
 export class RedisClientService {
@@ -23,7 +22,6 @@ export class RedisClientService {
 		return client;
 	}
 
-	@OnShutdown()
 	disconnectClients() {
 		for (const client of this.clients) {
 			client.disconnect();
@@ -143,6 +141,8 @@ export class RedisClientService {
 					process.exit(1);
 				}
 			}
+
+			this.logger.warn('Redis unavailable - trying to reconnect...');
 
 			return RETRY_INTERVAL;
 		};

--- a/packages/cli/src/services/redis/redis-client.service.ts
+++ b/packages/cli/src/services/redis/redis-client.service.ts
@@ -4,6 +4,7 @@ import { Logger } from '@/Logger';
 import ioRedis from 'ioredis';
 import type { Cluster, RedisOptions } from 'ioredis';
 import type { RedisClientType } from './RedisServiceBaseClasses';
+import { LOWEST_PRIORITY, OnShutdown } from '@/decorators/OnShutdown';
 
 @Service()
 export class RedisClientService {
@@ -22,6 +23,7 @@ export class RedisClientService {
 		return client;
 	}
 
+	@OnShutdown(LOWEST_PRIORITY)
 	disconnectClients() {
 		for (const client of this.clients) {
 			client.disconnect();

--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -16,7 +16,6 @@ import { type JobQueue, Queue } from '@/Queue';
 import { setupTestCommand } from '@test-integration/utils/testCommand';
 import { mockInstance } from '../../shared/mocking';
 import { AuditEventRelay } from '@/eventbus/audit-event-relay.service';
-import { RedisClientService } from '@/services/redis/redis-client.service';
 
 config.set('executions.mode', 'queue');
 config.set('binaryDataManager.availableModes', 'filesystem');
@@ -28,7 +27,6 @@ const externalSecretsManager = mockInstance(ExternalSecretsManager);
 const license = mockInstance(License);
 const messageEventBus = mockInstance(MessageEventBus);
 const auditEventRelay = mockInstance(AuditEventRelay);
-const redisClientService = mockInstance(RedisClientService);
 const orchestrationHandlerWorkerService = mockInstance(OrchestrationHandlerWorkerService);
 const queue = mockInstance(Queue);
 const orchestrationWorkerService = mockInstance(OrchestrationWorkerService);
@@ -53,20 +51,4 @@ test('worker initializes all its components', async () => {
 	expect(orchestrationWorkerService.init).toHaveBeenCalledTimes(1);
 	expect(orchestrationHandlerWorkerService.initWithOptions).toHaveBeenCalledTimes(1);
 	expect(messageEventBus.send).toHaveBeenCalledTimes(1);
-});
-
-it('should disconnect Redis clients after pausing queue', async () => {
-	const worker = await command.run();
-	const pauseSpy = jest.spyOn(queue, 'pause');
-	const disconnectSpy = jest.spyOn(redisClientService, 'disconnectClients');
-
-	await worker.run();
-	await worker.stopProcess();
-
-	expect(pauseSpy).toHaveBeenCalledTimes(1);
-	expect(disconnectSpy).toHaveBeenCalledTimes(1);
-
-	expect(pauseSpy.mock.invocationCallOrder[0]).toBeLessThan(
-		disconnectSpy.mock.invocationCallOrder[0],
-	);
 });

--- a/packages/cli/test/integration/shared/utils/testCommand.ts
+++ b/packages/cli/test/integration/shared/utils/testCommand.ts
@@ -11,6 +11,7 @@ export const setupTestCommand = <T extends BaseCommand>(Command: Class<T>) => {
 
 	// mock SIGINT/SIGTERM registration
 	process.once = jest.fn();
+	process.exit = jest.fn() as never;
 
 	beforeAll(async () => {
 		await testDb.init();


### PR DESCRIPTION
## Summary

During shutdown `BaseCommand.onTerminationSignal` calls `ShutdownService.shutdown` which eventually calls `RedisClientService.disconnectClients` and in parallel `Worker.stopProcess` pauses the queue with `jobQueue.pause`. If we try to pause after having disconnected, this can lead to `Error from queue`. 

Hence call `disconnectClients` only after pausing the queue and after waiting for the active executions to finish. Incidentally also move the warning `Redis unavailable - trying to reconnect...` from the client's `close` event to the retry strategy to prevent confusion.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C069YF49G8Y/p1720000315032489

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
