### PR TITLE
refactor(core): Track metrics state and categories in telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -20,7 +20,22 @@ const flushPromises = async () => await new Promise((resolve) => setImmediate(re
 describe('TelemetryEventRelay', () => {
 	const telemetry = mock<Telemetry>();
 	const license = mock<License>();
-	const globalConfig = mock<GlobalConfig>({ userManagement: { emails: { mode: 'smtp' } } });
+	const globalConfig = mock<GlobalConfig>({
+		userManagement: {
+			emails: {
+				mode: 'smtp',
+			},
+		},
+		endpoints: {
+			metrics: {
+				enable: true,
+				includeDefaultMetrics: true,
+				includeApiEndpoints: false,
+				includeCacheMetrics: false,
+				includeMessageEventBusMetrics: false,
+			},
+		},
+	});
 	const workflowRepository = mock<WorkflowRepository>();
 	const nodeTypes = mock<NodeTypes>();
 	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
@@ -927,6 +942,13 @@ describe('TelemetryEventRelay', () => {
 				'Instance started',
 				expect.objectContaining({
 					earliest_workflow_created: firstWorkflow.createdAt,
+					metrics: {
+						metrics_enabled: true,
+						metrics_category_default: true,
+						metrics_category_routes: false,
+						metrics_category_cache: false,
+						metrics_category_logs: false,
+					},
 				}),
 			);
 		});

--- a/packages/cli/src/events/telemetry-event-relay.ts
+++ b/packages/cli/src/events/telemetry-event-relay.ts
@@ -771,8 +771,6 @@ export class TelemetryEventRelay extends EventRelay {
 			},
 		};
 
-		console.log('info', info);
-
 		const firstWorkflow = await this.workflowRepository.findOne({
 			select: ['createdAt'],
 			order: { createdAt: 'ASC' },

--- a/packages/cli/src/events/telemetry-event-relay.ts
+++ b/packages/cli/src/events/telemetry-event-relay.ts
@@ -762,7 +762,16 @@ export class TelemetryEventRelay extends EventRelay {
 			license_tenant_id: config.getEnv('license.tenantId'),
 			binary_data_s3: isS3Available && isS3Selected && isS3Licensed,
 			multi_main_setup_enabled: config.getEnv('multiMainSetup.enabled'),
+			metrics: {
+				metrics_enabled: this.globalConfig.endpoints.metrics.enable,
+				metrics_category_default: this.globalConfig.endpoints.metrics.includeDefaultMetrics,
+				metrics_category_routes: this.globalConfig.endpoints.metrics.includeApiEndpoints,
+				metrics_category_cache: this.globalConfig.endpoints.metrics.includeCacheMetrics,
+				metrics_category_logs: this.globalConfig.endpoints.metrics.includeMessageEventBusMetrics,
+			},
 		};
+
+		console.log('info', info);
 
 		const firstWorkflow = await this.workflowRepository.findOne({
 			select: ['createdAt'],


### PR DESCRIPTION
As discussed here: https://linear.app/n8n/issue/PAY-1462/feature-expose-queue-length-to-metrics-endpoint#comment-ac27fc97 