### PR TITLE
fix(HTTP Request Node): Sanitize authorization headers

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -88,7 +88,14 @@ export function sanitizeUiMessage(
 			),
 		};
 	}
-
+	//redact headers with Base64 encoded credentials
+	const headers = sendRequest.headers as IDataObject;
+	if (headers) {
+		const headerKey = Object.keys(headers).find((key) => key.toLowerCase() === 'authorization');
+		if (headerKey) {
+			headers[headerKey] = REDACTED;
+		}
+	}
 	if (secrets && secrets.length > 0) {
 		return redact(sendRequest, secrets);
 	}

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -88,7 +88,6 @@ export function sanitizeUiMessage(
 			),
 		};
 	}
-	//redact headers with Base64 encoded credentials
 	const headers = sendRequest.headers as IDataObject;
 	if (headers) {
 		const headerKey = Object.keys(headers).find((key) => key.toLowerCase() === 'authorization');

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -88,11 +88,22 @@ export function sanitizeUiMessage(
 			),
 		};
 	}
+	const HEADER_BLOCKLIST = new Set([
+		'authorization',
+		'x-api-key',
+		'x-auth-token',
+		'cookie',
+		'proxy-authorization',
+		'sslclientcert',
+	]);
+
 	const headers = sendRequest.headers as IDataObject;
+
 	if (headers) {
-		const headerKey = Object.keys(headers).find((key) => key.toLowerCase() === 'authorization');
-		if (headerKey) {
-			headers[headerKey] = REDACTED;
+		for (const headerName of Object.keys(headers)) {
+			if (HEADER_BLOCKLIST.has(headerName.toLowerCase())) {
+				headers[headerName] = REDACTED;
+			}
 		}
 	}
 	if (secrets && secrets.length > 0) {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -136,5 +136,41 @@ describe('HTTP Node Utils', () => {
 				uri: 'https://example.com',
 			});
 		});
+		it('should redact the Authorization header', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				body: { sessionToken: 'secret', other: 'foo' },
+				headers: { authorization: 'Bearer some-sensitive-token', other: 'foo' },
+				auth: { user: 'user', password: 'secret' },
+			};
+			const authDataKeys = {};
+			const sanitizedRequest = sanitizeUiMessage(requestOptions, authDataKeys);
+
+			expect(sanitizedRequest.headers).toEqual({ authorization: REDACTED, other: 'foo' });
+		});
+
+		it('should leave headers unchanged if Authorization header is not present', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				body: { sessionToken: 'secret', other: 'foo' },
+				headers: { other: 'foo' },
+				auth: { user: 'user', password: 'secret' },
+			};
+			const authDataKeys = {};
+			const sanitizedRequest = sanitizeUiMessage(requestOptions, authDataKeys);
+
+			expect(sanitizedRequest.headers).toEqual({ other: 'foo' });
+		});
+
+		it('should handle case when headers are undefined', () => {
+			const requestOptions: IRequestOptions = {};
+
+			const authDataKeys = {};
+			const sanitizedRequest = sanitizeUiMessage(requestOptions, authDataKeys);
+
+			expect(sanitizedRequest.headers).toBeUndefined();
+		});
 	});
 });

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -150,6 +150,20 @@ describe('HTTP Node Utils', () => {
 			expect(sanitizedRequest.headers).toEqual({ authorization: REDACTED, other: 'foo' });
 		});
 
+		it('should redact the Authorization header when the key starts with an uppercase letter', () => {
+			const requestOptions: IRequestOptions = {
+				method: 'POST',
+				uri: 'https://example.com',
+				body: { sessionToken: 'secret', other: 'foo' },
+				headers: { Authorization: 'Basic another-sensitive-token', other: 'foo' },
+				auth: { user: 'user', password: 'secret' },
+			};
+			const authDataKeys = {};
+			const sanitizedRequest = sanitizeUiMessage(requestOptions, authDataKeys);
+
+			expect(sanitizedRequest.headers).toEqual({ Authorization: REDACTED, other: 'foo' });
+		});
+
 		it('should leave headers unchanged if Authorization header is not present', () => {
 			const requestOptions: IRequestOptions = {
 				method: 'POST',


### PR DESCRIPTION
## Summary
The following Credentials use Base64 encoded headers and therefore were missed from the sanitisation

- Customer IO
- Lemlist API
- Segment API
- UProc API

This PR sanitise the headers based on seeing any of these keys ['authorization', 'x-api-key', 'x-auth-token', 'cookie', 'proxy-authorization', 'sslclientcert'] regardless if the credentials were encoded or not

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1661/obfuscate-cred-info-in-http-node-error-messages-regression

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
