### PR TITLE
fix(core): Fix payload property in `workflow-post-execute` event

### DIFF
--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -137,12 +137,17 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-post-execute` for successful execution', () => {
+		it('should log on `workflow-post-execute` for finished execution', () => {
 			const payload = mock<RelayEventMap['workflow-post-execute']>({
 				executionId: 'some-id',
 				userId: 'some-id',
 				workflow: mock<IWorkflowBase>({ id: 'some-id', name: 'some-name' }),
-				runData: mock<IRun>({ status: 'success', mode: 'manual', data: { resultData: {} } }),
+				runData: mock<IRun>({
+					finished: true,
+					status: 'success',
+					mode: 'manual',
+					data: { resultData: {} },
+				}),
 			});
 
 			eventService.emit('workflow-post-execute', payload);
@@ -153,7 +158,7 @@ describe('LogStreamingEventRelay', () => {
 				eventName: 'n8n.workflow.success',
 				payload: {
 					...rest,
-					success: true,
+					success: true, // same as finished
 					isManual: true,
 					workflowName: 'some-name',
 					workflowId: 'some-id',
@@ -161,10 +166,11 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-post-execute` event for unsuccessful execution', () => {
+		it('should log on `workflow-post-execute` event for unfinished execution', () => {
 			const runData = mock<IRun>({
 				status: 'error',
 				mode: 'manual',
+				finished: false,
 				data: {
 					resultData: {
 						lastNodeExecuted: 'some-node',
@@ -193,7 +199,7 @@ describe('LogStreamingEventRelay', () => {
 				eventName: 'n8n.workflow.failed',
 				payload: {
 					...rest,
-					success: false,
+					success: false, // same as finished
 					isManual: true,
 					workflowName: 'some-name',
 					workflowId: 'some-id',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -137,7 +137,7 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-post-execute` for finished execution', () => {
+		it('should log on `workflow-post-execute` for successful execution', () => {
 			const payload = mock<RelayEventMap['workflow-post-execute']>({
 				executionId: 'some-id',
 				userId: 'some-id',
@@ -166,7 +166,7 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
-		it('should log on `workflow-post-execute` event for unfinished execution', () => {
+		it('should log on `workflow-post-execute` event for failed execution', () => {
 			const runData = mock<IRun>({
 				status: 'error',
 				mode: 'manual',

--- a/packages/cli/src/events/log-streaming-event-relay.ts
+++ b/packages/cli/src/events/log-streaming-event-relay.ts
@@ -112,12 +112,13 @@ export class LogStreamingEventRelay extends EventRelay {
 
 		const payload = {
 			...rest,
-			success: runData?.status === 'success',
+			success: !!runData?.finished, // despite the `success` name, this reports `finished` state
 			isManual: runData?.mode === 'manual',
 			workflowId: workflow.id,
 			workflowName: workflow.name,
 		};
 
+		console.log('payload.success', payload.success);
 		if (payload.success) {
 			void this.eventBus.sendWorkflowEvent({
 				eventName: 'n8n.workflow.success',

--- a/packages/cli/src/events/log-streaming-event-relay.ts
+++ b/packages/cli/src/events/log-streaming-event-relay.ts
@@ -118,7 +118,6 @@ export class LogStreamingEventRelay extends EventRelay {
 			workflowName: workflow.name,
 		};
 
-		console.log('payload.success', payload.success);
 		if (payload.success) {
 			void this.eventBus.sendWorkflowEvent({
 				eventName: 'n8n.workflow.success',


### PR DESCRIPTION
The `success` property in the payload for the `n8n.workflow.success` and `n8n.workflow.failed` log streaming events does not refer to whether the status was `'success'` but rather refers to whether the execution `finished` or not. This detail was misinterpreted when the event bus was decoupled from the event bus.

Ref. https://github.com/n8n-io/n8n/pull/9724/files#diff-a91344c72b2b4a696fa0b18ef1a154dad6d7594baba2285265e37b2695c4f9edL401

https://share.cleanshot.com/MKlnkCNW

https://linear.app/n8n/issue/PAY-1841