### PR TITLE
fix(core): Metadata inserts using existing IDs and failing with postgres

### DIFF
--- a/packages/cli/src/databases/migrations/common/1720101653148-AddConstraintToExecutionMetadata.ts
+++ b/packages/cli/src/databases/migrations/common/1720101653148-AddConstraintToExecutionMetadata.ts
@@ -108,5 +108,15 @@ export class AddConstraintToExecutionMetadata1720101653148 implements Reversible
 		await context.runQuery(
 			`ALTER TABLE ${executionMetadataTableTemp} RENAME TO ${executionMetadataTable};`,
 		);
+
+		if (context.dbType === 'postgresdb') {
+			// Update sequence so that inserts continue with the next highest id.
+			const tableName = escape.tableName('execution_metadata');
+			const sequenceName = escape.tableName('execution_metadata_temp_id_seq1');
+
+			await context.runQuery(
+				`SELECT setval('${sequenceName}', (SELECT MAX(id) FROM ${tableName}));`,
+			);
+		}
 	}
 }

--- a/packages/cli/src/databases/migrations/postgresdb/1721377157740-FixExecutionMetadataSequence.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/1721377157740-FixExecutionMetadataSequence.ts
@@ -1,0 +1,12 @@
+import type { IrreversibleMigration, MigrationContext } from '@db/types';
+
+export class FixExecutionMetadataSequence1721377157740 implements IrreversibleMigration {
+	async up({ queryRunner, escape }: MigrationContext) {
+		const tableName = escape.tableName('execution_metadata');
+		const sequenceName = escape.tableName('execution_metadata_temp_id_seq');
+
+		await queryRunner.query(
+			`SELECT setval('${sequenceName}', (SELECT MAX(id) FROM ${tableName}));`,
+		);
+	}
+}

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -58,6 +58,7 @@ import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNo
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
+import { FixExecutionMetadataSequence1721377157740 } from './1721377157740-FixExecutionMetadataSequence';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -119,4 +120,5 @@ export const postgresMigrations: Migration[] = [
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
 	AddConstraintToExecutionMetadata1720101653148,
+	FixExecutionMetadataSequence1721377157740,
 ];


### PR DESCRIPTION

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

In https://github.com/n8n-io/n8n/pull/9953 I created a new table and migrated data over.

Creating a new table creates a new sequence for the auto-incrementing id. The sequence is set to 1.

Inserting rows into the table which already contain ids will skip getting an id from the sequence and also skip the increment.

Next time a row is inserted which does not have an id already, the sequence is called to get the latest id, which then may clash with a row in the db.

This PR:
1. Creates another migration for postgres only that updates the sequence counter for the id to be `MAX(id) from execution-metadata`
2. Updates the down migration in the old PR to do the same thing


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1738/execution-metadata-table-id-sequence-reset

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] ~Tests included.~<!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
