### PR TITLE
fix(editor): Allow disabling SSO when config request fails

### DIFF
--- a/packages/editor-ui/src/views/SettingsSso.test.ts
+++ b/packages/editor-ui/src/views/SettingsSso.test.ts
@@ -111,7 +111,7 @@ describe('SettingsSso View', () => {
 		const ssoStore = mockedStore(useSSOStore);
 		ssoStore.isEnterpriseSamlEnabled = true;
 
-		const { getByTestId, getByRole } = renderView({ pinia });
+		const { getByTestId } = renderView({ pinia });
 
 		const saveButton = getByTestId('sso-save');
 		expect(saveButton).toBeDisabled();

--- a/packages/editor-ui/src/views/SettingsSso.test.ts
+++ b/packages/editor-ui/src/views/SettingsSso.test.ts
@@ -1,0 +1,180 @@
+import { createTestingPinia } from '@pinia/testing';
+import { createComponentRenderer } from '@/__tests__/render';
+import SettingsSso from './SettingsSso.vue';
+import { useSSOStore } from '@/stores/sso.store';
+import { useUIStore } from '@/stores/ui.store';
+import { within, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { mockedStore } from '@/__tests__/utils';
+
+const renderView = createComponentRenderer(SettingsSso);
+
+const samlConfig = {
+	metadata: 'metadata dummy',
+	metadataUrl:
+		'https://dev-qqkrykgkoo0p63d5.eu.auth0.com/samlp/metadata/KR1cSrRrxaZT2gV8ZhPAUIUHtEY4duhN',
+	entityID: 'https://n8n-tunnel.myhost.com/rest/sso/saml/metadata',
+	returnUrl: 'https://n8n-tunnel.myhost.com/rest/sso/saml/acs',
+};
+
+const telemetryTrack = vi.fn();
+vi.mock('@/composables/useTelemetry', () => ({
+	useTelemetry: () => ({
+		track: telemetryTrack,
+	}),
+}));
+
+const showError = vi.fn();
+vi.mock('@/composables/useToast', () => ({
+	useToast: () => ({
+		showError,
+	}),
+}));
+
+const confirmMessage = vi.fn();
+vi.mock('@/composables/useMessage', () => ({
+	useMessage: () => ({
+		confirm: confirmMessage,
+	}),
+}));
+
+describe('SettingsSso View', () => {
+	beforeEach(() => {
+		telemetryTrack.mockReset();
+		confirmMessage.mockReset();
+		showError.mockReset();
+	});
+
+	it('should show upgrade banner when enterprise SAML is disabled', async () => {
+		const pinia = createTestingPinia();
+		const ssoStore = mockedStore(useSSOStore);
+		ssoStore.isEnterpriseSamlEnabled = false;
+
+		const uiStore = useUIStore();
+
+		const { getByTestId } = renderView({ pinia });
+
+		const actionBox = getByTestId('sso-content-unlicensed');
+		expect(actionBox).toBeInTheDocument();
+
+		await userEvent.click(await within(actionBox).findByText('See plans'));
+		expect(uiStore.goToUpgrade).toHaveBeenCalledWith('sso', 'upgrade-sso');
+	});
+
+	it('should show user SSO config', async () => {
+		const pinia = createTestingPinia();
+
+		const ssoStore = mockedStore(useSSOStore);
+		ssoStore.isEnterpriseSamlEnabled = true;
+
+		ssoStore.getSamlConfig.mockResolvedValue(samlConfig);
+
+		const { getAllByTestId } = renderView({ pinia });
+
+		expect(ssoStore.getSamlConfig).toHaveBeenCalledTimes(1);
+
+		await waitFor(async () => {
+			const copyInputs = getAllByTestId('copy-input');
+			expect(copyInputs[0].textContent).toContain(samlConfig.returnUrl);
+			expect(copyInputs[1].textContent).toContain(samlConfig.entityID);
+		});
+	});
+
+	it('allows user to toggle SSO', async () => {
+		const pinia = createTestingPinia();
+
+		const ssoStore = mockedStore(useSSOStore);
+		ssoStore.isEnterpriseSamlEnabled = true;
+		ssoStore.isSamlLoginEnabled = false;
+
+		ssoStore.getSamlConfig.mockResolvedValue(samlConfig);
+
+		const { getByTestId } = renderView({ pinia });
+
+		const toggle = getByTestId('sso-toggle');
+
+		expect(toggle.textContent).toContain('Deactivated');
+
+		await userEvent.click(toggle);
+		expect(toggle.textContent).toContain('Activated');
+
+		await userEvent.click(toggle);
+		expect(toggle.textContent).toContain('Deactivated');
+	});
+
+	it("allows user to fill Identity Provider's URL", async () => {
+		confirmMessage.mockResolvedValueOnce('confirm');
+
+		const pinia = createTestingPinia();
+		const windowOpenSpy = vi.spyOn(window, 'open');
+
+		const ssoStore = mockedStore(useSSOStore);
+		ssoStore.isEnterpriseSamlEnabled = true;
+
+		const { getByTestId, getByRole } = renderView({ pinia });
+
+		const saveButton = getByTestId('sso-save');
+		expect(saveButton).toBeDisabled();
+
+		const urlinput = getByTestId('sso-provider-url');
+
+		expect(urlinput).toBeVisible();
+		await userEvent.type(urlinput, samlConfig.metadataUrl);
+
+		expect(saveButton).not.toBeDisabled();
+		await userEvent.click(saveButton);
+
+		expect(ssoStore.saveSamlConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ metadataUrl: samlConfig.metadataUrl }),
+		);
+
+		expect(ssoStore.testSamlConfig).toHaveBeenCalled();
+		expect(windowOpenSpy).toHaveBeenCalled();
+
+		expect(telemetryTrack).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ identity_provider: 'metadata' }),
+		);
+
+		expect(ssoStore.getSamlConfig).toHaveBeenCalledTimes(2);
+	});
+
+	it("allows user to fill Identity Provider's XML", async () => {
+		confirmMessage.mockResolvedValueOnce('confirm');
+
+		const pinia = createTestingPinia();
+		const windowOpenSpy = vi.spyOn(window, 'open');
+
+		const ssoStore = mockedStore(useSSOStore);
+		ssoStore.isEnterpriseSamlEnabled = true;
+
+		const { getByTestId } = renderView({ pinia });
+
+		const saveButton = getByTestId('sso-save');
+		expect(saveButton).toBeDisabled();
+
+		await userEvent.click(getByTestId('radio-button-xml'));
+
+		const xmlInput = getByTestId('sso-provider-xml');
+
+		expect(xmlInput).toBeVisible();
+		await userEvent.type(xmlInput, samlConfig.metadata);
+
+		expect(saveButton).not.toBeDisabled();
+		await userEvent.click(saveButton);
+
+		expect(ssoStore.saveSamlConfig).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: samlConfig.metadata }),
+		);
+
+		expect(ssoStore.testSamlConfig).toHaveBeenCalled();
+		expect(windowOpenSpy).toHaveBeenCalled();
+
+		expect(telemetryTrack).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ identity_provider: 'xml' }),
+		);
+
+		expect(ssoStore.getSamlConfig).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/editor-ui/src/views/SettingsSso.vue
+++ b/packages/editor-ui/src/views/SettingsSso.vue
@@ -134,6 +134,15 @@ const goToUpgrade = () => {
 	void uiStore.goToUpgrade('sso', 'upgrade-sso');
 };
 
