### PR TITLE
fix(n8n Form Trigger Node): Remove custom attribution option (no-changelog)

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -460,9 +460,6 @@
 					<div class='n8n-link'>
 						<a href={{n8nWebsiteLink}} target='_blank'>
 							Form automated with
-							{{#if customAttribution}}
-								{{{customAttribution}}}
-							{{else}}
 							<svg
 								width='73'
 								height='20'
@@ -489,7 +486,6 @@
 									fill='#101330'
 								/>
 							</svg>
-							{{/if}}
 						</a>
 					</div>
 				{{/if}}

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -40,7 +40,6 @@ export type FormTriggerData = {
 	formFields: FormTriggerInput[];
 	useResponseData?: boolean;
 	appendAttribution?: boolean;
-	customAttribution?: string;
 };
 
 export const FORM_TRIGGER_AUTHENTICATION_PROPERTY = 'authentication';

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -49,7 +49,6 @@ describe('FormTrigger, formWebhook', () => {
 
 		expect(mockRender).toHaveBeenCalledWith('form-trigger', {
 			appendAttribution: true,
-			customAttribution: undefined,
 			formDescription: 'Test Description',
 			formFields: [
 				{
@@ -247,7 +246,6 @@ describe('FormTrigger, prepareFormData', () => {
 			],
 			useResponseData: true,
 			appendAttribution: true,
-			customAttribution: undefined,
 			redirectUrl: 'https://example.com/thank-you',
 		});
 	});
@@ -293,7 +291,6 @@ describe('FormTrigger, prepareFormData', () => {
 			],
 			useResponseData: undefined,
 			appendAttribution: true,
-			customAttribution: undefined,
 		});
 	});
 

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -26,7 +26,6 @@ export function prepareFormData({
 	instanceId,
 	useResponseData,
 	appendAttribution = true,
-	customAttribution,
 }: {
 	formTitle: string;
 	formDescription: string;
@@ -38,7 +37,6 @@ export function prepareFormData({
 	instanceId?: string;
 	useResponseData?: boolean;
 	appendAttribution?: boolean;
-	customAttribution?: string;
 }) {
 	const validForm = formFields.length > 0;
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
@@ -58,7 +56,6 @@ export function prepareFormData({
 		formFields: [],
 		useResponseData,
 		appendAttribution,
-		customAttribution,
 	};
 
 	if (redirectUrl) {
@@ -157,7 +154,6 @@ export async function formWebhook(context: IWebhookFunctions) {
 		formSubmittedText?: string;
 		useWorkflowTimezone?: boolean;
 		appendAttribution?: boolean;
-		customAttribution?: string;
 	};
 	const res = context.getResponseObject();
 	const req = context.getRequestObject();
@@ -225,7 +221,6 @@ export async function formWebhook(context: IWebhookFunctions) {
 			instanceId,
 			useResponseData,
 			appendAttribution,
-			customAttribution: options.customAttribution as string,
 		});
 
 		res.render('form-trigger', data);

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -116,17 +116,6 @@ const descriptionV2: INodeTypeDescription = {
 			default: {},
 			options: [
 				{
-					displayName: 'Custom Attribution',
-					name: 'customAttribution',
-					type: 'string',
-					placeholder: 'e.g. <svg> ...</svg>',
-					description: "HTML code that will be shown at the bottom of the form instead n8n's logo",
-					default: '',
-					typeOptions: {
-						rows: 2,
-					},
-				},
-				{
 					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
 					displayName: 'Append n8n Attribution',
 					name: 'appendAttribution',


### PR DESCRIPTION
## Summary

Custom Attribution Option removed as to be addressed in farther customization update

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1505/form-trigger-improvements-p1
