### PR TITLE
fix(editor): Handle disabled nodes in schema view

### DIFF
--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -258,7 +258,7 @@
 			</div>
 
 			<div
-				v-else-if="paneType === 'input' && node?.disabled && !isInputSchemaView"
+				v-else-if="paneType === 'input' && !isInputSchemaView && node?.disabled"
 				:class="$style.center"
 			>
 				<n8n-text>

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -253,7 +253,7 @@
 				<NodeErrorView :error="subworkflowExecutionError" :class="$style.errorDisplay" />
 			</div>
 
-			<div v-else-if="!hasNodeRun && !isInputSchemaView" :class="$style.center">
+			<div v-else-if="!hasNodeRun && !(isInputSchemaView && node?.disabled)" :class="$style.center">
 				<slot name="node-not-run"></slot>
 			</div>
 

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -253,11 +253,14 @@
 				<NodeErrorView :error="subworkflowExecutionError" :class="$style.errorDisplay" />
 			</div>
 
-			<div v-else-if="!hasNodeRun" :class="$style.center">
+			<div v-else-if="!hasNodeRun && !isInputSchemaView" :class="$style.center">
 				<slot name="node-not-run"></slot>
 			</div>
 
-			<div v-else-if="paneType === 'input' && node?.disabled" :class="$style.center">
+			<div
+				v-else-if="paneType === 'input' && node?.disabled && !isInputSchemaView"
+				:class="$style.center"
+			>
 				<n8n-text>
 					{{ $locale.baseText('ndv.input.disabled', { interpolate: { nodeName: node.name } }) }}
 					<n8n-link @click="enableNode">

