### PR TITLE
fix(editor): Hide execution buttons in readonly mode in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -96,6 +96,7 @@ import { createEventBus } from 'n8n-design-system';
 import type { PinDataSource } from '@/composables/usePinnedData';
 import { useClipboard } from '@/composables/useClipboard';
 import { useBeforeUnload } from '@/composables/useBeforeUnload';
+import { getResourcePermissions } from '@/permissions';
 
 const LazyNodeCreation = defineAsyncComponent(
 	async () => await import('@/components/Node/NodeCreation.vue'),
@@ -203,7 +204,11 @@ const isReadOnlyEnvironment = computed(() => {
 });
 
 const isCanvasReadOnly = computed(() => {
-	return isDemoRoute.value || isReadOnlyEnvironment.value;
+	return (
+		isDemoRoute.value ||
+		isReadOnlyEnvironment.value ||
+		!(workflowPermissions.value.update ?? projectPermissions.value.workflow.update)
+	);
 });
 
 const fallbackNodes = computed<INodeUi[]>(() =>
@@ -882,6 +887,21 @@ function onClickConnectionAdd(connection: Connection) {
 }
 
 /**
+ * Permissions
+ */
+
+const workflowPermissions = computed(() => {
+	return getResourcePermissions(workflowsStore.getWorkflowById(workflowId.value)?.scopes).workflow;
+});
+
+const projectPermissions = computed(() => {
+	const project = route.query?.projectId
+		? projectsStore.myProjects.find((p) => p.id === route.query.projectId)
+		: projectsStore.currentProject ?? projectsStore.personalProject;
+	return getResourcePermissions(project?.scopes);
+});
+
+/**
  * Executions
  */
 
@@ -1511,7 +1531,7 @@ onDeactivated(() => {
 		@create:workflow="onCreateWorkflow"
 		@viewport-change="onViewportChange"
 	>
-		<div :class="$style.executionButtons">
+		<div v-if="!isCanvasReadOnly" :class="$style.executionButtons">
 			<CanvasRunWorkflowButton
 				:waiting-for-webhook="isExecutionWaitingForWebhook"
 				:disabled="isExecutionDisabled"


### PR DESCRIPTION
## Summary

Execution buttons were showing on readonly modes such as executions and demo.

<img width="1626" alt="image" src="https://github.com/user-attachments/assets/44c3e4bf-312c-4e81-accc-68be1e6419aa">
<img width="1625" alt="image" src="https://github.com/user-attachments/assets/ab9f81bc-06f6-4d0f-9acc-6a2f80772112">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7625/hide-execution-buttons-in-readonly-mode

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
