### PR TITLE
fix(Respond to Webhook Node): Fix issue stopping chat trigger response

### DIFF
--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -290,7 +290,7 @@ export class RespondToWebhook implements INodeType {
 		const items = this.getInputData();
 		const nodeVersion = this.getNode().typeVersion;
 
-		const WEBHOOK_NODE_TYPES = ['n8n-nodes-base.webhook', 'n8n-nodes-base.formTrigger'];
+		const WEBHOOK_NODE_TYPES = ['n8n-nodes-base.webhook', 'n8n-nodes-base.formTrigger', '@n8n/n8n-nodes-langchain.chatTrigger'];
 
 		try {
 			if (nodeVersion >= 1.1) {

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -290,7 +290,11 @@ export class RespondToWebhook implements INodeType {
 		const items = this.getInputData();
 		const nodeVersion = this.getNode().typeVersion;
 
-		const WEBHOOK_NODE_TYPES = ['n8n-nodes-base.webhook', 'n8n-nodes-base.formTrigger', '@n8n/n8n-nodes-langchain.chatTrigger'];
+		const WEBHOOK_NODE_TYPES = [
+			'n8n-nodes-base.webhook',
+			'n8n-nodes-base.formTrigger',
+			'@n8n/n8n-nodes-langchain.chatTrigger',
+		];
 
 		try {
 			if (nodeVersion >= 1.1) {


### PR DESCRIPTION
## Summary
Updates check to include the form trigger node

## Related Linear tickets, Github issues, and Community forum posts

Issue is explained at this [community forum post](https://community.n8n.io/t/respond-to-webhook-does-not-work-with-chat-trigger/51747).

Similar issue fixed by [PR #9157 ](https://github.com/n8n-io/n8n/pull/9157), but regarding a distinct node.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
