### PR TITLE
fix(editor): Set minimum zoom to 0 to allow fitting very large workflows in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -442,7 +442,7 @@ provide(CanvasKey, {
 		pan-on-scroll
 		snap-to-grid
 		:snap-grid="[GRID_SIZE, GRID_SIZE]"
-		:min-zoom="0.2"
+		:min-zoom="0"
 		:max-zoom="4"
 		:class="[$style.canvas, { [$style.visible]: paneReady }]"
 		data-test-id="canvas"


### PR DESCRIPTION
## Summary

<img width="1596" alt="image" src="https://github.com/user-attachments/assets/33b855d5-1d38-446f-a3df-dc1da6f5792b">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7689/large-workflow-zoom-fit-does-not-work-correctly

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
