### PR TITLE
fix(n8n Form Trigger Node): Show basic authentication modal on wrong credentials

### DIFF
--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -170,8 +170,8 @@ export async function formWebhook(
 		}
 	} catch (error) {
 		if (error instanceof WebhookAuthorizationError) {
-			res.writeHead(error.responseCode, { 'WWW-Authenticate': 'Basic realm="Webhook"' });
-			res.end(error.message);
+			res.setHeader('WWW-Authenticate', 'Basic realm="Enter credentials"');
+			res.status(401).send();
 			return { noWebhookResponse: true };
 		}
 		throw error;


### PR DESCRIPTION
## Summary

If Basic Authentication set in n8n trigger node and user did enter incorrect credentials modal would be shown again

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1569/n8n-form-trigger-node-allow-basic-auth-after-wrong-attempt
