### PR TITLE
fix(Text Classifier Node): Use proper documentation URL and respect continueOnFail

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -46,7 +46,7 @@ export class TextClassifier implements INodeType {
 			resources: {
 				primaryDocumentation: [
 					{
-						url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm/',
+						url: 'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier/',
 					},
 				],
 			},
@@ -203,20 +203,27 @@ export class TextClassifier implements INodeType {
 			discard: 'If there is not a very fitting category, select none of the categories.',
 		}[fallback];
 
-		const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
-			`${options.systemPromptTemplate ?? SYSTEM_PROMPT_TEMPLATE}
-{format_instructions}
-${multiClassPrompt}
-${fallbackPrompt}`,
-		);
-
 		const returnData: INodeExecutionData[][] = Array.from(
 			{ length: categories.length + (fallback === 'other' ? 1 : 0) },
 			(_) => [],
 		);
 		for (let itemIdx = 0; itemIdx < items.length; itemIdx++) {
+			const item = items[itemIdx];
+			item.pairedItem = { item: itemIdx };
 			const input = this.getNodeParameter('inputText', itemIdx) as string;
 			const inputPrompt = new HumanMessage(input);
+
+			const systemPromptTemplateOpt = this.getNodeParameter(
+				'options.systemPromptTemplate',
+				itemIdx,
+			) as string;
+			const systemPromptTemplate = SystemMessagePromptTemplate.fromTemplate(
+				`${systemPromptTemplateOpt ?? SYSTEM_PROMPT_TEMPLATE}
+{format_instructions}
+${multiClassPrompt}
+${fallbackPrompt}`,
+			);
+
 			const messages = [
 				await systemPromptTemplate.format({
 					categories: categories.map((cat) => cat.category).join(', '),
@@ -227,13 +234,27 @@ ${fallbackPrompt}`,
 			const prompt = ChatPromptTemplate.fromMessages(messages);
 			const chain = prompt.pipe(llm).pipe(parser).withConfig(getTracingConfig(this));
 
-			const output = await chain.invoke(messages);
-			categories.forEach((cat, idx) => {
-				if (output[cat.category]) returnData[idx].push(items[itemIdx]);
-			});
-			if (fallback === 'other' && output.fallback)
-				returnData[returnData.length - 1].push(items[itemIdx]);
+			try {
+				const output = await chain.invoke(messages);
+
+				categories.forEach((cat, idx) => {
+					if (output[cat.category]) returnData[idx].push(item);
+				});
+				if (fallback === 'other' && output.fallback) returnData[returnData.length - 1].push(item);
+			} catch (error) {
+				if (this.continueOnFail(error)) {
+					returnData[0].push({
+						json: { error: error.message },
+						pairedItem: { item: itemIdx },
+					});
+
+					continue;
+				}
+
+				throw error;
+			}
 		}
+
 		return returnData;
 	}
 }


### PR DESCRIPTION
## Summary

- Refer to the text-classifier documentation
- Respect `continueOnFail` on errors
- Get the system prompt for each item; there might be references to item-texts

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-244/fix-doc-link-text-classifier-and-respect-continueonerror

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
