### PR TITLE
fix: Number input defaults to 0 not allowing to have arbitrary precision

### DIFF
--- a/packages/design-system/src/components/N8nInputNumber/InputNumber.vue
+++ b/packages/design-system/src/components/N8nInputNumber/InputNumber.vue
@@ -14,7 +14,7 @@ type InputNumberProps = {
 const props = withDefaults(defineProps<InputNumberProps>(), {
 	size: undefined,
 	step: 1,
-	precision: 0,
+	precision: undefined,
 	min: -Infinity,
 	max: Infinity,
 });


### PR DESCRIPTION
## Summary
update default to `undefined` as was before this [PR](https://github.com/n8n-io/n8n/pull/9447)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1451/filter-component-switch-node-rounds-numbers-to-integers