### PR TITLE
feat(Question and Answer Chain Node): Customize question and answer prompt

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -155,7 +155,7 @@ export class ChainRetrievalQa implements INodeType {
 				name: 'customQAPrompt',
 				type: 'boolean',
 				default: false,
-				description: 'Enable to customize the Question and Answer prompt',
+				description: 'Whether to enable customization of the Question and Answer prompt',
 			},
 			{
 				displayName: 'Question and Answer Prompt Type',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -14,13 +14,14 @@ import {
 	ChatPromptTemplate,
 	SystemMessagePromptTemplate,
 	HumanMessagePromptTemplate,
-	PromptTemplate
-} from "@langchain/core/prompts";
+	PromptTemplate,
+} from '@langchain/core/prompts';
 import { getTemplateNoticeField } from '../../../utils/sharedFields';
 import { getPromptInputByType } from '../../../utils/helpers';
 import { getTracingConfig } from '../../../utils/tracing';
 
-const QA_PROMPT_TEMPLATE = "Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n\n{context}\n\nQuestion: {question}\nHelpful Answer:";
+const QA_PROMPT_TEMPLATE =
+	"Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n\n{context}\n\nQuestion: {question}\nHelpful Answer:";
 const CHAT_PROMPT_TEMPLATE = `Use the following pieces of context to answer the users question. 
 If you don't know the answer, just say that you don't know, don't try to make up an answer.
 ----------------
@@ -169,9 +170,9 @@ export class ChainRetrievalQa implements INodeType {
 						description: 'Uses a standard prompt template (for non-Chat Models)',
 					},
 					{
-						name: "Chat Prompt",
+						name: 'Chat Prompt',
 						value: 'chatPrompt',
-						description: "Uses a system message template (for Chat Models)",
+						description: 'Uses a system message template (for Chat Models)',
 					},
 				],
 				displayOptions: {
@@ -200,7 +201,8 @@ export class ChainRetrievalQa implements INodeType {
 				name: 'chatPromptTemplate',
 				type: 'string',
 				default: CHAT_PROMPT_TEMPLATE,
-				description: 'Template string for the Question and Answer prompt as a system message (for Chat Models)',
+				description:
+					'Template string for the Question and Answer prompt as a system message (for Chat Models)',
 				typeOptions: {
 					rows: 8,
 				},
@@ -229,38 +231,43 @@ export class ChainRetrievalQa implements INodeType {
 		const items = this.getInputData();
 
 		const customQAPrompt = this.getNodeParameter('customQAPrompt', 0, false) as boolean;
-		
+
 		const chainParameters = {} as {
 			prompt?: PromptTemplate | ChatPromptTemplate;
 		};
 
-		if(customQAPrompt){
+		if (customQAPrompt) {
 			const qAPromptType = this.getNodeParameter('qAPromptType', 0) as string;
 
-			if(qAPromptType == 'standardPrompt'){
-				const standardPromptTemplateParameter = this.getNodeParameter('standardPromptTemplate', 0) as string;
+			if (qAPromptType == 'standardPrompt') {
+				const standardPromptTemplateParameter = this.getNodeParameter(
+					'standardPromptTemplate',
+					0,
+				) as string;
 
 				const standardPromptTemplate = new PromptTemplate({
 					template: standardPromptTemplateParameter,
-					inputVariables: ['context', 'question']
+					inputVariables: ['context', 'question'],
 				});
 
 				chainParameters.prompt = standardPromptTemplate;
-			}
-			else if(qAPromptType == 'chatPrompt'){
-				const chatPromptTemplateParameter = this.getNodeParameter('chatPromptTemplate', 0) as string;
+			} else if (qAPromptType == 'chatPrompt') {
+				const chatPromptTemplateParameter = this.getNodeParameter(
+					'chatPromptTemplate',
+					0,
+				) as string;
 
 				const messages = [
 					SystemMessagePromptTemplate.fromTemplate(chatPromptTemplateParameter),
-					HumanMessagePromptTemplate.fromTemplate("{question}"),
+					HumanMessagePromptTemplate.fromTemplate('{question}'),
 				];
-		
+
 				const chatPromptTemplate = ChatPromptTemplate.fromMessages(messages);
 
 				chainParameters.prompt = chatPromptTemplate;
 			}
 		}
-		
+
 		const chain = RetrievalQAChain.fromLLM(model, retriever, chainParameters);
 
 		const returnData: INodeExecutionData[] = [];

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -186,7 +186,8 @@ export class ChainRetrievalQa implements INodeType {
 				name: 'standardPromptTemplate',
 				type: 'string',
 				default: QA_PROMPT_TEMPLATE,
-				description: 'Template string for the Question and Answer prompt (for non-Chat Models)',
+				description:
+					"Template string for the Question and Answer prompt (for non-Chat Models). This prompt expects the variables `{context}` (for the provided context) and `{question}` (for the user's question).",
 				typeOptions: {
 					rows: 8,
 				},
@@ -202,7 +203,7 @@ export class ChainRetrievalQa implements INodeType {
 				type: 'string',
 				default: CHAT_PROMPT_TEMPLATE,
 				description:
-					'Template string for the Question and Answer prompt as a system message (for Chat Models)',
+					'Template string for the Question and Answer prompt as a system message (for Chat Models). This prompt expects the variable `{context}` (for the provided context).',
 				typeOptions: {
 					rows: 8,
 				},


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
The PR adds the ability to  customize the Question and Answer prompt of the “Question and Answer Chain” node.

There are options to add a standard prompt (for non-Chat models) and a chat prompt, as a system message (for Chat models). The default langchain prompts are used as default values for these prompts.

If the "Custom Question and Answer Prompt" boolean is set to false (the default value), the node doesn't change it's behavior at all, so this isn't a breaking change.

In the current state (without this PR), the Question and Answer prompt is not customizable, and the default prompt is used, according to the Model Type, as defined in the [langchain code](https://github.com/langchain-ai/langchainjs/blob/main/langchain/src/chains/question_answering/stuff_prompts.ts).

To test this PR, you could add this node between the "Question and Anwser Chain" node and the Language Model node to log the used Input prompt on the web console:

![image](https://github.com/user-attachments/assets/d2b9192d-f728-4059-9753-d7e9afc17702)


`{
  "meta": {
    "instanceId": "72f1ea16a419b6b7665b6919b04c52751be5f8fdaa216af12b4f670d6bfb854a"
  },
  "nodes": [
    {
      "parameters": {
        "code": {
          "supplyData": {
            "code": "const llm = await this.getInputConnectionData('ai_languageModel', 0);\n\nllm.callbacks = [\n  {\n    handleLLMStart(llm, prompts){\n      const inputPrompt = prompts[0];\n      console.log(inputPrompt);\n    },\n  },\n];\n\nreturn llm;"
          }
        },
        "inputs": {
          "input": [
            {
              "type": "ai_languageModel",
              "maxConnections": 1,
              "required": true
            }
          ]
        },
        "outputs": {
          "output": [
            {
              "type": "ai_languageModel"
            }
          ]
        }
      },
      "id": "a036cc49-3b5f-4afd-a901-7060166d59f0",
      "name": "Log Input Prompt",
      "type": "@n8n/n8n-nodes-langchain.code",
      "typeVersion": 1,
      "position": [
        460,
        1060
      ]
    }
  ],
  "connections": {},
  "pinData": {}
}`

### PR screenshots:

![image](https://github.com/user-attachments/assets/4d9ba222-0596-4812-bc9f-92d989a3e244)
![image](https://github.com/user-attachments/assets/fad0a78a-0a3e-4875-b253-809c15efdd36)
![image](https://github.com/user-attachments/assets/fb4f10a6-e085-4ef7-8b04-ebf1d269b778)


## Related Linear tickets, Github issues, and Community forum posts

This PR implements the feature requested [here](https://community.n8n.io/t/customize-the-question-and-answer-chain-node-question-answering-prompt/50985), in which is further elaborated why this feature is useful.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
