### PR TITLE
feat(editor): Enable NodeView version switcher by default on internal (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -96,8 +96,16 @@ const importFileRef = ref<HTMLInputElement | undefined>();
 const tagsEventBus = createEventBus();
 const sourceControlModalEventBus = createEventBus();
 
-const nodeViewSwitcher = useLocalStorage('NodeView.switcher', import.meta.env.DEV ? 'true' : '');
+const nodeViewSwitcher = useLocalStorage('NodeView.switcher', '');
 const nodeViewVersion = useLocalStorage('NodeView.version', '1');
+
+const isNodeViewSwitcherEnabled = computed(() => {
+	return (
+		import.meta.env.DEV ||
+		nodeViewSwitcher.value === 'true' ||
+		settingsStore.deploymentType === 'n8n-internal'
+	);
+});
 
 const hasChanged = (prev: string[], curr: string[]) => {
 	if (prev.length !== curr.length) {
@@ -184,7 +192,7 @@ const workflowMenuItems = computed<ActionDropdownItem[]>(() => {
 		disabled: !onWorkflowPage.value || isNewWorkflow.value,
 	});
 
-	if (nodeViewSwitcher.value === 'true') {
+	if (isNodeViewSwitcherEnabled.value) {
 		actions.push({
 			id: WORKFLOW_MENU_ACTIONS.SWITCH_NODE_VIEW_VERSION,
 			label:


### PR DESCRIPTION
## Summary

Enables NodeView version switcher by default on internal deployment

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7549/make-the-new-canvas-the-default-on-internal-instance

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
