### PR TITLE
fix(editor): Remove body padding from storybook previews (no-changelog)

### DIFF
--- a/packages/design-system/.storybook/storybook.scss
+++ b/packages/design-system/.storybook/storybook.scss
@@ -15,3 +15,7 @@
 #storybook-root > * {
 	margin: var(--spacing-5xs);
 }
+
+body {
+	padding: 0 !important;
+}


### PR DESCRIPTION
## Summary
Remove padding from previews, to make it easier to approve Chromatic changes.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
