### PR TITLE
fix(OpenAI Chat Model Node): Respect baseURL override for /models

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -56,6 +56,18 @@ export class LmChatOpenAi implements INodeType {
 			getConnectionHintNoticeField([NodeConnectionType.AiChain, NodeConnectionType.AiAgent]),
 			{
 				displayName:
+					'When using non OpenAI models, not all models might be chat-compatible or support other features, like tools calling or JSON response format.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					hide: {
+						'/options.baseURL': [{ _cnd: { eq: undefined } }],
+					},
+				},
+			},
+			{
+				displayName:
 					'If using JSON response format, you must include word "json" in the prompt in your chain or agent. Also, make sure to select latest models released post November 2023.',
 				name: 'notice',
 				type: 'notice',
@@ -90,7 +102,11 @@ export class LmChatOpenAi implements INodeType {
 									{
 										type: 'filter',
 										properties: {
-											pass: "={{ $responseItem.id.startsWith('gpt-') && !$responseItem.id.includes('instruct') }}",
+											// If the baseURL is not set or is set to api.openai.com, include only chat models
+											pass: `={{
+												($parameter.options?.baseURL && !$parameter.options?.baseURL?.includes('api.openai.com')) ||
+												($responseItem.id.startsWith('gpt-') && !$responseItem.id.includes('instruct'))
+											}}`,
 										},
 									},
 									{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -56,18 +56,6 @@ export class LmChatOpenAi implements INodeType {
 			getConnectionHintNoticeField([NodeConnectionType.AiChain, NodeConnectionType.AiAgent]),
 			{
 				displayName:
-					'When using non OpenAI models, not all models might be chat-compatible or support other features, like tools calling or JSON response format.',
-				name: 'notice',
-				type: 'notice',
-				default: '',
-				displayOptions: {
-					hide: {
-						'/options.baseURL': [{ _cnd: { eq: undefined } }],
-					},
-				},
-			},
-			{
-				displayName:
 					'If using JSON response format, you must include word "json" in the prompt in your chain or agent. Also, make sure to select latest models released post November 2023.',
 				name: 'notice',
 				type: 'notice',
@@ -134,6 +122,18 @@ export class LmChatOpenAi implements INodeType {
 					},
 				},
 				default: 'gpt-3.5-turbo',
+			},
+			{
+				displayName:
+					'When using non-OpenAI models via "Base URL" override, not all models might be chat-compatible or support other features, like tools calling or JSON response format',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'/options.baseURL': [{ _cnd: { exists: true } }],
+					},
+				},
 			},
 			{
 				displayName: 'Options',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
@@ -198,7 +198,7 @@ export class LmOpenAi implements INodeType {
 				})) as { data: Array<{ owned_by: string; id: string }> };
 
 				for (const model of data) {
-					if (!model.owned_by?.startsWith('system')) continue;
+					if (!options.baseURL && !model.owned_by?.startsWith('system')) continue;
 					results.push({
 						name: model.id,
 						value: model.id,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
@@ -98,6 +98,18 @@ export class LmOpenAi implements INodeType {
 				},
 			},
 			{
+				displayName:
+					'When using non OpenAI models via Base URL override, not all models might be chat-compatible or support other features, like tools calling or JSON response format.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'/options.baseURL': [{ _cnd: { exists: true } }],
+					},
+				},
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				placeholder: 'Add Option',

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1284,7 +1284,8 @@ export type DisplayCondition =
 	| { _cnd: { startsWith: string } }
 	| { _cnd: { endsWith: string } }
 	| { _cnd: { includes: string } }
-	| { _cnd: { regex: string } };
+	| { _cnd: { regex: string } }
+	| { _cnd: { exists: true } };
 
 export interface IDisplayOptions {
 	hide?: {

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -359,7 +359,7 @@ const declarativeNodeOptionParameters: INodeProperties = {
 export function isSubNodeType(
 	typeDescription: Pick<INodeTypeDescription, 'outputs'> | null,
 ): boolean {
-	if (!typeDescription || !typeDescription.outputs || typeof typeDescription.outputs === 'string') {
+	if (!typeDescription?.outputs || typeof typeDescription.outputs === 'string') {
 		return false;
 	}
 	const outputTypes = getConnectionTypes(typeDescription.outputs);
@@ -488,9 +488,13 @@ const checkConditions = (
 
 			return actualValues.every((propertyValue) => {
 				if (key === 'eq') {
+					if (targetValue === null) return isEqual(propertyValue, undefined);
+
 					return isEqual(propertyValue, targetValue);
 				}
 				if (key === 'not') {
+					if (targetValue === null) return !isEqual(propertyValue, undefined);
+
 					return !isEqual(propertyValue, targetValue);
 				}
 				if (key === 'gte') {

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -488,13 +488,9 @@ const checkConditions = (
 
 			return actualValues.every((propertyValue) => {
 				if (key === 'eq') {
-					if (targetValue === null) return isEqual(propertyValue, undefined);
-
 					return isEqual(propertyValue, targetValue);
 				}
 				if (key === 'not') {
-					if (targetValue === null) return !isEqual(propertyValue, undefined);
-
 					return !isEqual(propertyValue, targetValue);
 				}
 				if (key === 'gte') {
@@ -524,6 +520,9 @@ const checkConditions = (
 				}
 				if (key === 'regex') {
 					return new RegExp(targetValue as string).test(propertyValue as string);
+				}
+				if (key === 'exists') {
+					return propertyValue !== null && propertyValue !== undefined && propertyValue !== '';
 				}
 				return false;
 			});

--- a/packages/workflow/test/NodeHelpers.conditions.test.ts
+++ b/packages/workflow/test/NodeHelpers.conditions.test.ts
@@ -1887,6 +1887,274 @@ describe('NodeHelpers', () => {
 					},
 				},
 			},
+			{
+				description:
+					'simple values with displayOptions "show" using exists condition. No values set.',
+				input: {
+					nodePropertiesArray: [
+						{
+							name: 'field1',
+							displayName: 'Field 1',
+							type: 'string',
+							default: '',
+						},
+						{
+							name: 'field2',
+							displayName: 'Field 2',
+							displayOptions: {
+								show: {
+									field1: [{ _cnd: { exists: true } }],
+								},
+							},
+							type: 'string',
+							default: 'default field2',
+						},
+					],
+					nodeValues: {},
+				},
+				output: {
+					noneDisplayedFalse: {
+						defaultsFalse: {},
+						defaultsTrue: {
+							field1: '',
+						},
+					},
+					noneDisplayedTrue: {
+						defaultsFalse: {},
+						defaultsTrue: {
+							field1: '',
+							field2: 'default field2',
+						},
+					},
+				},
+			},
+			{
+				description:
+					'simple values with displayOptions "show" using exists condition. Field1 has a value.',
+				input: {
+					nodePropertiesArray: [
+						{
+							name: 'field1',
+							displayName: 'Field 1',
+							type: 'string',
+							default: '',
+						},
+						{
+							name: 'field2',
+							displayName: 'Field 2',
+							displayOptions: {
+								show: {
+									field1: [{ _cnd: { exists: true } }],
+								},
+							},
+							type: 'string',
+							default: 'default field2',
+						},
+					],
+					nodeValues: {
+						field1: 'some value',
+					},
+				},
+				output: {
+					noneDisplayedFalse: {
+						defaultsFalse: {
+							field1: 'some value',
+						},
+						defaultsTrue: {
+							field1: 'some value',
+							field2: 'default field2',
+						},
+					},
+					noneDisplayedTrue: {
+						defaultsFalse: {
+							field1: 'some value',
+						},
+						defaultsTrue: {
+							field1: 'some value',
+							field2: 'default field2',
+						},
+					},
+				},
+			},
+			{
+				description:
+					'complex type "fixedCollection" with "multipleValues: false" and with displayOptions "show" using exists condition.',
+				input: {
+					nodePropertiesArray: [
+						{
+							name: 'values',
+							displayName: 'Values',
+							type: 'fixedCollection',
+							default: {},
+							options: [
+								{
+									name: 'data',
+									displayName: 'Data',
+									values: [
+										{
+											name: 'field1',
+											displayName: 'Field 1',
+											type: 'string',
+											default: '',
+										},
+										{
+											name: 'field2',
+											displayName: 'Field 2',
+											type: 'string',
+											displayOptions: {
+												show: {
+													field1: [{ _cnd: { exists: true } }],
+												},
+											},
+											default: 'default field2',
+										},
+									],
+								},
+							],
+						},
+					],
+					nodeValues: {
+						values: {
+							data: {
+								field1: 'some value',
+							},
+						},
+					},
+				},
+				output: {
+					noneDisplayedFalse: {
+						defaultsFalse: {
+							values: {
+								data: {
+									field1: 'some value',
+								},
+							},
+						},
+						defaultsTrue: {
+							values: {
+								data: {
+									field1: 'some value',
+									field2: 'default field2',
+								},
+							},
+						},
+					},
+					noneDisplayedTrue: {
+						defaultsFalse: {
+							values: {
+								data: {
+									field1: 'some value',
+								},
+							},
+						},
+						defaultsTrue: {
+							values: {
+								data: {
+									field1: 'some value',
+									field2: 'default field2',
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				description:
+					'complex type "collection" with "multipleValues: true" and with displayOptions "show" using exists condition.',
+				input: {
+					nodePropertiesArray: [
+						{
+							name: 'values',
+							displayName: 'Values',
+							type: 'collection',
+							typeOptions: {
+								multipleValues: true,
+							},
+							default: {},
+							options: [
+								{
+									name: 'field1',
+									displayName: 'Field 1',
+									type: 'string',
+									default: '',
+								},
+								{
+									name: 'field2',
+									displayName: 'Field 2',
+									type: 'string',
+									displayOptions: {
+										show: {
+											field1: [{ _cnd: { exists: true } }],
+										},
+									},
+									default: 'default field2',
+								},
+							],
+						},
+					],
+					nodeValues: {
+						values: [
+							{
+								field1: 'value1',
+							},
+							{
+								field1: '',
+							},
+							{},
+						],
+					},
+				},
+				output: {
+					noneDisplayedFalse: {
+						defaultsFalse: {
+							values: [
+								{
+									field1: 'value1',
+								},
+								{
+									field1: '',
+								},
+								{},
+							],
+						},
+						defaultsTrue: {
+							values: [
+								{
+									field1: 'value1',
+								},
+								{
+									field1: '',
+								},
+								{},
+							],
+						},
+					},
+					noneDisplayedTrue: {
+						defaultsFalse: {
+							values: [
+								{
+									field1: 'value1',
+								},
+								{
+									field1: '',
+								},
+								{},
+							],
+						},
+						defaultsTrue: {
+							values: [
+								{
+									field1: 'value1',
+								},
+								{
+									field1: '',
+								},
+								{},
+							],
+						},
+					},
+				},
+			},
 		];
 
 		for (const testData of tests) {


### PR DESCRIPTION
## Summary

- When using `options.baseURL` override, skip the `model` parameter filtering and render the fetched models(if any)
- If `options.baseURL` is set, notify the user that not all features might be supported. For this I had to implement a new condition type: 'exists' to check if the value is set

https://github.com/user-attachments/assets/fef6e074-a0e2-49c0-a68f-c0e5eb3dc9ec


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
