### PR TITLE
feat(editor): Add undo/redo create connection in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -708,6 +708,24 @@ describe('useCanvasOperations', () => {
 		});
 	});
 
+	describe('revertCreateConnection', () => {
+		it('deletes connection if both source and target nodes exist', () => {
+			const connection: [IConnection, IConnection] = [
+				{ node: 'sourceNode', type: NodeConnectionType.Main, index: 0 },
+				{ node: 'targetNode', type: NodeConnectionType.Main, index: 0 },
+			];
+			const testNode = createTestNode();
+
+			const removeConnectionSpy = vi.spyOn(workflowsStore, 'removeConnection');
+			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValue(testNode);
+			vi.spyOn(workflowsStore, 'getNodeById').mockReturnValue(testNode);
+
+			canvasOperations.revertCreateConnection(connection);
+
+			expect(removeConnectionSpy).toHaveBeenCalled();
+		});
+	});
+
 	describe('isConnectionAllowed', () => {
 		it('should return false if source and target nodes are the same', () => {
 			const node = mockNode({ id: '1', type: 'testType', name: 'Test Node' });

--- a/packages/editor-ui/src/utils/canvasUtilsV2.ts
+++ b/packages/editor-ui/src/utils/canvasUtilsV2.ts
@@ -74,6 +74,32 @@ export function mapLegacyConnectionsToCanvasConnections(
 	return mappedConnections;
 }
 
+export function mapLegacyConnectionToCanvasConnection(
+	sourceNode: INodeUi,
+	targetNode: INodeUi,
+	legacyConnection: [IConnection, IConnection],
+): Connection {
+	const source = sourceNode.id;
+	const sourceHandle = createCanvasConnectionHandleString({
+		mode: CanvasConnectionMode.Output,
+		type: legacyConnection[0].type,
+		index: legacyConnection[0].index,
+	});
+	const target = targetNode.id;
+	const targetHandle = createCanvasConnectionHandleString({
+		mode: CanvasConnectionMode.Input,
+		type: legacyConnection[1].type,
+		index: legacyConnection[1].index,
+	});
+
+	return {
+		source,
+		sourceHandle,
+		target,
+		targetHandle,
+	};
+}
+
 export function parseCanvasConnectionHandleString(handle: string | null | undefined) {
 	const [mode, type, index] = (handle ?? '').split('/');
 

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -149,6 +149,7 @@ const {
 	revertDeleteNode,
 	addNodes,
 	createConnection,
+	revertCreateConnection,
 	deleteConnection,
 	revertDeleteConnection,
 	setNodeActiveByName,
@@ -689,7 +690,11 @@ async function loadCredentials() {
  */
 
 function onCreateConnection(connection: Connection) {
-	createConnection(connection);
+	createConnection(connection, { trackHistory: true });
+}
+
+function onRevertCreateConnection({ connection }: { connection: [IConnection, IConnection] }) {
+	revertCreateConnection(connection);
 }
 
 function onCreateConnectionCancelled(event: ConnectStartEvent) {
@@ -974,7 +979,7 @@ function addUndoRedoEventBindings() {
 	// historyBus.on('nodeMove', onMoveNode);
 	// historyBus.on('revertAddNode', onRevertAddNode);
 	historyBus.on('revertRemoveNode', onRevertDeleteNode);
-	// historyBus.on('revertAddConnection', onRevertAddConnection);
+	historyBus.on('revertAddConnection', onRevertCreateConnection);
 	historyBus.on('revertRemoveConnection', onRevertDeleteConnection);
 	historyBus.on('revertRenameNode', onRevertRenameNode);
 	// historyBus.on('enableNodeToggle', onRevertEnableToggle);
@@ -984,7 +989,7 @@ function removeUndoRedoEventBindings() {
 	// historyBus.off('nodeMove', onMoveNode);
 	// historyBus.off('revertAddNode', onRevertAddNode);
 	historyBus.off('revertRemoveNode', onRevertDeleteNode);
-	// historyBus.off('revertAddConnection', onRevertAddConnection);
+	historyBus.off('revertAddConnection', onRevertCreateConnection);
 	historyBus.off('revertRemoveConnection', onRevertDeleteConnection);
 	historyBus.off('revertRenameNode', onRevertRenameNode);
 	// historyBus.off('enableNodeToggle', onRevertEnableToggle);


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/a5345fbd-910a-43f9-ae31-6fd0149d4091

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7431/as-a-user-i-want-to-be-able-to-undoredo-creating-a-connection-between

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
