### PR TITLE
fix(HelpScout Node): Fix issue with thread types not working correctly

### DIFF
--- a/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
+++ b/packages/nodes-base/nodes/HelpScout/HelpScout.node.ts
@@ -459,6 +459,13 @@ export class HelpScout implements INodeType {
 						const text = this.getNodeParameter('text', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 						const attachments = this.getNodeParameter('attachmentsUi', i) as IDataObject;
+						let threadType = this.getNodeParameter('type', i) as string;
+
+						// We need to update the types to match the API - Avoids a breaking change
+						const singular = ['reply', 'customer'];
+						if (!singular.includes(threadType)) {
+							threadType = `${threadType}s`;
+						}
 						const body: IThread = {
 							text,
 							attachments: [],
@@ -527,7 +534,7 @@ export class HelpScout implements INodeType {
 						responseData = await helpscoutApiRequest.call(
 							this,
 							'POST',
-							`/v2/conversations/${conversationId}/chats`,
+							`/v2/conversations/${conversationId}/${threadType}`,
 							body,
 						);
 						responseData = { success: true };


### PR DESCRIPTION
## Summary
We were asking the user to select a `type` but not doing anything with it, Some of the types are also plural so to avoid a "breaking" change we work around that.

On a future overhaul we should name the options correctly.

API Docs: https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/reply/

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/10079
