### PR TITLE
fix(Read/Write Files from Disk Node): Better error handling when file name missing (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
@@ -1,4 +1,10 @@
-import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+	JsonObject,
+} from 'n8n-workflow';
 
 import glob from 'fast-glob';
 import { errorMapper } from '../helpers/utils';
@@ -124,7 +130,6 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 					},
 				});
 			}
-
 			returnData.push(...newItems);
 		} catch (error) {
 			const nodeOperatioinError = errorMapper.call(this, error, itemIndex, {
@@ -142,7 +147,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				});
 				continue;
 			}
-			throw nodeOperatioinError;
+			throw new NodeApiError(this.getNode(), error as JsonObject, { itemIndex });
 		}
 	}
 

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/write.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/write.operation.ts
@@ -1,6 +1,11 @@
 import type { Readable } from 'stream';
-import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
-import { BINARY_ENCODING } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+	JsonObject,
+} from 'n8n-workflow';
+import { BINARY_ENCODING, NodeApiError } from 'n8n-workflow';
 
 import { errorMapper } from '../helpers/utils';
 import { updateDisplayOptions } from '@utils/utilities';
@@ -114,7 +119,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				});
 				continue;
 			}
-			throw nodeOperatioinError;
+			throw new NodeApiError(this.getNode(), error as JsonObject, { itemIndex });
 		}
 	}
 


### PR DESCRIPTION
This PR shows better error handling when file name missing instead of just throwing an internal error

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1524/readwrite-files-from-disk-node-better-error-handling-when-file-name

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
