### PR TITLE
refactor(core): Remove unused Sentry report from `WaitTracker` (no-changelog)

### DIFF
--- a/packages/cli/src/WaitTracker.ts
+++ b/packages/cli/src/WaitTracker.ts
@@ -75,21 +75,6 @@ export class WaitTracker {
 		for (const execution of executions) {
 			const executionId = execution.id;
 			if (this.waitingExecutions[executionId] === undefined) {
-				if (!(execution.waitTill instanceof Date)) {
-					// n8n expects waitTill to be a date object
-					// but for some reason it's not being converted
-					// we are handling this like this since it seems to address the issue
-					// for some users, as reported by Jon when using a custom image.
-					// Once we figure out why this it not a Date object, we can remove this.
-					ErrorReporter.error('Wait Till is not a date object', {
-						extra: {
-							variableType: typeof execution.waitTill,
-						},
-					});
-					if (typeof execution.waitTill === 'string') {
-						execution.waitTill = new Date(execution.waitTill);
-					}
-				}
 				const triggerTime = execution.waitTill!.getTime() - new Date().getTime();
 				this.waitingExecutions[executionId] = {
 					executionId,


### PR DESCRIPTION
Added at https://github.com/n8n-io/n8n/pull/8356, fixed at https://github.com/n8n-io/typeorm/pull/7, no Sentry reports in 90 days.