### PR TITLE
refactor(editor): Type source control event bus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/event-bus/source-control.ts
+++ b/packages/editor-ui/src/event-bus/source-control.ts
@@ -1,7 +1,7 @@
-import type { EventBus } from 'n8n-design-system/utils';
 import { createEventBus } from 'n8n-design-system/utils';
 
 export interface SourceControlEventBusEvents {
+	/** Event when latest changes were pulled from the source control */
 	pull: never;
 }
 

--- a/packages/editor-ui/src/event-bus/source-control.ts
+++ b/packages/editor-ui/src/event-bus/source-control.ts
@@ -1,3 +1,10 @@
+import type { EventBus } from 'n8n-design-system/utils';
 import { createEventBus } from 'n8n-design-system/utils';
 
-export const sourceControlEventBus = createEventBus();
+export interface SourceControlEventBusEvents {
+	pull: never;
+}
+
+export type SourceControlEventBus = EventBus<SourceControlEventBusEvents>;
+
+export const sourceControlEventBus = createEventBus<SourceControlEventBusEvents>();

--- a/packages/editor-ui/src/event-bus/source-control.ts
+++ b/packages/editor-ui/src/event-bus/source-control.ts
@@ -5,6 +5,4 @@ export interface SourceControlEventBusEvents {
 	pull: never;
 }
 
-export type SourceControlEventBus = EventBus<SourceControlEventBusEvents>;
-
 export const sourceControlEventBus = createEventBus<SourceControlEventBusEvents>();


### PR DESCRIPTION
## Summary

Builds on top of #10367

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
