### PR TITLE
fix(Telegram Trigger Node): Fix issue with videos not being downloaded

### DIFF
--- a/packages/nodes-base/nodes/Telegram/IEvent.ts
+++ b/packages/nodes-base/nodes/Telegram/IEvent.ts
@@ -7,6 +7,9 @@ interface EventBody {
 	document?: {
 		file_id: string;
 	};
+	video?: {
+		file_id: string;
+	};
 }
 
 export interface IEvent {

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -254,7 +254,8 @@ export class TelegramTrigger implements INodeType {
 
 			if (
 				(bodyData[key]?.photo && Array.isArray(bodyData[key]?.photo)) ||
-				bodyData[key]?.document
+				bodyData[key]?.document ||
+				bodyData[key]?.video
 			) {
 				if (additionalFields.imageSize) {
 					imageSize = additionalFields.imageSize as string;
@@ -276,6 +277,8 @@ export class TelegramTrigger implements INodeType {
 					}
 
 					fileId = image.file_id;
+				} else if (bodyData[key]?.video) {
+					fileId = bodyData[key]?.video?.file_id;
 				} else {
 					fileId = bodyData[key]?.document?.file_id;
 				}


### PR DESCRIPTION
## Summary
The telegram trigger node was downloading documents and images but ignoring videos, This fixes that.

![image](https://github.com/n8n-io/n8n/assets/4688521/357a9c38-429b-470c-874d-1bac5e5ac654)


## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/download-a-video-sent-in-a-telegram-chat/49923
