### PR TITLE
refactor(core): Expand Prometheus coverage to all routes

### DIFF
--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -106,7 +106,16 @@ describe('PrometheusMetricsService', () => {
 			});
 
 			expect(app.use).toHaveBeenCalledWith(
-				['/rest/', '/webhook/', '/webhook-waiting/', '/form-waiting/', '/webhook-test/', '/api/'],
+				[
+					'/rest/',
+					'/api/',
+					'/webhook/',
+					'/webhook-waiting/',
+					'/webhook-test/',
+					'/form/',
+					'/form-waiting/',
+					'/form-test/',
+				],
 				expect.any(Function),
 			);
 		});

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -47,7 +47,7 @@ export class PrometheusMetricsService {
 		this.initN8nVersionMetric();
 		this.initCacheMetrics();
 		this.initEventBusMetrics();
-		this.initApiMetrics(app);
+		this.initRouteMetrics(app);
 		this.mountMetricsEndpoint(app);
 	}
 
@@ -95,9 +95,9 @@ export class PrometheusMetricsService {
 	}
 
 	/**
-	 * Set up metrics for API endpoints with `express-prom-bundle`
+	 * Set up metrics for server routes with `express-prom-bundle`
 	 */
-	private initApiMetrics(app: express.Application) {
+	private initRouteMetrics(app: express.Application) {
 		if (!this.includes.metrics.api) return;
 
 		const metricsMiddleware = promBundle({
@@ -109,7 +109,16 @@ export class PrometheusMetricsService {
 		});
 
 		app.use(
-			['/rest/', '/webhook/', '/webhook-waiting/', '/form-waiting/', '/webhook-test/', '/api/'],
+			[
+				'/rest/',
+				'/api/',
+				'/webhook/',
+				'/webhook-waiting/',
+				'/webhook-test/',
+				'/form/',
+				'/form-waiting/',
+				'/form-test/',
+			],
 			metricsMiddleware,
 		);
 	}


### PR DESCRIPTION
We were missing `/form/` and `/form-test/`