### PR TITLE
feat(Elasticsearch Node): Add bulk operations for Elasticsearch

### DIFF
--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
@@ -4,11 +4,16 @@ import type {
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
+	JsonObject,
 } from 'n8n-workflow';
-import { jsonParse } from 'n8n-workflow';
+import { jsonParse, NodeApiError } from 'n8n-workflow';
 
 import omit from 'lodash/omit';
-import { elasticsearchApiRequest, elasticsearchApiRequestAllItems } from './GenericFunctions';
+import {
+	elasticsearchApiRequest,
+	elasticsearchApiRequestAllItems,
+	elasticsearchBulkApiRequest,
+} from './GenericFunctions';
 
 import { documentFields, documentOperations, indexFields, indexOperations } from './descriptions';
 
@@ -68,12 +73,14 @@ export class Elasticsearch implements INodeType {
 
 		let responseData;
 
+		let bulkBody: IDataObject = {};
+
 		for (let i = 0; i < items.length; i++) {
+			const bulkOperation = this.getNodeParameter('options.bulkOperation', i, false);
 			if (resource === 'document') {
 				// **********************************************************************
 				//                                document
 				// **********************************************************************
-
 				if (operation === 'delete') {
 					// ----------------------------------------
 					//             document: delete
@@ -84,8 +91,17 @@ export class Elasticsearch implements INodeType {
 					const indexId = this.getNodeParameter('indexId', i);
 					const documentId = this.getNodeParameter('documentId', i);
 
-					const endpoint = `/${indexId}/_doc/${documentId}`;
-					responseData = await elasticsearchApiRequest.call(this, 'DELETE', endpoint);
+					if (bulkOperation) {
+						bulkBody[i] = JSON.stringify({
+							delete: {
+								_index: indexId,
+								_id: documentId,
+							},
+						});
+					} else {
+						const endpoint = `/${indexId}/_doc/${documentId}`;
+						responseData = await elasticsearchApiRequest.call(this, 'DELETE', endpoint);
+					}
 				} else if (operation === 'get') {
 					// ----------------------------------------
 					//              document: get
@@ -223,12 +239,22 @@ export class Elasticsearch implements INodeType {
 					const indexId = this.getNodeParameter('indexId', i);
 					const { documentId } = additionalFields;
 
-					if (documentId) {
-						const endpoint = `/${indexId}/_doc/${documentId}`;
-						responseData = await elasticsearchApiRequest.call(this, 'PUT', endpoint, body);
+					if (bulkOperation) {
+						bulkBody[i] = JSON.stringify({
+							index: {
+								_index: indexId,
+								_id: documentId,
+							},
+						});
+						bulkBody[i] += '\n' + JSON.stringify(body);
 					} else {
-						const endpoint = `/${indexId}/_doc`;
-						responseData = await elasticsearchApiRequest.call(this, 'POST', endpoint, body);
+						if (documentId) {
+							const endpoint = `/${indexId}/_doc/${documentId}`;
+							responseData = await elasticsearchApiRequest.call(this, 'PUT', endpoint, body);
+						} else {
+							const endpoint = `/${indexId}/_doc`;
+							responseData = await elasticsearchApiRequest.call(this, 'POST', endpoint, body);
+						}
 					}
 				} else if (operation === 'update') {
 					// ----------------------------------------
@@ -261,7 +287,17 @@ export class Elasticsearch implements INodeType {
 					const documentId = this.getNodeParameter('documentId', i);
 
 					const endpoint = `/${indexId}/_update/${documentId}`;
-					responseData = await elasticsearchApiRequest.call(this, 'POST', endpoint, body);
+					if (bulkOperation) {
+						bulkBody[i] = JSON.stringify({
+							update: {
+								_index: indexId,
+								_id: documentId,
+							},
+						});
+						bulkBody[i] += '\n' + JSON.stringify(body);
+					} else {
+						responseData = await elasticsearchApiRequest.call(this, 'POST', endpoint, body);
+					}
 				}
 			} else if (resource === 'index') {
 				// **********************************************************************
@@ -341,13 +377,94 @@ export class Elasticsearch implements INodeType {
 					}
 				}
 			}
-			const executionData = this.helpers.constructExecutionMetaData(
-				this.helpers.returnJsonArray(responseData as IDataObject[]),
-				{ itemData: { item: i } },
-			);
-			returnData.push(...executionData);
-		}
 
+			if (!bulkOperation) {
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData: { item: i } },
+				);
+				returnData.push(...executionData);
+			}
+			if (Object.keys(bulkBody).length >= 50) {
+				responseData = (await elasticsearchBulkApiRequest.call(this, bulkBody)) as IDataObject[];
+				// Enumerate the response data items and pair to the key of the bulkBody
+				for (let j = 0; j < Object.keys(responseData).length; j++) {
+					const itemData = {
+						...(responseData[j].index as IDataObject),
+						...(responseData[j].update as IDataObject),
+						...(responseData[j].create as IDataObject),
+						...(responseData[j].delete as IDataObject),
+					};
+					if (itemData.error) {
+						const errorData = itemData.error as IDataObject;
+						const message = errorData.type as string;
+						const description = errorData.reason as string;
+						const itemIndex = parseInt(Object.keys(bulkBody)[j]);
+
+						if (this.continueOnFail()) {
+							returnData.push(
+								...this.helpers.constructExecutionMetaData(
+									this.helpers.returnJsonArray({ error: message, message: itemData.error }),
+									{ itemData: { item: itemIndex } },
+								),
+							);
+							continue;
+						} else {
+							throw new NodeApiError(this.getNode(), {
+								message,
+								description,
+								itemIndex,
+							} as JsonObject);
+						}
+					}
+					const executionData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray(itemData),
+						{ itemData: { item: parseInt(Object.keys(bulkBody)[j]) } },
+					);
+					returnData.push(...executionData);
+				}
+				bulkBody = {};
+			}
+		}
+		if (Object.keys(bulkBody).length) {
+			responseData = (await elasticsearchBulkApiRequest.call(this, bulkBody)) as IDataObject[];
+			// Enumerate the response data items and pair to the key of the bulkBody
+			for (let j = 0; j < Object.keys(responseData).length; j++) {
+				const itemData = {
+					...(responseData[j].index as IDataObject),
+					...(responseData[j].update as IDataObject),
+					...(responseData[j].create as IDataObject),
+					...(responseData[j].delete as IDataObject),
+				};
+				if (itemData.error) {
+					const errorData = itemData.error as IDataObject;
+					const message = errorData.type as string;
+					const description = errorData.reason as string;
+					const itemIndex = parseInt(Object.keys(bulkBody)[j]);
+
+					if (this.continueOnFail()) {
+						returnData.push(
+							...this.helpers.constructExecutionMetaData(
+								this.helpers.returnJsonArray({ error: message, message: itemData.error }),
+								{ itemData: { item: itemIndex } },
+							),
+						);
+						continue;
+					} else {
+						throw new NodeApiError(this.getNode(), {
+							message,
+							description,
+							itemIndex,
+						} as JsonObject);
+					}
+				}
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(itemData),
+					{ itemData: { item: parseInt(Object.keys(bulkBody)[j]) } },
+				);
+				returnData.push(...executionData);
+			}
+		}
 		return [returnData];
 	}
 }

