### PR TITLE
fix(core): Require mfa code for password change if its enabled

### DIFF
--- a/packages/cli/src/Mfa/mfa.service.ts
+++ b/packages/cli/src/Mfa/mfa.service.ts
@@ -60,7 +60,9 @@ export class MfaService {
 		if (mfaToken) {
 			const decryptedSecret = this.cipher.decrypt(user.mfaSecret!);
 			return this.totp.verifySecret({ secret: decryptedSecret, token: mfaToken });
-		} else if (mfaRecoveryCode) {
+		}
+
+		if (mfaRecoveryCode) {
 			const validCodes = user.mfaRecoveryCodes.map((code) => this.cipher.decrypt(code));
 			const index = validCodes.indexOf(mfaRecoveryCode);
 			if (index === -1) return false;
@@ -70,6 +72,7 @@ export class MfaService {
 			await this.authUserRepository.save(user);
 			return true;
 		}
+
 		return false;
 	}
 

--- a/packages/cli/src/controllers/__tests__/me.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/me.controller.test.ts
@@ -16,6 +16,9 @@ import { UserRepository } from '@/databases/repositories/user.repository';
 import { EventService } from '@/events/event.service';
 import { badPasswords } from '@test/testData';
 import { mockInstance } from '@test/mocking';
+import { AuthUserRepository } from '@/databases/repositories/authUser.repository';
+import { MfaService } from '@/Mfa/mfa.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 const browserId = 'test-browser-id';
 
@@ -25,6 +28,8 @@ describe('MeController', () => {
 	const eventService = mockInstance(EventService);
 	const userService = mockInstance(UserService);
 	const userRepository = mockInstance(UserRepository);
+	const mockMfaService = mockInstance(MfaService);
+	mockInstance(AuthUserRepository);
 	mockInstance(License).isWithinUsersLimit.mockReturnValue(true);
 	const controller = Container.get(MeController);
 
@@ -181,7 +186,7 @@ describe('MeController', () => {
 
 		it('should update the password in the DB, and issue a new cookie', async () => {
 			const req = mock<MeRequest.Password>({
-				user: mock({ password: passwordHash }),
+				user: mock({ password: passwordHash, mfaEnabled: false }),
 				body: { currentPassword: 'old_password', newPassword: 'NewPassword123' },
 				browserId,
 			});
@@ -212,6 +217,52 @@ describe('MeController', () => {
 			expect(eventService.emit).toHaveBeenCalledWith('user-updated', {
 				user: req.user,
 				fieldsChanged: ['password'],
+			});
+		});
+
+		describe('mfa enabled', () => {
+			it('should throw BadRequestError if mfa code is missing', async () => {
+				const req = mock<MeRequest.Password>({
+					user: mock({ password: passwordHash, mfaEnabled: true }),
+					body: { currentPassword: 'old_password', newPassword: 'NewPassword123' },
+				});
+
+				await expect(controller.updatePassword(req, mock())).rejects.toThrowError(
+					new BadRequestError('Two-factor code is required to change password.'),
+				);
+			});
+
+			it('should throw ForbiddenError if invalid mfa code is given', async () => {
+				const req = mock<MeRequest.Password>({
+					user: mock({ password: passwordHash, mfaEnabled: true }),
+					body: { currentPassword: 'old_password', newPassword: 'NewPassword123', mfaCode: '123' },
+				});
+				mockMfaService.validateMfa.mockResolvedValue(false);
+
+				await expect(controller.updatePassword(req, mock())).rejects.toThrowError(
+					new ForbiddenError('Invalid two-factor code.'),
+				);
+			});
+
+			it('should succeed when mfa code is correct', async () => {
+				const req = mock<MeRequest.Password>({
+					user: mock({ password: passwordHash, mfaEnabled: true }),
+					body: {
+						currentPassword: 'old_password',
+						newPassword: 'NewPassword123',
+						mfaCode: 'valid',
+					},
+					browserId,
+				});
+				const res = mock<Response>();
+				userRepository.save.calledWith(req.user).mockResolvedValue(req.user);
+				jest.spyOn(jwt, 'sign').mockImplementation(() => 'new-signed-token');
+				mockMfaService.validateMfa.mockResolvedValue(true);
+
+				const result = await controller.updatePassword(req, res);
+
+				expect(result).toEqual({ success: true });
+				expect(req.user.password).not.toBe(passwordHash);
 			});
 		});
 	});

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -23,6 +23,8 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { UserRepository } from '@/databases/repositories/user.repository';
 import { isApiEnabled } from '@/PublicApi';
 import { EventService } from '@/events/event.service';
+import { MfaService } from '@/Mfa/mfa.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 export const API_KEY_PREFIX = 'n8n_api_';
 
@@ -44,6 +46,7 @@ export class MeController {
 		private readonly passwordUtility: PasswordUtility,
 		private readonly userRepository: UserRepository,
 		private readonly eventService: EventService,
+		private readonly mfaService: MfaService,
 	) {}
 
 	/**
@@ -115,12 +118,12 @@ export class MeController {
 	/**
 	 * Update the logged-in user's password.
 	 */
-	@Patch('/password')
+	@Patch('/password', { rateLimit: true })
 	async updatePassword(req: MeRequest.Password, res: Response) {
 		const { user } = req;
-		const { currentPassword, newPassword } = req.body;
+		const { currentPassword, newPassword, mfaCode } = req.body;
 
-		// If SAML is enabled, we don't allow the user to change their email address
+		// If SAML is enabled, we don't allow the user to change their password
 		if (isSamlLicensedAndEnabled()) {
 			this.logger.debug('Attempted to change password for user, while SAML is enabled', {
 				userId: user.id,
@@ -144,6 +147,17 @@ export class MeController {
 		}
 
 		const validPassword = this.passwordUtility.validate(newPassword);
+
+		if (user.mfaEnabled) {
+			if (typeof mfaCode !== 'string') {
+				throw new BadRequestError('Two-factor code is required to change password.');
+			}
+
+			const isMfaTokenValid = await this.mfaService.validateMfa(user.id, mfaCode, undefined);
+			if (!isMfaTokenValid) {
+				throw new ForbiddenError('Invalid two-factor code.');
+			}
+		}
 
 		user.password = await this.passwordUtility.hash(validPassword);
 

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -224,7 +224,7 @@ export declare namespace MeRequest {
 	export type Password = AuthenticatedRequest<
 		{},
 		{},
-		{ currentPassword: string; newPassword: string; token?: string }
+		{ currentPassword: string; newPassword: string; mfaCode?: string }
 	>;
 	export type SurveyAnswers = AuthenticatedRequest<{}, {}, Record<string, string> | {}>;
 }

--- a/packages/editor-ui/src/api/users.ts
+++ b/packages/editor-ui/src/api/users.ts
@@ -116,9 +116,15 @@ export async function updateOtherUserSettings(
 	return await makeRestApiRequest(context, 'PATCH', `/users/${userId}/settings`, settings);
 }
 
+export type UpdateUserPasswordParams = {
+	newPassword: string;
+	currentPassword: string;
+	mfaCode?: string;
+};
+
 export async function updateCurrentUserPassword(
 	context: IRestApiContext,
-	params: { newPassword: string; currentPassword: string },
+	params: UpdateUserPasswordParams,
 ): Promise<void> {
 	return await makeRestApiRequest(context, 'PATCH', '/me/password', params);
 }

--- a/packages/editor-ui/src/components/__tests__/ChangePasswordModal.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ChangePasswordModal.test.ts
@@ -1,0 +1,20 @@
+import { createTestingPinia } from '@pinia/testing';
+import ChangePasswordModal from '@/components/ChangePasswordModal.vue';
+import type { createPinia } from 'pinia';
+import { createComponentRenderer } from '@/__tests__/render';
+
+const renderComponent = createComponentRenderer(ChangePasswordModal);
+
+describe('ChangePasswordModal', () => {
+	let pinia: ReturnType<typeof createPinia>;
+
+	beforeEach(() => {
+		pinia = createTestingPinia({});
+	});
+
+	it('should render correctly', () => {
+		const wrapper = renderComponent({ pinia });
+
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+});

--- a/packages/editor-ui/src/components/__tests__/__snapshots__/ChangePasswordModal.test.ts.snap
+++ b/packages/editor-ui/src/components/__tests__/__snapshots__/ChangePasswordModal.test.ts.snap
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ChangePasswordModal > should render correctly 1`] = `
+"<!--teleport start-->
+<!--teleport end-->"
+`;

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -98,6 +98,7 @@
 	"activationModal.yourWorkflowWillNowRegularlyCheck": "Your workflow will now regularly check {serviceName} for events and trigger executions for them.",
 	"auth.changePassword": "Change password",
 	"auth.changePassword.currentPassword": "Current password",
+	"auth.changePassword.mfaCode": "Two-factor code",
 	"auth.changePassword.error": "Problem changing the password",
 	"auth.changePassword.missingTokenError": "Missing token",
 	"auth.changePassword.missingUserIdError": "Missing user ID",

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -258,17 +258,8 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		addUsers([usersById.value[userId]]);
 	};
 
-	const updateCurrentUserPassword = async ({
-		password,
-		currentPassword,
-	}: {
-		password: string;
-		currentPassword: string;
-	}) => {
-		await usersApi.updateCurrentUserPassword(rootStore.restApiContext, {
-			newPassword: password,
-			currentPassword,
-		});
+	const updateCurrentUserPassword = async (params: usersApi.UpdateUserPasswordParams) => {
+		await usersApi.updateCurrentUserPassword(rootStore.restApiContext, params);
 	};
 
 	const deleteUser = async (params: { id: string; transferId?: string }) => {


### PR DESCRIPTION
## Summary

Require a valid MFA code when changing password, if MFA is enabled.

Also rate limit the change password endpoint.

MFA enabled:

![image](https://github.com/user-attachments/assets/d4934586-4a1f-4872-bb92-e05b5fc22c80)

MFA disabled:

![image](https://github.com/user-attachments/assets/ff9bc8cd-e7d9-490f-8136-5d57cb0d9514)


## Related Linear tickets, Github issues, and Community forum posts

[SEC-67](https://linear.app/n8n/issue/SEC-67/29-account-update-without-mfa)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
