### PR TITLE
fix(AI Agent Node): Fix issues with some tools not populating

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -13,7 +13,6 @@ import type { BaseLLM } from '@langchain/core/language_models/llms';
 import type { BaseChatMemory } from 'langchain/memory';
 import type { BaseChatMessageHistory } from '@langchain/core/chat_history';
 import { N8nTool } from './N8nTool';
-import { DynamicTool } from '@langchain/core/tools';
 
 function hasMethods<T>(obj: unknown, ...methodNames: Array<string | symbol>): obj is T {
 	return methodNames.every(
@@ -195,8 +194,6 @@ export const getConnectedTools = async (
 	const finalTools = [];
 
 	for (const tool of connectedTools) {
-		if (!(tool instanceof DynamicTool) && !(tool instanceof N8nTool)) continue;
-
 		const { name } = tool;
 		if (seenNames.has(name)) {
 			throw new NodeOperationError(


### PR DESCRIPTION
## Summary
To convert `StructuredDynamicTool` to `DynamicTool`we [changed some logic](https://github.com/n8n-io/n8n/pull/10246) in `getConnectedTools`, which would skip tools that are not DynamicTool && not N8nTool. This would prevent most of the tools from being used with an agent. This PR removes the check/skipping(`if (!(tool instanceof DynamicTool) && !(tool instanceof N8nTool)) continue;`) as it makes sense to always check for duplicate tool names, and there's already a check for `instanceof N8nTool` in case conversion is required.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
- https://github.com/n8n-io/n8n/issues/10401
- https://community.n8n.io/t/using-the-vector-store-tool/51805/5

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
