### PR TITLE
fix(editor): Fix incorrect node type version selection on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -444,7 +444,8 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		}
 
 		const nodesWithTypeVersion = nodes.map((node) => {
-			const typeVersion = resolveNodeVersion(requireNodeTypeDescription(node.type));
+			const typeVersion =
+				node.typeVersion ?? resolveNodeVersion(requireNodeTypeDescription(node.type));
 			return {
 				...node,
 				typeVersion,
@@ -478,6 +479,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 				);
 			} catch (error) {
 				toast.showError(error, i18n.baseText('error'));
+				console.error(error);
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

Fixes node type version for imported nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7566/fix-incorrect-node-type-selection-error

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
