### PR TITLE
ci: Remove hard-coded package version in unit tests (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -13,6 +13,7 @@ import type { SharedWorkflowRepository } from '@/databases/repositories/sharedWo
 import type { ProjectRelationRepository } from '@/databases/repositories/projectRelation.repository';
 import type { RelayEventMap } from '@/events/relay-event-map';
 import type { WorkflowEntity } from '@/databases/entities/WorkflowEntity';
+import { N8N_VERSION } from '@/constants';
 
 const flushPromises = async () => await new Promise((resolve) => setImmediate(resolve));
 
@@ -694,7 +695,7 @@ describe('TelemetryEventRelay', () => {
 				is_manual: false,
 				success: false,
 				user_id: 'user123',
-				version_cli: '1.54.0',
+				version_cli: N8N_VERSION,
 				workflow_id: 'workflow123',
 			});
 		});


### PR DESCRIPTION
## Summary
These tests started failing after the cli package version changed. This PR removes the hard-coded version, and uses the version from `package.json`. 

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
