### PR TITLE
fix(editor): Stop telemetry from triggering when initializing workflow in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -556,7 +556,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 				createConnectionToLastInteractedWithNode(nodeData, options);
 			}
 
-			if (options.telemetry !== false) {
+			if (options.telemetry) {
 				trackAddNode(nodeData, options);
 			}
 

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1250,7 +1250,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		workflowHelpers.initState(data);
 
 		// Add nodes and connections
-		await addNodes(data.nodes, { keepPristine: true, telemetry: false });
+		await addNodes(data.nodes, { keepPristine: true });
 		workflowsStore.setConnections(data.connections);
 	}
 

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1418,9 +1418,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		// Add the nodes with the changed node names, expressions and connections
 		historyStore.startRecordingUndo();
 
-		await addNodes(Object.values(tempWorkflow.nodes), {
-			telemetry: false,
-		});
+		await addNodes(Object.values(tempWorkflow.nodes));
 		addConnections(
 			mapLegacyConnectionsToCanvasConnections(
 				tempWorkflow.connectionsBySourceNode,

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -803,7 +803,7 @@ async function onAddNodesAndConnections(
 		return;
 	}
 
-	await addNodes(nodes, { dragAndDrop, position, trackHistory: true });
+	await addNodes(nodes, { dragAndDrop, position, trackHistory: true, telemetry: true });
 	await nextTick();
 
 	const offsetIndex = editableWorkflow.value.nodes.length - nodes.length;


### PR DESCRIPTION
## Summary

Stop telemetry from triggering when initializing workflow in new canvas

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7592/loading-a-wf-triggers-the-user-inserted-node-event-for-all-nodes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
