### PR TITLE
fix(editor): Scale output item selector input width with value

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/OutputItemSelect.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/OutputItemSelect.vue
@@ -10,7 +10,9 @@ const hoveringItem = computed(() => ndvStore.getHoveringItem);
 const hoveringItemIndex = computed(() => hoveringItem.value?.itemIndex);
 const isHoveringItem = computed(() => Boolean(hoveringItem.value));
 const itemsLength = computed(() => ndvStore.ndvInputDataWithPinnedData.length);
-const itemIndex = computed(() => hoveringItemIndex.value ?? ndvStore.expressionOutputItemIndex);
+const itemIndex = computed(
+	() => hoveringItemIndex.value ?? ndvStore.expressionOutputItemIndex ?? 0,
+);
 const max = computed(() => Math.max(itemsLength.value - 1, 0));
 const isItemIndexEditable = computed(() => !isHoveringItem.value && itemsLength.value > 0);
 const hideTableHoverHint = computed(() => ndvStore.isTableHoverOnboarded);
@@ -18,6 +20,8 @@ const canSelectPrevItem = computed(() => isItemIndexEditable.value && itemIndex.
 const canSelectNextItem = computed(
 	() => isItemIndexEditable.value && itemIndex.value < itemsLength.value - 1,
 );
+
+const inputCharWidth = computed(() => itemIndex.value.toString().length);
 
 function updateItemIndex(index: number) {
 	ndvStore.expressionOutputItemIndex = index;
@@ -47,6 +51,7 @@ function prevItem() {
 				:min="0"
 				:max="max"
 				:model-value="itemIndex"
+				:style="{ '--input-width': `calc(${inputCharWidth}ch + var(--spacing-s))` }"
 				@update:model-value="updateItemIndex"
 			></N8nInputNumber>
 			<N8nIconButton
@@ -89,14 +94,12 @@ function prevItem() {
 	align-items: center;
 }
 
-.input {
+.controls .input {
 	--input-height: 22px;
-	--input-width: 26px;
 	--input-border-top-left-radius: var(--border-radius-base);
 	--input-border-bottom-left-radius: var(--border-radius-base);
 	--input-border-top-right-radius: var(--border-radius-base);
 	--input-border-bottom-right-radius: var(--border-radius-base);
-	max-width: var(--input-width);
 	line-height: calc(var(--input-height) - var(--spacing-4xs));
 
 	&.hovering {
@@ -109,6 +112,7 @@ function prevItem() {
 		line-height: var(--input-height);
 		text-align: center;
 		padding: 0 var(--spacing-4xs);
+		max-width: var(--input-width);
 	}
 }
 </style>


### PR DESCRIPTION
## Summary

<img width="163" alt="image" src="https://github.com/user-attachments/assets/63d7c2e7-c185-4076-a12d-16bf36c3c761">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1590/expression-popunder-make-item-input-wider

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
