### PR TITLE
fix(editor): Fix parameter input glitch when there was an error loading remote options

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -254,7 +254,9 @@
 					:type="getStringInputType"
 					:rows="editorRows"
 					:disabled="
-						isReadOnly || remoteParameterOptionsLoading || remoteParameterOptionsLoadingIssues
+						isReadOnly ||
+						remoteParameterOptionsLoading ||
+						remoteParameterOptionsLoadingIssues !== null
 					"
 					:title="displayTitle"
 					:placeholder="getPlaceholder()"

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -253,7 +253,9 @@
 					:size="inputSize"
 					:type="getStringInputType"
 					:rows="editorRows"
-					:disabled="isReadOnly"
+					:disabled="
+						isReadOnly || remoteParameterOptionsLoading || remoteParameterOptionsLoadingIssues
+					"
 					:title="displayTitle"
 					:placeholder="getPlaceholder()"
 					@update:model-value="(valueChanged($event) as undefined) && onUpdateTextInput($event)"


### PR DESCRIPTION
## Summary

This PR disables the input field for a parameter, if there was an error loading remote parameter options.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-237/bug-loadoptions-drop-down-in-openai-model-broken

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
