### PR TITLE
fix(HTML Node): Fix small typo (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Html/Html.node.ts
+++ b/packages/nodes-base/nodes/Html/Html.node.ts
@@ -296,7 +296,7 @@ export class Html implements INodeType {
 						type: 'boolean',
 						default: true,
 						description:
-							'Whether to remove remove leading and trailing whitespaces, line breaks (newlines) and condense multiple consecutive whitespaces into a single space',
+							'Whether to remove leading and trailing whitespaces, line breaks (newlines) and condense multiple consecutive whitespaces into a single space',
 					},
 				],
 			},


### PR DESCRIPTION
## Summary

remove typo in tool tip for `cleanup` HTML feature

![image](https://github.com/n8n-io/n8n/assets/123465523/f58d1122-6669-48ae-9d71-c8fc3e5eb598)
