### PR TITLE
fix: When could not get itemIndex match return undefined, rather than all possible item indexes

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -1205,7 +1205,7 @@ export class WorkflowExecute {
 														pairedItemData,
 													);
 
-													if (constPairedItem === null) {
+													if (constPairedItem === null || constPairedItem === undefined) {
 														errorItems.push(item);
 													} else {
 														errorItems.push({

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1954,7 +1954,7 @@ export interface IWorkflowDataProxyData {
 		destinationNodeName: string,
 		incomingSourceData: ISourceData | null,
 		pairedItem: IPairedItemData,
-	) => INodeExecutionData | null;
+	) => INodeExecutionData | null | undefined;
 	constructor: any;
 }
 

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -759,7 +759,7 @@ export class WorkflowDataProxy {
 			destinationNodeName: string,
 			incomingSourceData: ISourceData | null,
 			pairedItem: IPairedItemData,
-		): INodeExecutionData | null => {
+		): INodeExecutionData | null | undefined => {
 			let taskData: ITaskData | undefined;
 
 			let sourceData: ISourceData | null = incomingSourceData;
@@ -842,22 +842,24 @@ export class WorkflowDataProxy {
 						if (results.every((result) => result === firstResult)) {
 							// All results are the same so return the first one
 							return firstResult;
+						} else {
+							return undefined;
 						}
 
-						throw createExpressionError('Invalid expression', {
-							messageTemplate: `Multiple matching items for expression [item ${
-								currentPairedItem.item || 0
-							}]`,
-							functionality: 'pairedItem',
-							functionOverrides: {
-								message: `Multiple matching items for code [item ${currentPairedItem.item || 0}]`,
-							},
-							nodeCause: destinationNodeName,
-							descriptionKey: isScriptingNode(destinationNodeName, that.workflow)
-								? 'pairedItemMultipleMatchesCodeNode'
-								: 'pairedItemMultipleMatches',
-							type: 'paired_item_multiple_matches',
-						});
+						// throw createExpressionError('Invalid expression', {
+						// 	messageTemplate: `Multiple matching items for expression [item ${
+						// 		currentPairedItem.item || 0
+						// 	}]`,
+						// 	functionality: 'pairedItem',
+						// 	functionOverrides: {
+						// 		message: `Multiple matching items for code [item ${currentPairedItem.item || 0}]`,
+						// 	},
+						// 	nodeCause: destinationNodeName,
+						// 	descriptionKey: isScriptingNode(destinationNodeName, that.workflow)
+						// 		? 'pairedItemMultipleMatchesCodeNode'
+						// 		: 'pairedItemMultipleMatches',
+						// 	type: 'paired_item_multiple_matches',
+						// });
 					}
 
 					return results[0];

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -304,18 +304,9 @@ describe('WorkflowDataProxy', () => {
 			}
 		});
 
-		test('$("NodeName").item, paired item error: more than 1 matching item', (done) => {
+		test('$("NodeName").item, paired item error: more than 1 matching item', () => {
 			const proxy = getProxyFromFixture(fixture.workflow, fixture.run, 'PairedItemMultipleMatches');
-			try {
-				proxy.$('Edit Fields').item;
-				done('should throw');
-			} catch (error) {
-				expect(error).toBeInstanceOf(ExpressionError);
-				const exprError = error as ExpressionError;
-				expect(exprError.message).toEqual('Invalid expression');
-				expect(exprError.context.type).toEqual('paired_item_multiple_matches');
-				done();
-			}
+			expect(proxy.$('Edit Fields').item).toEqual(undefined);
 		});
 
 		test('$("NodeName").item, paired item error: missing paired item', (done) => {


### PR DESCRIPTION
## Summary

Currently we are throwing `Multiple matching items for expression` error in such case 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1598/paireditem-when-we-dont-have-any-matches-return-paireditem-undefined