### PR TITLE
ci: Fix destroy benchmark env workflow (no-changelog)

### DIFF
--- a/.github/workflows/benchmark-destroy-nightly.yml
+++ b/.github/workflows/benchmark-destroy-nightly.yml
@@ -2,7 +2,7 @@ name: Destroy Benchmark Env
 
 on:
   schedule:
-    - cron: '30 4 * * *'
+    - cron: '0 1 * * *'
   workflow_dispatch:
 
 permissions:
@@ -25,16 +25,15 @@ jobs:
           tenant-id: ${{ secrets.BENCHMARK_ARM_TENANT_ID }}
           subscription-id: ${{ secrets.BENCHMARK_ARM_SUBSCRIPTION_ID }}
 
-      - run: Setup node
+      - run: corepack enable
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20.x
-          cache: pnpm
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Destroy cloud env
-        if: github.event.inputs.debug == 'true'
         run: pnpm destroy-cloud-env
         working-directory: packages/@n8n/benchmark


### PR DESCRIPTION

## Summary

Fix the workflow and run it at 01:00 before the nightly benchmark is run. That's because there's a limit how many reserved hosts we can provision at a time.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
