### PR TITLE
fix(editor): Prevent unloading when changes are pending in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useBeforeUnload.spec.ts
+++ b/packages/editor-ui/src/composables/useBeforeUnload.spec.ts
@@ -1,0 +1,86 @@
+import { useBeforeUnload } from '@/composables/useBeforeUnload';
+import { STORES, VIEWS } from '@/constants';
+import { useUIStore } from '@/stores/ui.store';
+import { useCanvasStore } from '@/stores/canvas.store';
+import type { useRoute } from 'vue-router';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { mock } from 'vitest-mock-extended';
+import { describe } from 'vitest';
+
+describe('useBeforeUnload', () => {
+	const defaultRoute = mock<ReturnType<typeof useRoute>>({ name: 'someRoute' });
+
+	let uiStore: ReturnType<typeof useUIStore>;
+	let canvasStore: ReturnType<typeof useCanvasStore>;
+
+	beforeEach(() => {
+		const pinia = createTestingPinia({
+			initialState: {
+				[STORES.UI]: {
+					stateIsDirty: false,
+				},
+			},
+		});
+		setActivePinia(pinia);
+
+		uiStore = useUIStore();
+		canvasStore = useCanvasStore();
+	});
+
+	describe('onBeforeUnload', () => {
+		it('should do nothing if route is demo', () => {
+			const route = mock<ReturnType<typeof useRoute>>({ name: VIEWS.DEMO });
+			const { onBeforeUnload } = useBeforeUnload({ route });
+			const event = new Event('beforeunload');
+
+			const result = onBeforeUnload(event);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should prompt user if state is dirty', () => {
+			uiStore.stateIsDirty = true;
+			const { onBeforeUnload } = useBeforeUnload({ route: defaultRoute });
+			const event = new Event('beforeunload');
+
+			const result = onBeforeUnload(event);
+
+			expect(result).toBe(true);
+		});
+
+		it('starts loading if state is not dirty', () => {
+			uiStore.stateIsDirty = false;
+			const startLoadingSpy = vi.spyOn(canvasStore, 'startLoading');
+			const { onBeforeUnload } = useBeforeUnload({ route: defaultRoute });
+			const event = new Event('beforeunload');
+
+			const result = onBeforeUnload(event);
+
+			expect(startLoadingSpy).toHaveBeenCalledWith(expect.any(String));
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('addBeforeUnloadEventBindings', () => {
+		it('should add beforeunload event listener', () => {
+			const { addBeforeUnloadEventBindings } = useBeforeUnload({ route: defaultRoute });
+			const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+			addBeforeUnloadEventBindings();
+
+			expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+		});
+	});
+
+	describe('removeBeforeUnloadEventBindings', () => {
+		it('should remove beforeunload event listener', () => {
+			const { removeBeforeUnloadEventBindings } = useBeforeUnload({ route: defaultRoute });
+			const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+			removeBeforeUnloadEventBindings();
+
+			expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+		});
+	});
+});

--- a/packages/editor-ui/src/composables/useBeforeUnload.spec.ts
+++ b/packages/editor-ui/src/composables/useBeforeUnload.spec.ts
@@ -49,7 +49,7 @@ describe('useBeforeUnload', () => {
 			expect(result).toBe(true);
 		});
 
-		it('starts loading if state is not dirty', () => {
+		it('should start loading if state is not dirty', () => {
 			uiStore.stateIsDirty = false;
 			const startLoadingSpy = vi.spyOn(canvasStore, 'startLoading');
 			const { onBeforeUnload } = useBeforeUnload({ route: defaultRoute });

--- a/packages/editor-ui/src/composables/useBeforeUnload.ts
+++ b/packages/editor-ui/src/composables/useBeforeUnload.ts
@@ -1,0 +1,41 @@
+import { useCanvasStore } from '@/stores/canvas.store';
+import { useUIStore } from '@/stores/ui.store';
+import { useI18n } from '@/composables/useI18n';
+import { computed } from 'vue';
+import { VIEWS } from '@/constants';
+import type { useRoute } from 'vue-router';
+
+export function useBeforeUnload({ route }: { route: ReturnType<typeof useRoute> }) {
+	const uiStore = useUIStore();
+	const canvasStore = useCanvasStore();
+
+	const i18n = useI18n();
+
+	const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
+
+	function onBeforeUnload(e: BeforeUnloadEvent) {
+		if (isDemoRoute.value || window.preventNodeViewBeforeUnload) {
+			return;
+		} else if (uiStore.stateIsDirty) {
+			e.returnValue = true; //Gecko + IE
+			return true; //Gecko + Webkit, Safari, Chrome etc.
+		} else {
+			canvasStore.startLoading(i18n.baseText('nodeView.redirecting'));
+			return;
+		}
+	}
+
+	function addBeforeUnloadEventBindings() {
+		window.addEventListener('beforeunload', onBeforeUnload);
+	}
+
+	function removeBeforeUnloadEventBindings() {
+		window.removeEventListener('beforeunload', onBeforeUnload);
+	}
+
+	return {
+		onBeforeUnload,
+		addBeforeUnloadEventBindings,
+		removeBeforeUnloadEventBindings,
+	};
+}

--- a/packages/editor-ui/src/composables/useBeforeUnload.ts
+++ b/packages/editor-ui/src/composables/useBeforeUnload.ts
@@ -5,6 +5,13 @@ import { computed } from 'vue';
 import { VIEWS } from '@/constants';
 import type { useRoute } from 'vue-router';
 
+/**
+ * Composable to handle the beforeunload event in canvas views.
+ *
+ * This hook will prevent closing the tab and prompt the user if the ui state is dirty
+ * (workflow has changes) and the user tries to leave the page.
+ */
+
 export function useBeforeUnload({ route }: { route: ReturnType<typeof useRoute> }) {
 	const uiStore = useUIStore();
 	const canvasStore = useCanvasStore();

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -3,6 +3,7 @@ import {
 	computed,
 	defineAsyncComponent,
 	nextTick,
+	onActivated,
 	onBeforeMount,
 	onBeforeUnmount,
 	onMounted,
@@ -1386,6 +1387,22 @@ function registerCustomActions() {
 }
 
 /**
+ * Unload
+ */
+
+function onBeforeUnload(e: BeforeUnloadEvent) {
+	if (isDemoRoute.value || window.preventNodeViewBeforeUnload) {
+		return;
+	} else if (uiStore.stateIsDirty) {
+		e.returnValue = true; //Gecko + IE
+		return true; //Gecko + Webkit, Safari, Chrome etc.
+	} else {
+		canvasStore.startLoading(i18n.baseText('nodeView.redirecting'));
+		return;
+	}
+}
+
+/**
  * Routing
  */
 
@@ -1408,6 +1425,10 @@ onBeforeMount(() => {
 	if (!isDemoRoute.value) {
 		pushConnectionStore.pushConnect();
 	}
+});
+
+onActivated(() => {
+	window.addEventListener('beforeunload', onBeforeUnload);
 });
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/0f6777e8-cc94-46d0-b005-b33b1c4d448f

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7587/weve-lost-the-warning-when-trying-to-close-the-tab-and-there-are

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
