### PR TITLE
fix(editor): Fix issue with existing credential not opening in HTTP agent tool

### DIFF
--- a/cypress/constants.ts
+++ b/cypress/constants.ts
@@ -55,6 +55,7 @@ export const AI_MEMORY_WINDOW_BUFFER_MEMORY_NODE_NAME = 'Window Buffer Memory';
 export const AI_TOOL_CALCULATOR_NODE_NAME = 'Calculator';
 export const AI_TOOL_CODE_NODE_NAME = 'Code Tool';
 export const AI_TOOL_WIKIPEDIA_NODE_NAME = 'Wikipedia';
+export const AI_TOOL_HTTP_NODE_NAME = 'HTTP Request Tool';
 export const AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME = 'OpenAI Chat Model';
 export const AI_OUTPUT_PARSER_AUTO_FIXING_NODE_NAME = 'Auto-fixing Output Parser';
 export const WEBHOOK_NODE_NAME = 'Webhook';

--- a/cypress/e2e/2-credentials.cy.ts
+++ b/cypress/e2e/2-credentials.cy.ts
@@ -1,5 +1,7 @@
-import type { ICredentialType } from 'n8n-workflow';
+import { type ICredentialType } from 'n8n-workflow';
 import {
+	AGENT_NODE_NAME,
+	AI_TOOL_HTTP_NODE_NAME,
 	GMAIL_NODE_NAME,
 	HTTP_REQUEST_NODE_NAME,
 	NEW_GOOGLE_ACCOUNT_NAME,
@@ -199,6 +201,31 @@ describe('Credentials', () => {
 			.nodeCredentialsSelect()
 			.find('input')
 			.should('have.value', NEW_CREDENTIAL_NAME2);
+	});
+
+	it('should edit credential for non-standard credential type', () => {
+		workflowPage.actions.visit();
+		workflowPage.actions.addNodeToCanvas(AGENT_NODE_NAME);
+		workflowPage.actions.addNodeToCanvas(AI_TOOL_HTTP_NODE_NAME);
+		workflowPage.getters.canvasNodes().last().click();
+		cy.get('body').type('{enter}');
+		cy.getByTestId('parameter-input-authentication').click();
+		cy.contains('Predefined Credential Type').click();
+		cy.getByTestId('credential-select').click();
+		cy.contains('Adalo API').click();
+		workflowPage.getters.nodeCredentialsSelect().click();
+		getVisibleSelect().find('li').last().click();
+		credentialsModal.actions.fillCredentialsForm();
+		workflowPage.getters.nodeCredentialsEditButton().click();
+		credentialsModal.getters.credentialsEditModal().should('be.visible');
+		credentialsModal.getters.name().click();
+		credentialsModal.actions.renameCredential(NEW_CREDENTIAL_NAME);
+		credentialsModal.getters.saveButton().click();
+		credentialsModal.getters.closeButton().click();
+		workflowPage.getters
+			.nodeCredentialsSelect()
+			.find('input')
+			.should('have.value', NEW_CREDENTIAL_NAME);
 	});
 
 	it('should setup generic authentication for HTTP node', () => {

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -430,7 +430,7 @@ const sidebarItems = computed(() => {
 const defaultCredentialTypeName = computed(() => {
 	let defaultName = credentialTypeName.value;
 	if (!defaultName || defaultName === 'null') {
-		if (activeNodeType.value?.credentials) {
+		if (activeNodeType.value?.credentials && activeNodeType.value.credentials.length > 0) {
 			defaultName = activeNodeType.value.credentials[0].name;
 		}
 	}


### PR DESCRIPTION
## Summary

This PR fixes an issue with the credential modal not opening in the HTTP Tool node. This happens because we except the `credentials` array to be populated in [CredentialEdit.vue](https://github.com/n8n-io/n8n/compare/ai-246-existing-http-tool-credential-doesnt-open?expand=1#diff-b32f398a40e2b97995b8c05fcb9dfc277bd9422b9914f2a183691d24a21883d2) but for HTTP Tool Node these credentials are part of regular parameters using `credentialsSelect` parameter type.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
