### PR TITLE
fix: Reduce variability in benchmarks (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/infra/modules/benchmark-vm/vars.tf
+++ b/packages/@n8n/benchmark/infra/modules/benchmark-vm/vars.tf
@@ -21,8 +21,8 @@ variable "ssh_public_key" {
 
 variable "vm_size" {
   description = "VM Size"
-  # 4 vCPUs, 16 GiB memory
-  default = "Standard_DC4s_v2"
+  # 8 vCPUs, 32 GiB memory
+  default = "Standard_DC8_v2"
 }
 
 variable "tags" {

--- a/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
+++ b/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
@@ -45,7 +45,7 @@ export function handleSummary(data) {
 		const augmentedTestScriptPath = this.augmentSummaryScript(scenario, scenarioRunName);
 		const runDirPath = path.dirname(augmentedTestScriptPath);
 
-		const flags: K6CliFlag[] = [['--quiet'], ['--duration', '1m'], ['--vus', '5']];
+		const flags: K6CliFlag[] = [['--quiet'], ['--duration', '3m'], ['--vus', '5']];
 
 		if (this.opts.k6ApiToken) {
 			flags.push(['--out', 'cloud']);


### PR DESCRIPTION
## Summary

- feat: Increase default benchmark run duration from 1 min to 3 mins
- feat: Double the benchmark VM size

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
