### PR TITLE
feat(core): Support bidirectional communication between specific mains and specific workers

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -240,7 +240,10 @@ export class Start extends BaseCommand {
 
 		await orchestrationService.init();
 
-		await Container.get(OrchestrationHandlerMainService).init();
+		await Container.get(OrchestrationHandlerMainService).initWithOptions({
+			queueModeId: this.queueModeId,
+			redisPublisher: Container.get(OrchestrationService).redisPublisher,
+		});
 
 		if (!orchestrationService.isMultiMainSetupEnabled) return;
 

--- a/packages/cli/src/services/__tests__/orchestration.service.test.ts
+++ b/packages/cli/src/services/__tests__/orchestration.service.test.ts
@@ -19,6 +19,7 @@ import { Push } from '@/push';
 import { ActiveWorkflowManager } from '@/ActiveWorkflowManager';
 import { mockInstance } from '@test/mocking';
 import { RedisClientService } from '@/services/redis/redis-client.service';
+import type { MainResponseReceivedHandlerOptions } from '../orchestration/main/types';
 
 const instanceSettings = Container.get(InstanceSettings);
 const redisClientService = mockInstance(RedisClientService);
@@ -96,8 +97,9 @@ describe('Orchestration Service', () => {
 	test('should handle worker responses', async () => {
 		const response = await handleWorkerResponseMessageMain(
 			JSON.stringify(workerRestartEventBusResponse),
+			mock<MainResponseReceivedHandlerOptions>(),
 		);
-		expect(response.command).toEqual('restartEventBus');
+		expect(response?.command).toEqual('restartEventBus');
 	});
 
 	test('should handle command messages from others', async () => {

--- a/packages/cli/src/services/orchestration.handler.base.service.ts
+++ b/packages/cli/src/services/orchestration.handler.base.service.ts
@@ -2,6 +2,7 @@ import Container from 'typedi';
 import { RedisService } from './redis.service';
 import type { RedisServicePubSubSubscriber } from './redis/RedisServicePubSubSubscriber';
 import type { WorkerCommandReceivedHandlerOptions } from './orchestration/worker/types';
+import type { MainResponseReceivedHandlerOptions } from './orchestration/main/types';
 
 export abstract class OrchestrationHandlerService {
 	protected initialized = false;
@@ -19,7 +20,9 @@ export abstract class OrchestrationHandlerService {
 		this.initialized = true;
 	}
 
-	async initWithOptions(options: WorkerCommandReceivedHandlerOptions) {
+	async initWithOptions(
+		options: WorkerCommandReceivedHandlerOptions | MainResponseReceivedHandlerOptions,
+	) {
 		await this.initSubscriber(options);
 		this.initialized = true;
 	}
@@ -29,5 +32,7 @@ export abstract class OrchestrationHandlerService {
 		this.initialized = false;
 	}
 
-	protected abstract initSubscriber(options?: WorkerCommandReceivedHandlerOptions): Promise<void>;
+	protected abstract initSubscriber(
+		options?: WorkerCommandReceivedHandlerOptions | MainResponseReceivedHandlerOptions,
+	): Promise<void>;
 }

--- a/packages/cli/src/services/orchestration/main/handleWorkerResponseMessageMain.ts
+++ b/packages/cli/src/services/orchestration/main/handleWorkerResponseMessageMain.ts
@@ -3,25 +3,40 @@ import Container from 'typedi';
 import { Logger } from '@/Logger';
 import { Push } from '../../../push';
 import type { RedisServiceWorkerResponseObject } from '../../redis/RedisServiceCommands';
+import { WORKER_RESPONSE_REDIS_CHANNEL } from '@/services/redis/RedisConstants';
+import type { MainResponseReceivedHandlerOptions } from './types';
 
-export async function handleWorkerResponseMessageMain(messageString: string) {
-	const workerResponse = jsonParse<RedisServiceWorkerResponseObject>(messageString);
-	if (workerResponse) {
-		switch (workerResponse.command) {
-			case 'getStatus':
-				const push = Container.get(Push);
-				push.broadcast('sendWorkerStatusMessage', {
-					workerId: workerResponse.workerId,
-					status: workerResponse.payload,
-				});
-				break;
-			case 'getId':
-				break;
-			default:
-				Container.get(Logger).debug(
-					`Received worker response ${workerResponse.command} from ${workerResponse.workerId}`,
-				);
-		}
+export async function handleWorkerResponseMessageMain(
+	messageString: string,
+	options: MainResponseReceivedHandlerOptions,
+) {
+	const workerResponse = jsonParse<RedisServiceWorkerResponseObject | null>(messageString, {
+		fallbackValue: null,
+	});
+
+	if (!workerResponse) {
+		Container.get(Logger).debug(
+			`Received invalid message via channel ${WORKER_RESPONSE_REDIS_CHANNEL}: "${messageString}"`,
+		);
+		return;
 	}
+
+	if (workerResponse.targets && !workerResponse.targets.includes(options.queueModeId)) return;
+
+	switch (workerResponse.command) {
+		case 'getStatus':
+			Container.get(Push).broadcast('sendWorkerStatusMessage', {
+				workerId: workerResponse.workerId,
+				status: workerResponse.payload,
+			});
+			break;
+		case 'getId':
+			break;
+		default:
+			Container.get(Logger).debug(
+				`Received worker response ${workerResponse.command} from ${workerResponse.workerId}`,
+			);
+	}
+
 	return workerResponse;
 }

--- a/packages/cli/src/services/orchestration/main/orchestration.handler.main.service.ts
+++ b/packages/cli/src/services/orchestration/main/orchestration.handler.main.service.ts
@@ -3,10 +3,11 @@ import { COMMAND_REDIS_CHANNEL, WORKER_RESPONSE_REDIS_CHANNEL } from '../../redi
 import { handleWorkerResponseMessageMain } from './handleWorkerResponseMessageMain';
 import { handleCommandMessageMain } from './handleCommandMessageMain';
 import { OrchestrationHandlerService } from '../../orchestration.handler.base.service';
+import type { MainResponseReceivedHandlerOptions } from './types';
 
 @Service()
 export class OrchestrationHandlerMainService extends OrchestrationHandlerService {
-	async initSubscriber() {
+	async initSubscriber(options: MainResponseReceivedHandlerOptions) {
 		this.redisSubscriber = await this.redisService.getPubSubSubscriber();
 
 		await this.redisSubscriber.subscribeToCommandChannel();
@@ -16,7 +17,7 @@ export class OrchestrationHandlerMainService extends OrchestrationHandlerService
 			'OrchestrationMessageReceiver',
 			async (channel: string, messageString: string) => {
 				if (channel === WORKER_RESPONSE_REDIS_CHANNEL) {
-					await handleWorkerResponseMessageMain(messageString);
+					await handleWorkerResponseMessageMain(messageString, options);
 				} else if (channel === COMMAND_REDIS_CHANNEL) {
 					await handleCommandMessageMain(messageString);
 				}

--- a/packages/cli/src/services/orchestration/main/types.ts
+++ b/packages/cli/src/services/orchestration/main/types.ts
@@ -1,0 +1,6 @@
+import type { RedisServicePubSubPublisher } from '@/services/redis/RedisServicePubSubPublisher';
+
+export type MainResponseReceivedHandlerOptions = {
+	queueModeId: string;
+	redisPublisher: RedisServicePubSubPublisher;
+};

--- a/packages/cli/src/services/redis/RedisServiceCommands.ts
+++ b/packages/cli/src/services/redis/RedisServiceCommands.ts
@@ -94,7 +94,7 @@ export type RedisServiceWorkerResponseObject = {
 				workflowId: string;
 			};
 	  }
-);
+) & { targets?: string[] };
 
 export type RedisServiceCommandObject = {
 	targets?: string[];


### PR DESCRIPTION
This PR allows specific a main to message one or more specific workers via a pubsub channel, and for a worker to message specific one or more specific mains via another pubsub channel. This is needed for Val's code execution agents setup - in scaling mode, workers will need to request script execution jobs from mains, and mains will need to send workers the results of those jobs completed by agents so that workers can continue executing.

## Context

Scaling mode relies on two pubsub channels for mains and workers to communicate: 

- the command channel
	- for a main to send commands to workers outside the Bull setup, e.g. to ask workers for worker IDs and statuses, to ask workers to reload the license, to ask workers to restart the event bus, to ask workers to reload external secrets providers, etc.
	- for a main to message peers in a multi-main setup, e.g. to add or remove triggers and pollers during leadership transition, to reflect workflow activation events in the UI (enabled, disabled, failed to enable), to relay execution lifecycle events for test webhooks if the main that handled the webhook differs from the main that created the webhook, to install or remove community packages based on what occurred in other mains, etc.
- the worker response channel
	- for a worker to send back results of commands, only needed by worker view right now

## Implementation

In our current setup, we have

- `worker/handleCommandMessageWorker.ts` for worker actions in reaction to commands from the main process via the command channel,
- `main/handleCommandMessageMain.ts` for main process actions in reaction to messages received from peers via the command channel, and
- `main/handleWorkerResponseMessageMain.ts` for main process actions in reaction to responses from workers via the worker response channel.

Main-to-main and worker-to-main communications already support targeting specific recipients, so this PR extends the existing setup to support targeting specific recipients in main-to-worker communications.  Please note the existing pubsub implementation needs heavy rework - this PR extends it as little as possible to unblock the agents initiative, until we have time to improve these foundations. 

## Testing

To test: 
- override the `queueModeId` for a worker and for a main, 
- add the below snippets to message a specific worker from a main and to message a specific main from a worker, 
- add logs at `handleCommandMessageWorker` and `handleWorkerResponseMessageMain` to see the messages, and
- start both main and worker.

```ts
// start.ts - at end of initOrchestration
const redisPublisher = await Container.get(RedisService).getPubSubPublisher();
await redisPublisher.publishToCommandChannel({
	command: 'getId',
	payload: {
		id: '123',
	},
	targets: ['some-worker'], // main: message specific worker
});

// worker.ts - at end of initOrchestration
const redisPublisher = await Container.get(RedisService).getPubSubPublisher();
await redisPublisher.publishToWorkerChannel({
	workerId: this.queueModeId,
	command: 'getId',
	payload: {
		id: '123',
	},
	targets: ['some-main'], // worker: message specific main
});
```


