### PR TITLE
fix(Google Sheets Node): Do not insert row_number as a new column, do not checkForSchemaChanges in update operation

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
@@ -5,11 +5,12 @@ import type {
 	ResourceMapperField,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import type {
-	ISheetUpdateData,
-	SheetProperties,
-	ValueInputOption,
-	ValueRenderOption,
+import {
+	ROW_NUMBER,
+	type ISheetUpdateData,
+	type SheetProperties,
+	type ValueInputOption,
+	type ValueRenderOption,
 } from '../../helpers/GoogleSheets.types';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
 import {
@@ -312,7 +313,7 @@ export async function execute(
 	};
 
 	const addNewColumn = (key: string) => {
-		if (!columnNames.includes(key)) {
+		if (!columnNames.includes(key) && key !== ROW_NUMBER) {
 			newColumns.add(key);
 		}
 	};

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -1,22 +1,14 @@
-import type {
-	IExecuteFunctions,
-	IDataObject,
-	INodeExecutionData,
-	ResourceMapperField,
-} from 'n8n-workflow';
+import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import type {
-	ISheetUpdateData,
-	SheetProperties,
-	ValueInputOption,
-	ValueRenderOption,
+import {
+	ROW_NUMBER,
+	type ISheetUpdateData,
+	type SheetProperties,
+	type ValueInputOption,
+	type ValueRenderOption,
 } from '../../helpers/GoogleSheets.types';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
-import {
-	cellFormatDefault,
-	checkForSchemaChanges,
-	untilSheetSelected,
-} from '../../helpers/GoogleSheets.utils';
+import { cellFormatDefault, untilSheetSelected } from '../../helpers/GoogleSheets.utils';
 import { cellFormat, handlingExtraData, locationDefine } from './commonDescription';
 
 export const description: SheetProperties = [
@@ -262,11 +254,6 @@ export async function execute(
 
 	columnNames = sheetData[keyRowIndex];
 
-	if (nodeVersion >= 4.4) {
-		const schema = this.getNodeParameter('columns.schema', 0) as ResourceMapperField[];
-		checkForSchemaChanges(this.getNode(), columnNames, schema);
-	}
-
 	const newColumns = new Set<string>();
 
 	const columnsToMatchOn: string[] =
@@ -305,7 +292,7 @@ export async function execute(
 	};
 
 	const addNewColumn = (key: string) => {
-		if (!columnNames.includes(key)) {
+		if (!columnNames.includes(key) && key !== ROW_NUMBER) {
 			newColumns.add(key);
 		}
 	};

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheets.utils.ts
@@ -343,11 +343,16 @@ export function checkForSchemaChanges(
 ) {
 	const updatedColumnNames: Array<{ oldName: string; newName: string }> = [];
 
+	//if sheet does not contain ROW_NUMBER ignore it as data come from read rows operation
+	const schemaColumns = columnNames.includes(ROW_NUMBER)
+		? schema.map((s) => s.id)
+		: schema.filter((s) => s.id !== ROW_NUMBER).map((s) => s.id);
+
 	for (const [columnIndex, columnName] of columnNames.entries()) {
-		const schemaEntry = schema[columnIndex];
+		const schemaEntry = schemaColumns[columnIndex];
 		if (schemaEntry === undefined) break;
-		if (columnName !== schema[columnIndex].id) {
-			updatedColumnNames.push({ oldName: schema[columnIndex].id, newName: columnName });
+		if (columnName !== schemaEntry) {
+			updatedColumnNames.push({ oldName: schemaEntry, newName: columnName });
 		}
 	}
 


### PR DESCRIPTION
## Summary

`row_number` column generated when reading data from sheet, if this data then used to upsert or update it would create `row_number` column in sheet, we prevent this to happen when in append operation and need to do this in upsert and update as well

After fix we would not insert row_number as a new column, but it would still be updated or appended if sheet already has one

----
checkForSchemaChanges intended to prevent shifts of columns if new one was added, it should not be checked in update as it is not positional bet key: value pair based

This fix removes `checkForSchemaChanges`  from update operation

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1489/google-sheets-deal-gracefully-with-column-updates
https://linear.app/n8n/issue/NODE-1381/google-sheets-insertupsert-shouldnt-create-a-row-number-col-by-default