### PR TITLE
fix: Prevent errors processed by n8n to be flagged as internal (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/error.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/error.ts
@@ -1,4 +1,6 @@
-export class ChatTriggerAuthorizationError extends Error {
+import { ApplicationError } from 'n8n-workflow';
+
+export class ChatTriggerAuthorizationError extends ApplicationError {
 	constructor(
 		readonly responseCode: number,
 		message?: string,

--- a/packages/cli/src/services/project.service.ts
+++ b/packages/cli/src/services/project.service.ts
@@ -19,8 +19,9 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { CacheService } from './cache/cache.service';
 import { License } from '@/License';
 import { UNLIMITED_LICENSE_QUOTA } from '@/constants';
+import { ApplicationError } from 'n8n-workflow';
 
-export class TeamProjectOverQuotaError extends Error {
+export class TeamProjectOverQuotaError extends ApplicationError {
 	constructor(limit: number) {
 		super(
 			`Attempted to create a new project but quota is already exhausted. You may have a maximum of ${limit} team projects.`,
@@ -28,7 +29,7 @@ export class TeamProjectOverQuotaError extends Error {
 	}
 }
 
-export class UnlicensedProjectRoleError extends Error {
+export class UnlicensedProjectRoleError extends ApplicationError {
 	constructor(role: ProjectRole) {
 		super(`Your instance is not licensed to use role "${role}".`);
 	}

--- a/packages/editor-ui/src/composables/useToast.ts
+++ b/packages/editor-ui/src/composables/useToast.ts
@@ -8,8 +8,9 @@ import { useUIStore } from '@/stores/ui.store';
 import { useI18n } from './useI18n';
 import { useExternalHooks } from './useExternalHooks';
 import { VIEWS } from '@/constants';
+import type { ApplicationError } from 'n8n-workflow';
 
-export interface NotificationErrorWithNodeAndDescription extends Error {
+export interface NotificationErrorWithNodeAndDescription extends ApplicationError {
 	node: {
 		name: string;
 	};

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -1,6 +1,6 @@
 import type { AxiosRequestConfig, Method, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
-import type { GenericValue, IDataObject } from 'n8n-workflow';
+import { ApplicationError, type GenericValue, type IDataObject } from 'n8n-workflow';
 import type { IExecutionFlattedResponse, IExecutionResponse, IRestApiContext } from '@/Interface';
 import { parse } from 'flatted';
 
@@ -13,7 +13,7 @@ if (!browserId && 'randomUUID' in crypto) {
 
 export const NO_NETWORK_ERROR_CODE = 999;
 
-export class ResponseError extends Error {
+export class ResponseError extends ApplicationError {
 	// The HTTP status code of response
 	httpStatusCode?: number;
 

--- a/packages/nodes-base/nodes/Code/ValidationError.ts
+++ b/packages/nodes-base/nodes/Code/ValidationError.ts
@@ -1,4 +1,6 @@
-export class ValidationError extends Error {
+import { ApplicationError } from 'n8n-workflow';
+
+export class ValidationError extends ApplicationError {
 	description = '';
 
 	itemIndex: number | undefined = undefined;
@@ -18,7 +20,7 @@ export class ValidationError extends Error {
 		itemIndex?: number;
 		lineNumber?: number;
 	}) {
-		super();
+		super(message);
 
 		this.lineNumber = lineNumber;
 		this.itemIndex = itemIndex;

--- a/packages/nodes-base/nodes/Code/test/workflow.do_not_obfuscate_validation_error.json
+++ b/packages/nodes-base/nodes/Code/test/workflow.do_not_obfuscate_validation_error.json
@@ -1,0 +1,86 @@
+{
+  "name": "errors falsely flagged as internal",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "d2ff695c-4ca0-457d-ae9e-666d2dc53a53",
+      "name": "When clicking ‘Test workflow’",
+      "type": "n8n-nodes-base.manualTrigger",
+      "position": [
+        360,
+        420
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "jsCode": "return {json: \"test\"}"
+      },
+      "id": "fc540f62-d671-49a2-b35d-aead4ed8bd10",
+      "name": "Code",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        420
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {},
+      "id": "d8335277-61af-42d8-9cf5-02a8b85df42b",
+      "name": "No Operation, do nothing",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        900,
+        500
+      ]
+    }
+  ],
+  "pinData": {
+    "No Operation, do nothing": [
+      {
+        "json": {
+          "error": "A 'json' property isn't an object [item 0]"
+        }
+      }
+    ]
+  },
+  "connections": {
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "Code",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Code": {
+      "main": [
+        [],
+        [
+          {
+            "node": "No Operation, do nothing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "1aa448f4-ac5f-497b-ae3c-62a5e9db63d4",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "be251a83c052a9862eeac953816fbb1464f89dfbf79d7ac490a8e336a8cc8bfd"
+  },
+  "id": "TlJvElz9tvmByCh3",
+  "tags": []
+}

--- a/packages/nodes-base/nodes/Webhook/error.ts
+++ b/packages/nodes-base/nodes/Webhook/error.ts
@@ -1,4 +1,6 @@
-export class WebhookAuthorizationError extends Error {
+import { ApplicationError } from 'n8n-workflow';
+
+export class WebhookAuthorizationError extends ApplicationError {
 	constructor(
 		readonly responseCode: number,
 		message?: string,

--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -10,6 +10,7 @@ import type {
 } from '../Interfaces';
 import { validateFieldType } from '../TypeValidation';
 import * as LoggerProxy from '../LoggerProxy';
+import { ApplicationError } from '../errors/application.error';
 
 type FilterConditionMetadata = {
 	index: number;
@@ -18,7 +19,7 @@ type FilterConditionMetadata = {
 	errorFormat: 'full' | 'inline';
 };
 
-export class FilterError extends Error {
+export class FilterError extends ApplicationError {
 	constructor(
 		message: string,
 		readonly description: string,


### PR DESCRIPTION
## Summary

Error has to be `instanceOf` `ApplicationError` to not be obfuscated



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1449/some-errors-falsely-flagged-as-internal
