### PR TITLE
fix(LinkedIn Node): Fix issue with some characters cutting off posts early

### DIFF
--- a/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
+++ b/packages/nodes-base/nodes/LinkedIn/LinkedIn.node.ts
@@ -121,10 +121,13 @@ export class LinkedIn implements INodeType {
 			try {
 				if (resource === 'post') {
 					if (operation === 'create') {
-						const text = this.getNodeParameter('text', i) as string;
+						let text = this.getNodeParameter('text', i) as string;
 						const shareMediaCategory = this.getNodeParameter('shareMediaCategory', i) as string;
 						const postAs = this.getNodeParameter('postAs', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
+
+						// LinkedIn uses "little text" https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/little-text-format?view=li-lms-2024-06
+						text = text.replace(/[\(*\)\[\]\{\}<>@|~_]/gm, (char) => '\\' + char);
 
 						let authorUrn = '';
 						let visibility = 'PUBLIC';
@@ -264,7 +267,9 @@ export class LinkedIn implements INodeType {
 								delete body.title;
 							}
 						} else {
-							Object.assign(body, { commentary: text });
+							Object.assign(body, {
+								commentary: text,
+							});
 						}
 						const endpoint = '/posts';
 						responseData = await linkedInApiRequest.call(this, 'POST', endpoint, body);


### PR DESCRIPTION
## Summary
This PR escapes some characters when posting LinkedIn text to fit with their 'little text' format.

![image](https://github.com/user-attachments/assets/861de194-cc94-419b-a1f3-b83eeaae925c)


## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/linkedin-node-not-posting-full-output/47477/5
