### PR TITLE
fix(core): Revert transactions until we remove the legacy sqlite driver 

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           N8N_ENCRYPTION_KEY: ${{secrets.ENCRYPTION_KEY}}
           SKIP_STATISTICS_EVENTS: true
+          DB_SQLITE_POOL_SIZE: 4
       # -
       #   name: Export credentials
       #   if: always()

--- a/packages/cli/src/databases/repositories/executionData.repository.ts
+++ b/packages/cli/src/databases/repositories/executionData.repository.ts
@@ -1,30 +1,11 @@
 import { Service } from 'typedi';
-import type { EntityManager } from '@n8n/typeorm';
-import type { IWorkflowBase } from 'n8n-workflow';
 import { DataSource, In, Repository } from '@n8n/typeorm';
 import { ExecutionData } from '../entities/ExecutionData';
-
-export interface CreateExecutionDataOpts extends Pick<ExecutionData, 'data' | 'executionId'> {
-	workflowData: Pick<IWorkflowBase, 'connections' | 'nodes' | 'name' | 'settings' | 'id'>;
-}
 
 @Service()
 export class ExecutionDataRepository extends Repository<ExecutionData> {
 	constructor(dataSource: DataSource) {
 		super(ExecutionData, dataSource.manager);
-	}
-
-	async createExecutionDataForExecution(
-		executionData: CreateExecutionDataOpts,
-		transactionManager: EntityManager,
-	) {
-		const { data, executionId, workflowData } = executionData;
-
-		return await transactionManager.insert(ExecutionData, {
-			executionId,
-			data,
-			workflowData,
-		});
 	}
 
 	async findByExecutionIds(executionIds: string[]) {

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -52,34 +52,5 @@ describe('ExecutionRepository', () => {
 			});
 			expect(executionData?.data).toEqual('[{"resultData":"1"},{}]');
 		});
-
-		it('should not create execution if execution data insert fails', async () => {
-			const executionRepo = Container.get(ExecutionRepository);
-			const executionDataRepo = Container.get(ExecutionDataRepository);
-
-			const workflow = await createWorkflow({ settings: { executionOrder: 'v1' } });
-			jest
-				.spyOn(executionDataRepo, 'createExecutionDataForExecution')
-				.mockRejectedValueOnce(new Error());
-
-			await expect(
-				async () =>
-					await executionRepo.createNewExecution({
-						workflowId: workflow.id,
-						data: {
-							//@ts-expect-error This is not needed for tests
-							resultData: {},
-						},
-						workflowData: workflow,
-						mode: 'manual',
-						startedAt: new Date(),
-						status: 'new',
-						finished: false,
-					}),
-			).rejects.toThrow();
-
-			const executionEntities = await executionRepo.find();
-			expect(executionEntities).toBeEmptyArray();
-		});
 	});
 });


### PR DESCRIPTION
## Summary
We added a transaction around execution creation [here](https://github.com/n8n-io/n8n/pull/10276), which in theory is a good idea, however because we are still using the non-pooling driver by default for sqlite, these transactions create nested transactions, possibly messing the DB us under highly concurrent load.
We should bring this transaction back once we remove the legacy driver. 

[Workflow Tests](https://github.com/n8n-io/n8n/actions/runs/10249760615)


## Review / Merge checklist

- [x] PR title and summary are descriptive