### PR TITLE
fix: Show a more user friendly error message if initial Db connection times out

### DIFF
--- a/packages/cli/src/databases/config.ts
+++ b/packages/cli/src/databases/config.ts
@@ -132,3 +132,9 @@ export function getConnectionOptions(): DataSourceOptions {
 			throw new ApplicationError('Database type currently not supported', { extra: { dbType } });
 	}
 }
+
+export function arePostgresOptions(
+	options: DataSourceOptions,
+): options is PostgresConnectionOptions {
+	return options.type === 'postgres';
+}

--- a/packages/workflow/src/errors/db-connection-timeout-error.ts
+++ b/packages/workflow/src/errors/db-connection-timeout-error.ts
@@ -1,0 +1,14 @@
+import { ApplicationError } from './application.error';
+
+export type DbConnectionTimeoutErrorOpts = {
+	configuredTimeoutInMs: number;
+	cause: Error;
+};
+
+export class DbConnectionTimeoutError extends ApplicationError {
+	constructor(opts: DbConnectionTimeoutErrorOpts) {
+		const numberFormat = Intl.NumberFormat();
+		const errorMessage = `Could not establish database connection within the configured timeout of ${numberFormat.format(opts.configuredTimeoutInMs)} ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.`;
+		super(errorMessage, { cause: opts.cause });
+	}
+}

--- a/packages/workflow/src/errors/ensure-error.ts
+++ b/packages/workflow/src/errors/ensure-error.ts
@@ -1,0 +1,9 @@
+/** Ensures `error` is an `Error */
+export function ensureError(error: unknown): Error {
+	return error instanceof Error
+		? error
+		: new Error('Error that was not an instance of Error was thrown', {
+				// We should never throw anything except something that derives from Error
+				cause: error,
+			});
+}

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -16,8 +16,5 @@ export { TriggerCloseError } from './trigger-close.error';
 export { NodeError } from './abstract/node.error';
 export { ExecutionBaseError } from './abstract/execution-base.error';
 export { ExpressionExtensionError } from './expression-extension.error';
-export {
-	DbConnectionTimeoutError,
-	DbConnectionTimeoutErrorOpts,
-} from './db-connection-timeout-error';
+export { DbConnectionTimeoutError } from './db-connection-timeout-error';
 export { ensureError } from './ensure-error';

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -16,3 +16,8 @@ export { TriggerCloseError } from './trigger-close.error';
 export { NodeError } from './abstract/node.error';
 export { ExecutionBaseError } from './abstract/execution-base.error';
 export { ExpressionExtensionError } from './expression-extension.error';
+export {
+	DbConnectionTimeoutError,
+	DbConnectionTimeoutErrorOpts,
+} from './db-connection-timeout-error';
+export { ensureError } from './ensure-error';


### PR DESCRIPTION
## Summary

Show a more user friendly error message if the initial Db connection times out.

If we wanted to have a better error message for all connection timeouts, we would have to make changes to our `typeorm` fork.