+const isToggleSsoDisabled = computed(() => {
+	/** Allow users to disable SSO even if config request fails */
+	if (ssoStore.isSamlLoginEnabled) {
+		return false;
+	}
+
+	return !ssoSettingsSaved.value;
+});
+
 onMounted(async () => {
 	if (!ssoStore.isEnterpriseSamlEnabled) {
 		return;
@@ -162,7 +171,8 @@ onMounted(async () => {
 				</template>
 				<el-switch
 					v-model="ssoStore.isSamlLoginEnabled"
-					:disabled="!ssoSettingsSaved"
+					data-test-id="sso-toggle"
+					:disabled="isToggleSsoDisabled"
 					:class="$style.switch"
 					:inactive-text="ssoActivatedLabel"
 				/>
@@ -205,11 +215,18 @@ onMounted(async () => {
 						name="metadataUrl"
 						size="large"
 						:placeholder="i18n.baseText('settings.sso.settings.ips.url.placeholder')"
+						data-test-id="sso-provider-url"
 					/>
 					<small>{{ i18n.baseText('settings.sso.settings.ips.url.help') }}</small>
 				</div>
 				<div v-show="ipsType === IdentityProviderSettingsType.XML">
-					<n8n-input v-model="metadata" type="textarea" name="metadata" :rows="4" />
+					<n8n-input
+						v-model="metadata"
+						type="textarea"
+						name="metadata"
+						:rows="4"
+						data-test-id="sso-provider-xml"
+					/>
 					<small>{{ i18n.baseText('settings.sso.settings.ips.xml.help') }}</small>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

Allow disabling SSO even when the request to fetch the configuration  `/rest/sso/saml/config` fails

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1812/bug-if-saml-config-breaks-the-ui-wont-allow-you-to-disable-it

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
