### PR TITLE
ci: Fix script name in gh workflow

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Run the benchmark with debug logging
         if: github.event.inputs.debug == 'true'
-        run: pnpm run-in-cloud  --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }} --debug
+        run: pnpm benchmark-in-cloud --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }} --debug
         working-directory: packages/@n8n/benchmark
 
       - name: Run the benchmark
         if: github.event.inputs.debug != 'true'
-        run: pnpm run-in-cloud  --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }}
+        run: pnpm benchmark-in-cloud --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }}
         working-directory: packages/@n8n/benchmark

--- a/packages/@n8n/benchmark/README.md
+++ b/packages/@n8n/benchmark/README.md
@@ -19,13 +19,13 @@ The benchmark suite consists of [benchmark scenarios](#benchmark-scenarios) and 
 ### locally
 
 ```sh
-pnpm run-locally
+pnpm benchmark-locally
 ```
 
 ### In the cloud
 
 ```sh
-pnpm run-in-cloud
+pnpm benchmark-in-cloud
 ```
 
 ## Running the `n8n-benchmark` cli


### PR DESCRIPTION
## Summary

The name of the script was renamed in #10589, but wasn't changed in the GH workflow or in the readme

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
