### PR TITLE
fix(core): Prevent multiple values in the execution metadata for the same key and executionId

### DIFF
--- a/packages/cli/src/databases/dsl/Column.ts
+++ b/packages/cli/src/databases/dsl/Column.ts
@@ -13,6 +13,8 @@ export class Column {
 
 	private defaultValue: unknown;
 
+	private primaryKeyConstraintName: string | undefined;
+
 	constructor(private name: string) {}
 
 	get bool() {
@@ -57,6 +59,12 @@ export class Column {
 		return this;
 	}
 
+	primaryWithName(name?: string) {
+		this.isPrimary = true;
+		this.primaryKeyConstraintName = name;
+		return this;
+	}
+
 	get notNull() {
 		this.isNullable = false;
 		return this;
@@ -74,12 +82,14 @@ export class Column {
 
 	// eslint-disable-next-line complexity
 	toOptions(driver: Driver): TableColumnOptions {
-		const { name, type, isNullable, isPrimary, isGenerated, length } = this;
+		const { name, type, isNullable, isPrimary, isGenerated, length, primaryKeyConstraintName } =
+			this;
 		const isMysql = 'mysql' in driver;
 		const isPostgres = 'postgres' in driver;
 		const isSqlite = 'sqlite' in driver;
 
 		const options: TableColumnOptions = {
+			primaryKeyConstraintName,
 			name,
 			isNullable,
 			isPrimary,

--- a/packages/cli/src/databases/entities/ExecutionMetadata.ts
+++ b/packages/cli/src/databases/entities/ExecutionMetadata.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, RelationId } from '@n8n/typeorm';
+import { Column, Entity, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from '@n8n/typeorm';
 import { ExecutionEntity } from './ExecutionEntity';
 
 @Entity()
@@ -11,10 +11,10 @@ export class ExecutionMetadata {
 	})
 	execution: ExecutionEntity;
 
-	@RelationId((executionMetadata: ExecutionMetadata) => executionMetadata.execution)
-	executionId: number;
+	@PrimaryColumn()
+	executionId: string;
 
-	@Column('text')
+	@PrimaryColumn('text')
 	key: string;
 
 	@Column('text')

--- a/packages/cli/src/databases/entities/ExecutionMetadata.ts
+++ b/packages/cli/src/databases/entities/ExecutionMetadata.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryColumn, PrimaryGeneratedColumn } from '@n8n/typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from '@n8n/typeorm';
 import { ExecutionEntity } from './ExecutionEntity';
 
 @Entity()
@@ -11,10 +11,10 @@ export class ExecutionMetadata {
 	})
 	execution: ExecutionEntity;
 
-	@PrimaryColumn()
+	@Column()
 	executionId: string;
 
-	@PrimaryColumn('text')
+	@Column('text')
 	key: string;
 
 	@Column('text')

--- a/packages/cli/src/databases/migrations/common/1720101653148-AddConstraintToExecutionMetadata.ts
+++ b/packages/cli/src/databases/migrations/common/1720101653148-AddConstraintToExecutionMetadata.ts
@@ -1,0 +1,85 @@
+import type { MigrationContext, ReversibleMigration } from '@db/types';
+
+export class AddConstraintToExecutionMetadata1720101653148 implements ReversibleMigration {
+	async up(context: MigrationContext) {
+		const { createTable, dropTable, column } = context.schemaBuilder;
+		const { escape } = context;
+
+		const executionMetadataTableRaw = 'execution_metadata';
+		const executionMetadataTable = escape.tableName(executionMetadataTableRaw);
+		const executionMetadataTableTempRaw = 'execution_metadata_temp';
+		const executionMetadataTableTemp = escape.tableName(executionMetadataTableTempRaw);
+		const id = escape.columnName('id');
+		const executionId = escape.columnName('executionId');
+		const key = escape.columnName('key');
+		const value = escape.columnName('value');
+
+		//CREATE TABLE `test_execution_metadata_temp` (`id` int NOT NULL AUTO_INCREMENT, `executionId` int NOT NULL, `key` text NOT NULL, `value` text NOT NULL, UNIQUE INDEX `IDX_1cd301d79996ba307cf3906f3e` (`executionId`, `key`), C ONSTRAINT `FK_8464d79ae0da9eca88e68bdb53b` FOREIGN KEY (`executionId`) REFERENCES `test_execution_entity` (`id`) ON DELETE CASCADE, PRIMARY KEY (`id`)) ENGINE=InnoDB
+		//CREATE TABLE `test_execution_metadata_temp` (`id` int NOT NULL AUTO_INCREMENT, `executionId` int NOT NULL, `key` text NOT NULL, `value` text NOT NULL, CONSTRAINT `FK_8464d79ae0da9eca88e68bdb53b` FOREIGN KEY (`executionId`) REFERE NCES `test_execution_entity` (`id`) ON DELETE CASCADE, PRIMARY KEY (`id`)) ENGINE=InnoDB
+
+		await createTable(executionMetadataTableTempRaw)
+			.withColumns(
+				column('id').int.notNull.primary.autoGenerate,
+				column('executionId').int.notNull,
+				// NOTE: This is a varchar(255) instead of text, because a unique index
+				// on text is not supported on mysql, also why should we support
+				// arbitrary length keys?
+				column('key').varchar(255).notNull,
+				column('value').text.notNull,
+			)
+			.withForeignKey('executionId', {
+				tableName: 'execution_entity',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withIndexOn(['executionId', 'key'], true);
+
+		await context.runQuery(`
+			INSERT INTO ${executionMetadataTableTemp} (${id}, ${executionId}, ${key}, ${value})
+			SELECT ${id}, ${executionId}, ${key}, ${value} FROM ${executionMetadataTable};
+		`);
+
+		await dropTable(executionMetadataTableRaw);
+		await context.runQuery(
+			`ALTER TABLE ${executionMetadataTableTemp} RENAME TO ${executionMetadataTable};`,
+		);
+	}
+
+	async down(context: MigrationContext) {
+		const { createTable, dropTable, column } = context.schemaBuilder;
+		const { escape } = context;
+
+		const executionMetadataTableRaw = 'execution_metadata';
+		const executionMetadataTable = escape.tableName(executionMetadataTableRaw);
+		const executionMetadataTableTempRaw = 'execution_metadata_temp';
+		const executionMetadataTableTemp = escape.tableName(executionMetadataTableTempRaw);
+		const id = escape.columnName('id');
+		const executionId = escape.columnName('executionId');
+		const key = escape.columnName('key');
+		const value = escape.columnName('value');
+
+		await createTable(executionMetadataTableTempRaw)
+			.withColumns(
+				column('id').int.notNull.primary.autoGenerate,
+				column('executionId').int.notNull,
+				column('key').text.notNull,
+				column('value').text.notNull,
+			)
+			.withForeignKey('executionId', {
+				tableName: 'execution_entity',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			});
+		//.withIndexOn(['executionId', 'key'], true);
+
+		await context.runQuery(`
+			INSERT INTO ${executionMetadataTableTemp} (${id}, ${executionId}, ${key}, ${value})
+			SELECT ${id}, ${executionId}, ${key}, ${value} FROM ${executionMetadataTable};
+		`);
+
+		await dropTable(executionMetadataTableRaw);
+		await context.runQuery(
+			`ALTER TABLE ${executionMetadataTableTemp} RENAME TO ${executionMetadataTable};`,
+		);
+	}
+}

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -58,6 +58,7 @@ import { MoveSshKeysToDatabase1711390882123 } from '../common/1711390882123-Move
 import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNodesAccess';
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
+import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -119,4 +120,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateProject1714133768519,
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
+	AddConstraintToExecutionMetadata1720101653148,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -57,6 +57,7 @@ import { MoveSshKeysToDatabase1711390882123 } from '../common/1711390882123-Move
 import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNodesAccess';
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
+import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -117,4 +118,5 @@ export const postgresMigrations: Migration[] = [
 	CreateProject1714133768519,
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
+	AddConstraintToExecutionMetadata1720101653148,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -55,6 +55,7 @@ import { MoveSshKeysToDatabase1711390882123 } from '../common/1711390882123-Move
 import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNodesAccess';
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
+import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -113,6 +114,7 @@ const sqliteMigrations: Migration[] = [
 	CreateProject1714133768519,
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
+	AddConstraintToExecutionMetadata1720101653148,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/services/executionMetadata.service.ts
+++ b/packages/cli/src/services/executionMetadata.service.ts
@@ -13,7 +13,7 @@ export class ExecutionMetadataService {
 		const metadataRows = [];
 		for (const [key, value] of Object.entries(executionMetadata)) {
 			metadataRows.push({
-				execution: { id: executionId },
+				executionId,
 				key,
 				value,
 			});

--- a/packages/cli/src/services/executionMetadata.service.ts
+++ b/packages/cli/src/services/executionMetadata.service.ts
@@ -6,11 +6,8 @@ import type { ExecutionMetadata } from '@db/entities/ExecutionMetadata';
 export class ExecutionMetadataService {
 	constructor(private readonly executionMetadataRepository: ExecutionMetadataRepository) {}
 
-	async save(
-		executionId: string,
-		executionMetadata: Record<string, string>,
-	): Promise<ExecutionMetadata[]> {
-		const metadataRows = [];
+	async save(executionId: string, executionMetadata: Record<string, string>): Promise<void> {
+		const metadataRows: Array<Pick<ExecutionMetadata, 'executionId' | 'key' | 'value'>> = [];
 		for (const [key, value] of Object.entries(executionMetadata)) {
 			metadataRows.push({
 				executionId,
@@ -19,6 +16,8 @@ export class ExecutionMetadataService {
 			});
 		}
 
-		return await this.executionMetadataRepository.save(metadataRows);
+		await this.executionMetadataRepository.upsert(metadataRows, {
+			conflictPaths: { executionId: true, key: true },
+		});
 	}
 }

--- a/packages/cli/test/integration/services/executionMetadata.service.test.ts
+++ b/packages/cli/test/integration/services/executionMetadata.service.test.ts
@@ -1,0 +1,55 @@
+import * as testDb from '../shared/testDb';
+import Container from 'typedi';
+import { ExecutionMetadataRepository } from '@/databases/repositories/executionMetadata.repository';
+import { ExecutionMetadataService } from '@/services/executionMetadata.service';
+import { createExecution } from '@test-integration/db/executions';
+import { createWorkflow } from '@test-integration/db/workflows';
+
+let executionMetadataRepository: ExecutionMetadataRepository;
+let executionMetadataService: ExecutionMetadataService;
+
+beforeAll(async () => {
+	await testDb.init();
+
+	executionMetadataRepository = Container.get(ExecutionMetadataRepository);
+	executionMetadataService = Container.get(ExecutionMetadataService);
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+afterEach(async () => {
+	await testDb.truncate(['User']);
+});
+
+describe('ProjectService', () => {
+	describe('save', () => {
+		it('should deduplicate entries by exeuctionId and key, keeping the latest one', async () => {
+			//
+			// ARRANGE
+			//
+			const workflow = await createWorkflow();
+			const execution = await createExecution({}, workflow);
+			const key = 'key';
+			const value1 = 'value1';
+			const value2 = 'value2';
+
+			//
+			// ACT
+			//
+			await executionMetadataService.save(execution.id, { [key]: value1 });
+			await executionMetadataService.save(execution.id, { [key]: value2 });
+
+			//
+			// ASSERT
+			//
+			const rows = await executionMetadataRepository.find({
+				where: { executionId: execution.id, key },
+			});
+
+			expect(rows).toHaveLength(1);
+			expect(rows[0]).toHaveProperty('value', value2);
+		});
+	});
+});

--- a/packages/cli/test/unit/ExecutionMetadataService.test.ts
+++ b/packages/cli/test/unit/ExecutionMetadataService.test.ts
@@ -15,20 +15,26 @@ describe('ExecutionMetadataService', () => {
 
 		await Container.get(ExecutionMetadataService).save(executionId, toSave);
 
-		expect(repository.save).toHaveBeenCalledTimes(1);
-		expect(repository.save.mock.calls[0]).toEqual([
+		expect(repository.upsert).toHaveBeenCalledTimes(1);
+		expect(repository.upsert.mock.calls[0]).toEqual([
 			[
 				{
-					execution: { id: executionId },
+					executionId,
 					key: 'test1',
 					value: 'value1',
 				},
 				{
-					execution: { id: executionId },
+					executionId,
 					key: 'test2',
 					value: 'value2',
 				},
 			],
+			{
+				conflictPaths: {
+					executionId: true,
+					key: true,
+				},
+			},
 		]);
 	});
 });


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

It's possible to save multiple values for the same key and execution in the execution metadata table.

A customer ran into this issue and reported it.

Here's simple workflow that demonstrates the issue:

![image](https://github.com/n8n-io/n8n/assets/927609/9c03ff17-aa4e-42ef-bf62-84ad89e60d99)


<details>
<summary>JSON</summary>

```json
{
  "meta": {
    "instanceId": "4abb53a5101e08a13d84bcfb6b9d64c86a13e3a76f9a17145019bd2bdbe67bd9"
  },
  "nodes": [
    {
      "parameters": {
        "dataToSave": {
          "values": [
            {
              "key": "foo",
              "value": "bar"
            }
          ]
        }
      },
      "id": "e3b4a24a-4e68-4a50-a839-866b693864dd",
      "name": "Execution Data",
      "type": "n8n-nodes-base.executionData",
      "typeVersion": 1,
      "position": [
        900,
        460
      ]
    },
    {
      "parameters": {
        "resume": "webhook",
        "options": {}
      },
      "id": "dcc7a4ff-f058-4c09-a389-d9e470c9c2aa",
      "name": "Wait",
      "type": "n8n-nodes-base.wait",
      "typeVersion": 1.1,
      "position": [
        1120,
        460
      ],
      "webhookId": "749f28ee-7457-4c7a-819a-a4ef3b07111f"
    },
    {
      "parameters": {
        "respondWith": "json",
        "responseBody": "={\n  \"resumeURL\": \"{{ $execution.resumeUrl }}\"\n}",
        "options": {}
      },
      "id": "13f3f6d2-75f4-4995-bb15-2c60cd8e1e36",
      "name": "Respond to Webhook",
      "type": "n8n-nodes-base.respondToWebhook",
      "typeVersion": 1.1,
      "position": [
        680,
        460
      ]
    },
    {
      "parameters": {
        "path": "65849dd2-e0ca-46f9-9a06-b9025b9b32ea",
        "responseMode": "responseNode",
        "options": {}
      },
      "id": "1849d407-e462-4c7c-8f78-5341ea669ffe",
      "name": "Webhook",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 2,
      "position": [
        460,
        460
      ],
      "webhookId": "65849dd2-e0ca-46f9-9a06-b9025b9b32ea"
    },
    {
      "parameters": {},
      "id": "a45ed3d2-bd9d-47f2-b828-b504257c78ff",
      "name": "No Operation, do nothing",
      "type": "n8n-nodes-base.noOp",
      "typeVersion": 1,
      "position": [
        1340,
        460
      ]
    }
  ],
  "connections": {
    "Execution Data": {
      "main": [
        [
          {
            "node": "Wait",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Wait": {
      "main": [
        [
          {
            "node": "No Operation, do nothing",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Respond to Webhook": {
      "main": [
        [
          {
            "node": "Execution Data",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Webhook": {
      "main": [
        [
          {
            "node": "Respond to Webhook",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

</details>

This will save the execution data twice in the database.

This PR makes sure that we upsert the execution metadata instead based on the `executionId` and `key`. This contains a migration that creates a unique index on those 2 columns and de-duplicates the rows, keeping the row with the highest id on conflict.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1720/bug-execution-metadata-is-duplicated-when-an-execution-is-continued

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
