### PR TITLE
fix(editor): Fix flaky drag n drop command in e2e tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -152,6 +152,8 @@ Cypress.Commands.add('drag', (selector, pos, options) => {
 			x: options?.abs ? xDiff : originalLocation.right + xDiff,
 			y: options?.abs ? yDiff : originalLocation.top + yDiff,
 		};
+		// Clicking on the input panel to make sure all popovers are closed before dragging
+		cy.getByTestId('ndv-input-panel').click();
 		if (options?.realMouse) {
 			element.realMouseDown();
 			element.realMouseMove(newPosition.x, newPosition.y);
@@ -190,6 +192,8 @@ Cypress.Commands.add('draganddrop', (draggableSelector, droppableSelector, optio
 			const pageY = coords.top + coords.height / 2;
 
 			if (draggableSelector) {
+				// Clicking on the input panel to make sure all popovers are closed before dragging
+				cy.getByTestId('ndv-input-panel').click();
 				// We can't use realMouseDown here because it hangs headless run
 				cy.get(draggableSelector).trigger('mousedown');
 			}


### PR DESCRIPTION
## Summary
Fixes flaky mapping tests by hiding the popovers before dragging

## Related Linear tickets, Github issues, and Community forum posts
Closes NODE-1586

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
