### PR TITLE
fix(editor): Fix node insert position on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -974,11 +974,12 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 		// If added node is a trigger and it's the first one added to the canvas
 		// we place it at canvasAddButtonPosition to replace the canvas add button
-		const position =
+		const position = (
 			nodeTypesStore.isTriggerNode(node.type) && triggerNodes.value.length === 0
-				? canvasStore.canvasAddButtonPosition
+				? [0, 0]
 				: // If no node is active find a free spot
-					(lastClickPosition.value as XYPosition);
+					lastClickPosition.value
+		) as XYPosition;
 
 		return NodeViewUtils.getNewNodePosition(workflowsStore.allNodes, position);
 	}


### PR DESCRIPTION
## Summary

Fix node position offset when inserting first node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7575/when-adding-first-node-its-not-inserted-at-the-same-place-as-the

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
