### PR TITLE
fix(AMQP Trigger Node): Manual execution updated error reduced wait time

### DIFF
--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -278,7 +278,7 @@ export class AmqpTrigger implements INodeType {
 					reject(
 						new NodeOperationError(
 							this.getNode(),
-							'Stopped because no message was received within 15 seconds',
+							'Aborted because no message received within 15 seconds',
 							{
 								description:
 									'This 15 seconds timeout is only set for manually triggered execution using "Test Step", active workflows will listen indefinitely',

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -276,11 +276,16 @@ export class AmqpTrigger implements INodeType {
 					connection.close();
 
 					reject(
-						new Error(
-							'Aborted, no message received within 30secs. This 30sec timeout is only set for "manually triggered execution". Active Workflows will listen indefinitely.',
+						new NodeOperationError(
+							this.getNode(),
+							'Stopped because no message was received within 15 seconds',
+							{
+								description:
+									'This 15 seconds timeout is only set for manually triggered execution using "Test Step", active workflows will listen indefinitely',
+							},
 						),
 					);
-				}, 30000);
+				}, 15000);
 				container.on('message', (context: EventContext) => {
 					// Check if the only property present in the message is body
 					// in which case we only emit the content of the body property

--- a/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
+++ b/packages/nodes-base/nodes/Amqp/AmqpTrigger.node.ts
@@ -281,7 +281,7 @@ export class AmqpTrigger implements INodeType {
 							'Aborted because no message received within 15 seconds',
 							{
 								description:
-									'This 15 seconds timeout is only set for manually triggered execution using "Test Step", active workflows will listen indefinitely',
+									'This 15sec timeout is only set for "manually triggered execution". Active Workflows will listen indefinitely.',
 							},
 						),
 					);


### PR DESCRIPTION
## Summary

Reduced wait time for message
Use `NodeOperationError` to prevent obfuscation

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/amqp-trigger-does-not-close-a-connection-when-triggered-manually/30872/4
https://linear.app/n8n/issue/NODE-813/amqp-trigger-manual-executions-cant-be-stopped