### PR TITLE
fix(AI Transform Node): Data Transformation > Other section should not contain node (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/Node/NodeCreator/composables/useViewStacks.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/composables/useViewStacks.ts
@@ -36,8 +36,14 @@ import { useI18n } from '@/composables/useI18n';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
-import type { INodeInputFilter, NodeConnectionType, Themed } from 'n8n-workflow';
+import {
+	AI_TRANSFORM_NODE_TYPE,
+	type INodeInputFilter,
+	type NodeConnectionType,
+	type Themed,
+} from 'n8n-workflow';
 import { useCanvasStore } from '@/stores/canvas.store';
+import { usePostHog } from '../../../../stores/posthog.store';
 
 interface ViewStack {
 	uuid?: string;
@@ -350,7 +356,14 @@ export const useViewStacks = defineStore('nodeCreatorViewStacks', () => {
 
 		if (!stack?.items) {
 			const subcategory = stack?.subcategory ?? DEFAULT_SUBCATEGORY;
-			const itemsInSubcategory = itemsBySubcategory.value[subcategory];
+			let itemsInSubcategory = itemsBySubcategory.value[subcategory];
+
+			const aiEnabled = usePostHog().isAiEnabled();
+			if (!aiEnabled) {
+				itemsInSubcategory = itemsInSubcategory.filter(
+					(item) => item.key !== AI_TRANSFORM_NODE_TYPE,
+				);
+			}
 			const sections = stack.sections;
 
 			if (sections) {

--- a/packages/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -64,7 +64,6 @@ import { NodeConnectionType } from 'n8n-workflow';
 import { useTemplatesStore } from '@/stores/templates.store';
 import type { BaseTextKey } from '@/plugins/i18n';
 import { camelCase } from 'lodash-es';
-import { usePostHog } from '@/stores/posthog.store';
 
 export interface NodeViewItemSection {
 	key: string;
@@ -431,12 +430,12 @@ export function TriggerView() {
 export function RegularView(nodes: SimplifiedNodeType[]) {
 	const i18n = useI18n();
 
-	const popularItemsSubcategory = [SET_NODE_TYPE, CODE_NODE_TYPE, DATETIME_NODE_TYPE];
-	const aiEnabled = usePostHog().isAiEnabled();
-
-	if (aiEnabled) {
-		popularItemsSubcategory.push(AI_TRANSFORM_NODE_TYPE);
-	}
+	const popularItemsSubcategory = [
+		SET_NODE_TYPE,
+		CODE_NODE_TYPE,
+		DATETIME_NODE_TYPE,
+		AI_TRANSFORM_NODE_TYPE,
+	];
 
 	const view: NodeView = {
 		value: REGULAR_NODE_CREATOR_VIEW,


### PR DESCRIPTION
## Summary

The AI Transform node is currently available on self-hosted in the nodes panel in Data Transformation > Other section but shouldn't as it is works only on cloud

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1616/ai-transform-node-hide-it-from-self-hosted
