### PR TITLE
fix(HubSpot Node): Migrate from v2 owners api

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/V1/HubspotV1.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/HubspotV1.node.ts
@@ -862,11 +862,11 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getOwners(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/owners/v2/owners';
-				const owners = await hubspotApiRequest.call(this, 'GET', endpoint);
-				for (const owner of owners) {
+				const endpoint = '/crm/v3/owners';
+				const { results } = await hubspotApiRequest.call(this, 'GET', endpoint);
+				for (const owner of results) {
 					const ownerName = owner.email;
-					const ownerId = owner.ownerId;
+					const ownerId = isNaN(parseInt(owner.id)) ? owner.id : parseInt(owner.id);
 					returnData.push({
 						name: ownerName,
 						value: ownerId,

--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -939,11 +939,11 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getOwners(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/owners/v2/owners';
-				const owners = await hubspotApiRequest.call(this, 'GET', endpoint);
-				for (const owner of owners) {
+				const endpoint = '/crm/v3/owners';
+				const { results } = await hubspotApiRequest.call(this, 'GET', endpoint);
+				for (const owner of results) {
 					const ownerName = owner.email;
-					const ownerId = owner.ownerId;
+					const ownerId = isNaN(parseInt(owner.id)) ? owner.id : parseInt(owner.id);
 					returnData.push({
 						name: ownerName,
 						value: ownerId,
@@ -1130,13 +1130,13 @@ export class HubspotV2 implements INodeType {
 				};
 			},
 			async searchOwners(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
-				const endpoint = '/owners/v2/owners';
-				const owners = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const endpoint = '/crm/v3/owners';
+				const { results } = await hubspotApiRequest.call(this, 'GET', endpoint, {});
 				return {
 					// tslint:disable-next-line: no-any
-					results: owners.map((b: any) => ({
+					results: results.map((b: any) => ({
 						name: b.email,
-						value: b.ownerId,
+						value: isNaN(parseInt(b.id)) ? b.id : parseInt(b.id),
 					})),
 				};
 			},


### PR DESCRIPTION
## Summary
Moves the v1 and v2 node away from the v2 hubspot owners api, In v2 the id is an int and in v3 it is a string, To prevent a breaking change we convert to an int but also keep in the option that HubSpot may decide in the future to actually use non numerical characters.

v2 API: https://developers.hubspot.com/beta-docs/reference/api/crm/owners/v2#get-a-list-of-owners
v3 API: https://developers.hubspot.com/beta-docs/reference/api/crm/owners/v3#get-%2Fcrm%2Fv3%2Fowners%2F

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1384/hubspot-owners-api-sunset
