### PR TITLE
feat(core): Logout should invalidate the auth token (no-changelog)

### DIFF
--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 import config from '@/config';
 import { AUTH_COOKIE_NAME, RESPONSE_ERROR_MESSAGES, Time } from '@/constants';
 import type { User } from '@db/entities/User';
+import { InvalidAuthTokenRepository } from '@db/repositories/invalidAuthToken.repository';
 import { UserRepository } from '@db/repositories/user.repository';
 import { AuthError } from '@/errors/response-errors/auth.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -53,6 +54,7 @@ export class AuthService {
 		private readonly jwtService: JwtService,
 		private readonly urlService: UrlService,
 		private readonly userRepository: UserRepository,
+		private readonly invalidAuthTokenRepository: InvalidAuthTokenRepository,
 	) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		this.authMiddleware = this.authMiddleware.bind(this);
@@ -62,6 +64,8 @@ export class AuthService {
 		const token = req.cookies[AUTH_COOKIE_NAME];
 		if (token) {
 			try {
+				const isInvalid = await this.invalidAuthTokenRepository.existsBy({ token });
+				if (isInvalid) throw new AuthError('Unauthorized');
 				req.user = await this.resolveJwt(token, req, res);
 			} catch (error) {
 				if (error instanceof JsonWebTokenError || error instanceof AuthError) {
@@ -78,6 +82,21 @@ export class AuthService {
 
 	clearCookie(res: Response) {
 		res.clearCookie(AUTH_COOKIE_NAME);
+	}
+
+	async invalidateToken(req: AuthenticatedRequest) {
+		const token = req.cookies[AUTH_COOKIE_NAME];
+		if (token) {
+			try {
+				const { exp } = this.jwtService.decode(token);
+				if (exp) {
+					await this.invalidAuthTokenRepository.insert({
+						token,
+						expiresAt: new Date(exp * 1000),
+					});
+				}
+			} catch {}
+		}
 	}
 
 	issueCookie(res: Response, user: User, browserId?: string) {

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -86,16 +86,17 @@ export class AuthService {
 
 	async invalidateToken(req: AuthenticatedRequest) {
 		const token = req.cookies[AUTH_COOKIE_NAME];
-		if (token) {
-			try {
-				const { exp } = this.jwtService.decode(token);
-				if (exp) {
-					await this.invalidAuthTokenRepository.insert({
-						token,
-						expiresAt: new Date(exp * 1000),
-					});
-				}
-			} catch {}
+		if (!token) return;
+		try {
+			const { exp } = this.jwtService.decode(token);
+			if (exp) {
+				await this.invalidAuthTokenRepository.insert({
+					token,
+					expiresAt: new Date(exp * 1000),
+				});
+			}
+		} catch (e) {
+			this.logger.warn('failed to invalidate auth token', { error: (e as Error).message });
 		}
 	}
 

--- a/packages/cli/src/controllers/__tests__/me.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/me.controller.test.ts
@@ -2,6 +2,7 @@ import type { Response } from 'express';
 import { Container } from 'typedi';
 import jwt from 'jsonwebtoken';
 import { mock, anyObject } from 'jest-mock-extended';
+
 import type { PublicUser } from '@/Interfaces';
 import type { User } from '@db/entities/User';
 import { API_KEY_PREFIX, MeController } from '@/controllers/me.controller';
@@ -11,13 +12,15 @@ import { UserService } from '@/services/user.service';
 import { ExternalHooks } from '@/ExternalHooks';
 import { License } from '@/License';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { UserRepository } from '@/databases/repositories/user.repository';
 import { EventService } from '@/events/event.service';
-import { badPasswords } from '@test/testData';
-import { mockInstance } from '@test/mocking';
-import { AuthUserRepository } from '@/databases/repositories/authUser.repository';
+import { AuthUserRepository } from '@db/repositories/authUser.repository';
+import { InvalidAuthTokenRepository } from '@db/repositories/invalidAuthToken.repository';
+import { UserRepository } from '@db/repositories/user.repository';
 import { MfaService } from '@/Mfa/mfa.service';
 import { InvalidMfaCodeError } from '@/errors/response-errors/invalid-mfa-code.error';
+
+import { badPasswords } from '@test/testData';
+import { mockInstance } from '@test/mocking';
 
 const browserId = 'test-browser-id';
 
@@ -28,6 +31,7 @@ describe('MeController', () => {
 	const userRepository = mockInstance(UserRepository);
 	const mockMfaService = mockInstance(MfaService);
 	mockInstance(AuthUserRepository);
+	mockInstance(InvalidAuthTokenRepository);
 	mockInstance(License).isWithinUsersLimit.mockReturnValue(true);
 	const controller = Container.get(MeController);
 

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -1,9 +1,9 @@
 import validator from 'validator';
+import { Response } from 'express';
 
 import { AuthService } from '@/auth/auth.service';
 import { Get, Post, RestController } from '@/decorators';
 import { RESPONSE_ERROR_MESSAGES } from '@/constants';
-import { Request, Response } from 'express';
 import type { User } from '@db/entities/User';
 import { AuthenticatedRequest, LoginRequest, UserRequest } from '@/requests';
 import type { PublicUser } from '@/Interfaces';
@@ -185,7 +185,8 @@ export class AuthController {
 
 	/** Log out a user */
 	@Post('/logout')
-	logout(_: Request, res: Response) {
+	async logout(req: AuthenticatedRequest, res: Response) {
+		await this.authService.invalidateToken(req);
 		this.authService.clearCookie(res);
 		return { loggedOut: true };
 	}

--- a/packages/cli/src/databases/entities/InvalidAuthToken.ts
+++ b/packages/cli/src/databases/entities/InvalidAuthToken.ts
@@ -1,0 +1,11 @@
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+import { datetimeColumnType } from './AbstractEntity';
+
+@Entity()
+export class InvalidAuthToken {
+	@PrimaryColumn()
+	token: string;
+
+	@Column(datetimeColumnType)
+	expiresAt: Date;
+}

--- a/packages/cli/src/databases/entities/index.ts
+++ b/packages/cli/src/databases/entities/index.ts
@@ -21,6 +21,7 @@ import { ExecutionData } from './ExecutionData';
 import { WorkflowHistory } from './WorkflowHistory';
 import { Project } from './Project';
 import { ProjectRelation } from './ProjectRelation';
+import { InvalidAuthToken } from './InvalidAuthToken';
 
 export const entities = {
 	AuthIdentity,
@@ -31,6 +32,7 @@ export const entities = {
 	ExecutionEntity,
 	InstalledNodes,
 	InstalledPackages,
+	InvalidAuthToken,
 	Settings,
 	SharedCredentials,
 	SharedWorkflow,

--- a/packages/cli/src/databases/migrations/common/1723627610222-CreateInvalidAuthTokenTable.ts
+++ b/packages/cli/src/databases/migrations/common/1723627610222-CreateInvalidAuthTokenTable.ts
@@ -1,0 +1,15 @@
+import type { MigrationContext, ReversibleMigration } from '@db/types';
+
+const tableName = 'invalid_auth_token';
+
+export class CreateInvalidAuthTokenTable1723627610222 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(tableName)
+			.withColumns(column('token').varchar(512).primary, column('expiresAt').timestamp().notNull)
+			.withIndexOn('token', true);
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(tableName);
+	}
+}

--- a/packages/cli/src/databases/migrations/common/1723627610222-CreateInvalidAuthTokenTable.ts
+++ b/packages/cli/src/databases/migrations/common/1723627610222-CreateInvalidAuthTokenTable.ts
@@ -4,9 +4,10 @@ const tableName = 'invalid_auth_token';
 
 export class CreateInvalidAuthTokenTable1723627610222 implements ReversibleMigration {
 	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
-		await createTable(tableName)
-			.withColumns(column('token').varchar(512).primary, column('expiresAt').timestamp().notNull)
-			.withIndexOn('token', true);
+		await createTable(tableName).withColumns(
+			column('token').varchar(512).primary,
+			column('expiresAt').timestamp().notNull,
+		);
 	}
 
 	async down({ schemaBuilder: { dropTable } }: MigrationContext) {

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -59,6 +59,7 @@ import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNo
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
+import { CreateInvalidAuthTokenTable1723627610222 } from '../common/1723627610222-CreateInvalidAuthTokenTable';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -121,4 +122,5 @@ export const mysqlMigrations: Migration[] = [
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
 	AddConstraintToExecutionMetadata1720101653148,
+	CreateInvalidAuthTokenTable1723627610222,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -59,6 +59,7 @@ import { MakeExecutionStatusNonNullable1714133768521 } from '../common/171413376
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
 import { FixExecutionMetadataSequence1721377157740 } from './1721377157740-FixExecutionMetadataSequence';
+import { CreateInvalidAuthTokenTable1723627610222 } from '../common/1723627610222-CreateInvalidAuthTokenTable';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -121,4 +122,5 @@ export const postgresMigrations: Migration[] = [
 	AddActivatedAtUserSetting1717498465931,
 	AddConstraintToExecutionMetadata1720101653148,
 	FixExecutionMetadataSequence1721377157740,
+	CreateInvalidAuthTokenTable1723627610222,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -56,6 +56,7 @@ import { RemoveNodesAccess1712044305787 } from '../common/1712044305787-RemoveNo
 import { MakeExecutionStatusNonNullable1714133768521 } from '../common/1714133768521-MakeExecutionStatusNonNullable';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddConstraintToExecutionMetadata1720101653148 } from '../common/1720101653148-AddConstraintToExecutionMetadata';
+import { CreateInvalidAuthTokenTable1723627610222 } from '../common/1723627610222-CreateInvalidAuthTokenTable';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -115,6 +116,7 @@ const sqliteMigrations: Migration[] = [
 	MakeExecutionStatusNonNullable1714133768521,
 	AddActivatedAtUserSetting1717498465931,
 	AddConstraintToExecutionMetadata1720101653148,
+	CreateInvalidAuthTokenTable1723627610222,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/databases/repositories/invalidAuthToken.repository.ts
+++ b/packages/cli/src/databases/repositories/invalidAuthToken.repository.ts
@@ -1,0 +1,10 @@
+import { Service } from 'typedi';
+import { DataSource, Repository } from '@n8n/typeorm';
+import { InvalidAuthToken } from '../entities/InvalidAuthToken';
+
+@Service()
+export class InvalidAuthTokenRepository extends Repository<InvalidAuthToken> {
+	constructor(dataSource: DataSource) {
+		super(InvalidAuthToken, dataSource.manager);
+	}
+}

--- a/packages/cli/src/services/jwt.service.ts
+++ b/packages/cli/src/services/jwt.service.ts
@@ -23,11 +23,15 @@ export class JwtService {
 		}
 	}
 
-	public sign(payload: object, options: jwt.SignOptions = {}): string {
+	sign(payload: object, options: jwt.SignOptions = {}): string {
 		return jwt.sign(payload, this.jwtSecret, options);
 	}
 
-	public verify<T = JwtPayload>(token: string, options: jwt.VerifyOptions = {}) {
+	decode(token: string) {
+		return jwt.decode(token) as JwtPayload;
+	}
+
+	verify<T = JwtPayload>(token: string, options: jwt.VerifyOptions = {}) {
 		return jwt.verify(token, this.jwtSecret, options) as T;
 	}
 }

--- a/packages/cli/test/integration/auth.api.test.ts
+++ b/packages/cli/test/integration/auth.api.test.ts
@@ -386,13 +386,19 @@ describe('GET /resolve-signup-token', () => {
 describe('POST /logout', () => {
 	test('should log user out', async () => {
 		const owner = await createUser({ role: 'global:owner' });
+		const ownerAgent = testServer.authAgentFor(owner);
+		// @ts-expect-error `accessInfo` types are incorrect
+		const cookie = ownerAgent.jar.getCookie(AUTH_COOKIE_NAME, { path: '/' });
 
-		const response = await testServer.authAgentFor(owner).post('/logout');
+		const response = await ownerAgent.post('/logout');
 
 		expect(response.statusCode).toBe(200);
 		expect(response.body).toEqual(LOGGED_OUT_RESPONSE_BODY);
 
 		const authToken = utils.getAuthToken(response);
 		expect(authToken).toBeUndefined();
+
+		ownerAgent.jar.setCookie(`${AUTH_COOKIE_NAME}=${cookie!.value}`);
+		await ownerAgent.get('/login').expect(401);
 	});
 });

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -859,3 +859,6 @@ export const INSECURE_CONNECTION_WARNING = `
 export const CanvasNodeKey = 'canvasNode' as unknown as InjectionKey<CanvasNodeInjectionData>;
 export const CanvasNodeHandleKey =
 	'canvasNodeHandle' as unknown as InjectionKey<CanvasNodeHandleInjectionData>;
+
+/** Auth */
+export const BROWSER_ID_STORAGE_KEY = 'n8n-browserId';

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -1,6 +1,6 @@
 import type { IUpdateUserSettingsReqPayload, UpdateGlobalRolePayload } from '@/api/users';
 import * as usersApi from '@/api/users';
-import { PERSONALIZATION_MODAL_KEY, STORES, ROLE } from '@/constants';
+import { BROWSER_ID_STORAGE_KEY, PERSONALIZATION_MODAL_KEY, STORES, ROLE } from '@/constants';
 import type {
 	Cloud,
 	IPersonalizationLatestVersion,
@@ -180,6 +180,8 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		postHogStore.reset();
 		uiStore.clearBannerStack();
 		npsSurveyStore.resetNpsSurveyOnLogOut();
+
+		localStorage.removeItem(BROWSER_ID_STORAGE_KEY);
 	};
 
 	const createOwner = async (params: {

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -1,16 +1,20 @@
 import type { AxiosRequestConfig, Method, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 import { ApplicationError, jsonParse, type GenericValue, type IDataObject } from 'n8n-workflow';
-import type { IExecutionFlattedResponse, IExecutionResponse, IRestApiContext } from '@/Interface';
 import { parse } from 'flatted';
 import { assert } from '@/utils/assert';
 
-const BROWSER_ID_STORAGE_KEY = 'n8n-browserId';
-let browserId = localStorage.getItem(BROWSER_ID_STORAGE_KEY);
-if (!browserId && 'randomUUID' in crypto) {
-	browserId = crypto.randomUUID();
-	localStorage.setItem(BROWSER_ID_STORAGE_KEY, browserId);
-}
+import { BROWSER_ID_STORAGE_KEY } from '@/constants';
+import type { IExecutionFlattedResponse, IExecutionResponse, IRestApiContext } from '@/Interface';
+
+const getBrowserId = () => {
+	let browserId = localStorage.getItem(BROWSER_ID_STORAGE_KEY);
+	if (!browserId && 'randomUUID' in crypto) {
+		browserId = crypto.randomUUID();
+		localStorage.setItem(BROWSER_ID_STORAGE_KEY, browserId);
+	}
+	return browserId;
+};
 
 export const NO_NETWORK_ERROR_CODE = 999;
 export const STREAM_SEPERATOR = '⧉⇋⇋➽⌑⧉§§\n';
@@ -82,6 +86,7 @@ export async function request(config: {
 		baseURL,
 		headers: headers ?? {},
 	};
+	const browserId = getBrowserId();
 	if (baseURL.startsWith('/') && browserId) {
 		options.headers!['browser-id'] = browserId;
 	}

--- a/packages/editor-ui/src/utils/apiUtils.ts
+++ b/packages/editor-ui/src/utils/apiUtils.ts
@@ -13,7 +13,7 @@ const getBrowserId = () => {
 		browserId = crypto.randomUUID();
 		localStorage.setItem(BROWSER_ID_STORAGE_KEY, browserId);
 	}
-	return browserId;
+	return browserId!;
 };
 
 export const NO_NETWORK_ERROR_CODE = 999;
@@ -86,9 +86,8 @@ export async function request(config: {
 		baseURL,
 		headers: headers ?? {},
 	};
-	const browserId = getBrowserId();
-	if (baseURL.startsWith('/') && browserId) {
-		options.headers!['browser-id'] = browserId;
+	if (baseURL.startsWith('/')) {
+		options.headers!['browser-id'] = getBrowserId();
 	}
 	if (
 		import.meta.env.NODE_ENV !== 'production' &&
@@ -209,11 +208,9 @@ export async function streamRequest<T>(
 	separator = STREAM_SEPERATOR,
 ): Promise<void> {
 	const headers: Record<string, string> = {
+		'browser-id': getBrowserId(),
 		'Content-Type': 'application/json',
 	};
-	if (browserId) {
-		headers['browser-id'] = browserId;
-	}
 	const assistantRequest: RequestInit = {
 		headers,
 		method: 'POST',


### PR DESCRIPTION
## Summary
When a user logs out, we should also invalidate the auth token to prevent it from being used again.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SEC-75

## Review / Merge checklist

- [x] PR title and summary are descriptive
