### PR TITLE
fix(editor): Remove item count from pinned data status icon in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.spec.ts
@@ -15,7 +15,7 @@ describe('CanvasNodeStatusIcons', () => {
 			},
 		});
 
-		expect(getByTestId('canvas-node-status-pinned')).toHaveTextContent('5');
+		expect(getByTestId('canvas-node-status-pinned')).toBeInTheDocument();
 	});
 
 	it('should render correctly for a running node', () => {

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -7,7 +7,6 @@ import { useCanvasNode } from '@/composables/useCanvasNode';
 const nodeHelpers = useNodeHelpers();
 
 const {
-	pinnedDataCount,
 	hasPinnedData,
 	issues,
 	hasIssues,
@@ -51,7 +50,6 @@ const hideNodeIssues = computed(() => false); // @TODO Implement this
 		:class="[$style.status, $style.pinnedData]"
 	>
 		<FontAwesomeIcon icon="thumbtack" />
-		<span v-if="pinnedDataCount > 1" :class="$style.count"> {{ pinnedDataCount }}</span>
 	</div>
 	<div v-else-if="executionStatus === 'unknown'">
 		<!-- Do nothing, unknown means the node never executed -->


### PR DESCRIPTION
## Summary

<img width="919" alt="Screenshot 2024-08-15 at 12 36 56" src="https://github.com/user-attachments/assets/44b2e751-a233-417d-9941-f86397385038">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7572/dont-show-a-number-next-to-the-pinned-icon-on-the-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
