### PR TITLE
ci: Pin node.js 22 to 22.4 (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -41,7 +41,7 @@ jobs:
     needs: install-and-build
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.4]
     with:
       ref: ${{ inputs.branch }}
       nodeVersion: ${{ matrix.node-version }}


### PR DESCRIPTION
Temporarily fix node.js 22 version until github CI gets the fix for https://github.com/nodejs/node/issues/53902

## Review / Merge checklist

- [x] PR title and summary are descriptive