### PR TITLE
feat(core): Make Postgres connection timeout configurable

### DIFF
--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -75,6 +75,10 @@ class PostgresConfig {
 	@Env('DB_POSTGRESDB_POOL_SIZE')
 	poolSize: number = 2;
 
+	/** Postgres connection timeout (ms) */
+	@Env('DB_POSTGRESDB_CONNECTION_TIMEOUT')
+	connectionTimeoutMs: number = 5000;
+
 	@Nested
 	ssl: PostgresSSLConfig;
 }

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -77,7 +77,7 @@ class PostgresConfig {
 
 	/** Postgres connection timeout (ms) */
 	@Env('DB_POSTGRESDB_CONNECTION_TIMEOUT')
-	connectionTimeoutMs: number = 5000;
+	connectionTimeoutMs: number = 1000;
 
 	@Nested
 	ssl: PostgresSSLConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -47,7 +47,7 @@ describe('GlobalConfig', () => {
 				poolSize: 2,
 				port: 5432,
 				schema: 'public',
-				connectionTimeoutMs: 5000,
+				connectionTimeoutMs: 1000,
 				ssl: {
 					ca: '',
 					cert: '',

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -47,6 +47,7 @@ describe('GlobalConfig', () => {
 				poolSize: 2,
 				port: 5432,
 				schema: 'public',
+				connectionTimeoutMs: 5000,
 				ssl: {
 					ca: '',
 					cert: '',

--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -104,6 +104,7 @@ const getPostgresConnectionOptions = (): PostgresConnectionOptions => {
 		schema: postgresConfig.schema,
 		poolSize: postgresConfig.poolSize,
 		migrations: postgresMigrations,
+		connectTimeoutMS: postgresConfig.connectionTimeoutMs,
 		ssl,
 	};
 };


### PR DESCRIPTION
Set a configurable connection timeout for Postgres, to more gracefully handle network issues leading to reconnection attempts.