### PR TITLE
ci: Use correct env in destroy benchmark env job (no-changelog)

### DIFF
--- a/.github/workflows/benchmark-destroy-nightly.yml
+++ b/.github/workflows/benchmark-destroy-nightly.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: benchmark
+    environment: benchmarking
 
     steps:
       - name: Checkout


### PR DESCRIPTION

## Summary

Similar to #10529

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
