### PR TITLE
fix(n8n Form Trigger Node): Fix issue preventing v1 node from working

### DIFF
--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -165,7 +165,9 @@ export async function formWebhook(
 		if (options.ignoreBots && isbot(req.headers['user-agent'])) {
 			throw new WebhookAuthorizationError(403);
 		}
-		await validateWebhookAuthentication(context, authProperty);
+		if (node.typeVersion > 1) {
+			await validateWebhookAuthentication(context, authProperty);
+		}
 	} catch (error) {
 		if (error instanceof WebhookAuthorizationError) {
 			res.writeHead(error.responseCode, { 'WWW-Authenticate': 'Basic realm="Webhook"' });


### PR DESCRIPTION
## Summary
When releasing the auth updates to the forum trigger we broke the v1 node because it doesn't have any authentication options.

This fix checks if the version is higher than 1 then validates the auth option.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1575/review-form-trigger-node-fix
