### PR TITLE
fix(editor): Cross-platform build for @n8n/chat (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "*",
     "@types/supertest": "^6.0.2",
+    "cross-env": "^7.0.3",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",
     "jest-expect-message": "^1.1.3",

--- a/packages/@n8n/chat/package.json
+++ b/packages/@n8n/chat/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "dev": "pnpm run storybook",
     "build": "pnpm build:vite && pnpm build:bundle",
-    "build:vite": "vite build",
-    "build:bundle": "INCLUDE_VUE=true vite build",
+    "build:vite": "cross-env vite build",
+    "build:bundle": "cross-env INCLUDE_VUE=true vite build",
     "preview": "vite preview",
     "test:dev": "vitest",
     "test": "vitest run",

--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -93,7 +93,6 @@
     "@types/luxon": "^3.2.0",
     "@types/uuid": "catalog:",
     "@vitest/coverage-v8": "catalog:frontend",
-    "cross-env": "^7.0.3",
     "miragejs": "^0.1.48",
     "unplugin-icons": "^0.19.0",
     "unplugin-vue-components": "^0.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       jest:
         specifier: ^29.6.2
         version: 29.6.2(@types/node@18.16.16)(ts-node@10.9.2(@types/node@18.16.16)(typescript@5.6.2))
@@ -1526,9 +1529,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: catalog:frontend
         version: 2.1.2(vitest@2.1.2(@types/node@18.16.16)(jsdom@23.0.1)(sass@1.64.1)(terser@5.16.1))
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       miragejs:
         specifier: ^0.1.48
         version: 0.1.48


### PR DESCRIPTION
### Fixed

- Build process for @n8n/chat package on Windows environments
  - This change allows the INCLUDE_VUE environment variable to be set correctly across different operating systems
