### PR TITLE
feat(Text Classifier Node): Add output fixing parser

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/SentimentAnalysis/SentimentAnalysis.node.ts
@@ -129,7 +129,8 @@ export class SentimentAnalysis implements INodeType {
 						name: 'enableAutoFixing',
 						type: 'boolean',
 						default: true,
-						description: 'Whether to enable auto-fixing for the output parser',
+						description:
+							'Whether to enable auto-fixing (may trigger an additional LLM call if output is broken)',
 					},
 				],
 			},

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -156,7 +156,8 @@ export class TextClassifier implements INodeType {
 						name: 'enableAutoFixing',
 						type: 'boolean',
 						default: true,
-						description: 'Whether to enable auto-fixing for the output parser',
+						description:
+							'Whether to enable auto-fixing (may trigger an additional LLM call if output is broken)',
 					},
 				],
 			},

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/TextClassifier.node.ts
@@ -12,7 +12,7 @@ import { NodeConnectionType } from 'n8n-workflow';
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
 import { HumanMessage } from '@langchain/core/messages';
 import { SystemMessagePromptTemplate, ChatPromptTemplate } from '@langchain/core/prompts';
-import { StructuredOutputParser } from 'langchain/output_parsers';
+import { OutputFixingParser, StructuredOutputParser } from 'langchain/output_parsers';
 import { z } from 'zod';
 import { getTracingConfig } from '../../../utils/tracing';
 
@@ -151,6 +151,13 @@ export class TextClassifier implements INodeType {
 							rows: 6,
 						},
 					},
+					{
+						displayName: 'Enable Auto-Fixing',
+						name: 'enableAutoFixing',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to enable auto-fixing for the output parser',
+					},
 				],
 			},
 		],
@@ -173,6 +180,7 @@ export class TextClassifier implements INodeType {
 			multiClass: boolean;
 			fallback?: string;
 			systemPromptTemplate?: string;
+			enableAutoFixing: boolean;
 		};
 		const multiClass = options?.multiClass ?? false;
 		const fallback = options?.fallback ?? 'discard';
@@ -192,7 +200,11 @@ export class TextClassifier implements INodeType {
 			]);
 		const schema = z.object(Object.fromEntries(schemaEntries));
 
-		const parser = StructuredOutputParser.fromZodSchema(schema);
+		const structuredParser = StructuredOutputParser.fromZodSchema(schema);
+
+		const parser = options.enableAutoFixing
+			? OutputFixingParser.fromLLM(llm, structuredParser)
+			: structuredParser;
 
 		const multiClassPrompt = multiClass
 			? 'Categories are not mutually exclusive, and multiple can be true'


### PR DESCRIPTION
## Summary

This PR adds an option to enable auto-fixing model's output using `OutputFixingParser`. The auto-fixing is enabled by default.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-281/text-classifier-unexpected-non-whitespace-character

https://github.com/n8n-io/n8n-docs/pull/2451

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
