### PR TITLE
refactor(editor): Add types to importCurlEventBus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -189,7 +189,6 @@ import type {
 	INodeProperties,
 	NodeParameterValue,
 	ConnectionTypes,
-	NodeParameterValueType,
 } from 'n8n-workflow';
 import {
 	NodeHelpers,
@@ -201,6 +200,7 @@ import {
 	displayParameter,
 } from 'n8n-workflow';
 import type {
+	CurlToJSONResponse,
 	INodeUi,
 	INodeUpdatePropertiesInformation,
 	IUpdateInformation,
@@ -235,9 +235,8 @@ import { useCredentialsStore } from '@/stores/credentials.store';
 import type { EventBus } from 'n8n-design-system';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
-import { importCurlEventBus } from '@/event-bus';
+import { importCurlEventBus, ndvEventBus } from '@/event-bus';
 import { useToast } from '@/composables/useToast';
-import { ndvEventBus } from '@/event-bus';
 
 export default defineComponent({
 	name: 'NodeSettings',
@@ -489,12 +488,12 @@ export default defineComponent({
 		ndvEventBus.off('updateParameterValue', this.valueChanged);
 	},
 	methods: {
-		setHttpNodeParameters(parameters: NodeParameterValueType) {
+		setHttpNodeParameters(parameters: CurlToJSONResponse) {
 			try {
 				this.valueChanged({
 					node: this.node?.name,
 					name: 'parameters',
-					value: parameters,
+					value: parameters as unknown as INodeParameters,
 				});
 			} catch {}
 		},

--- a/packages/editor-ui/src/event-bus/import-curl.ts
+++ b/packages/editor-ui/src/event-bus/import-curl.ts
@@ -1,3 +1,9 @@
+import type { CurlToJSONResponse } from '@/Interface';
 import { createEventBus } from 'n8n-design-system/utils';
 
-export const importCurlEventBus = createEventBus();
+export interface ImportCurlEventBusEvents {
+	/** Command to set the HTTP node parameters based on the curl to JSON response */
+	setHttpNodeParameters: CurlToJSONResponse;
+}
+
+export const importCurlEventBus = createEventBus<ImportCurlEventBusEvents>();


### PR DESCRIPTION
## Summary

Add types to importCurlEventBus

## Related Linear tickets, Github issues, and Community forum posts

[CAT-32](https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
