### PR TITLE
fix(editor): Add arrow end to connection line

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -14,7 +14,7 @@ import type {
 	NodeChange,
 	NodePositionChange,
 } from '@vue-flow/core';
-import { useVueFlow, VueFlow, PanelPosition } from '@vue-flow/core';
+import { useVueFlow, VueFlow, PanelPosition, MarkerType } from '@vue-flow/core';
 import { Background } from '@vue-flow/background';
 import { MiniMap } from '@vue-flow/minimap';
 import Node from './elements/nodes/CanvasNode.vue';
@@ -500,6 +500,7 @@ provide(CanvasKey, {
 		:nodes="nodes"
 		:edges="connections"
 		:apply-changes="false"
+		:connection-line-options="{ markerEnd: MarkerType.ArrowClosed }"
 		pan-on-scroll
 		snap-to-grid
 		:snap-grid="[GRID_SIZE, GRID_SIZE]"


### PR DESCRIPTION
## Summary

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/8afae228-ec02-4998-95a5-efaaf66f06a2) | ![image](https://github.com/user-attachments/assets/e02fe5a5-242e-46a7-8e9a-43e0090afd8d) |




## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/N8N-7696/no-arrow-end-at-the-connection-end

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
