### PR TITLE
fix(If Node): Ignore case when using 'contains' with an array and a string (#9893)

### DIFF
--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -285,12 +285,18 @@ export function executeFilterCondition(
 			switch (condition.operator.operation) {
 				case 'contains':
 					if (ignoreCase && typeof rightValue === 'string') {
-						rightValue = rightValue.toLocaleLowerCase();
+						const leftLower = left.map((i: unknown) =>
+							typeof i === 'string' ? i.toLocaleLowerCase() : i,
+						);
+						return leftLower.includes(rightValue.toLocaleLowerCase());
 					}
 					return left.includes(rightValue);
 				case 'notContains':
 					if (ignoreCase && typeof rightValue === 'string') {
-						rightValue = rightValue.toLocaleLowerCase();
+						const leftLower = left.map((i: unknown) =>
+							typeof i === 'string' ? i.toLocaleLowerCase() : i,
+						);
+						return !leftLower.includes(rightValue.toLocaleLowerCase());
 					}
 					return !left.includes(rightValue);
 				case 'lengthEquals':

--- a/packages/workflow/test/FilterParameter.test.ts
+++ b/packages/workflow/test/FilterParameter.test.ts
@@ -102,6 +102,48 @@ describe('FilterParameter', () => {
 				);
 				expect(result).toBe(false);
 			});
+
+			it('should evaluate strings in arrays case insensitive', () => {
+				const result = executeFilter(
+					filterFactory({
+						combinator: 'and',
+						conditions: [
+							{
+								id: '1',
+								leftValue: ['foo'],
+								rightValue: 'FOO',
+								operator: { operation: 'contains', type: 'array', rightType: 'string' },
+							},
+							{
+								id: '2',
+								leftValue: ['BAR'],
+								rightValue: 'bar',
+								operator: { operation: 'contains', type: 'array', rightType: 'string' },
+							},
+							{
+								id: '3',
+								leftValue: ['FOO'],
+								rightValue: 'FOO',
+								operator: { operation: 'contains', type: 'array', rightType: 'string' },
+							},
+							{
+								id: '4',
+								leftValue: ['bar'],
+								rightValue: 'bar',
+								operator: { operation: 'contains', type: 'array', rightType: 'string' },
+							},
+							{
+								id: '5',
+								leftValue: ['Bar'],
+								rightValue: 'baR',
+								operator: { operation: 'contains', type: 'array', rightType: 'string' },
+							},
+						],
+						options: { caseSensitive: false },
+					}),
+				);
+				expect(result).toBe(true);
+			});
 		});
 
 		describe('options.typeValidation', () => {


### PR DESCRIPTION


## Summary

The PR solvest the issue described on #9893. When using the `contains` operator with an array and a string, the `executeFilterCondition` method was just lowercasing the string but not the array, leading to the wrong comparison. The patch lowercases all strings in the array and doesn't assume all values are strings. 

The logic is duplicated for `contains` and `notContains` in case the array is long and it could make other operations slow, but if we believe this is unlikely it could be moved outside the `switch`.

A test has been added to verify the issue has been solved.

## Related Linear tickets, Github issues, and Community forum posts

#9893 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
