### PR TITLE
ci: Ignore certain paths for e2e tests for PRs (no-changelog)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,19 +4,49 @@ on:
   workflow_dispatch:
   pull_request_review:
     types: [submitted]
-    branches:
-      - 'master'
-    paths:
-      - packages/design-system/**
-      - .github/workflows/chromatic.yml
 
 concurrency:
   group: chromatic-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  get-metadata:
+    name: Get Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
+      - name: Determine changed files
+        uses: tomi/paths-filter-action@v3.0.2
+        id: changed
+        if: github.event_name == 'pull_request_review'
+        with:
+          filters: |
+            design_system:
+              - packages/design-system/**
+              - .github/workflows/chromatic.yml
+
+    outputs:
+      design_system_files_changed: ${{ steps.changed.outputs.design_system == 'true' }}
+      is_community_pr: ${{ contains(github.event.pull_request.labels.*.name, 'community') }}
+      is_pr_target_master: ${{ github.event.pull_request.base.ref == 'master' }}
+      is_dispatch: ${{ github.event_name == 'workflow_dispatch' }}
+      is_pr_approved: ${{ github.event.review.state == 'approved' }}
+
   chromatic:
-    if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'community') }}
+    needs: [get-metadata]
+    if: |
+      needs.get-metadata.outputs.is_dispatch == 'true' ||
+      (
+       needs.get-metadata.outputs.design_system_files_changed == 'true' &&
+       needs.get-metadata.outputs.is_community_pr == 'false' &&
+       needs.get-metadata.outputs.is_pr_target_master == 'true' &&
+       needs.get-metadata.outputs.is_pr_approved == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -10,8 +10,6 @@ on:
       - .github/workflows/ci-postgres-mysql.yml
   pull_request_review:
     types: [submitted]
-    branches:
-      - 'release/*'
 
 concurrency:
   group: db-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +19,7 @@ jobs:
   build:
     name: Install & Build
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_review' || startsWith(github.event.pull_request.base.ref, 'release/')
     steps:
       - uses: actions/checkout@v4.1.1
       - run: corepack enable

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -3,19 +3,51 @@ name: PR E2E
 on:
   pull_request_review:
     types: [submitted]
-    branches:
-      - 'master'
-      - 'release/*'
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  get-metadata:
+    name: Get Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
+      - name: Determine changed files
+        uses: tomi/paths-filter-action@v3.0.2
+        id: changed
+        with:
+          filters: |
+            not_ignored:
+              - '!.devcontainer/**'
+              - '!.github/*'
+              - '!.github/scripts/*'
+              - '!.github/workflows/benchmark-*'
+              - '!.github/workflows/check-*'
+              - '!.vscode/**'
+              - '!docker/**'
+              - '!packages/@n8n/benchmark/**'
+              - '!**/*.md'
+          predicate-quantifier: 'every'
+
+    outputs:
+      # The workflow should run when:
+      # - It has changes to files that are not ignored
+      # - It is not a community PR
+      # - It is targeting master or a release branch
+      should_run: ${{ steps.changed.outputs.not_ignored == 'true' && !contains(github.event.pull_request.labels.*.name, 'community') && (github.event.pull_request.base.ref == 'master' || startsWith(github.event.pull_request.base.ref, 'release/')) }}
+
   run-e2e-tests:
     name: E2E [Electron/Node 18]
     uses: ./.github/workflows/e2e-reusable.yml
-    if: ${{ github.event.review.state == 'approved' && !contains(github.event.pull_request.labels.*.name, 'community') }}
+    needs: [get-metadata]
+    if: ${{ github.event.review.state == 'approved' && needs.get-metadata.outputs.should_run == 'true' }}
     with:
       pr_number: ${{ github.event.pull_request.number }}
       user: ${{ github.event.pull_request.user.login || 'PR User' }}
@@ -25,11 +57,11 @@ jobs:
   post-e2e-tests:
     runs-on: ubuntu-latest
     name: E2E [Electron/Node 18] - Checks
-    needs: [run-e2e-tests]
+    needs: [get-metadata, run-e2e-tests]
     if: always()
     steps:
       - name: E2E success comment
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'community') && needs.run-e2e-tests.outputs.tests_passed == 'true' }}
+        if: ${{ needs.get-metadata.outputs.should_run == 'true' && needs.run-e2e-tests.outputs.tests_passed == 'true' }}
         uses: peter-evans/create-or-update-comment@v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

It's annoying to have to wait for ~10mins to merge a PR that has no changes to the actual n8n application code itself. This PR ignores certain paths so that e2e tests are not unnecessarily ran for these.

 GH actions pull_request_review event does not filtering based on branch or paths.
    This PR uses [paths-filter](https://github.com/dorny/paths-filter) action (or a fork of it to be precise)
    to check if the chromatic or e2e-tests-pr workflows should run. Using a fork since the action
    is missing an input from its yaml definition, but that feature has already been implemented.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
