### PR TITLE
fix(LangChain Code Node): Add clarifying comments to the default code (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -40,12 +40,18 @@ const defaultCodeExecute = `const { PromptTemplate } = require('@langchain/core/
 
 const query = 'Tell me a joke';
 const prompt = PromptTemplate.fromTemplate(query);
+
+// If you are allowing more than one language model input connection (-1 or
+// anything greater than 1), getInputConnectionData returns an array, so you
+// will have to change the code below it to deal with that. For example, use
+// llm[0] in the chain definition
+
 const llm = await this.getInputConnectionData('ai_languageModel', 0);
 let chain = prompt.pipe(llm);
 const output = await chain.invoke();
 return [ {json: { output } } ];`;
 
-const defaultCodeSupplyData = `const { WikipediaQueryRun } = require('langchain/tools');
+const defaultCodeSupplyData = `const { WikipediaQueryRun } = require( '@langchain/community/tools/wikipedia_query_run');
 return new WikipediaQueryRun();`;
 
 const langchainModules = ['langchain', '@langchain/*'];


### PR DESCRIPTION
## Summary

The default code expects a single language model input connection. If the user supplied -1 or greater than 1, the `getInputConnectionData` function returns an array. Forgetting to do so, yields a very unhelpful message from the langchain side, that it expects a runnable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-175/bug-langchain-code-node-loses-data-if-it-has-a-first-line
https://community.n8n.io/t/bug-langchain-code-node-code-reads-as-empty-in-some-cases/44612

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
