### PR TITLE
fix(editor): Remove `@n8n/permissions` from `n8n-workflow` (no-changelog)

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -385,9 +385,11 @@ export interface IExecutionResponse extends IExecutionBase {
 	executedNode?: string;
 }
 
+export type ExecutionSummaryWithScopes = ExecutionSummary & { scopes: Scope[] };
+
 export interface IExecutionsListResponse {
 	count: number;
-	results: ExecutionSummary[];
+	results: ExecutionSummaryWithScopes[];
 	estimated: boolean;
 }
 

--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsList.vue
@@ -7,7 +7,7 @@ import { useToast } from '@/composables/useToast';
 import { useMessage } from '@/composables/useMessage';
 import { useI18n } from '@/composables/useI18n';
 import { useTelemetry } from '@/composables/useTelemetry';
-import type { ExecutionFilterType, IWorkflowDb } from '@/Interface';
+import type { ExecutionFilterType, ExecutionSummaryWithScopes, IWorkflowDb } from '@/Interface';
 import type { ExecutionSummary } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useExecutionsStore } from '@/stores/executions.store';
@@ -16,7 +16,7 @@ import { getResourcePermissions } from '@/permissions';
 
 const props = withDefaults(
 	defineProps<{
-		executions: ExecutionSummary[];
+		executions: ExecutionSummaryWithScopes[];
 		filters: ExecutionFilterType;
 		total: number;
 		estimated: boolean;
@@ -165,7 +165,7 @@ function getExecutionWorkflowName(execution: ExecutionSummary): string {
 }
 
 function getExecutionWorkflowPermissions(
-	execution: ExecutionSummary,
+	execution: ExecutionSummaryWithScopes,
 ): PermissionsRecord['workflow'] {
 	return getResourcePermissions(execution.scopes).workflow;
 }

--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsPreview.test.ts
@@ -12,7 +12,7 @@ import { i18nInstance, I18nPlugin } from '@/plugins/i18n';
 import { FontAwesomePlugin } from '@/plugins/icons';
 import { GlobalComponentsPlugin } from '@/plugins/components';
 import { useWorkflowsStore } from '@/stores/workflows.store';
-import type { IWorkflowDb } from '@/Interface';
+import type { ExecutionSummaryWithScopes, IWorkflowDb } from '@/Interface';
 
 let pinia: ReturnType<typeof createPinia>;
 
@@ -49,7 +49,7 @@ const generateUndefinedNullOrString = () => {
 	}
 };
 
-const executionDataFactory = (): ExecutionSummary => ({
+const executionDataFactory = (): ExecutionSummaryWithScopes => ({
 	id: faker.string.uuid(),
 	finished: faker.datatype.boolean(),
 	mode: faker.helpers.arrayElement(['manual', 'trigger']),

--- a/packages/editor-ui/src/stores/executions.store.ts
+++ b/packages/editor-ui/src/stores/executions.store.ts
@@ -4,6 +4,7 @@ import type { IDataObject, ExecutionSummary } from 'n8n-workflow';
 import type {
 	ExecutionFilterType,
 	ExecutionsQueryFilter,
+	ExecutionSummaryWithScopes,
 	IExecutionDeleteFilter,
 	IExecutionFlattedResponse,
 	IExecutionResponse,
@@ -34,7 +35,7 @@ export const useExecutionsStore = defineStore('executions', () => {
 	const autoRefreshTimeout = ref<NodeJS.Timeout | null>(null);
 	const autoRefreshDelay = ref(4 * 1000); // Refresh data every 4 secs
 
-	const executionsById = ref<Record<string, ExecutionSummary>>({});
+	const executionsById = ref<Record<string, ExecutionSummaryWithScopes>>({});
 	const executionsCount = ref(0);
 	const executionsCountEstimated = ref(false);
 	const executions = computed(() => {
@@ -57,7 +58,7 @@ export const useExecutionsStore = defineStore('executions', () => {
 		}, {}),
 	);
 
-	const currentExecutionsById = ref<Record<string, ExecutionSummary>>({});
+	const currentExecutionsById = ref<Record<string, ExecutionSummaryWithScopes>>({});
 	const currentExecutions = computed(() => {
 		const data = Object.values(currentExecutionsById.value);
 
@@ -80,14 +81,14 @@ export const useExecutionsStore = defineStore('executions', () => {
 
 	const allExecutions = computed(() => [...currentExecutions.value, ...executions.value]);
 
-	function addExecution(execution: ExecutionSummary) {
+	function addExecution(execution: ExecutionSummaryWithScopes) {
 		executionsById.value[execution.id] = {
 			...execution,
 			mode: execution.mode,
 		};
 	}
 
-	function addCurrentExecution(execution: ExecutionSummary) {
+	function addCurrentExecution(execution: ExecutionSummaryWithScopes) {
 		currentExecutionsById.value[execution.id] = {
 			...execution,
 			mode: execution.mode,

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -39,7 +39,6 @@
     "@types/xml2js": "catalog:"
   },
   "dependencies": {
-    "@n8n/permissions": "workspace:*",
     "@n8n/tournament": "1.0.5",
     "@n8n_io/riot-tmpl": "4.0.0",
     "ast-types": "0.15.2",

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -10,7 +10,6 @@ import type { URLSearchParams } from 'url';
 import type { RequestBodyMatcher } from 'nock';
 import type { Client as SSHClient } from 'ssh2';
 
-import type { Scope } from '@n8n/permissions';
 import type { AuthenticationMethod } from './Authentication';
 import type { CODE_EXECUTION_MODES, CODE_LANGUAGES, LOG_LEVELS } from './Constants';
 import type { IDeferredPromise } from './DeferredPromise';
@@ -2464,7 +2463,6 @@ export interface ExecutionSummary {
 	nodeExecutionStatus?: {
 		[key: string]: IExecutionSummaryNodeExecutionResult;
 	};
-	scopes?: Scope[];
 }
 
 export interface IExecutionSummaryNodeExecutionResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1709,9 +1709,6 @@ importers:
 
   packages/workflow:
     dependencies:
-      '@n8n/permissions':
-        specifier: workspace:*
-        version: link:../@n8n/permissions
       '@n8n/tournament':
         specifier: 1.0.5
         version: 1.0.5


### PR DESCRIPTION
## Summary
We introduced `@n8n/permissions` as a dependency in `n8n-workflow`. This PR reverts that bit.

[Context](https://github.com/n8n-io/n8n/pull/9913#discussion_r1716645945)

## Review / Merge checklist

- [x] PR title and summary are descriptive