### PR TITLE
fix(core): Restore Redis cache key

### DIFF
--- a/packages/@n8n/config/src/configs/cache.config.ts
+++ b/packages/@n8n/config/src/configs/cache.config.ts
@@ -15,7 +15,7 @@ class MemoryConfig {
 class RedisConfig {
 	/** Prefix for cache keys in Redis. */
 	@Env('N8N_CACHE_REDIS_KEY_PREFIX')
-	prefix: string = 'redis';
+	prefix: string = 'cache';
 
 	/** Time to live (in milliseconds) for data cached in Redis. 0 for no TTL. */
 	@Env('N8N_CACHE_REDIS_TTL')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -181,7 +181,7 @@ describe('GlobalConfig', () => {
 				ttl: 3600000,
 			},
 			redis: {
-				prefix: 'redis',
+				prefix: 'cache',
 				ttl: 3600000,
 			},
 		},


### PR DESCRIPTION
Accidentally changed here: https://github.com/n8n-io/n8n/pull/10286#discussion_r1727361288