### PR TITLE
feat: Add n8n postgres setup to benchmarks (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    environment:
+      - POSTGRES_DB=n8n
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+  n8n:
+    image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
+    environment:
+      - N8N_DIAGNOSTICS_ENABLED=false
+      - N8N_USER_FOLDER=/n8n
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PASSWORD=password
+    ports:
+      - 5678:5678
+    volumes:
+      - ${RUN_DIR}:/n8n
+    depends_on:
+      - postgres
+  benchmark:
+    image: ghcr.io/n8n-io/n8n-benchmark:${N8N_BENCHMARK_VERSION:-latest}
+    depends_on:
+      - n8n
+    environment:
+      - N8N_BASE_URL=http://n8n:5678
+      - K6_API_TOKEN=${K6_API_TOKEN}

--- a/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
+++ b/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
@@ -45,7 +45,7 @@ async function main() {
 	});
 
 	try {
-		await dockerComposeClient.$('up', '-d', 'n8n');
+		await dockerComposeClient.$('up', '-d', '--remove-orphans', 'n8n');
 
 		await dockerComposeClient.$('run', 'benchmark', 'run', `--scenarioNamePrefix=${n8nSetupToUse}`);
 	} catch (error) {

--- a/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
+++ b/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
@@ -19,14 +19,17 @@ async function main() {
 	const n8nTag = argv.n8nDockerTag || process.env.N8N_DOCKER_TAG || 'latest';
 	const benchmarkTag = argv.benchmarkDockerTag || process.env.BENCHMARK_DOCKER_TAG || 'latest';
 	const k6ApiToken = argv.k6ApiToken || process.env.K6_API_TOKEN || undefined;
-	const runDir = argv.runDir || process.env.RUN_DIR || '/n8n';
+	const baseRunDir = argv.runDir || process.env.RUN_DIR || '/n8n';
 
-	if (!fs.existsSync(runDir)) {
+	if (!fs.existsSync(baseRunDir)) {
 		console.error(
-			`The run directory "${runDir}" does not exist. Please specify a valid directory using --runDir`,
+			`The run directory "${baseRunDir}" does not exist. Please specify a valid directory using --runDir`,
 		);
 		process.exit(1);
 	}
+
+	const runDir = path.join(baseRunDir, n8nSetupToUse);
+	fs.emptyDirSync(runDir);
 
 	const dockerComposeClient = new DockerComposeClient({
 		$: $({


### PR DESCRIPTION
## Summary

Built on top of #10589

Add benchmarks for n8n with Postgres

## Related Linear tickets, Github issues, and Community forum posts

[CAT-68](https://linear.app/n8n/issue/CAT-68/add-n8n-postgres-setup)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
