### PR TITLE
fix(Email Trigger (IMAP) Node): Handle gb2312 encoding correctly

### DIFF
--- a/packages/@n8n/imap/src/ImapSimple.ts
+++ b/packages/@n8n/imap/src/ImapSimple.ts
@@ -136,7 +136,7 @@ export class ImapSimple extends EventEmitter {
 
 				const data = result.parts[0].body as string;
 				const encoding = part.encoding.toUpperCase();
-				resolve(PartData.fromData(data, encoding));
+				resolve(PartData.fromData(data, encoding, part.params?.charset));
 			};
 
 			const fetchOnError = (error: Error) => {

--- a/packages/@n8n/imap/test/PartData.test.ts
+++ b/packages/@n8n/imap/test/PartData.test.ts
@@ -60,6 +60,14 @@ describe('QuotedPrintablePartData', () => {
 	});
 });
 
+describe('QuotedPrintableGB2312PartData', () => {
+	it('should correctly decode quoted-printable data', () => {
+		const data = '=C4=E3=BA=C3=A3=AC =CA=C0=BD=E7=A3=A1'; // '你好， 世界！' in quoted-printable with gb2312 encoding
+		const partData = new QuotedPrintablePartData(data, 'gb2312');
+		expect(partData.toString('gb2312')).toBe('你好， 世界！');
+	});
+});
+
 describe('SevenBitPartData', () => {
 	it('should correctly decode 7bit data', () => {
 		const data = 'Hello, world!';

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -321,7 +321,7 @@ export class EmailReadImapV2 implements INodeType {
 
 			try {
 				const partData = await connection.getPartData(message, part);
-				return partData.toString();
+				return partData.toString(part.params?.charset);
 			} catch {
 				return '';
 			}


### PR DESCRIPTION
## Summary

Fix encoding error for GB2312 emails received via IMAP.

When n8n receives emails encoded in GB2312, they are not decoded correctly. This PR addresses the encoding error.

<details>

<summary>Example GB2312 e-mail</summary>

``` txt
--_000_KL1PR02MB4788EE124D08D73A1E9A80309AA72KL1PR02MB4788apcp_
\nContent-Type: text/plain; charset="gb2312"
\nContent-Transfer-Encoding: base64
\n
\nMDAwMDAwMDAwMDAwxOO6w6OsIMrAveejoTAwMDAwMDAwMA0KDQpfX19fX19fX19fX19fX19fX19f
\nX19fX19fX19fX19fXw0Kt6K8/sjLOiBpMzY1IFRlY2ggPGhlbGxvQGkzNjUudGVjaD4NCreiy83K
\nsbzkOiAyMDI0xOo31MIxM8jVIDE2OjE1DQrK1bz+yMs6IGZlaWxvbmdwaG9uZUBnbWFpbC5jb20g
\nPGZlaWxvbmdwaG9uZUBnbWFpbC5jb20+DQrW98ziOiChvtbY0qqjutPQ0MW6xaOhob/NttfK1+m6
\nz7LfwtTM4dDRICNteWludmVzdHBpbG90X3VzXzIgLSAyMDI0LTA3LTEzDQoNCr3xyNXNttfK1+m6
\nz7j80MIgLSDDwLnJMrrFIKOosdLW1qO6VVNEo6kNCg0KyNXG2jogMjAyNC0wNy0xMw0KDQrN+Na3
\nOiBteWludmVzdHBpbG90X3VzXzI8aHR0cHM6Ly93d3cubXlpbnZlc3RwaWxvdC5jb20vcG9ydGZv
\nbGlvcy9teWludmVzdHBpbG90X3VzXzI+DQoNCr270tfQxbrFDQqz1tPQDQqx6rXEOiBRUVEgKMTJ
\n1rhFVEYpDQqx6rXEOiBYTEsgKL/GvLzWuMr9RVRGKQ0Kseq1xDogRlRFQyAo0MXPory8yvXWuMr9
\nKQ0Kseq1xDogWExZICi+q9Ghz/u30ca3sOW/6da4yv1FVEYpDQqx6rXEOiBWSUcgKMPAufq437rs
\nwPu5yUVURikNCrHqtcQ6IEVTR1UgKMPAufpFU0fTxbuv1rjK/SkNCsL0s/YNCr3xyNXO3rLZ1/cN
\nCsLyyOsNCrHqtcQ6IElDTE4gKMirx/LH5b3gxNzUtCkNCrHqtcQ6IEFSS0sgKLS00MJFVEYpDQq/
\n1bLWDQrX6brP1arSqg0KDQq+u9a1OiAyLjI4OA0KDQq4tLrPxOq++dT2s6TCyiglKTogMTMuNTMN
\nCg0Kz8TG1bHIwso6IDAuNTY0DQoNCrWxx7C72LO3KCUpOiAtMC41NTUNCg0K1/LI1dOvv/ew2bfW
\nscgoJSk6IDAuODIzDQoNCrPWstYNCg0Kseq1xDogVklHLCC1scewvNvWtTogMzM2ODguOCwgs9ay
\n1tW8scgoJSk6IDE0LjcyMQ0KDQrJz7TOvbvS17zbuPE6IDE1Ni40MjgsILPWstbK/cG/OiAxODAs
\nIMjVxto6IDIwMjMtMTEtMTMNCg0K06+/9yglKTogMTkuNjQ2DQoNCrHqtcQ6IEZURUMsILWxx7C8
\n29a1OiAzNjYyMy4yNSwgs9ay1tW8scgoJSk6IDE2LjAwMw0KDQrJz7TOvbvS17zbuPE6IDE1MS45
\nNTUsILPWstbK/cG/OiAyMDUsIMjVxto6IDIwMjQtMDUtMDYNCg0K06+/9yglKTogMTcuNTY4DQoN
\nCrHqtcQ6IFhMWSwgtbHHsLzb1rU6IDM0NDY4LjIsILPWstbVvLHIKCUpOiAxNS4wNjINCg0Kyc+0
\nzr270te827jxOiAxNzYuOTk4LCCz1rLWyv3BvzogMTgwLCDI1cbaOiAyMDI0LTA2LTA3DQoNCtOv
\nv/coJSk6IDguMTg4DQoNCrHqtcQ6IFFRUSwgtbHHsLzb1rU6IDM3NjA2LjMyLCCz1rLW1byxyCgl
\nKTogMTYuNDMzDQoNCsnPtM69u9LXvNu48TogMzYyLjc3Nywgs9ay1sr9wb86IDc2LCDI1cbaOiAy
\nMDIzLTExLTAzDQoNCtOvv/coJSk6IDM2LjM5OA0KDQqx6rXEOiBYTEssILWxx7C829a1OiAzNTc3
\nMS40LCCz1rLW1byxyCglKTogMTUuNjMxDQoNCsnPtM69u9LXvNu48TogMjAyLjk1NSwgs9ay1sr9
\nwb86IDE1MywgyNXG2jogMjAyNC0wNS0wNg0KDQrTr7/3KCUpOiAxNS4xOTgNCg0Kseq1xDogRVNH
\nVSwgtbHHsLzb1rU6IDM2MjUyLjU1LCCz1rLW1byxyCglKTogMTUuODQxDQoNCsnPtM69u9LXvNu4
\n8TogOTUuMzcsILPWstbK/cG/OiAyOTUsIMjVxto6IDIwMjMtMTEtMTMNCg0K06+/9yglKTogMjgu
\nODU2DQoNCtfpus++u9a1x/rP3828DQpb1+m6z7671rXH+s/fzbxdDQq9/MbavbvS1w0KW2h0dHBz
\nOi8vYXBpLm15aW52ZXN0cGlsb3QuY29tL3BpeGVsX2dpZl90cmFjay9wb3J0Zm9saW8vbXlpbnZl
\nc3RwaWxvdF91c18yXQ0K
\n
\n--_000_KL1PR02MB4788EE124D08D73A1E9A80309AA72KL1PR02MB4788apcp_
\nContent-Type: text/html; charset="gb2312"
\nContent-Transfer-Encoding: quoted-printable
\n
\n<html><head>
\n<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dgb2312">
\n<style type=3D"text/css" style=3D"display:none;"> P {margin-top:0;margin-bo=
\nttom:0;} </style>
\n</head>
\n<body dir=3D"ltr">
\n<div class=3D"elementToProof" style=3D"line-height: 22px; white-space: pre;=
\n font-family: Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, Calibri, Helv=
\netica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);">
\n000000000000=C4=E3=BA=C3=A3=AC =CA=C0=BD=E7=A3=A1000000000</div>
\n<div class=3D"elementToProof" style=3D"font-family: Aptos, Aptos_EmbeddedFo=
\nnt, Aptos_MSFontService, Calibri, Helvetica, sans-serif; font-size: 12pt; c=
\nolor: rgb(0, 0, 0);">
\n<br>
\n</div>
\n<div id=3D"appendonsend"></div>
\n<hr style=3D"display:inline-block;width:98%" tabindex=3D"-1">
\n<div id=3D"divRplyFwdMsg" dir=3D"ltr"><font face=3D"Calibri, sans-serif" st=
\nyle=3D"font-size:11pt" color=3D"#000000"><b>=B7=A2=BC=FE=C8=CB:</b> i365 Te=
\nch &lt;hello@i365.tech&gt;<br>
\n<b>=B7=A2=CB=CD=CA=B1=BC=E4:</b> 2024=C4=EA7=D4=C213=C8=D5 16:15<br>
\n<b>=CA=D5=BC=FE=C8=CB:</b> feilongphone@gmail.com &lt;feilongphone@gmail.co=
\nm&gt;<br>
\n<b>=D6=F7=CC=E2:</b> =A1=BE=D6=D8=D2=AA=A3=BA=D3=D0=D0=C5=BA=C5=A3=A1=A1=BF=
\n=CD=B6=D7=CA=D7=E9=BA=CF=B2=DF=C2=D4=CC=E1=D0=D1 #myinvestpilot_us_2 - 2024=
\n-07-13</font>
\n<div>&nbsp;</div>
\n</div>
\n<style>
\n<!--
\ndiv
\n	{font-family:Arial,sans-serif;
\n	margin:20px}
\nh1, h2, h3
\n	{color:#333}
\ndiv
\n	{margin-bottom:20px}
\np
\n	{margin:5px 0}
\n.x_position, .x_trade
\n	{border:1px solid #ddd;
\n	padding:10px;
\n	border-radius:5px}
\nimg
\n	{max-width:100%;
\n	height:auto}
\n.x_signal
\n	{padding:5px;
\n	margin-bottom:5px;
\n	border-left:5px solid #007BFF;
\n	background-color:#f1f1f1}
\n-->
\n</style>
\n<div>
\n<h1>=BD=F1=C8=D5=CD=B6=D7=CA=D7=E9=BA=CF=B8=FC=D0=C2 - =C3=C0=B9=C92=BA=C5 =
\n=A3=A8=B1=D2=D6=D6=A3=BAUSD=A3=A9</h1>
\n<p>=C8=D5=C6=DA: 2024-07-13</p>
\n<p>=CD=F8=D6=B7: <a href=3D"https://www.myinvestpilot.com/portfolios/myinve=
\nstpilot_us_2">myinvestpilot_us_2</a></p>
\n<h2>=BD=BB=D2=D7=D0=C5=BA=C5</h2>
\n<div>
\n<h3>=B3=D6=D3=D0</h3>
\n<div class=3D"x_signal">=B1=EA=B5=C4: QQQ (=C4=C9=D6=B8ETF)</div>
\n<div class=3D"x_signal">=B1=EA=B5=C4: XLK (=BF=C6=BC=BC=D6=B8=CA=FDETF)</di=
\nv>
\n<div class=3D"x_signal">=B1=EA=B5=C4: FTEC (=D0=C5=CF=A2=BC=BC=CA=F5=D6=B8=
\n=CA=FD)</div>
\n<div class=3D"x_signal">=B1=EA=B5=C4: XLY (=BE=AB=D1=A1=CF=FB=B7=D1=C6=B7=
\n=B0=E5=BF=E9=D6=B8=CA=FDETF)</div>
\n<div class=3D"x_signal">=B1=EA=B5=C4: VIG (=C3=C0=B9=FA=B8=DF=BA=EC=C0=FB=
\n=B9=C9ETF)</div>
\n<div class=3D"x_signal">=B1=EA=B5=C4: ESGU (=C3=C0=B9=FAESG=D3=C5=BB=AF=D6=
\n=B8=CA=FD)</div>
\n</div>
\n<div>
\n<h3>=C2=F4=B3=F6</h3>
\n<div class=3D"x_signal">=BD=F1=C8=D5=CE=DE=B2=D9=D7=F7</div>
\n</div>
\n<div>
\n<h3>=C2=F2=C8=EB</h3>
\n<div class=3D"x_signal">=B1=EA=B5=C4: ICLN (=C8=AB=C7=F2=C7=E5=BD=E0=C4=DC=
\n=D4=B4)</div>
\n<div class=3D"x_signal">=B1=EA=B5=C4: ARKK (=B4=B4=D0=C2ETF)</div>
\n</div>
\n<div>
\n<h3>=BF=D5=B2=D6</h3>
\n</div>
\n<h2>=D7=E9=BA=CF=D5=AA=D2=AA</h2>
\n<p>=BE=BB=D6=B5: 2.288</p>
\n<p>=B8=B4=BA=CF=C4=EA=BE=F9=D4=F6=B3=A4=C2=CA(%): 13.53</p>
\n<p>=CF=C4=C6=D5=B1=C8=C2=CA: 0.564</p>
\n<p>=B5=B1=C7=B0=BB=D8=B3=B7(%): -0.555</p>
\n<p>=D7=F2=C8=D5=D3=AF=BF=F7=B0=D9=B7=D6=B1=C8(%): 0.823</p>
\n<h2>=B3=D6=B2=D6</h2>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: VIG, =B5=B1=C7=B0=BC=DB=D6=B5: 33688.8, =B3=D6=B2=D6=D5=BC=
\n=B1=C8(%): 14.721</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 156.428, =B3=D6=B2=D6=CA=FD=C1=BF:=
\n 180, =C8=D5=C6=DA: 2023-11-13</p>
\n<p>=D3=AF=BF=F7(%): 19.646</p>
\n</div>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: FTEC, =B5=B1=C7=B0=BC=DB=D6=B5: 36623.25, =B3=D6=B2=D6=D5=
\n=BC=B1=C8(%): 16.003</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 151.955, =B3=D6=B2=D6=CA=FD=C1=BF:=
\n 205, =C8=D5=C6=DA: 2024-05-06</p>
\n<p>=D3=AF=BF=F7(%): 17.568</p>
\n</div>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: XLY, =B5=B1=C7=B0=BC=DB=D6=B5: 34468.2, =B3=D6=B2=D6=D5=BC=
\n=B1=C8(%): 15.062</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 176.998, =B3=D6=B2=D6=CA=FD=C1=BF:=
\n 180, =C8=D5=C6=DA: 2024-06-07</p>
\n<p>=D3=AF=BF=F7(%): 8.188</p>
\n</div>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: QQQ, =B5=B1=C7=B0=BC=DB=D6=B5: 37606.32, =B3=D6=B2=D6=D5=
\n=BC=B1=C8(%): 16.433</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 362.777, =B3=D6=B2=D6=CA=FD=C1=BF:=
\n 76, =C8=D5=C6=DA: 2023-11-03</p>
\n<p>=D3=AF=BF=F7(%): 36.398</p>
\n</div>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: XLK, =B5=B1=C7=B0=BC=DB=D6=B5: 35771.4, =B3=D6=B2=D6=D5=BC=
\n=B1=C8(%): 15.631</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 202.955, =B3=D6=B2=D6=CA=FD=C1=BF:=
\n 153, =C8=D5=C6=DA: 2024-05-06</p>
\n<p>=D3=AF=BF=F7(%): 15.198</p>
\n</div>
\n<div class=3D"x_position">
\n<p>=B1=EA=B5=C4: ESGU, =B5=B1=C7=B0=BC=DB=D6=B5: 36252.55, =B3=D6=B2=D6=D5=
\n=BC=B1=C8(%): 15.841</p>
\n<p>=C9=CF=B4=CE=BD=BB=D2=D7=BC=DB=B8=F1: 95.37, =B3=D6=B2=D6=CA=FD=C1=BF: 2=
\n95, =C8=D5=C6=DA: 2023-11-13</p>
\n<p>=D3=AF=BF=F7(%): 28.856</p>
\n</div>
\n<h2>=D7=E9=BA=CF=BE=BB=D6=B5=C7=FA=CF=DF=CD=BC</h2>
\n<img alt=3D"=D7=E9=BA=CF=BE=BB=D6=B5=C7=FA=CF=DF=CD=BC" src=3D"https://medi=
\na.i365.tech/myinvestpilot/portfolios/myinvestpilot_us_2/myinvestpilot_us_2_=
\nportfolio_fullsize.png">
\n<h2>=BD=FC=C6=DA=BD=BB=D2=D7</h2>
\n<img src=3D"https://api.myinvestpilot.com/pixel_gif_track/portfolio/myinves=
\ntpilot_us_2">
\n</div>
\n</body>
\n</html>
\n
\n--_000_KL1PR02MB4788EE124D08D73A1E9A80309AA72KL1PR02MB4788apcp_--
\n

```

</details>

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
