### PR TITLE
fix: Require mfa code to change email

### DIFF
--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -42,6 +42,11 @@ export class UserUpdatePayload implements Pick<User, 'email' | 'firstName' | 'la
 	@IsString({ message: 'Last name must be of type string.' })
 	@Length(1, 32, { message: 'Last name must be $constraint1 to $constraint2 characters long.' })
 	lastName: string;
+
+	@IsOptional()
+	@Expose()
+	@IsString({ message: 'Two factor code must be a string.' })
+	mfaCode?: string;
 }
 
 export class UserSettingsUpdatePayload {

--- a/packages/editor-ui/src/api/users.ts
+++ b/packages/editor-ui/src/api/users.ts
@@ -89,14 +89,17 @@ export async function changePassword(
 	await makeRestApiRequest(context, 'POST', '/change-password', params);
 }
 
+export type UpdateCurrentUserParams = {
+	id?: string;
+	firstName?: string;
+	lastName?: string;
+	email: string;
+	mfaCode?: string;
+};
+
 export async function updateCurrentUser(
 	context: IRestApiContext,
-	params: {
-		id?: string;
-		firstName?: string;
-		lastName?: string;
-		email: string;
-	},
+	params: UpdateCurrentUserParams,
 ): Promise<IUserResponse> {
 	return await makeRestApiRequest(context, 'PATCH', '/me', params);
 }

--- a/packages/editor-ui/src/event-bus/mfa.ts
+++ b/packages/editor-ui/src/event-bus/mfa.ts
@@ -7,8 +7,10 @@ export interface MfaModalClosedEventPayload {
 }
 
 export interface MfaModalEvents {
+	/** Command to request closing of the modal */
 	close: MfaModalClosedEventPayload | undefined;
 
+	/** Event that the modal has been closed */
 	closed: MfaModalClosedEventPayload | undefined;
 }
 

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -224,12 +224,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		await usersApi.changePassword(rootStore.restApiContext, params);
 	};
 
-	const updateUser = async (params: {
-		id: string;
-		firstName: string;
-		lastName: string;
-		email: string;
-	}) => {
+	const updateUser = async (params: usersApi.UpdateCurrentUserParams) => {
 		const user = await usersApi.updateCurrentUser(rootStore.restApiContext, params);
 		addUsers([user]);
 	};

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -16,6 +16,16 @@ import { createFormEventBus } from 'n8n-design-system/utils';
 import type { MfaModalEvents } from '@/event-bus/mfa';
 import { promptMfaCodeBus } from '@/event-bus/mfa';
 
+type UserBasicDetailsForm = {
+	firstName: string;
+	lastName: string;
+	email: string;
+};
+
+type UserBasicDetailsWithMfa = UserBasicDetailsForm & {
+	mfaCode?: string;
+};
+
 const i18n = useI18n();
 const { showToast, showError } = useToast();
 
@@ -114,12 +124,17 @@ onMounted(() => {
 function onInput() {
 	hasAnyBasicInfoChanges.value = true;
 }
+
 function onReadyToSubmit(ready: boolean) {
 	readyToSubmit.value = ready;
 }
-async function onSubmit(form: { firstName: string; lastName: string; email: string }) {
+
+/** Saves users basic info and personalization settings */
+async function saveUserSettings(params: UserBasicDetailsWithMfa) {
 	try {
-		await Promise.all([updateUserBasicInfo(form), updatePersonalisationSettings()]);
+		// The MFA code might be invalid so we update the user's basic info first
+		await updateUserBasicInfo(params);
+		await updatePersonalisationSettings();
 
 		showToast({
 			title: i18n.baseText('settings.personal.personalSettingsUpdated'),
@@ -130,19 +145,43 @@ async function onSubmit(form: { firstName: string; lastName: string; email: stri
 		showError(e, i18n.baseText('settings.personal.personalSettingsUpdatedError'));
 	}
 }
-async function updateUserBasicInfo(form: { firstName: string; lastName: string; email: string }) {
+
+async function onSubmit(form: UserBasicDetailsForm) {
+	if (!usersStore.currentUser?.mfaEnabled) {
+		await saveUserSettings(form);
+		return;
+	}
+
+	uiStore.openModal(PROMPT_MFA_CODE_MODAL_KEY);
+
+	promptMfaCodeBus.once('closed', async (payload: MfaModalEvents['closed']) => {
+		if (!payload) {
+			// User closed the modal without submitting the form
+			return;
+		}
+
+		await saveUserSettings({
+			...form,
+			mfaCode: payload.mfaCode,
+		});
+	});
+}
+
+async function updateUserBasicInfo(userBasicInfo: UserBasicDetailsWithMfa) {
 	if (!hasAnyBasicInfoChanges.value || !usersStore.currentUserId) {
 		return;
 	}
 
 	await usersStore.updateUser({
 		id: usersStore.currentUserId,
-		firstName: form.firstName,
-		lastName: form.lastName,
-		email: form.email,
+		firstName: userBasicInfo.firstName,
+		lastName: userBasicInfo.lastName,
+		email: userBasicInfo.email,
+		mfaCode: userBasicInfo.mfaCode,
 	});
 	hasAnyBasicInfoChanges.value = false;
 }
+
 async function updatePersonalisationSettings() {
 	if (!hasAnyPersonalisationChanges.value) {
 		return;
@@ -150,12 +189,15 @@ async function updatePersonalisationSettings() {
 
 	uiStore.setTheme(currentSelectedTheme.value);
 }
+
 function onSaveClick() {
 	formBus.value.emit('submit');
 }
+
 function openPasswordModal() {
 	uiStore.openModal(CHANGE_PASSWORD_MODAL_KEY);
 }
+
 function onMfaEnableClick() {
 	uiStore.openModal(MFA_SETUP_MODAL_KEY);
 }

--- a/packages/editor-ui/src/views/__tests__/SettingsPersonalView.test.ts
+++ b/packages/editor-ui/src/views/__tests__/SettingsPersonalView.test.ts
@@ -92,6 +92,7 @@ describe('SettingsPersonalView', () => {
 		});
 
 		it('should commit the theme change after clicking save', async () => {
+			vi.spyOn(usersStore, 'updateUser').mockReturnValue(Promise.resolve());
 			const { getByPlaceholderText, findByText, getByTestId } = renderComponent({ pinia });
 			await waitAllPromises();
 
@@ -102,6 +103,9 @@ describe('SettingsPersonalView', () => {
 			await waitAllPromises();
 
 			getByTestId('save-settings-button').click();
+
+			await waitAllPromises();
+
 			expect(uiStore.theme).toBe('dark');
 		});
 	});


### PR DESCRIPTION
## Summary

Continuation of #10345.

Require MFA code when changing email address if MFA is enabled.


https://github.com/user-attachments/assets/e559b64e-93ad-4e87-b269-4a4cc62740e4



## Related Linear tickets, Github issues, and Community forum posts

[SEC-67](https://linear.app/n8n/issue/SEC-67/29-account-update-without-mfa)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
