### PR TITLE
feat(Schedule Trigger Node): Add rule name and include in the output

### DIFF
--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -403,6 +403,13 @@ export class ScheduleTrigger implements INodeType {
 								},
 								hint: 'Format: [Second] [Minute] [Hour] [Day of Month] [Month] [Day of Week]',
 							},
+							{
+								displayName: 'Rule Name',
+								name: 'ruleName',
+								type: 'string',
+								default: '',
+								placeholder: 'eg. backup',
+							},
 						],
 					},
 				],
@@ -437,6 +444,7 @@ export class ScheduleTrigger implements INodeType {
 				Minute: momentTz.format('mm'),
 				Second: momentTz.format('ss'),
 				Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
+				Rule: recurrence.ruleName,
 			};
 
 			this.emit([this.helpers.returnJsonArray([resultData])]);
@@ -446,10 +454,12 @@ export class ScheduleTrigger implements INodeType {
 			interval,
 			cronExpression: toCronExpression(interval),
 			recurrence: intervalToRecurrence(interval, i),
+			ruleName: interval.ruleName || `Rule ${i + 1}`,
 		}));
 
 		if (this.getMode() !== 'manual') {
-			for (const { interval, cronExpression, recurrence } of rules) {
+			for (const { interval, cronExpression, recurrence, ruleName } of rules) {
+				recurrence.ruleName = ruleName;
 				try {
 					this.helpers.registerCron(cronExpression, () => executeTrigger(recurrence));
 				} catch (error) {
@@ -465,7 +475,8 @@ export class ScheduleTrigger implements INodeType {
 			return {};
 		} else {
 			const manualTriggerFunction = async () => {
-				const { interval, cronExpression, recurrence } = rules[0];
+				const { interval, cronExpression, recurrence, ruleName } = rules[0];
+				recurrence.ruleName = ruleName;
 				if (interval.field === 'cronExpression') {
 					try {
 						sendAt(cronExpression);

--- a/packages/nodes-base/nodes/Schedule/SchedulerInterface.ts
+++ b/packages/nodes-base/nodes/Schedule/SchedulerInterface.ts
@@ -1,40 +1,47 @@
 import type { CronExpression } from 'n8n-workflow';
 
 export type IRecurrenceRule =
-	| { activated: false }
+	| { activated: false; ruleName?: string }
 	| {
 			activated: true;
 			index: number;
 			intervalSize: number;
 			typeInterval: 'hours' | 'days' | 'weeks' | 'months';
+			ruleName?: string;
 	  };
 
 export type ScheduleInterval =
 	| {
 			field: 'cronExpression';
+			ruleName?: string;
 			expression: CronExpression;
 	  }
 	| {
 			field: 'seconds';
+			ruleName?: string;
 			secondsInterval: number;
 	  }
 	| {
 			field: 'minutes';
+			ruleName?: string;
 			minutesInterval: number;
 	  }
 	| {
 			field: 'hours';
+			ruleName?: string;
 			hoursInterval: number;
 			triggerAtMinute?: number;
 	  }
 	| {
 			field: 'days';
+			ruleName?: string;
 			daysInterval: number;
 			triggerAtHour?: number;
 			triggerAtMinute?: number;
 	  }
 	| {
 			field: 'weeks';
+			ruleName?: string;
 			weeksInterval: number;
 			triggerAtDay: number[];
 			triggerAtHour?: number;
@@ -42,6 +49,7 @@ export type ScheduleInterval =
 	  }
 	| {
 			field: 'months';
+			ruleName?: string;
 			monthsInterval: number;
 			triggerAtDayOfMonth?: number;
 			triggerAtHour?: number;

--- a/packages/nodes-base/nodes/Schedule/tests/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/tests/ScheduleTrigger.node.test.ts
@@ -70,6 +70,7 @@ describe('ScheduleTrigger', () => {
 				Timezone: 'Europe/Berlin (UTC+01:00)',
 				Year: '2023',
 				timestamp: '2023-12-28T15:30:30.000+01:00',
+				Rule: 'Rule 1',
 			});
 
 			jest.setSystemTime(new Date(firstTriggerData.json.timestamp as string));


### PR DESCRIPTION
## Summary

At the moment the schedule trigger node doesn't deduplicate triggers when the are multiple rules that overlap. That is for a 5 and 10 second trigger, every 10s it will fire twice. There is no easy way to tell which rule trigger rule caused this. This PR adds the option to include a rule name which is included in the output.

Any rule without a name defined will default to `Rule X` based on its indexed position.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/422b71b8-4599-40ea-ba2e-1c6d460fd2b9">

<img width="980" alt="image" src="https://github.com/user-attachments/assets/e2d08d82-90be-48dc-b219-b5c1c89d96ca">

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
