### PR TITLE
ci: Omit benchmark scope commits from changelog (no-changelog)

### DIFF
--- a/.github/scripts/update-changelog.mjs
+++ b/.github/scripts/update-changelog.mjs
@@ -16,7 +16,11 @@ const changelogStream = conventionalChangelog({
 	releaseCount: 1,
 	tagPrefix: 'n8n@',
 	transform: (commit, callback) => {
-		callback(null, commit.header.includes('(no-changelog)') ? undefined : commit);
+		const hasNoChangelogInHeader = commit.header.includes('(no-changelog)');
+		const isBenchmarkScope = commit.scope === 'benchmark';
+
+		// Ignore commits that have 'benchmark' scope or '(no-changelog)' in the header
+		callback(null, hasNoChangelogInHeader || isBenchmarkScope ? undefined : commit);
 	},
 }).on('error', (err) => {
 	console.error(err.stack);


### PR DESCRIPTION

## Summary

Commits with scope 'benchmark' are for the benchmark suite. They shouldn't end up in the n8n app changelog.

Related PR:

https://github.com/n8n-io/validate-n8n-pull-request-title/pull/7

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
