### PR TITLE
fix(editor): Update design system Avatar component to show initials also when only firstName or lastName is given

### DIFF
--- a/packages/design-system/src/components/N8nAvatar/Avatar.vue
+++ b/packages/design-system/src/components/N8nAvatar/Avatar.vue
@@ -1,14 +1,14 @@
 <template>
 	<span :class="['n8n-avatar', $style.container]" v-bind="$attrs">
 		<Avatar
-			v-if="firstName"
+			v-if="name"
 			:size="getSize(size)"
-			:name="firstName + ' ' + lastName"
+			:name="name"
 			variant="marble"
 			:colors="getColors(colors)"
 		/>
-		<div v-else :class="[$style.empty, $style[size]]"></div>
-		<span v-if="firstName" :class="$style.initials">{{ initials }}</span>
+		<span v-else :class="[$style.empty, $style[size]]" />
+		<span v-if="name" :class="$style.initials">{{ initials }}</span>
 	</span>
 </template>
 
@@ -38,7 +38,8 @@ const props = withDefaults(defineProps<AvatarProps>(), {
 	],
 });
 
-const initials = computed(() => getInitials(`${props.firstName} ${props.lastName}`));
+const name = computed(() => `${props.firstName} ${props.lastName}`.trim());
+const initials = computed(() => getInitials(name.value));
 
 const getColors = (colors: string[]): string[] => {
 	const style = getComputedStyle(document.body);
@@ -62,6 +63,7 @@ const getSize = (size: string): number => sizes[size];
 }
 
 .empty {
+	display: block;
 	border-radius: 50%;
 	background-color: var(--color-foreground-dark);
 	opacity: 0.3;
@@ -72,7 +74,8 @@ const getSize = (size: string): number => sizes[size];
 	font-size: var(--font-size-2xs);
 	font-weight: var(--font-weight-bold);
 	color: var(--color-avatar-font);
-	text-shadow: 0px 1px 6px rgba(25, 11, 9, 0.3);
+	text-shadow: 0 1px 6px rgba(25, 11, 9, 0.3);
+	text-transform: uppercase;
 }
 
 .small {

--- a/packages/design-system/src/components/N8nAvatar/__tests__/Avatar.test.ts
+++ b/packages/design-system/src/components/N8nAvatar/__tests__/Avatar.test.ts
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/vue';
+import N8nAvatar from '../Avatar.vue';
+
+describe('components', () => {
+	describe('N8nAlert', () => {
+		test.each([
+			['Firstname', 'Lastname', 'FL'],
+			['Firstname', undefined, 'Fi'],
+			[undefined, 'Lastname', 'La'],
+			[undefined, undefined, ''],
+			['', '', ''],
+		])('should render initials for name "%s %s" as %s', (firstName, lastName, initials) => {
+			const { container, getByText } = render(N8nAvatar, {
+				props: { firstName, lastName },
+			});
+
+			if (firstName || lastName) {
+				expect(container.querySelector('svg')).toBeVisible();
+				expect(getByText(initials)).toBeVisible();
+			} else {
+				expect(container.querySelector('svg')).not.toBeInTheDocument();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The avatar icon and initials may not show up on the cloud because users are not forced to give both a first name and a last name there.

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1620](https://linear.app/n8n/issue/PAY-1620/bug-owner-icon-not-showing-in-this-sharing-modal)

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
