### PR TITLE
fix(core): Fix duplicate Redis publisher

### DIFF
--- a/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
+++ b/packages/cli/src/services/redis/RedisServiceBaseClasses.ts
@@ -45,6 +45,8 @@ class RedisServiceBase {
 				this.logger.warn('Error with Redis: ', error);
 			}
 		});
+
+		this.isInitialized = true;
 	}
 
 	async destroy(): Promise<void> {


### PR DESCRIPTION
Noticed while working on #10377 that we are creating two separate Redis publishers when booting up a main. Two are unneeded and wasteful, so this PR prevents the duplicate.

Skipped test for now - our Redis setup is too convoluted, needs revamping. This issue would not have been an issue if this setup had been using the DI container to enforce singletons.

Before             | After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/6f235e5d-c37e-415d-be84-fd47c2cb47e6) | ![](https://github.com/user-attachments/assets/ef86568b-b410-4e26-8800-f73214bbc7bc) 



