### PR TITLE
fix(Nextcloud Node): Fix broken folder sharing and user actions & New action: share file/folder via internal link

### DIFF
--- a/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/NextCloud/GenericFunctions.ts
@@ -19,9 +19,8 @@ export async function nextCloudApiRequest(
 	headers?: IDataObject,
 	encoding?: null | undefined,
 	query?: IDataObject,
+	webDavEndpoint: boolean = true,
 ) {
-	const resource = this.getNodeParameter('resource', 0);
-	const operation = this.getNodeParameter('operation', 0);
 	const authenticationMethod = this.getNodeParameter('authentication', 0);
 
 	let credentials;
@@ -47,11 +46,7 @@ export async function nextCloudApiRequest(
 
 	options.uri = `${credentials.webDavUrl}/${encodeURI(endpoint)}`;
 
-	if (resource === 'user' && operation === 'create') {
-		options.uri = options.uri.replace('/remote.php/webdav', '');
-	}
-
-	if (resource === 'file' && operation === 'share') {
+	if (!webDavEndpoint) {
 		options.uri = options.uri.replace('/remote.php/webdav', '');
 	}
 

--- a/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
+++ b/packages/nodes-base/nodes/NextCloud/NextCloud.node.ts
@@ -472,6 +472,10 @@ export class NextCloud implements INodeType {
 						value: 1,
 					},
 					{
+						name: 'Internal Link',
+						value: 200,
+					},
+					{
 						name: 'Public Link',
 						value: 3,
 					},
@@ -594,6 +598,13 @@ export class NextCloud implements INodeType {
 								value: 2,
 							},
 						],
+						displayOptions: {
+							show: {
+								'/resource': ['file', 'folder'],
+								'/operation': ['share'],
+								'/shareType': [7, 4, 1, 3, 0],
+							},
+						},
 						default: 1,
 						description: 'The share permissions to set',
 					},
@@ -877,6 +888,7 @@ export class NextCloud implements INodeType {
 		let endpoint = '';
 		let requestMethod: IHttpRequestMethods = 'GET';
 		let responseData: any;
+		let useWebDavEndpoint: boolean = true;
 
 		let body: string | Buffer | IDataObject = '';
 		const headers: IDataObject = {};
@@ -958,32 +970,52 @@ export class NextCloud implements INodeType {
 						//         share
 						// ----------------------------------
 
-						requestMethod = 'POST';
-
-						endpoint = 'ocs/v2.php/apps/files_sharing/api/v1/shares';
-
-						headers['OCS-APIRequest'] = true;
-						headers['Content-Type'] = 'application/x-www-form-urlencoded';
-
 						const bodyParameters = this.getNodeParameter('options', i);
-
 						bodyParameters.path = this.getNodeParameter('path', i) as string;
 						bodyParameters.shareType = this.getNodeParameter('shareType', i) as number;
 
-						if (bodyParameters.shareType === 0) {
-							bodyParameters.shareWith = this.getNodeParameter('user', i) as string;
-						} else if (bodyParameters.shareType === 7) {
-							bodyParameters.shareWith = this.getNodeParameter('circleId', i) as number;
-						} else if (bodyParameters.shareType === 4) {
-							bodyParameters.shareWith = this.getNodeParameter('email', i) as string;
-						} else if (bodyParameters.shareType === 1) {
-							bodyParameters.shareWith = this.getNodeParameter('groupId', i) as number;
-						}
+						// Internal link?
+						if (bodyParameters.shareType === 200) {
+							// ----------------------------------
+							//      share:internalLink
+							// ----------------------------------
 
-						// @ts-ignore
-						body = new URLSearchParams(bodyParameters).toString();
+							headers['Content-Type'] = 'application/xml';
+							body = `<?xml version="1.0" encoding="UTF-8"?>
+							<d:propfind xmlns:d="DAV:">
+								<d:prop xmlns:oc="http://owncloud.org/ns">
+									<oc:fileid/>
+								</d:prop>
+							</d:propfind>`;
+
+							requestMethod = 'PROPFIND' as IHttpRequestMethods;
+							endpoint = this.getNodeParameter('path', i) as string;
+						} else {
+							requestMethod = 'POST';
+							useWebDavEndpoint = false;
+
+							endpoint = 'ocs/v2.php/apps/files_sharing/api/v1/shares';
+
+							headers['OCS-APIRequest'] = true;
+							headers['Content-Type'] = 'application/x-www-form-urlencoded';
+
+							if (bodyParameters.shareType === 0) {
+								bodyParameters.shareWith = this.getNodeParameter('user', i) as string;
+							} else if (bodyParameters.shareType === 7) {
+								bodyParameters.shareWith = this.getNodeParameter('circleId', i) as number;
+							} else if (bodyParameters.shareType === 4) {
+								bodyParameters.shareWith = this.getNodeParameter('email', i) as string;
+							} else if (bodyParameters.shareType === 1) {
+								bodyParameters.shareWith = this.getNodeParameter('groupId', i) as number;
+							}
+
+							// @ts-ignore
+							body = new URLSearchParams(bodyParameters).toString();
+						}
 					}
 				} else if (resource === 'user') {
+					useWebDavEndpoint = false;
+
 					if (operation === 'create') {
 						// ----------------------------------
 						//         user:create
@@ -1097,6 +1129,7 @@ export class NextCloud implements INodeType {
 						headers,
 						encoding,
 						qs,
+						useWebDavEndpoint,
 					);
 				} catch (error) {
 					if (this.continueOnFail(error)) {
@@ -1134,32 +1167,81 @@ export class NextCloud implements INodeType {
 						endpoint,
 					);
 				} else if (['file', 'folder'].includes(resource) && operation === 'share') {
-					// eslint-disable-next-line @typescript-eslint/no-loop-func
-					const jsonResponseData: IDataObject = await new Promise((resolve, reject) => {
-						parseString(responseData as string, { explicitArray: false }, (err, data) => {
-							if (err) {
-								return reject(err);
-							}
+					const bodyParameters = this.getNodeParameter('options', i);
+					bodyParameters.path = this.getNodeParameter('path', i) as string;
+					bodyParameters.shareType = this.getNodeParameter('shareType', i) as number;
 
-							if (data.ocs.meta.status !== 'ok') {
-								return reject(
-									new NodeApiError(
-										this.getNode(),
-										(data.ocs.meta.message as JsonObject) || (data.ocs.meta.status as JsonObject),
-									),
-								);
-							}
+					if (bodyParameters.shareType === 200) {
+						// Make sure, we end the path in a slash because this is what will be returned by NextCloud
+						if (bodyParameters.path.slice(-1) !== '/') {
+							bodyParameters.path += '/';
+						}
 
-							resolve(data.ocs.data as IDataObject);
+						// eslint-disable-next-line @typescript-eslint/no-loop-func
+						const jsonResponseData: IDataObject = await new Promise((resolve, reject) => {
+							parseString(responseData as string, { explicitArray: false }, (err, data) => {
+								if (err) {
+									return reject(err);
+								}
+								resolve(data as IDataObject);
+							});
 						});
-					});
+						const baseUrl = credentials.webDavUrl.toString().replace('/remote.php/webdav', '');
+						if (
+							jsonResponseData['d:multistatus'] !== undefined &&
+							jsonResponseData['d:multistatus'] !== null &&
+							(jsonResponseData['d:multistatus'] as IDataObject)['d:response'] !== null
+						) {
+							// @ts-ignore
+							const response = jsonResponseData['d:multistatus']['d:response'];
+							// when getting the file id for a folder, we also get the whole folder content.
+							// In that case we need to find the file id of the folder itself
+							if (Array.isArray(response)) {
+								response.forEach((item: IDataObject) => {
+									if (
+										item['d:href']?.toString().replace('/remote.php/webdav', '') ===
+										bodyParameters.path
+									) {
+										// @ts-ignore
+										const fileid = item['d:propstat']['d:prop']['oc:fileid'] as IDataObject;
+										const internalLink = `${baseUrl}/f/${fileid}`;
+										returnData.push({ json: { link: internalLink }, pairedItem: { item: i } });
+									}
+								});
+							} else {
+								const fileid = response['d:propstat']['d:prop']['oc:fileid'] as IDataObject;
+								const internalLink = `${baseUrl}/f/${fileid}`;
+								returnData.push({ json: { link: internalLink }, pairedItem: { item: i } });
+							}
+						}
+					} else {
+						// eslint-disable-next-line @typescript-eslint/no-loop-func
+						const jsonResponseData: IDataObject = await new Promise((resolve, reject) => {
+							parseString(responseData as string, { explicitArray: false }, (err, data) => {
+								if (err) {
+									return reject(err);
+								}
 
-					const executionData = this.helpers.constructExecutionMetaData(
-						wrapData(jsonResponseData),
-						{ itemData: { item: i } },
-					);
+								if (data.ocs.meta.status !== 'ok') {
+									return reject(
+										new NodeApiError(
+											this.getNode(),
+											(data.ocs.meta.message as JsonObject) || (data.ocs.meta.status as JsonObject),
+										),
+									);
+								}
 
-					returnData.push(...executionData);
+								resolve(data.ocs.data as IDataObject);
+							});
+						});
+
+						const executionData = this.helpers.constructExecutionMetaData(
+							wrapData(jsonResponseData),
+							{ itemData: { item: i } },
+						);
+
+						returnData.push(...executionData);
+					}
 				} else if (resource === 'user') {
 					if (operation !== 'getAll') {
 						// eslint-disable-next-line @typescript-eslint/no-loop-func


### PR DESCRIPTION
## Summary

* fixed issue in NextCloud node: all user actions except create and all folder share actions were broken, because they wrongfully addressed the webdav endpoint
* added sharing via internal link for files and folders

<img width="492" alt="image" src="https://github.com/user-attachments/assets/87210846-65f7-4ea3-8bcc-b3fe8f17c575">


## Related Linear tickets, Github issues, and Community forum posts

Error when sharing:
https://community.n8n.io/t/nextcloud-node-doesnt-give-a-public-link/23000

Inability to get file id (they are the basis for internal links):
https://community.n8n.io/t/nextcloud-node-how-to-get-the-ids-of-folders-and-files/30903/7
https://community.n8n.io/t/add-support-in-the-http-request-node-for-the-propfind-http-method/27697

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
