### PR TITLE
refactor(editor): Add types to global link actions event bus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useGlobalLinkActions.ts
+++ b/packages/editor-ui/src/composables/useGlobalLinkActions.ts
@@ -3,15 +3,16 @@
  * unsafe onclick attribute
  */
 import { reactive, computed, onMounted, onUnmounted } from 'vue';
+import type { LinkActionFn, RegisterCustomActionOpts } from '@/event-bus';
 import { globalLinkActionsEventBus } from '@/event-bus';
 
 const state = reactive({
-	customActions: {} as Record<string, Function>,
+	customActions: {} as Record<string, LinkActionFn>,
 	delegatedClickHandler: null as null | ((e: MouseEvent) => void),
 });
 
 export function useGlobalLinkActions() {
-	function registerCustomAction({ key, action }: { key: string; action: Function }) {
+	function registerCustomAction({ key, action }: RegisterCustomActionOpts) {
 		state.customActions[key] = action;
 	}
 	function unregisterCustomAction(key: string) {
@@ -51,7 +52,7 @@ export function useGlobalLinkActions() {
 		}
 	}
 
-	const availableActions = computed<{ [key: string]: Function }>(() => ({
+	const availableActions = computed<{ [key: string]: LinkActionFn }>(() => ({
 		reload,
 		...state.customActions,
 	}));

--- a/packages/editor-ui/src/event-bus/global-link-actions.ts
+++ b/packages/editor-ui/src/event-bus/global-link-actions.ts
@@ -1,0 +1,16 @@
+import { createEventBus } from 'n8n-design-system/utils';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LinkActionFn = (args: any) => void;
+
+export type RegisterCustomActionOpts = {
+	key: string;
+	action: LinkActionFn;
+};
+
+export interface GlobalLinkActionsEventBusEvents {
+	/** See useGlobalLinkActions.ts */
+	registerCustomAction: RegisterCustomActionOpts;
+}
+
+export const globalLinkActionsEventBus = createEventBus();

--- a/packages/editor-ui/src/event-bus/global-link-actions.ts
+++ b/packages/editor-ui/src/event-bus/global-link-actions.ts
@@ -1,7 +1,7 @@
 import { createEventBus } from 'n8n-design-system/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type LinkActionFn = (args: any) => void;
+export type LinkActionFn = (...args: any[]) => void;
 
 export type RegisterCustomActionOpts = {
 	key: string;

--- a/packages/editor-ui/src/event-bus/global-link-actions.ts
+++ b/packages/editor-ui/src/event-bus/global-link-actions.ts
@@ -10,7 +10,7 @@ export type RegisterCustomActionOpts = {
 
 export interface GlobalLinkActionsEventBusEvents {
 	/** See useGlobalLinkActions.ts */
-	registerCustomAction: RegisterCustomActionOpts;
+	registerGlobalLinkAction: RegisterCustomActionOpts;
 }
 
-export const globalLinkActionsEventBus = createEventBus();
+export const globalLinkActionsEventBus = createEventBus<GlobalLinkActionsEventBusEvents>();

--- a/packages/editor-ui/src/event-bus/index.ts
+++ b/packages/editor-ui/src/event-bus/index.ts
@@ -1,6 +1,6 @@
 export * from './code-node-editor';
 export * from './data-pinning';
-export * from './link-actions';
+export * from './global-link-actions';
 export * from './html-editor';
 export * from './import-curl';
 export * from './node-view';

--- a/packages/editor-ui/src/event-bus/link-actions.ts
+++ b/packages/editor-ui/src/event-bus/link-actions.ts
@@ -1,3 +1,0 @@
-import { createEventBus } from 'n8n-design-system/utils';
-
-export const globalLinkActionsEventBus = createEventBus();


### PR DESCRIPTION
## Summary

Add types to global link actions event bus. Also rename the file to correspond the event bus name.

## Related Linear tickets, Github issues, and Community forum posts

[CAT-32](https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
