### PR TITLE
fix(Notion Node): Fix issue preventing some database page urls from working

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
@@ -601,7 +601,7 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}).*',
 							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
@@ -609,7 +609,7 @@ export const databasePageFields: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -622,14 +622,14 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'^(([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}))[ \t]*',
+								'^(([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))[ \t]*',
 							errorMessage: 'Not a valid Notion Database Page ID',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
-					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})',
+					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12})',
 				},
 				url: '=https://www.notion.so/{{$value.replace(/-/g, "")}}',
 			},
@@ -1070,7 +1070,7 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}).*',
 							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
@@ -1078,7 +1078,7 @@ export const databasePageFields: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -1091,14 +1091,14 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'^(([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}))[ \t]*',
+								'^(([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))[ \t]*',
 							errorMessage: 'Not a valid Notion Database Page ID',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
-					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})',
+					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12})',
 				},
 				url: '=https://www.notion.so/{{$value.replace(/-/g, "")}}',
 			},
@@ -1161,7 +1161,7 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}).*',
 							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
@@ -1169,7 +1169,7 @@ export const databasePageFields: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -1182,14 +1182,14 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'^(([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}))[ \t]*',
-							errorMessage: 'Not a valid Notion Database ID',
+								'^(([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})|([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}))[ \t]*',
+							errorMessage: 'Not a valid Notion Database Page ID',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
-					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12})',
+					regex: '^([0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12})',
 				},
 				url: '=https://www.notion.so/{{$value.replace(/-/g, "")}}',
 			},

--- a/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/DatabasePageDescription.ts
@@ -601,7 +601,7 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
 							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
@@ -609,7 +609,7 @@ export const databasePageFields: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -1070,7 +1070,7 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
 							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
