### PR TITLE
feat(editor): Add A/B testing feature flag for credential docs modal

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -13,7 +13,12 @@ import AuthTypeSelector from '@/components/CredentialEdit/AuthTypeSelector.vue';
 import EnterpriseEdition from '@/components/EnterpriseEdition.ee.vue';
 import { useI18n } from '@/composables/useI18n';
 import { useTelemetry } from '@/composables/useTelemetry';
-import { BUILTIN_CREDENTIALS_DOCS_URL, DOCS_DOMAIN, EnterpriseEditionFeature } from '@/constants';
+import {
+	BUILTIN_CREDENTIALS_DOCS_URL,
+	CREDENTIAL_DOCS_EXPERIMENT,
+	DOCS_DOMAIN,
+	EnterpriseEditionFeature,
+} from '@/constants';
 import type { PermissionsRecord } from '@/permissions';
 import { addCredentialTranslation } from '@/plugins/i18n';
 import { useCredentialsStore } from '@/stores/credentials.store';
@@ -28,6 +33,7 @@ import GoogleAuthButton from './GoogleAuthButton.vue';
 import OauthButton from './OauthButton.vue';
 import CredentialDocs from './CredentialDocs.vue';
 import { CREDENTIAL_MARKDOWN_DOCS } from './docs';
+import { usePostHog } from '@/stores/posthog.store';
 
 type Props = {
 	mode: string;
@@ -162,6 +168,11 @@ const isMissingCredentials = computed(() => props.credentialType === null);
 const isNewCredential = computed(() => props.mode === 'new' && !props.credentialId);
 
 const docs = computed(() => CREDENTIAL_MARKDOWN_DOCS[props.credentialType.name]);
+const showCredentialDocs = computed(
+	() =>
+		usePostHog().getVariant(CREDENTIAL_DOCS_EXPERIMENT.name) ===
+			CREDENTIAL_DOCS_EXPERIMENT.variant && docs.value,
+);
 
 function onDataChange(event: IUpdateInformation): void {
 	emit('update', event);
@@ -335,7 +346,7 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 			</EnterpriseEdition>
 		</div>
 		<CredentialDocs
-			v-if="docs"
+			v-if="showCredentialDocs"
 			:credential-type="credentialType"
 			:documentation-url="documentationUrl"
 			:docs="docs"

--- a/packages/editor-ui/src/constants.ts
+++ b/packages/editor-ui/src/constants.ts
@@ -694,13 +694,18 @@ export const MORE_ONBOARDING_OPTIONS_EXPERIMENT = {
 };
 
 export const EXECUTION_ANNOTATION_EXPERIMENT = '023_execution_annotation';
-
+export const CREDENTIAL_DOCS_EXPERIMENT = {
+	name: '024_credential_docs',
+	control: 'control',
+	variant: 'variant',
+};
 export const EXPERIMENTS_TO_TRACK = [
 	ASK_AI_EXPERIMENT.name,
 	TEMPLATE_CREDENTIAL_SETUP_EXPERIMENT,
 	CANVAS_AUTO_ADD_MANUAL_TRIGGER_EXPERIMENT.name,
 	AI_ASSISTANT_EXPERIMENT.name,
 	MORE_ONBOARDING_OPTIONS_EXPERIMENT.name,
+	CREDENTIAL_DOCS_EXPERIMENT.name,
 ];
 
 export const MFA_FORM = {


### PR DESCRIPTION
## Summary
This PR Add feature flag to enable A/B testing for credential docs modal which is available for GMail, AWS and OpenAI credentials
The modal is currently shown to all users. After this change, it will be hidden by default and only shown to users in a specific test group.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1670/creds-modal-follow-up-ab-testing-setup

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
