### PR TITLE
refactor(editor): Add types to codeNodeEditorEventBus (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -118,7 +118,7 @@ const i18n = useI18n();
 const telemetry = useTelemetry();
 
 onMounted(() => {
-	if (!props.isReadOnly) codeNodeEditorEventBus.on('error-line-number', highlightLine);
+	if (!props.isReadOnly) codeNodeEditorEventBus.on('highlightLine', highlightLine);
 
 	codeNodeEditorEventBus.on('codeDiffApplied', diffApplied);
 
@@ -188,7 +188,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	codeNodeEditorEventBus.off('codeDiffApplied', diffApplied);
-	if (!props.isReadOnly) codeNodeEditorEventBus.off('error-line-number', highlightLine);
+	if (!props.isReadOnly) codeNodeEditorEventBus.off('highlightLine', highlightLine);
 });
 
 const aiEnabled = computed(() => {

--- a/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
+++ b/packages/editor-ui/src/components/SqlEditor/SqlEditor.vue
@@ -154,7 +154,7 @@ watch(segments, () => {
 });
 
 onMounted(() => {
-	codeNodeEditorEventBus.on('error-line-number', highlightLine);
+	codeNodeEditorEventBus.on('highlightLine', highlightLine);
 
 	if (props.fullscreen) {
 		focus();
@@ -162,7 +162,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-	codeNodeEditorEventBus.off('error-line-number', highlightLine);
+	codeNodeEditorEventBus.off('highlightLine', highlightLine);
 });
 
 function line(lineNumber: number): Line | null {

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -295,7 +295,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 
 			const lineNumber = runDataExecuted?.data?.resultData?.error?.lineNumber;
 
-			codeNodeEditorEventBus.emit('error-line-number', lineNumber || 'final');
+			codeNodeEditorEventBus.emit('highlightLine', lineNumber ?? 'final');
 
 			const workflow = workflowHelpers.getCurrentWorkflow();
 			if (runDataExecuted.waitTill !== undefined) {

--- a/packages/editor-ui/src/event-bus/code-node-editor.ts
+++ b/packages/editor-ui/src/event-bus/code-node-editor.ts
@@ -1,3 +1,13 @@
 import { createEventBus } from 'n8n-design-system/utils';
 
-export const codeNodeEditorEventBus = createEventBus();
+export type ErrorLineNumberEvent = number | 'final';
+
+export interface CodeNodeEditorEventBusEvents {
+	/** Event that a diff have been applied to the code node editor */
+	codeDiffApplied: never;
+
+	/** Command to highlight a specific line in the code node editor */
+	'error-line-number': ErrorLineNumberEvent;
+}
+
+export const codeNodeEditorEventBus = createEventBus<CodeNodeEditorEventBusEvents>();

--- a/packages/editor-ui/src/event-bus/code-node-editor.ts
+++ b/packages/editor-ui/src/event-bus/code-node-editor.ts
@@ -1,13 +1,13 @@
 import { createEventBus } from 'n8n-design-system/utils';
 
-export type ErrorLineNumberEvent = number | 'final';
+export type HighlightLineEvent = number | 'final';
 
 export interface CodeNodeEditorEventBusEvents {
 	/** Event that a diff have been applied to the code node editor */
 	codeDiffApplied: never;
 
 	/** Command to highlight a specific line in the code node editor */
-	'error-line-number': ErrorLineNumberEvent;
+	highlightLine: HighlightLineEvent;
 }
 
 export const codeNodeEditorEventBus = createEventBus<CodeNodeEditorEventBusEvents>();


### PR DESCRIPTION
## Summary

Add types to codeNodeEditorEventBus

## Related Linear tickets, Github issues, and Community forum posts

[CAT-32](https://linear.app/n8n/issue/CAT-32/type-event-bus-usages-in-editor)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
