### PR TITLE
ci: Remove flaky e2e tests from past 30 days (no-changelog)

### DIFF
--- a/cypress/e2e/10-undo-redo.cy.ts
+++ b/cypress/e2e/10-undo-redo.cy.ts
@@ -20,24 +20,6 @@ describe('Undo/Redo', () => {
 		WorkflowPage.actions.visit();
 	});
 
-	it('should undo/redo adding nodes', () => {
-		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
-		WorkflowPage.actions.hitUndo();
-		WorkflowPage.getters.canvasNodes().should('have.have.length', 0);
-		WorkflowPage.actions.hitRedo();
-		WorkflowPage.getters.canvasNodes().should('have.have.length', 1);
-	});
-
-	it('should undo/redo adding connected nodes', () => {
-		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
-		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
-		WorkflowPage.actions.hitUndo();
-		WorkflowPage.getters.canvasNodes().should('have.have.length', 1);
-		WorkflowPage.actions.hitRedo();
-		WorkflowPage.getters.canvasNodes().should('have.have.length', 2);
-		WorkflowPage.getters.nodeConnections().should('have.length', 1);
-	});
-
 	it('should undo/redo adding node in the middle', () => {
 		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
 		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
@@ -222,21 +204,6 @@ describe('Undo/Redo', () => {
 		WorkflowPage.getters.disabledNodes().should('have.length', 0);
 		WorkflowPage.actions.hitRedo();
 		WorkflowPage.getters.disabledNodes().should('have.length', 2);
-	});
-
-	it('should undo/redo renaming node using NDV', () => {
-		WorkflowPage.actions.addNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
-		WorkflowPage.actions.addNodeToCanvas(CODE_NODE_NAME);
-		WorkflowPage.getters.canvasNodes().last().click();
-		cy.get('body').type('{enter}');
-		ndv.actions.rename(CODE_NODE_NEW_NAME);
-		cy.get('body').type('{esc}');
-		WorkflowPage.actions.hitUndo();
-		cy.get('body').type('{esc}');
-		WorkflowPage.getters.canvasNodeByName(CODE_NODE_NAME).should('exist');
-		WorkflowPage.actions.hitRedo();
-		cy.get('body').type('{esc}');
-		WorkflowPage.getters.canvasNodeByName(CODE_NODE_NEW_NAME).should('exist');
 	});
 
 	it('should undo/redo renaming node using keyboard shortcut', () => {

--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -238,37 +238,6 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 		getVisibleSelect().find('li').should('have.length', 2);
 	});
 
-	it('should only show credentials in their personal project for members', () => {
-		cy.enableFeature('sharing');
-		cy.reload();
-
-		// Create a notion credential as the owner
-		credentialsPage.getters.emptyListCreateCredentialButton().click();
-		credentialsModal.actions.createNewCredential('Notion API');
-
-		// Create another notion credential as the owner, but share it with member
-		// 0
-		credentialsPage.getters.createCredentialButton().click();
-		credentialsModal.actions.createNewCredential('Notion API', false);
-		credentialsModal.actions.changeTab('Sharing');
-		credentialsModal.actions.addUser(INSTANCE_MEMBERS[0].email);
-		credentialsModal.actions.saveSharing();
-
-		// As the member, create a new notion credential and a workflow
-		cy.signinAsMember();
-		cy.visit(credentialsPage.url);
-		credentialsPage.getters.createCredentialButton().click();
-		credentialsModal.actions.createNewCredential('Notion API');
-		cy.visit(workflowsPage.url);
-		workflowsPage.actions.createWorkflowFromCard();
-		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
-
-		// Only the own credential the shared one (+ the 'Create new' option)
-		// should be in the dropdown
-		workflowPage.getters.nodeCredentialsSelect().click();
-		getVisibleSelect().find('li').should('have.length', 3);
-	});
-
 	it('should only show credentials in their personal project for members if the workflow was shared with them', () => {
 		const workflowName = 'Test workflow';
 		cy.enableFeature('sharing');

--- a/cypress/e2e/17-workflow-tags.cy.ts
+++ b/cypress/e2e/17-workflow-tags.cy.ts
@@ -51,28 +51,6 @@ describe('Workflow tags', () => {
 		wf.getters.tagPills().should('have.length', 0); // none attached
 	});
 
-	it('should update a tag via modal', () => {
-		wf.actions.openTagManagerModal();
-
-		const [first] = TEST_TAGS;
-
-		cy.contains('Create a tag').click();
-		cy.getByTestId('tags-table').find('input').type(first).type('{enter}');
-		cy.getByTestId('tags-table').should('contain.text', first);
-		cy.getByTestId('edit-tag-button').eq(-1).click({ force: true });
-		cy.wait(300);
-		cy.getByTestId('tags-table')
-			.find('.el-input--large')
-			.should('be.visible')
-			.type(' Updated')
-			.type('{enter}');
-		cy.contains('Done').click();
-		wf.getters.createTagButton().click();
-		wf.getters.tagsInDropdown().should('have.length', 1); // one stored
-		wf.getters.tagsInDropdown().contains('Updated').should('exist');
-		wf.getters.tagPills().should('have.length', 0); // none attached
-	});
-
 	it('should detach a tag inline by clicking on X on tag pill', () => {
 		wf.getters.createTagButton().click();
 		wf.actions.addTags(TEST_TAGS);

--- a/cypress/e2e/20-workflow-executions.cy.ts
+++ b/cypress/e2e/20-workflow-executions.cy.ts
@@ -98,45 +98,6 @@ describe('Current Workflow Executions', () => {
 			.should('be.visible');
 	});
 
-	it('should auto load more items if there is space and auto scroll', () => {
-		cy.viewport(1280, 960);
-		executionsTab.actions.createManualExecutions(24);
-
-		cy.intercept('GET', '/rest/executions?filter=*').as('getExecutions');
-		cy.intercept('GET', '/rest/executions/*').as('getExecution');
-		executionsTab.actions.switchToExecutionsTab();
-
-		cy.wait(['@getExecutions']);
-		executionsTab.getters.executionListItems().its('length').should('be.gte', 10);
-
-		cy.getByTestId('current-executions-list').scrollTo('bottom');
-		cy.wait(['@getExecutions']);
-		executionsTab.getters.executionListItems().should('have.length', 24);
-
-		executionsTab.getters.executionListItems().eq(14).click();
-		cy.wait(['@getExecution']);
-		cy.reload();
-
-		cy.wait(['@getExecutions']);
-		executionsTab.getters.executionListItems().eq(14).should('not.be.visible');
-		executionsTab.getters.executionListItems().should('have.length', 24);
-		executionsTab.getters.executionListItems().first().should('not.be.visible');
-		cy.getByTestId('current-executions-list').scrollTo(0, 0);
-		executionsTab.getters.executionListItems().first().should('be.visible');
-		executionsTab.getters.executionListItems().eq(14).should('not.be.visible');
-
-		executionsTab.actions.switchToEditorTab();
-		executionsTab.actions.switchToExecutionsTab();
-
-		cy.wait(['@getExecutions']);
-		executionsTab.getters.executionListItems().eq(14).should('not.be.visible');
-		executionsTab.getters.executionListItems().should('have.length', 24);
-		executionsTab.getters.executionListItems().first().should('not.be.visible');
-		cy.getByTestId('current-executions-list').scrollTo(0, 0);
-		executionsTab.getters.executionListItems().first().should('be.visible');
-		executionsTab.getters.executionListItems().eq(14).should('not.be.visible');
-	});
-
 	it('should show workflow data in executions tab after hard reload and modify name and tags', () => {
 		executionsTab.actions.switchToExecutionsTab();
 		checkMainHeaderELements();

--- a/cypress/e2e/2106-ADO-pinned-data-execution-preview.cy.ts
+++ b/cypress/e2e/2106-ADO-pinned-data-execution-preview.cy.ts
@@ -1,5 +1,4 @@
 import { WorkflowExecutionsTab, WorkflowPage as WorkflowPageClass } from '../pages';
-import { BACKEND_BASE_URL } from '../constants';
 
 const workflowPage = new WorkflowPageClass();
 const executionsTab = new WorkflowExecutionsTab();
@@ -15,33 +14,6 @@ describe('ADO-2106 connections should be colored correctly for pinned data in ex
 		workflowPage.getters.zoomToFitButton().click();
 
 		workflowPage.getters.getConnectionBetweenNodes('Webhook', 'Set').should('have.class', 'pinned');
-	});
-
-	it('should not color connections for pinned data nodes for production executions', () => {
-		workflowPage.actions.activateWorkflow();
-
-		// Execute the workflow
-		cy.request('POST', `${BACKEND_BASE_URL}/webhook/23fc3930-b8f9-41d9-89db-b647291a2201`, {
-			here: 'is some data',
-		}).then((response) => {
-			expect(response.status).to.eq(200);
-		});
-
-		executionsTab.actions.switchToExecutionsTab();
-
-		executionsTab.getters.successfulExecutionListItems().should('have.length', 1);
-
-		executionsTab.getters
-			.workflowExecutionPreviewIframe()
-			.should('be.visible')
-			.its('0.contentDocument.body')
-			.should('not.be.empty')
-
-			.then(cy.wrap)
-			.find('.jtk-connector[data-source-node="Webhook"][data-target-node="Set"]')
-			.should('have.class', 'success')
-			.should('have.class', 'has-run')
-			.should('not.have.class', 'pinned');
 	});
 
 	it('should color connections for pinned data nodes for manual executions', () => {

--- a/cypress/e2e/24-ndv-paired-item.cy.ts
+++ b/cypress/e2e/24-ndv-paired-item.cy.ts
@@ -162,64 +162,6 @@ describe('NDV', () => {
 		ndv.getters.inputTableRow(3).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
 	});
 
-	it('resolves expression with default item when input node is not parent, while still pairing items', () => {
-		cy.fixture('Test_workflow_5.json').then((data) => {
-			cy.get('body').paste(JSON.stringify(data));
-		});
-		workflowPage.actions.zoomToFit();
-		workflowPage.actions.executeWorkflow();
-		workflowPage.actions.openNode('Set2');
-
-		ndv.getters.inputPanel().contains('6 items').should('exist');
-		ndv.getters
-			.outputRunSelector()
-			.find('input')
-			.should('exist')
-			.should('have.value', '2 of 2 (6 items)');
-
-		ndv.actions.switchInputMode('Table');
-		ndv.actions.switchOutputMode('Table');
-
-		ndv.getters.backToCanvas().realHover(); // reset to default hover
-		ndv.getters.inputTableRow(1).should('have.text', '1111');
-
-		ndv.getters.inputTableRow(1).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
-		ndv.getters.inputTableRow(1).realHover();
-		cy.wait(100);
-		ndv.getters.outputHoveringItem().should('not.exist');
-		ndv.getters.parameterExpressionPreview('value').should('include.text', '1111');
-
-		ndv.actions.selectInputNode('Code1');
-		ndv.getters.inputTableRow(1).realHover();
-		ndv.getters.inputTableRow(1).should('have.text', '1000');
-
-		ndv.getters.inputTableRow(1).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
-		ndv.getters.outputTableRow(1).should('have.text', '1000');
-		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
-
-		ndv.actions.selectInputNode('Code');
-
-		ndv.getters.inputTableRow(1).realHover();
-		cy.wait(100);
-		ndv.getters.inputTableRow(1).should('have.text', '6666');
-
-		ndv.getters.inputTableRow(1).invoke('attr', 'data-test-id').should('equal', 'hovering-item');
-
-		ndv.getters.outputHoveringItem().should('not.exist');
-		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
-
-		ndv.actions.selectInputNode('When clicking');
-
-		ndv.getters.inputTableRow(1).realHover();
-		ndv.getters
-			.inputTableRow(1)
-			.should('have.text', "This is an item, but it's empty.")
-			.realHover();
-
-		ndv.getters.outputHoveringItem().should('have.length', 6);
-		ndv.getters.parameterExpressionPreview('value').should('include.text', '1000');
-	});
-
 	it('can pair items between input and output across branches and runs', () => {
 		cy.fixture('Test_workflow_5.json').then((data) => {
 			cy.get('body').paste(JSON.stringify(data));

--- a/cypress/e2e/25-stickies.cy.ts
+++ b/cypress/e2e/25-stickies.cy.ts
@@ -1,7 +1,5 @@
-import type { Interception } from 'cypress/types/net-stubbing';
 import { META_KEY } from '../constants';
 import { WorkflowPage as WorkflowPageClass } from '../pages/workflow';
-import { getPopper } from '../utils';
 
 const workflowPage = new WorkflowPageClass();
 
@@ -80,32 +78,6 @@ describe('Canvas Actions', () => {
 		workflowPage.actions.deleteSticky();
 
 		workflowPage.getters.stickies().should('have.length', 0);
-	});
-
-	it('change sticky color', () => {
-		workflowPage.actions.addSticky();
-
-		workflowPage.getters.stickies().should('have.length', 1);
-
-		workflowPage.actions.toggleColorPalette();
-
-		getPopper().should('be.visible');
-
-		workflowPage.actions.pickColor();
-
-		workflowPage.actions.toggleColorPalette();
-
-		getPopper().should('not.be.visible');
-
-		workflowPage.actions.saveWorkflowOnButtonClick();
-
-		cy.wait('@createWorkflow').then((interception: Interception) => {
-			const { request } = interception;
-			const color = request.body?.nodes[0]?.parameters?.color;
-			expect(color).to.equal(2);
-		});
-
-		workflowPage.getters.stickies().should('have.length', 1);
 	});
 
 	it('edits sticky and updates content as markdown', () => {

--- a/cypress/e2e/30-editor-after-route-changes.cy.ts
+++ b/cypress/e2e/30-editor-after-route-changes.cy.ts
@@ -128,11 +128,6 @@ describe('Editor actions should work', () => {
 		createNewWorkflowAndActivate();
 	});
 
-	it('after saving a new workflow', () => {
-		editWorkflowAndDeactivate();
-		editWorkflowMoreAndActivate();
-	});
-
 	it('after switching between Editor and Executions', () => {
 		cy.intercept('GET', '/rest/executions?filter=*').as('getExecutions');
 

--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -1,10 +1,8 @@
-import { getVisibleSelect } from '../utils';
 import { MANUAL_TRIGGER_NODE_DISPLAY_NAME, NOTION_NODE_NAME } from '../constants';
 import { NDV, WorkflowPage } from '../pages';
 import { NodeCreator } from '../pages/features/node-creator';
 import { clickCreateNewCredential } from '../composables/ndv';
 import { setCredentialValues } from '../composables/modals/credential-modal';
-import { successToast } from '../pages/notifications';
 
 const workflowPage = new WorkflowPage();
 const ndv = new NDV();
@@ -337,38 +335,6 @@ describe('NDV', () => {
 			ndv.actions.validateExpressionPreview('value', output ?? input);
 			ndv.getters.parameterInput('value').clear();
 		});
-	});
-
-	it('should not retrieve remote options when required params throw errors', () => {
-		workflowPage.actions.addInitialNodeToCanvas('E2e Test', { action: 'Remote Options' });
-
-		ndv.getters.parameterInput('remoteOptions').click();
-		getVisibleSelect().find('.el-select-dropdown__item').should('have.length', 3);
-
-		ndv.actions.setInvalidExpression({ fieldName: 'fieldId' });
-
-		ndv.getters.inputPanel().click(); // remove focus from input, hide expression preview
-
-		ndv.getters.parameterInput('remoteOptions').click();
-
-		ndv.getters.parameterInputIssues('remoteOptions').realHover({ scrollBehavior: false });
-		// Remote options dropdown should not be visible
-		ndv.getters.parameterInput('remoteOptions').find('.el-select').should('not.exist');
-	});
-
-	it('should retrieve remote options when non-required params throw errors', () => {
-		workflowPage.actions.addInitialNodeToCanvas('E2e Test', { action: 'Remote Options' });
-
-		ndv.getters.parameterInput('remoteOptions').click();
-		getVisibleSelect().find('.el-select-dropdown__item').should('have.length', 3);
-		ndv.getters.parameterInput('remoteOptions').click();
-
-		ndv.actions.setInvalidExpression({ fieldName: 'otherField' });
-
-		ndv.getters.nodeParameters().click(); // remove focus from input, hide expression preview
-
-		ndv.getters.parameterInput('remoteOptions').click();
-		getVisibleSelect().find('.el-select-dropdown__item').should('have.length', 3);
 	});
 
 	it('should flag issues as soon as params are set', () => {
@@ -735,23 +701,6 @@ describe('NDV', () => {
 			cy.get('[data-action=openSelectiveNodeCreator]').contains('Insert one').click();
 			nodeCreator.getters.activeSubcategory().should('contain', group);
 			cy.realPress('Escape');
-		});
-	});
-
-	it('Stop listening for trigger event from NDV', () => {
-		cy.intercept('POST', '/rest/workflows/**/run').as('workflowRun');
-		workflowPage.actions.addInitialNodeToCanvas('Local File Trigger', {
-			keepNdvOpen: true,
-			action: 'On Changes To A Specific File',
-			isTrigger: true,
-		});
-		ndv.getters.triggerPanelExecuteButton().should('exist');
-		ndv.getters.triggerPanelExecuteButton().realClick();
-		ndv.getters.triggerPanelExecuteButton().should('contain', 'Stop Listening');
-		ndv.getters.triggerPanelExecuteButton().realClick();
-		cy.wait('@workflowRun').then(() => {
-			ndv.getters.triggerPanelExecuteButton().should('contain', 'Test step');
-			successToast().should('exist');
 		});
 	});
 


### PR DESCRIPTION
This PR removes the [13 flaky e2e tests in the past month](https://cloud.cypress.io/projects/5hbsdn/analytics/flaky-tests?branches=%5B%7B%22value%22%3A%22master%22%2C%22label%22%3A%22master%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222024-06-22%22%2C%22endDate%22%3A%222024-07-22%22%7D&viewBy=TEST_CASE)

Sorted by flakiness rate:

1. NDV → should not retrieve remote options when required params throw errors
2. NDV → Stop listening for trigger event from NDV
3. Undo/Redo → should undo/redo adding connected nodes
4. NDV → resolves expression with default item when input node is not parent, while still pairing items
5. Undo/Redo → should undo/redo adding nodes
6. Current Workflow Executions → should auto load more items if there is space and auto scroll
7. Undo/Redo → should undo/redo renaming node using NDV
8. NDV → should retrieve remote options when non-required params throw errors
9. Scheduler Node → should execute once per second when activated
10. Stickies → change sticky color
11. Editor actions should work → after saving a new workflow
12. Credential Usage in Cross Shared Workflows → should only show credentials in their personal project for members
13. ADO 2106 connections should be colored correctly for pinned data in executions preview → should not color connections for pinned data nodes for production executions
14. **Extra:** Workflow tags > should update a tag via a modal

Follow-up story: https://linear.app/n8n/issue/N8N-7522