### PR TITLE
refactor(editor): Add types to ndv event bus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -744,7 +744,6 @@ export default defineComponent({
 			if (this.node) {
 				this.historyStore.pushCommandToUndo(new RenameNodeCommand(this.node.name, name));
 			}
-			// @ts-ignore
 			this.valueChanged({
 				value: name,
 				name: 'name',

--- a/packages/editor-ui/src/event-bus/ndv.ts
+++ b/packages/editor-ui/src/event-bus/ndv.ts
@@ -1,3 +1,21 @@
+import type { IUpdateInformation } from '@/Interface';
 import { createEventBus } from 'n8n-design-system/utils';
 
-export const ndvEventBus = createEventBus();
+export type Position = 'minLeft' | 'maxRight' | 'initial';
+
+export type CreateNewCredentialOpts = {
+	type: string;
+	showAuthOptions: boolean;
+};
+
+export interface NdvEventBusEvents {
+	/** Command to let the user create a new credential by opening the credentials modal */
+	'credential.createNew': CreateNewCredentialOpts;
+
+	/** Command to set the NDV panels' (input, output, main) positions based on the given value */
+	setPositionByName: Position;
+
+	updateParameterValue: IUpdateInformation;
+}
+
+export const ndvEventBus = createEventBus<NdvEventBusEvents>();


### PR DESCRIPTION
## Summary

Add types to ndv event bus

## Related Linear tickets, Github issues, and Community forum posts

[CAT-32](https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
