### PR TITLE
docs: Prevent 301 redirects from failing on doc url tests (no-changelog)

### DIFF
--- a/.github/scripts/validate-docs-links.js
+++ b/.github/scripts/validate-docs-links.js
@@ -72,7 +72,7 @@ const checkLinks = async (packageName, kind) => {
 	const invalidUrls = [];
 	for (const [name, statusCode] of statuses) {
 		if (statusCode === null) missingDocs.push(name);
-		if (statusCode !== 200) invalidUrls.push(name);
+		if (statusCode !== 200 && statusCode !== 301) invalidUrls.push(name);
 	}
 
 	if (missingDocs.length)


### PR DESCRIPTION
## Summary
The Orbit credential redirects to the /integrations/ page for now and this results in the the the test failing, It will fail if we redirect anything else so this ignores the 301 status as well as the 200 status.