### PR TITLE
feat(AI Agent Node): Add tutorial link to agent node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -9,7 +9,6 @@ import type {
 	INodeTypeDescription,
 	INodeProperties,
 } from 'n8n-workflow';
-import { getTemplateNoticeField } from '../../../utils/sharedFields';
 import { promptTypeOptions, textInput } from '../../../utils/descriptions';
 import { conversationalAgentProperties } from './agents/ConversationalAgent/description';
 import { conversationalAgentExecute } from './agents/ConversationalAgent/execute';
@@ -305,10 +304,14 @@ export class Agent implements INodeType {
 		],
 		properties: [
 			{
-				...getTemplateNoticeField(1954),
+				displayName:
+					'Tip: Get a feel for agents with our quick <a href="https://docs.n8n.io/advanced-ai/intro-tutorial/" target="_blank">tutorial</a> or see an <a href="/templates/1954" target="_blank">example</a> of how this node works',
+				name: 'notice_tip',
+				type: 'notice',
+				default: '',
 				displayOptions: {
 					show: {
-						agent: ['conversationalAgent'],
+						agent: ['conversationalAgent', 'toolsAgent'],
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
Add a link to tutorial to the agent node's NDV

![CleanShot 2024-08-21 at 11 42 25@2x](https://github.com/user-attachments/assets/99bf82b0-9c0b-4b11-832e-6767cb7e6567)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
