### PR TITLE
fix: HTTP Request tool - allow hyphens in placeholders

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -355,7 +355,7 @@ export const configureResponseOptimizer = (ctx: IExecuteFunctions, itemIndex: nu
 };
 
 const extractPlaceholders = (text: string): string[] => {
-	const placeholder = /(\{[a-zA-Z0-9_]+\})/g;
+	const placeholder = /(\{[a-zA-Z0-9_-]+\})/g;
 	const returnData: string[] = [];
 
 	const matches = text.matchAll(placeholder);


### PR DESCRIPTION
## Summary

allow hyphens in placeholders

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-216/http-request-tool-better-error-when-placeholder-contains-non
