### PR TITLE
fix: Fix issue with some errors not being handled correctly (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -167,7 +167,7 @@ export abstract class NodeError extends ExecutionBaseError {
 		}
 
 		// if code is provided and it is in the list of common errors set the message and return early
-		if (code && COMMON_ERRORS[code.toUpperCase()]) {
+		if (code && typeof code !== 'number' && COMMON_ERRORS[code.toUpperCase()]) {
 			newMessage = COMMON_ERRORS[code] as string;
 			messages.push(message);
 			return [newMessage, messages];

--- a/packages/workflow/src/errors/abstract/node.error.ts
+++ b/packages/workflow/src/errors/abstract/node.error.ts
@@ -167,7 +167,7 @@ export abstract class NodeError extends ExecutionBaseError {
 		}
 
 		// if code is provided and it is in the list of common errors set the message and return early
-		if (code && typeof code !== 'number' && COMMON_ERRORS[code.toUpperCase()]) {
+		if (code && typeof code === 'string' && COMMON_ERRORS[code.toUpperCase()]) {
 			newMessage = COMMON_ERRORS[code] as string;
 			messages.push(message);
 			return [newMessage, messages];

--- a/packages/workflow/test/NodeErrors.test.ts
+++ b/packages/workflow/test/NodeErrors.test.ts
@@ -1,4 +1,4 @@
-import type { INode } from '@/Interfaces';
+import type { INode, JsonObject } from '@/Interfaces';
 import { NodeOperationError } from '@/errors';
 import { NodeApiError } from '@/errors/node-api.error';
 import { UNKNOWN_ERROR_DESCRIPTION, UNKNOWN_ERROR_MESSAGE } from '../src/Constants';
@@ -259,5 +259,23 @@ describe('NodeApiError message and description logic', () => {
 
 		expect(nodeApiError.message).toEqual(UNKNOWN_ERROR_MESSAGE);
 		expect(nodeApiError.description).toEqual(UNKNOWN_ERROR_DESCRIPTION);
+	});
+
+	it('case: Error code sent as "any"', () => {
+		const error = {
+			code: 400,
+			message: "Invalid value 'test' for viewId parameter.",
+			status: 'INVALID_ARGUMENT',
+		};
+		const [message, ...rest] = error.message.split('\n');
+		const description = rest.join('\n');
+		const httpCode = error.code as any;
+		const nodeApiError = new NodeApiError(node, error as JsonObject, {
+			message,
+			description,
+			httpCode,
+		});
+
+		expect(nodeApiError.message).toEqual(error.message);
 	});
 });


### PR DESCRIPTION
## Summary
The descriptive error message check was failing to upperCase the error code which in most cases should be a string, However some nodes like Google Analytics sent the code as `any` causing the check to break.

This PR adds in a quick type check and a test to prevent it happening again, We should really move towards dropping `any` where possible as it causes unexpected issues. 

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1563/google-analytics-node-failing-since-recent-upgrade
https://community.n8n.io/t/google-analytics-node-returning-code-touppercase-is-not-a-function/49037

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
