### PR TITLE
fix: Project Viewer always seeing a connection error when testing credentials

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -127,11 +127,11 @@ export class CredentialsController {
 		const mergedCredentials = deepCopy(credentials);
 		const decryptedData = this.credentialsService.decrypt(storedCredential);
 
-		// When a sharee opens a credential, the fields and the credential data are missing
-		// so the payload will be empty
+		// When a sharee (or project viewer) opens a credential, the fields and the
+		// credential data are missing so the payload will be empty
 		// We need to replace the credential contents with the db version if that's the case
 		// So the credential can be tested properly
-		this.credentialsService.replaceCredentialContentsForSharee(
+		await this.credentialsService.replaceCredentialContentsForSharee(
 			req.user,
 			storedCredential,
 			decryptedData,

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -38,6 +38,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { ProjectRelation } from '@/databases/entities/ProjectRelation';
 import { RoleService } from '@/services/role.service';
 import { UserRepository } from '@/databases/repositories/user.repository';
+import { userHasScope } from '@/permissions/checkAccess';
 
 export type CredentialsGetSharedOptions =
 	| { allowGlobalScope: true; globalScope: Scope }
@@ -599,28 +600,20 @@ export class CredentialsService {
 		);
 	}
 
-	replaceCredentialContentsForSharee(
+	async replaceCredentialContentsForSharee(
 		user: User,
 		credential: CredentialsEntity,
 		decryptedData: ICredentialDataDecryptedObject,
 		mergedCredentials: ICredentialsDecrypted,
 	) {
-		credential.shared.forEach((sharedCredentials) => {
-			if (sharedCredentials.role === 'credential:owner') {
-				if (sharedCredentials.project.type === 'personal') {
-					// Find the owner of this personal project
-					sharedCredentials.project.projectRelations.forEach((projectRelation) => {
-						if (
-							projectRelation.role === 'project:personalOwner' &&
-							projectRelation.user.id !== user.id
-						) {
-							// If we realize that the current user does not own this credential
-							// We replace the payload with the stored decrypted data
-							mergedCredentials.data = decryptedData;
-						}
-					});
-				}
-			}
-		});
+		// We may want to change this to 'credential:decrypt' if that gets added, but this
+		// works for now. The only time we wouldn't want to do this is if the user
+		// could actually be testing the credential before saving it, so this should cover
+		// the cases we need it for.
+		if (
+			!(await userHasScope(user, ['credential:update'], false, { credentialId: credential.id }))
+		) {
+			mergedCredentials.data = decryptedData;
+		}
 	}
 }


### PR DESCRIPTION
## Related Linear tickets, Github issues, and Community forum posts

[PAY-1844](https://linear.app/n8n/issue/PAY-1844/project-viewer-always-gets-connection-error-when-testing-credentials)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
