### PR TITLE
build: Fix `cli` nodemon config

### DIFF
--- a/packages/cli/nodemon.json
+++ b/packages/cli/nodemon.json
@@ -1,6 +1,6 @@
 {
 	"ignore": ["**/*.spec.ts", ".git", "node_modules"],
-	"watch": ["commands", "index.ts", "src"],
+	"watch": ["dist"],
 	"exec": "npm start",
-	"ext": "ts"
+	"ext": "js"
 }


### PR DESCRIPTION

## Summary

We use `nodemon` to watch for changing in files restart the n8n application when the files change. At the moment we are watching the `commands` and `src` directories as well as `index.ts`. However, `npm start` runs against the built files from `dist` directory. That's why it makes more sense to actually watch files in the `dist` directory.

More context:
https://n8nio.slack.com/archives/C03MZF137FV/p1725023150044619


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
