### PR TITLE
ci: Fixes to benchmarks in cloud

### DIFF
--- a/.github/workflows/benchmark-destroy-nightly.yml
+++ b/.github/workflows/benchmark-destroy-nightly.yml
@@ -2,7 +2,7 @@ name: Destroy Benchmark Env
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -58,6 +58,10 @@ jobs:
           tenant-id: ${{ env.ARM_TENANT_ID }}
           subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
+      - name: Destroy any existing environment
+        run: pnpm destroy-cloud-env
+        working-directory: packages/@n8n/benchmark
+
       - name: Run the benchmark with debug logging
         if: github.event.inputs.debug == 'true'
         run: pnpm benchmark-in-cloud --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }} --debug

--- a/packages/@n8n/benchmark/infra/modules/benchmark-vm/vars.tf
+++ b/packages/@n8n/benchmark/infra/modules/benchmark-vm/vars.tf
@@ -21,8 +21,6 @@ variable "ssh_public_key" {
 
 variable "vm_size" {
   description = "VM Size"
-  # 8 vCPUs, 32 GiB memory
-  default = "Standard_DC8_v2"
 }
 
 variable "tags" {

--- a/packages/@n8n/benchmark/infra/vars.tf
+++ b/packages/@n8n/benchmark/infra/vars.tf
@@ -15,8 +15,8 @@ variable "host_size_family" {
 
 variable "vm_size" {
   description = "VM Size"
-  # 2 vCPUs, 8 GiB memory
-  default = "Standard_DC2s_v2"
+  # 8 vCPUs, 32 GiB memory
+  default = "Standard_DC8_v2"
 }
 
 variable "number_of_vms" {

--- a/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
+++ b/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
@@ -30,6 +30,8 @@ async function main() {
 
 	const runDir = path.join(baseRunDir, n8nSetupToUse);
 	fs.emptyDirSync(runDir);
+	// Make sure the n8n container user (node) has write permissions to the run directory
+	await $`chmod 777 ${runDir}`;
 
 	const dockerComposeClient = new DockerComposeClient({
 		$: $({

--- a/packages/@n8n/benchmark/scripts/runInCloud.mjs
+++ b/packages/@n8n/benchmark/scripts/runInCloud.mjs
@@ -122,9 +122,7 @@ async function ensureVmIsReachable(sshClient) {
  * @returns Path where the scripts are located on the VM
  */
 async function transferScriptsToVm(sshClient) {
-	await sshClient.ssh('rm -rf ~/n8n');
-
-	await sshClient.ssh('git clone --depth=1 https://github.com/n8n-io/n8n.git');
+	await sshClient.ssh('rm -rf ~/n8n && git clone --depth=1 https://github.com/n8n-io/n8n.git');
 
 	return '~/n8n/packages/@n8n/benchmark/scripts';
 }


### PR DESCRIPTION
## Summary

- Run destroy benchmark env workflow after nightly benchmark
- Destroy env before running nightly benchmark
- Use correct VM size
- Wait until the data disk becomes available
- Fix n8n container permissions in the docker volume
- Combine two ssh commands into one for less overhead

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
