### PR TITLE
refactor(editor): Standardize how we use `defineEmits` in components using the composition API (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/frontend.js
+++ b/packages/@n8n_io/eslint-config/frontend.js
@@ -16,12 +16,7 @@ module.exports = {
 
 	overrides: [
 		{
-			files: [
-				'**/*.test.ts',
-				'**/test/**/*.ts',
-				'**/__tests__/**/*.ts',
-				'**/*.stories.ts',
-			],
+			files: ['**/*.test.ts', '**/test/**/*.ts', '**/__tests__/**/*.ts', '**/*.stories.ts'],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 			},
@@ -60,6 +55,7 @@ module.exports = {
 		'vue/prop-name-casing': ['error', 'camelCase'],
 		'vue/attribute-hyphenation': ['error', 'always'],
 		'import/no-extraneous-dependencies': 'warn',
+		'vue/define-emits-declaration': ['error', 'type-literal'],
 
 		// TODO: fix these
 		'@typescript-eslint/no-unsafe-call': 'off',

--- a/packages/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
+++ b/packages/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
@@ -102,8 +102,8 @@ const getItemClasses = (item: ActionDropdownItem): Record<string, boolean> => {
 };
 
 const $emit = defineEmits<{
-	(event: 'select', action: string): void;
-	(event: 'visibleChange', open: boolean): void;
+	select: [action: string];
+	visibleChange: [open: boolean];
 }>();
 const elementDropdown = ref<InstanceType<typeof ElDropdown>>();
 

--- a/packages/design-system/src/components/N8nActionToggle/ActionToggle.vue
+++ b/packages/design-system/src/components/N8nActionToggle/ActionToggle.vue
@@ -69,8 +69,8 @@ withDefaults(defineProps<ActionToggleProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'action', value: string): void;
-	(event: 'visible-change', value: boolean): void;
+	action: [value: string];
+	'visible-change': [value: boolean];
 }>();
 const onCommand = (value: string) => $emit('action', value);
 const onVisibleChange = (value: boolean) => $emit('visible-change', value);

--- a/packages/design-system/src/components/N8nCheckbox/Checkbox.vue
+++ b/packages/design-system/src/components/N8nCheckbox/Checkbox.vue
@@ -45,10 +45,11 @@ withDefaults(defineProps<CheckboxProps>(), {
 	labelSize: 'medium',
 });
 
-const $emit = defineEmits<{
-	updateModelValue: [value: CheckboxValueType];
+const emit = defineEmits<{
+	'update:modelValue': [value: CheckboxValueType];
 }>();
-const onUpdateModelValue = (value: CheckboxValueType) => $emit('update:modelValue', value);
+
+const onUpdateModelValue = (value: CheckboxValueType) => emit('update:modelValue', value);
 
 const checkbox = ref<InstanceType<typeof ElCheckbox>>();
 const onLabelClick = () => {

--- a/packages/design-system/src/components/N8nCheckbox/Checkbox.vue
+++ b/packages/design-system/src/components/N8nCheckbox/Checkbox.vue
@@ -46,7 +46,7 @@ withDefaults(defineProps<CheckboxProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'update:modelValue', value: CheckboxValueType): void;
+	updateModelValue: [value: CheckboxValueType];
 }>();
 const onUpdateModelValue = (value: CheckboxValueType) => $emit('update:modelValue', value);
 

--- a/packages/design-system/src/components/N8nColorPicker/ColorPicker.vue
+++ b/packages/design-system/src/components/N8nColorPicker/ColorPicker.vue
@@ -36,9 +36,9 @@ const colorPickerProps = computed(() => {
 });
 
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string | null): void;
-	(event: 'change', value: string | null): void;
-	(event: 'active-change', value: string | null): void;
+	'update:modelValue': [value: string | null];
+	change: [value: string | null];
+	'active-change': [value: string | null];
 }>();
 
 const onChange = (value: string | null) => {

--- a/packages/design-system/src/components/N8nDatatable/Datatable.vue
+++ b/packages/design-system/src/components/N8nDatatable/Datatable.vue
@@ -85,8 +85,8 @@ const props = withDefaults(defineProps<DatatableProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'update:currentPage', value: number): void;
-	(event: 'update:rowsPerPage', value: number): void;
+	'update:currentPage': [value: number];
+	'update:rowsPerPage': [value: number];
 }>();
 
 const { t } = useI18n();

--- a/packages/design-system/src/components/N8nFormBox/FormBox.vue
+++ b/packages/design-system/src/components/N8nFormBox/FormBox.vue
@@ -69,9 +69,9 @@ withDefaults(defineProps<FormBoxProps>(), {
 
 const formBus = createEventBus();
 const $emit = defineEmits<{
-	(event: 'submit', value: { [key: string]: Value }): void;
-	(event: 'update', value: { name: string; value: Value }): void;
-	(event: 'secondaryClick', value: Event): void;
+	submit: [value: { [key: string]: Value }];
+	update: [value: { name: string; value: Value }];
+	secondaryClick: [value: Event];
 }>();
 
 const onUpdateModelValue = (e: { name: string; value: Value }) => $emit('update', e);

--- a/packages/design-system/src/components/N8nFormInput/FormInput.vue
+++ b/packages/design-system/src/components/N8nFormInput/FormInput.vue
@@ -158,11 +158,11 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'validate', shouldValidate: boolean): void;
-	(event: 'update:modelValue', value: Validatable): void;
-	(event: 'focus'): void;
-	(event: 'blur'): void;
-	(event: 'enter'): void;
+	validate: [shouldValidate: boolean];
+	'update:modelValue': [value: Validatable];
+	focus: [];
+	blur: [];
+	enter: [];
 }>();
 
 const state = reactive({

--- a/packages/design-system/src/components/N8nFormInputs/FormInputs.vue
+++ b/packages/design-system/src/components/N8nFormInputs/FormInputs.vue
@@ -27,10 +27,10 @@ const props = withDefaults(defineProps<FormInputsProps>(), {
 });
 
 const emit = defineEmits<{
-	(name: 'update', _: { name: string; value: Value }): boolean;
-	(name: 'update:modelValue', value: Record<string, Value>): boolean;
-	(name: 'submit', value: Record<string, Value>): boolean;
-	(name: 'ready', value: boolean): boolean;
+	update: [value: { name: string; value: Value }];
+	'update:modelValue': [value: Record<string, Value>];
+	submit: [value: Record<string, Value>];
+	ready: [value: boolean];
 }>();
 
 const showValidationWarnings = ref(false);

--- a/packages/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
+++ b/packages/design-system/src/components/N8nInfoAccordion/InfoAccordion.vue
@@ -69,8 +69,8 @@ const props = withDefaults(defineProps<InfoAccordionProps>(), {
 	eventBus: () => createEventBus(),
 });
 const $emit = defineEmits<{
-	(name: 'click:body', e: MouseEvent): void;
-	(name: 'tooltipClick', item: string, e: MouseEvent): void;
+	'click:body': [e: MouseEvent];
+	tooltipClick: [item: string, e: MouseEvent];
 }>();
 
 const expanded = ref(false);

--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -156,8 +156,8 @@ const htmlContent = computed(() => {
 });
 
 const $emit = defineEmits<{
-	(event: 'markdown-click', link: string, e: MouseEvent): void;
-	(event: 'update-content', content: string): void;
+	'markdown-click': [link: string, e: MouseEvent];
+	'update-content': [content: string];
 }>();
 
 const onClick = (event: MouseEvent) => {

--- a/packages/design-system/src/components/N8nMenu/Menu.vue
+++ b/packages/design-system/src/components/N8nMenu/Menu.vue
@@ -83,8 +83,8 @@ const props = withDefaults(defineProps<MenuProps>(), {
 const $route = useRoute();
 
 const $emit = defineEmits<{
-	(event: 'select', itemId: string): void;
-	(event: 'update:modelValue', itemId: string): void;
+	select: [itemId: string];
+	'update:modelValue': [itemId: string];
 }>();
 
 const activeTab = ref(props.modelValue);

--- a/packages/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
+++ b/packages/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
@@ -18,7 +18,7 @@ export interface Props {
 defineProps<Props>();
 
 defineEmits<{
-	(event: 'tooltipClick', $e: MouseEvent): void;
+	tooltipClick: [e: MouseEvent];
 }>();
 
 const { t } = useI18n();

--- a/packages/design-system/src/components/N8nNotice/Notice.vue
+++ b/packages/design-system/src/components/N8nNotice/Notice.vue
@@ -36,7 +36,7 @@ const props = withDefaults(defineProps<NoticeProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'action', key: string): void;
+	action: [key: string];
 }>();
 
 const $style = useCssModule();

--- a/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
+++ b/packages/design-system/src/components/N8nRadioButtons/RadioButtons.vue
@@ -39,7 +39,7 @@ const props = withDefaults(defineProps<RadioButtonsProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'update:modelValue', value: string, e: MouseEvent): void;
+	'update:modelValue': [value: string, e: MouseEvent];
 }>();
 
 const onClick = (

--- a/packages/design-system/src/components/N8nResizeWrapper/ResizeWrapper.vue
+++ b/packages/design-system/src/components/N8nResizeWrapper/ResizeWrapper.vue
@@ -80,9 +80,9 @@ export interface ResizeData {
 }
 
 const $emit = defineEmits<{
-	(event: 'resizestart'): void;
-	(event: 'resize', value: ResizeData): void;
-	(event: 'resizeend'): void;
+	resizestart: [];
+	resize: [value: ResizeData];
+	resizeend: [];
 }>();
 
 const enabledDirections = computed((): Direction[] => {

--- a/packages/design-system/src/components/N8nSticky/Sticky.vue
+++ b/packages/design-system/src/components/N8nSticky/Sticky.vue
@@ -94,13 +94,13 @@ const props = withDefaults(defineProps<StickyProps>(), {
 	backgroundColor: 1,
 });
 
-const $emit = defineEmits<{
-	(event: 'edit', editing: boolean): void;
-	(event: 'update:modelValue', value: string): void;
-	(event: 'markdown-click', link: string, e: Event): void;
-	(event: 'resize', values: ResizeData): void;
-	(event: 'resizestart'): void;
-	(event: 'resizeend'): void;
+const emit = defineEmits<{
+	edit: [editing: boolean];
+	'update:modelValue': [value: string];
+	'markdown-click': [link: string, e: Event];
+	resize: [values: ResizeData];
+	resizestart: [];
+	resizeend: [];
 }>();
 
 const { t } = useI18n();
@@ -137,33 +137,33 @@ watch(
 );
 
 const onDoubleClick = () => {
-	if (!props.readOnly) $emit('edit', true);
+	if (!props.readOnly) emit('edit', true);
 };
 
 const onInputBlur = () => {
-	if (!isResizing.value) $emit('edit', false);
+	if (!isResizing.value) emit('edit', false);
 };
 
 const onUpdateModelValue = (value: string) => {
-	$emit('update:modelValue', value);
+	emit('update:modelValue', value);
 };
 
 const onMarkdownClick = (link: string, event: Event) => {
-	$emit('markdown-click', link, event);
+	emit('markdown-click', link, event);
 };
 
 const onResize = (values: ResizeData) => {
-	$emit('resize', values);
+	emit('resize', values);
 };
 
 const onResizeStart = () => {
 	isResizing.value = true;
-	$emit('resizestart');
+	emit('resizestart');
 };
 
 const onResizeEnd = () => {
 	isResizing.value = false;
-	$emit('resizeend');
+	emit('resizeend');
 };
 
 const onInputScroll = (event: WheelEvent) => {

--- a/packages/design-system/src/components/N8nTabs/Tabs.vue
+++ b/packages/design-system/src/components/N8nTabs/Tabs.vue
@@ -111,8 +111,8 @@ onUnmounted(() => {
 });
 
 const $emit = defineEmits<{
-	(event: 'tooltipClick', tab: string, e: MouseEvent): void;
-	(event: 'update:modelValue', tab: string): void;
+	tooltipClick: [tab: string, e: MouseEvent];
+	'update:modelValue': [tab: string];
 }>();
 
 const handleTooltipClick = (tab: string, event: MouseEvent) => $emit('tooltipClick', tab, event);

--- a/packages/design-system/src/components/N8nTags/Tags.vue
+++ b/packages/design-system/src/components/N8nTags/Tags.vue
@@ -43,8 +43,8 @@ const props = withDefaults(defineProps<TagsProp>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'expand', value: boolean): void;
-	(event: 'click:tag', tagId: string, e: MouseEvent): void;
+	expand: [value: boolean];
+	'click:tag': [tagId: string, e: MouseEvent];
 }>();
 
 const { t } = useI18n();

--- a/packages/design-system/src/components/N8nUserSelect/UserSelect.vue
+++ b/packages/design-system/src/components/N8nUserSelect/UserSelect.vue
@@ -55,8 +55,8 @@ const props = withDefaults(defineProps<UserSelectProps>(), {
 });
 
 const $emit = defineEmits<{
-	(event: 'blur'): void;
-	(event: 'focus'): void;
+	blur: [];
+	focus: [];
 }>();
 
 const { t } = useI18n();

--- a/packages/design-system/src/components/N8nUsersList/UsersList.vue
+++ b/packages/design-system/src/components/N8nUsersList/UsersList.vue
@@ -105,11 +105,11 @@ const getActions = (user: IUser): UserAction[] => {
 	return props.actions.filter((action) => (action.guard ?? defaultGuard)(user));
 };
 
-const $emit = defineEmits<{
-	(event: 'action', _: { action: string; userId: string }): void;
+const emit = defineEmits<{
+	action: [value: { action: string; userId: string }];
 }>();
 const onUserAction = (user: IUser, action: string) =>
-	$emit('action', {
+	emit('action', {
 		action,
 		userId: user.id,
 	});

--- a/packages/editor-ui/src/components/AIAssistantChat/NextStepPopup.vue
+++ b/packages/editor-ui/src/components/AIAssistantChat/NextStepPopup.vue
@@ -8,7 +8,7 @@ const aiStore = useAIStore();
 const locale = useI18n();
 const telemetry = useTelemetry();
 
-const emit = defineEmits<{ (event: 'optionSelected', option: string): void }>();
+const emit = defineEmits<{ optionSelected: [option: string] }>();
 
 const aiAssistantChatOpen = computed(() => aiStore.assistantChatOpen);
 

--- a/packages/editor-ui/src/components/AIAssistantChat/QuickReplies.vue
+++ b/packages/editor-ui/src/components/AIAssistantChat/QuickReplies.vue
@@ -10,7 +10,7 @@ type QuickReply = {
 const locale = useI18n();
 
 const emit = defineEmits<{
-	(event: 'replySelected', value: QuickReply): void;
+	replySelected: [value: QuickReply];
 }>();
 
 defineProps<{

--- a/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
+++ b/packages/editor-ui/src/components/AssignmentCollection/Assignment.vue
@@ -26,8 +26,8 @@ const props = defineProps<Props>();
 const assignment = ref<AssignmentValue>(props.modelValue);
 
 const emit = defineEmits<{
-	(event: 'update:model-value', value: AssignmentValue): void;
-	(event: 'remove'): void;
+	'update:model-value': [value: AssignmentValue];
+	remove: [];
 }>();
 
 const ndvStore = useNDVStore();

--- a/packages/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
+++ b/packages/editor-ui/src/components/AssignmentCollection/AssignmentCollection.vue
@@ -27,10 +27,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), { isReadOnly: false });
 
 const emit = defineEmits<{
-	(
-		event: 'valueChanged',
-		value: { name: string; node: string; value: AssignmentCollectionValue },
-	): void;
+	valueChanged: [value: { name: string; node: string; value: AssignmentCollectionValue }];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/AssignmentCollection/TypeSelect.vue
+++ b/packages/editor-ui/src/components/AssignmentCollection/TypeSelect.vue
@@ -12,7 +12,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-	(event: 'update:model-value', type: string): void;
+	'update:model-value': [type: string];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/BinaryDataDisplay.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplay.vue
@@ -31,7 +31,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(event: 'close'): void;
+	close: [];
 }>();
 
 const nodeHelpers = useNodeHelpers();

--- a/packages/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -28,10 +28,10 @@ import {
 } from '@/constants';
 
 const emit = defineEmits<{
-	(e: 'submit', code: string): void;
-	(e: 'replaceCode', code: string): void;
-	(e: 'startedLoading'): void;
-	(e: 'finishedLoading'): void;
+	submit: [code: string];
+	replaceCode: [code: string];
+	startedLoading: [];
+	finishedLoading: [];
 }>();
 
 const props = defineProps<{

--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -94,7 +94,7 @@ const props = withDefaults(defineProps<Props>(), {
 	rows: 4,
 });
 const emit = defineEmits<{
-	'update:ModelValue': [value: string];
+	'update:modelValue': [value: string];
 }>();
 
 const message = useMessage();

--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -94,7 +94,7 @@ const props = withDefaults(defineProps<Props>(), {
 	rows: 4,
 });
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string): void;
+	'update:ModelValue': [value: string];
 }>();
 
 const message = useMessage();

--- a/packages/editor-ui/src/components/CollectionParameter.vue
+++ b/packages/editor-ui/src/components/CollectionParameter.vue
@@ -76,8 +76,9 @@ export interface Props {
 	isReadOnly?: boolean;
 }
 const emit = defineEmits<{
-	(event: 'valueChanged', value: IUpdateInformation): void;
+	valueChanged: [value: IUpdateInformation];
 }>();
+
 const props = defineProps<Props>();
 const ndvStore = useNDVStore();
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/ContextMenu/ContextMenu.vue
+++ b/packages/editor-ui/src/components/ContextMenu/ContextMenu.vue
@@ -7,7 +7,7 @@ import { watch, ref } from 'vue';
 const contextMenu = useContextMenu();
 const { position, isOpen, actions, target } = contextMenu;
 const dropdown = ref<InstanceType<typeof N8nActionDropdown>>();
-const emit = defineEmits<{ (event: 'action', action: ContextMenuAction, nodes: INode[]): void }>();
+const emit = defineEmits<{ action: [action: ContextMenuAction, nodes: INode[]] }>();
 
 watch(
 	isOpen,

--- a/packages/editor-ui/src/components/CopyInput.vue
+++ b/packages/editor-ui/src/components/CopyInput.vue
@@ -48,7 +48,7 @@ const props = withDefaults(defineProps<Props>(), {
 	toastTitle: useI18n().baseText('generic.copiedToClipboard'),
 });
 const emit = defineEmits<{
-	(event: 'copy'): void;
+	copy: [];
 }>();
 
 const clipboard = useClipboard();

--- a/packages/editor-ui/src/components/CredentialEdit/AuthTypeSelector.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/AuthTypeSelector.vue
@@ -22,7 +22,7 @@ export interface Props {
 }
 
 const emit = defineEmits<{
-	(event: 'authTypeChanged', value: string): void;
+	authTypeChanged: [value: string];
 }>();
 
 const nodeTypesStore = useNodeTypesStore();

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -215,11 +215,11 @@ const props = withDefaults(defineProps<Props>(), {
 	credentialPermissions: () => ({}) as PermissionsMap<CredentialScope>,
 });
 const emit = defineEmits<{
-	(event: 'update', value: IUpdateInformation): void;
-	(event: 'authTypeChanged', value: string): void;
-	(event: 'scrollToTop'): void;
-	(event: 'retest'): void;
-	(event: 'oauth'): void;
+	update: [value: IUpdateInformation];
+	authTypeChanged: [value: string];
+	scrollToTop: [];
+	retest: [];
+	oauth: [];
 }>();
 
 const credentialsStore = useCredentialsStore();

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialInputs.vue
@@ -47,7 +47,7 @@ const credentialDataValues = computed(
 );
 
 const emit = defineEmits<{
-	(event: 'update', value: IUpdateInformation): void;
+	update: [value: IUpdateInformation];
 }>();
 
 function valueChanged(parameterData: IUpdateInformation) {

--- a/packages/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
+++ b/packages/editor-ui/src/components/CredentialPicker/CredentialPicker.vue
@@ -14,9 +14,9 @@ const props = defineProps<{
 }>();
 
 const $emit = defineEmits<{
-	(event: 'credentialSelected', credentialId: string): void;
-	(event: 'credentialDeselected'): void;
-	(event: 'credentialModalOpened'): void;
+	credentialSelected: [credentialId: string];
+	credentialDeselected: [];
+	credentialModalOpened: [];
 }>();
 
 const uiStore = useUIStore();

--- a/packages/editor-ui/src/components/CredentialPicker/CredentialsDropdown.vue
+++ b/packages/editor-ui/src/components/CredentialPicker/CredentialsDropdown.vue
@@ -13,8 +13,8 @@ const props = defineProps<{
 }>();
 
 const $emit = defineEmits<{
-	(event: 'credentialSelected', credentialId: string): void;
-	(event: 'newCredential'): void;
+	credentialSelected: [credentialId: string];
+	newCredential: [];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/Draggable.vue
+++ b/packages/editor-ui/src/components/Draggable.vue
@@ -30,10 +30,11 @@ type Props = {
 };
 
 const props = withDefaults(defineProps<Props>(), { tag: 'div', disabled: false });
+
 const emit = defineEmits<{
-	(event: 'drag', value: XYPosition): void;
-	(event: 'dragstart', value: HTMLElement): void;
-	(event: 'dragend', value: HTMLElement): void;
+	drag: [value: XYPosition];
+	dragstart: [value: HTMLElement];
+	dragend: [value: HTMLElement];
 }>();
 
 const isDragging = ref(false);

--- a/packages/editor-ui/src/components/DraggableTarget.vue
+++ b/packages/editor-ui/src/components/DraggableTarget.vue
@@ -24,8 +24,9 @@ const props = withDefaults(defineProps<Props>(), {
 	stickyOffset: () => [0, 0],
 	stickyOrigin: 'top-left',
 });
+
 const emit = defineEmits<{
-	(event: 'drop', value: string): void;
+	drop: [value: string];
 }>();
 
 const hovering = ref(false);

--- a/packages/editor-ui/src/components/DropArea/DropArea.vue
+++ b/packages/editor-ui/src/components/DropArea/DropArea.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import DraggableTarget from '@/components/DraggableTarget.vue';
 
-const emit = defineEmits<{ (event: 'drop', value: string): void }>();
+const emit = defineEmits<{ drop: [value: string] }>();
 
 const onDrop = (value: string) => {
 	emit('drop', value);

--- a/packages/editor-ui/src/components/ExpandableInput/ExpandableInputEdit.vue
+++ b/packages/editor-ui/src/components/ExpandableInput/ExpandableInputEdit.vue
@@ -30,10 +30,10 @@ type Props = {
 
 const props = defineProps<Props>();
 const emit = defineEmits<{
-	(event: 'update:model-value', value: string): void;
-	(event: 'enter', value: string): void;
-	(event: 'blur', value: string): void;
-	(event: 'esc'): void;
+	'update:model-value': [value: string];
+	enter: [value: string];
+	blur: [value: string];
+	esc: [];
 }>();
 
 const inputRef = ref<HTMLInputElement>();

--- a/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
+++ b/packages/editor-ui/src/components/ExpressionEditorModal/ExpressionEditorModalInput.vue
@@ -37,9 +37,9 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'change', value: { value: string; segments: Segment[] }): void;
-	(event: 'focus'): void;
-	(event: 'close'): void;
+	change: [value: { value: string; segments: Segment[] }];
+	focus: [];
+	close: [];
 }>();
 
 const root = ref<HTMLElement>();

--- a/packages/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/editor-ui/src/components/ExpressionParameterInput.vue
@@ -40,9 +40,9 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
 	'modal-opener-click': [];
-	'updated:model-value': [value: string];
+	'update:model-value': [value: string];
 	focus: [];
-	bluer: [];
+	blur: [];
 }>();
 
 const telemetry = useTelemetry();

--- a/packages/editor-ui/src/components/ExpressionParameterInput.vue
+++ b/packages/editor-ui/src/components/ExpressionParameterInput.vue
@@ -39,10 +39,10 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'modal-opener-click'): void;
-	(event: 'update:model-value', value: string): void;
-	(event: 'focus'): void;
-	(event: 'blur'): void;
+	'modal-opener-click': [];
+	'updated:model-value': [value: string];
+	focus: [];
+	bluer: [];
 }>();
 
 const telemetry = useTelemetry();

--- a/packages/editor-ui/src/components/ExternalSecretsProviderConnectionSwitch.ee.vue
+++ b/packages/editor-ui/src/components/ExternalSecretsProviderConnectionSwitch.ee.vue
@@ -7,7 +7,7 @@ import { computed, onMounted, ref } from 'vue';
 import type { EventBus } from 'n8n-design-system/utils';
 
 const emit = defineEmits<{
-	(e: 'change', value: boolean): void;
+	change: [value: boolean];
 }>();
 
 const props = withDefaults(

--- a/packages/editor-ui/src/components/Feedback.vue
+++ b/packages/editor-ui/src/components/Feedback.vue
@@ -2,7 +2,7 @@
 import { useI18n } from '@/composables/useI18n';
 
 const emit = defineEmits<{
-	(e: 'update:modelValue', feedback: 'positive' | 'negative'): void;
+	'update:modelValue': [feedback: 'positive' | 'negative'];
 }>();
 
 defineProps<{

--- a/packages/editor-ui/src/components/FilterConditions/CombinatorSelect.vue
+++ b/packages/editor-ui/src/components/FilterConditions/CombinatorSelect.vue
@@ -11,7 +11,7 @@ interface Props {
 defineProps<Props>();
 
 const emit = defineEmits<{
-	(event: 'combinatorChange', value: FilterTypeCombinator): void;
+	combinatorChange: [value: FilterTypeCombinator];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/FilterConditions/Condition.vue
+++ b/packages/editor-ui/src/components/FilterConditions/Condition.vue
@@ -43,8 +43,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'update', value: FilterConditionValue): void;
-	(event: 'remove'): void;
+	update: [value: FilterConditionValue];
+	remove: [];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
+++ b/packages/editor-ui/src/components/FilterConditions/FilterConditions.vue
@@ -35,7 +35,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), { readOnly: false });
 
 const emit = defineEmits<{
-	(event: 'valueChanged', value: { name: string; node: string; value: FilterValue }): void;
+	valueChanged: [value: { name: string; node: string; value: FilterValue }];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
+++ b/packages/editor-ui/src/components/FilterConditions/OperatorSelect.vue
@@ -18,7 +18,7 @@ const shouldRenderItems = ref(false);
 const submenu = ref('none');
 
 const emit = defineEmits<{
-	(event: 'operatorChange', value: string): void;
+	operatorChange: [value: string];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
+++ b/packages/editor-ui/src/components/HtmlEditor/HtmlEditor.vue
@@ -59,7 +59,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'update:model-value', value: string): void;
+	'update:model-value': [value: string];
 }>();
 
 const htmlEditor = ref<HTMLElement>();

--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -39,9 +39,9 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'update:model-value', value: { value: string; segments: Segment[] }): void;
-	(event: 'update:selection', value: { state: EditorState; selection: SelectionRange }): void;
-	(event: 'focus'): void;
+	'update:model-value': [value: { value: string; segments: Segment[] }];
+	'update:selection': [value: { state: EditorState; selection: SelectionRange }];
+	focus: [];
 }>();
 
 const ndvStore = useNDVStore();

--- a/packages/editor-ui/src/components/InlineNameEdit.vue
+++ b/packages/editor-ui/src/components/InlineNameEdit.vue
@@ -44,7 +44,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string): void;
+	'update:modelValue': [value: string];
 }>();
 
 const isNameEdit = ref(false);

--- a/packages/editor-ui/src/components/InlineTextEdit.vue
+++ b/packages/editor-ui/src/components/InlineTextEdit.vue
@@ -46,8 +46,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(event: 'toggle'): void;
-	(event: 'submit', payload: { name: string; onSubmit: (updated: boolean) => void }): void;
+	toggle: [];
+	submit: [payload: { name: string; onSubmit: (updated: boolean) => void }];
 }>();
 
 const isDisabled = ref(props.disabled);

--- a/packages/editor-ui/src/components/InputNodeSelect.vue
+++ b/packages/editor-ui/src/components/InputNodeSelect.vue
@@ -17,7 +17,7 @@ type Props = {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-	(event: 'update:model-value', value: string): void;
+	'update:model-value': [value: string];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/JsEditor/JsEditor.vue
+++ b/packages/editor-ui/src/components/JsEditor/JsEditor.vue
@@ -41,7 +41,7 @@ type Props = {
 
 const props = withDefaults(defineProps<Props>(), { fillParent: false, isReadOnly: false, rows: 4 });
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string): void;
+	'update:modelValue': [value: string];
 }>();
 
 onMounted(() => {

--- a/packages/editor-ui/src/components/JsonEditor/JsonEditor.vue
+++ b/packages/editor-ui/src/components/JsonEditor/JsonEditor.vue
@@ -41,7 +41,7 @@ type Props = {
 
 const props = withDefaults(defineProps<Props>(), { fillParent: false, isReadOnly: false, rows: 4 });
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string): void;
+	'update:modelValue': [value: string];
 }>();
 
 const jsonEditorRef = ref<HTMLDivElement>();

--- a/packages/editor-ui/src/components/MainHeader/TabBar.vue
+++ b/packages/editor-ui/src/components/MainHeader/TabBar.vue
@@ -29,7 +29,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-	(key: 'update:modelValue', tab: MAIN_HEADER_TABS, event: MouseEvent): void;
+	'update:modelValue': [tab: MAIN_HEADER_TABS, event: MouseEvent];
 }>();
 
 function onUpdateModelValue(tab: MAIN_HEADER_TABS, event: MouseEvent): void {

--- a/packages/editor-ui/src/components/NDVFloatingNodes.vue
+++ b/packages/editor-ui/src/components/NDVFloatingNodes.vue
@@ -57,7 +57,7 @@ const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();
 const workflow = workflowsStore.getCurrentWorkflow();
 const emit = defineEmits<{
-	(key: 'switchSelectedNode', nodeName: string): void;
+	switchSelectedNode: [nodeName: string];
 }>();
 
 interface NodeConfig {

--- a/packages/editor-ui/src/components/NDVSubConnections.vue
+++ b/packages/editor-ui/src/components/NDVSubConnections.vue
@@ -140,8 +140,8 @@ const nodeTypesStore = useNodeTypesStore();
 const nodeHelpers = useNodeHelpers();
 const { debounce } = useDebounce();
 const emit = defineEmits<{
-	(event: 'switchSelectedNode', nodeName: string): void;
-	(event: 'openConnectionNodeCreator', nodeName: string, connectionType: ConnectionTypes): void;
+	switchSelectedNode: [nodeName: string];
+	openConnectionNodeCreator: [nodeName: string, connectionType: ConnectionTypes];
 }>();
 
 interface NodeConfig {

--- a/packages/editor-ui/src/components/Node/NodeCreation.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreation.vue
@@ -27,8 +27,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'addNodes', value: AddedNodesAndConnections): void;
-	(event: 'toggleNodeCreator', value: ToggleNodeCreatorOptions): void;
+	addNodes: [value: AddedNodesAndConnections];
+	toggleNodeCreator: [value: ToggleNodeCreatorOptions];
 }>();
 
 const state = reactive({

--- a/packages/editor-ui/src/components/Node/NodeCreator/Modes/ActionsMode.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/Modes/ActionsMode.vue
@@ -30,7 +30,7 @@ import type { IDataObject } from 'n8n-workflow';
 import { useTelemetry } from '@/composables/useTelemetry';
 
 const emit = defineEmits<{
-	(event: 'nodeTypeSelected', _: [actionKey: string, nodeName: string] | [nodeName: string]): void;
+	nodeTypeSelected: [value: [actionKey: string, nodeName: string] | [nodeName: string]];
 }>();
 const telemetry = useTelemetry();
 

--- a/packages/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/Modes/NodesMode.vue
@@ -32,7 +32,7 @@ export interface Props {
 }
 
 const emit = defineEmits<{
-	(event: 'nodeTypeSelected', nodeTypes: string[]): void;
+	nodeTypeSelected: [nodeTypes: string[]];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/Node/NodeCreator/NodeCreator.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/NodeCreator.vue
@@ -49,8 +49,8 @@ const props = defineProps<Props>();
 const { resetViewStacks } = useViewStacks();
 const { registerKeyHook } = useKeyboardNavigation();
 const emit = defineEmits<{
-	(event: 'closeNodeCreator'): void;
-	(event: 'nodeTypeSelected', value: string[]): void;
+	closeNodeCreator: [];
+	nodeTypeSelected: [value: string[]];
 }>();
 const uiStore = useUIStore();
 const aiStore = useAIStore();

--- a/packages/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/Panel/SearchBar.vue
@@ -38,7 +38,7 @@ withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: string): void;
+	'update:modelValue': [value: string];
 }>();
 
 const state = reactive({

--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -176,16 +176,12 @@ import { useI18n } from '@/composables/useI18n';
 import { storeToRefs } from 'pinia';
 
 const emit = defineEmits<{
-	(value: 'saveKeyboardShortcut', event: KeyboardEvent): void;
-	(value: 'valueChanged', parameterData: IUpdateInformation): void;
-	(value: 'switchSelectedNode', nodeTypeName: string): void;
-	(
-		value: 'openConnectionNodeCreator',
-		nodeTypeName: string,
-		connectionType: NodeConnectionType,
-	): void;
-	(value: 'redrawNode', nodeName: string): void;
-	(value: 'stopExecution'): void;
+	saveKeyboardShortcut: [event: KeyboardEvent];
+	valueChanged: [parameterData: IUpdateInformation];
+	switchSelectedNode: [nodeTypeName: string];
+	openConnectionNodeCreator: [nodeTypeName: string, connectionType: NodeConnectionType];
+	redrawNode: [nodeName: string];
+	stopExecution: [];
 }>();
 
 const props = withDefaults(

--- a/packages/editor-ui/src/components/NodeIcon.vue
+++ b/packages/editor-ui/src/components/NodeIcon.vue
@@ -57,7 +57,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'click'): void;
+	click: [];
 }>();
 
 const rootStore = useRootStore();

--- a/packages/editor-ui/src/components/NodeSettingsTabs.vue
+++ b/packages/editor-ui/src/components/NodeSettingsTabs.vue
@@ -38,7 +38,7 @@ const props = withDefaults(defineProps<Props>(), {
 	pushRef: '',
 });
 const emit = defineEmits<{
-	(event: 'update:model-value', tab: Tab): void;
+	'update:model-value': [tab: Tab];
 }>();
 
 const externalHooks = useExternalHooks();

--- a/packages/editor-ui/src/components/NodeTitle.vue
+++ b/packages/editor-ui/src/components/NodeTitle.vue
@@ -58,7 +58,7 @@ const props = withDefaults(defineProps<Props>(), {
 	readOnly: false,
 });
 const emit = defineEmits<{
-	(event: 'update:model-value', value: string): void;
+	'update:model-value': [value: string];
 }>();
 const editName = ref(false);
 const newName = ref('');

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -569,11 +569,11 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'focus'): void;
-	(event: 'blur'): void;
-	(event: 'drop', expression: string): void;
-	(event: 'textInput', update: IUpdateInformation): void;
-	(event: 'update', update: IUpdateInformation): void;
+	focus: [];
+	blur: [];
+	drop: [expression: string];
+	textInput: [update: IUpdateInformation];
+	update: [update: IUpdateInformation];
 }>();
 
 const externalHooks = useExternalHooks();

--- a/packages/editor-ui/src/components/ParameterInputExpanded.vue
+++ b/packages/editor-ui/src/components/ParameterInputExpanded.vue
@@ -84,7 +84,7 @@ const props = withDefaults(defineProps<Props>(), {
 	label: () => ({ size: 'small' }),
 });
 const emit = defineEmits<{
-	(event: 'update', value: IUpdateInformation): void;
+	update: [value: IUpdateInformation];
 }>();
 
 const focused = ref(false);

--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -121,8 +121,8 @@ const props = withDefaults(defineProps<Props>(), {
 	label: () => ({ size: 'small' }),
 });
 const emit = defineEmits<{
-	(event: 'blur'): void;
-	(event: 'update', value: IUpdateInformation): void;
+	blur: [];
+	update: [value: IUpdateInformation];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -212,9 +212,9 @@ type Props = {
 
 const props = withDefaults(defineProps<Props>(), { path: '', hiddenIssuesInputs: () => [] });
 const emit = defineEmits<{
-	(event: 'activate'): void;
-	(event: 'valueChanged', value: IUpdateInformation): void;
-	(event: 'parameterBlur', value: string): void;
+	active: [];
+	valueChanged: [value: IUpdateInformation];
+	parameterBlur: [value: string];
 }>();
 
 const nodeTypesStore = useNodeTypesStore();

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -212,7 +212,7 @@ type Props = {
 
 const props = withDefaults(defineProps<Props>(), { path: '', hiddenIssuesInputs: () => [] });
 const emit = defineEmits<{
-	active: [];
+	activate: [];
 	valueChanged: [value: IUpdateInformation];
 	parameterBlur: [value: string];
 }>();

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -101,11 +101,11 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'focus'): void;
-	(event: 'blur'): void;
-	(event: 'drop', value: string): void;
-	(event: 'update', value: IUpdateInformation): void;
-	(event: 'textInput', value: IUpdateInformation): void;
+	focus: [];
+	blur: [];
+	drop: [value: string];
+	update: [value: IUpdateInformation];
+	textInput: [value: IUpdateInformation];
 }>();
 
 const router = useRouter();

--- a/packages/editor-ui/src/components/Projects/ProjectDeleteDialog.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectDeleteDialog.vue
@@ -12,7 +12,7 @@ type Props = {
 const props = defineProps<Props>();
 const visible = defineModel<boolean>();
 const emit = defineEmits<{
-	(e: 'confirmDelete', value?: string): void;
+	confirmDelete: [value?: string];
 }>();
 
 const locale = useI18n();

--- a/packages/editor-ui/src/components/Projects/ProjectSharing.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectSharing.vue
@@ -22,8 +22,8 @@ const model = defineModel<(ProjectSharingData | null) | ProjectSharingData[]>({
 	required: true,
 });
 const emit = defineEmits<{
-	(event: 'projectAdded', value: ProjectSharingData): void;
-	(event: 'projectRemoved', value: ProjectSharingData): void;
+	projectAdded: [value: ProjectSharingData];
+	projectRemoved: [value: ProjectSharingData];
 }>();
 
 const selectedProject = ref(Array.isArray(model.value) ? '' : model.value?.id ?? '');

--- a/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -50,10 +50,10 @@ const {
 } = useNodeSpecificationValues(props.parameter.typeOptions);
 
 const emit = defineEmits<{
-	(event: 'fieldValueChanged', value: IUpdateInformation): void;
-	(event: 'removeField', field: string): void;
-	(event: 'addField', field: string): void;
-	(event: 'refreshFieldList'): void;
+	fieldValueChanged: [value: IUpdateInformation];
+	removeField: [field: string];
+	addField: [field: string];
+	refreshFieldList: [];
 }>();
 
 const ndvStore = useNDVStore();

--- a/packages/editor-ui/src/components/ResourceMapper/MappingModeSelect.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/MappingModeSelect.vue
@@ -44,8 +44,8 @@ const mappingModeOptions = [
 ];
 
 const emit = defineEmits<{
-	(event: 'modeChanged', value: string): void;
-	(event: 'retryFetch'): void;
+	modeChanged: [value: string];
+	retryFetch: [];
 }>();
 
 const selected = ref(props.initialValue);

--- a/packages/editor-ui/src/components/ResourceMapper/MatchingColumnsSelect.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/MatchingColumnsSelect.vue
@@ -53,8 +53,8 @@ watch(
 );
 
 const emit = defineEmits<{
-	(event: 'matchingColumnsChanged', value: string[]): void;
-	(event: 'refreshFieldList'): void;
+	matchingColumnsChanged: [value: string[]];
+	refreshFieldList: [];
 }>();
 
 const availableMatchingFields = computed<ResourceMapperField[]>(() => {

--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -41,7 +41,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'valueChanged', value: IUpdateInformation): void;
+	valueChanged: [value: IUpdateInformation];
 }>();
 
 const state = reactive({

--- a/packages/editor-ui/src/components/RunDataPinButton.vue
+++ b/packages/editor-ui/src/components/RunDataPinButton.vue
@@ -18,7 +18,7 @@ type Props = {
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
-	(event: 'togglePinData'): void;
+	togglePinData: [];
 }>();
 
 const visible = computed(() =>

--- a/packages/editor-ui/src/components/RunDataSchema.vue
+++ b/packages/editor-ui/src/components/RunDataSchema.vue
@@ -67,7 +67,7 @@ const { getNodeInputData } = useNodeHelpers();
 const { debounce } = useDebounce();
 
 const emit = defineEmits<{
-	(event: 'clear:search'): void;
+	'clear:search': [];
 }>();
 
 const nodeSchema = computed(() =>

--- a/packages/editor-ui/src/components/RunDataSearch.vue
+++ b/packages/editor-ui/src/components/RunDataSearch.vue
@@ -16,8 +16,8 @@ const OPEN_WIDTH = '204px';
 const OPEN_MIN_WIDTH = '120px';
 
 const emit = defineEmits<{
-	(event: 'update:modelValue', value: Props['modelValue']): void;
-	(event: 'focus'): void;
+	'update:modelValue': [value: Props['modelValue']];
+	focus: [];
 }>();
 
 const props = withDefaults(defineProps<Props>(), {

--- a/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -77,7 +77,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'update:model-value', value: string): void;
+	'update:model-value': [value: string];
 }>();
 
 const sqlEditor = ref<HTMLElement>();

--- a/packages/editor-ui/src/components/VariablesRow.vue
+++ b/packages/editor-ui/src/components/VariablesRow.vue
@@ -18,10 +18,10 @@ const settingsStore = useSettingsStore();
 const usersStore = useUsersStore();
 
 const emit = defineEmits<{
-	(event: 'save', data: IResource): void;
-	(event: 'cancel', data: IResource): void;
-	(event: 'edit', data: IResource): void;
-	(event: 'delete', data: IResource): void;
+	save: [data: IResource];
+	cancel: [data: IResource];
+	edit: [data: IResource];
+	delete: [data: IResource];
 }>();
 
 const props = withDefaults(

--- a/packages/editor-ui/src/components/WorkflowCard.vue
+++ b/packages/editor-ui/src/components/WorkflowCard.vue
@@ -56,8 +56,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(event: 'expand:tags'): void;
-	(event: 'click:tag', tagId: string, e: PointerEvent): void;
+	'expand:tags': [];
+	'click:tag': [tagId: string, e: PointerEvent];
 }>();
 
 const toast = useToast();

--- a/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryContent.vue
+++ b/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryContent.vue
@@ -21,14 +21,13 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(
-		event: 'action',
+	action: [
 		value: {
 			action: WorkflowHistoryActionTypes[number];
 			id: WorkflowVersionId;
 			data: { formattedCreatedAt: string };
 		},
-	): void;
+	];
 }>();
 
 const workflowVersionPreview = computed<IWorkflowDb | undefined>(() => {

--- a/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryList.vue
+++ b/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryList.vue
@@ -22,17 +22,16 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(
-		event: 'action',
+	action: [
 		value: {
 			action: WorkflowHistoryActionTypes[number];
 			id: WorkflowVersionId;
 			data: { formattedCreatedAt: string };
 		},
-	): void;
-	(event: 'preview', value: { event: MouseEvent; id: WorkflowVersionId }): void;
-	(event: 'loadMore', value: WorkflowHistoryRequestParams): void;
-	(event: 'upgrade'): void;
+	];
+	preview: [value: { event: MouseEvent; id: WorkflowVersionId }];
+	loadMore: [value: WorkflowHistoryRequestParams];
+	upgrade: [];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryListItem.vue
+++ b/packages/editor-ui/src/components/WorkflowHistory/WorkflowHistoryListItem.vue
@@ -16,16 +16,15 @@ const props = defineProps<{
 	isActive: boolean;
 }>();
 const emit = defineEmits<{
-	(
-		event: 'action',
+	action: [
 		value: {
 			action: WorkflowHistoryActionTypes[number];
 			id: WorkflowVersionId;
 			data: { formattedCreatedAt: string };
 		},
-	): void;
-	(event: 'preview', value: { event: MouseEvent; id: WorkflowVersionId }): void;
-	(event: 'mounted', value: { index: number; offsetTop: number; isActive: boolean }): void;
+	];
+	preview: [value: { event: MouseEvent; id: WorkflowVersionId }];
+	mounted: [value: { index: number; offsetTop: number; isActive: boolean }];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/WorkflowPreview.vue
+++ b/packages/editor-ui/src/components/WorkflowPreview.vue
@@ -53,7 +53,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(event: 'close'): void;
+	close: [];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/banners/BaseBanner.vue
+++ b/packages/editor-ui/src/components/banners/BaseBanner.vue
@@ -19,7 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-	(event: 'close'): void;
+	close: [];
 }>();
 
 const hasTrailingContent = computed(() => {

--- a/packages/editor-ui/src/components/canvas/elements/buttons/CanvasExecuteWorkflowButton.vue
+++ b/packages/editor-ui/src/components/canvas/elements/buttons/CanvasExecuteWorkflowButton.vue
@@ -5,7 +5,7 @@ import { useI18n } from '@/composables/useI18n';
 import { useUIStore } from '@/stores/ui.store';
 
 defineEmits<{
-	(key: 'click', event: MouseEvent): void;
+	click: [event: MouseEvent];
 }>();
 
 const uiStore = useUIStore();

--- a/packages/editor-ui/src/components/executions/ExecutionsFilter.vue
+++ b/packages/editor-ui/src/components/executions/ExecutionsFilter.vue
@@ -36,7 +36,7 @@ const props = withDefaults(defineProps<ExecutionFilterProps>(), {
 	teleported: true,
 });
 const emit = defineEmits<{
-	(event: 'filterChanged', value: ExecutionFilterType): void;
+	filterChanged: [value: ExecutionFilterType];
 }>();
 const debouncedEmit = debounce(emit, {
 	debounceTime: 500,

--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
@@ -26,8 +26,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(event: 'update:filters', value: ExecutionFilterType): void;
-	(event: 'execution:stop'): void;
+	'update:filters': [value: ExecutionFilterType];
+	'execution:stop': [];
 }>();
 
 const i18n = useI18n();

--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
@@ -12,9 +12,9 @@ import { useExecutionHelpers } from '@/composables/useExecutionHelpers';
 type Command = 'retrySaved' | 'retryOriginal' | 'delete';
 
 const emit = defineEmits<{
-	(event: 'stop', data: ExecutionSummary): void;
-	(event: 'select', data: ExecutionSummary): void;
-	(event: Command, data: ExecutionSummary): void;
+	stop: [data: ExecutionSummary];
+	select: [data: ExecutionSummary];
+	Command: [data: ExecutionSummary];
 }>();
 
 const props = withDefaults(

--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
@@ -14,7 +14,9 @@ type Command = 'retrySaved' | 'retryOriginal' | 'delete';
 const emit = defineEmits<{
 	stop: [data: ExecutionSummary];
 	select: [data: ExecutionSummary];
-	Command: [data: ExecutionSummary];
+	retrySaved: [data: ExecutionSummary];
+	retryOriginal: [data: ExecutionSummary];
+	delete: [data: ExecutionSummary];
 }>();
 
 const props = withDefaults(
@@ -148,6 +150,7 @@ function onSelect() {
 }
 
 async function handleActionItemClick(commandData: Command) {
+	//@ts-ignore todo: fix this type
 	emit(commandData, props.execution);
 }
 </script>

--- a/packages/editor-ui/src/views/MfaView.vue
+++ b/packages/editor-ui/src/views/MfaView.vue
@@ -116,9 +116,9 @@ const i18 = useI18n();
 // ---------------------------------------------------------------------------
 
 const emit = defineEmits<{
-	(event: 'onFormChanged', formField: string): void;
-	(event: 'onBackClick', formField: string): void;
-	(event: 'submit', form: { token: string; recoveryCode: string }): void;
+	onFormChanged: [formField: string];
+	onBackClick: [formField: string];
+	submit: [{ token: string; recoveryCode: string }];
 }>();
 
 // #endregion

--- a/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
+++ b/packages/editor-ui/src/views/SetupWorkflowFromTemplateView/SetupTemplateFormStep.vue
@@ -28,11 +28,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(
-		e: 'credentialSelected',
-		event: { credentialUsageKey: TemplateCredentialKey; credentialId: string },
-	): void;
-	(e: 'credentialDeselected', event: { credentialUsageKey: TemplateCredentialKey }): void;
+	credentialSelected: [event: { credentialUsageKey: TemplateCredentialKey; credentialId: string }];
+	credentialDeselected: [event: { credentialUsageKey: TemplateCredentialKey }];
 }>();
 
 // Stores


### PR DESCRIPTION
## Summary

1. Add linting rule to enforce `defineEmits` to use [type literal](https://eslint.vuejs.org/rules/define-emits-declaration#type-literal).
2. Make all `defineEmits` use the same format.
3. Replace `$emit` for `emit` where we use `defineEmits` 

## Related Linear tickets, Github issues, and Community forum posts

Internal discussion -> https://n8nio.slack.com/archives/C03594NKD7W/p1719917361969629

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
