### PR TITLE
fix(Google Sheets Node): Fix Google Sheet URL regex

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/Sheet.resource.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/Sheet.resource.ts
@@ -157,14 +157,14 @@ export const descriptions: INodeProperties[] = [
 				extractValue: {
 					type: 'regex',
 					regex:
-						'https:\\/\\/docs\\.google\\.com/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+\\/edit\\#gid=([0-9]+)',
+						'https:\\/\\/docs\\.google.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)',
 				},
 				validation: [
 					{
 						type: 'regex',
 						properties: {
 							regex:
-								'https:\\/\\/docs\\.google\\.com/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+\\/edit\\#gid=([0-9]+)',
+								'https:\\/\\/docs\\.google.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)',
 							errorMessage: 'Not a valid Sheet URL',
 						},
 					},


### PR DESCRIPTION
## Summary

When pasting the URL of a Google Sheet, the node used to say the URL is invalid:

![image](https://github.com/user-attachments/assets/94f4c500-af96-4b52-8bd9-394309a0c7a3)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1509/sheet-url-is-invalid-when-pasting-url

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
