### PR TITLE
fix: Rename Assistant back

### DIFF
--- a/packages/design-system/src/locale/lang/en.ts
+++ b/packages/design-system/src/locale/lang/en.ts
@@ -32,7 +32,7 @@ export default {
 	'askAssistantButton.askAssistant': 'Ask Assistant',
 	'assistantChat.errorParsingMarkdown': 'Error parsing markdown content',
 	'assistantChat.aiAssistantLabel': 'AI Assistant',
-	'assistantChat.aiAssistantName': 'Ava',
+	'assistantChat.aiAssistantName': 'Assistant',
 	'assistantChat.sessionEndMessage.1':
 		'This Assistant session has ended. To start a new session with the Assistant, click an',
 	'assistantChat.sessionEndMessage.2': 'button in n8n',


### PR DESCRIPTION
## Summary
Rename Assistant back to "Assistant"

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
