### PR TITLE
fix: Fix scenario prefix not being passed (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/scripts/runOnVm/runOnVm.mjs
+++ b/packages/@n8n/benchmark/scripts/runOnVm/runOnVm.mjs
@@ -26,14 +26,13 @@ async function main() {
 			N8N_VERSION: n8nTag,
 			BENCHMARK_VERSION: benchmarkTag,
 			K6_API_TOKEN: k6ApiToken,
-			N8N_BENCHMARK_SCENARIO_NAME_PREFIX: n8nSetupToUse,
 		},
 	});
 
 	try {
 		await $$`docker-compose up -d n8n`;
 
-		await $$`docker-compose run benchmark run`;
+		await $$`docker-compose run benchmark run --scenarioNamePrefix=${n8nSetupToUse} `;
 	} catch (error) {
 		console.error('An error occurred while running the benchmarks:');
 		console.error(error);

--- a/packages/@n8n/benchmark/src/commands/run.ts
+++ b/packages/@n8n/benchmark/src/commands/run.ts
@@ -16,10 +16,14 @@ export default class RunCommand extends Command {
 			description: 'Comma-separated list of test scenarios to run',
 			required: false,
 		}),
+		scenarioNamePrefix: Flags.string({
+			description: 'Prefix for the scenario name. Defaults to Unnamed',
+			required: false,
+		}),
 	};
 
 	async run() {
-		const config = loadConfig();
+		const config = await this.loadConfigAndMergeWithFlags();
 		const scenarioLoader = new ScenarioLoader();
 
 		const scenarioRunner = new ScenarioRunner(
@@ -40,5 +44,16 @@ export default class RunCommand extends Command {
 		const allScenarios = scenarioLoader.loadAll(config.get('testScenariosPath'));
 
 		await scenarioRunner.runManyScenarios(allScenarios);
+	}
+
+	private async loadConfigAndMergeWithFlags() {
+		const config = loadConfig();
+		const { flags } = await this.parse(RunCommand);
+
+		if (flags.scenarioNamePrefix) {
+			config.set('scenarioNamePrefix', flags.scenarioNamePrefix);
+		}
+
+		return config;
 	}
 }


### PR DESCRIPTION
## Summary

Prefix is used to distinguish different n8n setups from each others. The name prefix was not passed correctly to the test runner.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
