### PR TITLE
fix: Remove unimplemented Postgres credentials options

### DIFF
--- a/packages/nodes-base/credentials/CrateDb.credentials.ts
+++ b/packages/nodes-base/credentials/CrateDb.credentials.ts
@@ -52,14 +52,6 @@ export class CrateDb implements ICredentialType {
 					name: 'Require',
 					value: 'require',
 				},
-				{
-					name: 'Verify (Not Implemented)',
-					value: 'verify',
-				},
-				{
-					name: 'Verify-Full (Not Implemented)',
-					value: 'verify-full',
-				},
 			],
 			default: 'disable',
 		},

--- a/packages/nodes-base/credentials/Postgres.credentials.ts
+++ b/packages/nodes-base/credentials/Postgres.credentials.ts
@@ -65,14 +65,6 @@ export class Postgres implements ICredentialType {
 					name: 'Require',
 					value: 'require',
 				},
-				{
-					name: 'Verify (Not Implemented)',
-					value: 'verify',
-				},
-				{
-					name: 'Verify-Full (Not Implemented)',
-					value: 'verify-full',
-				},
 			],
 			default: 'disable',
 		},

--- a/packages/nodes-base/credentials/QuestDb.credentials.ts
+++ b/packages/nodes-base/credentials/QuestDb.credentials.ts
@@ -52,14 +52,6 @@ export class QuestDb implements ICredentialType {
 					name: 'Require',
 					value: 'require',
 				},
-				{
-					name: 'Verify (Not Implemented)',
-					value: 'verify',
-				},
-				{
-					name: 'Verify-Full (Not Implemented)',
-					value: 'verify-full',
-				},
 			],
 			default: 'disable',
 		},

--- a/packages/nodes-base/credentials/TimescaleDb.credentials.ts
+++ b/packages/nodes-base/credentials/TimescaleDb.credentials.ts
@@ -64,14 +64,6 @@ export class TimescaleDb implements ICredentialType {
 					name: 'Require',
 					value: 'require',
 				},
-				{
-					name: 'Verify (Not Implemented)',
-					value: 'verify',
-				},
-				{
-					name: 'Verify-Full (Not Implemented)',
-					value: 'verify-full',
-				},
 			],
 			default: 'disable',
 		},


### PR DESCRIPTION
This PR removes unimplemented Postgres credentials options as they are not needed with pgpromise
The options were also removed from the following nodes too as they use Postgres
- TimescaleDb
- CrateDb
- QuestDb

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1324/postgres-based-node-credentials-not-implemented-options

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
