### PR TITLE
fix(core): Fix SSH Tunnels when using private key

### DIFF
--- a/packages/nodes-base/utils/sshTunnel.properties.ts
+++ b/packages/nodes-base/utils/sshTunnel.properties.ts
@@ -78,7 +78,7 @@ export const sshTunnelProperties: INodeProperties[] = [
 	},
 	{
 		displayName: 'Private Key',
-		name: 'sshPrivateKey',
+		name: 'privateKey', // TODO: Rename to sshPrivateKey
 		type: 'string',
 		typeOptions: {
 			rows: 4,
@@ -94,7 +94,7 @@ export const sshTunnelProperties: INodeProperties[] = [
 	},
 	{
 		displayName: 'Passphrase',
-		name: 'sshPassphrase',
+		name: 'passphrase', // TODO: Rename to sshPassphrase
 		type: 'string',
 		default: '',
 		description: 'Passphrase used to create the key, if no passphrase was used leave empty',


### PR DESCRIPTION
## Summary
in #9906 I accidentally changed the property names for private-key for SSH tunnels.
I had originally changed the name during testing, but had reverted to the original names. Unfortunately (since our schemas aren't typesafe), I missed one spot. 

This means that any **new** Postgres or MySQL credential created on version 1.50 or 1.51, with SSH tunneling using private-key are not working right now.

Once this fix is released, those non-working credentials would need to be edited, and the private-key/passphrase would need to be re-entered.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/node-mysql-with-ssh-tunnel-configuration/50412
https://community.n8n.io/t/unable-to-connect-postgres-db-with-n8n/39615


## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included
- [x] PR Labeled with `release/backport`