### PR TITLE
fix(editor): Remove push event listeners when migrating away from the canvas

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/MainHeader.vue
+++ b/packages/editor-ui/src/components/MainHeader/MainHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeMount, onMounted } from 'vue';
+import { ref, computed, watch, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
 import type { RouteLocation, RouteLocationRaw } from 'vue-router';
 import { useRouter, useRoute } from 'vue-router';
 import WorkflowDetails from '@/components/MainHeader/WorkflowDetails.vue';
@@ -55,6 +55,10 @@ watch(route, (to, from) => {
 
 onBeforeMount(() => {
 	pushConnection.initialize();
+});
+
+onBeforeUnmount(() => {
+	pushConnection.terminate();
 });
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
3 weeks ago we refactored this file, and forgot to port over the [cleanup code](https://github.com/n8n-io/n8n/pull/9789/files#diff-699cec5e7baa8a4f892ddc27687e0fb14d7668b9e037db2ab6e8ce31c338f5a7L105-L107) for `pushConnection` on `beforeUnmount`.


## Related Linear tickets, Github issues, and Community forum posts
N8N-7509
https://community.n8n.io/t/why-is-my-code-getting-executed-twice/49980

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] PR Labeled with `release/backport`