### PR TITLE
refactor: Mark defaults.color as deprecated in node descriptions

### DIFF
--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1814,9 +1814,17 @@ export interface INodeOutputConfiguration {
 
 export type ExpressionString = `={{${string}}}`;
 
+export type NodeDefaults = Partial<{
+	/**
+	 * @deprecated Use {@link INodeTypeBaseDescription.iconColor|iconColor} instead. `iconColor` supports dark mode and uses preset colors from n8n's design system.
+	 */
+	color: string;
+	name: string;
+}>;
+
 export interface INodeTypeDescription extends INodeTypeBaseDescription {
 	version: number | number[];
-	defaults: INodeParameters;
+	defaults: NodeDefaults;
 	eventTriggerDescription?: string;
 	activationMessage?: string;
 	inputs: Array<ConnectionTypes | INodeInputConfiguration> | ExpressionString;


### PR DESCRIPTION
## Summary

<img width="840" alt="image" src="https://github.com/user-attachments/assets/6fd98add-cfe6-4f94-96b8-b53fa187ccdd">


<img width="1220" alt="image" src="https://github.com/user-attachments/assets/c912e84c-fb44-4ff9-bc41-571be6a0b46b">


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
