### PR TITLE
feat(HTTP Request Node): Add option to disable lowercase headers

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -807,6 +807,13 @@ export class HttpRequestV3 implements INodeType {
 							default: 'brackets',
 						},
 						{
+							displayName: 'Lowercase Headers',
+							name: 'lowercaseHeaders',
+							type: 'boolean',
+							default: true,
+							description: 'Whether to lowercase header names',
+						},
+						{
 							displayName: 'Redirects',
 							name: 'redirect',
 							placeholder: 'Add Redirect',
@@ -1388,6 +1395,7 @@ export class HttpRequestV3 implements INodeType {
 				allowUnauthorizedCerts,
 				queryParameterArrays,
 				response,
+				lowercaseHeaders,
 			} = this.getNodeParameter('options', itemIndex, {}) as {
 				batching: { batch: { batchSize: number; batchInterval: number } };
 				proxy: string;
@@ -1398,6 +1406,7 @@ export class HttpRequestV3 implements INodeType {
 					response: { neverError: boolean; responseFormat: string; fullResponse: boolean };
 				};
 				redirect: { redirect: { maxRedirects: number; followRedirects: boolean } };
+				lowercaseHeaders: boolean;
 			};
 
 			const url = this.getNodeParameter('url', itemIndex) as string;
@@ -1611,7 +1620,9 @@ export class HttpRequestV3 implements INodeType {
 				}
 				requestOptions.headers = {
 					...requestOptions.headers,
-					...keysToLowercase(additionalHeaders),
+					...(lowercaseHeaders === undefined || lowercaseHeaders
+						? keysToLowercase(additionalHeaders)
+						: additionalHeaders),
 				};
 			}
 


### PR DESCRIPTION
## Summary

The Http Request node is lowercasing all http header names. While http header names should be case-insensitive (see [RFC 7230](https://www.rfc-editor.org/rfc/rfc7230#section-3.2)), sometimes n8n users are connecting to services that don't follow standards, e.g. only accepting "Username" header but not "username". 

To support these scenarios, lets add an option "Lowercase Headers" that defaults to true

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1520/http-request-node-option-to-disable-lowercase-headers
