### PR TITLE
fix(n8n Form Trigger Node): Do not rerun trigger when it has run data

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -6,7 +6,6 @@ import type {
 	IWorkflowDb,
 } from '@/Interface';
 import type {
-	IDataObject,
 	IRunData,
 	IRunExecutionData,
 	ITaskData,
@@ -14,24 +13,20 @@ import type {
 	Workflow,
 	StartNodeData,
 	IRun,
+	INode,
 } from 'n8n-workflow';
 import { NodeConnectionType } from 'n8n-workflow';
 
 import { useToast } from '@/composables/useToast';
 import { useNodeHelpers } from '@/composables/useNodeHelpers';
 
-import {
-	CHAT_TRIGGER_NODE_TYPE,
-	FORM_TRIGGER_NODE_TYPE,
-	WAIT_NODE_TYPE,
-	WORKFLOW_LM_CHAT_MODAL_KEY,
-} from '@/constants';
+import { CHAT_TRIGGER_NODE_TYPE, WORKFLOW_LM_CHAT_MODAL_KEY } from '@/constants';
 import { useTitleChange } from '@/composables/useTitleChange';
 import { useRootStore } from '@/stores/root.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/stores/workflows.store';
-import { openPopUpWindow } from '@/utils/executionUtils';
+import { displayForm } from '@/utils/executionUtils';
 import { useExternalHooks } from '@/composables/useExternalHooks';
 import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import type { useRouter } from 'vue-router';
@@ -261,61 +256,44 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			const runWorkflowApiResponse = await runWorkflowApi(startRunData);
 			const pinData = workflowData.pinData ?? {};
 
-			for (const node of workflowData.nodes) {
-				const hasNodeRun =
-					workflowsStore.getWorkflowExecution?.data?.resultData?.runData?.hasOwnProperty(node.name);
-
-				if (hasNodeRun || pinData[node.name]) continue;
-
-				if (![FORM_TRIGGER_NODE_TYPE, WAIT_NODE_TYPE].includes(node.type)) {
-					continue;
-				}
-
-				if (
-					options.destinationNode &&
-					options.destinationNode !== node.name &&
-					!directParentNodes.includes(node.name)
-				) {
-					continue;
-				}
-
-				if (node.name === options.destinationNode || !node.disabled) {
-					let testUrl = '';
-
-					if (node.type === FORM_TRIGGER_NODE_TYPE) {
-						const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
-						if (nodeType?.webhooks?.length) {
-							testUrl = workflowHelpers.getWebhookUrl(nodeType.webhooks[0], node, 'test');
-						}
+			const getTestUrl = (() => {
+				return (node: INode) => {
+					const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+					if (nodeType?.webhooks?.length) {
+						return workflowHelpers.getWebhookUrl(nodeType.webhooks[0], node, 'test');
 					}
+					return '';
+				};
+			})();
 
-					if (
-						node.type === WAIT_NODE_TYPE &&
-						node.parameters.resume === 'form' &&
-						runWorkflowApiResponse.executionId
-					) {
-						const workflowTriggerNodes = workflow
-							.getTriggerNodes()
-							.map((triggerNode) => triggerNode.name);
+			const shouldShowForm = (() => {
+				return (node: INode) => {
+					const workflowTriggerNodes = workflow
+						.getTriggerNodes()
+						.map((triggerNode) => triggerNode.name);
 
-						const showForm =
-							options.destinationNode === node.name ||
-							directParentNodes.includes(node.name) ||
-							workflowTriggerNodes.some((triggerNode) =>
-								workflowsStore.isNodeInOutgoingNodeConnections(triggerNode, node.name),
-							);
+					const showForm =
+						options.destinationNode === node.name ||
+						directParentNodes.includes(node.name) ||
+						workflowTriggerNodes.some((triggerNode) =>
+							workflowsStore.isNodeInOutgoingNodeConnections(triggerNode, node.name),
+						);
+					return showForm;
+				};
+			})();
 
-						if (!showForm) continue;
-
-						const { webhookSuffix } = (node.parameters.options ?? {}) as IDataObject;
-						const suffix =
-							webhookSuffix && typeof webhookSuffix !== 'object' ? `/${webhookSuffix}` : '';
-						testUrl = `${rootStore.formWaitingUrl}/${runWorkflowApiResponse.executionId}${suffix}`;
-					}
-
-					if (testUrl && options.source !== 'RunData.ManualChatMessage') openPopUpWindow(testUrl);
-				}
-			}
+			displayForm({
+				nodes: workflowData.nodes,
+				runData: workflowsStore.getWorkflowExecution?.data?.resultData?.runData,
+				destinationNode: options.destinationNode,
+				pinData,
+				directParentNodes,
+				formWaitingUrl: rootStore.formWaitingUrl,
+				executionId: runWorkflowApiResponse.executionId,
+				source: options.source,
+				getTestUrl,
+				shouldShowForm,
+			});
 
 			await useExternalHooks().run('workflowRun.runWorkflow', {
 				nodeName: options.destinationNode,

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -262,7 +262,10 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			const pinData = workflowData.pinData ?? {};
 
 			for (const node of workflowData.nodes) {
-				if (pinData[node.name]) continue;
+				const hasNodeRun =
+					workflowsStore.getWorkflowExecution?.data?.resultData?.runData?.hasOwnProperty(node.name);
+
+				if (hasNodeRun || pinData[node.name]) continue;
 
 				if (![FORM_TRIGGER_NODE_TYPE, WAIT_NODE_TYPE].includes(node.type)) {
 					continue;

--- a/packages/editor-ui/src/utils/__tests__/executionUtils.spec.ts
+++ b/packages/editor-ui/src/utils/__tests__/executionUtils.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { displayForm, openPopUpWindow } from '../executionUtils';
+import type { INode, IRunData, IPinData } from 'n8n-workflow';
+
+const FORM_TRIGGER_NODE_TYPE = 'formTrigger';
+const WAIT_NODE_TYPE = 'waitNode';
+
+vi.mock('../executionUtils', async () => {
+	const actual = await vi.importActual('../executionUtils');
+	return {
+		...actual,
+		openPopUpWindow: vi.fn(),
+	};
+});
+
+describe('displayForm', () => {
+	const getTestUrlMock = vi.fn();
+	const shouldShowFormMock = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should not call openPopUpWindow if node has already run or is pinned', () => {
+		const nodes: INode[] = [
+			{
+				id: '1',
+				name: 'Node1',
+				typeVersion: 1,
+				type: FORM_TRIGGER_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+			{
+				id: '2',
+				name: 'Node2',
+				typeVersion: 1,
+				type: WAIT_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		const runData: IRunData = { Node1: [] };
+		const pinData: IPinData = { Node2: [{ json: { data: {} } }] };
+
+		displayForm({
+			nodes,
+			runData,
+			pinData,
+			destinationNode: undefined,
+			directParentNodes: [],
+			formWaitingUrl: 'http://example.com',
+			executionId: undefined,
+			source: undefined,
+			getTestUrl: getTestUrlMock,
+			shouldShowForm: shouldShowFormMock,
+		});
+
+		expect(openPopUpWindow).not.toHaveBeenCalled();
+	});
+
+	it('should skip nodes if destinationNode does not match and node is not a directParentNode', () => {
+		const nodes: INode[] = [
+			{
+				id: '1',
+				name: 'Node1',
+				typeVersion: 1,
+				type: FORM_TRIGGER_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+			{
+				id: '2',
+				name: 'Node2',
+				typeVersion: 1,
+				type: WAIT_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		displayForm({
+			nodes,
+			runData: undefined,
+			pinData: {},
+			destinationNode: 'Node3',
+			directParentNodes: ['Node4'],
+			formWaitingUrl: 'http://example.com',
+			executionId: '12345',
+			source: undefined,
+			getTestUrl: getTestUrlMock,
+			shouldShowForm: shouldShowFormMock,
+		});
+
+		expect(openPopUpWindow).not.toHaveBeenCalled();
+	});
+
+	it('should not open pop-up if source is "RunData.ManualChatMessage"', () => {
+		const nodes: INode[] = [
+			{
+				id: '1',
+				name: 'Node1',
+				typeVersion: 1,
+				type: FORM_TRIGGER_NODE_TYPE,
+				position: [0, 0],
+				parameters: {},
+			},
+		];
+
+		getTestUrlMock.mockReturnValue('http://test-url.com');
+
+		displayForm({
+			nodes,
+			runData: undefined,
+			pinData: {},
+			destinationNode: undefined,
+			directParentNodes: [],
+			formWaitingUrl: 'http://example.com',
+			executionId: undefined,
+			source: 'RunData.ManualChatMessage',
+			getTestUrl: getTestUrlMock,
+			shouldShowForm: shouldShowFormMock,
+		});
+
+		expect(openPopUpWindow).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

When running using Test step from NDV or canvas node button existing data from trigger should be used and node should not run
![image](https://github.com/user-attachments/assets/a44edb91-e597-4494-b371-c86cee270d41)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1611/form-trigger-runs-when-running-downstream-node-when-it-shouldnt