### PR TITLE
fix: Add original error message to messages, do not obfuscate if description provided in options (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/node-operation.error.ts
+++ b/packages/workflow/src/errors/node-operation.error.ts
@@ -34,7 +34,11 @@ export class NodeOperationError extends NodeError {
 			error.messages.forEach((message) => this.addToMessages(message));
 		}
 
-		if (obfuscateErrorMessage) this.message = OBFUSCATED_ERROR_MESSAGE;
+		if (obfuscateErrorMessage && !options.description) {
+			const originalMessage = typeof error === 'string' ? error : (error.message as string);
+			this.addToMessages(originalMessage);
+			this.message = OBFUSCATED_ERROR_MESSAGE;
+		}
 		if (options.message) this.message = options.message;
 		if (options.level) this.level = options.level;
 		if (options.functionality) this.functionality = options.functionality;


### PR DESCRIPTION
## Summary

add original message to messages for debugging purposes
if description provided in error that means this error was processed so do not obfuscate it

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1528/error-obfuscation-fixes

