### PR TITLE
feat(editor): Make expression autocomplete search case-insensitive

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/completions.test.ts
@@ -217,6 +217,14 @@ describe('Resolution-based completions', () => {
 				Object.keys(object).length + extensions({ typeName: 'object' }).length,
 			);
 		});
+
+		test('should return case-insensitive completions', () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockReturnValueOnce('abc');
+
+			const result = completions('{{ "abc".tolowerca| }}');
+			expect(result).toHaveLength(1);
+			expect(result?.at(0)).toEqual(expect.objectContaining({ label: 'toLowerCase()' }));
+		});
 	});
 
 	describe('indexed access completions', () => {

--- a/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
@@ -98,7 +98,7 @@ export function datatypeCompletions(context: CompletionContext): CompletionResul
 	}
 
 	if (tail !== '') {
-		options = options.filter((o) => prefixMatch(o.label, tail) && o.label !== tail);
+		options = options.filter((o) => prefixMatch(o.label, tail));
 	}
 
 	let from = word.to - tail.length;

--- a/packages/editor-ui/src/plugins/codemirror/completions/utils.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/utils.ts
@@ -59,7 +59,7 @@ export function longestCommonPrefix(...strings: string[]) {
 }
 
 export const prefixMatch = (first: string, second: string) =>
-	first.startsWith(second) && first !== second;
+	first.toLocaleLowerCase().startsWith(second.toLocaleLowerCase()) && first !== second;
 
 export const isPseudoParam = (candidate: string) => {
 	const PSEUDO_PARAMS = ['notice']; // user input disallowed


### PR DESCRIPTION
## Summary

<img width="706" alt="image" src="https://github.com/n8n-io/n8n/assets/8850410/7b5b4ed2-2cd3-4a15-8e02-2210fbddff62">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1374/expressions-make-autocomplete-case-insensitive-support-aliases

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
