### PR TITLE
fix(editor): Sending 'Assistant session started event' to posthog (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/AskAssistant/AskAssistantFloatingButton.vue
+++ b/packages/editor-ui/src/components/AskAssistant/AskAssistantFloatingButton.vue
@@ -28,16 +28,12 @@ const lastUnread = computed(() => {
 
 const onClick = () => {
 	assistantStore.openChat();
-	telemetry.track(
-		'User opened assistant',
-		{
-			source: 'canvas',
-			task: 'placeholder',
-			has_existing_session: !assistantStore.isSessionEnded,
-			workflow_id: workflowStore.workflowId,
-		},
-		{ withPostHog: true },
-	);
+	telemetry.track('User opened assistant', {
+		source: 'canvas',
+		task: 'placeholder',
+		has_existing_session: !assistantStore.isSessionEnded,
+		workflow_id: workflowStore.workflowId,
+	});
 };
 </script>
 

--- a/packages/editor-ui/src/components/AskAssistant/NewAssistantSessionModal.vue
+++ b/packages/editor-ui/src/components/AskAssistant/NewAssistantSessionModal.vue
@@ -29,19 +29,15 @@ const close = () => {
 
 const startNewSession = async () => {
 	await assistantStore.initErrorHelper(props.data.context);
-	telemetry.track(
-		'User opened assistant',
-		{
-			source: 'error',
-			task: 'error',
-			has_existing_session: true,
-			workflow_id: workflowsStore.workflowId,
-			node_type: props.data.context.node.type,
-			error: props.data.context.error,
-			chat_session_id: assistantStore.currentSessionId,
-		},
-		{ withPostHog: true },
-	);
+	telemetry.track('User opened assistant', {
+		source: 'error',
+		task: 'error',
+		has_existing_session: true,
+		workflow_id: workflowsStore.workflowId,
+		node_type: props.data.context.node.type,
+		error: props.data.context.error,
+		chat_session_id: assistantStore.currentSessionId,
+	});
 	close();
 };
 </script>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -433,18 +433,14 @@ async function onAskAssistantClick() {
 		return;
 	}
 	await assistantStore.initErrorHelper(errorPayload);
-	telemetry.track(
-		'User opened assistant',
-		{
-			source: 'error',
-			task: 'error',
-			has_existing_session: false,
-			workflow_id: workflowsStore.workflowId,
-			node_type: node.value.type,
-			error: props.error,
-		},
-		{ withPostHog: true },
-	);
+	telemetry.track('User opened assistant', {
+		source: 'error',
+		task: 'error',
+		has_existing_session: false,
+		workflow_id: workflowsStore.workflowId,
+		node_type: node.value.type,
+		error: props.error,
+	});
 }
 </script>
 

--- a/packages/editor-ui/src/stores/assistant.store.ts
+++ b/packages/editor-ui/src/stores/assistant.store.ts
@@ -245,10 +245,14 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	function onEachStreamingMessage(response: ChatRequest.ResponsePayload, id: string) {
 		if (response.sessionId && !currentSessionId.value) {
 			currentSessionId.value = response.sessionId;
-			telemetry.track('Assistant session started', {
-				chat_session_id: currentSessionId.value,
-				task: 'error',
-			});
+			telemetry.track(
+				'Assistant session started',
+				{
+					chat_session_id: currentSessionId.value,
+					task: 'error',
+				},
+				{ withPostHog: true },
+			);
 		} else if (currentSessionId.value !== response.sessionId) {
 			return;
 		}


### PR DESCRIPTION
## Summary
- Sending `Assistant session started event` to posthog
- Not sending any of the `User opened assistant` events to posthog

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO2-78

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
