### PR TITLE
feat(Git) "Disable ceritificate check" option

### DIFF
--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -182,6 +182,19 @@ export class Git implements INodeType {
 				required: true,
 				description: 'Local path to which the git repository should be cloned into',
 			},
+			{
+				displayName: 'Disable certificate check',
+				name: 'disableCertCheck',
+				type: 'boolean',
+				default: false,
+				noDataExpression: true,
+				description: 'Disable git ssl certificate check',
+				displayOptions: {
+					show : {
+						operation: ['clone', 'fetch', 'pull', 'push', 'pushTags'],
+					},
+				},
+			},
 
 			...addFields,
 			...addConfigFields,
@@ -214,10 +227,12 @@ export class Git implements INodeType {
 		};
 
 		const operation = this.getNodeParameter('operation', 0);
+
 		const returnItems: INodeExecutionData[] = [];
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			try {
 				const repositoryPath = this.getNodeParameter('repositoryPath', itemIndex, '') as string;
+				const disableCertCheck = this.getNodeParameter('disableCertCheck', itemIndex, false) as boolean;
 				const options = this.getNodeParameter('options', itemIndex, {});
 
 				if (operation === 'clone') {
@@ -231,6 +246,7 @@ export class Git implements INodeType {
 
 				const gitOptions: Partial<SimpleGitOptions> = {
 					baseDir: repositoryPath,
+					config: [`http.sslVerify=${disableCertCheck}`]
 				};
 
 				const git: SimpleGit = simpleGit(gitOptions)

--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -246,7 +246,7 @@ export class Git implements INodeType {
 
 				const gitOptions: Partial<SimpleGitOptions> = {
 					baseDir: repositoryPath,
-					config: [`http.sslVerify=${disableCertCheck}`]
+					config: [`http.sslVerify=${!disableCertCheck}`]
 				};
 
 				const git: SimpleGit = simpleGit(gitOptions)


### PR DESCRIPTION
## Summary

This pr adds new ``Disable certificate check`` boolean option to Git node to disable ssl verification. 

Note: I have noticed that Git addConfig option already helps to add key value git configuration to given repository. Unfortunately Git addConfig option doesn't help me during cloning operation because repository hasn't been created yet.

Please lmk if this change is okay, so i can provide tests

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

