### PR TITLE
fix(core): Scheduler tasks should not trigger on follower instances

### DIFF
--- a/packages/core/src/ScheduledTaskManager.ts
+++ b/packages/core/src/ScheduledTaskManager.ts
@@ -1,13 +1,24 @@
 import { Service } from 'typedi';
 import { CronJob } from 'cron';
 import type { CronExpression, Workflow } from 'n8n-workflow';
+import { InstanceSettings } from './InstanceSettings';
 
 @Service()
 export class ScheduledTaskManager {
+	constructor(private readonly instanceSettings: InstanceSettings) {}
+
 	readonly cronJobs = new Map<string, CronJob[]>();
 
 	registerCron(workflow: Workflow, cronExpression: CronExpression, onTick: () => void) {
-		const cronJob = new CronJob(cronExpression, onTick, undefined, true, workflow.timezone);
+		const cronJob = new CronJob(
+			cronExpression,
+			() => {
+				if (this.instanceSettings.isLeader) onTick();
+			},
+			undefined,
+			true,
+			workflow.timezone,
+		);
 		const cronJobsForWorkflow = this.cronJobs.get(workflow.id);
 		if (cronJobsForWorkflow) {
 			cronJobsForWorkflow.push(cronJob);

--- a/packages/core/test/ScheduledTaskManager.test.ts
+++ b/packages/core/test/ScheduledTaskManager.test.ts
@@ -1,9 +1,11 @@
 import type { Workflow } from 'n8n-workflow';
 import { mock } from 'jest-mock-extended';
 
+import type { InstanceSettings } from '@/InstanceSettings';
 import { ScheduledTaskManager } from '@/ScheduledTaskManager';
 
 describe('ScheduledTaskManager', () => {
+	const instanceSettings = mock<InstanceSettings>({ isLeader: true });
 	const workflow = mock<Workflow>({ timezone: 'GMT' });
 	const everyMinute = '0 * * * * *';
 	const onTick = jest.fn();
@@ -13,7 +15,7 @@ describe('ScheduledTaskManager', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
-		scheduledTaskManager = new ScheduledTaskManager();
+		scheduledTaskManager = new ScheduledTaskManager(instanceSettings);
 	});
 
 	it('should throw when workflow timezone is invalid', () => {
@@ -39,6 +41,15 @@ describe('ScheduledTaskManager', () => {
 		expect(onTick).not.toHaveBeenCalled();
 		jest.advanceTimersByTime(10 * 60 * 1000); // 10 minutes
 		expect(onTick).toHaveBeenCalledTimes(10);
+	});
+
+	it('should should not invoke on follower instances', async () => {
+		scheduledTaskManager = new ScheduledTaskManager(mock<InstanceSettings>({ isLeader: false }));
+		scheduledTaskManager.registerCron(workflow, everyMinute, onTick);
+
+		expect(onTick).not.toHaveBeenCalled();
+		jest.advanceTimersByTime(10 * 60 * 1000); // 10 minutes
+		expect(onTick).not.toHaveBeenCalled();
 	});
 
 	it('should deregister CronJobs for a workflow', async () => {

--- a/packages/nodes-base/nodes/Schedule/tests/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/tests/ScheduleTrigger.node.test.ts
@@ -1,6 +1,6 @@
 import * as n8nWorkflow from 'n8n-workflow';
 import type { INode, ITriggerFunctions, Workflow } from 'n8n-workflow';
-import { returnJsonArray } from 'n8n-core';
+import { type InstanceSettings, returnJsonArray } from 'n8n-core';
 import { ScheduledTaskManager } from 'n8n-core/dist/ScheduledTaskManager';
 import { mock } from 'jest-mock-extended';
 import { ScheduleTrigger } from '../ScheduleTrigger.node';
@@ -18,7 +18,8 @@ describe('ScheduleTrigger', () => {
 
 	const node = mock<INode>({ typeVersion: 1 });
 	const workflow = mock<Workflow>({ timezone });
-	const scheduledTaskManager = new ScheduledTaskManager();
+	const instanceSettings = mock<InstanceSettings>({ isLeader: true });
+	const scheduledTaskManager = new ScheduledTaskManager(instanceSettings);
 	const helpers = mock<ITriggerFunctions['helpers']>({
 		returnJsonArray,
 		registerCron: (cronExpression, onTick) =>


### PR DESCRIPTION
## Summary
When n8n is running in multi-main mode, it's possible for a short while for multiple main instances to have active timers for scheduled tasks (until the leadership handover finishes). During this time if a scheduled task is invoked on a non-leader instance, it should simply be ignored.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1607

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [x] PR Labeled with `release/backport`