### PR TITLE
fix: Fix the issue in Trigger Nodes where poll time was not loaded

### DIFF
--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -74,8 +74,8 @@ export class NodeTypes implements INodeTypes {
 
 		if (type in knownNodes) {
 			const { className, sourcePath } = knownNodes[type];
-			const loaded: INodeType | IVersionedNodeType = loadClassInIsolation(sourcePath, className);
-			if (NodeHelpers.isINodeType(loaded)) NodeHelpers.applySpecialNodeParameters(loaded);
+			const loaded: INodeType = loadClassInIsolation(sourcePath, className);
+			NodeHelpers.applySpecialNodeParameters(loaded);
 
 			loadedNodes[type] = { sourcePath, type: loaded };
 			return loadedNodes[type];

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -353,13 +353,6 @@ const declarativeNodeOptionParameters: INodeProperties = {
 };
 
 /**
- * Determines if the node is of INodeType
- */
-export function isINodeType(obj: unknown): obj is INodeType {
-	return typeof obj === 'object' && obj !== null && 'execute' in obj;
-}
-
-/**
  * Modifies the description of the passed in object, such that it can be used
  * as an AI Agent Tool.
  * Returns the modified item (not copied)


### PR DESCRIPTION
## Summary
This PR Fixes the issue in loading the poll time for Trigger nodes introduced in https://github.com/n8n-io/n8n/pull/10641

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1686/gmail-trigger-node-cant-activate-the-workflow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
