### PR TITLE
refactor(core): Stop reporting disk I/O error to Sentry (no-changelog)

### DIFF
--- a/packages/cli/src/ErrorReporting.ts
+++ b/packages/cli/src/ErrorReporting.ts
@@ -69,7 +69,7 @@ export const initErrorHandling = async () => {
 
 		if (
 			originalException instanceof QueryFailedError &&
-			originalException.message.includes('SQLITE_FULL')
+			['SQLITE_FULL', 'SQLITE_IOERR'].some((errMsg) => originalException.message.includes(errMsg))
 		) {
 			return null;
 		}


### PR DESCRIPTION
Disk full error is not actionable in-app, so we should not be reporting it.

Example:
- https://n8nio.sentry.io/issues/5584406040 (see user in `server_name` under Tags)
- https://n8nio.slack.com/archives/C035U62EB2R/p1722835763720189