### PR TITLE
feat: Return scopes on executions (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/projectRelation.repository.ts
+++ b/packages/cli/src/databases/repositories/projectRelation.repository.ts
@@ -61,4 +61,12 @@ export class ProjectRelationRepository extends Repository<ProjectRelation> {
 
 		return [...new Set(rows.map((r) => r.userId))];
 	}
+
+	async findAllByUser(userId: string) {
+		return await this.find({
+			where: {
+				userId,
+			},
+		});
+	}
 }

--- a/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
+++ b/packages/cli/src/databases/repositories/sharedWorkflow.repository.ts
@@ -200,4 +200,13 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			})
 		)?.project;
 	}
+
+	async getRelationsByWorkflowIdsAndProjectIds(workflowIds: string[], projectIds: string[]) {
+		return await this.find({
+			where: {
+				workflowId: In(workflowIds),
+				projectId: In(projectIds),
+			},
+		});
+	}
 }

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -31,6 +31,7 @@ describe('ExecutionService', () => {
 		mock(),
 		concurrencyControl,
 		mock(),
+		mock(),
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/executions/__tests__/executions.controller.test.ts
+++ b/packages/cli/src/executions/__tests__/executions.controller.test.ts
@@ -74,6 +74,8 @@ describe('ExecutionsController', () => {
 			},
 		];
 
+		executionService.findRangeWithCount.mockResolvedValue(NO_EXECUTIONS);
+
 		describe('if either status or range provided', () => {
 			test.each(QUERIES_WITH_EITHER_STATUS_OR_RANGE)(
 				'should fetch executions per query',

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -8,7 +8,6 @@ import type {
 	IRunExecutionData,
 	WorkflowExecuteMode,
 	ExecutionStatus,
-	ExecutionSummary,
 } from 'n8n-workflow';
 import {
 	ApplicationError,
@@ -41,7 +40,6 @@ import { QueuedExecutionRetryError } from '@/errors/queued-execution-retry.error
 import { ConcurrencyControlService } from '@/concurrency/concurrency-control.service';
 import { AbortedExecutionRetryError } from '@/errors/aborted-execution-retry.error';
 import { License } from '@/License';
-import type { Scope } from '@n8n/permissions';
 import type { User } from '@/databases/entities/User';
 import { WorkflowSharingService } from '@/workflows/workflowSharing.service';
 
@@ -484,15 +482,14 @@ export class ExecutionService {
 		return await this.executionRepository.stopDuringRun(execution);
 	}
 
-	async enrichExecutionSummariesWithScopes(user: User, summaries: ExecutionSummary[]) {
-		const summariesWithScopes = summaries as Array<ExecutionSummary & { scopes: Scope[] }>;
+	async addScopes(user: User, summaries: ExecutionSummaries.ExecutionSummaryWithScopes[]) {
 		const workflowIds = [...new Set(summaries.map((s) => s.workflowId))];
 
 		const scopes = Object.fromEntries(
 			await this.workflowSharingService.getSharedWorkflowScopes(workflowIds, user),
 		);
 
-		for (const s of summariesWithScopes) {
+		for (const s of summaries) {
 			s.scopes = scopes[s.workflowId] ?? [];
 		}
 	}

--- a/packages/cli/src/executions/execution.types.ts
+++ b/packages/cli/src/executions/execution.types.ts
@@ -1,6 +1,12 @@
 import type { ExecutionEntity } from '@/databases/entities/ExecutionEntity';
 import type { AuthenticatedRequest } from '@/requests';
-import type { ExecutionStatus, IDataObject, WorkflowExecuteMode } from 'n8n-workflow';
+import type { Scope } from '@n8n/permissions';
+import type {
+	ExecutionStatus,
+	ExecutionSummary,
+	IDataObject,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
 
 export declare namespace ExecutionRequest {
 	namespace QueryParams {
@@ -83,6 +89,8 @@ export namespace ExecutionSummaries {
 			stoppedAt?: 'DESC';
 		};
 	};
+
+	export type ExecutionSummaryWithScopes = ExecutionSummary & { scopes: Scope[] };
 }
 
 export type QueueRecoverySettings = {

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -53,10 +53,14 @@ export class ExecutionsController {
 		const noRange = !query.range.lastId || !query.range.firstId;
 
 		if (noStatus && noRange) {
-			return await this.executionService.findLatestCurrentAndCompleted(query);
+			const executions = await this.executionService.findLatestCurrentAndCompleted(query);
+			await this.executionService.enrichExecutionSummariesWithScopes(req.user, executions.results);
+			return executions;
 		}
 
-		return await this.executionService.findRangeWithCount(query);
+		const executions = await this.executionService.findRangeWithCount(query);
+		await this.executionService.enrichExecutionSummariesWithScopes(req.user, executions.results);
+		return executions;
 	}
 
 	@Get('/:id')

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -1,4 +1,4 @@
-import { ExecutionRequest } from './execution.types';
+import { ExecutionRequest, type ExecutionSummaries } from './execution.types';
 import { ExecutionService } from './execution.service';
 import { Get, Post, RestController } from '@/decorators';
 import { EnterpriseExecutionsService } from './execution.service.ee';
@@ -54,12 +54,18 @@ export class ExecutionsController {
 
 		if (noStatus && noRange) {
 			const executions = await this.executionService.findLatestCurrentAndCompleted(query);
-			await this.executionService.enrichExecutionSummariesWithScopes(req.user, executions.results);
+			await this.executionService.addScopes(
+				req.user,
+				executions.results as ExecutionSummaries.ExecutionSummaryWithScopes[],
+			);
 			return executions;
 		}
 
 		const executions = await this.executionService.findRangeWithCount(query);
-		await this.executionService.enrichExecutionSummariesWithScopes(req.user, executions.results);
+		await this.executionService.addScopes(
+			req.user,
+			executions.results as ExecutionSummaries.ExecutionSummaryWithScopes[],
+		);
 		return executions;
 	}
 

--- a/packages/cli/src/workflows/workflowSharing.service.ts
+++ b/packages/cli/src/workflows/workflowSharing.service.ts
@@ -8,12 +8,14 @@ import { RoleService } from '@/services/role.service';
 import type { Scope } from '@n8n/permissions';
 import type { ProjectRole } from '@/databases/entities/ProjectRelation';
 import type { WorkflowSharingRole } from '@/databases/entities/SharedWorkflow';
+import { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
 
 @Service()
 export class WorkflowSharingService {
 	constructor(
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly roleService: RoleService,
+		private readonly projectRelationRepository: ProjectRelationRepository,
 	) {}
 
 	/**
@@ -63,5 +65,34 @@ export class WorkflowSharingService {
 		});
 
 		return sharedWorkflows.map(({ workflowId }) => workflowId);
+	}
+
+	async getSharedWorkflowScopes(
+		workflowIds: string[],
+		user: User,
+	): Promise<Array<[string, Scope[]]>> {
+		const projectRelations = await this.projectRelationRepository.find({
+			where: {
+				userId: user.id,
+			},
+		});
+		const sharedWorkflows = await this.sharedWorkflowRepository.find({
+			where: {
+				workflowId: In(workflowIds),
+				projectId: In(projectRelations.map((p) => p.projectId)),
+			},
+		});
+
+		return workflowIds.map((workflowId) => {
+			return [
+				workflowId,
+				this.roleService.combineResourceScopes(
+					'workflow',
+					user,
+					sharedWorkflows.filter((s) => s.workflowId === workflowId),
+					projectRelations,
+				),
+			];
+		});
 	}
 }

--- a/packages/cli/src/workflows/workflowSharing.service.ts
+++ b/packages/cli/src/workflows/workflowSharing.service.ts
@@ -71,17 +71,12 @@ export class WorkflowSharingService {
 		workflowIds: string[],
 		user: User,
 	): Promise<Array<[string, Scope[]]>> {
-		const projectRelations = await this.projectRelationRepository.find({
-			where: {
-				userId: user.id,
-			},
-		});
-		const sharedWorkflows = await this.sharedWorkflowRepository.find({
-			where: {
-				workflowId: In(workflowIds),
-				projectId: In(projectRelations.map((p) => p.projectId)),
-			},
-		});
+		const projectRelations = await this.projectRelationRepository.findAllByUser(user.id);
+		const sharedWorkflows =
+			await this.sharedWorkflowRepository.getRelationsByWorkflowIdsAndProjectIds(
+				workflowIds,
+				projectRelations.map((p) => p.projectId),
+			);
 
 		return workflowIds.map((workflowId) => {
 			return [

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -30,6 +30,7 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(),
 		);
 	});
 

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -49,14 +49,14 @@ describe('GET /executions', () => {
 		expect(response2.body.data.count).toBe(1);
 	});
 
-	test('should return scopes a scopes array for each execution', async () => {
+	test('should return a scopes array for each execution', async () => {
 		testServer.license.enable('feat:sharing');
 		const workflow = await createWorkflow({}, owner);
 		await shareWorkflowWithUsers(workflow, [member]);
 		await createSuccessfulExecution(workflow);
 
-		const response1 = await testServer.authAgentFor(member).get('/executions').expect(200);
-		expect(response1.body.data.results[0].scopes).toContain('workflow:execute');
+		const response = await testServer.authAgentFor(member).get('/executions').expect(200);
+		expect(response.body.data.results[0].scopes).toContain('workflow:execute');
 	});
 });
 

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -48,6 +48,16 @@ describe('GET /executions', () => {
 		const response2 = await testServer.authAgentFor(member).get('/executions').expect(200);
 		expect(response2.body.data.count).toBe(1);
 	});
+
+	test('should return scopes a scopes array for each execution', async () => {
+		testServer.license.enable('feat:sharing');
+		const workflow = await createWorkflow({}, owner);
+		await shareWorkflowWithUsers(workflow, [member]);
+		await createSuccessfulExecution(workflow);
+
+		const response1 = await testServer.authAgentFor(member).get('/executions').expect(200);
+		expect(response1.body.data.results[0].scopes).toContain('workflow:execute');
+	});
 });
 
 describe('GET /executions/:id', () => {


### PR DESCRIPTION
## Summary

Adds scopes to the executions list. This is to allow the frontend to remove the delete button for the to be released viewer role.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1789](https://linear.app/n8n/issue/PAY-1789/add-scopes-to-global-executions-view)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
