### PR TITLE
feat(Asana Node): Add support for project privacy settings

### DIFF
--- a/packages/nodes-base/nodes/Asana/Asana.node.ts
+++ b/packages/nodes-base/nodes/Asana/Asana.node.ts
@@ -1448,6 +1448,27 @@ export class Asana implements INodeType {
 						default: '',
 						description: 'Basic description or notes for the project',
 					},
+					{
+						displayName: 'Privacy Setting',
+						name: 'privacy_setting',
+						type: 'options',
+						options: [
+							{
+								name: 'Private',
+								value: 'private',
+							},
+							{
+								name: 'Private to Team',
+								value: 'private_to_team',
+							},
+							{
+								name: 'Public to Workspace',
+								value: 'public_to_workspace',
+							},
+						],
+						default: 'private',
+						description: 'The privacy setting of the project',
+					},
 				],
 			},
 			// ----------------------------------
@@ -1658,6 +1679,27 @@ export class Asana implements INodeType {
 						type: 'string',
 						default: '',
 						description: 'The new assignee/cardinal for this project',
+					},
+					{
+						displayName: 'Privacy Setting',
+						name: 'privacy_setting',
+						type: 'options',
+						options: [
+							{
+								name: 'Private',
+								value: 'private',
+							},
+							{
+								name: 'Private to Team',
+								value: 'private_to_team',
+							},
+							{
+								name: 'Public to Workspace',
+								value: 'public_to_workspace',
+							},
+						],
+						default: 'private',
+						description: 'The privacy setting of the project',
 					},
 					{
 						displayName: 'Team Name or ID',


### PR DESCRIPTION
## Summary
Adds support for the privacy setting field for projects

API Docs: https://developers.asana.com/reference/createproject

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1385/asana-field-deprecation-projectpublic
