### PR TITLE
fix(core): Restore log event `n8n.workflow.failed`

### DIFF
--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -175,7 +175,7 @@ export class InternalHooks {
 			runData.status = 'canceled';
 		}
 
-		telemetryProperties.success = !!runData?.finished; // xyz
+		telemetryProperties.success = !!runData?.finished;
 
 		// const executionStatus: ExecutionStatus = runData?.status ?? 'unknown';
 		const executionStatus: ExecutionStatus = runData

--- a/packages/cli/src/InternalHooks.ts
+++ b/packages/cli/src/InternalHooks.ts
@@ -175,7 +175,7 @@ export class InternalHooks {
 			runData.status = 'canceled';
 		}
 
-		telemetryProperties.success = !!runData?.finished;
+		telemetryProperties.success = !!runData?.finished; // xyz
 
 		// const executionStatus: ExecutionStatus = runData?.status ?? 'unknown';
 		const executionStatus: ExecutionStatus = runData

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -651,6 +651,12 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 					executionId,
 					success: runData.status === 'success',
 					isManual: runData.mode === 'manual',
+					lastNodeExecuted: runData?.data.resultData.lastNodeExecuted,
+					errorNodeType:
+						runData?.data.resultData.error && 'node' in runData?.data.resultData.error
+							? runData?.data.resultData.error.node?.type
+							: undefined,
+					errorMessage: runData?.data.resultData.error?.message.toString(),
 				});
 			},
 			async function (this: WorkflowHooks, fullRunData: IRun) {
@@ -940,6 +946,12 @@ async function executeWorkflow(
 		success: data.status === 'success',
 		isManual: data.mode === 'manual',
 		userId: additionalData.userId,
+		lastNodeExecuted: data?.data.resultData.lastNodeExecuted,
+		errorNodeType:
+			data?.data.resultData.error && 'node' in data?.data.resultData.error
+				? data?.data.resultData.error.node?.type
+				: undefined,
+		errorMessage: data?.data.resultData.error?.message.toString(),
 	});
 
 	// subworkflow either finished, or is in status waiting due to a wait node, both cases are considered successes here

--- a/packages/cli/src/WorkflowExecuteAdditionalData.ts
+++ b/packages/cli/src/WorkflowExecuteAdditionalData.ts
@@ -651,12 +651,7 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 					executionId,
 					success: runData.status === 'success',
 					isManual: runData.mode === 'manual',
