### PR TITLE
fix: Tweak the copy for Add more warnings to nodes (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/__tests__/nodeViewUtils.spec.ts
+++ b/packages/editor-ui/src/utils/__tests__/nodeViewUtils.spec.ts
@@ -69,7 +69,7 @@ describe('getGenericHints', () => {
 		expect(hints).toEqual([
 			{
 				message:
-					"The operation is performed for each input item. Use the 'Execute Once' setting to execute it only once for the first input item.",
+					'This node runs multiple times, once for each input item. Use ‘Execute Once’ in the node settings if you want to run it only once.',
 				location: 'outputPane',
 			},
 		]);

--- a/packages/editor-ui/src/utils/nodeViewUtils.ts
+++ b/packages/editor-ui/src/utils/nodeViewUtils.ts
@@ -1223,7 +1223,7 @@ export function getGenericHints({
 		if (!executeOnce) {
 			nodeHints.push({
 				message:
-					"The operation is performed for each input item. Use the 'Execute Once' setting to execute it only once for the first input item.",
+					'This node runs multiple times, once for each input item. Use ‘Execute Once’ in the node settings if you want to run it only once.',
 				location: 'outputPane',
 			});
 		}

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -2149,7 +2149,7 @@ export class HttpRequestV3 implements INodeType {
 				[
 					{
 						message:
-							"The result has a 'data' property which contains an array of items, you can split this array into separate items by using the 'Split Out' node",
+							'To split the contents of ‘data’ into separate items for easier processing, add a ‘Spilt Out’ node after this one',
 						location: 'outputPane',
 					},
 				],


### PR DESCRIPTION
## Summary
This PR changes the copy for 
**Execute Once hint** (on list like operations 'getAll', 'getMany', 'read', 'search' when input data length more then 1)

_from_
"The operation is performed for each input item. Use the 'Execute Once' setting to only execute it only once for the first input item."

_to_
"This node runs multiple times, once for each input item. Use ‘Execute Once’ in the node settings if you want to run it only once."


**HttpRequest node**
(if single return item with data property containing array, after execution)

_from_
*"The result has a 'data' property which contains an array of items, you can split this array into separate items by using the 'Split Out' node"*

_to_
"To split the contents of ‘data’ into separate items for easier processing, add a ‘Spilt Out’ node after this one"

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1683/add-more-warnings-to-nodes-copy-tweaks

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
