### PR TITLE
fix(core): Ensure OAuth token data is not stubbed in source control

### DIFF
--- a/packages/cli/src/environments/sourceControl/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/environments/sourceControl/__tests__/source-control-export.service.test.ts
@@ -1,0 +1,85 @@
+import mock from 'jest-mock-extended/lib/Mock';
+import { SourceControlExportService } from '../sourceControlExport.service.ee';
+import type { SourceControlledFile } from '../types/sourceControlledFile';
+import { Cipher, type InstanceSettings } from 'n8n-core';
+import { SharedCredentialsRepository } from '@/databases/repositories/sharedCredentials.repository';
+import { mockInstance } from '@test/mocking';
+
+import type { SharedCredentials } from '@/databases/entities/SharedCredentials';
+import type { CredentialsEntity } from '@/databases/entities/CredentialsEntity';
+import Container from 'typedi';
+import { ApplicationError, deepCopy } from 'n8n-workflow';
+
+// https://github.com/jestjs/jest/issues/4715
+function deepSpyOn<O extends object, M extends keyof O>(object: O, methodName: M) {
+	const spy = jest.fn();
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	const originalMethod = object[methodName];
+
+	if (typeof originalMethod !== 'function') {
+		throw new ApplicationError(`${methodName.toString()} is not a function`, { level: 'warning' });
+	}
+
+	object[methodName] = function (...args: unknown[]) {
+		const clonedArgs = deepCopy(args);
+		spy(...clonedArgs);
+		return originalMethod.apply(this, args);
+	} as O[M];
+
+	return spy;
+}
+
+describe('SourceControlExportService', () => {
+	const service = new SourceControlExportService(
+		mock(),
+		mock(),
+		mock(),
+		mock<InstanceSettings>({ n8nFolder: '' }),
+	);
+
+	describe('exportCredentialsToWorkFolder', () => {
+		it('should export credentials to work folder', async () => {
+			/**
+			 * Arrange
+			 */
+			// @ts-expect-error Private method
+			const replaceSpy = deepSpyOn(service, 'replaceCredentialData');
+
+			mockInstance(SharedCredentialsRepository).findByCredentialIds.mockResolvedValue([
+				mock<SharedCredentials>({
+					credentials: mock<CredentialsEntity>({
+						data: Container.get(Cipher).encrypt(
+							JSON.stringify({
+								authUrl: 'test',
+								accessTokenUrl: 'test',
+								clientId: 'test',
+								clientSecret: 'test',
+								oauthTokenData: {
+									access_token: 'test',
+									token_type: 'test',
+									expires_in: 123,
+									refresh_token: 'test',
+								},
+							}),
+						),
+					}),
+				}),
+			]);
+
+			/**
+			 * Act
+			 */
+			await service.exportCredentialsToWorkFolder([mock<SourceControlledFile>()]);
+
+			/**
+			 * Assert
+			 */
+			expect(replaceSpy).toHaveBeenCalledWith({
+				authUrl: 'test',
+				accessTokenUrl: 'test',
+				clientId: 'test',
+				clientSecret: 'test',
+			});
+		});
+	});
+});

--- a/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlExport.service.ee.ts
@@ -293,11 +293,18 @@ export class SourceControlExportService {
 						};
 					}
 
+					/**
+					 * Edge case: Do not export `oauthTokenData`, so that that the
+					 * pulling instance reconnects instead of trying to use stubbed values.
+					 */
+					const credentialData = credentials.getData();
+					const { oauthTokenData, ...rest } = credentialData;
+
 					const stub: ExportableCredential = {
 						id,
 						name,
 						type,
-						data: this.replaceCredentialData(credentials.getData()),
+						data: this.replaceCredentialData(rest),
 						ownedBy: owner,
 					};
 

--- a/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
+++ b/packages/cli/src/environments/sourceControl/sourceControlImport.service.ee.ts
@@ -326,7 +326,12 @@ export class SourceControlImportService {
 				if (existingCredential?.data) {
 					newCredentialObject.data = existingCredential.data;
 				} else {
-					newCredentialObject.setData(data);
+					/**
+					 * Edge case: Do not import `oauthTokenData`, so that that the
+					 * pulling instance reconnects instead of trying to use stubbed values.
+					 */
+					const { oauthTokenData, ...rest } = data;
+					newCredentialObject.setData(rest);
 				}
 
 				this.logger.debug(`Updating credential id ${newCredentialObject.id as string}`);

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -1342,7 +1342,9 @@ export async function requestOAuth2(
 	// if it's the first time using the credentials, get the access token and save it into the DB.
 	if (
 		credentials.grantType === 'clientCredentials' &&
-		(oauthTokenData === undefined || Object.keys(oauthTokenData).length === 0)
+		(oauthTokenData === undefined ||
+			Object.keys(oauthTokenData).length === 0 ||
+			oauthTokenData.access_token === '') // stub
 	) {
 		const { data } = await oAuthClient.credentials.getToken();
 		// Find the credentials


### PR DESCRIPTION
## Summary

When pulling a generic OAuth2 credential from source control, `oauthTokenData` is being copied over as a stub, which causes the pulling instance not to attempt to fetch the token at runtime.

If on top of this the OAuth2 credential is for the client credentials flow, for which there is no connection test, the user will then only see the issue at the time of execution instead of when filling in credential details.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1711

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
