### PR TITLE
test(editor): Increase test coverage for users settings page and modal

### DIFF
--- a/packages/editor-ui/src/__tests__/utils.ts
+++ b/packages/editor-ui/src/__tests__/utils.ts
@@ -4,6 +4,9 @@ import type { ISettingsState } from '@/Interface';
 import { UserManagementAuthenticationMethod } from '@/Interface';
 import { defaultSettings } from './defaults';
 import { APP_MODALS_ELEMENT_ID } from '@/constants';
+import type { Mock } from 'vitest';
+import type { Store, StoreDefinition } from 'pinia';
+import type { ComputedRef } from 'vue';
 
 /**
  * Retries the given assertion until it passes or the timeout is reached
@@ -107,4 +110,29 @@ export const createAppModals = () => {
 
 export const cleanupAppModals = () => {
 	document.body.innerHTML = '';
+};
+
+/**
+ * Typescript helper for mocking pinia store actions return value
+ *
+ * @see https://pinia.vuejs.org/cookbook/testing.html#Mocking-the-returned-value-of-an-action
+ */
+export const mockedStore = <TStoreDef extends () => unknown>(
+	useStore: TStoreDef,
+): TStoreDef extends StoreDefinition<infer Id, infer State, infer Getters, infer Actions>
+	? Store<
+			Id,
+			State,
+			Record<string, never>,
+			{
+				[K in keyof Actions]: Actions[K] extends (...args: infer Args) => infer ReturnT
+					? Mock<Args, ReturnT>
+					: Actions[K];
+			}
+		> & {
+			[K in keyof Getters]: Getters[K] extends ComputedRef<infer T> ? T : never;
+		}
+	: ReturnType<TStoreDef> => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return useStore() as any;
 };

--- a/packages/editor-ui/src/components/DeleteUserModal.test.ts
+++ b/packages/editor-ui/src/components/DeleteUserModal.test.ts
@@ -57,9 +57,11 @@ const global = {
 	},
 };
 
