### PR TITLE
ci: Make pinning e2e test work locally (no-changelog)

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -99,8 +99,6 @@ jobs:
           runTests: false
           install: false
           build: pnpm build
-        env:
-          VUE_APP_MAX_PINNED_DATA_SIZE: 16384
 
       - name: Cypress install
         working-directory: cypress

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -25,9 +25,4 @@ module.exports = defineConfig({
 		screenshotsFolder: 'screenshots',
 		videosFolder: 'videos',
 	},
-	env: {
-		MAX_PINNED_DATA_SIZE: process.env.VUE_APP_MAX_PINNED_DATA_SIZE
-			? parseInt(process.env.VUE_APP_MAX_PINNED_DATA_SIZE, 10)
-			: 16 * 1024,
-	},
 });

--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -12,8 +12,13 @@ const workflowPage = new WorkflowPage();
 const ndv = new NDV();
 
 describe('Data pinning', () => {
+	const maxPinnedDataSize = 16384;
+
 	beforeEach(() => {
 		workflowPage.actions.visit();
+		cy.window().then((win) => {
+			win.maxPinnedDataSize = maxPinnedDataSize;
+		});
 	});
 
 	it('Should be able to pin node output', () => {
@@ -139,7 +144,7 @@ describe('Data pinning', () => {
 
 		ndv.actions.pastePinnedData([
 			{
-				test: '1'.repeat(Cypress.env('MAX_PINNED_DATA_SIZE') as number),
+				test: '1'.repeat(maxPinnedDataSize),
 			},
 		]);
 		errorToast().should('contain', 'Workflow has reached the maximum allowed pinned data size');

--- a/cypress/scripts/run-e2e.js
+++ b/cypress/scripts/run-e2e.js
@@ -13,7 +13,6 @@ function runTests(options) {
 	process.env.N8N_USER_FOLDER = userFolder;
 	process.env.E2E_TESTS = 'true';
 	process.env.NODE_OPTIONS = '--dns-result-order=ipv4first';
-	process.env.VUE_APP_MAX_PINNED_DATA_SIZE = `${16 * 1024}`;
 
 	if (options.customEnv) {
 		Object.keys(options.customEnv).forEach((key) => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -64,6 +64,7 @@ declare global {
 					innerWidth: number;
 					innerHeight: number;
 					preventNodeViewBeforeUnload?: boolean;
+					maxPinnedDataSize?: number;
 					featureFlags: {
 						override: (feature: string, value: unknown) => void;
 					};

--- a/packages/editor-ui/src/composables/usePinnedData.ts
+++ b/packages/editor-ui/src/composables/usePinnedData.ts
@@ -140,6 +140,10 @@ export function usePinnedData(
 		}
 	}
 
+	function getMaxPinnedDataSize() {
+		return window.maxPinnedDataSize ?? MAX_PINNED_DATA_SIZE;
+	}
+
 	function isValidSize(data: string | object): boolean {
 		const targetNode = unref(node);
 		if (!targetNode) {
@@ -154,13 +158,13 @@ export function usePinnedData(
 		const newPinData = { ...currentPinData, [targetNode.name]: data };
 		const newPinDataSize = workflowsStore.getPinDataSize(newPinData);
 
-		if (newPinDataSize > MAX_PINNED_DATA_SIZE) {
+		if (newPinDataSize > getMaxPinnedDataSize()) {
 			toast.showError(
 				new Error(
 					i18n.baseText('ndv.pinData.error.tooLarge.description', {
 						interpolate: {
 							size: toMegaBytes(newPinDataSize),
-							limit: toMegaBytes(MAX_PINNED_DATA_SIZE),
+							limit: toMegaBytes(getMaxPinnedDataSize()),
 						},
 					}),
 				),

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -9,9 +9,7 @@ import type { InjectionKey } from 'vue';
 
 export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16; // Workflow size limit in bytes
 export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow request metadata (i.e. headers) size in bytes
-export const MAX_PINNED_DATA_SIZE = import.meta.env.VUE_APP_MAX_PINNED_DATA_SIZE
-	? parseInt(import.meta.env.VUE_APP_MAX_PINNED_DATA_SIZE, 10)
-	: 1024 * 1024 * 12; // 12 MB; Workflow pinned data size limit in bytes
+export const MAX_PINNED_DATA_SIZE = window.maxPinnedDataSize ?? 1024 * 1024 * 12; // 12 MB; Workflow pinned data size limit in bytes
 export const MAX_DISPLAY_DATA_SIZE = 1024 * 1024; // 1 MB
 export const MAX_DISPLAY_DATA_SIZE_SCHEMA_VIEW = 1024 * 1024 * 4; // 4 MB
 export const MAX_DISPLAY_ITEMS_AUTO_ALL = 250;

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -9,7 +9,7 @@ import type { InjectionKey } from 'vue';
 
 export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16; // Workflow size limit in bytes
 export const MAX_EXPECTED_REQUEST_SIZE = 2048; // Expected maximum workflow request metadata (i.e. headers) size in bytes
-export const MAX_PINNED_DATA_SIZE = window.maxPinnedDataSize ?? 1024 * 1024 * 12; // 12 MB; Workflow pinned data size limit in bytes
+export const MAX_PINNED_DATA_SIZE = 1024 * 1024 * 12; // 12 MB; Workflow pinned data size limit in bytes
 export const MAX_DISPLAY_DATA_SIZE = 1024 * 1024; // 1 MB
 export const MAX_DISPLAY_DATA_SIZE_SCHEMA_VIEW = 1024 * 1024 * 4; // 4 MB
 export const MAX_DISPLAY_ITEMS_AUTO_ALL = 250;

--- a/packages/editor-ui/src/shims.d.ts
+++ b/packages/editor-ui/src/shims.d.ts
@@ -11,7 +11,6 @@ declare global {
 			PROD: boolean;
 			NODE_ENV: 'development' | 'production';
 			VUE_APP_URL_BASE_API: string;
-			VUE_APP_MAX_PINNED_DATA_SIZE: string;
 		};
 	}
 
@@ -20,6 +19,7 @@ declare global {
 		REST_ENDPOINT: string;
 		n8nExternalHooks?: PartialDeep<ExternalHooks>;
 		preventNodeViewBeforeUnload?: boolean;
+		maxPinnedDataSize?: number;
 	}
 
 	namespace JSX {


### PR DESCRIPTION
## Summary
The current e2e setup depends on the custom max pinned-data size to be set at compile time, which only works if the person testing it remembers to set the env variable. 
This PR changes the setup to let us customize the max max pinned-data size at runtime instead, like we do for `preventNodeViewBeforeUnload`.

This unblocks #9696

## Review / Merge checklist

- [x] PR title and summary are descriptive