### PR TITLE
refactor(editor): Add types to htmlEditorEventBus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/event-bus/html-editor.ts
+++ b/packages/editor-ui/src/event-bus/html-editor.ts
@@ -1,3 +1,8 @@
 import { createEventBus } from 'n8n-design-system/utils';
 
-export const htmlEditorEventBus = createEventBus();
+export interface HtmlEditorEventBusEvents {
+	/** Command to format the content in the HtmlEditor */
+	'format-html': never;
+}
+
+export const htmlEditorEventBus = createEventBus<HtmlEditorEventBusEvents>();


### PR DESCRIPTION
## Summary

Add types to htmlEditorEventBus

## Related Linear tickets, Github issues, and Community forum posts

[CAT-32](https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
