### PR TITLE
fix(Google Sheets Trigger Node): Show sheet name is too long error

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
@@ -561,6 +561,12 @@ export class GoogleSheetsTrigger implements INodeType {
 			}
 
 			if (event === 'anyUpdate' || event === 'rowUpdate') {
+				if (sheetName.length > 31) {
+					throw new NodeOperationError(
+						this.getNode(),
+						'Sheet name is too long choose a name with 31 characters or less',
+					);
+				}
 				const sheetRange = `${sheetName}!${range}`;
 
 				let dataStartIndex = startIndex - 1;


### PR DESCRIPTION
## Summary
The Google sheet trigger for row updates and any updates uses XLSX which limits the sheet name length to 31 chars, causing the workflow to error out strangely. This PR shows an error message telling the user to change the sheet name.

for a long term solution we need to consider an alternative for  XLSX that is better suited for Google Sheets

## Related Linear tickets, Github issues, and Community forum posts
 https://linear.app/n8n/issue/NODE-966/google-sheets-trigger-fails-if-sheet-name-is-too-long
 Github Issue https://github.com/n8n-io/n8n/issues/7854 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
