### PR TITLE
feat(Stripe Trigger Node): Add Stripe webhook descriptions based on the workflow ID and name

### DIFF
--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.json
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.json
@@ -1,6 +1,6 @@
 {
 	"node": "n8n-nodes-base.stripeTrigger",
-	"nodeVersion": "1.1",
+	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Finance & Accounting", "Sales"],
 	"resources": {

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.json
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.json
@@ -1,6 +1,6 @@
 {
 	"node": "n8n-nodes-base.stripeTrigger",
-	"nodeVersion": "1.0",
+	"nodeVersion": "1.1",
 	"codexVersion": "1.0",
 	"categories": ["Finance & Accounting", "Sales"],
 	"resources": {

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -865,12 +865,16 @@ export class StripeTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 
+				const webhookDescription = `Created by n8n for workflow ID ${this.getWorkflow().id}:
+				 ${this.getWorkflow().name}`;
+
 				const events = this.getNodeParameter('events', []);
 
 				const endpoint = '/webhook_endpoints';
 
 				const body = {
 					url: webhookUrl,
+					description: webhookDescription,
 					enabled_events: events,
 				};
 

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -865,8 +865,7 @@ export class StripeTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 
-				const webhookDescription = `Created by n8n for workflow ID ${this.getWorkflow().id}:
-				 ${this.getWorkflow().name}`;
+				const webhookDescription = `Created by n8n for workflow ID: ${this.getWorkflow().id}`;
 
 				const events = this.getNodeParameter('events', []);
 


### PR DESCRIPTION
## Summary

Right now n8n creates the needed Stripe Webhooks while adding Stripe Trigger nodes without specifying a description for that Stripe Webhook.

That is, you can end up having a list of Stripe Webhooks which do not reveal any kind of contextual information. In case of receiving an errors spike alert from Stripe, which demands a quick response, you do not have any more information rather than the webhook URL where it points to:

![2024_07_06-12_31_11](https://github.com/n8n-io/n8n/assets/986235/429128ed-7a9c-4791-bfbd-43134cbd587a)

With this PR n8n will start adding the following description to these webhooks:

```javascript
`Created by n8n for workflow ID $workflowId: $workflowName`;
```

This allows to have a better idea of the implications of an error spike in webhook calls, or just knowing why you have _N_ declared Stripe Webhooks and where they come from.

Take into account that, even if you manually add the Stripe Webhook description from the Stripe Workbench, it will be removed while updating n8n because it de-register the webhooks and create them again. So this is the only approach I can think of in order to maintain the webhook descriptions in place 😊

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
