### PR TITLE
feat: Add benchmarking of pooled sqlite (no-changelog)

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Run the benchmark with debug logging
         if: github.event.inputs.debug == 'true'
-        run: pnpm run-in-cloud sqlite --debug
+        run: pnpm run-in-cloud --debug
         working-directory: packages/@n8n/benchmark
 
       - name: Run the benchmark
         if: github.event.inputs.debug != 'true'
-        run: pnpm run-in-cloud sqlite
+        run: pnpm run-in-cloud
         working-directory: packages/@n8n/benchmark

--- a/packages/@n8n/benchmark/scripts/runOnVm/bootstrap.sh
+++ b/packages/@n8n/benchmark/scripts/runOnVm/bootstrap.sh
@@ -10,8 +10,8 @@ CURRENT_USER=$(whoami)
 # Mount the data disk
 if [ -d "/n8n" ]; then
 	echo "Data disk already mounted. Clearing it..."
-	rm -rf /n8n/*
-	rm -rf /n8n/.[!.]*
+	sudo rm -rf /n8n/*
+	sudo rm -rf /n8n/.[!.]*
 else
 	sudo mkdir -p /n8n
 	sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%

--- a/packages/@n8n/benchmark/scripts/runOnVm/n8nSetups/sqlite-legacy/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/runOnVm/n8nSetups/sqlite-legacy/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n
-      - DB_SQLITE_POOL_SIZE=3
-      - DB_SQLITE_ENABLE_WAL=true
     ports:
       - 5678:5678
     volumes:

--- a/packages/@n8n/benchmark/scripts/runOnVm/runOnVm.mjs
+++ b/packages/@n8n/benchmark/scripts/runOnVm/runOnVm.mjs
@@ -2,23 +2,19 @@
 /**
  * This script runs the benchmarks using a given docker compose setup
  */
+// @ts-check
+import path from 'path';
+import { $, argv, fs } from 'zx';
 
-import { $ } from 'zx';
-
-const [n8nSetupToUse] = argv._;
-
-if (!n8nSetupToUse) {
-	printUsage();
-	process.exit(1);
-}
-
-function printUsage() {
-	console.log('Usage: zx runOnVm.mjs <envName>');
-	console.log('   eg: zx runOnVm.mjs sqlite');
-}
+const paths = {
+	n8nSetupsDir: path.join(__dirname, 'n8nSetups'),
+};
 
 async function main() {
-	const composeFilePath = path.join(__dirname, 'n8nSetups', n8nSetupToUse);
+	const [n8nSetupToUse] = argv._;
+	validateN8nSetup(n8nSetupToUse);
+
+	const composeFilePath = path.join(paths.n8nSetupsDir, n8nSetupToUse);
 	const n8nTag = argv.n8nDockerTag || process.env.N8N_DOCKER_TAG || 'latest';
 	const benchmarkTag = argv.benchmarkDockerTag || process.env.BENCHMARK_DOCKER_TAG || 'latest';
 	const k6ApiToken = argv.k6ApiToken || process.env.K6_API_TOKEN || undefined;
@@ -30,6 +26,7 @@ async function main() {
 			N8N_VERSION: n8nTag,
 			BENCHMARK_VERSION: benchmarkTag,
 			K6_API_TOKEN: k6ApiToken,
+			N8N_BENCHMARK_SCENARIO_NAME_PREFIX: n8nSetupToUse,
 		},
 	});
 
@@ -50,6 +47,30 @@ async function main() {
 async function dumpN8nInstanceLogs($$) {
 	console.error('n8n instance logs:');
 	await $$`docker-compose logs n8n`;
+}
+
+function printUsage() {
+	const availableSetups = getAllN8nSetups();
+	console.log('Usage: zx runOnVm.mjs <n8n setup to use>');
+	console.log(`   eg: zx runOnVm.mjs ${availableSetups[0]}`);
+	console.log('');
+	console.log('Available setups:');
+	console.log(availableSetups.join(', '));
+}
+
+/**
+ * @returns {string[]}
+ */
+function getAllN8nSetups() {
+	return fs.readdirSync(paths.n8nSetupsDir);
+}
+
+function validateN8nSetup(givenSetup) {
+	const availableSetups = getAllN8nSetups();
+	if (!availableSetups.includes(givenSetup)) {
+		printUsage();
+		process.exit(1);
+	}
 }
 
 main();

--- a/packages/@n8n/benchmark/src/commands/run.ts
+++ b/packages/@n8n/benchmark/src/commands/run.ts
@@ -34,6 +34,7 @@ export default class RunCommand extends Command {
 				email: config.get('n8n.user.email'),
 				password: config.get('n8n.user.password'),
 			},
+			config.get('scenarioNamePrefix'),
 		);
 
 		const allScenarios = scenarioLoader.loadAll(config.get('testScenariosPath'));

--- a/packages/@n8n/benchmark/src/config/config.ts
+++ b/packages/@n8n/benchmark/src/config/config.ts
@@ -31,6 +31,12 @@ const configSchema = {
 			},
 		},
 	},
+	scenarioNamePrefix: {
+		doc: 'Prefix for the scenario name',
+		format: String,
+		default: 'Unnamed',
+		env: 'N8N_BENCHMARK_SCENARIO_NAME_PREFIX',
+	},
 	k6: {
 		executablePath: {
 			doc: 'The path to the k6 binary',

--- a/packages/@n8n/benchmark/src/testExecution/scenarioRunner.ts
+++ b/packages/@n8n/benchmark/src/testExecution/scenarioRunner.ts
@@ -17,6 +17,7 @@ export class ScenarioRunner {
 			email: string;
 			password: string;
 		},
+		private readonly scenarioPrefix: string,
 	) {}
 
 	async runManyScenarios(scenarios: Scenario[]) {
@@ -38,13 +39,25 @@ export class ScenarioRunner {
 	}
 
 	private async runSingleTestScenario(testDataImporter: ScenarioDataImporter, scenario: Scenario) {
-		console.log('Running scenario:', scenario.name);
+		const scenarioRunName = this.formTestScenarioRunName(scenario);
+		console.log('Running scenario:', scenarioRunName);
 
 		console.log('Loading and importing data');
 		const testData = await this.dataLoader.loadDataForScenario(scenario);
 		await testDataImporter.importTestScenarioData(testData.workflows);
 
 		console.log('Executing scenario script');
-		await this.k6Executor.executeTestScenario(scenario);
+		await this.k6Executor.executeTestScenario(scenario, {
+			scenarioRunName,
+		});
+	}
+
+	/**
+	 * Forms a name for the scenario by combining prefix and scenario name.
+	 * The benchmarks are ran against different n8n setups, so we use the
+	 * prefix to differentiate between them.
+	 */
+	private formTestScenarioRunName(scenario: Scenario) {
+		return `${this.scenarioPrefix}-${scenario.name}`;
 	}
 }


### PR DESCRIPTION
## Summary

Adds benchmarks for pooled sqlite.

The non-pooled sqlite was renamed to `sqlite-legacy` and the pooled one goes with the name `sqlite`.

Also adds a "run name" for scenario runs to distinguish benchmarks with different n8n setups from each other in Grafana Cloud.

## Related Linear tickets, Github issues, and Community forum posts

[CAT-66](https://linear.app/n8n/issue/CAT-66/add-pooled-sqlite-n8n-setup)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
