### PR TITLE
fix(core): Ensure correct `Cache-Control` header on `/` as well (no-changelog)

### DIFF
--- a/packages/cli/src/Server.ts
+++ b/packages/cli/src/Server.ts
@@ -335,6 +335,7 @@ export class Server extends AbstractServer {
 			// Route all UI urls to index.html to support history-api
 			const nonUIRoutes: Readonly<string[]> = [
 				'assets',
+				'static',
 				'types',
 				'healthz',
 				'metrics',
@@ -372,12 +373,12 @@ export class Server extends AbstractServer {
 
 			this.app.use(
 				'/',
+				historyApiHandler,
 				express.static(staticCacheDir, {
 					...cacheOptions,
 					setHeaders: setCustomCacheHeader,
 				}),
 				express.static(EDITOR_UI_DIST_DIR, cacheOptions),
-				historyApiHandler,
 			);
 		} else {
 			this.app.use('/', express.static(staticCacheDir, cacheOptions));


### PR DESCRIPTION
## Summary
`express.static` handles `/` automatically, and returns `index.html`. Setting `index: false` in cache options doesn't solve this unfortunately. So, to ensure that `/` gets the same `Cache-Control` header as any other UI route, we need to move the `historyApiHandler` middleware before any `express.static` handler.


## Review / Merge checklist

- [x] PR title and summary are descriptive