### PR TITLE
refactor(core): Rename `UsageMetrics` to `LicenseMetrics` (no-changelog)

### DIFF
--- a/packages/cli/src/License.ts
+++ b/packages/cli/src/License.ts
@@ -17,7 +17,7 @@ import type { RedisServicePubSubPublisher } from './services/redis/RedisServiceP
 import { RedisService } from './services/redis.service';
 import { OrchestrationService } from '@/services/orchestration.service';
 import { OnShutdown } from '@/decorators/OnShutdown';
-import { UsageMetricsService } from './services/usageMetrics.service';
+import { LicenseMetricsService } from '@/metrics/license-metrics.service';
 
 type FeatureReturnType = Partial<
 	{
@@ -38,7 +38,7 @@ export class License {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly orchestrationService: OrchestrationService,
 		private readonly settingsRepository: SettingsRepository,
-		private readonly usageMetricsService: UsageMetricsService,
+		private readonly licenseMetricsService: LicenseMetricsService,
 	) {}
 
 	/**
@@ -82,10 +82,10 @@ export class License {
 			? async (features: TFeatures) => await this.onFeatureChange(features)
 			: async () => {};
 		const collectUsageMetrics = isMainInstance
-			? async () => await this.usageMetricsService.collectUsageMetrics()
+			? async () => await this.licenseMetricsService.collectUsageMetrics()
 			: async () => [];
 		const collectPassthroughData = isMainInstance
-			? async () => await this.usageMetricsService.collectPassthroughData()
+			? async () => await this.licenseMetricsService.collectPassthroughData()
 			: async () => ({});
 
 		const renewalEnabled = this.renewalEnabled(instanceType);

--- a/packages/cli/src/databases/repositories/license-metrics.repository.ts
+++ b/packages/cli/src/databases/repositories/license-metrics.repository.ts
@@ -3,15 +3,15 @@ import { GlobalConfig } from '@n8n/config';
 import { DataSource, Repository, Entity } from '@n8n/typeorm';
 
 @Entity()
-export class UsageMetrics {}
+export class LicenseMetrics {}
 
 @Service()
-export class UsageMetricsRepository extends Repository<UsageMetrics> {
+export class LicenseMetricsRepository extends Repository<LicenseMetrics> {
 	constructor(
 		dataSource: DataSource,
 		private readonly globalConfig: GlobalConfig,
 	) {
-		super(UsageMetrics, dataSource.manager);
+		super(LicenseMetrics, dataSource.manager);
 	}
 
 	toTableName(name: string) {

--- a/packages/cli/src/metrics/__tests__/license-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/license-metrics.service.test.ts
@@ -1,12 +1,12 @@
 import { mock } from 'jest-mock-extended';
-import { UsageMetricsService } from '@/services/usageMetrics.service';
+import { LicenseMetricsService } from '@/metrics/license-metrics.service';
 import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import type { UsageMetricsRepository } from '@/databases/repositories/usageMetrics.repository';
+import type { LicenseMetricsRepository } from '@/databases/repositories/license-metrics.repository';
 
-describe('UsageMetricsService', () => {
+describe('LicenseMetricsService', () => {
 	const workflowRepository = mock<WorkflowRepository>();
-	const usageMetricsService = new UsageMetricsService(
-		mock<UsageMetricsRepository>(),
+	const licenseMetricsService = new LicenseMetricsService(
+		mock<LicenseMetricsRepository>(),
 		workflowRepository,
 	);
 
@@ -21,7 +21,7 @@ describe('UsageMetricsService', () => {
 			/**
 			 * Act
 			 */
-			const result = await usageMetricsService.collectPassthroughData();
+			const result = await licenseMetricsService.collectPassthroughData();
 
 			/**
 			 * Assert

--- a/packages/cli/src/metrics/license-metrics.service.ts
+++ b/packages/cli/src/metrics/license-metrics.service.ts
@@ -1,11 +1,11 @@
-import { UsageMetricsRepository } from '@/databases/repositories/usageMetrics.repository';
+import { LicenseMetricsRepository } from '@/databases/repositories/license-metrics.repository';
 import { Service } from 'typedi';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
 
 @Service()
-export class UsageMetricsService {
+export class LicenseMetricsService {
 	constructor(
-		private readonly usageMetricsRepository: UsageMetricsRepository,
+		private readonly licenseMetricsRepository: LicenseMetricsRepository,
 		private readonly workflowRepository: WorkflowRepository,
 	) {}
 
@@ -18,7 +18,7 @@ export class UsageMetricsService {
 			totalCredentials,
 			productionExecutions,
 			manualExecutions,
-		} = await this.usageMetricsRepository.getLicenseRenewalMetrics();
+		} = await this.licenseMetricsRepository.getLicenseRenewalMetrics();
 
 		return [
 			{ name: 'activeWorkflows', value: activeWorkflows },

--- a/packages/cli/test/integration/license-metrics.repository.test.ts
+++ b/packages/cli/test/integration/license-metrics.repository.test.ts
@@ -1,4 +1,4 @@
-import { UsageMetricsRepository } from '@/databases/repositories/usageMetrics.repository';
+import { LicenseMetricsRepository } from '@/databases/repositories/license-metrics.repository';
 import { createAdmin, createMember, createOwner, createUser } from './shared/db/users';
 import * as testDb from './shared/testDb';
 import Container from 'typedi';
@@ -7,14 +7,14 @@ import { createManyCredentials } from './shared/db/credentials';
 import { WorkflowStatisticsRepository } from '@/databases/repositories/workflowStatistics.repository';
 import { StatisticsNames } from '@/databases/entities/WorkflowStatistics';
 
-describe('UsageMetricsRepository', () => {
-	let usageMetricsRepository: UsageMetricsRepository;
+describe('LicenseMetricsRepository', () => {
+	let licenseMetricsRepository: LicenseMetricsRepository;
 	let workflowStatisticsRepository: WorkflowStatisticsRepository;
 
 	beforeAll(async () => {
 		await testDb.init();
 
-		usageMetricsRepository = Container.get(UsageMetricsRepository);
+		licenseMetricsRepository = Container.get(LicenseMetricsRepository);
 
 		workflowStatisticsRepository = Container.get(WorkflowStatisticsRepository);
 	});
@@ -27,7 +27,7 @@ describe('UsageMetricsRepository', () => {
 		await testDb.terminate();
 	});
 
-	describe('getLicenseRenewalMetrics()', () => {
+	describe('getLicenseRenewalMetrics', () => {
 		test('should return license renewal metrics', async () => {
 			const [firstWorkflow, secondWorkflow] = await createManyWorkflows(2, { active: false });
 
@@ -60,7 +60,7 @@ describe('UsageMetricsRepository', () => {
 				),
 			]);
 
-			const metrics = await usageMetricsRepository.getLicenseRenewalMetrics();
+			const metrics = await licenseMetricsRepository.getLicenseRenewalMetrics();
 
 			expect(metrics).toStrictEqual({
 				enabledUsers: 4,
@@ -76,7 +76,7 @@ describe('UsageMetricsRepository', () => {
 		test('should handle zero execution statistics correctly', async () => {
 			await Promise.all([createOwner(), createManyWorkflows(3, { active: true })]);
 
-			const metrics = await usageMetricsRepository.getLicenseRenewalMetrics();
+			const metrics = await licenseMetricsRepository.getLicenseRenewalMetrics();
 
 			expect(metrics).toStrictEqual({
 				enabledUsers: 1,


### PR DESCRIPTION
Since "usage metrics" are meant only for license purposes, let's rename for clarity. "Usage" is too vague because we also generate prometheus metrics from event logs and API requests produced by usage.

This PR only renames files and symbols, no logic changes.

Follow-up to https://github.com/n8n-io/n8n/pull/10050