### PR TITLE
fix(core): Add DB host to n8n environment variables for dev-containers (no-changelog)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,5 +19,6 @@ services:
       - ..:/workspaces:cached
     command: sleep infinity
     environment:
+      DB_POSTGRESDB_HOST: postgres
       DB_TYPE: postgresdb
       DB_POSTGRESDB_PASSWORD: password


### PR DESCRIPTION
## Summary

In the dev container, n8n failed to start up properly: it knew to connect to a Postgres DB, but could not connect to it on localhost.
This change can be tested by using the devcontainer plugin in VSCode.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
