### PR TITLE
fix(core): Declutter webhook insertion errors

### DIFF
--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -227,6 +227,7 @@ export class ActiveWorkflowManager {
 	 * deregister those webhooks from external services.
 	 */
 	async clearWebhooks(workflowId: string) {
+		console.log('========== clearWebhooks');
 		const workflowData = await this.workflowRepository.findOne({
 			where: { id: workflowId },
 		});

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -227,7 +227,6 @@ export class ActiveWorkflowManager {
 	 * deregister those webhooks from external services.
 	 */
 	async clearWebhooks(workflowId: string) {
-		console.log('========== clearWebhooks');
 		const workflowData = await this.workflowRepository.findOne({
 			where: { id: workflowId },
 		});

--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -179,12 +179,12 @@ describe('WebhookService', () => {
 	});
 
 	describe('createWebhook()', () => {
-		test('should create the webhook', async () => {
+		test('should store webhook in DB', async () => {
 			const mockWebhook = createWebhook('GET', 'user/:id');
 
 			await webhookService.storeWebhook(mockWebhook);
 
-			expect(webhookRepository.insert).toHaveBeenCalledWith(mockWebhook);
+			expect(webhookRepository.upsert).toHaveBeenCalledWith(mockWebhook, ['method', 'webhookPath']);
 		});
 	});
 });

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -93,7 +93,7 @@ export class WebhookService {
 	async storeWebhook(webhook: WebhookEntity) {
 		void this.cacheService.set(webhook.cacheKey, webhook);
 
-		return await this.webhookRepository.insert(webhook);
+		await this.webhookRepository.upsert(webhook, ['method', 'webhookPath']);
 	}
 
 	createWebhook(data: Partial<WebhookEntity>) {


### PR DESCRIPTION
In cloud instances it's not uncommon to see webhook insertion errors cluttering startup log. Over time this has come up repeatedly during debugging:

- https://n8nio.slack.com/archives/C0356NQGRGA/p1723449851009429
- https://n8nio.slack.com/archives/C034S4SV6LX/p1722262806875799
- https://n8nio.slack.com/archives/C034S4SV6LX/p1715755406026579
- https://n8nio.slack.com/archives/C069HS026UF/p1724330029088569

Sample error:


```
QueryFailedError: SQLITE_CONSTRAINT: UNIQUE constraint failed: webhook_entity.webhookPath, webhook_entity.method
    at Statement.handler (/Users/ivov/Development/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-10_@sentry+node@7.87.0_ioredis@5.3.2_mssql@10.0.2_mysql2@3.11.0_pg@8.12.0_dwf5ipxhmlf7bsniwdy2uapm3y/node_modules/src/driver/sqlite/SqliteQueryRunner.ts:137:29) {
  query: 'INSERT INTO "webhook_entity"("workflowId", "webhookPath", "method", "node", "webhookId", "pathLength") VALUES (?, ?, ?, ?, NULL, NULL)',
  parameters: [
    'MBo7OqRrDbalqERS',
    'dbe65803-f138-4772-8698-a9a307623514',
    'GET',
    'Webhook'
  ],
  driverError: [Error: SQLITE_CONSTRAINT: UNIQUE constraint failed: webhook_entity.webhookPath, webhook_entity.method] {
    errno: 19,
    code: 'SQLITE_CONSTRAINT'
  },
  errno: 19,
  code: 'SQLITE_CONSTRAINT'
}
```

As of 1.15 we no longer deregister webhooks from DB on shutdown, so re-registration on startup causes [this line](https://github.com/n8n-io/n8n/blob/c97a96d314d4cd72b9a971993af5d5f1e32ccf48/packages/cli/src/webhooks/webhook.service.ts#L96) to throw a benign but confusing query failed error, one per registered webhook.

Long-term we should look for a cleaner way to handle webhook de- and re-registration in DB, so that duplicate insertions are only an edge case. For now this PR is meant to help reduce noise when debugging cloud issues.
