### PR TITLE
docs: Update wording in X credentials

### DIFF
--- a/packages/nodes-base/credentials/TwitterOAuth1Api.credentials.ts
+++ b/packages/nodes-base/credentials/TwitterOAuth1Api.credentials.ts
@@ -36,8 +36,8 @@ export class TwitterOAuth1Api implements ICredentialType {
 		},
 		{
 			displayName:
-				'Some operations requires a Basic or a Pro API for more informations see <a href="https://developer.twitter.com/en/products/twitter-api" target="_blank">X API Docs</a>',
-			name: 'apiPermissioms',
+				'Some operations require a Basic or Pro API. Refer to <a href="https://developer.x.com/en/docs/twitter-api" target="_blank">X API Docs</a> for more information.',
+			name: 'apiPermissions',
 			type: 'notice',
 			default: '',
 		},

--- a/packages/nodes-base/credentials/TwitterOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/TwitterOAuth2Api.credentials.ts
@@ -28,8 +28,8 @@ export class TwitterOAuth2Api implements ICredentialType {
 	properties: INodeProperties[] = [
 		{
 			displayName:
-				'Some operations requires a Basic or a Pro API for more informations see <a href="https://developer.twitter.com/en/products/twitter-api" target="_blank">X API Docs</a>',
-			name: 'apiPermissioms',
+				'Some operations require a Basic or Pro API. Refer to <a href="https://developer.x.com/en/docs/twitter-api" target="_blank">X API Docs</a> for more information.',
+			name: 'apiPermissions',
 			type: 'notice',
 			default: '',
 		},


### PR DESCRIPTION
## Summary
Updates the URL and wording in the notice that appears when using X credentials.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/DOC-1020/xtwitter-oauth2-credential-helper-text-includes-bad-url