-					lastNodeExecuted: runData?.data.resultData.lastNodeExecuted,
-					errorNodeType:
-						runData?.data.resultData.error && 'node' in runData?.data.resultData.error
-							? runData?.data.resultData.error.node?.type
-							: undefined,
-					errorMessage: runData?.data.resultData.error?.message.toString(),
+					runData,
 				});
 			},
 			async function (this: WorkflowHooks, fullRunData: IRun) {
@@ -946,12 +941,7 @@ async function executeWorkflow(
 		success: data.status === 'success',
 		isManual: data.mode === 'manual',
 		userId: additionalData.userId,
-		lastNodeExecuted: data?.data.resultData.lastNodeExecuted,
-		errorNodeType:
-			data?.data.resultData.error && 'node' in data?.data.resultData.error
-				? data?.data.resultData.error.node?.type
-				: undefined,
-		errorMessage: data?.data.resultData.error?.message.toString(),
+		runData: data,
 	});
 
 	// subworkflow either finished, or is in status waiting due to a wait node, both cases are considered successes here

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -173,6 +173,12 @@ export class WorkflowRunner {
 						success: executionData?.status === 'success',
 						isManual: data.executionMode === 'manual',
 						userId: data.userId,
+						lastNodeExecuted: executionData?.data.resultData.lastNodeExecuted,
+						errorNodeType:
+							executionData?.data.resultData.error && 'node' in executionData?.data.resultData.error
+								? executionData?.data.resultData.error.node?.type
+								: undefined,
+						errorMessage: executionData?.data.resultData.error?.message.toString(),
 					});
 					if (this.externalHooks.exists('workflow.postExecute')) {
 						try {

--- a/packages/cli/src/WorkflowRunner.ts
+++ b/packages/cli/src/WorkflowRunner.ts
@@ -173,12 +173,7 @@ export class WorkflowRunner {
 						success: executionData?.status === 'success',
 						isManual: data.executionMode === 'manual',
 						userId: data.userId,
-						lastNodeExecuted: executionData?.data.resultData.lastNodeExecuted,
-						errorNodeType:
-							executionData?.data.resultData.error && 'node' in executionData?.data.resultData.error
-								? executionData?.data.resultData.error.node?.type
-								: undefined,
-						errorMessage: executionData?.data.resultData.error?.message.toString(),
+						runData: executionData,
 					});
 					if (this.externalHooks.exists('workflow.postExecute')) {
 						try {

--- a/packages/cli/src/eventbus/audit-event-relay.service.ts
+++ b/packages/cli/src/eventbus/audit-event-relay.service.ts
@@ -121,10 +121,37 @@ export class AuditEventRelay {
 		});
 	}
 
-	private workflowPostExecute(event: Event['workflow-post-execute']) {
+	private workflowPostExecute({
+		executionId,
+		success,
+		userId,
+		workflowId,
+		isManual,
+		workflowName,
+		metadata,
+		lastNodeExecuted,
+		errorNodeType,
+		errorMessage,
+	}: Event['workflow-post-execute']) {
+		const payload: Event['workflow-post-execute'] = {
+			executionId,
+			success,
+			userId,
+			workflowId,
+			isManual,
+			workflowName,
+			metadata,
+		};
+
+		if (!success) {
+			payload.lastNodeExecuted = lastNodeExecuted;
+			payload.errorNodeType = errorNodeType;
+			payload.errorMessage = errorMessage;
+		}
+
 		void this.eventBus.sendWorkflowEvent({
-			eventName: 'n8n.workflow.success',
-			payload: event,
+			eventName: success ? 'n8n.workflow.success' : 'n8n.workflow.failed',
+			payload,
 		});
 	}
 

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -1,4 +1,4 @@
-import type { AuthenticationMethod, IWorkflowBase } from 'n8n-workflow';
+import type { AuthenticationMethod, IRun, IWorkflowBase } from 'n8n-workflow';
 import type { IWorkflowExecutionDataProcess } from '@/Interfaces';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { GlobalRole } from '@/databases/entities/User';
@@ -46,11 +46,7 @@ export type Event = {
 		isManual: boolean;
 		workflowName: string;
 		metadata?: Record<string, string>;
-
-		// failed case
-		lastNodeExecuted?: string;
-		errorNodeType?: string;
-		errorMessage?: string;
+		runData?: IRun;
 	};
 
 	'node-pre-execute': {

--- a/packages/cli/src/eventbus/event.types.ts
+++ b/packages/cli/src/eventbus/event.types.ts
@@ -46,6 +46,11 @@ export type Event = {
 		isManual: boolean;
 		workflowName: string;
 		metadata?: Record<string, string>;
+
+		// failed case
+		lastNodeExecuted?: string;
+		errorNodeType?: string;
+		errorMessage?: string;
 	};
 
 	'node-pre-execute': {

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -296,6 +296,12 @@ export class ExecutionRecoveryService {
 			executionId: execution.id,
 			success: execution.status === 'success',
 			isManual: execution.mode === 'manual',
+			lastNodeExecuted: execution.data.resultData.lastNodeExecuted,
+			errorNodeType:
+				execution.data.resultData.error && 'node' in execution.data.resultData.error
+					? execution.data.resultData.error.node?.type
+					: undefined,
+			errorMessage: execution.data.resultData.error?.message.toString(),
 		});
 
 		const externalHooks = getWorkflowHooksMain(

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -296,12 +296,7 @@ export class ExecutionRecoveryService {
 			executionId: execution.id,
 			success: execution.status === 'success',
 			isManual: execution.mode === 'manual',
-			lastNodeExecuted: execution.data.resultData.lastNodeExecuted,
-			errorNodeType:
-				execution.data.resultData.error && 'node' in execution.data.resultData.error
-					? execution.data.resultData.error.node?.type
-					: undefined,
-			errorMessage: execution.data.resultData.error?.message.toString(),
+			runData: execution,
 		});
 
 		const externalHooks = getWorkflowHooksMain(


### PR DESCRIPTION
## Summary

Accidentally removed [here](https://github.com/n8n-io/n8n/pull/9724/files#diff-a91344c72b2b4a696fa0b18ef1a154dad6d7594baba2285265e37b2695c4f9edL525) while disentangling event bus from internal hooks.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/recent-updates-to-n8n-fail-to-send-n8n-workflow-failed-events-over-log-streaming/50984

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
