### PR TITLE
fix(editor): Fix workflow execution list scrolling after filter change

### DIFF
--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsSidebar.vue
@@ -186,6 +186,9 @@ export default defineComponent({
 			this.$emit('refresh');
 		},
 		onFilterChanged(filter: ExecutionFilterType) {
+			this.autoScrollDeps.activeExecutionSet = false;
+			this.autoScrollDeps.scroll = true;
+			this.mountedItems = [];
 			this.$emit('filterUpdated', filter);
 		},
 		reloadExecutions(): void {


### PR DESCRIPTION
## Summary

Workflow executions list scrolling stops working after the filter is used
![2024-07-26 16 04 09](https://github.com/user-attachments/assets/9bbc60f4-61a6-4a53-a6e4-a007d7323871)

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1785](https://linear.app/n8n/issue/PAY-1785/bug-any-filtering-on-workflow-executions-views-stops-scrolling-from#comment-5c615bf9)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included.
- [x] PR Labeled with `release/backport`