--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/Elasticsearch.node.ts
@@ -246,7 +246,7 @@ export class Elasticsearch implements INodeType {
 								_id: documentId,
 							},
 						});
-						bulkBody[i] += '\n' + JSON.stringify(body);
+						bulkBody[i] += `\n${JSON.stringify(body)}`;
 					} else {
 						if (documentId) {
 							const endpoint = `/${indexId}/_doc/${documentId}`;
@@ -294,7 +294,7 @@ export class Elasticsearch implements INodeType {
 								_id: documentId,
 							},
 						});
-						bulkBody[i] += '\n' + JSON.stringify(body);
+						bulkBody[i] += `\n${JSON.stringify(body)}`;
 					} else {
 						responseData = await elasticsearchApiRequest.call(this, 'POST', endpoint, body);
 					}
@@ -387,20 +387,13 @@ export class Elasticsearch implements INodeType {
 			}
 			if (Object.keys(bulkBody).length >= 50) {
 				responseData = (await elasticsearchBulkApiRequest.call(this, bulkBody)) as IDataObject[];
-				// Enumerate the response data items and pair to the key of the bulkBody
-				for (let j = 0; j < Object.keys(responseData).length; j++) {
-					const itemData = {
-						...(responseData[j].index as IDataObject),
-						...(responseData[j].update as IDataObject),
-						...(responseData[j].create as IDataObject),
-						...(responseData[j].delete as IDataObject),
-					};
+				for (let j = 0; j < responseData.length; j++) {
+					const itemData = responseData[j];
 					if (itemData.error) {
 						const errorData = itemData.error as IDataObject;
 						const message = errorData.type as string;
 						const description = errorData.reason as string;
 						const itemIndex = parseInt(Object.keys(bulkBody)[j]);
-
 						if (this.continueOnFail()) {
 							returnData.push(
 								...this.helpers.constructExecutionMetaData(
@@ -428,20 +421,13 @@ export class Elasticsearch implements INodeType {
 		}
 		if (Object.keys(bulkBody).length) {
 			responseData = (await elasticsearchBulkApiRequest.call(this, bulkBody)) as IDataObject[];
-			// Enumerate the response data items and pair to the key of the bulkBody
-			for (let j = 0; j < Object.keys(responseData).length; j++) {
-				const itemData = {
-					...(responseData[j].index as IDataObject),
-					...(responseData[j].update as IDataObject),
-					...(responseData[j].create as IDataObject),
-					...(responseData[j].delete as IDataObject),
-				};
+			for (let j = 0; j < responseData.length; j++) {
+				const itemData = responseData[j];
 				if (itemData.error) {
 					const errorData = itemData.error as IDataObject;
 					const message = errorData.type as string;
 					const description = errorData.reason as string;
 					const itemIndex = parseInt(Object.keys(bulkBody)[j]);
-
 					if (this.continueOnFail()) {
 						returnData.push(
 							...this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/descriptions/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/descriptions/DocumentDescription.ts
@@ -81,6 +81,28 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['document'],
+				operation: ['delete'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Bulk Delete',
+				name: 'bulkOperation',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to use the bulk operation to delete the document/s',
+			},
+		],
+	},
 
 	// ----------------------------------------
 	//              document: get
@@ -645,6 +667,13 @@ export const documentFields: INodeProperties[] = [
 		},
 		options: [
 			{
+				displayName: 'Bulk Create',
+				name: 'bulkOperation',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to use the bulk operation to create the document/s',
+			},
+			{
 				displayName: 'Pipeline ID',
 				name: 'pipeline',
 				description: 'ID of the pipeline to use to preprocess incoming documents',
@@ -802,6 +831,13 @@ export const documentFields: INodeProperties[] = [
 			},
 		},
 		options: [
+			{
+				displayName: 'Bulk Update',
+				name: 'bulkOperation',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to use the bulk operation to update the document/s',
+			},
 			{
 				displayName: 'Refresh',
 				name: 'refresh',


### PR DESCRIPTION
## Summary
Add support for Elasticsearch [bulk operations](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) to:
- Create (actually upsert)
- Update
- Delete

It defaults to 50 items per batch, but should be easy enough to make configurable. Depending on data size it could be reasonable to do batches of 100, 200, 500.

On 247 items the node time went from over a **minute (75s)** to **2s**.

## Old
<img width="323" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/18a364ac-3526-4a16-a9e6-f0ea6634cb6c">

## With _bulk
<img width="323" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/ce274f66-a540-41f5-b71c-a16952a9f9af">

## Errors
It should handle item indices and error correctly
<img width="775" alt="image" src="https://github.com/n8n-io/n8n/assets/939704/683b82cd-0da5-447a-b44d-b6a4c9a0c0dd">


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
