### PR TITLE
fix: HTTP Request tool - do not error on missing headers 

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -49,7 +49,8 @@ const genericCredentialRequest = async (ctx: IExecuteFunctions, itemIndex: numbe
 		const headerAuth = await ctx.getCredentials('httpHeaderAuth', itemIndex);
 
 		return async (options: IHttpRequestOptions) => {
-			options.headers![headerAuth.name as string] = headerAuth.value;
+			if (!options.headers) options.headers = {};
+			options.headers[headerAuth.name as string] = headerAuth.value;
 			return await ctx.helpers.httpRequest(options);
 		};
 	}
@@ -58,9 +59,7 @@ const genericCredentialRequest = async (ctx: IExecuteFunctions, itemIndex: numbe
 		const queryAuth = await ctx.getCredentials('httpQueryAuth', itemIndex);
 
 		return async (options: IHttpRequestOptions) => {
-			if (!options.qs) {
-				options.qs = {};
-			}
+			if (!options.qs) options.qs = {};
 			options.qs[queryAuth.name as string] = queryAuth.value;
 			return await ctx.helpers.httpRequest(options);
 		};


### PR DESCRIPTION
## Summary
fix for:
Attempting to use Header Auth credentials for the AI Agent's HTTP tool fails with the following error:
```
{
  "response": "There was an error: \"Cannot set properties of undefined (setting 'Authorization')\""
}
```
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AI-210/community-issue-http-tool-header-auth-not-working-as-expected
https://github.com/n8n-io/n8n/issues/9971