### PR TITLE
refactor(Text Classifier Node): Mark the text classifier node as black

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -34,6 +34,7 @@ export class TextClassifier implements INodeType {
 		displayName: 'Text Classifier',
 		name: 'textClassifier',
 		icon: 'fa:tags',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Classify your text into distinct categories',


### PR DESCRIPTION

## Summary

<img width="375" alt="image" src="https://github.com/user-attachments/assets/460fa7e2-effe-4919-84d9-ebfe0dfb4c60">
<img width="350" alt="image" src="https://github.com/user-attachments/assets/966fd810-f3f8-437a-ac41-786dc191bba0">

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
