### PR TITLE
feat(editor): Add old execution status rendering in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -123,6 +123,7 @@ function openContextMenu(event: MouseEvent) {
 	--configurable-node--icon-offset: 40px;
 	--configurable-node--icon-size: 30px;
 	--trigger-node--border-radius: 36px;
+	--canvas-node--status-icons-offset: var(--spacing-2xs);
 
 	height: var(--canvas-node--height);
 	width: var(--canvas-node--width);
@@ -248,8 +249,8 @@ function openContextMenu(event: MouseEvent) {
 
 .statusIcons {
 	position: absolute;
-	bottom: var(--spacing-2xs);
-	right: var(--spacing-2xs);
+	bottom: var(--canvas-node--status-icons-offset);
+	right: var(--canvas-node--status-icons-offset);
 }
 
 .triggerIcon {

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -88,7 +88,13 @@ const hideNodeIssues = computed(() => false); // @TODO Implement this
 }
 
 .running {
-	color: var(--color-primary);
+	width: calc(100% - 2 * var(--canvas-node--status-icons-offset));
+	height: calc(100% - 2 * var(--canvas-node--status-icons-offset));
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 3.75em;
+	color: hsla(var(--color-primary-h), var(--color-primary-s), var(--color-primary-l), 0.7);
 }
 
 .issues {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/71bef466-024d-4ab5-ab4e-7265de19e456

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7571/implement-the-old-rendering-of-an-executing-node-with-the-big-spinning

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
