### PR TITLE
fix(Email Trigger (IMAP) Node): Reconnect not working correctly

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -634,8 +634,6 @@ export class EmailReadImapV2 implements INodeType {
 					this.logger.verbose(`IMAP connection experienced an error: (${errorCode})`, {
 						error: error as Error,
 					});
-					// eslint-disable-next-line @typescript-eslint/no-use-before-define
-					await closeFunction();
 					this.emitError(error as Error);
 				});
 				return conn;


### PR DESCRIPTION
## Summary

On disconnect even with the reconnect option enabled the node is not connecting again so the workflow shows as being active but isn't.

To fix this issue, the call to closeFunction upon IMAP connection errors is removed. This change prevents the workflow from being deactivated.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1400/imap-node-reconnect-not-working-correctly

GH Issue: 

https://github.com/n8n-io/n8n/issues/9666

Community Issue: 

https://community.n8n.io/t/n8n-bug-report-imap-trigger-not-working-after-a-period-of-time/47796

https://community.n8n.io/t/imap-trigger-not-working-after-a-period-of-time/49470

Zammad: 

https://support.n8n.io/#ticket/zoom/6159

https://support.n8n.io/#ticket/zoom/6184

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
