### PR TITLE
fix(AWS Comprehend Node): Add paired item support

### DIFF
--- a/packages/nodes-base/nodes/Aws/Comprehend/AwsComprehend.node.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/AwsComprehend.node.ts
@@ -187,7 +187,7 @@ export class AwsComprehend implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		const returnData: IDataObject[] = [];
+		const returnData: INodeExecutionData[] = [];
 		let responseData;
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
@@ -270,19 +270,23 @@ export class AwsComprehend implements INodeType {
 					}
 				}
 
-				if (Array.isArray(responseData)) {
-					returnData.push.apply(returnData, responseData as IDataObject[]);
-				} else {
-					returnData.push(responseData as IDataObject);
-				}
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData),
+					{ itemData: { item: i } },
+				);
+				returnData.push(...executionData);
 			} catch (error) {
 				if (this.continueOnFail(error)) {
-					returnData.push({ error: error.message });
+					const executionData = this.helpers.constructExecutionMetaData(
+						this.helpers.returnJsonArray({ error: error.message }),
+						{ itemData: { item: i } },
+					);
+					returnData.push(...executionData);
 					continue;
 				}
 				throw error;
 			}
 		}
-		return [this.helpers.returnJsonArray(returnData)];
+		return [returnData];
 	}
 }

--- a/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehend.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehend.node.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock';
+import { getWorkflowFilenames, initBinaryDataService, testWorkflows } from '@test/nodes/Helpers';
+
+const workflows = getWorkflowFilenames(__dirname);
+
+describe('Test AWS Comprehend Node', () => {
+	describe('Detect Language', () => {
+		let mock: nock.Scope;
+		const now = 1683028800000;
+		const response = {
+			Languages: [
+				{
+					LanguageCode: 'en',
+					Score: 0.9774383902549744,
+				},
+				{
+					LanguageCode: 'de',
+					Score: 0.010717987082898617,
+				},
+			],
+		};
+		beforeAll(async () => {
+			jest.useFakeTimers({ doNotFake: ['nextTick'], now });
+
+			await initBinaryDataService();
+
+			nock.disableNetConnect();
+			const baseUrl = 'https://comprehend.eu-central-1.amazonaws.com';
+
+			mock = nock(baseUrl);
+		});
+
+		beforeEach(async () => {
+			mock.post('/').reply(200, response);
+		});
+		afterAll(() => {
+			nock.restore();
+		});
+
+		testWorkflows(workflows);
+	});
+});

