### PR TITLE
feat(editor): Add undo/redo enabling/disabling a node in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -24,7 +24,6 @@ import { useCredentialsStore } from '@/stores/credentials.store';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { telemetry } from '@/plugins/telemetry';
 import { useClipboard } from '@/composables/useClipboard';
-import { useNodeHelpers } from '@/composables/useNodeHelpers';
 
 vi.mock('vue-router', async (importOriginal) => {
 	const actual = await importOriginal<{}>();
@@ -48,7 +47,6 @@ describe('useCanvasOperations', () => {
 	let credentialsStore: ReturnType<typeof useCredentialsStore>;
 	let canvasOperations: ReturnType<typeof useCanvasOperations>;
 	let workflowHelpers: ReturnType<typeof useWorkflowHelpers>;
-	let nodeHelpers: ReturnType<typeof useNodeHelpers>;
 
 	const lastClickPosition = ref<XYPosition>([450, 450]);
 	const router = useRouter();
@@ -64,7 +62,6 @@ describe('useCanvasOperations', () => {
 		nodeTypesStore = useNodeTypesStore();
 		credentialsStore = useCredentialsStore();
 		workflowHelpers = useWorkflowHelpers({ router });
-		nodeHelpers = useNodeHelpers();
 
 		const workflowId = 'test';
 		const workflow = mock<IWorkflowDb>({

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -346,10 +346,25 @@ export function useCanvasOperations({
 
 	function toggleNodesDisabled(
 		ids: string[],
-		{ trackHistory = true }: { trackHistory?: boolean } = {},
+		{ trackHistory = true, trackBulk = true }: { trackHistory?: boolean; trackBulk?: boolean } = {},
 	) {
+		if (trackBulk) {
+			historyStore.startRecordingUndo();
+		}
+
 		const nodes = workflowsStore.getNodesByIds(ids);
 		nodeHelpers.disableNodes(nodes, trackHistory);
+
+		if (trackBulk) {
+			historyStore.stopRecordingUndo();
+		}
+	}
+
+	function revertToggleNodeDisabled(nodeName: string) {
+		const node = workflowsStore.getNodeByName(nodeName);
+		if (node) {
+			nodeHelpers.disableNodes([node]);
+		}
 	}
 
 	function toggleNodesPinned(ids: string[], source: PinDataSource) {
@@ -1595,6 +1610,7 @@ export function useCanvasOperations({
 		setNodeActiveByName,
 		setNodeSelected,
 		toggleNodesDisabled,
+		revertToggleNodeDisabled,
 		toggleNodesPinned,
 		setNodeParameters,
 		renameNode,

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -139,6 +139,7 @@ const {
 	setNodeActive,
 	setNodeSelected,
 	toggleNodesDisabled,
+	revertToggleNodeDisabled,
 	toggleNodesPinned,
 	setNodeParameters,
 	deleteNode,
@@ -463,6 +464,10 @@ function onToggleNodeDisabled(id: string) {
 	}
 
 	toggleNodesDisabled([id]);
+}
+
+function onRevertToggleNodeDisabled({ nodeName }: { nodeName: string }) {
+	revertToggleNodeDisabled(nodeName);
 }
 
 function onToggleNodesDisabled(ids: string[]) {
@@ -977,7 +982,7 @@ function addUndoRedoEventBindings() {
 	// historyBus.on('revertAddConnection', onRevertAddConnection);
 	historyBus.on('revertRemoveConnection', onRevertDeleteConnection);
 	historyBus.on('revertRenameNode', onRevertRenameNode);
-	// historyBus.on('enableNodeToggle', onRevertEnableToggle);
+	historyBus.on('enableNodeToggle', onRevertToggleNodeDisabled);
 }
 
 function removeUndoRedoEventBindings() {
@@ -987,7 +992,7 @@ function removeUndoRedoEventBindings() {
 	// historyBus.off('revertAddConnection', onRevertAddConnection);
 	historyBus.off('revertRemoveConnection', onRevertDeleteConnection);
 	historyBus.off('revertRenameNode', onRevertRenameNode);
-	// historyBus.off('enableNodeToggle', onRevertEnableToggle);
+	historyBus.off('enableNodeToggle', onRevertToggleNodeDisabled);
 }
 
 /**


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/3e3c9ec2-5b35-4360-9409-608d2b6e84d0



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7524/as-a-user-i-want-to-be-able-to-undoredo-setting-a-node-as-disabled

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
