### PR TITLE
fix(editor): Close node creator when clicking on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1026,6 +1026,7 @@ async function checkAndInitDebugMode() {
 function onClickPane(position: CanvasNode['position']) {
 	lastClickPosition.value = [position.x, position.y];
 	canvasStore.newNodeInsertPosition = [position.x, position.y];
+	uiStore.isCreateNodeActive = false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes node creator when clicking on canvas

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7502/node-creator-should-close-when-clicking-on-canvas

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
