### PR TITLE
refactor(core): Move queue recovery to scaling service (no-changelog)

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -30,7 +30,6 @@ import type { IWorkflowExecutionDataProcess } from '@/Interfaces';
 import { ExecutionService } from '@/executions/execution.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowRunner } from '@/WorkflowRunner';
-import { ExecutionRecoveryService } from '@/executions/execution-recovery.service';
 import { EventService } from '@/events/event.service';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
@@ -305,7 +304,6 @@ export class Start extends BaseCommand {
 		await this.server.start();
 
 		Container.get(PruningService).init();
-		Container.get(ExecutionRecoveryService).init();
 
 		if (config.getEnv('executions.mode') === 'regular') {
 			await this.runEnqueuedExecutions();

--- a/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
@@ -9,7 +9,6 @@ import { createExecution } from '@test-integration/db/executions';
 import * as testDb from '@test-integration/testDb';
 
 import { mock } from 'jest-mock-extended';
-import { OrchestrationService } from '@/services/orchestration.service';
 import { ExecutionRecoveryService } from '@/executions/execution-recovery.service';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import { Push } from '@/push';
@@ -27,13 +26,11 @@ describe('ExecutionRecoveryService', () => {
 	const instanceSettings = new InstanceSettings();
 
 	let executionRecoveryService: ExecutionRecoveryService;
-	let orchestrationService: OrchestrationService;
 	let executionRepository: ExecutionRepository;
 
 	beforeAll(async () => {
 		await testDb.init();
 		executionRepository = Container.get(ExecutionRepository);
-		orchestrationService = Container.get(OrchestrationService);
 
 		executionRecoveryService = new ExecutionRecoveryService(
 			mock(),

--- a/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
@@ -10,7 +10,6 @@ import * as testDb from '@test-integration/testDb';
 
 import { mock } from 'jest-mock-extended';
 import { OrchestrationService } from '@/services/orchestration.service';
-import config from '@/config';
 import { ExecutionRecoveryService } from '@/executions/execution-recovery.service';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import { Push } from '@/push';
@@ -41,7 +40,6 @@ describe('ExecutionRecoveryService', () => {
 			instanceSettings,
 			push,
 			executionRepository,
-			orchestrationService,
 			mock(),
 		);
 	});
@@ -53,72 +51,10 @@ describe('ExecutionRecoveryService', () => {
 	afterEach(async () => {
 		jest.restoreAllMocks();
 		await testDb.truncate(['Execution', 'ExecutionData', 'Workflow']);
-		executionRecoveryService.shutdown();
 	});
 
 	afterAll(async () => {
 		await testDb.terminate();
-	});
-
-	describe('scheduleQueueRecovery', () => {
-		describe('queue mode', () => {
-			it('if leader, should schedule queue recovery', () => {
-				/**
-				 * Arrange
-				 */
-				config.set('executions.mode', 'queue');
-				const scheduleSpy = jest.spyOn(executionRecoveryService, 'scheduleQueueRecovery');
-
-				/**
-				 * Act
-				 */
-				executionRecoveryService.init();
-
-				/**
-				 * Assert
-				 */
-				expect(scheduleSpy).toHaveBeenCalled();
-			});
-
-			it('if follower, should do nothing', () => {
-				/**
-				 * Arrange
-				 */
-				config.set('executions.mode', 'queue');
-				instanceSettings.markAsFollower();
-				const scheduleSpy = jest.spyOn(executionRecoveryService, 'scheduleQueueRecovery');
-
-				/**
-				 * Act
-				 */
-				executionRecoveryService.init();
-
-				/**
-				 * Assert
-				 */
-				expect(scheduleSpy).not.toHaveBeenCalled();
-			});
-		});
-
-		describe('regular mode', () => {
-			it('should do nothing', () => {
-				/**
-				 * Arrange
-				 */
-				config.set('executions.mode', 'regular');
-				const scheduleSpy = jest.spyOn(executionRecoveryService, 'scheduleQueueRecovery');
-
-				/**
-				 * Act
-				 */
-				executionRecoveryService.init();
-
-				/**
-				 * Assert
-				 */
-				expect(scheduleSpy).not.toHaveBeenCalled();
-			});
-		});
 	});
 
 	describe('recoverFromLogs', () => {

--- a/packages/cli/src/executions/execution.types.ts
+++ b/packages/cli/src/executions/execution.types.ts
@@ -93,23 +93,6 @@ export namespace ExecutionSummaries {
 	export type ExecutionSummaryWithScopes = ExecutionSummary & { scopes: Scope[] };
 }
 
-export type QueueRecoverySettings = {
-	/**
-	 * ID of timeout for next scheduled recovery cycle.
-	 */
-	timeout?: NodeJS.Timeout;
-
-	/**
-	 * Number of in-progress executions to check per cycle.
-	 */
-	batchSize: number;
-
-	/**
-	 * Time (in milliseconds) to wait before the next cycle.
-	 */
-	waitMs: number;
-};
-
 export type StopResult = {
 	mode: WorkflowExecuteMode;
 	startedAt: Date;

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -90,6 +90,7 @@ export class ScalingService {
 		this.stopQueueRecovery();
 
 		this.logger.debug('[ScalingService] Queue recovery stopped');
+
 		let count = 0;
 
 		while (this.getRunningJobsCount() !== 0) {

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -1,5 +1,5 @@
 import Container, { Service } from 'typedi';
-import { ApplicationError, BINARY_ENCODING } from 'n8n-workflow';
+import { ApplicationError, BINARY_ENCODING, jsonStringify } from 'n8n-workflow';
 import { ActiveExecutions } from '@/ActiveExecutions';
 import config from '@/config';
 import { Logger } from '@/Logger';
@@ -8,9 +8,21 @@ import { HIGHEST_SHUTDOWN_PRIORITY } from '@/constants';
 import { OnShutdown } from '@/decorators/OnShutdown';
 import { JOB_TYPE_NAME, QUEUE_NAME } from './constants';
 import { JobProcessor } from './job-processor';
-import type { JobQueue, Job, JobData, JobOptions, JobMessage, JobStatus, JobId } from './types';
+import type {
+	JobQueue,
+	Job,
+	JobData,
+	JobOptions,
+	JobMessage,
+	JobStatus,
+	JobId,
+	QueueRecoverySettings,
+} from './types';
 import type { IExecuteResponsePromiseData } from 'n8n-workflow';
 import { GlobalConfig } from '@n8n/config';
+import { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import { InstanceSettings } from 'n8n-core';
+import { OrchestrationService } from '@/services/orchestration.service';
 
 @Service()
 export class ScalingService {
@@ -23,6 +35,9 @@ export class ScalingService {
 		private readonly activeExecutions: ActiveExecutions,
 		private readonly jobProcessor: JobProcessor,
 		private readonly globalConfig: GlobalConfig,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly orchestrationService: OrchestrationService,
 	) {}
 
 	// #region Lifecycle
@@ -42,6 +57,14 @@ export class ScalingService {
 		});
 
 		this.registerListeners();
+
+		if (this.instanceSettings.isLeader) this.scheduleQueueRecovery();
+
+		if (this.orchestrationService.isMultiMainSetupEnabled) {
+			this.orchestrationService.multiMainSetup
+				.on('leader-takeover', () => this.scheduleQueueRecovery())
+				.on('leader-stepdown', () => this.stopQueueRecovery());
+		}
 
 		this.logger.debug('[ScalingService] Queue setup completed');
 	}
@@ -63,6 +86,10 @@ export class ScalingService {
 		await this.queue.pause(true, true);
 
 		this.logger.debug('[ScalingService] Queue paused');
+
+		this.stopQueueRecovery();
+
+		this.logger.debug('[ScalingService] Queue recovery stopped');
 	}
 
 	async pingQueue() {
@@ -214,4 +241,86 @@ export class ScalingService {
 
 		throw new ApplicationError('This method must be called on a `worker` instance');
 	}
+
+	// #region Queue recovery
+
+	private readonly queueRecoverySettings: QueueRecoverySettings = {
+		batchSize: config.getEnv('executions.queueRecovery.batchSize'),
+		waitMs: config.getEnv('executions.queueRecovery.interval') * 60 * 1000,
+	};
+
+	scheduleQueueRecovery(waitMs = this.queueRecoverySettings.waitMs) {
+		this.queueRecoverySettings.timeout = setTimeout(async () => {
+			try {
+				const nextWaitMs = await this.recoverFromQueue();
+				this.scheduleQueueRecovery(nextWaitMs);
+			} catch (error) {
+				this.logger.error('[ScalingService] Failed to recover dangling executions from queue', {
+					msg: this.toErrorMsg(error),
+				});
+				this.logger.error('[ScalingService] Retrying...');
+
+				this.scheduleQueueRecovery();
+			}
+		}, waitMs);
+
+		const wait = [this.queueRecoverySettings.waitMs / (60 * 1000), 'min'].join(' ');
+
+		this.logger.debug(`[ScalingService] Scheduled queue recovery check for next ${wait}`);
+	}
+
+	stopQueueRecovery() {
+		clearTimeout(this.queueRecoverySettings.timeout);
+	}
+
+	/**
+	 * Mark in-progress executions as `crashed` if stored in DB as `new` or `running`
+	 * but absent from the queue. Return time until next recovery cycle.
+	 */
+	private async recoverFromQueue() {
+		const { waitMs, batchSize } = this.queueRecoverySettings;
+
+		const storedIds = await this.executionRepository.getInProgressExecutionIds(batchSize);
+
+		if (storedIds.length === 0) {
+			this.logger.debug('[ScalingService] Completed queue recovery check, no dangling executions');
+			return waitMs;
+		}
+
+		const runningJobs = await this.findJobsByStatus(['active', 'waiting']);
+
+		const queuedIds = new Set(runningJobs.map((job) => job.data.executionId));
+
+		if (queuedIds.size === 0) {
+			this.logger.debug('[ScalingService] Completed queue recovery check, no dangling executions');
+			return waitMs;
+		}
+
+		const danglingIds = storedIds.filter((id) => !queuedIds.has(id));
+
+		if (danglingIds.length === 0) {
+			this.logger.debug('[ScalingService] Completed queue recovery check, no dangling executions');
+			return waitMs;
+		}
+
+		await this.executionRepository.markAsCrashed(danglingIds);
+
+		this.logger.info(
+			'[ScalingService] Completed queue recovery check, recovered dangling executions',
+			{ danglingIds },
+		);
+
+		// if this cycle used up the whole batch size, it is possible for there to be
+		// dangling executions outside this check, so speed up next cycle
+
+		return storedIds.length >= this.queueRecoverySettings.batchSize ? waitMs / 2 : waitMs;
+	}
+
+	private toErrorMsg(error: unknown) {
+		return error instanceof Error
+			? error.message
+			: jsonStringify(error, { replaceCircularRefs: true });
+	}
+
+	// #endregion
 }

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -4,7 +4,7 @@ import { ActiveExecutions } from '@/ActiveExecutions';
 import config from '@/config';
 import { Logger } from '@/Logger';
 import { MaxStalledCountError } from '@/errors/max-stalled-count.error';
-import { HIGHEST_SHUTDOWN_PRIORITY } from '@/constants';
+import { HIGHEST_SHUTDOWN_PRIORITY, Time } from '@/constants';
 import { OnShutdown } from '@/decorators/OnShutdown';
 import { JOB_TYPE_NAME, QUEUE_NAME } from './constants';
 import { JobProcessor } from './job-processor';
@@ -280,7 +280,7 @@ export class ScalingService {
 			}
 		}, waitMs);
 
-		const wait = [this.queueRecoverySettings.waitMs / (60 * 1000), 'min'].join(' ');
+		const wait = [this.queueRecoverySettings.waitMs / Time.minutes.toMilliseconds, 'min'].join(' ');
 
 		this.logger.debug(`[ScalingService] Scheduled queue recovery check for next ${wait}`);
 	}

--- a/packages/cli/src/scaling/types.ts
+++ b/packages/cli/src/scaling/types.ts
@@ -54,7 +54,7 @@ export type RunningJob = {
 
 export type RunningJobSummary = Omit<RunningJob, 'run'>;
 
-export type QueueRecoverySettings = {
+export type QueueRecoveryContext = {
 	/** ID of timeout for next scheduled recovery cycle. */
 	timeout?: NodeJS.Timeout;
 

--- a/packages/cli/src/scaling/types.ts
+++ b/packages/cli/src/scaling/types.ts
@@ -53,3 +53,14 @@ export type RunningJob = {
 };
 
 export type RunningJobSummary = Omit<RunningJob, 'run'>;
+
+export type QueueRecoverySettings = {
+	/** ID of timeout for next scheduled recovery cycle. */
+	timeout?: NodeJS.Timeout;
+
+	/** Number of in-progress executions to check per cycle. */
+	batchSize: number;
+
+	/** Time (in milliseconds) to wait until the next cycle. */
+	waitMs: number;
+};


### PR DESCRIPTION
Queue recovery belongs in the scaling service, which did not exist when queue recovery was created.