### PR TITLE
fix(Clockify Node): Add more operations and fix missing options

### DIFF
--- a/packages/nodes-base/nodes/Clockify/ClientDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/ClientDescription.ts
@@ -130,10 +130,10 @@ export const clientFields: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				resource: ['client'],

--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -789,23 +789,17 @@ export class Clockify implements INodeType {
 						const options = this.getNodeParameter('options', i, {});
 
 						// Get current UTC time
-						let end = new Date().toISOString();
-
-						if (typeof options.end === 'string') {
-							if (!options.end.endsWith('Z')) {
-								options.end += 'Z';
-							}
-							end = options.end;
-						}
+						options.end = (options.end || new Date().toISOString()) as string;
 
 						if (typeof options.end === 'string' && !options.end.endsWith('Z')) {
 							options.end += 'Z';
 						}
+
 						responseData = await clockifyApiRequest.call(
 							this,
 							'PATCH',
 							`/workspaces/${workspaceId}/user/${userId}/time-entries`,
-							{ end },
+							options,
 							{},
 						);
 					}

--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -746,7 +746,69 @@ export class Clockify implements INodeType {
 							qs,
 						);
 					}
+					if (operation === 'getAll') {
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
+						const inProgress = this.getNodeParameter('inProgress', i) as boolean;
+						const userId = this.getNodeParameter('userId', i, '') as string;
+						const options = this.getNodeParameter('options', i, {});
 
+						let url = `/workspaces/${workspaceId}`;
+
+						if (inProgress) {
+							url += '/time-entries/status/in-progress';
+						} else {
+							url += `/user/${userId}/time-entries`;
+						}
+
+						const dateTimeFields = ['start', 'end', 'get-week-before'];
+						for (const dtField of dateTimeFields) {
+							if (options[dtField] && typeof options[dtField] === 'string') {
+								if (!options[dtField].endsWith('Z')) {
+									options[dtField] += 'Z';
+								}
+							}
+						}
+
+						Object.assign(qs, options);
+
+						if (options['get-week-before']) {
+							responseData = await clockifyApiRequest.call(this, 'GET', url, {}, qs);
+						} else if (returnAll) {
+							responseData = await clockifyApiRequestAllItems.call(this, 'GET', url, {}, qs);
+						} else {
+							qs.limit = this.getNodeParameter('limit', i);
+							responseData = await clockifyApiRequestAllItems.call(this, 'GET', url, {}, qs);
+							responseData = responseData.splice(0, qs.limit);
+						}
+					}
+
+					if (operation === 'stopTimer') {
+						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
+						const userId = this.getNodeParameter('userId', i, '') as string;
+						const options = this.getNodeParameter('options', i, {});
+
+						// Get current UTC time
+						let end = new Date().toISOString();
+
+						if (typeof options.end === 'string') {
+							if (!options.end.endsWith('Z')) {
+								options.end += 'Z';
+							}
+							end = options.end;
+						}
+
+						if (typeof options.end === 'string' && !options.end.endsWith('Z')) {
+							options.end += 'Z';
+						}
+						responseData = await clockifyApiRequest.call(
+							this,
+							'PATCH',
+							`/workspaces/${workspaceId}/user/${userId}/time-entries`,
+							{ end },
+							{},
+						);
+					}
 					if (operation === 'update') {
 						const timezone = this.getTimezone();
 
@@ -794,6 +856,18 @@ export class Clockify implements INodeType {
 				}
 
 				if (resource === 'user') {
+					if (operation === 'get') {
+						const workspaceId = this.getNodeParameter('workspaceId', i) as string;
+						const userId = this.getNodeParameter('userId', i) as string;
+
+						responseData = await clockifyApiRequest.call(
+							this,
+							'GET',
+							`/workspaces/${workspaceId}/member-profile/${userId}`,
+							{},
+							qs,
+						);
+					}
 					if (operation === 'getAll') {
 						const returnAll = this.getNodeParameter('returnAll', i);
 
@@ -825,6 +899,9 @@ export class Clockify implements INodeType {
 							responseData = responseData.splice(0, qs.limit);
 						}
 					}
+				}
+				if (operation === 'getSelf') {
+					responseData = await clockifyApiRequest.call(this, 'GET', '/user', {}, qs);
 				}
 
 				if (resource === 'workspace') {

--- a/packages/nodes-base/nodes/Clockify/Clockify.node.ts
+++ b/packages/nodes-base/nodes/Clockify/Clockify.node.ts
@@ -734,6 +734,10 @@ export class Clockify implements INodeType {
 
 						const timeEntryId = this.getNodeParameter('timeEntryId', i) as string;
 
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+
+						Object.assign(qs, additionalFields);
+
 						responseData = await clockifyApiRequest.call(
 							this,
 							'GET',

--- a/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
@@ -29,6 +29,9 @@ export async function clockifyApiRequest(
 		uri: `${BASE_URL}/${resource}`,
 		json: true,
 		useQuerystring: true,
+		qsStringifyOptions: {
+			arrayFormat: 'repeat',
+		},
 	};
 	return await this.helpers.requestWithAuthentication.call(this, 'clockifyApi', options);
 }
@@ -45,7 +48,7 @@ export async function clockifyApiRequestAllItems(
 
 	let responseData;
 
-	query['page-size'] = 50;
+	query['page-size'] = query.limit ? Math.min(parseInt(query.limit as string), 1000) : 1000;
 
 	query.page = 1;
 
@@ -56,7 +59,7 @@ export async function clockifyApiRequestAllItems(
 
 		const limit = query.limit as number | undefined;
 		if (limit && returnData.length >= limit) {
-			return returnData;
+			return returnData.slice(0, limit);
 		}
 
 		query.page++;

--- a/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Clockify/GenericFunctions.ts
@@ -63,7 +63,7 @@ export async function clockifyApiRequestAllItems(
 		}
 
 		query.page++;
-	} while (responseData.length !== 0);
+	} while (responseData.length !== 0 && returnData.length >= query['page-size']);
 
 	return returnData;
 }

--- a/packages/nodes-base/nodes/Clockify/ProjectDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/ProjectDescription.ts
@@ -66,10 +66,10 @@ export const projectFields: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['create'],
@@ -224,10 +224,10 @@ export const projectFields: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll'],

--- a/packages/nodes-base/nodes/Clockify/TagDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TagDescription.ts
@@ -110,10 +110,10 @@ export const tagFields: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				operation: ['getAll'],

--- a/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
@@ -193,25 +193,28 @@ export const timeEntryFields: INodeProperties[] = [
 		},
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
-				operation: ['get'],
 				resource: ['timeEntry'],
+				operation: ['get'],
 			},
 		},
 		default: {},
 		options: [
 			{
-				displayName: 'Consider Duration Format',
-				name: 'consider-duration-format',
+				displayName: 'Hydrated',
+				name: 'hydrated',
 				type: 'boolean',
 				default: false,
 				description:
-					"Whether to return the time entry's duration rounded to minutes or seconds based on duration format (hh:mm or hh:mm:ss) from workspace settings",
+					"Whether to return the time entry's project, task and tags in full and not just their IDs",
+			},
+		],
+	},
 			},
 			{
 				displayName: 'Hydrated',
@@ -246,8 +249,8 @@ export const timeEntryFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				operation: ['update'],
 				resource: ['timeEntry'],
+				operation: ['update'],
 			},
 		},
 		default: {},

