### PR TITLE
fix(editor): Make schema view use the correct output

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -781,4 +781,33 @@ describe('NDV', () => {
 		ndv.actions.expressionSelectItem(1);
 		ndv.getters.inlineExpressionEditorOutput().should('have.text', '1');
 	});
+
+	it('should show data from the correct output in schema view', () => {
+		cy.createFixtureWorkflow('Test_workflow_multiple_outputs.json');
+		workflowPage.actions.zoomToFit();
+
+		workflowPage.actions.executeWorkflow();
+		workflowPage.actions.openNode('Only Item 1');
+		ndv.getters.inputPanel().should('be.visible');
+		ndv.getters
+			.inputPanel()
+			.find('[data-test-id=run-data-schema-item]')
+			.should('contain.text', 'onlyOnItem1');
+		ndv.actions.close();
+
+		workflowPage.actions.openNode('Only Item 2');
+		ndv.getters.inputPanel().should('be.visible');
+		ndv.getters
+			.inputPanel()
+			.find('[data-test-id=run-data-schema-item]')
+			.should('contain.text', 'onlyOnItem2');
+		ndv.actions.close();
+
+		workflowPage.actions.openNode('Only Item 3');
+		ndv.getters.inputPanel().should('be.visible');
+		ndv.getters
+			.inputPanel()
+			.find('[data-test-id=run-data-schema-item]')
+			.should('contain.text', 'onlyOnItem3');
+	});
 });

--- a/cypress/fixtures/Test_workflow_multiple_outputs.json
+++ b/cypress/fixtures/Test_workflow_multiple_outputs.json
@@ -1,0 +1,223 @@
+{
+  "name": "Multiple outputs",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "64b27674-3da6-46ce-9008-e173182efa48",
+      "name": "When clicking ‘Test workflow’",
+      "type": "n8n-nodes-base.manualTrigger",
+      "position": [
+        16,
+        -32
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.code }}",
+                    "rightValue": 1,
+                    "operator": {
+                      "type": "number",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "Item1"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "id": "a659050f-0867-471d-8914-d499b6ad7b31",
+                    "leftValue": "={{ $json.code }}",
+                    "rightValue": 2,
+                    "operator": {
+                      "type": "number",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "Item2"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "id": "109fc001-53af-48f1-b79c-5e9afc8b94bd",
+                    "leftValue": "={{ $json.code }}",
+                    "rightValue": 3,
+                    "operator": {
+                      "type": "number",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "Item3"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.switch",
+      "position": [
+        192,
+        -32
+      ],
+      "id": "3863cc7a-8f45-46fc-a60c-36aad5b12877",
+      "name": "Switch",
+      "typeVersion": 3
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "f71bac89-8852-41b2-98dd-cb689f011dcb",
+              "name": "",
+              "value": "",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "position": [
+        480,
+        -192
+      ],
+      "id": "85940094-4656-4cdf-a871-1b3b46421de3",
+      "name": "Only Item 1",
+      "typeVersion": 3.4
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "position": [
+        480,
+        -32
+      ],
+      "id": "a7f4e2b5-8cc9-4881-aa06-38601988740e",
+      "name": "Only Item 2",
+      "typeVersion": 3.4
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "position": [
+        480,
+        128
+      ],
+      "id": "7e44ad56-415a-4991-a70e-fea86c430031",
+      "name": "Only Item 3",
+      "typeVersion": 3.4
+    }
+  ],
+  "pinData": {
+    "When clicking ‘Test workflow’": [
+      {
+        "json": {
+          "name": "First item",
+          "onlyOnItem1": true,
+          "code": 1
+        }
+      },
+      {
+        "json": {
+          "name": "Second item",
+          "onlyOnItem2": true,
+          "code": 2
+        }
+      },
+      {
+        "json": {
+          "name": "Third item",
+          "onlyOnItem3": true,
+          "code": 3
+        }
+      }
+    ]
+  },
+  "connections": {
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "Switch",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch": {
+      "main": [
+        [
+          {
+            "node": "Only Item 1",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Only Item 2",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Only Item 3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "1e2a7b45-7730-42d6-989e-f3fa80de303e",
+  "meta": {
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "V2ld4YU11fsHgr1z",
+  "tags": []
+}

--- a/packages/editor-ui/src/components/RunDataSchema.vue
+++ b/packages/editor-ui/src/components/RunDataSchema.vue
@@ -121,7 +121,15 @@ const loadNodeData = async (node: INodeUi) => {
 	const pinData = workflowsStore.pinDataByNodeName(node.name);
 	const data =
 		pinData ??
-		executionDataToJson(getNodeInputData(node, 0, 0, props.paneType, props.connectionType) ?? []);
+		executionDataToJson(
+			getNodeInputData(
+				node,
+				props.runIndex,
+				props.outputIndex,
+				props.paneType,
+				props.connectionType,
+			) ?? [],
+		);
 
 	nodesData.value[node.name] = {
 		schema: getSchemaForExecutionData(data),


### PR DESCRIPTION
## Summary

Schema view was always showing the data from the first output

Added e2e test to cover this

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1486/schema-view-schema-taken-from-wrong-output-branch

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
