### PR TITLE
fix(core): Fix handling of common events for relays

### DIFF
--- a/packages/cli/src/eventbus/audit-event-relay.service.ts
+++ b/packages/cli/src/eventbus/audit-event-relay.service.ts
@@ -38,8 +38,8 @@ export class AuditEventRelay {
 		this.eventService.on('user-password-reset-request-click', (event) =>
 			this.userPasswordResetRequestClick(event),
 		);
-		this.eventService.on('public-api-key-created', (event) => this.apiKeyCreated(event));
-		this.eventService.on('public-api-key-deleted', (event) => this.apiKeyDeleted(event));
+		this.eventService.on('public-api-key-created', (event) => this.publicApiKeyCreated(event));
+		this.eventService.on('public-api-key-deleted', (event) => this.publicApiKeyDeleted(event));
 		this.eventService.on('email-failed', (event) => this.emailFailed(event));
 		this.eventService.on('credentials-created', (event) => this.credentialsCreated(event));
 		this.eventService.on('credentials-deleted', (event) => this.credentialsDeleted(event));
@@ -257,7 +257,7 @@ export class AuditEventRelay {
 	 */
 
 	@Redactable()
-	private apiKeyCreated({ user }: Event['public-api-key-created']) {
+	private publicApiKeyCreated({ user }: Event['public-api-key-created']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.api.created',
 			payload: user,
@@ -265,7 +265,7 @@ export class AuditEventRelay {
 	}
 
 	@Redactable()
-	private apiKeyDeleted({ user }: Event['public-api-key-deleted']) {
+	private publicApiKeyDeleted({ user }: Event['public-api-key-deleted']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.api.deleted',
 			payload: user,

--- a/packages/cli/src/eventbus/audit-event-relay.service.ts
+++ b/packages/cli/src/eventbus/audit-event-relay.service.ts
@@ -257,22 +257,18 @@ export class AuditEventRelay {
 	 */
 
 	@Redactable()
-	private apiKeyCreated(event: Event['public-api-key-created']) {
-		if ('publicApi' in event) return;
-
+	private apiKeyCreated({ user }: Event['public-api-key-created']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.api.created',
-			payload: event.user,
+			payload: user,
 		});
 	}
 
 	@Redactable()
-	private apiKeyDeleted(event: Event['public-api-key-deleted']) {
-		if ('publicApi' in event) return;
-
+	private apiKeyDeleted({ user }: Event['public-api-key-deleted']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.user.api.deleted',
-			payload: event.user,
+			payload: user,
 		});
 	}
 

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -269,7 +269,7 @@ export type Event = {
 	};
 
 	/**
-	 * Common events
+	 * Events listened to by more than one relay
 	 */
 
 	'public-api-key-created': {

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -112,14 +112,6 @@ export type Event = {
 		apiVersion: string;
 	};
 
-	'public-api-key-created':
-		| { user: UserLike } // audit
-		| { user: UserLike; publicApi: boolean }; // telemetry
-
-	'public-api-key-deleted':
-		| { user: UserLike } // audit
-		| { user: UserLike; publicApi: boolean }; // telemetry
-
 	'email-failed': {
 		user: UserLike;
 		messageType:
@@ -274,5 +266,19 @@ export type Event = {
 		isValid: boolean;
 		isNew: boolean;
 		errorMessage?: string;
+	};
+
+	/**
+	 * Common events
+	 */
+
+	'public-api-key-created': {
+		user: UserLike; // audit and telemetry
+		publicApi: boolean; // telemetry only
+	};
+
+	'public-api-key-deleted': {
+		user: UserLike; // audit and telemetry
+		publicApi: boolean; // telemetry only
 	};
 };

--- a/packages/cli/src/telemetry/telemetry-event-relay.service.ts
+++ b/packages/cli/src/telemetry/telemetry-event-relay.service.ts
@@ -210,8 +210,6 @@ export class TelemetryEventRelay {
 	}
 
 	private publicApiKeyCreated(event: Event['public-api-key-created']) {
-		if (!('publicApi' in event)) return;
-
 		const { user, publicApi } = event;
 
 		void this.telemetry.track('API key created', {
@@ -221,8 +219,6 @@ export class TelemetryEventRelay {
 	}
 
 	private publicApiKeyDeleted(event: Event['public-api-key-deleted']) {
-		if (!('publicApi' in event)) return;
-
 		const { user, publicApi } = event;
 
 		void this.telemetry.track('API key deleted', {


### PR DESCRIPTION
Currently we check for the presence or absence of a relay-specific key. This is preventing the event from being handled in the relay that does not use the relay-specific key. 

Instead, since the payload always includes all keys, for common events every relay should always forward the event, but taking care to pick what it needs from the payload.

Follow-up to: #10121