### PR TITLE
feat(editor): Improve node selection outline in new canvas (no-changelog)

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -71,6 +71,7 @@
 	--color-canvas-dot: var(--prim-gray-670);
 	--color-canvas-read-only-line: var(--prim-gray-800);
 	--color-canvas-selected: var(--prim-gray-0-alpha-025);
+	--color-canvas-selected-transparent: var(--color-canvas-selected);
 
 	// Nodes
 	--color-node-background: var(--prim-gray-740);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -79,6 +79,7 @@
 	--color-canvas-dot: var(--prim-gray-120);
 	--color-canvas-read-only-line: var(--prim-gray-30);
 	--color-canvas-selected: var(--prim-gray-70);
+	--color-canvas-selected-transparent: hsla(var(--prim-gray-h), 47%, 30%, 0.1);
 
 	// Nodes
 	--color-node-background: var(--color-background-xlight);

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -184,7 +184,7 @@ function openContextMenu(event: MouseEvent) {
 	 */
 
 	&.selected {
-		box-shadow: 0 0 0 4px var(--color-canvas-selected);
+		box-shadow: 0 0 0 8px var(--color-canvas-selected-transparent);
 	}
 
 	&.success {


### PR DESCRIPTION
## Summary

<img width="1725" alt="Screenshot 2024-08-15 at 12 29 04" src="https://github.com/user-attachments/assets/54d573a0-41ac-48c5-bc08-160fe85eeafa">
<img width="1727" alt="Screenshot 2024-08-15 at 12 30 10" src="https://github.com/user-attachments/assets/d3106e85-a641-4771-a215-d546f71c3441">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7570/the-selected-border-around-nodes-isnt-as-thick-as-on-the-old-canvas

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
