### PR TITLE
feat(editor): Open NDV when a node is added to canvas v2 (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -10,7 +10,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useHistoryStore } from '@/stores/history.store';
 import { useNDVStore } from '@/stores/ndv.store';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import {
 	createTestNode,
 	createTestWorkflowObject,
@@ -166,6 +166,20 @@ describe('useCanvasOperations', () => {
 				type: 'type',
 			});
 			expect(result.credentials).toBeUndefined();
+		});
+
+		it('should open NDV when specified', async () => {
+			nodeTypesStore.setNodeTypes([mockNodeTypeDescription({ name: 'type' })]);
+
+			await canvasOperations.addNode(
+				{
+					type: 'type',
+					name: 'Test Name',
+				},
+				{ openNDV: true },
+			);
+
+			expect(ndvStore.activeNodeName).toBe('Test Name');
 		});
 	});
 

--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -10,7 +10,7 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useHistoryStore } from '@/stores/history.store';
 import { useNDVStore } from '@/stores/ndv.store';
-import { nextTick, ref } from 'vue';
+import { ref } from 'vue';
 import {
 	createTestNode,
 	createTestWorkflowObject,

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -76,7 +76,7 @@ import type {
 import { NodeConnectionType, NodeHelpers, TelemetryHelpers } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 import type { Ref } from 'vue';
-import { computed } from 'vue';
+import { computed, nextTick } from 'vue';
 import type { useRouter } from 'vue-router';
 
 type AddNodeData = Partial<INodeUi> & {
@@ -428,6 +428,12 @@ export function useCanvasOperations({
 
 		workflowsStore.setNodePristine(nodeData.name, true);
 		uiStore.stateIsDirty = true;
+
+		if (options.openNDV) {
+			void nextTick(() => {
+				ndvStore.setActiveNodeName(nodeData.name);
+			});
+		}
 
 		return nodeData;
 	}


### PR DESCRIPTION
## Summary

Open NDV when a node is added to canvas v2

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7503/ndv-should-open-when-creating-a-new-node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
