### PR TITLE
fix(core): Use Custom cache-control headers force cache-revalidation on `/types/*.json` (no-changelog)

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -364,10 +364,18 @@ export class Server extends AbstractServer {
 					next();
 				}
 			};
+			const setCustomCacheHeader = (res: express.Response) => {
+				if (/^\/types\/(nodes|credentials).json$/.test(res.req.url)) {
+					res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+				}
+			};
 
 			this.app.use(
 				'/',
-				express.static(staticCacheDir, cacheOptions),
+				express.static(staticCacheDir, {
+					...cacheOptions,
+					setHeaders: setCustomCacheHeader,
+				}),
 				express.static(EDITOR_UI_DIST_DIR, cacheOptions),
 				historyApiHandler,
 			);


### PR DESCRIPTION
## Summary
Since `/types/*.json` does not contain any cache-busting string in the url, and since these files can change quite a bit between releases, they should not be as aggressively cached as other static assets.

## Review / Merge checklist

- [x] PR title and summary are descriptive