### PR TITLE
feat(Monday.com Node): Check for error response 

### DIFF
--- a/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MondayCom/GenericFunctions.ts
@@ -37,7 +37,22 @@ export async function mondayComApiRequest(
 		if (authenticationMethod === 'oAuth2') {
 			credentialType = 'mondayComOAuth2Api';
 		}
-		return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
+
+		const responseData = await this.helpers.requestWithAuthentication.call(
+			this,
+			credentialType,
+			options,
+		);
+
+		if (
+			responseData.hasOwnProperty('error_message') ||
+			responseData.hasOwnProperty('error_code') ||
+			responseData.hasOwnProperty('errors')
+		) {
+			throw new NodeApiError(this.getNode(), responseData as JsonObject);
+		}
+
+		return responseData;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
@@ -87,6 +102,14 @@ export async function mondayComApiPaginatedRequest(
 					},
 				})) as IDataObject
 			).data as { next_items_page: { cursor: string; items: IDataObject[] } };
+
+			if (
+				responseData.hasOwnProperty('error_message') ||
+				responseData.hasOwnProperty('error_code') ||
+				responseData.hasOwnProperty('errors')
+			) {
+				throw new NodeApiError(this.getNode(), responseData as JsonObject);
+			}
 
 			if (responseData && responseData.next_items_page) {
 				returnData.push.apply(returnData, responseData.next_items_page.items);


### PR DESCRIPTION
## Summary

Currently the response is not checked for any error. `responseData` will have no `data` property and therefore only an `Internal error` will be thrown (e.g. [https://github.com/n8n-io/n8n/blob/e5c7534ebae0d7f42749f76270ca00eb49964d12/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts#L541C6-L575C7](https://github.com/n8n-io/n8n/blob/e5c7534ebae0d7f42749f76270ca00eb49964d12/packages/nodes-base/nodes/MondayCom/MondayCom.node.ts#L541C6-L575C7)).

The response is now checked for any errors.

## Related Linear tickets, Github issues, and Community forum posts
monday.com has 3 different error formats:
https://developer.monday.com/api-reference/docs/errors