### PR TITLE
refactor(editor): Remove `id` param from PATCH /me calls (no-changelog)

### DIFF
--- a/packages/editor-ui/src/api/users.ts
+++ b/packages/editor-ui/src/api/users.ts
@@ -90,7 +90,6 @@ export async function changePassword(
 }
 
 export type UpdateCurrentUserParams = {
-	id?: string;
 	firstName?: string;
 	lastName?: string;
 	email: string;

--- a/packages/editor-ui/src/stores/sso.store.ts
+++ b/packages/editor-ui/src/stores/sso.store.ts
@@ -70,7 +70,6 @@ export const useSSOStore = defineStore('sso', () => {
 
 	const updateUser = async (params: { firstName: string; lastName: string }) =>
 		await updateCurrentUser(rootStore.restApiContext, {
-			id: usersStore.currentUser!.id,
 			email: usersStore.currentUser!.email!,
 			...params,
 		});

--- a/packages/editor-ui/src/views/SettingsPersonalView.vue
+++ b/packages/editor-ui/src/views/SettingsPersonalView.vue
@@ -173,7 +173,6 @@ async function updateUserBasicInfo(userBasicInfo: UserBasicDetailsWithMfa) {
 	}
 
 	await usersStore.updateUser({
-		id: usersStore.currentUserId,
 		firstName: userBasicInfo.firstName,
 		lastName: userBasicInfo.lastName,
 		email: userBasicInfo.email,


### PR DESCRIPTION
## Summary

The PATCH /me endpoint does not take an `id` param.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
