### PR TITLE
feat(editor): Add localStorage flag to prevent opening NDV in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -132,6 +132,8 @@ export function useCanvasOperations({
 	const externalHooks = useExternalHooks();
 	const clipboard = useClipboard();
 
+	const preventOpeningNDV = !!localStorage.getItem('NodeView.preventOpeningNDV');
+
 	const editableWorkflow = computed(() => workflowsStore.workflow);
 	const editableWorkflowObject = computed(() => workflowsStore.getCurrentWorkflow());
 
@@ -531,7 +533,7 @@ export function useCanvasOperations({
 		workflowsStore.setNodePristine(nodeData.name, true);
 		uiStore.stateIsDirty = true;
 
-		if (options.openNDV) {
+		if (options.openNDV && !preventOpeningNDV) {
 			void nextTick(() => {
 				ndvStore.setActiveNodeName(nodeData.name);
 			});


### PR DESCRIPTION
## Summary

Adds `NodeView.preventOpeningNDV` localStorage flag to prevent opening NDV after adding a node, used for demo purposes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7510/as-a-user-i-want-to-be-able-to-disable-opening-ndv-automatically-after

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
