### PR TITLE
refactor(editor): Use form event bus everywhere (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/ChangePasswordModal.vue
+++ b/packages/editor-ui/src/components/ChangePasswordModal.vue
@@ -34,12 +34,12 @@ import { useToast } from '@/composables/useToast';
 import { CHANGE_PASSWORD_MODAL_KEY } from '../constants';
 import Modal from '@/components/Modal.vue';
 import { useUsersStore } from '@/stores/users.store';
-import { createEventBus } from 'n8n-design-system/utils';
+import { createFormEventBus, createEventBus } from 'n8n-design-system/utils';
 import type { IFormInputs, IFormInput } from '@/Interface';
 import { useI18n } from '@/composables/useI18n';
 
 const config = ref<IFormInputs | null>(null);
-const formBus = createEventBus();
+const formBus = createFormEventBus();
 const modalBus = createEventBus();
 const password = ref('');
 const loading = ref(false);

--- a/packages/editor-ui/src/components/InviteUsersModal.vue
+++ b/packages/editor-ui/src/components/InviteUsersModal.vue
@@ -75,7 +75,7 @@ import {
 import { useUsersStore } from '@/stores/users.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUIStore } from '@/stores/ui.store';
-import { createEventBus } from 'n8n-design-system/utils';
+import { createFormEventBus, createEventBus } from 'n8n-design-system/utils';
 import { useClipboard } from '@/composables/useClipboard';
 
 const NAME_EMAIL_FORMAT_REGEX = /^.* <(.*)>$/;
@@ -110,7 +110,7 @@ export default defineComponent({
 	data() {
 		return {
 			config: null as IFormInputs | null,
-			formBus: createEventBus(),
+			formBus: createFormEventBus(),
 			modalBus: createEventBus(),
 			emails: '',
 			role: ROLE.Member as InvitableRoleName,

--- a/packages/editor-ui/src/components/PersonalizationModal.vue
+++ b/packages/editor-ui/src/components/PersonalizationModal.vue
@@ -144,7 +144,7 @@ import { useUIStore } from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useRootStore } from '@/stores/root.store';
 import { useUsersStore } from '@/stores/users.store';
-import { createEventBus } from 'n8n-design-system/utils';
+import { createEventBus, createFormEventBus } from 'n8n-design-system/utils';
 import { usePostHog } from '@/stores/posthog.store';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 import { useUsageStore } from '@/stores/usage.store';
@@ -180,7 +180,7 @@ export default defineComponent({
 			showAllIndustryQuestions: true,
 			registerForEnterpriseTrial: false,
 			modalBus: createEventBus(),
-			formBus: createEventBus(),
+			formBus: createFormEventBus(),
 			domainBlocklist: [] as string[],
 		};
 	},

--- a/packages/editor-ui/src/components/PromptMfaCodeModal/PromptMfaCodeModal.vue
+++ b/packages/editor-ui/src/components/PromptMfaCodeModal/PromptMfaCodeModal.vue
@@ -45,7 +45,7 @@ import { createFormEventBus } from 'n8n-design-system';
 
 const i18n = useI18n();
 
-const formBus = ref(createFormEventBus());
+const formBus = createFormEventBus();
 const readyToSubmit = ref(false);
 
 const formFields: IFormInputs = [
@@ -69,7 +69,7 @@ function onSubmit(values: { mfaCode: string }) {
 }
 
 function onClickSave() {
-	formBus.value.emit('submit');
+	formBus.emit('submit');
 }
 
 function onFormReady(isReady: boolean) {

--- a/packages/editor-ui/src/views/SettingsLdapView.vue
+++ b/packages/editor-ui/src/views/SettingsLdapView.vue
@@ -157,7 +157,7 @@ import { mapStores } from 'pinia';
 import { useUsersStore } from '@/stores/users.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUIStore } from '@/stores/ui.store';
-import { createEventBus } from 'n8n-design-system/utils';
+import { createFormEventBus } from 'n8n-design-system/utils';
 import type { TableColumnCtx } from 'element-plus';
 
 type TableRow = {
@@ -222,7 +222,7 @@ export default defineComponent({
 			loadingTable: false,
 			hasAnyChanges: false,
 			formInputs: null as null | IFormInputs,
-			formBus: createEventBus(),
+			formBus: createFormEventBus(),
 			readyToSubmit: false,
 			page: 0,
 			loginEnabled: false,

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -21,7 +21,7 @@ const { showToast, showError } = useToast();
 
 const hasAnyBasicInfoChanges = ref<boolean>(false);
 const formInputs = ref<null | IFormInputs>(null);
-const formBus = ref(createFormEventBus());
+const formBus = createFormEventBus();
 const readyToSubmit = ref(false);
 const currentSelectedTheme = ref(useUIStore().theme);
 const themeOptions = ref<Array<{ name: ThemeOption; label: string }>>([
@@ -151,7 +151,7 @@ async function updatePersonalisationSettings() {
 	uiStore.setTheme(currentSelectedTheme.value);
 }
 function onSaveClick() {
-	formBus.value.emit('submit');
+	formBus.emit('submit');
 }
 function openPasswordModal() {
 	uiStore.openModal(CHANGE_PASSWORD_MODAL_KEY);


### PR DESCRIPTION
## Summary

Builds on top of #10367

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
