### PR TITLE
fix(editor): Fix edge button background color in dark mode in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -35,6 +35,7 @@ function onDelete() {
 	<div :class="classes" data-test-id="canvas-edge-toolbar">
 		<N8nIconButton
 			v-if="isAddButtonVisible"
+			class="canvas-edge-toolbar-button"
 			data-test-id="add-connection-button"
 			type="tertiary"
 			size="small"
@@ -44,6 +45,7 @@ function onDelete() {
 		/>
 		<N8nIconButton
 			data-test-id="delete-connection-button"
+			class="canvas-edge-toolbar-button"
 			type="tertiary"
 			size="small"
 			icon="trash"
@@ -60,5 +62,12 @@ function onDelete() {
 	align-items: center;
 	gap: var(--spacing-2xs);
 	pointer-events: all;
+}
+</style>
+
+<style lang="scss">
+[data-theme='dark'] .canvas-edge-toolbar-button {
+	--button-background-color: var(--color-background-base);
+	--button-hover-background-color: var(--color-background-light);
 }
 </style>


### PR DESCRIPTION
## Summary

<img width="522" alt="Screenshot 2024-08-19 at 15 06 35" src="https://github.com/user-attachments/assets/26f3cc8e-874e-48fc-b792-6dc8deaefc9f">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7591/edge-operation-buttons-missing-background-in-dark-mode

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
