### PR TITLE
fix(Gmail Trigger Node): Don't return date instances, but date strings instead

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -202,6 +202,11 @@ export async function parseRawEmail(
 		headers,
 		headerLines: undefined,
 		attachments: undefined,
+		// Having data in IDataObjects that is not representable in JSON leads to
+		// inconsistencies between test executions and production executions.
+		// During a manual execution this would be stringified and during a
+		// production execution the next node would receive a date instance.
+		date: responseData.date ? responseData.date.toISOString() : responseData.date,
 	}) as IDataObject;
 
 	return {

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -1,6 +1,7 @@
-import type { INode } from 'n8n-workflow';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { DateTime } from 'luxon';
-import { prepareTimestamp } from '../../GenericFunctions';
+import { mock } from 'jest-mock-extended';
+import { parseRawEmail, prepareTimestamp } from '../../GenericFunctions';
 
 const node: INode = {
 	id: '1',
@@ -106,5 +107,23 @@ describe('Google Gmail v2, prepareTimestamp', () => {
 		expect(() => prepareTimestamp(node, 0, '', dateInput, 'after')).toThrow(
 			"Invalid date/time in 'Received After' field",
 		);
+	});
+});
+
+describe('parseRawEmail', () => {
+	it('should return a date string', async () => {
+		// ARRANGE
+		const executionFunctions = mock<IExecuteFunctions>();
+		const rawEmail = 'Date: Wed, 28 Aug 2024 00:36:37 -0700'.replace(/\n/g, '\r\n');
+
+		// ACT
+		const { json } = await parseRawEmail.call(
+			executionFunctions,
+			{ raw: Buffer.from(rawEmail, 'utf8').toString('base64') },
+			'attachment_',
+		);
+
+		// ASSERT
+		expect(typeof json.date).toBe('string');
 	});
 });


### PR DESCRIPTION
## Summary

The Gmail Trigger node uses a library to parse emails and that library parses the date header into an instance of Date. Data Objects don't support complex types, e.g. classes, they only support basic data types, like numbers and strings.

Returning a complex data type led to weird behaviour down the line in the workflow. E.g. passing the date instance through a set node would stringify it multiple times and you'd end up with a date string with double quotes.

This PR turns the date instance into a ISO date string before passing it along to other nodes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1810/date-string-contains-double-quotes-at-the-start-and-the-end-when

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
