### PR TITLE
fix(editor): Fix rendering of SVG icons in public chat on iOS

### DIFF
--- a/packages/@n8n/chat/src/components/Input.vue
+++ b/packages/@n8n/chat/src/components/Input.vue
@@ -247,6 +247,10 @@ function onOpenFileDialog() {
 	justify-content: center;
 	transition: color var(--chat--transition-duration) ease;
 
+	svg {
+		min-width: fit-content;
+	}
+
 	&:hover,
 	&:focus {
 		background: var(


### PR DESCRIPTION
## Summary

This PR fixes an issue on iOS where send/file-upload buttons wouldn't render correctly due to collapsing SVG width.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
