### PR TITLE
feat(editor): Add readonly mode to new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/__tests__/data/canvas.ts
+++ b/packages/editor-ui/src/__tests__/data/canvas.ts
@@ -64,12 +64,20 @@ export function createCanvasNodeProps({
 	id = 'node',
 	label = 'Test Node',
 	selected = false,
+	readOnly = false,
 	data = {},
-}: { id?: string; label?: string; selected?: boolean; data?: Partial<CanvasNodeData> } = {}) {
+}: {
+	id?: string;
+	label?: string;
+	selected?: boolean;
+	readOnly?: boolean;
+	data?: Partial<CanvasNodeData>;
+} = {}) {
 	return {
 		id,
 		label,
 		selected,
+		readOnly,
 		data: createCanvasNodeData(data),
 	};
 }

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -267,7 +267,7 @@ async function onFitView() {
 	await fitView({ maxZoom: 1.2, padding: 0.1 });
 }
 
-async function setReadonly(value: boolean) {
+function setReadonly(value: boolean) {
 	setInteractive(!value);
 	elementsSelectable.value = true;
 }

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -331,10 +331,6 @@ function onContextMenuAction(action: ContextMenuAction, nodeIds: string[]) {
 onMounted(() => {
 	props.eventBus.on('fitView', onFitView);
 	props.eventBus.on('selectNodes', onSelectNodes);
-
-	if (props.readOnly) {
-		setReadonly(props.readOnly);
-	}
 });
 
 onUnmounted(() => {
@@ -347,7 +343,9 @@ onPaneReady(async () => {
 	paneReady.value = true;
 });
 
-watch(() => props.readOnly, setReadonly);
+watch(() => props.readOnly, setReadonly, {
+	immediate: true,
+});
 </script>
 
 <template>

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -50,7 +50,7 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 				:nodes="mappedNodes"
 				:connections="mappedConnections"
 				:event-bus="eventBus"
-				:readOnly="readOnly"
+				:read-only="readOnly"
 				v-bind="$attrs"
 			/>
 		</div>

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -17,6 +17,7 @@ const props = withDefaults(
 		workflowObject: Workflow;
 		fallbackNodes?: IWorkflowDb['nodes'];
 		eventBus?: EventBus;
+		readOnly?: boolean;
 	}>(),
 	{
 		id: 'canvas',
@@ -49,6 +50,7 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 				:nodes="mappedNodes"
 				:connections="mappedConnections"
 				:event-bus="eventBus"
+				:readOnly="readOnly"
 				v-bind="$attrs"
 			/>
 		</div>

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
@@ -38,6 +38,26 @@ describe('CanvasEdge', () => {
 		expect(emitted()).toHaveProperty('delete');
 	});
 
+	it('should emit add event when toolbar add is clicked', async () => {
+		const { emitted, getByTestId } = renderComponent();
+		const addButton = getByTestId('add-connection-button');
+
+		await fireEvent.click(addButton);
+
+		expect(emitted()).toHaveProperty('add');
+	});
+
+	it('should not render toolbar actions when readOnly', async () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				readOnly: true,
+			},
+		});
+
+		expect(() => getByTestId('add-connection-button')).toThrow();
+		expect(() => getByTestId('delete-connection-button')).toThrow();
+	});
+
 	it('should compute edgeStyle correctly', () => {
 		const { container } = renderComponent();
 

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
 }>();
 
 export type CanvasEdgeProps = EdgeProps<CanvasConnectionData> & {
+	readOnly?: boolean;
 	hovered?: boolean;
 };
 
@@ -51,7 +52,7 @@ const edgeStyle = computed(() => ({
 }));
 
 const edgeLabel = computed(() => {
-	if (isFocused.value) {
+	if (isFocused.value && !props.readOnly) {
 		return '';
 	}
 
@@ -117,7 +118,7 @@ function onDelete() {
 		:label-style="edgeLabelStyle"
 		:label-show-bg="false"
 	/>
-	<EdgeLabelRenderer>
+	<EdgeLabelRenderer v-if="!readOnly">
 		<CanvasEdgeToolbar
 			:type="connectionType"
 			:class="edgeToolbarClasses"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.spec.ts
@@ -91,6 +91,29 @@ describe('CanvasNode', () => {
 			await fireEvent.mouseOver(node);
 
 			expect(getByTestId('canvas-node-toolbar')).toBeInTheDocument();
+			expect(getByTestId('execute-node-button')).toBeInTheDocument();
+			expect(getByTestId('disable-node-button')).toBeInTheDocument();
+			expect(getByTestId('delete-node-button')).toBeInTheDocument();
+			expect(getByTestId('overflow-node-button')).toBeInTheDocument();
+		});
+
+		it('should contain only context menu when node is disabled', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					...createCanvasNodeProps({
+						readOnly: true,
+					}),
+				},
+			});
+
+			const node = getByTestId('canvas-node');
+			await fireEvent.mouseOver(node);
+
+			expect(getByTestId('canvas-node-toolbar')).toBeInTheDocument();
+			expect(() => getByTestId('execute-node-button')).toThrow();
+			expect(() => getByTestId('disable-node-button')).toThrow();
+			expect(() => getByTestId('delete-node-button')).toThrow();
+			expect(getByTestId('overflow-node-button')).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
@@ -17,6 +17,10 @@ import { useContextMenu } from '@/composables/useContextMenu';
 import { Position } from '@vue-flow/core';
 import type { XYPosition, NodeProps } from '@vue-flow/core';
 
+type Props = NodeProps<CanvasNodeData> & {
+	readOnly?: boolean;
+};
+
 const emit = defineEmits<{
 	add: [id: string, handle: string];
 	delete: [id: string];
@@ -28,7 +32,8 @@ const emit = defineEmits<{
 	update: [id: string, parameters: Record<string, unknown>];
 	move: [id: string, position: XYPosition];
 }>();
-const props = defineProps<NodeProps<CanvasNodeData>>();
+
+const props = defineProps<Props>();
 
 const nodeTypesStore = useNodeTypesStore();
 const contextMenu = useContextMenu();
@@ -248,6 +253,7 @@ watch(
 		<CanvasNodeToolbar
 			v-if="nodeTypeDescription"
 			data-test-id="canvas-node-toolbar"
+			:read-only="readOnly"
 			:class="$style.canvasNodeToolbar"
 			@delete="onDelete"
 			@toggle="onDisabledToggle"
@@ -256,7 +262,7 @@ watch(
 		/>
 
 		<CanvasNodeRenderer
-			@dblclick="onActivate"
+			@dblclick.stop="onActivate"
 			@move="onMove"
 			@update="onUpdate"
 			@open:contextmenu="onOpenContextMenuFromNode"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
@@ -11,6 +11,10 @@ const emit = defineEmits<{
 	'open:contextmenu': [event: MouseEvent];
 }>();
 
+const props = defineProps<{
+	readOnly?: boolean;
+}>();
+
 const $style = useCssModule();
 const i18n = useI18n();
 
@@ -24,6 +28,7 @@ const nodeDisabledTitle = 'Test';
 
 const isExecuteNodeVisible = computed(() => {
 	return (
+		!props.readOnly &&
 		render.value.type === CanvasNodeRenderType.Default &&
 		'configuration' in render.value.options &&
 		!render.value.options.configuration
@@ -31,8 +36,10 @@ const isExecuteNodeVisible = computed(() => {
 });
 
 const isDisableNodeVisible = computed(() => {
-	return render.value.type === CanvasNodeRenderType.Default;
+	return !props.readOnly && render.value.type === CanvasNodeRenderType.Default;
 });
+
+const isDeleteNodeVisible = computed(() => !props.readOnly);
 
 function executeNode() {
 	emit('run');
@@ -76,6 +83,7 @@ function onOpenContextMenu(event: MouseEvent) {
 				@click="onToggleNode"
 			/>
 			<N8nIconButton
+				v-if="isDeleteNodeVisible"
 				data-test-id="delete-node-button"
 				type="tertiary"
 				size="small"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
@@ -26,6 +26,11 @@ const workflowRunning = false;
 // @TODO
 const nodeDisabledTitle = 'Test';
 
+const classes = computed(() => ({
+	[$style.canvasNodeToolbar]: true,
+	[$style.readOnly]: props.readOnly,
+}));
+
 const isExecuteNodeVisible = computed(() => {
 	return (
 		!props.readOnly &&
@@ -59,7 +64,7 @@ function onOpenContextMenu(event: MouseEvent) {
 </script>
 
 <template>
-	<div :class="$style.canvasNodeToolbar">
+	<div :class="classes">
 		<div :class="$style.canvasNodeToolbarItems">
 			<N8nIconButton
 				v-if="isExecuteNodeVisible"
@@ -107,6 +112,9 @@ function onOpenContextMenu(event: MouseEvent) {
 <style lang="scss" module>
 .canvasNodeToolbar {
 	padding-bottom: var(--spacing-2xs);
+	display: flex;
+	justify-content: flex-end;
+	width: 100%;
 }
 
 .canvasNodeToolbarItems {

--- a/packages/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/editor-ui/src/composables/useCanvasMapping.ts
@@ -213,8 +213,11 @@ export function useCanvasMapping({
 			const lastNodeExecuted = workflowExecution?.data?.resultData?.lastNodeExecuted;
 
 			if (workflowExecution && lastNodeExecuted && isExecutionSummary(workflowExecution)) {
-				if (node.name === workflowExecution.data?.resultData?.lastNodeExecuted) {
-					const waitDate = new Date(workflowExecution.waitTill as Date);
+				if (
+					node.name === workflowExecution.data?.resultData?.lastNodeExecuted &&
+					workflowExecution.waitTill
+				) {
+					const waitDate = new Date(workflowExecution.waitTill);
 
 					if (waitDate.toISOString() === WAIT_TIME_UNLIMITED) {
 						acc[node.id] = i18n.baseText(

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1164,7 +1164,6 @@ async function onPostMessageReceived(messageEvent: MessageEvent) {
 				toast.showError(e, i18n.baseText('openWorkflow.workflowImportError'));
 			}
 		} else if (json && json.command === 'openExecution') {
-			console.log('json', json);
 			try {
 				// If this NodeView is used in preview mode (in iframe) it will not have access to the main app store
 				// so everything it needs has to be sent using post messages and passed down to child components


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/ed7cc867-822e-4f50-9388-964b188fc9a2



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7475/as-a-user-i-want-to-be-able-to-freely-switch-between-executions-and
https://linear.app/n8n/issue/N8N-7483/as-a-user-i-want-the-execution-view-to-be-rendered-using-the-new

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