+const renderModal = createComponentRenderer(DeleteUserModal);
+
 describe('DeleteUserModal', () => {
 	it('should delete invited users', async () => {
-		const { getByTestId } = createComponentRenderer(DeleteUserModal)({
+		const { getByTestId } = renderModal({
 			props: {
 				activeId: invitedUser.id,
 			},
@@ -77,7 +79,7 @@ describe('DeleteUserModal', () => {
 	});
 
 	it('should delete user and transfer workflows and credentials', async () => {
-		const { getByTestId, getAllByRole } = createComponentRenderer(DeleteUserModal)({
+		const { getByTestId, getAllByRole } = renderModal({
 			props: {
 				activeId: user.id,
 			},
@@ -110,7 +112,7 @@ describe('DeleteUserModal', () => {
 	});
 
 	it('should delete user without transfer', async () => {
-		const { getByTestId, getAllByRole, getByRole } = createComponentRenderer(DeleteUserModal)({
+		const { getByTestId, getAllByRole, getByRole } = renderModal({
 			props: {
 				activeId: user.id,
 			},

--- a/packages/editor-ui/src/components/DeleteUserModal.test.ts
+++ b/packages/editor-ui/src/components/DeleteUserModal.test.ts
@@ -1,0 +1,143 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import DeleteUserModal from './DeleteUserModal.vue';
+import { createTestingPinia } from '@pinia/testing';
+import { getDropdownItems } from '@/__tests__/utils';
+import { createProjectListItem } from '@/__tests__/data/projects';
+import { createUser } from '@/__tests__/data/users';
+
+import { DELETE_USER_MODAL_KEY } from '@/constants';
+import { ProjectTypes } from '@/types/projects.types';
+import userEvent from '@testing-library/user-event';
+import { useUsersStore } from '@/stores/users.store';
+
+const ModalStub = {
+	template: `
+		<div>
+			<slot name="header" />
+			<slot name="title" />
+			<slot name="content" />
+			<slot name="footer" />
+		</div>
+	`,
+};
+
+const loggedInUser = createUser();
+const invitedUser = createUser({ firstName: undefined });
+const user = createUser();
+
+const initialState = {
+	ui: {
+		modalsById: {
+			[DELETE_USER_MODAL_KEY]: {
+				open: true,
+			},
+		},
+		modalStack: [DELETE_USER_MODAL_KEY],
+	},
+	projects: {
+		projects: [
+			ProjectTypes.Personal,
+			ProjectTypes.Personal,
+			ProjectTypes.Team,
+			ProjectTypes.Team,
+		].map(createProjectListItem),
+	},
+	users: {
+		usersById: {
+			[loggedInUser.id]: loggedInUser,
+			[user.id]: user,
+			[invitedUser.id]: invitedUser,
+		},
+	},
+};
+
+const global = {
+	stubs: {
+		Modal: ModalStub,
+	},
+};
+
+describe('DeleteUserModal', () => {
+	it('should delete invited users', async () => {
+		const { getByTestId } = createComponentRenderer(DeleteUserModal)({
+			props: {
+				activeId: invitedUser.id,
+			},
+			global,
+			pinia: createTestingPinia({
+				initialState,
+			}),
+		});
+
+		const userStore = useUsersStore();
+
+		await userEvent.click(getByTestId('confirm-delete-user-button'));
+
+		expect(userStore.deleteUser).toHaveBeenCalledWith({ id: invitedUser.id });
+	});
+
+	it('should transfer workflows and credentials when deleting user', async () => {
+		const { getByTestId, getAllByRole } = createComponentRenderer(DeleteUserModal)({
+			props: {
+				activeId: user.id,
+			},
+			global,
+			pinia: createTestingPinia({
+				initialState,
+			}),
+		});
+
+		const confirmButton = getByTestId('confirm-delete-user-button');
+		expect(confirmButton).toBeDisabled();
+
+		await userEvent.click(getAllByRole('radio')[0]);
+
+		const projectSelect = getByTestId('project-sharing-select');
+		expect(projectSelect).toBeVisible();
+
+		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
+		await userEvent.click(projectSelectDropdownItems[0]);
+
+		const userStore = useUsersStore();
+
+		expect(confirmButton).toBeEnabled();
+		await userEvent.click(confirmButton);
+
+		expect(userStore.deleteUser).toHaveBeenCalledWith({
+			id: user.id,
+			transferId: expect.any(String),
+		});
+	});
+
+	it('should transfer workflows and credentials when deleting user', async () => {
+		const { getByTestId, getAllByRole, getByRole } = createComponentRenderer(DeleteUserModal)({
+			props: {
+				activeId: user.id,
+			},
+			global,
+			pinia: createTestingPinia({
+				initialState,
+			}),
+		});
+
+		const userStore = useUsersStore();
+
+		const confirmButton = getByTestId('confirm-delete-user-button');
+		expect(confirmButton).toBeDisabled();
+
+		await userEvent.click(getAllByRole('radio')[1]);
+
+		const input = getByRole('textbox');
+
+		await userEvent.type(input, 'delete all ');
+		expect(confirmButton).toBeDisabled();
+
+		await userEvent.type(input, 'data');
+		expect(confirmButton).toBeEnabled();
+
+		await userEvent.click(confirmButton);
+		expect(userStore.deleteUser).toHaveBeenCalledWith({
+			id: user.id,
+		});
+	});
+});

--- a/packages/editor-ui/src/components/DeleteUserModal.test.ts
+++ b/packages/editor-ui/src/components/DeleteUserModal.test.ts
@@ -9,6 +9,7 @@ import { DELETE_USER_MODAL_KEY } from '@/constants';
 import { ProjectTypes } from '@/types/projects.types';
 import userEvent from '@testing-library/user-event';
 import { useUsersStore } from '@/stores/users.store';
+import { STORES } from '@/constants';
 
 const ModalStub = {
 	template: `
@@ -26,7 +27,7 @@ const invitedUser = createUser({ firstName: undefined });
 const user = createUser();
 
 const initialState = {
-	ui: {
+	[STORES.UI]: {
 		modalsById: {
 			[DELETE_USER_MODAL_KEY]: {
 				open: true,
@@ -34,7 +35,7 @@ const initialState = {
 		},
 		modalStack: [DELETE_USER_MODAL_KEY],
 	},
-	projects: {
+	[STORES.PROJECTS]: {
 		projects: [
 			ProjectTypes.Personal,
 			ProjectTypes.Personal,
@@ -42,7 +43,7 @@ const initialState = {
 			ProjectTypes.Team,
 		].map(createProjectListItem),
 	},
-	users: {
+	[STORES.USERS]: {
 		usersById: {
 			[loggedInUser.id]: loggedInUser,
 			[user.id]: user,
@@ -58,17 +59,20 @@ const global = {
 };
 
 const renderModal = createComponentRenderer(DeleteUserModal);
+let pinia: ReturnType<typeof createTestingPinia>;
 
 describe('DeleteUserModal', () => {
+	beforeEach(() => {
+		pinia = createTestingPinia({ initialState });
+	});
+
 	it('should delete invited users', async () => {
 		const { getByTestId } = renderModal({
 			props: {
 				activeId: invitedUser.id,
 			},
 			global,
-			pinia: createTestingPinia({
-				initialState,
-			}),
+			pinia,
 		});
 
 		const userStore = useUsersStore();
@@ -84,9 +88,7 @@ describe('DeleteUserModal', () => {
 				activeId: user.id,
 			},
 			global,
-			pinia: createTestingPinia({
-				initialState,
-			}),
+			pinia,
 		});
 
 		const confirmButton = getByTestId('confirm-delete-user-button');
@@ -117,9 +119,7 @@ describe('DeleteUserModal', () => {
 				activeId: user.id,
 			},
 			global,
-			pinia: createTestingPinia({
-				initialState,
-			}),
+			pinia,
 		});
 
 		const userStore = useUsersStore();

--- a/packages/editor-ui/src/components/DeleteUserModal.test.ts
+++ b/packages/editor-ui/src/components/DeleteUserModal.test.ts
@@ -76,7 +76,7 @@ describe('DeleteUserModal', () => {
 		expect(userStore.deleteUser).toHaveBeenCalledWith({ id: invitedUser.id });
 	});
 
-	it('should transfer workflows and credentials when deleting user', async () => {
+	it('should delete user and transfer workflows and credentials', async () => {
 		const { getByTestId, getAllByRole } = createComponentRenderer(DeleteUserModal)({
 			props: {
 				activeId: user.id,
@@ -109,7 +109,7 @@ describe('DeleteUserModal', () => {
 		});
 	});
 
-	it('should transfer workflows and credentials when deleting user', async () => {
+	it('should delete user without transfer', async () => {
 		const { getByTestId, getAllByRole, getByRole } = createComponentRenderer(DeleteUserModal)({
 			props: {
 				activeId: user.id,

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -639,6 +639,7 @@ export const enum STORES {
 	PUSH = 'push',
 	ASSISTANT = 'assistant',
 	BECOME_TEMPLATE_CREATOR = 'becomeTemplateCreator',
+	PROJECTS = 'projects',
 }
 
 export const enum SignInType {

--- a/packages/editor-ui/src/stores/projects.store.ts
+++ b/packages/editor-ui/src/stores/projects.store.ts
@@ -18,8 +18,9 @@ import { hasPermission } from '@/utils/rbac/permissions';
 import type { IWorkflowDb } from '@/Interface';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useCredentialsStore } from '@/stores/credentials.store';
+import { STORES } from '@/constants';
 
-export const useProjectsStore = defineStore('projects', () => {
+export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 	const route = useRoute();
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();

--- a/packages/editor-ui/src/views/SettingsUsersView.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsersView.test.ts
@@ -11,6 +11,7 @@ import { createTestingPinia, type TestingOptions } from '@pinia/testing';
 import { merge } from 'lodash-es';
 import { useUIStore } from '@/stores/ui.store';
 import { useSSOStore } from '@/stores/sso.store';
+import { STORES } from '@/constants';
 
 const loggedInUser = createUser();
 const invitedUser = createUser({
@@ -24,7 +25,7 @@ const userWithDisabledSSO = createUser({
 });
 
 const initialState = {
-	users: {
+	[STORES.USERS]: {
 		currentUserId: loggedInUser.id,
 		usersById: {
 			[loggedInUser.id]: loggedInUser,
@@ -33,7 +34,7 @@ const initialState = {
 			[userWithDisabledSSO.id]: userWithDisabledSSO,
 		},
 	},
-	settings: { settings: { enterprise: { advancedPermissions: true } } },
+	[STORES.SETTINGS]: { settings: { enterprise: { advancedPermissions: true } } },
 };
 
 const getInitialState = (state: TestingOptions['initialState'] = {}) =>
@@ -138,7 +139,7 @@ describe('SettingsUsersView', () => {
 	it('shows warning when advanced permissions are not enabled', async () => {
 		const pinia = createTestingPinia({
 			initialState: getInitialState({
-				settings: { settings: { enterprise: { advancedPermissions: false } } },
+				[STORES.SETTINGS]: { settings: { enterprise: { advancedPermissions: false } } },
 			}),
 		});
 

--- a/packages/editor-ui/src/views/SettingsUsersView.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsersView.test.ts
@@ -1,25 +1,69 @@
 import { within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import { createPinia, setActivePinia } from 'pinia';
 import { createComponentRenderer } from '@/__tests__/render';
-import { cleanupAppModals, createAppModals, getDropdownItems } from '@/__tests__/utils';
-import ModalRoot from '@/components/ModalRoot.vue';
-import DeleteUserModal from '@/components/DeleteUserModal.vue';
+import { getDropdownItems, mockedStore } from '@/__tests__/utils';
 import SettingsUsersView from '@/views/SettingsUsersView.vue';
-import { useProjectsStore } from '@/stores/projects.store';
 import { useUsersStore } from '@/stores/users.store';
 import { createUser } from '@/__tests__/data/users';
-import { createProjectListItem } from '@/__tests__/data/projects';
 import { useRBACStore } from '@/stores/rbac.store';
-import { DELETE_USER_MODAL_KEY, EnterpriseEditionFeature } from '@/constants';
-import * as usersApi from '@/api/users';
 import { useSettingsStore } from '@/stores/settings.store';
-import { defaultSettings } from '@/__tests__/defaults';
-import { ProjectTypes } from '@/types/projects.types';
+import { createTestingPinia, type TestingOptions } from '@pinia/testing';
+import { merge } from 'lodash-es';
+import { useUIStore } from '@/stores/ui.store';
+import { useSSOStore } from '@/stores/sso.store';
+
+const loggedInUser = createUser();
+const invitedUser = createUser({
+	firstName: undefined,
+	inviteAcceptUrl: 'dummy',
+	role: 'global:admin',
+});
+const user = createUser();
+const userWithDisabledSSO = createUser({
+	settings: { allowSSOManualLogin: true },
+});
+
+const initialState = {
+	users: {
+		currentUserId: loggedInUser.id,
+		usersById: {
+			[loggedInUser.id]: loggedInUser,
+			[invitedUser.id]: invitedUser,
+			[user.id]: user,
+			[userWithDisabledSSO.id]: userWithDisabledSSO,
+		},
+	},
+	settings: { settings: { enterprise: { advancedPermissions: true } } },
+};
+
+const getInitialState = (state: TestingOptions['initialState'] = {}) =>
+	merge({}, initialState, state);
+
+const copy = vi.fn();
+vi.mock('@/composables/useClipboard', () => ({
+	useClipboard: () => ({
+		copy,
+	}),
+}));
+
+const renderView = createComponentRenderer(SettingsUsersView);
+
+const triggerUserAction = async (userListItem: HTMLElement, action: string) => {
+	expect(userListItem).toBeInTheDocument();
+
+	const actionToggle = within(userListItem).getByTestId('action-toggle');
+	const actionToggleButton = within(actionToggle).getByRole('button');
+	expect(actionToggleButton).toBeVisible();
+
+	await userEvent.click(actionToggle);
+	const actionToggleId = actionToggleButton.getAttribute('aria-controls');
+
+	const actionDropdown = document.getElementById(actionToggleId as string) as HTMLElement;
+	await userEvent.click(within(actionDropdown).getByTestId(`action-${action}`));
+};
 
 const showToast = vi.fn();
 const showError = vi.fn();
-
 vi.mock('@/composables/useToast', () => ({
 	useToast: () => ({
 		showToast,
@@ -27,157 +71,205 @@ vi.mock('@/composables/useToast', () => ({
 	}),
 }));
 
-const wrapperComponentWithModal = {
-	components: { SettingsUsersView, ModalRoot, DeleteUserModal },
-	template: `
-		<div>
-		<SettingsUsersView />
-		<ModalRoot name="${DELETE_USER_MODAL_KEY}">
-			<template #default="{ modalName, activeId }">
-				<DeleteUserModal :modal-name="modalName" :active-id="activeId" />
-			</template>
-		</ModalRoot>
-		</div>
-	`,
-};
-
-const renderComponent = createComponentRenderer(wrapperComponentWithModal);
-
-const loggedInUser = createUser();
-const users = Array.from({ length: 3 }, createUser);
-const projects = [
-	ProjectTypes.Personal,
-	ProjectTypes.Personal,
-	ProjectTypes.Team,
-	ProjectTypes.Team,
-].map(createProjectListItem);
-
-let pinia: ReturnType<typeof createPinia>;
-let projectsStore: ReturnType<typeof useProjectsStore>;
-let usersStore: ReturnType<typeof useUsersStore>;
-let rbacStore: ReturnType<typeof useRBACStore>;
-
 describe('SettingsUsersView', () => {
-	beforeEach(() => {
-		pinia = createPinia();
-		setActivePinia(pinia);
-		projectsStore = useProjectsStore();
-		usersStore = useUsersStore();
-		rbacStore = useRBACStore();
-
-		createAppModals();
-
-		useSettingsStore().settings.enterprise = {
-			...defaultSettings.enterprise,
-			[EnterpriseEditionFeature.AdvancedExecutionFilters]: true,
-		};
-
-		vi.spyOn(rbacStore, 'hasScope').mockReturnValue(true);
-		vi.spyOn(usersApi, 'getUsers').mockResolvedValue(users);
-		vi.spyOn(usersStore, 'allUsers', 'get').mockReturnValue(users);
-		vi.spyOn(projectsStore, 'getAllProjects').mockImplementation(
-			async () => await Promise.resolve(),
-		);
-		vi.spyOn(projectsStore, 'projects', 'get').mockReturnValue(projects);
-
-		usersStore.currentUserId = loggedInUser.id;
-
+	afterEach(() => {
+		copy.mockReset();
 		showToast.mockReset();
 		showError.mockReset();
 	});
 
-	afterEach(() => {
-		cleanupAppModals();
+	it('hides invite button visibility based on user permissions', async () => {
+		const pinia = createTestingPinia({ initialState: getInitialState() });
+		const userStore = useUsersStore(pinia);
+		// @ts-expect-error: mocked getter
+		userStore.currentUser = createUser({ isDefaultUser: true });
+
+		const { queryByTestId } = renderView({ pinia });
+
+		expect(queryByTestId('settings-users-invite-button')).not.toBeInTheDocument();
 	});
 
-	it('should show confirmation modal before deleting user and delete with transfer', async () => {
-		const deleteUserSpy = vi.spyOn(usersStore, 'deleteUser').mockImplementation(async () => {});
+	describe('Below quota', () => {
+		const pinia = createTestingPinia({ initialState: getInitialState() });
 
-		const { getByTestId } = renderComponent({ pinia });
+		const settingsStore = useSettingsStore(pinia);
+		// @ts-expect-error: mocked getter
+		settingsStore.isBelowUserQuota = false;
 
-		const userListItem = getByTestId(`user-list-item-${users[0].email}`);
-		expect(userListItem).toBeInTheDocument();
+		it('disables the invite button', async () => {
+			const { getByTestId } = renderView({ pinia });
 
-		const actionToggle = within(userListItem).getByTestId('action-toggle');
-		const actionToggleButton = within(actionToggle).getByRole('button');
-		expect(actionToggleButton).toBeVisible();
+			expect(getByTestId('settings-users-invite-button')).toBeDisabled();
+		});
 
-		await userEvent.click(actionToggle);
-		const actionToggleId = actionToggleButton.getAttribute('aria-controls');
+		it('allows the user to upgrade', async () => {
+			const { getByTestId } = renderView({ pinia });
+			const uiStore = useUIStore();
 
-		const actionDropdown = document.getElementById(actionToggleId as string) as HTMLElement;
-		const actionDelete = within(actionDropdown).getByTestId('action-delete');
-		await userEvent.click(actionDelete);
+			const actionBox = getByTestId('action-box');
+			expect(actionBox).toBeInTheDocument();
 
-		const modal = getByTestId('deleteUser-modal');
-		expect(modal).toBeVisible();
-		const confirmButton = within(modal).getByTestId('confirm-delete-user-button');
-		expect(confirmButton).toBeDisabled();
+			await userEvent.click(await within(actionBox).findByText('View plans'));
 
-		await userEvent.click(within(modal).getAllByRole('radio')[0]);
-
-		const projectSelect = getByTestId('project-sharing-select');
-		expect(projectSelect).toBeVisible();
-
-		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
-		await userEvent.click(projectSelectDropdownItems[0]);
-
-		expect(confirmButton).toBeEnabled();
-		await userEvent.click(confirmButton);
-		expect(deleteUserSpy).toHaveBeenCalledWith({
-			id: users[0].id,
-			transferId: expect.any(String),
+			expect(uiStore.goToUpgrade).toHaveBeenCalledWith('settings-users', 'upgrade-users');
 		});
 	});
 
-	it('should show confirmation modal before deleting user and delete without transfer', async () => {
-		const deleteUserSpy = vi.spyOn(usersStore, 'deleteUser').mockImplementation(async () => {});
+	it('disables the invite button on SAML login', async () => {
+		const pinia = createTestingPinia({ initialState: getInitialState() });
+		const ssoStore = useSSOStore(pinia);
+		ssoStore.isSamlLoginEnabled = true;
 
-		const { getByTestId } = renderComponent({ pinia });
+		const { getByTestId } = renderView({ pinia });
 
-		const userListItem = getByTestId(`user-list-item-${users[0].email}`);
-		expect(userListItem).toBeInTheDocument();
+		expect(getByTestId('settings-users-invite-button')).toBeDisabled();
+	});
 
-		const actionToggle = within(userListItem).getByTestId('action-toggle');
-		const actionToggleButton = within(actionToggle).getByRole('button');
-		expect(actionToggleButton).toBeVisible();
+	it('shows the invite modal', async () => {
+		const pinia = createTestingPinia({ initialState: getInitialState() });
+		const { getByTestId } = renderView({ pinia });
 
-		await userEvent.click(actionToggle);
-		const actionToggleId = actionToggleButton.getAttribute('aria-controls');
+		const uiStore = useUIStore();
+		await userEvent.click(getByTestId('settings-users-invite-button'));
 
-		const actionDropdown = document.getElementById(actionToggleId as string) as HTMLElement;
-		const actionDelete = within(actionDropdown).getByTestId('action-delete');
-		await userEvent.click(actionDelete);
+		expect(uiStore.openModal).toHaveBeenCalledWith('inviteUser');
+	});
 
-		const modal = getByTestId('deleteUser-modal');
-		expect(modal).toBeVisible();
-		const confirmButton = within(modal).getByTestId('confirm-delete-user-button');
-		expect(confirmButton).toBeDisabled();
+	it('shows warning when advanced permissions are not enabled', async () => {
+		const pinia = createTestingPinia({
+			initialState: getInitialState({
+				settings: { settings: { enterprise: { advancedPermissions: false } } },
+			}),
+		});
 
-		await userEvent.click(within(modal).getAllByRole('radio')[1]);
+		const { getByText } = renderView({ pinia });
 
-		const input = within(modal).getByRole('textbox');
+		expect(getByText('to unlock the ability to create additional admin users'));
+	});
 
-		await userEvent.type(input, 'delete all ');
-		expect(confirmButton).toBeDisabled();
+	describe('per user actions', () => {
+		it('should copy invite link to clipboard', async () => {
+			const action = 'copyInviteLink';
 
-		await userEvent.type(input, 'data');
-		expect(confirmButton).toBeEnabled();
+			const pinia = createTestingPinia({ initialState: getInitialState() });
 
-		await userEvent.click(confirmButton);
-		expect(deleteUserSpy).toHaveBeenCalledWith({
-			id: users[0].id,
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${invitedUser.email}`), action);
+
+			expect(copy).toHaveBeenCalledWith(invitedUser.inviteAcceptUrl);
+			expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('should re invite users', async () => {
+			const action = 'reinvite';
+
+			const pinia = createTestingPinia({ initialState: getInitialState() });
+
+			const settingsStore = useSettingsStore(pinia);
+			// @ts-expect-error: mocked getter
+			settingsStore.isSmtpSetup = true;
+
+			const userStore = useUsersStore();
+
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${invitedUser.email}`), action);
+
+			expect(userStore.reinviteUser).toHaveBeenCalled();
+			expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('should show delete users modal with the right permissions', async () => {
+			const action = 'delete';
+
+			const pinia = createTestingPinia({ initialState: getInitialState() });
+
+			const rbacStore = mockedStore(useRBACStore);
+			rbacStore.hasScope.mockReturnValue(true);
+
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${user.email}`), action);
+
+			const uiStore = useUIStore();
+			expect(uiStore.openDeleteUserModal).toHaveBeenCalledWith(user.id);
+		});
+
+		it('should allow coping reset password link', async () => {
+			const action = 'copyPasswordResetLink';
+
+			const pinia = createTestingPinia({ initialState: getInitialState() });
+
+			const rbacStore = mockedStore(useRBACStore);
+			rbacStore.hasScope.mockReturnValue(true);
+
+			const userStore = mockedStore(useUsersStore);
+			userStore.getUserPasswordResetLink.mockResolvedValue({ link: 'dummy-reset-password' });
+
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${user.email}`), action);
+
+			expect(userStore.getUserPasswordResetLink).toHaveBeenCalledWith(user);
+
+			expect(copy).toHaveBeenCalledWith('dummy-reset-password');
+			expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('should enable SSO manual login', async () => {
+			const action = 'allowSSOManualLogin';
+
+			const pinia = createTestingPinia({ initialState: getInitialState() });
+
+			const settingsStore = useSettingsStore(pinia);
+			// @ts-expect-error: mocked getter
+			settingsStore.isSamlLoginEnabled = true;
+
+			const userStore = useUsersStore();
+
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${user.email}`), action);
+			expect(userStore.updateOtherUserSettings).toHaveBeenCalledWith(user.id, {
+				allowSSOManualLogin: true,
+			});
+			expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('should disable SSO manual login', async () => {
+			const action = 'disallowSSOManualLogin';
+
+			const pinia = createTestingPinia({ initialState: getInitialState() });
+
+			const settingsStore = useSettingsStore(pinia);
+			// @ts-expect-error: mocked getter
+			settingsStore.isSamlLoginEnabled = true;
+
+			const userStore = useUsersStore();
+
+			const { getByTestId } = renderView({ pinia });
+
+			await triggerUserAction(getByTestId(`user-list-item-${userWithDisabledSSO.email}`), action);
+
+			expect(userStore.updateOtherUserSettings).toHaveBeenCalledWith(userWithDisabledSSO.id, {
+				allowSSOManualLogin: false,
+			});
+			expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
 		});
 	});
 
 	it("should show success toast when changing a user's role", async () => {
-		const updateGlobalRoleSpy = vi.spyOn(usersStore, 'updateGlobalRole').mockResolvedValue();
+		const pinia = createTestingPinia({ initialState: getInitialState() });
 
-		const { getByTestId } = createComponentRenderer(SettingsUsersView)({
-			pinia,
-		});
+		const rbacStore = mockedStore(useRBACStore);
+		rbacStore.hasScope.mockReturnValue(true);
 
-		const userListItem = getByTestId(`user-list-item-${users.at(-1)?.email}`);
+		const userStore = useUsersStore();
+
+		const { getByTestId } = renderView({ pinia });
+
+		const userListItem = getByTestId(`user-list-item-${invitedUser.email}`);
 		expect(userListItem).toBeInTheDocument();
 
 		const roleSelect = within(userListItem).getByTestId('user-role-select');
@@ -185,7 +277,7 @@ describe('SettingsUsersView', () => {
 		const roleDropdownItems = await getDropdownItems(roleSelect);
 		await userEvent.click(roleDropdownItems[0]);
 
-		expect(updateGlobalRoleSpy).toHaveBeenCalledWith(
+		expect(userStore.updateGlobalRole).toHaveBeenCalledWith(
 			expect.objectContaining({ newRoleName: 'global:member' }),
 		);
 


### PR DESCRIPTION
## Summary

This were more like and e2e test disguised as an Unit test.

Separated it into two so each one test their own logic.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-1904/increaser-test-coverage-for-users-settings-page

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
