### PR TITLE
docs: Fix broken PostgREST guide link in Supabase node

### DIFF
--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -242,7 +242,7 @@ export function getFilters(
 		},
 		{
 			displayName:
-				'See <a href="https://postgrest.org/en/v9.0/api.html#horizontal-filtering-rows" target="_blank">PostgREST guide</a> to creating filters',
+				'See <a href="https://postgrest.org/en/stable/references/api/tables_views.html#horizontal-filtering" target="_blank">PostgREST guide</a> to creating filters',
 			name: 'jsonNotice',
 			type: 'notice',
 			displayOptions: {


### PR DESCRIPTION
## Summary
The PostgREST guide link at the Supabase node is broken. This PR fixes the link.

Currently broken link: [https://postgrest.org/en/v9.0/api.html#horizontal-filtering-rows](https://postgrest.org/en/v9.0/api.html#horizontal-filtering-rows)
New working link: https://postgrest.org/en/stable/references/api/tables_views.html#horizontal-filtering

<img width="800" alt="Bildschirmfoto 2024-09-04 um 12 50 22" src="https://github.com/user-attachments/assets/51f39bd6-2448-4c73-a747-3ffaf50e2df3">
