### PR TITLE
refactor(benchmark): Separate cloud env provisioning from running benchmarks

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -24,6 +24,9 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.BENCHMARK_ARM_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.BENCHMARK_ARM_TENANT_ID }}
   K6_API_TOKEN: ${{ secrets.K6_API_TOKEN }}
+  N8N_TAG: ${{ inputs.n8n_tag || 'nightly' }}
+  N8N_BENCHMARK_TAG: ${{ inputs.benchmark_tag || 'latest' }}
+  DEBUG: ${{ inputs.debug == 'true' && '--debug' || '' }}
 
 permissions:
   id-token: write
@@ -62,12 +65,23 @@ jobs:
         run: pnpm destroy-cloud-env
         working-directory: packages/@n8n/benchmark
 
-      - name: Run the benchmark with debug logging
-        if: github.event.inputs.debug == 'true'
-        run: pnpm benchmark-in-cloud --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }} --debug
+      - name: Provision the environment
+        run: pnpm provision-cloud-env ${{ env.DEBUG }}
         working-directory: packages/@n8n/benchmark
 
       - name: Run the benchmark
-        if: github.event.inputs.debug != 'true'
-        run: pnpm benchmark-in-cloud --n8nTag ${{ inputs.n8n_tag || 'nightly' }} --benchmarkTag ${{ inputs.benchmark_tag || 'latest' }}
+        run: pnpm benchmark-in-cloud --n8nTag ${{ env.N8N_TAG }} --benchmarkTag ${{ env.N8N_BENCHMARK_TAG }} ${{ env.DEBUG }}
+        working-directory: packages/@n8n/benchmark
+
+        # We need to login again because the access token expires
+      - name: Azure login
+        uses: azure/login@v2.1.1
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Destroy the environment
+        if: always()
+        run: pnpm destroy-cloud-env ${{ env.DEBUG }}
         working-directory: packages/@n8n/benchmark

--- a/packages/@n8n/benchmark/package.json
+++ b/packages/@n8n/benchmark/package.json
@@ -13,6 +13,7 @@
     "benchmark": "zx scripts/run.mjs",
     "benchmark-in-cloud": "pnpm benchmark --env cloud",
     "benchmark-locally": "pnpm benchmark --env local",
+    "provision-cloud-env": "zx scripts/provisionCloudEnv.mjs",
     "destroy-cloud-env": "zx scripts/destroyCloudEnv.mjs",
     "watch": "concurrently \"tsc -w -p tsconfig.build.json\" \"tsc-alias -w -p tsconfig.build.json\""
   },

--- a/packages/@n8n/benchmark/scripts/clients/terraformClient.mjs
+++ b/packages/@n8n/benchmark/scripts/clients/terraformClient.mjs
@@ -18,6 +18,16 @@ export class TerraformClient {
 	}
 
 	/**
+	 * Provisions the environment
+	 */
+	async provisionEnvironment() {
+		console.log('Provisioning cloud environment...');
+
+		await this.$$`terraform init`;
+		await this.$$`terraform apply -input=false -auto-approve`;
+	}
+
+	/**
 	 * @typedef {Object} BenchmarkEnv
 	 * @property {string} vmName
 	 * @property {string} ip
@@ -26,12 +36,7 @@ export class TerraformClient {
 	 *
 	 * @returns {Promise<BenchmarkEnv>}
 	 */
-	async provisionEnvironment() {
-		console.log('Provisioning cloud environment...');
-
-		await this.$$`terraform init`;
-		await this.$$`terraform apply -input=false -auto-approve`;
-
+	async getTerraformOutputs() {
 		const privateKeyName = await this.extractPrivateKey();
 
 		return {
@@ -42,12 +47,11 @@ export class TerraformClient {
 		};
 	}
 
-	async destroyEnvironment() {
-		if (!fs.existsSync(paths.terraformStateFile)) {
-			console.log('No cloud environment to destroy. Skipping...');
-			return;
-		}
+	hasTerraformState() {
+		return fs.existsSync(paths.terraformStateFile);
+	}
 
+	async destroyEnvironment() {
 		console.log('Destroying cloud environment...');
 
 		await this.$$`terraform destroy -input=false -auto-approve`;

--- a/packages/@n8n/benchmark/scripts/provisionCloudEnv.mjs
+++ b/packages/@n8n/benchmark/scripts/provisionCloudEnv.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env zx
+/**
+ * Provisions the cloud benchmark environment
+ *
+ * NOTE: Must be run in the root of the package.
+ */
+// @ts-check
+import { which, minimist } from 'zx';
+import { TerraformClient } from './clients/terraformClient.mjs';
+
+const args = minimist(process.argv.slice(3), {
+	boolean: ['debug'],
+});
+
+const isVerbose = !!args.debug;
+
+export async function provision() {
+	await ensureDependencies();
+
+	const terraformClient = new TerraformClient({
+		isVerbose,
+	});
+
+	await terraformClient.provisionEnvironment();
+}
+
+async function ensureDependencies() {
+	await which('terraform');
+}
+
+provision().catch((error) => {
+	console.error('An error occurred while provisioning cloud env:');
+	console.error(error);
+
+	process.exit(1);
+});

--- a/packages/@n8n/benchmark/scripts/run.mjs
+++ b/packages/@n8n/benchmark/scripts/run.mjs
@@ -1,12 +1,9 @@
 #!/usr/bin/env zx
 /**
  * Script to run benchmarks either on the cloud benchmark environment or locally.
+ * The cloud environment needs to be provisioned using Terraform before running the benchmarks.
  *
  * NOTE: Must be run in the root of the package.
- *
- * Usage:
- * 	 zx scripts/run.mjs
- *
  */
 // @ts-check
 import fs from 'fs';


### PR DESCRIPTION
## Summary

The access token in GH actions workflow expires very soon after creation. This causes the cloud env destroying to fail because the benchmarks take some time to run. This separates the provisioning and destroying of infra from running the benchmarks. That way we can perform another login before destroying the env.

See e.g. https://github.com/n8n-io/n8n/actions/runs/10696461238/job/29651684237

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
