### PR TITLE
fix(core): Stopping an execution should reject any response promises

### DIFF
--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -6,7 +6,12 @@ import type {
 	IRun,
 	ExecutionStatus,
 } from 'n8n-workflow';
-import { ApplicationError, createDeferredPromise, sleep } from 'n8n-workflow';
+import {
+	ApplicationError,
+	createDeferredPromise,
+	ExecutionCancelledError,
+	sleep,
+} from 'n8n-workflow';
 
 import type {
 	ExecutionPayload,
@@ -20,7 +25,6 @@ import { ExecutionRepository } from '@db/repositories/execution.repository';
 import { Logger } from '@/Logger';
 import { ConcurrencyControlService } from './concurrency/concurrency-control.service';
 import config from './config';
-import { ExecutionCancelledError } from '@/errors/execution-cancelled.error';
 
 @Service()
 export class ActiveExecutions {

--- a/packages/cli/src/ActiveExecutions.ts
+++ b/packages/cli/src/ActiveExecutions.ts
@@ -143,10 +143,7 @@ export class ActiveExecutions {
 			promise.resolve(fullRunData);
 		}
 
-		// Remove from the list of active executions
-		delete this.activeExecutions[executionId];
-
-		this.concurrencyControl.release({ mode: execution.executionData.executionMode });
+		this.postExecuteCleanup(executionId);
 	}
 
 	/**
@@ -166,6 +163,20 @@ export class ActiveExecutions {
 		for (const promise of execution.postExecutePromises) {
 			promise.reject(reason);
 		}
+
+		this.postExecuteCleanup(executionId);
+	}
+
+	private postExecuteCleanup(executionId: string) {
+		const execution = this.activeExecutions[executionId];
+		if (execution === undefined) {
+			return;
+		}
+
+		// Remove from the list of active executions
+		delete this.activeExecutions[executionId];
+
+		this.concurrencyControl.release({ mode: execution.executionData.executionMode });
 	}
 
 	/**

--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -86,7 +86,7 @@ export class WaitTracker {
 		}
 	}
 
-	async stopExecution(executionId: string) {
+	stopExecution(executionId: string) {
 		if (!this.waitingExecutions[executionId]) return;
 
 		clearTimeout(this.waitingExecutions[executionId].timer);

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -189,6 +189,7 @@ export class WorkflowRunner {
 					}
 				})
 				.catch((error) => {
+					if (error instanceof ExecutionCancelledError) return;
 					ErrorReporter.error(error);
 					this.logger.error(
 						'There was a problem running internal hook "onWorkflowPostExecute"',

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -18,7 +18,6 @@ import {
 	ErrorReporterProxy as ErrorReporter,
 	ExecutionCancelledError,
 	Workflow,
-	WorkflowOperationError,
 } from 'n8n-workflow';
 
 import PCancelable from 'p-cancelable';

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -16,6 +16,7 @@ import type {
 } from 'n8n-workflow';
 import {
 	ErrorReporterProxy as ErrorReporter,
+	ExecutionCancelledError,
 	Workflow,
 	WorkflowOperationError,
 } from 'n8n-workflow';
@@ -426,7 +427,7 @@ export class WorkflowRunner {
 						{ retryOf: data.retryOf ? data.retryOf.toString() : undefined },
 					);
 
-					const error = new WorkflowOperationError('Workflow-Execution has been canceled!');
+					const error = new ExecutionCancelledError(executionId);
 					await this.processError(error, new Date(), data.executionMode, executionId, hooksWorker);
 
 					reject(error);

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -643,6 +643,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	async stopDuringRun(execution: IExecutionResponse) {
 		const error = new WorkflowOperationError('Workflow-Execution has been canceled!');
 
+		execution.data = execution.data || { resultData: {} };
 		execution.data.resultData.error = {
 			...error,
 			message: error.message,

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -20,14 +20,16 @@ import type {
 	SelectQueryBuilder,
 } from '@n8n/typeorm';
 import { parse, stringify } from 'flatted';
+import { GlobalConfig } from '@n8n/config';
 import {
 	ApplicationError,
-	WorkflowOperationError,
 	type ExecutionStatus,
 	type ExecutionSummary,
 	type IRunExecutionData,
 } from 'n8n-workflow';
 import { BinaryDataService } from 'n8n-core';
+import { ExecutionCancelledError, ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
+
 import type {
 	ExecutionPayload,
 	IExecutionBase,
@@ -43,9 +45,7 @@ import { ExecutionDataRepository } from './executionData.repository';
 import { Logger } from '@/Logger';
 import type { ExecutionSummaries } from '@/executions/execution.types';
 import { PostgresLiveRowsRetrievalError } from '@/errors/postgres-live-rows-retrieval.error';
-import { GlobalConfig } from '@n8n/config';
 import { separate } from '@/utils';
-import { ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
 
 export interface IGetExecutionsQueryFilter {
 	id?: FindOperator<string> | string;
@@ -641,9 +641,9 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	}
 
 	async stopDuringRun(execution: IExecutionResponse) {
-		const error = new WorkflowOperationError('Workflow-Execution has been canceled!');
+		const error = new ExecutionCancelledError(execution.id);
 
-		execution.data = execution.data || { resultData: {} };
+		execution.data ??= { resultData: { runData: {} } };
 		execution.data.resultData.error = {
 			...error,
 			message: error.message,

--- a/packages/cli/src/errors/execution-cancelled.error.ts
+++ b/packages/cli/src/errors/execution-cancelled.error.ts
@@ -1,0 +1,10 @@
+import { ApplicationError } from 'n8n-workflow';
+
+export class ExecutionCancelledError extends ApplicationError {
+	constructor(executionId: string) {
+		super('The execution was cancelled', {
+			level: 'warning',
+			extra: { executionId },
+		});
+	}
+}

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -444,11 +444,11 @@ export class ExecutionService {
 		}
 
 		if (this.activeExecutions.has(execution.id)) {
-			await this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(execution.id);
 		}
 
 		if (this.waitTracker.has(execution.id)) {
-			await this.waitTracker.stopExecution(execution.id);
+			this.waitTracker.stopExecution(execution.id);
 		}
 
 		return await this.executionRepository.stopDuringRun(execution);
@@ -461,11 +461,11 @@ export class ExecutionService {
 		}
 
 		if (this.activeExecutions.has(execution.id)) {
-			await this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.stopExecution(execution.id);
 		}
 
 		if (this.waitTracker.has(execution.id)) {
-			await this.waitTracker.stopExecution(execution.id);
+			this.waitTracker.stopExecution(execution.id);
 		}
 
 		const job = await this.queue.findRunningJobBy({ executionId: execution.id });

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -29,6 +29,7 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(),
 		);
 	});
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -19,6 +19,7 @@ import type { Workflow } from './Workflow';
 import type { WorkflowActivationError } from './errors/workflow-activation.error';
 import type { WorkflowOperationError } from './errors/workflow-operation.error';
 import type { WorkflowHooks } from './WorkflowHooks';
+import type { ExecutionCancelledError } from './errors';
 import type { NodeOperationError } from './errors/node-operation.error';
 import type { NodeApiError } from './errors/node-api.error';
 import type { AxiosProxyConfig } from 'axios';
@@ -80,6 +81,7 @@ export type ExecutionError =
 	| ExpressionError
 	| WorkflowActivationError
 	| WorkflowOperationError
+	| ExecutionCancelledError
 	| NodeOperationError
 	| NodeApiError;
 

--- a/packages/workflow/src/errors/execution-cancelled.error.ts
+++ b/packages/workflow/src/errors/execution-cancelled.error.ts
@@ -1,6 +1,6 @@
-import { ApplicationError } from 'n8n-workflow';
+import { ExecutionBaseError } from './abstract/execution-base.error';
 
-export class ExecutionCancelledError extends ApplicationError {
+export class ExecutionCancelledError extends ExecutionBaseError {
 	constructor(executionId: string) {
 		super('The execution was cancelled', {
 			level: 'warning',

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -1,6 +1,7 @@
 export { ApplicationError } from './application.error';
 export { ExpressionError } from './expression.error';
 export { CredentialAccessError } from './credential-access-error';
+export { ExecutionCancelledError } from './execution-cancelled.error';
 export { NodeApiError } from './node-api.error';
 export { NodeOperationError } from './node-operation.error';
 export { NodeSslError } from './node-ssl.error';


### PR DESCRIPTION
## Summary
When an execution is cancelled via the `/rest/executions/:id/stop` endpoint, it should reject any `postExecutePromises` promises, and not create another `postExecutePromise` that never resolves.

## Related Linear tickets, Github issues, and Community forum posts
PAY-1730

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included