### PR TITLE
feat(Facebook Graph API Node): Update node to support API v18 - v20

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -81,6 +81,18 @@ export class FacebookGraphApi implements INodeType {
 						value: '',
 					},
 					{
+						name: 'v20.0',
+						value: 'v20.0',
+					},
+					{
+						name: 'v19.0',
+						value: 'v19.0',
+					},
+					{
+						name: 'v18.0',
+						value: 'v18.0',
+					},
+					{
 						name: 'v17.0',
 						value: 'v17.0',
 					},


### PR DESCRIPTION
## Summary
Until we overhaul this node we need to manually update the versions of the API, I may in the future make a light 1.1 version of the node where the version is just a string to reduce maintenance.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1584/community-issue-facebook-graph-api-needs-to-support-api-v20
https://github.com/n8n-io/n8n/issues/10407