### PR TITLE
ci: Do not run notify-pr-status workflow on community PRs (no-changelog)

### DIFF
--- a/.github/workflows/notify-pr-status.yml
+++ b/.github/workflows/notify-pr-status.yml
@@ -16,6 +16,7 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.merged == false && github.event.action == 'closed')
     steps:
       - uses: fjogeleit/http-request-action@dea46570591713c7de04a5b556bf2ff7bdf0aa9c # v1
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'community')}}
         name: Notify
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

This workflow needs a secret, that is not available on PRs from forks.

## Review / Merge checklist

- [x] PR title and summary are descriptive