### PR TITLE
fix(core): Stop explicit redis client disconnect on shutdown

### DIFF
--- a/packages/cli/src/services/redis/redis-client.service.ts
+++ b/packages/cli/src/services/redis/redis-client.service.ts
@@ -2,11 +2,9 @@ import { Service } from 'typedi';
 import { Logger } from '@/logger';
 import ioRedis from 'ioredis';
 import type { Cluster, RedisOptions } from 'ioredis';
-import type { RedisClientType } from './redis.types';
-
-import { OnShutdown } from '@/decorators/on-shutdown';
-import { LOWEST_SHUTDOWN_PRIORITY } from '@/constants';
 import { GlobalConfig } from '@n8n/config';
+
+import type { RedisClientType } from './redis.types';
 
 @Service()
 export class RedisClientService {
@@ -26,13 +24,6 @@ export class RedisClientService {
 		this.clients.add(client);
 
 		return client;
-	}
-
-	@OnShutdown(LOWEST_SHUTDOWN_PRIORITY)
-	disconnectClients() {
-		for (const client of this.clients) {
-			client.disconnect();
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
We are temporarily removing this code, until we can refactor all shutdown sequences to start using `@OnShutdown`, to prevent any code (being called from `stopProcess`) from trying to use a terminated redis connection. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1843

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] PR Labeled with `release/backport`