### PR TITLE
fix(Postgres Node): Expressions in query parameters for Postgres executeQuery operation

### DIFF
--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -11,7 +11,7 @@ export class Postgres extends VersionedNodeType {
 			name: 'postgres',
 			icon: 'file:postgres.svg',
 			group: ['input'],
-			defaultVersion: 2.4,
+			defaultVersion: 2.5,
 			description: 'Get, add and update data in Postgres',
 			parameterPane: 'wide',
 		};
@@ -23,6 +23,7 @@ export class Postgres extends VersionedNodeType {
 			2.2: new PostgresV2(baseDescription),
 			2.3: new PostgresV2(baseDescription),
 			2.4: new PostgresV2(baseDescription),
+			2.5: new PostgresV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -3,6 +3,7 @@ import type {
 	IExecuteFunctions,
 	INodeExecutionData,
 	INodeProperties,
+	NodeParameterValueType,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
@@ -78,22 +79,45 @@ export async function execute(
 
 			const rawReplacements = (node.parameters.options as IDataObject)?.queryReplacement as string;
 
-			if (rawReplacements) {
-				const rawValues = rawReplacements
-					.replace(/^=+/, '')
+			const stringToArray = (str: NodeParameterValueType | undefined) => {
+				if (!str) return [];
+				return String(str)
 					.split(',')
 					.filter((entry) => entry)
 					.map((entry) => entry.trim());
+			};
 
-				for (const rawValue of rawValues) {
-					const resolvables = getResolvables(rawValue);
+			if (rawReplacements) {
+				const nodeVersion = nodeOptions.nodeVersion as number;
 
+				if (nodeVersion >= 2.5) {
+					const rawValues = rawReplacements.replace(/^=+/, '');
+					const resolvables = getResolvables(rawValues);
 					if (resolvables.length) {
 						for (const resolvable of resolvables) {
-							values.push(this.evaluateExpression(`${resolvable}`, i) as IDataObject);
+							const evaluatedValues = stringToArray(this.evaluateExpression(`${resolvable}`, i));
+							if (evaluatedValues.length) values.push(...evaluatedValues);
 						}
 					} else {
-						values.push(rawValue);
+						values.push(...stringToArray(rawValues));
+					}
+				} else {
+					const rawValues = rawReplacements
+						.replace(/^=+/, '')
+						.split(',')
+						.filter((entry) => entry)
+						.map((entry) => entry.trim());
+
+					for (const rawValue of rawValues) {
+						const resolvables = getResolvables(rawValue);
+
+						if (resolvables.length) {
+							for (const resolvable of resolvables) {
+								values.push(this.evaluateExpression(`${resolvable}`, i) as IDataObject);
+							}
+						} else {
+							values.push(rawValue);
+						}
 					}
 				}
 			}

--- a/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
@@ -8,7 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'postgres',
 	icon: 'file:postgres.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2, 2.3, 2.4],
+	version: [2, 2.1, 2.2, 2.3, 2.4, 2.5],
 	subtitle: '={{ $parameter["operation"] }}',
 	description: 'Get, add and update data in Postgres',
 	defaults: {


### PR DESCRIPTION
## Summary

This PR fixes using expressions in query parameters for Postgres executeQuery operation, the query parameters field is expected as comma separated string or an expression that can be evaluated to a comma separated string.
the issue was splitting based on ' , ' before evaluating the expression. 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1431/postgres-expressions-in-query-params-broken
https://community.n8n.io/t/postgres-node-in-operator-with-parameters/47801/9

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
