### PR TITLE
fix(core): Enforce max timeout during graceful shutdown for main with active executions

### DIFF
--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -313,7 +313,7 @@ export abstract class BaseCommand extends Command {
 		this.exit(exitCode);
 	}
 
-	private onTerminationSignal(signal: string) {
+	protected onTerminationSignal(signal: string) {
 		return async () => {
 			if (this.shutdownService.isShuttingDown()) {
 				this.logger.info(`Received ${signal}. Already shutting down...`);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -328,7 +328,7 @@ export class Start extends BaseCommand {
 					this.openBrowser();
 				} else if (key.charCodeAt(0) === 3) {
 					// Ctrl + c got pressed
-					void this.stopProcess();
+					void this.onTerminationSignal('SIGINT')();
 				} else {
 					// When anything else got pressed, record it and send it on enter into the child process
 


### PR DESCRIPTION
## Summary

Enforce max timeout (i.e. force shutdown) for main process with active executions in scaling mode. 

## Testing

To reproduce: 

- Set up a 5s cron workflow and activate it
- Start main in scaling mode, no worker
- Wait for main to enqueue 1+ active executions
- Send SIGINT
- Before: Main waits forever, disregards max timeout
- After: Main waits until max timeout

> TODO: Include `ActiveExecutions.shutdown` in `ShutdownService` instead. Inclusion currently not working. Using `@OnShutdown` on a method like this that contains `sleep` causes it to return at that line, not waiting for active executions to finish, whereas using `OnShutdown` on the method but removing `sleep` causes the max timeout to be ignored. @tomi Do you have any pointers?

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C069HS026UF/p1720175322945359

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
