### PR TITLE
fix(core): Flush responses for ai streaming endpoints

### DIFF
--- a/packages/cli/src/controllers/ai-assistant.controller.ts
+++ b/packages/cli/src/controllers/ai-assistant.controller.ts
@@ -1,13 +1,13 @@
 import type { Response } from 'express';
 import type { AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
 import { WritableStream } from 'node:stream/web';
-import { InternalServerError } from 'express-openapi-validator/dist/openapi.validator';
 import { strict as assert } from 'node:assert';
 import { ErrorReporterProxy } from 'n8n-workflow';
 
 import { Post, RestController } from '@/decorators';
-import { AiAssistantService } from '@/services/ai-assistant.service';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { AiAssistantRequest } from '@/requests';
+import { AiAssistantService } from '@/services/ai-assistant.service';
 
 type FlushableResponse = Response & { flush: () => void };
 
@@ -34,7 +34,7 @@ export class AiAssistantController {
 		} catch (e) {
 			assert(e instanceof Error);
 			ErrorReporterProxy.error(e);
-			throw new InternalServerError({ message: `Something went wrong: ${e.message}` });
+			throw new InternalServerError(`Something went wrong: ${e.message}`);
 		}
 	}
 
@@ -47,7 +47,7 @@ export class AiAssistantController {
 		} catch (e) {
 			assert(e instanceof Error);
 			ErrorReporterProxy.error(e);
-			throw new InternalServerError({ message: `Something went wrong: ${e.message}` });
+			throw new InternalServerError(`Something went wrong: ${e.message}`);
 		}
 	}
 }

--- a/packages/cli/src/controllers/ai-assistant.controller.ts
+++ b/packages/cli/src/controllers/ai-assistant.controller.ts
@@ -1,12 +1,13 @@
-import { Post, RestController } from '@/decorators';
-import { AiAssistantService } from '@/services/ai-assistant.service';
-import { AiAssistantRequest } from '@/requests';
 import type { Response } from 'express';
 import type { AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
 import { WritableStream } from 'node:stream/web';
 import { InternalServerError } from 'express-openapi-validator/dist/openapi.validator';
 import { strict as assert } from 'node:assert';
 import { ErrorReporterProxy } from 'n8n-workflow';
+
+import { Post, RestController } from '@/decorators';
+import { AiAssistantService } from '@/services/ai-assistant.service';
+import { AiAssistantRequest } from '@/requests';
 
 type FlushableResponse = Response & { flush: () => void };
 

--- a/packages/cli/src/controllers/ai-assistant.controller.ts
+++ b/packages/cli/src/controllers/ai-assistant.controller.ts
@@ -1,28 +1,42 @@
 import { Post, RestController } from '@/decorators';
 import { AiAssistantService } from '@/services/ai-assistant.service';
 import { AiAssistantRequest } from '@/requests';
-import { Response } from 'express';
+import type { Response } from 'express';
 import type { AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
-import { Readable, promises } from 'node:stream';
+import { Readable, promises, Writable } from 'node:stream';
 import { InternalServerError } from 'express-openapi-validator/dist/openapi.validator';
 import { strict as assert } from 'node:assert';
 import { ErrorReporterProxy } from 'n8n-workflow';
+
+type FlushableResponse = Response & { flush: () => void };
+
+class OutputStream extends Writable {
+	constructor(private readonly res: FlushableResponse) {
+		super();
+		this.once('finish', () => this.res.end());
+		res.header('Content-type', 'application/json-lines').flush();
+	}
+
+	// eslint-disable-next-line id-denylist
+	override _write(chunk: any, encoding: BufferEncoding, cb: (error?: Error | null) => void) {
+		this.res.write(chunk, encoding);
+		this.res.flush();
+		cb();
+	}
+}
 
 @RestController('/ai-assistant')
 export class AiAssistantController {
 	constructor(private readonly aiAssistantService: AiAssistantService) {}
 
 	@Post('/chat', { rateLimit: { limit: 100 } })
-	async chat(req: AiAssistantRequest.Chat, res: Response) {
+	async chat(req: AiAssistantRequest.Chat, res: FlushableResponse) {
 		try {
-			const stream = await this.aiAssistantService.chat(req.body, req.user);
-
-			if (stream.body) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-				await promises.pipeline(Readable.fromWeb(stream.body), res);
+			const aiResponse = await this.aiAssistantService.chat(req.body, req.user);
+			if (aiResponse.body) {
+				await promises.pipeline(Readable.fromWeb(aiResponse.body), new OutputStream(res));
 			}
 		} catch (e) {
-			// todo add sentry reporting
 			assert(e instanceof Error);
 			ErrorReporterProxy.error(e);
 			throw new InternalServerError({ message: `Something went wrong: ${e.message}` });

--- a/packages/cli/src/controllers/ai-assistant.controller.ts
+++ b/packages/cli/src/controllers/ai-assistant.controller.ts
@@ -3,27 +3,12 @@ import { AiAssistantService } from '@/services/ai-assistant.service';
 import { AiAssistantRequest } from '@/requests';
 import type { Response } from 'express';
 import type { AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
-import { Readable, promises, Writable } from 'node:stream';
+import { WritableStream } from 'node:stream/web';
 import { InternalServerError } from 'express-openapi-validator/dist/openapi.validator';
 import { strict as assert } from 'node:assert';
 import { ErrorReporterProxy } from 'n8n-workflow';
 
 type FlushableResponse = Response & { flush: () => void };
-
-class OutputStream extends Writable {
-	constructor(private readonly res: FlushableResponse) {
-		super();
-		this.once('finish', () => this.res.end());
-		res.header('Content-type', 'application/json-lines').flush();
-	}
-
-	// eslint-disable-next-line id-denylist
-	override _write(chunk: any, encoding: BufferEncoding, cb: (error?: Error | null) => void) {
-		this.res.write(chunk, encoding);
-		this.res.flush();
-		cb();
-	}
-}
 
 @RestController('/ai-assistant')
 export class AiAssistantController {
@@ -34,7 +19,16 @@ export class AiAssistantController {
 		try {
 			const aiResponse = await this.aiAssistantService.chat(req.body, req.user);
 			if (aiResponse.body) {
-				await promises.pipeline(Readable.fromWeb(aiResponse.body), new OutputStream(res));
+				res.header('Content-type', 'application/json-lines').flush();
+				await aiResponse.body.pipeTo(
+					new WritableStream({
+						write(chunk) {
+							res.write(chunk);
+							res.flush();
+						},
+					}),
+				);
+				res.end();
 			}
 		} catch (e) {
 			assert(e instanceof Error);


### PR DESCRIPTION
## Summary
When an endpoint in our current setup wants to stream responses, it needs to call `res.flush()` after every chunk is written.

In the long run we should probably move this check into `ControllerRegistry`, and check that if a controller method returns a `ReadableStream`, then we automatically setup streaming. But that requires a bit more refactor that is beyond the scope of this PR.

## Review / Merge checklist

- [x] PR title and summary are descriptive