### PR TITLE
build(core): Change node version from 18.10 to 18.12 to address pnmp install requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ If you already have VS Code and Docker installed, you can click [here](https://v
 
 #### Node.js
 
-[Node.js](https://nodejs.org/en/) version 18.10 or newer is required for development purposes.
+[Node.js](https://nodejs.org/en/) version 18.12 or newer is required for development purposes.
 
 #### pnpm
 
@@ -82,9 +82,9 @@ This automatically sets up file-links between modules which depend on each other
 
 #### corepack
 
-We recommend enabling [Node.js corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) with `corepack enable`.
+We recommend enabling [Node.js corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) with `corepack enable`.
 
-With Node.js v16.17 or newer, you can install the latest version of pnpm: `corepack prepare pnpm@latest --activate`. If you use an older version install at least version 7.18 of pnpm via: `corepack prepare pnpm@7.18.0 --activate`.
+With Node.js v18.12 or newer, you can install the latest version of pnpm: `corepack prepare pnpm@latest --activate`. If you use an older version install at least version 7.18 of pnpm via: `corepack prepare pnpm@7.18.0 --activate`.
 
 **IMPORTANT**: If you have installed Node.js via homebrew, you'll need to run `brew install corepack`, since homebrew explicitly removes `npm` and `corepack` from [the `node` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/node.rb#L66).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.50.0",
   "private": true,
   "engines": {
-    "node": ">=18.10",
+    "node": ">=18.12",
     "pnpm": ">=9.1"
   },
   "packageManager": "pnpm@9.1.4",


### PR DESCRIPTION
## Summary

This pertains to the issue self-reported. I had a problem running `pnmp install` due to a complaint about node 18.10 - It doesn't seem like it would be a problem to require greater than or equal to 18.12 to avoid this.

## Related Linear tickets, Github issues, and Community forum posts

#10002 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. (e2e already runs 18.12) <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
