### PR TITLE
refactor(core): Suppress `MaxListenersExceededWarning` in the logs

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -320,11 +320,9 @@ export class Worker extends BaseCommand {
 
 		const envConcurrency = config.getEnv('executions.concurrency.productionLimit');
 		const concurrency = envConcurrency !== -1 ? envConcurrency : flags.concurrency;
+		Worker.jobQueue.setConcurrency(concurrency);
 
-		void Worker.jobQueue.process(
-			concurrency,
-			async (job) => await this.runJob(job, this.nodeTypes),
-		);
+		void Worker.jobQueue.process(async (job) => await this.runJob(job, this.nodeTypes));
 
 		Worker.jobQueue.getBullObjectInstance().on('global:progress', (jobId: JobId, progress) => {
 			// Progress of a job got updated which does get used


### PR DESCRIPTION
## Summary
Our current Bull setup has quite a few event listeners on the queue object. The number of events is also directly dependent on the concurrency value. The total number of listeners is `8 + concurrency * 2`. So, most of out queue mode users see their logs often flooding with `MaxListenersExceededWarning`. This warning doesn't really have much relevance for us, but the noise this creates in the logs is enough to create a github issue or a community post every now and then.
This PR aims to suppress this warning, to make the logs less noisy, and to reduce the number of posts we get about this.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/maxlistenersexceededwarning/49680
https://community.n8n.io/t/maxlistenersexceededwarning-in-queue-mode/33808
https://community.n8n.io/t/maxlistenersexceededwarning-message-on-n8n-queue-mode/25462


## Review / Merge checklist

- [x] PR title and summary are descriptive