### PR TITLE
fix(core): Redact `csrfSecret` when returning oauth credentials to the frontend

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -407,7 +407,7 @@ export class CredentialsService {
 
 		for (const dataKey of Object.keys(copiedData)) {
 			// The frontend only cares that this value isn't falsy.
-			if (dataKey === 'oauthTokenData') {
+			if (dataKey === 'oauthTokenData' || dataKey === 'csrfSecret') {
 				if (copiedData[dataKey].toString().length > 0) {
 					copiedData[dataKey] = CREDENTIAL_BLANKING_VALUE;
 				} else {


### PR DESCRIPTION
## Summary
We store the temporary CSRF state in the DB during an auth flow. During this time, if the frontend requests that particular credential, we are returning the decrypted `csrfSecret` in the response when `includeData` is set to `true`.
Ideally we should only be returning the credentials fields that are actually editable in the UI, and removing the rest. But, that is a much bigger change, and I'd like to patch this potential security concern right away. 


## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included