### PR TITLE
feat(Pinecone Vector Store Node, Supabase Vector Store Node): Add update operation to vector store nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -49,17 +49,6 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-// const updateFields: INodeProperties[] = [
-// 	{
-// 		displayName: 'Options',
-// 		name: 'options',
-// 		type: 'collection',
-// 		placeholder: 'Add Option',
-// 		default: {},
-// 		options: [pineconeNamespaceField, metadataFilterField],
-// 	},
-// ];
-
 export const VectorStorePinecone = createVectorStoreNode({
 	meta: {
 		displayName: 'Pinecone Vector Store',
@@ -80,7 +69,6 @@ export const VectorStorePinecone = createVectorStoreNode({
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
-	// updateFields,
 	sharedFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
 		const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -49,16 +49,16 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-const updateFields: INodeProperties[] = [
-	{
-		displayName: 'Options',
-		name: 'options',
-		type: 'collection',
-		placeholder: 'Add Option',
-		default: {},
-		options: [pineconeNamespaceField, metadataFilterField],
-	},
-];
+// const updateFields: INodeProperties[] = [
+// 	{
+// 		displayName: 'Options',
+// 		name: 'options',
+// 		type: 'collection',
+// 		placeholder: 'Add Option',
+// 		default: {},
+// 		options: [pineconeNamespaceField, metadataFilterField],
+// 	},
+// ];
 
 export const VectorStorePinecone = createVectorStoreNode({
 	meta: {
@@ -74,12 +74,13 @@ export const VectorStorePinecone = createVectorStoreNode({
 				required: true,
 			},
 		],
+		operationModes: ['load', 'insert', 'retrieve', 'update'],
 	},
 	methods: { listSearch: { pineconeIndexSearch } },
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
-	updateFields,
+	// updateFields,
 	sharedFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
 		const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {
@@ -143,50 +144,4 @@ export const VectorStorePinecone = createVectorStoreNode({
 			pineconeIndex,
 		});
 	},
-	async updateVectorStore() {
-		return;
-	},
-	// async updateVectorStore(context, embeddings, document, itemIndex) {
-	// 	const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {
-	// 		extractValue: true,
-	// 	}) as string;
-	//
-	// 	const documentId = context.getNodeParameter('id', itemIndex, '', {
-	// 		extractValue: true,
-	// 	}) as string;
-	//
-	// 	if (!documentId) {
-	// 		throw new NodeOperationError(context.getNode(), 'ID is required');
-	// 	}
-	//
-	// 	const credentials = await context.getCredentials('pineconeApi');
-	//
-	// 	const client = new Pinecone({
-	// 		apiKey: credentials.apiKey as string,
-	// 	});
-	//
-	// 	const indexes = ((await client.listIndexes()).indexes ?? []).map((i) => i.name);
-	//
-	// 	if (!indexes.includes(index)) {
-	// 		throw new NodeOperationError(context.getNode(), `Index ${index} not found`, {
-	// 			itemIndex,
-	// 			description: 'Please check that the index exists in your vector store',
-	// 		});
-	// 	}
-	//
-	// 	const pineconeIndex = client.Index(index);
-	//
-	// 	const text = document.pageContent;
-	//
-	// 	console.log('UPDATE WILL HAPPEN HERE');
-	//
-	// 	const config: PineconeStoreParams = {
-	// 		pineconeIndex,
-	// 	};
-	// 	const vectorStore = await PineconeStore.fromExistingIndex(embeddings, config);
-	//
-	// 	await vectorStore.addVectors(await embeddings.embedDocuments([text]), [document], {
-	// 		ids: [documentId],
-	// 	});
-	// },
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -9,6 +9,15 @@ import { pineconeIndexSearch } from '../shared/methods/listSearch';
 
 const sharedFields: INodeProperties[] = [pineconeIndexRLC];
 
+const pineconeNamespaceField: INodeProperties = {
+	displayName: 'Pinecone Namespace',
+	name: 'pineconeNamespace',
+	type: 'string',
+	description:
+		'Partition the records in an index into namespaces. Queries and other operations are then limited to one namespace, so different requests can search different subsets of your index.',
+	default: '',
+};
+
 const retrieveFields: INodeProperties[] = [
 	{
 		displayName: 'Options',
@@ -16,17 +25,7 @@ const retrieveFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		options: [
-			{
-				displayName: 'Pinecone Namespace',
-				name: 'pineconeNamespace',
-				type: 'string',
-				description:
-					'Partition the records in an index into namespaces. Queries and other operations are then limited to one namespace, so different requests can search different subsets of your index.',
-				default: '',
-			},
-			metadataFilterField,
-		],
+		options: [pineconeNamespaceField, metadataFilterField],
 	},
 ];
 
@@ -45,17 +44,22 @@ const insertFields: INodeProperties[] = [
 				default: false,
 				description: 'Whether to clear the namespace before inserting new data',
 			},
-			{
-				displayName: 'Pinecone Namespace',
-				name: 'pineconeNamespace',
-				type: 'string',
-				description:
-					'Partition the records in an index into namespaces. Queries and other operations are then limited to one namespace, so different requests can search different subsets of your index.',
-				default: '',
-			},
+			pineconeNamespaceField,
 		],
 	},
 ];
+
+const updateFields: INodeProperties[] = [
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		options: [pineconeNamespaceField, metadataFilterField],
+	},
+];
+
 export const VectorStorePinecone = createVectorStoreNode({
 	meta: {
 		displayName: 'Pinecone Vector Store',
@@ -75,6 +79,7 @@ export const VectorStorePinecone = createVectorStoreNode({
 	retrieveFields,
 	loadFields: retrieveFields,
 	insertFields,
+	updateFields,
 	sharedFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
 		const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {
@@ -138,4 +143,50 @@ export const VectorStorePinecone = createVectorStoreNode({
 			pineconeIndex,
 		});
 	},
+	async updateVectorStore() {
+		return;
+	},
+	// async updateVectorStore(context, embeddings, document, itemIndex) {
+	// 	const index = context.getNodeParameter('pineconeIndex', itemIndex, '', {
+	// 		extractValue: true,
+	// 	}) as string;
+	//
+	// 	const documentId = context.getNodeParameter('id', itemIndex, '', {
+	// 		extractValue: true,
+	// 	}) as string;
+	//
+	// 	if (!documentId) {
+	// 		throw new NodeOperationError(context.getNode(), 'ID is required');
+	// 	}
+	//
+	// 	const credentials = await context.getCredentials('pineconeApi');
+	//
+	// 	const client = new Pinecone({
+	// 		apiKey: credentials.apiKey as string,
+	// 	});
+	//
+	// 	const indexes = ((await client.listIndexes()).indexes ?? []).map((i) => i.name);
+	//
+	// 	if (!indexes.includes(index)) {
+	// 		throw new NodeOperationError(context.getNode(), `Index ${index} not found`, {
+	// 			itemIndex,
+	// 			description: 'Please check that the index exists in your vector store',
+	// 		});
+	// 	}
+	//
+	// 	const pineconeIndex = client.Index(index);
+	//
+	// 	const text = document.pageContent;
+	//
+	// 	console.log('UPDATE WILL HAPPEN HERE');
+	//
+	// 	const config: PineconeStoreParams = {
+	// 		pineconeIndex,
+	// 	};
+	// 	const vectorStore = await PineconeStore.fromExistingIndex(embeddings, config);
+	//
+	// 	await vectorStore.addVectors(await embeddings.embedDocuments([text]), [document], {
+	// 		ids: [documentId],
+	// 	});
+	// },
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -6,6 +6,14 @@ import { metadataFilterField } from '../../../utils/sharedFields';
 import { supabaseTableNameRLC } from '../shared/descriptions';
 import { supabaseTableNameSearch } from '../shared/methods/listSearch';
 
+const queryNameField: INodeProperties = {
+	displayName: 'Query Name',
+	name: 'queryName',
+	type: 'string',
+	default: 'match_documents',
+	description: 'Name of the query to use for matching documents',
+};
+
 const sharedFields: INodeProperties[] = [supabaseTableNameRLC];
 const insertFields: INodeProperties[] = [
 	{
@@ -14,17 +22,10 @@ const insertFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		options: [
-			{
-				displayName: 'Query Name',
-				name: 'queryName',
-				type: 'string',
-				default: 'match_documents',
-				description: 'Name of the query to use for matching documents',
-			},
-		],
+		options: [queryNameField],
 	},
 ];
+
 const retrieveFields: INodeProperties[] = [
 	{
 		displayName: 'Options',
@@ -32,18 +33,12 @@ const retrieveFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		options: [
-			{
-				displayName: 'Query Name',
-				name: 'queryName',
-				type: 'string',
-				default: 'match_documents',
-				description: 'Name of the query to use for matching documents',
-			},
-			metadataFilterField,
-		],
+		options: [queryNameField, metadataFilterField],
 	},
 ];
+
+const updateFields: INodeProperties[] = [...insertFields];
+
 export const VectorStoreSupabase = createVectorStoreNode({
 	meta: {
 		description: 'Work with your data in Supabase Vector Store',
@@ -67,6 +62,7 @@ export const VectorStoreSupabase = createVectorStoreNode({
 	insertFields,
 	loadFields: retrieveFields,
 	retrieveFields,
+	updateFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
 		const tableName = context.getNodeParameter('tableName', itemIndex, '', {
 			extractValue: true,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -58,6 +58,7 @@ export const VectorStoreSupabase = createVectorStoreNode({
 				required: true,
 			},
 		],
+		operationModes: ['load', 'insert', 'retrieve', 'update'],
 	},
 	methods: {
 		listSearch: { supabaseTableNameSearch },

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -235,7 +235,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 		methods = args.methods;
 
 		async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-			const mode = this.getNodeParameter('mode', 0) as 'load' | 'insert' | 'retrieve' | 'update';
+			const mode = this.getNodeParameter('mode', 0) as NodeOperationMode;
 
 			const embeddings = (await this.getInputConnectionData(
 				NodeConnectionType.AiEmbedding,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -54,6 +54,7 @@ interface VectorStoreNodeConstructorArgs {
 	insertFields?: INodeProperties[];
 	loadFields?: INodeProperties[];
 	retrieveFields?: INodeProperties[];
+	updateFields?: INodeProperties[];
 	populateVectorStore: (
 		context: IExecuteFunctions,
 		embeddings: Embeddings,
@@ -227,6 +228,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 				},
 				...transformDescriptionForOperationMode(args.loadFields ?? [], 'load'),
 				...transformDescriptionForOperationMode(args.retrieveFields ?? [], 'retrieve'),
+				...transformDescriptionForOperationMode(args.updateFields ?? [], 'update'),
 			],
 		};
 

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -15,7 +15,7 @@ export function getMetadataFiltersValues(
 	ctx: IExecuteFunctions,
 	itemIndex: number,
 ): Record<string, never> | undefined {
-	const options = ctx.getNodeParameter('options', itemIndex);
+	const options = ctx.getNodeParameter('options', itemIndex, {});
 
 	if (options.metadata) {
 		const { metadataValues: metadata } = options.metadata as {

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2127,6 +2127,7 @@ export const eventNamesAiNodes = [
 	'n8n.ai.llm.generated',
 	'n8n.ai.llm.error',
 	'n8n.ai.vector.store.populated',
+	'n8n.ai.vector.store.updated',
 ] as const;
 
 export type EventNamesAiNodesType = (typeof eventNamesAiNodes)[number];


### PR DESCRIPTION
## Summary

This pull request adds the update operation to the vector store nodes.
To implement the update operation user needs to specify the ID of an existing embedding.

Important to note: 
1. Update operation could not be implemented the same way as insert operation. It requires input items to correspond 1-1 with the vector store entry (otherwise "update item by ID" operation would make little sense). This is why the vector store node in update mode doesn't have DocumentLoader input and do not split input into chunks.
2. It uses LangChain VectorStore's upsert feature under the hood. Of the n8n vector store nodes only Pinecone and Supabase had upsert feature implemented so far.
3. Update mode is disabled by default for new vector store integrations, it should be enabled case by case (i.e. when the vector store provider has upsert implemented in langchain).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-202/add-update-operations-to-vector-store-nodes
Docs: https://github.com/n8n-io/n8n-docs/pull/2245

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
