### PR TITLE
fix(Trello Node): Use body for POST requests

### DIFF
--- a/packages/nodes-base/nodes/Trello/Trello.node.ts
+++ b/packages/nodes-base/nodes/Trello/Trello.node.ts
@@ -224,11 +224,11 @@ export class Trello implements INodeType {
 						requestMethod = 'POST';
 						endpoint = 'boards';
 
-						qs.name = this.getNodeParameter('name', i) as string;
-						qs.desc = this.getNodeParameter('description', i) as string;
+						body.name = this.getNodeParameter('name', i) as string;
+						body.desc = this.getNodeParameter('description', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, additionalFields);
+						Object.assign(body, additionalFields);
 					} else if (operation === 'delete') {
 						// ----------------------------------
 						//         delete
@@ -350,13 +350,13 @@ export class Trello implements INodeType {
 						requestMethod = 'POST';
 						endpoint = 'cards';
 
-						qs.idList = this.getNodeParameter('listId', i) as string;
+						body.idList = this.getNodeParameter('listId', i) as string;
 
-						qs.name = this.getNodeParameter('name', i) as string;
-						qs.desc = this.getNodeParameter('description', i) as string;
+						body.name = this.getNodeParameter('name', i) as string;
+						body.desc = this.getNodeParameter('description', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, additionalFields);
+						Object.assign(body, additionalFields);
 					} else if (operation === 'delete') {
 						// ----------------------------------
 						//         delete
@@ -410,7 +410,7 @@ export class Trello implements INodeType {
 							extractValue: true,
 						}) as string;
 
-						qs.text = this.getNodeParameter('text', i) as string;
+						body.text = this.getNodeParameter('text', i) as string;
 
 						requestMethod = 'POST';
 
@@ -472,12 +472,12 @@ export class Trello implements INodeType {
 						requestMethod = 'POST';
 						endpoint = 'lists';
 
-						qs.idBoard = this.getNodeParameter('idBoard', i) as string;
+						body.idBoard = this.getNodeParameter('idBoard', i) as string;
 
-						qs.name = this.getNodeParameter('name', i) as string;
+						body.name = this.getNodeParameter('name', i) as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, additionalFields);
+						Object.assign(body, additionalFields);
 					} else if (operation === 'get') {
 						// ----------------------------------
 						//         get
@@ -563,12 +563,12 @@ export class Trello implements INodeType {
 
 						const url = this.getNodeParameter('url', i) as string;
 
-						Object.assign(qs, {
+						Object.assign(body, {
 							url,
 						});
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, additionalFields);
+						Object.assign(body, additionalFields);
 
 						endpoint = `cards/${cardId}/attachments`;
 					} else if (operation === 'delete') {
@@ -638,10 +638,10 @@ export class Trello implements INodeType {
 
 						const name = this.getNodeParameter('name', i) as string;
 
-						Object.assign(qs, { name });
+						Object.assign(body, { name });
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, additionalFields);
+						Object.assign(body, additionalFields);
 
 						endpoint = `cards/${cardId}/checklists`;
 					} else if (operation === 'delete') {
@@ -716,7 +716,7 @@ export class Trello implements INodeType {
 
 						const name = this.getNodeParameter('name', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
-						Object.assign(qs, { name, ...additionalFields });
+						Object.assign(body, { name, ...additionalFields });
 					} else if (operation === 'deleteCheckItem') {
 						// ----------------------------------
 						//         deleteCheckItem
@@ -785,7 +785,7 @@ export class Trello implements INodeType {
 						const name = this.getNodeParameter('name', i) as string;
 						const color = this.getNodeParameter('color', i) as string;
 
-						Object.assign(qs, {
+						Object.assign(body, {
 							idBoard,
 							name,
 							color,
@@ -857,7 +857,7 @@ export class Trello implements INodeType {
 
 						const id = this.getNodeParameter('id', i) as string;
 
-						qs.value = id;
+						body.value = id;
 
 						endpoint = `/cards/${cardId}/idLabels`;
 					} else if (operation === 'removeLabel') {


### PR DESCRIPTION
## Summary
Trello API also supports replacing query parameters with a JSON request body instead. Using the request body avoids too long URLs which could produce 413 responses (Content Too Large).
