### PR TITLE
fix(editor): Improve the contrast in the Chat Window in dark mode (no-changelog)

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -35,7 +35,7 @@
 
 	// LangChain
 	--color-lm-chat-messages-background: var(--prim-gray-820);
-	--color-lm-chat-bot-background: var(--prim-gray-540);
+	--color-lm-chat-bot-background: var(--prim-gray-740);
 	--color-lm-chat-bot-border: var(--prim-gray-490);
 	--color-lm-chat-user-background: var(--prim-color-alt-a-shade-100);
 	--color-lm-chat-user-border: var(--prim-color-alt-a);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -68,7 +68,6 @@
 	// LangChain
 	--color-lm-chat-messages-background: var(--color-background-base);
 	--color-lm-chat-bot-background: var(--prim-gray-0);
-	--color-lm-chat-bot-color: var(--color-text-dark);
 	--color-lm-chat-user-background: var(--prim-color-alt-a);
 	--color-lm-chat-user-color: var(--color-text-xlight);
 

--- a/packages/editor-ui/src/components/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat.vue
@@ -631,7 +631,6 @@ export default defineComponent({
 
 				&.bot {
 					background-color: var(--color-lm-chat-bot-background);
-					color: var(--color-lm-chat-bot-color);
 					float: left;
 					border-bottom-left-radius: 0;
 


### PR DESCRIPTION
## Summary
This PR fixes the contrast in the Chat Window in dark mode. Light mode colors are unaffected.
 
Before
![image](https://github.com/n8n-io/n8n/assets/196144/0ab91bd2-718d-4b21-bb33-f585bef2beb8)

After
![image](https://github.com/n8n-io/n8n/assets/196144/65f2debc-bd6f-461d-87da-97d108d903a3)

## Review / Merge checklist

- [x] PR title and summary are descriptive