### PR TITLE
fix(Google Sheets Node): Add column names row if sheet is empty

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -275,7 +275,10 @@ export async function execute(
 		//if no trailing empty row exists in the sheet update operation will fail
 		await sheet.appendEmptyRowsOrColumns(sheetId, 1, 0);
 
-		const lastRow = (sheetData ?? []).length + 1;
+		// if shhetData is undefined it means that the sheet was empty
+		// we did add row with column names in the first row (autoMapInputData)
+		// to account for that length has to be 1 and we append data in the next row
+		const lastRow = (sheetData ?? [{}]).length + 1;
 
 		await sheet.appendSheetData({
 			inputData,

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -275,7 +275,7 @@ export async function execute(
 		//if no trailing empty row exists in the sheet update operation will fail
 		await sheet.appendEmptyRowsOrColumns(sheetId, 1, 0);
 
-		// if shhetData is undefined it means that the sheet was empty
+		// if sheetData is undefined it means that the sheet was empty
 		// we did add row with column names in the first row (autoMapInputData)
 		// to account for that length has to be 1 and we append data in the next row
 		const lastRow = (sheetData ?? [{}]).length + 1;


### PR DESCRIPTION
## Summary

fix for issue: Append operation no longer uses the “Keys” as column names it creates table without column names.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/since-1-50-1-update-google-sheet-node-works-incorrectly/50547
https://linear.app/n8n/issue/NODE-1527/google-sheet-append-row-operation-no-longer-uses-the-keys-as-column
https://github.com/n8n-io/n8n/pull/9950

