### PR TITLE
fix(MongoDB Node): Fix checks on projection feature call

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -210,7 +210,11 @@ export class MongoDb implements INodeType {
 						query = query.sort(sort);
 					}
 
-					if (projection && projection instanceof Document) {
+					if (
+						projection &&
+						Object.keys(projection).length !== 0 &&
+						projection.constructor === Object
+					) {
 						query = query.project(projection);
 					}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When we setup a projection, n8n throws an error "missing Document instance".
For some reason, this file is unable to retrieve the instance from the bson package, and I can't figure out how (or if ?) I had to
introduce this direct dependency.

I've updated the checks on the projection using the same naive tests that for the Sort cursor option.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.  => not needed
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
   => probably needed but I don't know how we can setup the tests
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
