### PR TITLE
fix(core): Allow license:clear command to be used for licenses that failed renewal

### DIFF
--- a/packages/cli/src/commands/license/clear.ts
+++ b/packages/cli/src/commands/license/clear.ts
@@ -12,10 +12,12 @@ export class ClearLicenseCommand extends BaseCommand {
 	async run() {
 		this.logger.info('Clearing license from database.');
 
-		// Invoke shutdown() to force any floating entitlements to be released
-		const license = Container.get(License);
-		await license.init();
-		await license.shutdown();
+		// Attempt to invoke shutdown() to force any floating entitlements to be released
+		try {
+			const license = Container.get(License);
+			await license.init();
+			await license.shutdown();
+		} catch {}
 
 		await Container.get(SettingsRepository).delete({
 			key: SETTINGS_LICENSE_CERT_KEY,

--- a/packages/cli/src/commands/license/clear.ts
+++ b/packages/cli/src/commands/license/clear.ts
@@ -13,9 +13,9 @@ export class ClearLicenseCommand extends BaseCommand {
 		this.logger.info('Clearing license from database.');
 
 		// Attempt to invoke shutdown() to force any floating entitlements to be released
+		const license = Container.get(License);
+		await license.init();
 		try {
-			const license = Container.get(License);
-			await license.init();
 			await license.shutdown();
 		} catch {}
 

--- a/packages/cli/src/commands/license/clear.ts
+++ b/packages/cli/src/commands/license/clear.ts
@@ -17,7 +17,9 @@ export class ClearLicenseCommand extends BaseCommand {
 		await license.init();
 		try {
 			await license.shutdown();
-		} catch {}
+		} catch {
+			this.logger.info('License shutdown failed. Continuing with clearing license from database.');
+		}
 
 		await Container.get(SettingsRepository).delete({
 			key: SETTINGS_LICENSE_CERT_KEY,

--- a/packages/cli/test/integration/commands/license.cmd.test.ts
+++ b/packages/cli/test/integration/commands/license.cmd.test.ts
@@ -1,9 +1,13 @@
-import { License } from '@/license';
-import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
-import { ClearLicenseCommand } from '@/commands/license/clear';
+import { Container } from 'typedi';
 
 import { setupTestCommand } from '@test-integration/utils/test-command';
 import { mockInstance } from '../../shared/mocking';
+
+import { ClearLicenseCommand } from '@/commands/license/clear';
+import { SETTINGS_LICENSE_CERT_KEY } from '@/constants';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
+import { License } from '@/license';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 mockInstance(LoadNodesAndCredentials);
 const license = mockInstance(License);
@@ -14,4 +18,18 @@ test('license:clear invokes shutdown() to release any floating entitlements', as
 
 	expect(license.init).toHaveBeenCalledTimes(1);
 	expect(license.shutdown).toHaveBeenCalledTimes(1);
+});
+
+test('license:clear deletes the license from the DB even if shutdown() fails', async () => {
+	license.shutdown.mockRejectedValueOnce(new Error('shutdown failed'));
+
+	const settingsRepository = Container.get(SettingsRepository);
+
+	settingsRepository.delete = jest.fn();
+
+	await command.run();
+
+	expect(settingsRepository.delete).toHaveBeenCalledWith({
+		key: SETTINGS_LICENSE_CERT_KEY,
+	});
 });


### PR DESCRIPTION
The `license:clear` command attempts to renew the license before deleting the license information from the database to free up any floating entitlements. However, if the renewal fails (e.g., due to a device fingerprint mismatch), the command errors out before the database record is deleted. This PR addresses the issue by handling errors from the renewal attempt without interrupting the deletion process.