### PR TITLE
fix(core): VM2 sandbox should not throw on `new Promise`

### DIFF
--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -153,7 +153,7 @@
     "@langchain/textsplitters": "0.0.3",
     "@mozilla/readability": "^0.5.0",
     "@n8n/typeorm": "0.3.20-10",
-    "@n8n/vm2": "3.9.24",
+    "@n8n/vm2": "3.9.25",
     "@pinecone-database/pinecone": "3.0.0",
     "@qdrant/js-client-rest": "1.9.0",
     "@supabase/supabase-js": "2.43.4",

--- a/packages/nodes-base/nodes/Code/test/Code.workflow.json
+++ b/packages/nodes-base/nodes/Code/test/Code.workflow.json
@@ -59,6 +59,34 @@
 			"type": "n8n-nodes-base.code",
 			"typeVersion": 1,
 			"position": [460, 860]
+		},
+		{
+			"parameters": {
+				"mode": "runOnceForEachItem",
+				"jsCode": "const json = $input.item.json\njson.myNewField = await (async () => json.value)();\n\nreturn $input.item;"
+			},
+			"id": "3cff4a64-c3fd-47d3-a33e-3c446846138f",
+			"name": "With Async Functions",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 1,
+			"position": [
+				460,
+				1200
+			]
+		},
+		{
+			"parameters": {
+				"mode": "runOnceForEachItem",
+				"jsCode": "const json = $input.item.json\njson.myNewField = await new Promise((resolve) => resolve(json.value));\n\nreturn $input.item;"
+			},
+			"id": "947e4e3e-2da3-40c5-97da-830c4572fc05",
+			"name": "With Promises",
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 1,
+			"position": [
+				460,
+				1380
+			]
 		}
 	],
 	"pinData": {
@@ -91,6 +119,34 @@
 			}
 		],
 		"Run Once for Each Item  (Legacy Syntax)": [
+			{
+				"json": {
+					"value": 1,
+					"myNewField": 1
+				}
+			},
+			{
+				"json": {
+					"value": 2,
+					"myNewField": 2
+				}
+			}
+		],
+		"With Async Functions": [
+			{
+				"json": {
+					"value": 1,
+					"myNewField": 1
+				}
+			},
+			{
+				"json": {
+					"value": 2,
+					"myNewField": 2
+				}
+			}
+		],
+		"With Promises": [
 			{
 				"json": {
 					"value": 1,
@@ -137,6 +193,16 @@
 					},
 					{
 						"node": "Run Once for Each Item  (Legacy Syntax)",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "With Async Functions",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "With Promises",
 						"type": "main",
 						"index": 0
 					}

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -830,7 +830,7 @@
   "dependencies": {
     "@kafkajs/confluent-schema-registry": "1.0.6",
     "@n8n/imap": "workspace:*",
-    "@n8n/vm2": "3.9.24",
+    "@n8n/vm2": "3.9.25",
     "amqplib": "0.10.3",
     "alasql": "^4.4.0",
     "aws4": "1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,8 +390,8 @@ importers:
         specifier: 0.3.20-10
         version: 0.3.20-10(@sentry/node@7.87.0)(ioredis@5.3.2)(mssql@10.0.2)(mysql2@3.10.0)(pg@8.11.3)(redis@4.6.12)(sqlite3@5.1.7)
       '@n8n/vm2':
-        specifier: 3.9.24
-        version: 3.9.24
+        specifier: 3.9.25
+        version: 3.9.25
       '@pinecone-database/pinecone':
         specifier: 3.0.0
         version: 3.0.0
@@ -1448,8 +1448,8 @@ importers:
         specifier: workspace:*
         version: link:../@n8n/imap
       '@n8n/vm2':
-        specifier: 3.9.24
-        version: 3.9.24
+        specifier: 3.9.25
+        version: 3.9.25
       alasql:
         specifier: ^4.4.0
         version: 4.4.0(encoding@0.1.13)
@@ -4211,8 +4211,8 @@ packages:
       typeorm-aurora-data-api-driver:
         optional: true
 
-  '@n8n/vm2@3.9.24':
-    resolution: {integrity: sha512-O4z67yVgUs2FHkcw3vbGnxdC1EglpzOj966kPkK4gtW+ZmTTFRfEB+2Ehq6PMthgg/Ou5JCLSR3wvQIZFFt4Pg==}
+  '@n8n/vm2@3.9.25':
+    resolution: {integrity: sha512-qoGLFzyHBW7HKpwXkl05QKsIh3GkDw6lOiTOWYlUDnOIQ1b7EgM+O5EMjrMGy7r+kz52+Q7o6GLxBIcxVI8rEg==}
     engines: {node: '>=18.10', pnpm: '>=9.6'}
     hasBin: true
 
@@ -6005,11 +6005,6 @@ packages:
 
   acorn@7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.11.2:
-    resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -16710,7 +16705,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@n8n/vm2@3.9.24':
+  '@n8n/vm2@3.9.25':
     dependencies:
       acorn: 8.12.1
       acorn-walk: 8.3.2
@@ -19360,15 +19355,13 @@ snapshots:
       acorn: 8.12.1
       acorn-walk: 8.3.2
 
-  acorn-jsx@5.3.2(acorn@8.11.2):
+  acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.12.1
 
   acorn-walk@8.3.2: {}
 
   acorn@7.4.1: {}
-
-  acorn@8.11.2: {}
 
   acorn@8.12.1: {}
 
@@ -21481,8 +21474,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint-visitor-keys: 3.4.3
 
   esprima-next@5.8.4: {}


### PR DESCRIPTION
## Summary
In an attempt to prevent CVE-2023-37466, I added a fix [here](https://github.com/n8n-io/vm2/pull/2/commits/e43c6357f98f1936c9561b96b18326867425d5c1). But this also broke any code that uses `new Promise`.
So, I've re-done the fix [here](https://github.com/n8n-io/vm2/pull/3/commits/13651c25a31d979466b07892ec9215f4593eb2d5), added tests in that repo, and also added tests for the code node to prevent something like this from happening again.

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included