### PR TITLE
fix(editor): Auto-focus expression input when switching from "fixed" mode

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -941,6 +941,14 @@ watch(remoteParameterOptionsLoading, () => {
 	tempValue.value = displayValue.value as string;
 });
 
+// Focus input field when changing from fixed value to expression
+watch(isModelValueExpression, async (isExpression, wasExpression) => {
+	if (isExpression && !wasExpression) {
+		await nextTick();
+		inputField.value?.focus();
+	}
+});
+
 onUpdated(async () => {
 	await nextTick();
 


### PR DESCRIPTION
## Summary
A small fix to retain input focus when switching to expression mode.

https://github.com/user-attachments/assets/acb3c38b-d55d-4992-8513-6e2b1bdee308



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
