### PR TITLE
docs: Change display name for WhatsApp Trigger API Credential

### DIFF
--- a/packages/nodes-base/credentials/WhatsAppApi.credentials.ts
+++ b/packages/nodes-base/credentials/WhatsAppApi.credentials.ts
@@ -22,7 +22,7 @@ export class WhatsAppApi implements ICredentialType {
 			required: true,
 		},
 		{
-			displayName: 'Bussiness Account ID',
+			displayName: 'Business Account ID',
 			type: 'string',
 			name: 'businessAccountId',
 			default: '',

--- a/packages/nodes-base/credentials/WhatsAppTriggerApi.credentials.ts
+++ b/packages/nodes-base/credentials/WhatsAppTriggerApi.credentials.ts
@@ -3,7 +3,7 @@ import type { ICredentialTestRequest, ICredentialType, INodeProperties } from 'n
 export class WhatsAppTriggerApi implements ICredentialType {
 	name = 'whatsAppTriggerApi';
 
-	displayName = 'WhatsApp API';
+	displayName = 'WhatsApp OAuth API';
 
 	documentationUrl = 'whatsApp';
 


### PR DESCRIPTION
## Summary
Updated display name for WhatsApp Trigger node credentials to match docs and cause less confusion

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1561/whatsapp-credential-names-make-clear-which-one-is-oauth