### PR TITLE
fix: Better error message when calling data transformation functions on a null value

### DIFF
--- a/packages/workflow/src/Extensions/utils.ts
+++ b/packages/workflow/src/Extensions/utils.ts
@@ -21,12 +21,8 @@ export const convertToDateTime = (value: string | Date | DateTime): DateTime | u
 
 export function checkIfValueDefinedOrThrow<T>(value: T, functionName: string): void {
 	if (value === undefined || value === null) {
-		throw new ExpressionExtensionError(
-			`${functionName}() could not be called on "${String(value)}" type`,
-			{
-				description:
-					'You are trying to access a field that does not exist, modify your expression or set a default value',
-			},
-		);
+		throw new ExpressionExtensionError(`${functionName} can't be used on ${String(value)} value`, {
+			description: `To ignore this error, add a ? to the variable before this function, e.g. my_var?.${functionName}`,
+		});
 	}
 }

--- a/packages/workflow/test/ExpressionExtensions/ExpressionExtension.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/ExpressionExtension.test.ts
@@ -250,10 +250,7 @@ describe('tmpl Expression Parser', () => {
 				extend(undefined, 'toDateTime', []);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ExpressionExtensionError);
-				expect(error).toHaveProperty(
-					'message',
-					'toDateTime() could not be called on "undefined" type',
-				);
+				expect(error).toHaveProperty('message', "toDateTime can't be used on undefined value");
 			}
 		});
 		test('input is null', () => {
@@ -261,7 +258,7 @@ describe('tmpl Expression Parser', () => {
 				extend(null, 'startsWith', []);
 			} catch (error) {
 				expect(error).toBeInstanceOf(ExpressionExtensionError);
-				expect(error).toHaveProperty('message', 'startsWith() could not be called on "null" type');
+				expect(error).toHaveProperty('message', "startsWith can't be used on null value");
 			}
 		});
 		test('input should be converted to upper case', () => {


### PR DESCRIPTION
## Summary

Updated error message and description as requested by product

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1497/expressions-better-error-message-when-calling-data-transformation
https://linear.app/n8n/issue/NODE-1454/filterifswitch-nodes-improve-output-panel-error-if-a-field-is-missing