--- a/packages/editor-ui/src/components/RunDataSchema.vue
+++ b/packages/editor-ui/src/components/RunDataSchema.vue
@@ -330,19 +330,19 @@ watch(
 					>
 						<div :class="$style.innerSchema" @transitionstart.stop>
 							<div
-								v-if="isDataEmpty(currentNode.schema)"
-								:class="$style.notice"
-								data-test-id="run-data-schema-empty"
-							>
-								{{ i18n.baseText('dataMapping.schemaView.emptyData') }}
-							</div>
-
-							<div
 								v-if="currentNode.node.disabled"
 								:class="$style.notice"
 								data-test-id="run-data-schema-disabled"
 							>
 								{{ i18n.baseText('dataMapping.schemaView.disabled') }}
+							</div>
+
+							<div
+								v-else-if="isDataEmpty(currentNode.schema)"
+								:class="$style.notice"
+								data-test-id="run-data-schema-empty"
+							>
+								{{ i18n.baseText('dataMapping.schemaView.emptyData') }}
 							</div>
 
 							<RunDataSchemaItem

--- a/packages/editor-ui/src/components/RunDataSchema.vue
+++ b/packages/editor-ui/src/components/RunDataSchema.vue
@@ -285,6 +285,7 @@ watch(
 
 					<div :class="$style.title">
 						{{ currentNode.node.name }}
+						<span v-if="currentNode.node.disabled">({{ $locale.baseText('node.disabled') }})</span>
 					</div>
 					<font-awesome-icon
 						v-if="currentNode.nodeType.group.includes('trigger')"
@@ -330,10 +331,18 @@ watch(
 						<div :class="$style.innerSchema" @transitionstart.stop>
 							<div
 								v-if="isDataEmpty(currentNode.schema)"
-								:class="$style.empty"
+								:class="$style.notice"
 								data-test-id="run-data-schema-empty"
 							>
 								{{ i18n.baseText('dataMapping.schemaView.emptyData') }}
+							</div>
+
+							<div
+								v-if="currentNode.node.disabled"
+								:class="$style.notice"
+								data-test-id="run-data-schema-disabled"
+							>
+								{{ i18n.baseText('dataMapping.schemaView.disabled') }}
 							</div>
 
 							<RunDataSchemaItem
@@ -421,7 +430,7 @@ watch(
 		scroll-margin-top: var(--header-height);
 	}
 
-	.empty {
+	.notice {
 		padding-left: var(--spacing-l);
 	}
 }
@@ -443,7 +452,7 @@ watch(
 	}
 }
 
-.empty {
+.notice {
 	font-size: var(--font-size-2xs);
 	color: var(--color-text-light);
 }

--- a/packages/editor-ui/src/components/__tests__/RunDataSchema.test.ts
+++ b/packages/editor-ui/src/components/__tests__/RunDataSchema.test.ts
@@ -14,12 +14,21 @@ const mockNode1 = createTestNode({
 	name: 'Set1',
 	type: SET_NODE_TYPE,
 	typeVersion: 1,
+	disabled: false,
 });
 
 const mockNode2 = createTestNode({
 	name: 'Set2',
 	type: SET_NODE_TYPE,
 	typeVersion: 1,
+	disabled: false,
+});
+
+const disabledNode = createTestNode({
+	name: 'Disabled Node',
+	type: SET_NODE_TYPE,
+	typeVersion: 1,
+	disabled: true,
 });
 
 async function setupStore() {
@@ -28,7 +37,7 @@ async function setupStore() {
 		name: 'Test Workflow',
 		connections: {},
 		active: true,
-		nodes: [mockNode1, mockNode2],
+		nodes: [mockNode1, mockNode2, disabledNode],
 	});
 
 	const pinia = createPinia();
@@ -160,6 +169,18 @@ describe('RunDataSchema.vue', () => {
 
 		const { getAllByTestId } = renderComponent();
 		expect(getAllByTestId('run-data-schema-empty').length).toBe(1);
+	});
+
+	it('renders disabled nodes correctly', () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				nodes: [{ name: disabledNode.name, indicies: [], depth: 1 }],
+			},
+		});
+		expect(getByTestId('run-data-schema-disabled')).toBeInTheDocument();
+		expect(getByTestId('run-data-schema-node-name')).toHaveTextContent(
+			`${disabledNode.name} (Deactivated)`,
+		);
 	});
 
 	test.each([[[{ tx: false }, { tx: false }]], [[{ tx: '' }, { tx: '' }]], [[{ tx: [] }]]])(

--- a/packages/editor-ui/src/components/__tests__/__snapshots__/RunDataSchema.test.ts.snap
+++ b/packages/editor-ui/src/components/__tests__/__snapshots__/RunDataSchema.test.ts.snap
@@ -1382,7 +1382,8 @@ exports[`RunDataSchema.vue > renders schema with spaces and dots 1`] = `
             class="title"
             data-v-46dade00=""
           >
-            Set1
+            Set1 
+            <!--v-if-->
           </div>
           <!--v-if-->
         </div>
@@ -1932,7 +1933,8 @@ exports[`RunDataSchema.vue > renders schema with spaces and dots 1`] = `
             class="title"
             data-v-46dade00=""
           >
-            Set2
+            Set2 
+            <!--v-if-->
           </div>
           <!--v-if-->
         </div>

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -606,6 +606,7 @@
 	"dataMapping.tableView.tableColumnsExceeded.tooltip": "Your data has more than {columnLimit} columns so some are hidden. Switch to {link} to see all data.",
 	"dataMapping.tableView.tableColumnsExceeded.tooltip.link": "JSON view",
 	"dataMapping.schemaView.emptyData": "No fields - item(s) exist, but they're empty",
+	"dataMapping.schemaView.disabled": "This node is disabled and will just pass data through",
 	"dataMapping.schemaView.noMatches": "No results for '{search}'",
 	"displayWithChange.cancelEdit": "Cancel Edit",
 	"displayWithChange.clickToChange": "Click to Change",


### PR DESCRIPTION
## Summary

Schema view should still render a list of nodes when the previous node is disabled.
Disabled nodes should be marked Deactivated and have a description when expanded:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/473d7f33-d36e-4568-9eb3-191fa2f1c94c">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1496/schema-view-handle-disabled-nodes

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
