### PR TITLE
fix(Calendly Trigger Node): Fix issue with webhook url matching

### DIFF
--- a/packages/nodes-base/nodes/Calendly/CalendlyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Calendly/CalendlyTrigger.node.ts
@@ -116,7 +116,7 @@ export class CalendlyTrigger implements INodeType {
 			async checkExists(this: IHookFunctions): Promise<boolean> {
 				const webhookUrl = this.getNodeWebhookUrl('default');
 				const webhookData = this.getWorkflowStaticData('node');
-				const events = this.getNodeParameter('events') as string;
+				const events = this.getNodeParameter('events') as string[];
 
 				const authenticationType = await getAuthenticationType.call(this);
 
@@ -160,16 +160,14 @@ export class CalendlyTrigger implements INodeType {
 					const { collection } = await calendlyApiRequest.call(this, 'GET', endpoint, {}, qs);
 
 					for (const webhook of collection) {
-						if (webhook.callback_url === webhookUrl) {
-							for (const event of events) {
-								if (!webhook.events.includes(event)) {
-									return false;
-								}
-							}
+						if (
+							webhook.callback_url === webhookUrl &&
+							events.length === webhook.events.length &&
+							events.every((event: string) => webhook.events.includes(event))
+						) {
+							webhookData.webhookURI = webhook.uri;
+							return true;
 						}
-
-						webhookData.webhookURI = webhook.uri;
-						return true;
 					}
 				}
 
@@ -178,7 +176,7 @@ export class CalendlyTrigger implements INodeType {
 			async create(this: IHookFunctions): Promise<boolean> {
 				const webhookData = this.getWorkflowStaticData('node');
 				const webhookUrl = this.getNodeWebhookUrl('default');
-				const events = this.getNodeParameter('events') as string;
+				const events = this.getNodeParameter('events') as string[];
 
 				const authenticationType = await getAuthenticationType.call(this);
 


### PR DESCRIPTION
## Summary
The webhook matching logic in `checkExists` was wrong - so it was matching existing Calendly webhooks to new workflows.

Note: the same bug probably exists in the v1 implementation of Calendly node (for the `authenticationType === 'apiKey'` variant). I'm not fixing that because I don't have a way to manually test it (Calendly no longer allows generating the v1 api key, it only generates the new access tokens). 

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
