### PR TITLE
docs: Add notice to S3 node to mention AWS S3 node (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/S3/S3.node.ts
+++ b/packages/nodes-base/nodes/S3/S3.node.ts
@@ -44,6 +44,13 @@ export class S3 implements INodeType {
 		],
 		properties: [
 			{
+				displayName:
+					"This node is for services that use the S3 standard, e.g. Minio or Digital Ocean Spaces. For AWS S3 use the 'AWS S3' node.",
+				name: 's3StandardNotice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Resource',
 				name: 'resource',
 				type: 'options',


### PR DESCRIPTION
## Summary
Adds a notice to the S3 node to let users know it isn't intended for AWS S3

![image](https://github.com/user-attachments/assets/6b9d4e59-1c2f-475c-a239-912585611aac)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1398/help-users-distinguish-aws-s3-and-s3-nodes
