### PR TITLE
feat(editor): Add undo/redo creating a node in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -333,6 +333,19 @@ describe('useCanvasOperations', () => {
 		});
 	});
 
+	describe('revertAddNode', () => {
+		it('deletes node if it exists', async () => {
+			const node = createTestNode();
+			vi.spyOn(workflowsStore, 'getNodeByName').mockReturnValueOnce(node);
+			vi.spyOn(workflowsStore, 'getNodeById').mockReturnValueOnce(node);
+			const removeNodeByIdSpy = vi.spyOn(workflowsStore, 'removeNodeById');
+
+			await canvasOperations.revertAddNode(node.name);
+
+			expect(removeNodeByIdSpy).toHaveBeenCalledWith(node.id);
+		});
+	});
+
 	describe('deleteNode', () => {
 		it('should delete node and track history', () => {
 			const removeNodeByIdSpy = vi

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -490,6 +490,15 @@ export function useCanvasOperations({
 		return nodeData;
 	}
 
+	async function revertAddNode(nodeName: string) {
+		const node = workflowsStore.getNodeByName(nodeName);
+		if (!node) {
+			return;
+		}
+
+		deleteNode(node.id);
+	}
+
 	function createConnectionToLastInteractedWithNode(node: INodeUi, options: AddNodeOptions = {}) {
 		const lastInteractedWithNode = uiStore.lastInteractedWithNode;
 		if (!lastInteractedWithNode) {
@@ -1590,6 +1599,7 @@ export function useCanvasOperations({
 		triggerNodes,
 		addNodes,
 		addNode,
+		revertAddNode,
 		updateNodePosition,
 		setNodeActive,
 		setNodeActiveByName,

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -378,10 +378,16 @@ export function useCanvasOperations({
 		options: {
 			dragAndDrop?: boolean;
 			position?: XYPosition;
+			trackHistory?: boolean;
+			trackBulk?: boolean;
 		} = {},
 	) {
 		let insertPosition = options.position;
 		let lastAddedNode: INodeUi | undefined;
+
+		if (options.trackBulk) {
+			historyStore.startRecordingUndo();
+		}
 
 		for (const nodeAddData of nodes) {
 			const { isAutoAdd, openDetail: openNDV, ...node } = nodeAddData;
@@ -397,7 +403,7 @@ export function useCanvasOperations({
 						...options,
 						openNDV,
 						isAutoAdd,
-						trackHistory: true,
+						trackHistory: options.trackHistory,
 					},
 				);
 			} catch (error) {
@@ -415,6 +421,10 @@ export function useCanvasOperations({
 		if (lastAddedNode) {
 			// @TODO Figure out what this does and why it's needed
 			updatePositionForNodeWithMultipleInputs(lastAddedNode);
+		}
+
+		if (options.trackBulk) {
+			historyStore.stopRecordingUndo();
 		}
 	}
 

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -148,6 +148,7 @@ const {
 	duplicateNodes,
 	revertDeleteNode,
 	addNodes,
+	revertAddNode,
 	createConnection,
 	deleteConnection,
 	revertDeleteConnection,
@@ -802,6 +803,10 @@ async function onAddNodesAndConnections(
 	uiStore.resetLastInteractedWith();
 }
 
+async function onRevertAddNode({ node }: { node: INodeUi }) {
+	await revertAddNode(node.name);
+}
+
 async function onSwitchActiveNode(nodeName: string) {
 	setNodeActiveByName(nodeName);
 }
@@ -972,7 +977,7 @@ const chatTriggerNodePinnedData = computed(() => {
 
 function addUndoRedoEventBindings() {
 	// historyBus.on('nodeMove', onMoveNode);
-	// historyBus.on('revertAddNode', onRevertAddNode);
+	historyBus.on('revertAddNode', onRevertAddNode);
 	historyBus.on('revertRemoveNode', onRevertDeleteNode);
 	// historyBus.on('revertAddConnection', onRevertAddConnection);
 	historyBus.on('revertRemoveConnection', onRevertDeleteConnection);
@@ -982,7 +987,7 @@ function addUndoRedoEventBindings() {
 
 function removeUndoRedoEventBindings() {
 	// historyBus.off('nodeMove', onMoveNode);
-	// historyBus.off('revertAddNode', onRevertAddNode);
+	historyBus.off('revertAddNode', onRevertAddNode);
 	historyBus.off('revertRemoveNode', onRevertDeleteNode);
 	// historyBus.off('revertAddConnection', onRevertAddConnection);
 	historyBus.off('revertRemoveConnection', onRevertDeleteConnection);

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -775,7 +775,7 @@ async function onAddNodesAndConnections(
 		return;
 	}
 
-	await addNodes(nodes, { dragAndDrop, position });
+	await addNodes(nodes, { dragAndDrop, position, trackHistory: true });
 
 	const offsetIndex = editableWorkflow.value.nodes.length - nodes.length;
 	const mappedConnections: CanvasConnectionCreateData[] = connections.map(({ from, to }) => {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/52d9ee52-2b58-4e19-b364-2730c07293ce

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7430/as-a-user-i-want-to-be-able-to-undoredo-creating-a-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
