### PR TITLE
feat(editor): Improve node label readability in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -213,7 +213,7 @@ function openContextMenu(event: MouseEvent) {
 	top: 100%;
 	position: absolute;
 	width: 100%;
-	min-width: 200px;
+	min-width: calc(var(--canvas-node--width) * 2);
 	margin-top: var(--spacing-2xs);
 	display: flex;
 	flex-direction: column;
@@ -223,16 +223,27 @@ function openContextMenu(event: MouseEvent) {
 
 .label {
 	font-size: var(--font-size-m);
-	line-height: var(--font-line-height-compact);
 	text-align: center;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+	overflow-wrap: anywhere;
+	font-weight: var(--font-weight-bold);
+	line-height: var(--font-line-height-compact);
 }
 
 .subtitle {
+	width: 100%;
+	text-align: center;
 	color: var(--color-text-light);
 	font-size: var(--font-size-xs);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	line-height: var(--font-line-height-compact);
+	font-weight: 400;
 }
 
 .statusIcons {


### PR DESCRIPTION
## Summary

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/0253ba8e-199b-4204-b052-f35b7706ca42">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7573/font-of-node-titles-and-labels-is-harder-to-read-than-before
https://linear.app/n8n/issue/N8N-7574/long-node-subtitles-arent-truncated

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
