### PR TITLE
fix(editor): Show item count in output panel schema view

### DIFF
--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -196,7 +196,7 @@
 				hasNodeRun &&
 				((dataCount > 0 && maxRunIndex === 0) || search) &&
 				!isArtificialRecoveredEventItem &&
-				!isSchemaView
+				!isInputSchemaView
 			"
 			v-show="!editMode.enabled && !hasRunError"
 			:class="[$style.itemsCount, { [$style.muted]: paneType === 'input' && maxRunIndex === 0 }]"


### PR DESCRIPTION
## Summary

<img width="878" alt="image" src="https://github.com/user-attachments/assets/7f80e253-676e-47f7-b163-6933ceee68a3">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1513/schema-view-item-count-no-longer-shows-in-output-pane-of-ndv

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
