### PR TITLE
fix(editor): Fix lazy loaded component not using suspense (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -50,15 +50,17 @@
 				data-test-id="run-data-pane-header"
 				@click.stop
 			>
-				<LazyRunDataSearch
-					v-if="showIOSearch"
-					v-model="search"
-					:class="$style.search"
-					:pane-type="paneType"
-					:display-mode="displayMode"
-					:is-area-active="isPaneActive"
-					@focus="activatePane"
-				/>
+				<Suspense>
+					<LazyRunDataSearch
+						v-if="showIOSearch"
+						v-model="search"
+						:class="$style.search"
+						:pane-type="paneType"
+						:display-mode="displayMode"
+						:is-area-active="isPaneActive"
+						@focus="activatePane"
+					/>
+				</Suspense>
 
 				<n8n-radio-buttons
 					v-show="


### PR DESCRIPTION
## Summary

Lazy loaded component was not using `<Suspense>`, causing a scheduler flush when rendered in the new canvas.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7569/clicking-the-ndv-scrim-after-executing-makes-the-fe-unresponsive

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
