### PR TITLE
fix(OpenAI Chat Model Node): Prevent filtering of fine-tuned models in model selector

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -94,6 +94,7 @@ export class LmChatOpenAi implements INodeType {
 											// If the baseURL is not set or is set to api.openai.com, include only chat models
 											pass: `={{
 												($parameter.options?.baseURL && !$parameter.options?.baseURL?.includes('api.openai.com')) ||
+												$responseItem.id.startsWith('ft:') ||
 												($responseItem.id.startsWith('gpt-') && !$responseItem.id.includes('instruct'))
 											}}`,
 										},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
@@ -76,7 +76,10 @@ export async function modelSearch(
 	this: ILoadOptionsFunctions,
 	filter?: string,
 ): Promise<INodeListSearchResult> {
-	return await getModelSearch((model) => model.id.startsWith('gpt-'))(this, filter);
+	return await getModelSearch((model) => model.id.startsWith('gpt-') || model.id.startsWith('ft:'))(
+		this,
+		filter,
+	);
 }
 
 export async function imageModelSearch(


### PR DESCRIPTION
## Summary
We're currently filtering out non-chat models by checking if the model ID starts with `gpt-` unfortunately, this also filters out fine-tuned models which start with `ft:`. This PR fixes that by allowing listing of models which start with `ft:`

## Related Linear tickets, Github issues, and Community forum posts
- https://community.n8n.io/t/how-to-use-fine-tuned-openai-model/53283

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
