### PR TITLE
fix(Google Sheets Node): Update name and hint for useAppend option

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -14,7 +14,7 @@ import {
 	mapFields,
 	untilSheetSelected,
 } from '../../helpers/GoogleSheets.utils';
-import { cellFormat, handlingExtraData } from './commonDescription';
+import { cellFormat, handlingExtraData, useAppendOption } from './commonDescription';
 
 export const description: SheetProperties = [
 	{
@@ -198,14 +198,7 @@ export const description: SheetProperties = [
 				...handlingExtraData,
 				displayOptions: { show: { '/columns.mappingMode': ['autoMapInputData'] } },
 			},
-			{
-				displayName: 'Use Append',
-				name: 'useAppend',
-				type: 'boolean',
-				default: false,
-				description:
-					'Whether to use append instead of update(default), this is more efficient but in some cases data might be misaligned',
-			},
+			useAppendOption,
 		],
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
@@ -18,7 +18,12 @@ import {
 	checkForSchemaChanges,
 	untilSheetSelected,
 } from '../../helpers/GoogleSheets.utils';
-import { cellFormat, handlingExtraData, locationDefine } from './commonDescription';
+import {
+	cellFormat,
+	handlingExtraData,
+	locationDefine,
+	useAppendOption,
+} from './commonDescription';
 
 export const description: SheetProperties = [
 	{
@@ -212,14 +217,7 @@ export const description: SheetProperties = [
 				...handlingExtraData,
 				displayOptions: { show: { '/columns.mappingMode': ['autoMapInputData'] } },
 			},
-			{
-				displayName: 'Use Append',
-				name: 'useAppend',
-				type: 'boolean',
-				default: false,
-				description:
-					'Whether to use append instead of update(default), this is more efficient but in some cases data might be misaligned',
-			},
+			useAppendOption,
 		],
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
@@ -258,3 +258,13 @@ export const handlingExtraData: INodeProperties = {
 	default: 'insertInNewColumn',
 	description: "What do to with fields that don't match any columns in the Google Sheet",
 };
+
+export const useAppendOption: INodeProperties = {
+	displayName: 'Minimise API Calls',
+	name: 'useAppend',
+	type: 'boolean',
+	default: false,
+	hint: 'Use if your sheet has no gaps between rows or columns',
+	description:
+		'Whether to use append instead of update(default), this is more efficient but in some cases data might be misaligned',
+};

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/versionDescription.ts
@@ -20,7 +20,7 @@ export const versionDescription: INodeTypeDescription = {
 	hints: [
 		{
 			message:
-				"Use the 'Use Append' option for greater efficiency if your sheet is uniformly formatted without gaps between columns or rows",
+				"Use the 'Minimise API Calls' option for greater efficiency if your sheet is uniformly formatted without gaps between columns or rows",
 			displayCondition:
 				'={{$parameter["operation"] === "append" && !$parameter["options"]["useAppend"]}}',
 			whenToDisplay: 'beforeExecution',


### PR DESCRIPTION
## Summary

option renamed to "Minimise API calls"
added hint "Use if your sheet has no gaps between rows or columns"

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1559/google-sheets-better-naming-for-use-append-option
