### PR TITLE
refactor(editor): Boost n8n Form Trigger in nodes-panel search results

### DIFF
--- a/packages/editor-ui/src/utils/sortUtils.ts
+++ b/packages/editor-ui/src/utils/sortUtils.ts
@@ -139,10 +139,12 @@ function fuzzyMatchRecursive(
 	if (matched) {
 		outScore = 100;
 
-		// Apply leading letter penalty
-		let penalty = LEADING_LETTER_PENALTY * matches[0];
-		penalty = penalty < MAX_LEADING_LETTER_PENALTY ? MAX_LEADING_LETTER_PENALTY : penalty;
-		outScore += penalty;
+		// Apply leading letter penalty (if not n8n-prefixed)
+		if (!target.toLowerCase().startsWith('n8n')) {
+			let penalty = LEADING_LETTER_PENALTY * matches[0];
+			penalty = penalty < MAX_LEADING_LETTER_PENALTY ? MAX_LEADING_LETTER_PENALTY : penalty;
+			outScore += penalty;
+		}
 
 		//Apply unmatched penalty
 		const unmatched = target.length - nextMatch;

--- a/packages/nodes-base/nodes/Form/FormTrigger.node.json
+++ b/packages/nodes-base/nodes/Form/FormTrigger.node.json
@@ -3,7 +3,7 @@
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Core Nodes"],
-	"alias": ["_Form", "form", "table", "submit", "post"],
+	"alias": ["table", "submit", "post"],
 	"resources": {
 		"primaryDocumentation": [
 			{


### PR DESCRIPTION
Exempt `n8n`-prefixed node names from leading letter penalty when calculating the score to rank search results.

https://n8nio.slack.com/archives/C03594NKD7W/p1722848436798459