### PR TITLE
ci: Run nightly benchmark against nightly n8n image (no-changelog)

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -1,5 +1,5 @@
 name: Run Nightly Benchmark
-run-name: Benchmark ${{ inputs.n8n_tag }}
+run-name: Benchmark ${{ inputs.n8n_tag || 'nightly' }}
 
 on:
   schedule:
@@ -60,10 +60,10 @@ jobs:
 
       - name: Run the benchmark with debug logging
         if: github.event.inputs.debug == 'true'
-        run: pnpm run-in-cloud --debug
+        run: pnpm run-in-cloud  --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }} --debug
         working-directory: packages/@n8n/benchmark
 
       - name: Run the benchmark
         if: github.event.inputs.debug != 'true'
-        run: pnpm run-in-cloud
+        run: pnpm run-in-cloud  --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }}
         working-directory: packages/@n8n/benchmark


### PR DESCRIPTION

## Summary

Run nightly benchmark against nightly n8n image

Depends on #10580

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
