### PR TITLE
fix(editor): Add pinned data only to manual executions in execution view

### DIFF
--- a/cypress/fixtures/Execution-pinned-data-check.json
+++ b/cypress/fixtures/Execution-pinned-data-check.json
@@ -1,0 +1,133 @@
+{
+  "name": "PAY-1707",
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "eaa428a8-eb9d-478a-b997-aed6ed298507",
+      "name": "Edit Fields",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        920,
+        380
+      ]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "6b285c91-e7ea-4943-8ba3-59ce01a35d20",
+      "name": "Edit Fields1",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        920,
+        540
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return Array.from({length: 5}, _ => ({}))"
+      },
+      "id": "70e682aa-dfef-4db7-a158-971ec7976d49",
+      "name": "Code",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        700,
+        380
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "return Array.from({length: 5}, _ => ({}))"
+      },
+      "id": "d5ee979e-9f53-4e62-8eb2-cdb92be8ea6e",
+      "name": "Code1",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        700,
+        540
+      ]
+    },
+    {
+      "parameters": {
+        "path": "dd660366-ca4a-4736-8b1f-454560e87bfb",
+        "options": {}
+      },
+      "id": "20c33c8a-ab2f-4dd4-990f-6390feeb840c",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        480,
+        440
+      ],
+      "webhookId": "dd660366-ca4a-4736-8b1f-454560e87bfb"
+    }
+  ],
+  "pinData": {
+    "Code1": [
+      {
+        "json": {}
+      },
+      {
+        "json": {}
+      }
+    ]
+  },
+  "connections": {
+    "Code1": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Code": {
+      "main": [
+        [
+          {
+            "node": "Edit Fields",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Code",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Code1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": true,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "01e6693e-54f3-432d-9b1f-922ef92b4ab6",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "8a47b83b4479b11330fdf21ccc96d4a8117035a968612e452b4c87bfd09c16c7"
+  },
+  "id": "hU0gp19G29ehWktc",
+  "tags": []
+}

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -998,7 +998,7 @@ export default defineComponent({
 			});
 			this.workflowsStore.setWorkflowId(PLACEHOLDER_EMPTY_WORKFLOW_ID);
 			this.workflowsStore.setWorkflowExecutionData(data);
-			if (data.workflowData.pinData) {
+			if (data.workflowData.pinData && data.mode === 'manual') {
 				this.workflowsStore.setWorkflowPinData(data.workflowData.pinData);
 			}
 


### PR DESCRIPTION
## Summary

Node pinned data is overwriting execution output data in the executions view.
Pinned data should be shown only in the execution view when the workflow is manually executed.

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1707](https://linear.app/n8n/issue/PAY-1707/execution-view-shows-pinned-data-as-output-data)

Download and import the following workflow to test the fix
[Execution-pinned-data-check.json](https://github.com/user-attachments/files/16813095/Execution-pinned-data-check.json)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included.
- [ ] PR Labeled with `release/backport`