```
Error: There was an error initializing DB
    at Start.exitWithCrash (/n8n/packages/cli/src/commands/base-command.ts:161:23)
    at /n8n/packages/cli/src/commands/base-command.ts:71:39
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    ... 5 lines matching cause stack trace ...
    at /n8n/packages/cli/bin/n8n:65:2 {
  [cause]: DbConnectionTimeoutError: Could not establish database connection within the configured timeout of 1 000 ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.
      at Object.init (/n8n/packages/cli/src/db.ts:69:12)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Start.init (/n8n/packages/cli/src/commands/base-command.ts:70:3)
      at Start.init (/n8n/packages/cli/src/commands/start.ts:195:3)
      at Start._run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/command.js:301:13)
      at Config.runCommand (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/config/config.js:424:25)
      at run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/main.js:94:16)
      at /n8n/packages/cli/bin/n8n:65:2 {
    level: 'error',
    tags: { packageName: 'cli' },
    extra: undefined,
    [cause]: Error: Connection terminated due to connection timeout
        at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
        at Object.onceWrapper (node:events:633:28)
        at Connection.emit (node:events:519:28)
        at Connection.emit (node:domain:488:12)
        at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
        at Socket.emit (node:events:519:28)
        at Socket.emit (node:domain:488:12)
        at TCP.<anonymous> (node:net:338:12)
  }
} undefined
DbConnectionTimeoutError: Could not establish database connection within the configured timeout of 1 000 ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.
    at Object.init (/n8n/packages/cli/src/db.ts:69:12)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Start.init (/n8n/packages/cli/src/commands/base-command.ts:70:3)
    at Start.init (/n8n/packages/cli/src/commands/start.ts:195:3)
    at Start._run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/command.js:301:13)
    at Config.runCommand (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/config/config.js:424:25)
    at run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/main.js:94:16)
    at /n8n/packages/cli/bin/n8n:65:2 {
  level: 'error',
  tags: { packageName: 'cli' },
  extra: undefined,
  [cause]: Error: Connection terminated due to connection timeout
      at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
      at Object.onceWrapper (node:events:633:28)
      at Connection.emit (node:events:519:28)
      at Connection.emit (node:domain:488:12)
      at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
      at Socket.emit (node:events:519:28)
      at Socket.emit (node:domain:488:12)
      at TCP.<anonymous> (node:net:338:12)
} undefined
Error: Connection terminated due to connection timeout
    at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
    at Object.onceWrapper (node:events:633:28)
    at Connection.emit (node:events:519:28)
    at Connection.emit (node:domain:488:12)
    at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
    at Socket.emit (node:events:519:28)
    at Socket.emit (node:domain:488:12)
    at TCP.<anonymous> (node:net:338:12) undefined
Error: There was an error initializing DB
    at Start.exitWithCrash (/n8n/packages/cli/src/commands/base-command.ts:161:23)
    at /n8n/packages/cli/src/commands/base-command.ts:71:39
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    ... 5 lines matching cause stack trace ...
    at /n8n/packages/cli/bin/n8n:65:2 {
  [cause]: DbConnectionTimeoutError: Could not establish database connection within the configured timeout of 1 000 ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.
      at Object.init (/n8n/packages/cli/src/db.ts:69:12)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Start.init (/n8n/packages/cli/src/commands/base-command.ts:70:3)
      at Start.init (/n8n/packages/cli/src/commands/start.ts:195:3)
      at Start._run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/command.js:301:13)
      at Config.runCommand (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/config/config.js:424:25)
      at run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/main.js:94:16)
      at /n8n/packages/cli/bin/n8n:65:2 {
    level: 'error',
    tags: { packageName: 'cli' },
    extra: undefined,
    [cause]: Error: Connection terminated due to connection timeout
        at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
        at Object.onceWrapper (node:events:633:28)
        at Connection.emit (node:events:519:28)
        at Connection.emit (node:domain:488:12)
        at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
        at Socket.emit (node:events:519:28)
        at Socket.emit (node:domain:488:12)
        at TCP.<anonymous> (node:net:338:12)
  }
} undefined
DbConnectionTimeoutError: Could not establish database connection within the configured timeout of 1 000 ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.
    at Object.init (/n8n/packages/cli/src/db.ts:69:12)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Start.init (/n8n/packages/cli/src/commands/base-command.ts:70:3)
    at Start.init (/n8n/packages/cli/src/commands/start.ts:195:3)
    at Start._run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/command.js:301:13)
    at Config.runCommand (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/config/config.js:424:25)
    at run (/n8n/node_modules/.pnpm/@oclif+core@4.0.7/node_modules/@oclif/core/lib/main.js:94:16)
    at /n8n/packages/cli/bin/n8n:65:2 {
  level: 'error',
  tags: { packageName: 'cli' },
  extra: undefined,
  [cause]: Error: Connection terminated due to connection timeout
      at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
      at Object.onceWrapper (node:events:633:28)
      at Connection.emit (node:events:519:28)
      at Connection.emit (node:domain:488:12)
      at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
      at Socket.emit (node:events:519:28)
      at Socket.emit (node:domain:488:12)
      at TCP.<anonymous> (node:net:338:12)
} undefined
Error: Connection terminated due to connection timeout
    at Connection.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/client.js:132:73)
    at Object.onceWrapper (node:events:633:28)
    at Connection.emit (node:events:519:28)
    at Connection.emit (node:domain:488:12)
    at Socket.<anonymous> (/n8n/node_modules/.pnpm/pg@8.12.0/node_modules/pg/lib/connection.js:63:12)
    at Socket.emit (node:events:519:28)
    at Socket.emit (node:domain:488:12)
    at TCP.<anonymous> (node:net:338:12) undefined
[nodemon] app crashed - waiting for file changes before starting...
```

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
