### PR TITLE
Allow Raw JSON in Discord node

### DIFF
--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -111,6 +111,10 @@ export function prepareOptions(options: IDataObject, guildId?: string) {
 		};
 	}
 
+	if (options.raw_json) {
+		return {...options, ...(JSON.parse(options.raw_json))}
+	}
+
 	return options;
 }
 


### PR DESCRIPTION
(WIP)

I want the ability to add raw JSON in an n8n Discord Send node.
I think an easy way to achieve this is by adding another Option called "Raw JSON" and allowing the user to enter anything in there, and simply using the spread operator to control that.
