### PR TITLE
fix(core): Respect prefix for all Prometheus metrics

### DIFF
--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+## 1.52.0
+
+### What changed?
+
+Prometheus metrics enabled via `N8N_METRICS_INCLUDE_DEFAULT_METRICS` and `N8N_METRICS_INCLUDE_API_ENDPOINTS` were fixed to include the default `n8n_` prefix.
+
+### When is action necessary?
+
+If you are using Prometheus metrics from these categories and are using a non-empty prefix, please update those metrics to match their new prefixed names.
+
 ## 1.47.0
 
 ### What changed?

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -86,7 +86,7 @@ describe('PrometheusMetricsService', () => {
 			expect(service.counters.cacheUpdatesTotal?.inc).toHaveBeenCalledWith(0);
 		});
 
-		it('should set up API metrics with `express-prom-bundle`', async () => {
+		it('should set up route metrics with `express-prom-bundle`', async () => {
 			config.set('endpoints.metrics.includeApiEndpoints', true);
 			config.set('endpoints.metrics.includeApiPathLabel', true);
 			config.set('endpoints.metrics.includeApiMethodLabel', true);

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -10,8 +10,7 @@ import { CacheService } from '@/services/cache/cache.service';
 import { MessageEventBus } from '@/eventbus/MessageEventBus/MessageEventBus';
 import { EventMessageTypeNames } from 'n8n-workflow';
 import type { EventMessageTypes } from '@/eventbus';
-
-type MetricCategory = 'default' | 'routes' | 'cache' | 'logs';
+import type { Includes, MetricCategory, MetricLabel } from './types';
 
 @Service()
 export class PrometheusMetricsService {
@@ -24,7 +23,7 @@ export class PrometheusMetricsService {
 
 	private readonly prefix = config.getEnv('endpoints.metrics.prefix');
 
-	private readonly includes = {
+	private readonly includes: Includes = {
 		metrics: {
 			default: config.getEnv('endpoints.metrics.includeDefaultMetrics'),
 			routes: config.getEnv('endpoints.metrics.includeApiEndpoints'),
@@ -65,18 +64,14 @@ export class PrometheusMetricsService {
 		}
 	}
 
-	enableLabels(labels: string[]) {
-		for (const label of labels as Array<
-			keyof (typeof PrometheusMetricsService)['prototype']['includes']['labels']
-		>) {
+	enableLabels(labels: MetricLabel[]) {
+		for (const label of labels) {
 			this.includes.labels[label] = true;
 		}
 	}
 
 	disableAllLabels() {
-		for (const label of Object.keys(this.includes.labels) as Array<
-			keyof (typeof PrometheusMetricsService)['prototype']['includes']['labels']
-		>) {
+		for (const label of Object.keys(this.includes.labels) as MetricLabel[]) {
 			this.includes.labels[label] = false;
 		}
 	}

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -59,8 +59,8 @@ export class PrometheusMetricsService {
 	}
 
 	disableAllMetrics() {
-		for (const metric of Object.keys(this.includes.metrics) as MetricCategory[]) {
-			this.includes.metrics[metric] = false;
+		for (const metric in this.includes.metrics) {
+			this.includes.metrics[metric as MetricCategory] = false;
 		}
 	}
 
@@ -71,8 +71,8 @@ export class PrometheusMetricsService {
 	}
 
 	disableAllLabels() {
-		for (const label of Object.keys(this.includes.labels) as MetricLabel[]) {
-			this.includes.labels[label] = false;
+		for (const label in this.includes.labels) {
+			this.includes.labels[label as MetricLabel] = false;
 		}
 	}
 

--- a/packages/cli/src/metrics/types.ts
+++ b/packages/cli/src/metrics/types.ts
@@ -1,0 +1,14 @@
+export type MetricCategory = 'default' | 'routes' | 'cache' | 'logs';
+
+export type MetricLabel =
+	| 'credentialsType'
+	| 'nodeType'
+	| 'workflowId'
+	| 'apiPath'
+	| 'apiMethod'
+	| 'apiStatusCode';
+
+export type Includes = {
+	metrics: Record<MetricCategory, boolean>;
+	labels: Record<MetricLabel, boolean>;
+};

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -26,6 +26,7 @@ describe('Metrics', () => {
 
 	beforeEach(() => {
 		prometheusService.disableAllMetrics();
+		prometheusService.disableAllLabels();
 	});
 
 	it('should return n8n version', async () => {
@@ -73,7 +74,9 @@ describe('Metrics', () => {
 		 */
 		expect(response.status).toEqual(200);
 		expect(response.type).toEqual('text/plain');
-		expect(toLines(response)).toContain('nodejs_heap_space_size_total_bytes{space="read_only"} 0');
+		expect(toLines(response)).toContain(
+			'n8n_test_nodejs_heap_space_size_total_bytes{space="read_only"} 0',
+		);
 	});
 
 	it('should not return default metrics if disabled', async () => {
@@ -145,5 +148,62 @@ describe('Metrics', () => {
 		expect(lines).not.toContain('n8n_test_cache_hits_total 0');
 		expect(lines).not.toContain('n8n_test_cache_misses_total 0');
 		expect(lines).not.toContain('n8n_test_cache_updates_total 0');
+	});
+
+	it('should return route metrics if enabled', async () => {
+		/**
+		 * Arrange
+		 */
+		prometheusService.enableMetric('routes');
+		await prometheusService.init(server.app);
+		await agent.get('/api/v1/workflows');
+
+		/**
+		 * Act
+		 */
+		const response = await agent.get('/metrics');
+
+		/**
+		 * Assert
+		 */
+		expect(response.status).toEqual(200);
+		expect(response.type).toEqual('text/plain');
+
+		const lines = toLines(response);
+
+		expect(lines).toContain('n8n_test_http_request_duration_seconds_count 1');
+		expect(lines).toContainEqual(
+			expect.stringContaining('n8n_test_http_request_duration_seconds_sum'),
+		);
+		expect(lines).toContainEqual(
+			expect.stringContaining('n8n_test_http_request_duration_seconds_bucket'),
+		);
+	});
+
+	it('should return labels in route metrics', async () => {
+		/**
+		 * ARrange
+		 */
+		prometheusService.enableMetric('routes');
+		prometheusService.enableLabels(['apiMethod', 'apiPath', 'apiStatusCode']);
+		await prometheusService.init(server.app);
+		await agent.get('/webhook-test/some-uuid');
+
+		/**
+		 * Act
+		 */
+		const response = await agent.get('/metrics');
+
+		/**
+		 * Assert
+		 */
+		expect(response.status).toEqual(200);
+		expect(response.type).toEqual('text/plain');
+
+		const lines = toLines(response);
+
+		expect(lines).toContainEqual(expect.stringContaining('method="GET"'));
+		expect(lines).toContainEqual(expect.stringContaining('path="/webhook-test/some-uuid"'));
+		expect(lines).toContainEqual(expect.stringContaining('status_code="404"'));
 	});
 });

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -76,9 +76,10 @@ describe('Metrics', () => {
 		 */
 		expect(response.status).toEqual(200);
 		expect(response.type).toEqual('text/plain');
-		expect(toLines(response)).toContain(
-			'n8n_test_nodejs_heap_space_size_total_bytes{space="read_only"} 0',
-		);
+
+		const lines = toLines(response);
+
+		expect(lines).toContain('n8n_test_nodejs_heap_space_size_total_bytes{space="read_only"} 0');
 	});
 
 	it('should not return default metrics if disabled', async () => {

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -52,7 +52,9 @@ describe('Metrics', () => {
 
 		const { version, major, minor, patch } = n8nVersion;
 
-		expect(toLines(response)).toContain(
+		const lines = toLines(response);
+
+		expect(lines).toContain(
 			`n8n_test_version_info{version="v${version}",major="${major}",minor="${minor}",patch="${patch}"} 1`,
 		);
 	});
@@ -180,7 +182,7 @@ describe('Metrics', () => {
 		);
 	});
 
-	it('should return labels in route metrics', async () => {
+	it('should return labels in route metrics if enabled', async () => {
 		/**
 		 * ARrange
 		 */


### PR DESCRIPTION
Prometheus metrics from `express-prom-bundle` and `prom-client` were not respecting `N8N_METRICS_PREFIX`