### PR TITLE
fix: Google Contacts node warm up request, Google Calendar node events>getAll fields option

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
@@ -657,6 +657,15 @@ export const eventFields: INodeProperties[] = [
 				description: 'At least some part of the event must be before this time',
 			},
 			{
+				displayName: 'Fields',
+				name: 'fields',
+				type: 'string',
+				placeholder: 'e.g. items(ID,status,summary)',
+				default: '',
+				description:
+					"Specify fields to return, by default a predefined by Google set of commonly used fields would be returned. To return all fields, use '*', <a href='https://developers.google.com/calendar/api/guides/performance#partial' target='_blank'>more info</a>.",
+			},
+			{
 				displayName: 'iCalUID',
 				name: 'iCalUID',
 				type: 'string',

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -436,6 +436,10 @@ export class GoogleCalendar implements INodeType {
 						if (options.updatedMin) {
 							qs.updatedMin = addTimezoneToDate(options.updatedMin as string, tz || timezone);
 						}
+						if (options.fields) {
+							qs.fields = options.fields as string;
+						}
+
 						if (returnAll) {
 							responseData = await googleApiRequestAllItems.call(
 								this,

--- a/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
@@ -92,6 +92,19 @@ export class GoogleContacts implements INodeType {
 		let responseData;
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
+
+		// Warmup cache
+		// https://developers.google.com/people/v1/contacts#protocol_1
+		if (resource === 'contact' && operation === 'getAll') {
+			await googleApiRequest.call(this, 'GET', '/people:searchContacts', undefined, {
+				query: '',
+				readMask: 'names',
+			});
+			await googleApiRequest.call(this, 'GET', '/people/me/connections', undefined, {
+				personFields: 'names',
+			});
+		}
+
 		for (let i = 0; i < length; i++) {
 			try {
 				if (resource === 'contact') {


### PR DESCRIPTION
## Summary

People API requires [warm up request](https://developers.google.com/people/v1/contacts)
`Fields` suggested in [ Performance tips](https://developers.google.com/calendar/api/guides/performance#partial)

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1678/google-nodes-investigate-sending-warm-up-requests
https://community.n8n.io/t/google-contact-find-failing-occasionally-randomly/52519
