### PR TITLE
ci: Fix nightly image not being pushed to ghcr

### DIFF
--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -32,6 +32,9 @@ on:
         required: false
         default: ''
 
+env:
+  N8N_TAG: ${{ inputs.tag || 'nightly' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -76,10 +79,10 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ github.event.inputs.tag || 'nightly' }}
+          tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ env.N8N_TAG }}
 
       - name: Login to GitHub Container Registry
-        if: github.event.inputs.tag == 'nightly'
+        if: env.N8N_TAG == 'nightly'
         uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
@@ -87,7 +90,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image to GHCR
-        if: github.event.inputs.tag == 'nightly'
+        if: env.N8N_TAG == 'nightly'
         run: |
           docker buildx imagetools create \
             --tag ghcr.io/${{ github.repository_owner }}/n8n:nightly \


### PR DESCRIPTION
## Summary

Pushing of nightly images to ghcr was added in #10580. However, when the workflow runs on a cron schedule, it does not have inputs. Hence the checks were failing. This fixes it so that the default value is used in the if conditions.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
