### PR TITLE
fix(core): Clear active execution on cancellation in scaling mode

### DIFF
--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -235,6 +235,7 @@ describe('ExecutionService', () => {
 					 * Assert
 					 */
 					expect(waitTracker.stopExecution).not.toHaveBeenCalled();
+					expect(activeExecutions.stopExecution).toHaveBeenCalled();
 					expect(queue.findRunningJobBy).toBeCalledWith({ executionId: execution.id });
 					expect(queue.stopJob).toHaveBeenCalled();
 					expect(executionRepository.stopDuringRun).toHaveBeenCalled();
@@ -260,6 +261,7 @@ describe('ExecutionService', () => {
 					 * Assert
 					 */
 					expect(waitTracker.stopExecution).toHaveBeenCalledWith(execution.id);
+					expect(activeExecutions.stopExecution).toHaveBeenCalled();
 					expect(queue.findRunningJobBy).toBeCalledWith({ executionId: execution.id });
 					expect(queue.stopJob).toHaveBeenCalled();
 					expect(executionRepository.stopDuringRun).toHaveBeenCalled();

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -460,6 +460,10 @@ export class ExecutionService {
 			return await this.stopInRegularMode(execution);
 		}
 
+		if (this.activeExecutions.has(execution.id)) {
+			await this.activeExecutions.stopExecution(execution.id);
+		}
+
 		if (this.waitTracker.has(execution.id)) {
 			await this.waitTracker.stopExecution(execution.id);
 		}


### PR DESCRIPTION
## Summary

This PR fixes a minor issue where cancelling an execution in scaling mode was leading to the execution not being cleared from active executions, blocking main's shutdown.

To reproduce, start main and worker in queue mode, activate a cron+wait workflow, cancel the execution midway through, then send `SIGINT` to main. The cancelled execution lingers on in `ActiveExecutions.activeExecutions` so main waits for it during shutdown.

## Related Linear tickets, Github issues, and Community forum posts

None, noticed while working on scaling mode.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
