### PR TITLE
refactor(core): Decouple projects telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -16,7 +16,7 @@ import { InstanceSettings } from 'n8n-core';
 import config from '@/config';
 import { N8N_VERSION } from '@/constants';
 import type { AuthProviderType } from '@db/entities/AuthIdentity';
-import type { GlobalRole, User } from '@db/entities/User';
+import type { User } from '@db/entities/User';
 import { SharedWorkflowRepository } from '@db/repositories/sharedWorkflow.repository';
 import { WorkflowRepository } from '@db/repositories/workflow.repository';
 import { determineFinalExecutionStatus } from '@/executionLifecycleHooks/shared/sharedHookFunctions';
@@ -30,7 +30,6 @@ import { EventsService } from '@/services/events.service';
 import { NodeTypes } from '@/NodeTypes';
 import { Telemetry } from '@/telemetry';
 import type { Project } from '@db/entities/Project';
-import type { ProjectRole } from '@db/entities/ProjectRelation';
 import { ProjectRelationRepository } from './databases/repositories/projectRelation.repository';
 import { SharedCredentialsRepository } from './databases/repositories/sharedCredentials.repository';
 import { MessageEventBus } from './eventbus/MessageEventBus/MessageEventBus';
@@ -833,32 +832,5 @@ export class InternalHooks {
 		error_message?: string | undefined;
 	}): Promise<void> {
 		return await this.telemetry.track('User updated external secrets settings', saveData);
-	}
-
-	async onTeamProjectCreated(data: { user_id: string; role: GlobalRole }) {
-		return await this.telemetry.track('User created project', data);
-	}
-
-	async onTeamProjectDeleted(data: {
-		user_id: string;
-		role: GlobalRole;
-		project_id: string;
-		removal_type: 'delete' | 'transfer';
-		target_project_id?: string;
-	}) {
-		return await this.telemetry.track('User deleted project', data);
-	}
-
-	async onTeamProjectUpdated(data: {
-		user_id: string;
-		role: GlobalRole;
-		project_id: string;
-		members: Array<{ user_id: string; role: ProjectRole }>;
-	}) {
-		return await this.telemetry.track('Project settings updated', data);
-	}
-
-	async onConcurrencyLimitHit({ threshold }: { threshold: number }) {
-		await this.telemetry.track('User hit concurrency limit', { threshold });
 	}
 }

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -112,7 +112,7 @@ export abstract class BaseCommand extends Command {
 
 		await Container.get(PostHogClient).init();
 		await Container.get(InternalHooks).init();
-		Container.get(TelemetryEventRelay).init();
+		await Container.get(TelemetryEventRelay).init();
 	}
 
 	protected setInstanceType(instanceType: N8nInstanceType) {

--- a/packages/cli/src/commands/BaseCommand.ts
+++ b/packages/cli/src/commands/BaseCommand.ts
@@ -23,6 +23,7 @@ import { initExpressionEvaluator } from '@/ExpressionEvaluator';
 import { generateHostInstanceId } from '@db/utils/generators';
 import { WorkflowHistoryManager } from '@/workflows/workflowHistory/workflowHistoryManager.ee';
 import { ShutdownService } from '@/shutdown/Shutdown.service';
+import { TelemetryEventRelay } from '@/telemetry/telemetry-event-relay.service';
 
 export abstract class BaseCommand extends Command {
 	protected logger = Container.get(Logger);
@@ -111,6 +112,7 @@ export abstract class BaseCommand extends Command {
 
 		await Container.get(PostHogClient).init();
 		await Container.get(InternalHooks).init();
+		Container.get(TelemetryEventRelay).init();
 	}
 
 	protected setInstanceType(instanceType: N8nInstanceType) {

--- a/packages/cli/src/controllers/project.controller.ts
+++ b/packages/cli/src/controllers/project.controller.ts
@@ -198,7 +198,7 @@ export class ProjectController {
 			this.eventRelay.emit('team-project-updated', {
 				userId: req.user.id,
 				role: req.user.role,
-				members: req.body.relations.map(({ userId, role }) => ({ userId, role })),
+				members: req.body.relations,
 				projectId: req.params.projectId,
 			});
 		}

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -1,5 +1,7 @@
 import type { AuthenticationMethod, IWorkflowBase } from 'n8n-workflow';
 import type { IWorkflowExecutionDataProcess } from '@/Interfaces';
+import type { ProjectRole } from '@/databases/entities/ProjectRelation';
+import type { GlobalRole } from '@/databases/entities/User';
 
 export type UserLike = {
 	id: string;
@@ -10,7 +12,7 @@ export type UserLike = {
 };
 
 /**
- * Events sent by services and consumed by relays, e.g. `AuditEventRelay`.
+ * Events sent by services and consumed by relays, e.g. `AuditEventRelay` and `TelemetryEventRelay`.
  */
 export type Event = {
 	'workflow-created': {
@@ -189,5 +191,27 @@ export type Event = {
 
 	'execution-started-during-bootup': {
 		executionId: string;
+		'team-project-updated': {
+			userId: string;
+			role: GlobalRole;
+			members: Array<{
+				userId: string;
+				role: ProjectRole;
+			}>;
+			projectId: string;
+		};
+
+		'team-project-deleted': {
+			userId: string;
+			role: GlobalRole;
+			projectId: string;
+			removalType: 'transfer' | 'delete';
+			targetProjectId?: string;
+		};
+
+		'team-project-created': {
+			userId: string;
+			role: GlobalRole;
+		};
 	};
 };

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -191,27 +191,28 @@ export type Event = {
 
 	'execution-started-during-bootup': {
 		executionId: string;
-		'team-project-updated': {
-			userId: string;
-			role: GlobalRole;
-			members: Array<{
-				userId: string;
-				role: ProjectRole;
-			}>;
-			projectId: string;
-		};
+	};
 
-		'team-project-deleted': {
+	'team-project-updated': {
+		userId: string;
+		role: GlobalRole;
+		members: Array<{
 			userId: string;
-			role: GlobalRole;
-			projectId: string;
-			removalType: 'transfer' | 'delete';
-			targetProjectId?: string;
-		};
+			role: ProjectRole;
+		}>;
+		projectId: string;
+	};
 
-		'team-project-created': {
-			userId: string;
-			role: GlobalRole;
-		};
+	'team-project-deleted': {
+		userId: string;
+		role: GlobalRole;
+		projectId: string;
+		removalType: 'transfer' | 'delete';
+		targetProjectId?: string;
+	};
+
+	'team-project-created': {
+		userId: string;
+		role: GlobalRole;
 	};
 };

--- a/packages/cli/src/telemetry/telemetry-event-relay.service.ts
+++ b/packages/cli/src/telemetry/telemetry-event-relay.service.ts
@@ -11,8 +11,10 @@ export class TelemetryEventRelay {
 		private readonly telemetry: Telemetry,
 	) {}
 
-	init() {
+	async init() {
 		if (!config.getEnv('diagnostics.enabled')) return;
+
+		await this.telemetry.init();
 
 		this.setupHandlers();
 	}

--- a/packages/cli/src/telemetry/telemetry-event-relay.service.ts
+++ b/packages/cli/src/telemetry/telemetry-event-relay.service.ts
@@ -1,0 +1,58 @@
+import { Service } from 'typedi';
+import { EventRelay } from '@/eventbus/event-relay.service';
+import type { Event } from '@/eventbus/event.types';
+import { Telemetry } from '.';
+import config from '@/config';
+
+@Service()
+export class TelemetryEventRelay {
+	constructor(
+		private readonly eventRelay: EventRelay,
+		private readonly telemetry: Telemetry,
+	) {}
+
+	init() {
+		if (!config.getEnv('diagnostics.enabled')) return;
+
+		this.setupHandlers();
+	}
+
+	private setupHandlers() {
+		this.eventRelay.on('team-project-updated', (event) => this.teamProjectUpdated(event));
+		this.eventRelay.on('team-project-deleted', (event) => this.teamProjectDeleted(event));
+		this.eventRelay.on('team-project-created', (event) => this.teamProjectCreated(event));
+	}
+
+	private teamProjectUpdated({ userId, role, members, projectId }: Event['team-project-updated']) {
+		void this.telemetry.track('Project settings updated', {
+			user_id: userId,
+			role,
+			// eslint-disable-next-line @typescript-eslint/no-shadow
+			members: members.map(({ userId: user_id, role }) => ({ user_id, role })),
+			project_id: projectId,
+		});
+	}
+
+	private teamProjectDeleted({
+		userId,
+		role,
+		projectId,
+		removalType,
+		targetProjectId,
+	}: Event['team-project-deleted']) {
+		void this.telemetry.track('User deleted project', {
+			user_id: userId,
+			role,
+			project_id: projectId,
+			removal_type: removalType,
+			target_project_id: targetProjectId,
+		});
+	}
+
+	private teamProjectCreated({ userId, role }: Event['team-project-created']) {
+		void this.telemetry.track('User created project', {
+			user_id: userId,
+			role,
+		});
+	}
+}

--- a/packages/cli/test/integration/shared/utils/testCommand.ts
+++ b/packages/cli/test/integration/shared/utils/testCommand.ts
@@ -4,6 +4,8 @@ import { mock } from 'jest-mock-extended';
 
 import type { BaseCommand } from '@/commands/BaseCommand';
 import * as testDb from '../testDb';
+import { TelemetryEventRelay } from '@/telemetry/telemetry-event-relay.service';
+import { mockInstance } from '@test/mocking';
 
 export const setupTestCommand = <T extends BaseCommand>(Command: Class<T>) => {
 	const config = mock<Config>();
@@ -19,6 +21,7 @@ export const setupTestCommand = <T extends BaseCommand>(Command: Class<T>) => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		mockInstance(TelemetryEventRelay);
 	});
 
 	afterAll(async () => {


### PR DESCRIPTION
`InternalHooks` takes multiple dependencies and is imported by multiple services only for telemetry. This overly couples telemetry to all services, creates dependency cycles, causes telemetry payloads to be computed even when telemetry is disabled, etc.

We should decouple telemetry from `InternalHooks` using `EventEmitter` and finally tear down `InternalHooks` altogether, as we [did recently](https://github.com/n8n-io/n8n/pull/9724) for `EventBus`. This PR starts this by setting up the telemetry relay and porting over projects telemetry.

Extracted from #9846