### PR TITLE
fix(MQTT Node): Node hangs forever on failed connection

### DIFF
--- a/packages/nodes-base/nodes/MQTT/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MQTT/GenericFunctions.ts
@@ -1,5 +1,5 @@
-import { connectAsync, type IClientOptions, type MqttClient } from 'mqtt';
-import { randomString } from 'n8n-workflow';
+import { connect, type IClientOptions, type MqttClient } from 'mqtt';
+import { ApplicationError, randomString } from 'n8n-workflow';
 import { formatPrivateKey } from '@utils/utilities';
 
 interface BaseMqttCredential {
@@ -49,5 +49,15 @@ export const createClient = async (credentials: MqttCredential): Promise<MqttCli
 		clientOptions.rejectUnauthorized = credentials.rejectUnauthorized;
 	}
 
-	return await connectAsync(clientOptions);
+	return await new Promise((resolve, reject) => {
+		const client = connect(clientOptions);
+
+		client.on('connect', () => {
+			resolve(client);
+		});
+
+		client.on('error', (error) => {
+			reject(new ApplicationError(error.message));
+		});
+	});
 };


### PR DESCRIPTION
## Summary

if connection was not successful node hangs forever when using `connectAsync`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1421/mqtt-node-hangs-forever-on-failed-connection