--- a/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehendTestWorkflow.json
+++ b/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehendTestWorkflow.json
@@ -1,0 +1,94 @@
+{
+  "name": "node-aws-comprehend",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "73cf15c4-15f9-43aa-a535-26d840601480",
+      "name": "When clicking ‘Test workflow’",
+      "type": "n8n-nodes-base.manualTrigger",
+      "position": [
+        820,
+        360
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "51b7eee5-8cc9-4e09-a2f4-65ffb3cc17f6",
+              "name": "text",
+              "value": "This is a test.",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "76a71bac-81fe-4b28-b15b-483efa827d12",
+      "name": "Edit Fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        1060,
+        600
+      ]
+    },
+    {
+      "parameters": {
+        "text": "={{ $json.text }}"
+      },
+      "id": "61665744-5a4e-4f49-a027-16bd527cbeb9",
+      "name": "AWS Comprehend",
+      "type": "n8n-nodes-base.awsComprehend",
+      "typeVersion": 1,
+      "position": [
+        1480,
+        440
+      ],
+      "credentials": {
+        "aws": {
+          "id": "124",
+          "name": "AWS creds"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Edit Fields": {
+      "main": [
+        [
+          {
+            "node": "AWS Comprehend",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "21f5ca33-74a0-4e28-b4ba-b90154db8d53",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "yAlSAFNzvjfThNOR",
+  "tags": []
+}

--- a/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehendTestWorkflow.json
+++ b/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehendTestWorkflow.json
@@ -1,94 +1,125 @@
 {
   "name": "node-aws-comprehend",
-  "nodes": [
-    {
-      "parameters": {},
-      "id": "73cf15c4-15f9-43aa-a535-26d840601480",
-      "name": "When clicking ‘Test workflow’",
-      "type": "n8n-nodes-base.manualTrigger",
-      "position": [
-        820,
-        360
-      ],
-      "typeVersion": 1
-    },
-    {
-      "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "51b7eee5-8cc9-4e09-a2f4-65ffb3cc17f6",
-              "name": "text",
-              "value": "This is a test.",
-              "type": "string"
-            }
-          ]
-        },
-        "options": {}
-      },
-      "id": "76a71bac-81fe-4b28-b15b-483efa827d12",
-      "name": "Edit Fields",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1060,
-        600
-      ]
-    },
-    {
-      "parameters": {
-        "text": "={{ $json.text }}"
-      },
-      "id": "61665744-5a4e-4f49-a027-16bd527cbeb9",
-      "name": "AWS Comprehend",
-      "type": "n8n-nodes-base.awsComprehend",
-      "typeVersion": 1,
-      "position": [
-        1480,
-        440
-      ],
-      "credentials": {
-        "aws": {
-          "id": "124",
-          "name": "AWS creds"
-        }
-      }
-    }
-  ],
-  "pinData": {},
-  "connections": {
-    "Edit Fields": {
-      "main": [
-        [
-          {
-            "node": "AWS Comprehend",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "When clicking ‘Test workflow’": {
-      "main": [
-        [
-          {
-            "node": "Edit Fields",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    }
-  },
-  "active": false,
-  "settings": {
-    "executionOrder": "v1"
-  },
-  "versionId": "21f5ca33-74a0-4e28-b4ba-b90154db8d53",
-  "meta": {
-    "templateCredsSetupCompleted": true,
-    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
-  },
-  "id": "yAlSAFNzvjfThNOR",
-  "tags": []
-}
+		"nodes": [
+			{
+				"parameters": {},
+				"id": "53b6020d-5aa2-435f-9ee1-407111c0e3ee",
+				"name": "When clicking ‘Test workflow’",
+				"type": "n8n-nodes-base.manualTrigger",
+				"position": [
+					680,
+					380
+				],
+				"typeVersion": 1
+			},
+			{
+				"parameters": {
+					"assignments": {
+						"assignments": [
+							{
+								"id": "51b7eee5-8cc9-4e09-a2f4-65ffb3cc17f6",
+								"name": "text",
+								"value": "This is a test.",
+								"type": "string"
+							}
+						]
+					},
+					"options": {}
+				},
+				"id": "b3beaf43-fe4c-43e1-a8cb-5a0740050611",
+				"name": "Edit Fields",
+				"type": "n8n-nodes-base.set",
+				"typeVersion": 3.4,
+				"position": [
+					900,
+					380
+				]
+			},
+			{
+				"parameters": {
+					"text": "={{ $json.text }}"
+				},
+				"id": "a6a8a24c-0e58-40e7-8bf4-13a56edc6264",
+				"name": "AWS Comprehend",
+				"type": "n8n-nodes-base.awsComprehend",
+				"typeVersion": 1,
+				"position": [
+					1100,
+					380
+				],
+				"credentials": {
+					"aws": {
+						"id": "TyNATsPCTvPF0tvG",
+						"name": "AWS account"
+					}
+				}
+			},
+			{
+				"parameters": {},
+				"id": "bfc4b84d-8cf1-4650-bf3c-2b1cdc677afc",
+				"name": "No Operation, do nothing",
+				"type": "n8n-nodes-base.noOp",
+				"typeVersion": 1,
+				"position": [
+					1320,
+					380
+				]
+			}
+		],
+		"pinData": {
+			"No Operation, do nothing": [
+				{
+					"json": {
+						"de": 0.010717987082898617,
+						"en": 0.9774383902549744
+					}
+				}
+			]
+		},
+		"connections": {
+			"Edit Fields": {
+				"main": [
+					[
+						{
+							"node": "AWS Comprehend",
+							"type": "main",
+							"index": 0
+						}
+					]
+				]
+			},
+			"When clicking ‘Test workflow’": {
+				"main": [
+					[
+						{
+							"node": "Edit Fields",
+							"type": "main",
+							"index": 0
+						}
+					]
+				]
+			},
+			"AWS Comprehend": {
+				"main": [
+					[
+						{
+							"node": "No Operation, do nothing",
+							"type": "main",
+							"index": 0
+						}
+					]
+				]
+			}
+		},
+		"active": false,
+		"settings": {
+			"executionOrder": "v1"
+		},
+		"versionId": "eae3c601-56b8-42ec-a0b7-14df8d697043",
+		"meta": {
+			"templateCredsSetupCompleted": true,
+			"instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+		},
+		"id": "fuOmKcLPWAxKi0bn",
+		"tags": []
+	}


### PR DESCRIPTION
## Summary

This PR Adds support for paired items to The AWS Comprehend Node.

Note:
This PR includes the addition of a test for the node. While this test is not comprehensive, it represents an improvement from having no tests at all for this node. It serves as an initial step towards better test coverage and should help in identifying any issues related to this node.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1459/aws-comprehend-add-paired-item-support

[<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->](https://linear.app/n8n/issue/NODE-1459/aws-comprehend-add-paired-item-support)

Community: https://community.n8n.io/t/issue-with-passing-data-to-future-nodes/49481/7

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] Tests included. 

