### PR TITLE
feat(editor): Change selection to be default canvas behaviour (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -30,6 +30,7 @@ import type { PinDataSource } from '@/composables/usePinnedData';
 import { isPresent } from '@/utils/typesUtils';
 import { GRID_SIZE } from '@/utils/nodeViewUtils';
 import { CanvasKey } from '@/constants';
+import { onKeyDown, onKeyUp } from '@vueuse/core';
 
 const $style = useCssModule();
 
@@ -107,11 +108,29 @@ const {
 	findNode,
 } = useVueFlow({ id: props.id, deleteKeyCode: null });
 
+const isPaneReady = ref(false);
+
+const classes = computed(() => ({
+	[$style.canvas]: true,
+	[$style.ready]: isPaneReady.value,
+	[$style.draggable]: isPanningEnabled.value,
+}));
+
 /**
  * Key bindings
  */
 
 const disableKeyBindings = computed(() => !props.keyBindings);
+
+const isPanningEnabled = ref(false);
+
+onKeyDown('Shift', () => {
+	isPanningEnabled.value = true;
+});
+
+onKeyUp('Shift', () => {
+	isPanningEnabled.value = false;
+});
 
 useKeybindings(
 	{
@@ -138,19 +157,13 @@ useKeybindings(
 	{ disabled: disableKeyBindings },
 );
 
-const contextMenu = useContextMenu();
-
-const lastSelectedNode = computed(() => selectedNodes.value[selectedNodes.value.length - 1]);
-
-const hasSelection = computed(() => selectedNodes.value.length > 0);
-
-const selectedNodeIds = computed(() => selectedNodes.value.map((node) => node.id));
-
-const paneReady = ref(false);
-
 /**
  * Nodes
  */
+
+const lastSelectedNode = computed(() => selectedNodes.value[selectedNodes.value.length - 1]);
+const hasSelection = computed(() => selectedNodes.value.length > 0);
+const selectedNodeIds = computed(() => selectedNodes.value.map((node) => node.id));
 
 function onClickNodeAdd(id: string, handle: string) {
 	emit('click:node:add', id, handle);
@@ -343,6 +356,8 @@ function setReadonly(value: boolean) {
  * Context menu
  */
 
+const contextMenu = useContextMenu();
+
 function onOpenContextMenu(event: MouseEvent) {
 	contextMenu.open(event, {
 		source: 'canvas',
@@ -417,7 +432,7 @@ onUnmounted(() => {
 
 onPaneReady(async () => {
 	await onFitView();
-	paneReady.value = true;
+	isPaneReady.value = true;
 });
 
 watch(() => props.readOnly, setReadonly, {
@@ -444,7 +459,10 @@ provide(CanvasKey, {
 		:snap-grid="[GRID_SIZE, GRID_SIZE]"
 		:min-zoom="0.2"
 		:max-zoom="4"
-		:class="[$style.canvas, { [$style.visible]: paneReady }]"
+		:class="classes"
+		:selection-key-code="isPanningEnabled ? null : true"
+		:select-nodes-on-drag="true"
+		pan-activation-key-code="Shift"
 		data-test-id="canvas"
 		@edge-mouse-enter="onMouseEnterEdge"
 		@edge-mouse-leave="onMouseLeaveEdge"
@@ -524,8 +542,16 @@ provide(CanvasKey, {
 .canvas {
 	opacity: 0;
 
-	&.visible {
+	&.ready {
 		opacity: 1;
+	}
+
+	&.draggable :global(.vue-flow__pane) {
+		cursor: grab;
+	}
+
+	:global(.vue-flow__pane.dragging) {
+		cursor: grabbing;
 	}
 }
 </style>

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -122,13 +122,14 @@ const classes = computed(() => ({
 
 const disableKeyBindings = computed(() => !props.keyBindings);
 
+const panningKeyCode = 'Shift';
 const isPanningEnabled = ref(false);
 
-onKeyDown('Shift', () => {
+onKeyDown(panningKeyCode, () => {
 	isPanningEnabled.value = true;
 });
 
-onKeyUp('Shift', () => {
+onKeyUp(panningKeyCode, () => {
 	isPanningEnabled.value = false;
 });
 
@@ -161,6 +162,7 @@ useKeybindings(
  * Nodes
  */
 
+const selectionKeyCode = computed(() => (isPanningEnabled.value ? null : true));
 const lastSelectedNode = computed(() => selectedNodes.value[selectedNodes.value.length - 1]);
 const hasSelection = computed(() => selectedNodes.value.length > 0);
 const selectedNodeIds = computed(() => selectedNodes.value.map((node) => node.id));
@@ -460,9 +462,8 @@ provide(CanvasKey, {
 		:min-zoom="0.2"
 		:max-zoom="4"
 		:class="classes"
-		:selection-key-code="isPanningEnabled ? null : true"
-		:select-nodes-on-drag="true"
-		pan-activation-key-code="Shift"
+		:selection-key-code="selectionKeyCode"
+		:pan-activation-key-code="panningKeyCode"
 		data-test-id="canvas"
 		@edge-mouse-enter="onMouseEnterEdge"
 		@edge-mouse-leave="onMouseLeaveEdge"

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -29,10 +29,6 @@
 	&.draggable {
 		cursor: default;
 	}
-
-	&.dragging {
-		cursor: grabbing;
-	}
 }
 
 .vue-flow__node {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/3f517973-63b9-436d-92a5-16842fdb6a93



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7690/change-selection-to-no-longer-require-shift-key-to-be-pressed

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
