### PR TITLE
feat(Send Email Node): Smtp credential improvements

### DIFF
--- a/packages/nodes-base/credentials/Smtp.credentials.ts
+++ b/packages/nodes-base/credentials/Smtp.credentials.ts
@@ -42,6 +42,17 @@ export class Smtp implements ICredentialType {
 			default: true,
 		},
 		{
+			displayName: 'Disable STARTTLS',
+			name: 'disableStartTls',
+			type: 'boolean',
+			default: false,
+			displayOptions: {
+				show: {
+					secure: [false],
+				},
+			},
+		},
+		{
 			displayName: 'Client Host Name',
 			name: 'hostName',
 			type: 'string',

--- a/packages/nodes-base/nodes/EmailSend/v2/EmailSendV2.node.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/EmailSendV2.node.ts
@@ -26,6 +26,7 @@ const versionDescription: INodeTypeDescription = {
 		{
 			name: 'smtp',
 			required: true,
+			testedBy: 'smtpConnectionTest',
 		},
 	],
 	properties: [
@@ -69,6 +70,10 @@ export class EmailSendV2 implements INodeType {
 			...versionDescription,
 		};
 	}
+
+	methods = {
+		credentialTest: { smtpConnectionTest: send.smtpConnectionTest },
+	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		let returnData: INodeExecutionData[][] = [];

--- a/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
@@ -1,6 +1,9 @@
 import type {
+	ICredentialsDecrypted,
+	ICredentialTestFunctions,
 	IDataObject,
 	IExecuteFunctions,
+	INodeCredentialTestResult,
 	INodeExecutionData,
 	INodeProperties,
 	JsonObject,
@@ -228,6 +231,28 @@ function configureTransport(credentials: IDataObject, options: EmailSendOptions)
 	}
 
 	return createTransport(connectionOptions);
+}
+
+export async function smtpConnectionTest(
+	this: ICredentialTestFunctions,
+	credential: ICredentialsDecrypted,
+): Promise<INodeCredentialTestResult> {
+	const credentials = credential.data!;
+	const transporter = configureTransport(credentials, {});
+	try {
+		await transporter.verify();
+		return {
+			status: 'OK',
+			message: 'Connection successful!',
+		};
+	} catch (error) {
+		return {
+			status: 'Error',
+			message: error.message,
+		};
+	} finally {
+		transporter.close();
+	}
 }
 
 export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
@@ -213,6 +213,10 @@ function configureTransport(credentials: IDataObject, options: EmailSendOptions)
 		secure: credentials.secure as boolean,
 	};
 
+	if (credentials.secure === false) {
+		connectionOptions.ignoreTLS = credentials.disableStartTls as boolean;
+	}
+
 	if (typeof credentials.hostName === 'string' && credentials.hostName) {
 		connectionOptions.name = credentials.hostName;
 	}


### PR DESCRIPTION
## Summary
This PR:
1. Adds credentials test for the SMTP credential, and
2. Adds an option to disable STARTTLS (`false` by default)

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/send-mail-client-network-socket-disconnected-before-secure-tls-connection-was-established/50536

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs/pull/2254)
- [ ] Tests included
