### PR TITLE
ci: Trigger Docker releases on tag creation instead of release publishing (no-changelog)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,8 +1,9 @@
 name: Docker Image CI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'n8n@*'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
When we create releases programmatically, `release:published` event doesn't trigger the `docker-images` workflow. 
This PR switches to triggering that workflow on tag creation instead, in the hope that we can stop having to manually re-create releases, just to trigger the docker builds.


## Review / Merge checklist

- [x] PR title and summary are descriptive