### PR TITLE
refactor: Silence `@n8n/nodes-langchain` lint warnings (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p tsconfig.build.json && pnpm n8n-copy-icons && pnpm build:metadata",
     "build:metadata": "pnpm n8n-generate-known && pnpm n8n-generate-ui-types",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials",
+    "lint": "eslint nodes credentials --quiet",
     "lintfix": "eslint nodes credentials --fix",
     "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\" --onSuccess \"pnpm n8n-generate-ui-types\"",
     "test": "jest",


### PR DESCRIPTION
To remove all this noise from `Unchanged files with check annotations` at bottom of every PR

e.g. https://github.com/n8n-io/n8n/pull/10113/files