### PR TITLE
feat(benchmark): Add benchmark scenario for binary files

### DIFF
--- a/packages/@n8n/benchmark/scenarios/binaryData/binaryData.json
+++ b/packages/@n8n/benchmark/scenarios/binaryData/binaryData.json
@@ -1,0 +1,67 @@
+{
+	"createdAt": "2024-09-03T11:51:56.540Z",
+	"updatedAt": "2024-09-03T12:22:21.000Z",
+	"name": "Binary Data",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": {
+				"httpMethod": "POST",
+				"path": "binary-files-benchmark",
+				"responseMode": "responseNode",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [0, 0],
+			"id": "bfe19f12-3655-440f-be5c-8d71665c6353",
+			"name": "Webhook",
+			"webhookId": "109d7b13-93ad-42b0-a9ce-ca49e1817b35"
+		},
+		{
+			"parameters": { "respondWith": "binary", "options": {} },
+			"type": "n8n-nodes-base.respondToWebhook",
+			"typeVersion": 1.1,
+			"position": [740, 0],
+			"id": "cd957c9b-6b7a-4423-aac3-6df4d8bb571e",
+			"name": "Respond to Webhook"
+		},
+		{
+			"parameters": {
+				"operation": "write",
+				"fileName": "=file-{{ Date.now() }}-{{ Math.random() }}.js",
+				"dataPropertyName": "file",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.readWriteFile",
+			"typeVersion": 1,
+			"position": [260, 0],
+			"id": "f2ce4709-7697-4bc6-8eca-6c222485297a",
+			"name": "Write File to Disk"
+		},
+		{
+			"parameters": { "fileSelector": "={{ $json.fileName }}", "options": {} },
+			"type": "n8n-nodes-base.readWriteFile",
+			"typeVersion": 1,
+			"position": [500, 0],
+			"id": "198e8a6c-81a3-4b34-b099-501961a02006",
+			"name": "Read File from Disk"
+		}
+	],
+	"connections": {
+		"Webhook": { "main": [[{ "node": "Write File to Disk", "type": "main", "index": 0 }]] },
+		"Write File to Disk": {
+			"main": [[{ "node": "Read File from Disk", "type": "main", "index": 0 }]]
+		},
+		"Read File from Disk": {
+			"main": [[{ "node": "Respond to Webhook", "type": "main", "index": 0 }]]
+		}
+	},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": null,
+	"pinData": {},
+	"versionId": "8dd197c0-d1ea-43c3-9f88-9d11e7b081a0",
+	"triggerCount": 1,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/binaryData/binaryData.manifest.json
+++ b/packages/@n8n/benchmark/scenarios/binaryData/binaryData.manifest.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../scenario.schema.json",
+	"name": "BinaryData",
+	"description": "Send a binary file to a webhook, write it to FS, read it from FS and receive it back",
+	"scenarioData": { "workflowFiles": ["binaryData.json"] },
+	"scriptPath": "binaryData.script.js"
+}

--- a/packages/@n8n/benchmark/scenarios/binaryData/binaryData.script.js
+++ b/packages/@n8n/benchmark/scenarios/binaryData/binaryData.script.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const apiBaseUrl = __ENV.API_BASE_URL;
+
+const file = open(__ENV.SCRIPT_FILE_PATH, 'b');
+const filename = String(__ENV.SCRIPT_FILE_PATH).split('/').pop();
+
+export default function () {
+	const data = {
+		filename,
+		file: http.file(file, filename, 'application/javascript'),
+	};
+
+	const res = http.post(`${apiBaseUrl}/webhook/binary-files-benchmark`, data);
+
+	check(res, {
+		'is status 200': (r) => r.status === 200,
+		'has correct content type': (r) =>
+			r.headers['Content-Type'] === 'application/javascript; charset=utf-8',
+	});
+}

--- a/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
+++ b/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
@@ -60,6 +60,7 @@ export function handleSummary(data) {
 			env: {
 				API_BASE_URL: this.opts.n8nApiBaseUrl,
 				K6_CLOUD_TOKEN: this.opts.k6ApiToken,
+				SCRIPT_FILE_PATH: augmentedTestScriptPath,
 			},
 		})`${k6ExecutablePath} run ${flattedFlags} ${augmentedTestScriptPath}`;
 

--- a/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
+++ b/packages/@n8n/benchmark/src/testExecution/k6Executor.ts
@@ -83,7 +83,7 @@ export function handleSummary(data) {
 
 		const augmentedTestScript = `${testScript}\n\n${summaryScript}`;
 
-		const tempFilePath = tmpfile(`${scenarioRunName}.ts`, augmentedTestScript);
+		const tempFilePath = tmpfile(`${scenarioRunName}.js`, augmentedTestScript);
 
 		return tempFilePath;
 	}


### PR DESCRIPTION
## Summary

Add benchmark scenario for binary files

## Related Linear tickets, Github issues, and Community forum posts

[CAT-91](https://linear.app/n8n/issue/CAT-91/add-benchmark-scenario-for-binary-files)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
