### PR TITLE
feat(MySQL Node): Return decimal types as numbers

### DIFF
--- a/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
+++ b/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	ICredentialType,
+	INodeProperties,
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+} from 'n8n-workflow';
 
 export class AcuitySchedulingApi implements ICredentialType {
 	name = 'acuitySchedulingApi';
@@ -22,4 +27,21 @@ export class AcuitySchedulingApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			auth: {
+				username: '={{$credentials.username}}',
+				password: '={{$credentials.password}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://acuityscheduling.com/api/v1',
+			url: '/appointments',
+		},
+	};
 }

--- a/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
+++ b/packages/nodes-base/credentials/AcuitySchedulingApi.credentials.ts
@@ -1,9 +1,4 @@
-import type {
-	ICredentialType,
-	INodeProperties,
-	IAuthenticateGeneric,
-	ICredentialTestRequest,
-} from 'n8n-workflow';
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class AcuitySchedulingApi implements ICredentialType {
 	name = 'acuitySchedulingApi';
@@ -27,21 +22,4 @@ export class AcuitySchedulingApi implements ICredentialType {
 			default: '',
 		},
 	];
-
-	authenticate: IAuthenticateGeneric = {
-		type: 'generic',
-		properties: {
-			auth: {
-				username: '={{$credentials.username}}',
-				password: '={{$credentials.password}}',
-			},
-		},
-	};
-
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: 'https://acuityscheduling.com/api/v1',
-			url: '/appointments',
-		},
-	};
 }

--- a/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/MySql/v2/actions/common.descriptions.ts
@@ -135,6 +135,16 @@ export const optionsCollection: INodeProperties = {
 			},
 		},
 		{
+			displayName: 'Output Decimals as Numbers',
+			name: 'decimalNumbers',
+			type: 'boolean',
+			default: false,
+			description: 'Whether to output DECIMAL types as numbers instead of strings',
+			displayOptions: {
+				show: { '/operation': ['select', 'executeQuery'] },
+			},
+		},
+		{
 			displayName: 'Priority',
 			name: 'priority',
 			type: 'options',

--- a/packages/nodes-base/nodes/MySql/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/MySql/v2/transport/index.ts
@@ -24,6 +24,7 @@ export async function createPool(
 		password: credentials.password,
 		multipleStatements: true,
 		supportBigNumbers: true,
+		decimalNumbers: false,
 	};
 
 	if (credentials.ssl) {
@@ -53,6 +54,10 @@ export async function createPool(
 
 	if (options?.largeNumbersOutput === 'text') {
 		connectionOptions.bigNumberStrings = true;
+	}
+
+	if (options?.decimalNumbers === true) {
+		connectionOptions.decimalNumbers = true;
 	}
 
 	if (!credentials.sshTunnel) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- adds option to return Decimal values as number format instead of strings

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-1553/mysql-node-decimal-types-are-returned-as-strings
- https://community.n8n.io/t/mysql-select-and-numbers/51104

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
