### PR TITLE
fix(GitHub Node): File Create operation prevent duplicated base64 encoding

### DIFF
--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -114,3 +114,8 @@ export async function githubApiRequestAllItems(
 	} while (responseData.headers.link?.includes('next'));
 	return returnData;
 }
+
+export function isBase64(content: string) {
+	const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+	return base64regex.test(content);
+}

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -9,7 +9,12 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 
 import { snakeCase } from 'change-case';
-import { getFileSha, githubApiRequest, githubApiRequestAllItems } from './GenericFunctions';
+import {
+	getFileSha,
+	githubApiRequest,
+	githubApiRequestAllItems,
+	isBase64,
+} from './GenericFunctions';
 
 import { getRepositories, getUsers } from './SearchFunctions';
 
@@ -1981,11 +1986,12 @@ export class Github implements INodeType {
 							// TODO: Does this work with filesystem mode
 							body.content = binaryData.data;
 						} else {
-							// Is text file
-							// body.content = Buffer.from(this.getNodeParameter('fileContent', i) as string, 'base64');
-							body.content = Buffer.from(
-								this.getNodeParameter('fileContent', i) as string,
-							).toString('base64');
+							const fileContent = this.getNodeParameter('fileContent', i) as string;
+							if (isBase64(fileContent)) {
+								body.content = fileContent;
+							} else {
+								body.content = Buffer.from(fileContent).toString('base64');
+							}
 						}
 
 						endpoint = `/repos/${owner}/${repository}/contents/${encodeURI(filePath)}`;


### PR DESCRIPTION
## Summary

The Github node's File Create operation using text content (not binary data) would always encode base64, even if the content was already encoded (e.g. using Extract From File node).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-139/github-file-create-fails-with-when-using-the-binary-data-option
