### PR TITLE
feat(editor): Set default canvas version to version 2 on internal deployment (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeViewSwitcher.vue
+++ b/packages/editor-ui/src/views/NodeViewSwitcher.vue
@@ -10,9 +10,11 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { useCanvasOperations } from '@/composables/useCanvasOperations';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
+import { useSettingsStore } from '@/stores/settings.store';
 
 const workflowsStore = useWorkflowsStore();
 const sourceControlStore = useSourceControlStore();
+const settingsStore = useSettingsStore();
 
 const router = useRouter();
 const route = useRoute();
@@ -20,7 +22,10 @@ const workflowHelpers = useWorkflowHelpers({ router });
 
 const { resetWorkspace } = useCanvasOperations({ router });
 
-const nodeViewVersion = useLocalStorage('NodeView.version', '1');
+const nodeViewVersion = useLocalStorage(
+	'NodeView.version',
+	settingsStore.deploymentType === 'n8n-internal' ? '2' : '1',
+);
 
 const workflowId = computed<string>(() => route.params.name as string);
 


### PR DESCRIPTION
## Summary

N/A

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7593/make-the-new-canvas-the-default-version-on-internal

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
