### PR TITLE
test(core): Stop showing JWT warning during test runs (no-changelog)

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -96,9 +96,10 @@ config.validate({
 });
 const userManagement = config.get('userManagement');
 if (userManagement.jwtRefreshTimeoutHours >= userManagement.jwtSessionDurationHours) {
-	console.warn(
-		'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS needs to smaller than N8N_USER_MANAGEMENT_JWT_DURATION_HOURS. Setting N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS to 0 for now.',
-	);
+	if (!inTest)
+		console.warn(
+			'N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS needs to smaller than N8N_USER_MANAGEMENT_JWT_DURATION_HOURS. Setting N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS to 0 for now.',
+		);
 
 	config.set('userManagement.jwtRefreshTimeoutHours', 0);
 }


### PR DESCRIPTION
This clutters the test report on every run: https://github.com/n8n-io/n8n/actions/runs/10176111657/job/28144836964#step:9:2412