### PR TITLE
feat(benchmark): Add benchmark scenario for the httprequest node

### DIFF
--- a/packages/@n8n/benchmark/scenarios/httpNode/httpNode.json
+++ b/packages/@n8n/benchmark/scenarios/httpNode/httpNode.json
@@ -1,0 +1,213 @@
+{
+	"createdAt": "2024-09-04T07:18:29.011Z",
+	"updatedAt": "2024-09-04T07:27:58.000Z",
+	"id": "rUXzWNGsUDUmgaFS",
+	"name": "HTTP Request",
+	"active": false,
+	"nodes": [
+		{
+			"parameters": {
+				"httpMethod": "POST",
+				"path": "benchmark-http-node",
+				"responseMode": "responseNode",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.webhook",
+			"typeVersion": 2,
+			"position": [-60, 20],
+			"id": "f11378b4-5f28-4a6c-9332-5878342cd3cf",
+			"name": "Webhook",
+			"webhookId": "c40014cc-4d64-4fcf-8c13-9e94b6792756"
+		},
+		{
+			"parameters": {
+				"respondWith": "allIncomingItems",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.respondToWebhook",
+			"typeVersion": 1.1,
+			"position": [1060, 20],
+			"id": "f42552c7-9c6e-4616-b9d5-ac79445ef4ed",
+			"name": "Respond to Webhook"
+		},
+		{
+			"parameters": {
+				"url": "http://mockapi:8080/users/clair.bahringer/received_events/public",
+				"options": {
+					"response": {
+						"response": {
+							"fullResponse": true
+						}
+					}
+				}
+			},
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2,
+			"position": [300, -180],
+			"id": "20de816e-0fbe-4e28-bc53-f508a2dda117",
+			"name": "Mock public received events"
+		},
+		{
+			"parameters": {
+				"url": "http://mockapi:8080/repos/udke6pujoywnagxkcvab2riw23khzn2tibo2vincws32qexb50ey7h97d42vnzyol0rxypgsg4pomsf7sgnmdaihstljw8edcijrwmy7mfi76yif19c4/47i31dh737el215j62ts2f2782nw3ss26rul3s8jw13u3vu0xm349a5hyay5asmwnlnf7nx8p9h4g62so6s1cis7xv9puj5j98t4m980sbe2455fn1obccjl/events",
+				"options": {
+					"response": {
+						"response": {
+							"fullResponse": true
+						}
+					}
+				}
+			},
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2,
+			"position": [300, 20],
+			"id": "083e02b3-a257-49a8-8f7d-42222cb9194c",
+			"name": "Mock repository events"
+		},
+		{
+			"parameters": {
+				"url": "http://mockapi:8080/orgs/g02pp066qoyithcjevhd6m1wfii3c4x51k39n9apybljhx69/events",
+				"options": {
+					"response": {
+						"response": {
+							"fullResponse": true
+						}
+					}
+				}
+			},
+			"type": "n8n-nodes-base.httpRequest",
+			"typeVersion": 4.2,
+			"position": [300, 220],
+			"id": "f4c3b5d2-0257-4883-a585-ade4c3a1082c",
+			"name": "Mock organization events"
+		},
+		{
+			"parameters": {
+				"numberInputs": 3
+			},
+			"type": "n8n-nodes-base.merge",
+			"typeVersion": 3,
+			"position": [600, 20],
+			"id": "273985b7-b0ae-4cde-bbe9-7b3e4b29fe61",
+			"name": "Merge"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "89608adb-f487-416f-a7d8-3ebb1f7b50e5",
+							"name": "statusCode",
+							"value": "={{ $json.statusCode }}",
+							"type": "number"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "231275a7-44e7-47bb-8ccf-fe62dc48356b",
+			"name": "Select statusCode",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [820, 20]
+		}
+	],
+	"connections": {
+		"Webhook": {
+			"main": [
+				[
+					{
+						"node": "Mock public received events",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Mock repository events",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Mock organization events",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Mock public received events": {
+			"main": [
+				[
+					{
+						"node": "Merge",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Mock repository events": {
+			"main": [
+				[
+					{
+						"node": "Merge",
+						"type": "main",
+						"index": 1
+					}
+				]
+			]
+		},
+		"Mock organization events": {
+			"main": [
+				[
+					{
+						"node": "Merge",
+						"type": "main",
+						"index": 2
+					}
+				]
+			]
+		},
+		"Merge": {
+			"main": [
+				[
+					{
+						"node": "Select statusCode",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Select statusCode": {
+			"main": [
+				[
+					{
+						"node": "Respond to Webhook",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"settings": { "executionOrder": "v1" },
+	"staticData": null,
+	"meta": null,
+	"pinData": {
+		"Webhook": [
+			{
+				"json": {
+					"headers": { "host": "localhost:5678", "user-agent": "curl/8.6.0", "accept": "*/*" },
+					"params": {},
+					"query": {},
+					"body": {},
+					"webhookUrl": "http://localhost:5678/webhook-test/benchmark-http-node",
+					"executionMode": "test"
+				}
+			}
+		]
+	},
+	"versionId": "9fa91e54-e73a-4a34-b781-d64f2b02f333",
+	"triggerCount": 0,
+	"tags": []
+}

--- a/packages/@n8n/benchmark/scenarios/httpNode/httpNode.manifest.json
+++ b/packages/@n8n/benchmark/scenarios/httpNode/httpNode.manifest.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../scenario.schema.json",
+	"name": "HttpNode",
+	"description": "Webhook -> 3x HTTP request to a mock API -> Merge -> Respond to Webhook. Requires a mock API running at http://mockapi:8080",
+	"scenarioData": { "workflowFiles": ["httpNode.json"] },
+	"scriptPath": "httpNode.script.js"
+}

--- a/packages/@n8n/benchmark/scenarios/httpNode/httpNode.script.js
+++ b/packages/@n8n/benchmark/scenarios/httpNode/httpNode.script.js
@@ -1,0 +1,15 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const apiBaseUrl = __ENV.API_BASE_URL;
+
+export default function () {
+	const res = http.post(`${apiBaseUrl}/webhook/benchmark-http-node`);
+
+	check(res, {
+		'is status 200': (r) => r.status === 200,
+		'http requests were OK': (r) =>
+			// Response body is an array of the request status codes made with HttpNodes
+			JSON.parse(r.body).every((request) => request.statusCode === 200),
+	});
+}

--- a/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
@@ -1,4 +1,11 @@
 services:
+  mockapi:
+    image: wiremock/wiremock:3.9.1
+    ports:
+      - '8088:8080'
+    volumes:
+      - ${MOCK_API_DATA_PATH}/mappings:/home/wiremock/mappings
+
   postgres:
     image: postgres:16
     restart: always
@@ -32,8 +39,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      mockapi:
+        condition: service_started
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10

--- a/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/postgres/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: postgres:16
     restart: always
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - POSTGRES_DB=n8n
       - POSTGRES_USER=postgres
@@ -18,7 +18,7 @@ services:
 
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n

--- a/packages/@n8n/benchmark/scripts/n8nSetups/queue/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/queue/docker-compose.yml
@@ -1,4 +1,11 @@
 services:
+  mockapi:
+    image: wiremock/wiremock:3.9.1
+    ports:
+      - '8088:8080'
+    volumes:
+      - ${MOCK_API_DATA_PATH}/mappings:/home/wiremock/mappings
+
   redis:
     image: redis:6-alpine
     ports:
@@ -49,7 +56,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n_worker1:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10
@@ -81,7 +88,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n_worker2:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10
@@ -113,8 +120,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      mockapi:
+        condition: service_started
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10

--- a/packages/@n8n/benchmark/scripts/n8nSetups/queue/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/queue/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   postgres:
     image: postgres:16
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     restart: always
     environment:
       - POSTGRES_DB=n8n
@@ -27,7 +27,7 @@ services:
 
   n8n_worker1:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n/worker1
@@ -56,7 +56,7 @@ services:
 
   n8n_worker2:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n/worker2
@@ -88,7 +88,7 @@ services:
 
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n/main

--- a/packages/@n8n/benchmark/scripts/n8nSetups/sqlite-legacy/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/sqlite-legacy/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n

--- a/packages/@n8n/benchmark/scripts/n8nSetups/sqlite-legacy/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/sqlite-legacy/docker-compose.yml
@@ -1,4 +1,11 @@
 services:
+  mockapi:
+    image: wiremock/wiremock:3.9.1
+    ports:
+      - '8088:8080'
+    volumes:
+      - ${MOCK_API_DATA_PATH}/mappings:/home/wiremock/mappings
+
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
     user: root:root
@@ -10,10 +17,13 @@ services:
     volumes:
       - ${RUN_DIR}:/n8n
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10
+    depends_on:
+      mockapi:
+        condition: service_started
 
   benchmark:
     image: ghcr.io/n8n-io/n8n-benchmark:${N8N_BENCHMARK_VERSION:-latest}

--- a/packages/@n8n/benchmark/scripts/n8nSetups/sqlite/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/sqlite/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
-    user: ${RUN_USER_AND_GROUP}
+    user: root:root
     environment:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_USER_FOLDER=/n8n

--- a/packages/@n8n/benchmark/scripts/n8nSetups/sqlite/docker-compose.yml
+++ b/packages/@n8n/benchmark/scripts/n8nSetups/sqlite/docker-compose.yml
@@ -1,4 +1,11 @@
 services:
+  mockapi:
+    image: wiremock/wiremock:3.9.1
+    ports:
+      - '8088:8080'
+    volumes:
+      - ${MOCK_API_DATA_PATH}/mappings:/home/wiremock/mappings
+
   n8n:
     image: ghcr.io/n8n-io/n8n:${N8N_VERSION:-latest}
     user: root:root
@@ -12,10 +19,13 @@ services:
     volumes:
       - ${RUN_DIR}:/n8n
     healthcheck:
-      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      test: ['CMD-SHELL', 'wget --spider -q http://n8n:5678/healthz || exit 1']
       interval: 5s
       timeout: 5s
       retries: 10
+    depends_on:
+      mockapi:
+        condition: service_started
 
   benchmark:
     image: ghcr.io/n8n-io/n8n-benchmark:${N8N_BENCHMARK_VERSION:-latest}

--- a/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
+++ b/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
@@ -32,12 +32,6 @@ async function main() {
 	const runDir = path.join(baseRunDir, n8nSetupToUse);
 	fs.emptyDirSync(runDir);
 
-	if (!process.getuid) {
-		console.error('Windows is not supported');
-		process.exit(1);
-	}
-
-	const currentUserId = process.getuid();
 	const dockerComposeClient = new DockerComposeClient({
 		$: $({
 			cwd: composeFilePath,
@@ -47,7 +41,6 @@ async function main() {
 				BENCHMARK_VERSION: benchmarkTag,
 				K6_API_TOKEN: k6ApiToken,
 				RUN_DIR: runDir,
-				RUN_USER_AND_GROUP: `${currentUserId}:${currentUserId}`,
 			},
 		}),
 	});

--- a/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
+++ b/packages/@n8n/benchmark/scripts/runForN8nSetup.mjs
@@ -9,6 +9,7 @@ import { DockerComposeClient } from './clients/dockerComposeClient.mjs';
 
 const paths = {
 	n8nSetupsDir: path.join(__dirname, 'n8nSetups'),
+	mockApiDataPath: path.join(__dirname, 'mockApi'),
 };
 
 async function main() {
@@ -41,6 +42,7 @@ async function main() {
 				BENCHMARK_VERSION: benchmarkTag,
 				K6_API_TOKEN: k6ApiToken,
 				RUN_DIR: runDir,
+				MOCK_API_DATA_PATH: paths.mockApiDataPath,
 			},
 		}),
 	});


### PR DESCRIPTION
## Summary

Add http node benchmark

Adds a wiremock mock Github API for each n8n setup. The API definition
is from https://library.wiremock.org/catalog/api/g/github.com/github-com-ghes-2-21/

Also changes each container to be run as root, so we don't have to fight with file permissions

![image](https://github.com/user-attachments/assets/bc10692a-6bce-45de-9916-d75d8b017c80)

![image](https://github.com/user-attachments/assets/b4e52dbb-52cc-47fa-a941-d8d1d239ec64)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
