### PR TITLE
fix(editor): Fix overflow in AI Assistant chat messages

### DIFF
--- a/packages/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -308,12 +308,14 @@ p {
 	border: var(--border-base);
 	border-top: 0;
 	height: 100%;
-	overflow: scroll;
+	overflow-x: hidden;
+	overflow-y: auto;
 	padding-bottom: 250px; // make scrollable at the end
 	position: relative;
 
-	pre {
-		text-wrap: stable;
+	pre,
+	code {
+		text-wrap: wrap;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes code blocks overflow in assistant messages caused by `text-wrap: stable` [not being supported in Chrome](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap#browser_compatibility).
- Also, switches to `scroll: auto` for the assistant chat

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO2-29

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