@@ -1078,7 +1078,7 @@ export const databasePageFields: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -1161,15 +1161,15 @@ export const databasePageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
-							errorMessage: 'Not a valid Notion Database URL',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
 				},
 			},
 			{

--- a/packages/nodes-base/nodes/Notion/shared/descriptions/PageDescription.ts
+++ b/packages/nodes-base/nodes/Notion/shared/descriptions/PageDescription.ts
@@ -94,15 +94,15 @@ export const pageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
-							errorMessage: 'Not a valid Notion Page URL',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
 				},
 			},
 			{
@@ -174,15 +174,15 @@ export const pageFields: INodeProperties[] = [
 						type: 'regex',
 						properties: {
 							regex:
-								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
-							errorMessage: 'Not a valid Notion Page URL',
+								'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}).*',
+							errorMessage: 'Not a valid Notion Database Page URL',
 						},
 					},
 				],
 				extractValue: {
 					type: 'regex',
 					regex:
-						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{2,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
+						'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})',
 				},
 			},
 			{

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -1,4 +1,4 @@
-import { formatBlocks } from '../shared/GenericFunctions';
+import { extractPageId, formatBlocks } from '../shared/GenericFunctions';
 
 describe('Test NotionV2, formatBlocks', () => {
 	it('should format to_do block', () => {
@@ -29,5 +29,41 @@ describe('Test NotionV2, formatBlocks', () => {
 				},
 			},
 		]);
+	});
+});
+
+describe('Test Notion', () => {
+	describe('extractPageId', () => {
+		const baseUrl = 'https://www.notion.so/fake-instance';
+		test('should return the part after "p="', () => {
+			const page = `${baseUrl}?p=4eb10d5001254b7faaa831d72d9445aa`;
+			const result = extractPageId(page);
+			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+		});
+		test('should return the last part after splitting by "-" when URL contains "-" and "https"', () => {
+			const page = `${baseUrl}/some-page-4eb10d5001254b7faaa831d72d9445aa`;
+			const result = extractPageId(page);
+			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+		});
+		test('should return the last part after splitting by "-" when URL contains "-" and "https" and ignore extra url param', () => {
+			const page = `${baseUrl}/some-page-4eb10d5001254b7faaa831d72d9445aa?pvs=4`;
+			const result = extractPageId(page);
+			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+		});
+		test('should return just the ID', () => {
+			const page = `${baseUrl}/4eb10d5001254b7faaa831d72d9445aa`;
+			const result = extractPageId(page);
+			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+		});
+		test('should return the input as is when no conditions are met', () => {
+			const page = `${baseUrl}/some-page`;
+			const result = extractPageId(page);
+			expect(result).toBe(page);
+		});
+		test('should return the input as is when input is an empty string', () => {
+			const page = '';
+			const result = extractPageId(page);
+			expect(result).toBe(page);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -35,35 +35,38 @@ describe('Test NotionV2, formatBlocks', () => {
 describe('Test Notion', () => {
 	describe('extractPageId', () => {
 		const baseUrl = 'https://www.notion.so/fake-instance';
+		const testId = '4eb10d5001254b7faaa831d72d9445aa';
+		const extractPattern =
+			'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})';
+
+		// RLC does some Regex extraction before extractPageId is called
+		const extractIdFromUrl = (url: string): string => {
+			const match = url.match(extractPattern);
+			return match ? match[1] : url;
+		};
+
 		test('should return the part after "p="', () => {
-			const page = `${baseUrl}?p=4eb10d5001254b7faaa831d72d9445aa`;
-			const result = extractPageId(page);
-			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+			const page = `${baseUrl}?p=${testId}`;
+			const result = extractPageId(extractIdFromUrl(page));
+			expect(result).toBe(testId);
 		});
+
 		test('should return the last part after splitting by "-" when URL contains "-" and "https"', () => {
-			const page = `${baseUrl}/some-page-4eb10d5001254b7faaa831d72d9445aa`;
-			const result = extractPageId(page);
-			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+			const page = `${baseUrl}/some-page-${testId}`;
+			const result = extractPageId(extractIdFromUrl(page));
+			expect(result).toBe(testId);
 		});
-		test('should return the last part after splitting by "-" when URL contains "-" and "https" and ignore extra url param', () => {
-			const page = `${baseUrl}/some-page-4eb10d5001254b7faaa831d72d9445aa?pvs=4`;
-			const result = extractPageId(page);
-			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
+
+		test('should return the last part after splitting by "-" when URL contains "-"', () => {
+			const page = `${baseUrl}/1-${testId}`;
+			const result = extractPageId(extractIdFromUrl(page));
+			expect(result).toBe(testId);
 		});
+
 		test('should return just the ID', () => {
-			const page = `${baseUrl}/4eb10d5001254b7faaa831d72d9445aa`;
-			const result = extractPageId(page);
-			expect(result).toBe('4eb10d5001254b7faaa831d72d9445aa');
-		});
-		test('should return the input as is when no conditions are met', () => {
-			const page = `${baseUrl}/some-page`;
-			const result = extractPageId(page);
-			expect(result).toBe(page);
-		});
-		test('should return the input as is when input is an empty string', () => {
-			const page = '';
-			const result = extractPageId(page);
-			expect(result).toBe(page);
+			const page = `${baseUrl}/${testId}`;
+			const result = extractPageId(extractIdFromUrl(page));
+			expect(result).toBe(testId);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -73,9 +73,17 @@ describe('Test Notion', () => {
 			}
 		});
 
-		test('should return just the ID', () => {
+		test('should return just the id when there is an instance name', () => {
 			for (const testId of testIds) {
 				const page = `${baseUrl}/${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
+		});
+
+		test('should return the id when there is no instance name', () => {
+			for (const testId of testIds) {
+				const page = `https://www.notion.so/${testId}`;
 				const result = extractPageId(extractIdFromUrl(page));
 				expect(result).toBe(testId);
 			}

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -33,12 +33,16 @@ describe('Test NotionV2, formatBlocks', () => {
 });
 
 describe('Test Notion', () => {
-	describe('extractPageId', () => {
-		const baseUrl = 'https://www.notion.so/fake-instance';
-		const testId = '4eb10d5001254b7faaa831d72d9445aa';
+	const baseUrl = 'https://www.notion.so/fake-instance';
+	const testIds = [
+		'4eb10d5001254b7faaa831d72d9445aa', // Taken from Notion
+		'fffb95d3060b80309027eb9c99605ec3', // Taken from user comment
+		'a6356387779d4df485449a72a408f0d4', // Random v4 UUID
+		'f4c1217e48f711ef94540242ac120002', // Random v1 UUID
+	];
+	describe('extractPageId From URL', () => {
 		const extractPattern =
-			'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12})';
-
+			'(?:https|http)://www.notion.so/(?:[a-z0-9-]{2,}/)?(?:[a-zA-Z0-9-]{1,}-)?([0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12})';
 		// RLC does some Regex extraction before extractPageId is called
 		const extractIdFromUrl = (url: string): string => {
 			const match = url.match(extractPattern);
@@ -46,27 +50,35 @@ describe('Test Notion', () => {
 		};
 
 		test('should return the part after "p="', () => {
-			const page = `${baseUrl}?p=${testId}`;
-			const result = extractPageId(extractIdFromUrl(page));
-			expect(result).toBe(testId);
+			for (const testId of testIds) {
+				const page = `${baseUrl}?p=${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
 		});
 
-		test('should return the last part after splitting by "-" when URL contains "-" and "https"', () => {
-			const page = `${baseUrl}/some-page-${testId}`;
-			const result = extractPageId(extractIdFromUrl(page));
-			expect(result).toBe(testId);
+		test('should return the last part after splitting by "-" when URL contains multiple "-"', () => {
+			for (const testId of testIds) {
+				const page = `${baseUrl}/some-page-${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
 		});
 
-		test('should return the last part after splitting by "-" when URL contains "-"', () => {
-			const page = `${baseUrl}/1-${testId}`;
-			const result = extractPageId(extractIdFromUrl(page));
-			expect(result).toBe(testId);
+		test('should return the last part after splitting by "-" when URL contains one "-"', () => {
+			for (const testId of testIds) {
+				const page = `${baseUrl}/1-${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
 		});
 
 		test('should return just the ID', () => {
-			const page = `${baseUrl}/${testId}`;
-			const result = extractPageId(extractIdFromUrl(page));
-			expect(result).toBe(testId);
+			for (const testId of testIds) {
+				const page = `${baseUrl}/${testId}`;
+				const result = extractPageId(extractIdFromUrl(page));
+				expect(result).toBe(testId);
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixes an issue with the RLC regex that was incorrectly flagging `https://www.notion.so/fake-instance/x-ID` as invalid. Also added test for `extractPageId` that uses the regex pattern first.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/notion-update-by-url-not-working-for-guest-added-pages/50095
