### PR TITLE
fix: Better errors in Switch, If and Filter nodes

### DIFF
--- a/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
+++ b/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
@@ -1,10 +1,12 @@
 import set from 'lodash/set';
-import type {
-	IExecuteFunctions,
-	INodeExecutionData,
-	INodeType,
-	INodeTypeBaseDescription,
-	INodeTypeDescription,
+import {
+	ApplicationError,
+	NodeOperationError,
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeType,
+	type INodeTypeBaseDescription,
+	type INodeTypeDescription,
 } from 'n8n-workflow';
 import { ENABLE_LESS_STRICT_TYPE_VALIDATION } from '../../../utils/constants';
 
@@ -101,7 +103,18 @@ export class FilterV2 implements INodeType {
 				if (this.continueOnFail(error)) {
 					discardedItems.push(item);
 				} else {
-					throw error;
+					if (error instanceof NodeOperationError) {
+						throw error;
+					}
+
+					if (error instanceof ApplicationError) {
+						set(error, 'context.itemIndex', itemIndex);
+						throw error;
+					}
+
+					throw new NodeOperationError(this.getNode(), error, {
+						itemIndex,
+					});
 				}
 			}
 		});

--- a/packages/nodes-base/nodes/If/V2/IfV2.node.ts
+++ b/packages/nodes-base/nodes/If/V2/IfV2.node.ts
@@ -1,10 +1,12 @@
 import set from 'lodash/set';
-import type {
-	IExecuteFunctions,
-	INodeExecutionData,
-	INodeType,
-	INodeTypeBaseDescription,
-	INodeTypeDescription,
+import {
+	ApplicationError,
+	NodeOperationError,
+	type IExecuteFunctions,
+	type INodeExecutionData,
+	type INodeType,
+	type INodeTypeBaseDescription,
+	type INodeTypeDescription,
 } from 'n8n-workflow';
 import { ENABLE_LESS_STRICT_TYPE_VALIDATION } from '../../../utils/constants';
 
@@ -101,7 +103,18 @@ export class IfV2 implements INodeType {
 				if (this.continueOnFail(error)) {
 					falseItems.push(item);
 				} else {
-					throw error;
+					if (error instanceof NodeOperationError) {
+						throw error;
+					}
+
+					if (error instanceof ApplicationError) {
+						set(error, 'context.itemIndex', itemIndex);
+						throw error;
+					}
+
+					throw new NodeOperationError(this.getNode(), error, {
+						itemIndex,
+					});
 				}
 			}
 		});

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -9,7 +9,7 @@ import type {
 	INodeTypeBaseDescription,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { ApplicationError, NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import set from 'lodash/set';
 import { capitalize } from '@utils/utilities';
 import { ENABLE_LESS_STRICT_TYPE_VALIDATION } from '../../../utils/constants';
@@ -382,7 +382,18 @@ export class SwitchV3 implements INodeType {
 					returnData[0].push({ json: { error: error.message } });
 					continue;
 				}
-				throw new NodeOperationError(this.getNode(), error);
+				if (error instanceof NodeOperationError) {
+					throw error;
+				}
+
+				if (error instanceof ApplicationError) {
+					set(error, 'context.itemIndex', itemIndex);
+					throw error;
+				}
+
+				throw new NodeOperationError(this.getNode(), error, {
+					itemIndex,
+				});
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes for errors thrown in those nodes to add itemIndex information

## Related Linear tickets, Github issues, and Community forum posts

node-1554-switch-node-item-index-not-included-in-error-messages