--- a/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
@@ -27,8 +27,20 @@ export const timeEntryOperations: INodeProperties[] = [
 			{
 				name: 'Get',
 				value: 'get',
-				description: 'Get time entrie',
+				description: 'Get a time entry',
 				action: 'Get a time entry',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many time entries',
+				action: 'Get many time entries',
+			},
+			{
+				name: 'Stop Timer',
+				value: 'stopTimer',
+				description: 'Stop currently running timer on workspace for user',
+				action: 'Stop currently running timer ',
 			},
 			{
 				name: 'Update',
@@ -215,6 +227,104 @@ export const timeEntryFields: INodeProperties[] = [
 			},
 		],
 	},
+	/* -------------------------------------------------------------------------- */
+	/*                               timeEntry:getAll                            */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'In Progress',
+		name: 'inProgress',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['getAll'],
+			},
+		},
+		description: 'Whether to return return in progress time entries for the workspace',
+	},
+	{
+		displayName: 'User Name or ID',
+		name: 'userId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+		typeOptions: {
+			loadOptionsDependsOn: ['workspaceId'],
+			loadOptionsMethod: 'loadUsersForWorkspace',
+		},
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['getAll'],
+				inProgress: [false],
+			},
+		},
+		default: '',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 100,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['getAll'],
+				inProgress: [false],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Project Name or ID',
+				name: 'project',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsDependsOn: ['workspaceId'],
+					loadOptionsMethod: 'loadProjectsForWorkspace',
+				},
+				default: '',
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description:
+					"If provided, you'll get a filtered list of time entires that contain the provided string in their description",
 			},
 			{
 				displayName: 'Hydrated',
@@ -223,6 +333,98 @@ export const timeEntryFields: INodeProperties[] = [
 				default: false,
 				description:
 					"Whether to return the time entry's project, task and tags in full and not just their IDs",
+			},
+			{
+				displayName: 'Start',
+				name: 'start',
+				type: 'dateTime',
+				default: '',
+				description: 'Start time in UTC',
+			},
+			{
+				displayName: 'End',
+				name: 'end',
+				type: 'dateTime',
+				default: '',
+				description: 'End time in UTC',
+			},
+			{
+				displayName: 'Week Before',
+				name: 'get-week-before',
+				type: 'dateTime',
+				default: '',
+				description: 'Get the week before this datetime in UTC',
+			},
+			{
+				displayName: 'Task',
+				name: 'task',
+				type: 'string',
+				default: '',
+				description:
+					"If provided, you'll get a filtered list of time entries that matches the provided string in their task ID",
+			},
+			{
+				displayName: 'Tag Names or IDs',
+				name: 'tags',
+				type: 'multiOptions',
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsDependsOn: ['workspaceId'],
+					loadOptionsMethod: 'loadTagsForWorkspace',
+				},
+				default: [],
+			},
+			// in-progress boolean
+			{
+				displayName: 'In Progress',
+				name: 'in-progress',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to filter only in progress time entries',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                             timeEntry:stopTimer                            */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'User Name or ID',
+		name: 'userId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+		typeOptions: {
+			loadOptionsDependsOn: ['workspaceId'],
+			loadOptionsMethod: 'loadUsersForWorkspace',
+		},
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['stopTimer'],
+			},
+		},
+		default: '',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		displayOptions: {
+			show: {
+				resource: ['timeEntry'],
+				operation: ['stopTimer'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'End Time',
+				name: 'end',
+				type: 'dateTime',
+				default: '',
+				description: 'Specify the end time of the time entry',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/TimeEntryDescription.ts
@@ -248,7 +248,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'userId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['workspaceId'],
 			loadOptionsMethod: 'loadUsersForWorkspace',
@@ -311,7 +311,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'project',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadProjectsForWorkspace',
@@ -368,7 +368,7 @@ export const timeEntryFields: INodeProperties[] = [
 				name: 'tags',
 				type: 'multiOptions',
 				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsDependsOn: ['workspaceId'],
 					loadOptionsMethod: 'loadTagsForWorkspace',
@@ -393,7 +393,7 @@ export const timeEntryFields: INodeProperties[] = [
 		name: 'userId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['workspaceId'],
 			loadOptionsMethod: 'loadUsersForWorkspace',

--- a/packages/nodes-base/nodes/Clockify/UserDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/UserDescription.ts
@@ -59,10 +59,10 @@ export const userFields: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
-		displayName: 'Additional Fields',
+		displayName: 'Options',
 		name: 'additionalFields',
 		type: 'collection',
-		placeholder: 'Add Field',
+		placeholder: 'Add option',
 		displayOptions: {
 			show: {
 				resource: ['user'],

--- a/packages/nodes-base/nodes/Clockify/UserDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/UserDescription.ts
@@ -13,10 +13,22 @@ export const userOperations: INodeProperties[] = [
 		},
 		options: [
 			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a user',
+				action: 'Get a user',
+			},
+			{
 				name: 'Get Many',
 				value: 'getAll',
 				description: 'Get many users',
 				action: 'Get many users',
+			},
+			{
+				name: 'Get Self',
+				value: 'getSelf',
+				description: 'Retrieve currently logged-in user',
+				action: 'Get currently logged-in user',
 			},
 		],
 		default: 'getAll',
@@ -24,6 +36,28 @@ export const userOperations: INodeProperties[] = [
 ];
 
 export const userFields: INodeProperties[] = [
+	/* -------------------------------------------------------------------------- */
+	/*                                  user:get                                  */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'User Name or ID',
+		name: 'userId',
+		type: 'options',
+		description:
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+		typeOptions: {
+			loadOptionsDependsOn: ['workspaceId'],
+			loadOptionsMethod: 'loadUsersForWorkspace',
+		},
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['user'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+	},
 	/* -------------------------------------------------------------------------- */
 	/*                                 user:getAll                                */
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Clockify/UserDescription.ts
+++ b/packages/nodes-base/nodes/Clockify/UserDescription.ts
@@ -44,7 +44,7 @@ export const userFields: INodeProperties[] = [
 		name: 'userId',
 		type: 'options',
 		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
+			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 		typeOptions: {
 			loadOptionsDependsOn: ['workspaceId'],
 			loadOptionsMethod: 'loadUsersForWorkspace',


### PR DESCRIPTION
## Summary

PR updates the Clockify node to:
1. Fix options that weren't passed to the API for time entries
2. Rename `Additional Fields` to `Options` where it makes sense
3. Add operations to
   - Get user by ID
   - Get own user
   - Get many time entries with many filter options
   - Stop currently running timer
4. Improve performance by increasing the page-size to 1000 from 50 which works for all current returnAll operations
5. Set `qsStringifyOptions` to `repeat` to work with multiple QS params like tags

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
