### PR TITLE
feat(editor): Enable `NodeView.switcher` by default in dev mode (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -96,7 +96,7 @@ const importFileRef = ref<HTMLInputElement | undefined>();
 const tagsEventBus = createEventBus();
 const sourceControlModalEventBus = createEventBus();
 
-const nodeViewSwitcher = useLocalStorage('NodeView.switcher', '');
+const nodeViewSwitcher = useLocalStorage('NodeView.switcher', import.meta.env.DEV ? 'true' : '');
 const nodeViewVersion = useLocalStorage('NodeView.version', '1');
 
 const hasChanged = (prev: string[], curr: string[]) => {


### PR DESCRIPTION
## Summary

Sets the `NodeView.switcher` flag to `true` by default in dev mode.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7527/enable-nodeviewswitcher-by-default-in-dev-mode

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
