### PR TITLE
fix(NocoDB Node): Add warning level to loadOptions errors (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
+++ b/packages/nodes-base/nodes/NocoDB/NocoDB.node.ts
@@ -238,6 +238,9 @@ export class NocoDB implements INodeType {
 						new Error(`Error while fetching ${version === 3 ? 'bases' : 'projects'}!`, {
 							cause: e,
 						}),
+						{
+							level: 'warning',
+						},
 					);
 				}
 			},
@@ -258,12 +261,18 @@ export class NocoDB implements INodeType {
 						throw new NodeOperationError(
 							this.getNode(),
 							new Error('Error while fetching tables!', { cause: e }),
+							{
+								level: 'warning',
+							},
 						);
 					}
 				} else {
 					throw new NodeOperationError(
 						this.getNode(),
 						`No  ${version === 3 ? 'base' : 'project'} selected!`,
+						{
+							level: 'warning',
+						},
 					);
 				}
 			},


### PR DESCRIPTION
## Summary
Adds warning level to loadOptions, When the node is first added with no credential we shouldn't report the error to Sentry.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1409/silence-error-nocodb-axioserror-403-msgunauthorized-access
