### PR TITLE
feat(editor): Tweak node creator search logic for AI sub-nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -84,7 +84,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 			codex: {
 				categories: ['AI'],
 				subcategories: {
-					AI: ['Vector Stores'],
+					AI: ['Vector Stores', 'Root Nodes'],
 				},
 				resources: {
 					primaryDocumentation: [

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2622,7 +2622,7 @@ export default defineComponent({
 
 			// Automatically deselect all nodes and select the current one and also active
 			// current node. But only if it's added manually by the user (not by undo/redo mechanism)
-			if (trackHistory) {
+			if (trackHistory && !isAutoAdd) {
 				this.deselectAllNodes();
 				setTimeout(() => {
 					this.nodeSelectedByName(


### PR DESCRIPTION
## Summary
This PR implements the following tweaks for node creator:
- Revert categorization(#9484) of regular and trigger non-ai nodes to show them as a flat list
- Show vector store nodes as root nodes 
- Hide sub-nodes if the node creator was opened from the `node_connection_drop` or `plus_endpoint` source
- Correctly connect a node to `lastSelectedNode` if chat trigger is auto-added

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/AI-195/node-subcategory-display-and-insertion-tweaks

## Review / Merge checklist
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
