### PR TITLE
fix(editor): Adjust default zoom level in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -269,7 +269,8 @@ function emitWithLastSelectedNode(emitFn: (id: string) => void) {
  * View
  */
 
-const zoom = ref(1);
+const defaultZoom = 1;
+const zoom = ref(defaultZoom);
 
 function onClickPane(event: MouseEvent) {
 	const bounds = viewportRef.value?.getBoundingClientRect() ?? { left: 0, top: 0 };
@@ -282,7 +283,7 @@ function onClickPane(event: MouseEvent) {
 }
 
 async function onFitView() {
-	await fitView({ maxZoom: 1.2, padding: 0.2 });
+	await fitView({ maxZoom: defaultZoom, padding: 0.2 });
 }
 
 async function onZoomTo(zoomLevel: number) {
@@ -298,7 +299,7 @@ async function onZoomOut() {
 }
 
 async function onResetZoom() {
-	await onZoomTo(1);
+	await onZoomTo(defaultZoom);
 }
 
 function onViewportChange(viewport: ViewportTransform) {


### PR DESCRIPTION
## Summary

Adjusted default zoom level.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7583/default-zoom-level-isnt-the-same-a-little-too-zoomed-in

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
