### PR TITLE
ci: Disable turbo cache when running tests for coverage collection (no-changelog)

### DIFF
--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -50,6 +50,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup build cache
+        if: inputs.collectCoverage != true
         uses: rharkor/caching-for-turbo@v1.5
 
       - name: Build

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://turbo.build/schema.json",
 	"ui": "stream",
+	"globalEnv": ["CI", "COVERAGE_ENABLED"],
 	"tasks": {
 		"clean": {
 			"cache": false


### PR DESCRIPTION
## Summary

[When we enabled turborepo cache](https://github.com/n8n-io/n8n/pull/9696), we accidentally broke coverage collection because the updated turborepo does not pass in env variables to tasks by default, so `COVERAGE_ENABLED` never getting set to `true` anymore.

[Successful run](https://github.com/n8n-io/n8n/actions/runs/10369237334/job/28704647334#step:12:47)

## Review / Merge checklist

- [x] PR title and summary are descriptive
