### PR TITLE
ci: Use correct env for benchmark nightly workflow (no-changelog)

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: benchmark
+    environment: benchmarking
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Fix the env name
