### PR TITLE
fix: Fix edge case in log in (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/src/n8nApiClient/n8nApiClient.ts
+++ b/packages/@n8n/benchmark/src/n8nApiClient/n8nApiClient.ts
@@ -75,11 +75,11 @@ export class N8nApiClient {
 		}
 	}
 
-	protected getRestEndpointUrl(endpoint: string) {
-		return `${this.apiBaseUrl}/rest${endpoint}`;
+	async delay(ms: number): Promise<void> {
+		return await new Promise((resolve) => setTimeout(resolve, ms));
 	}
 
-	private async delay(ms: number): Promise<void> {
-		return await new Promise((resolve) => setTimeout(resolve, ms));
+	protected getRestEndpointUrl(endpoint: string) {
+		return `${this.apiBaseUrl}/rest${endpoint}`;
 	}
 }


### PR DESCRIPTION
## Summary

Apparently n8n can respond with 200 OK to a login request but with a body containing the string 'n8n is starting up. Please wait' during startup. This adds retry in the case where the n8n instance is still starting up.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
