### PR TITLE
refactor(nodes-base): return response body on RespondToWebhook

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -427,6 +427,10 @@ export class RespondToWebhook implements INodeType {
 				statusCode,
 			};
 
+			items[0].json.body = responseBody;
+			items[0].json.headers = { ...(items[0].json.headers as object), ...headers };
+			items[0].json.statusCode = response.statusCode;
+
 			this.sendResponse(response);
 		} catch (error) {
 			if (this.continueOnFail(error)) {


### PR DESCRIPTION
## Summary

Returns `body`, `statusCode` & `headers` in `RespondToWebbhook` node.

This is useful to have access to workflow response in postExecute workflows hooks.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

## Test Proof

![image](https://github.com/user-attachments/assets/826b7748-4172-4d40-951a-3ddf7b4a7732)

