### PR TITLE
refactor(core): Increase Postgres connection timeout to 20 seconds

### DIFF
--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -77,7 +77,7 @@ class PostgresConfig {
 
 	/** Postgres connection timeout (ms) */
 	@Env('DB_POSTGRESDB_CONNECTION_TIMEOUT')
-	connectionTimeoutMs: number = 1000;
+	connectionTimeoutMs: number = 20000;
 
 	@Nested
 	ssl: PostgresSSLConfig;

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -77,7 +77,7 @@ class PostgresConfig {
 
 	/** Postgres connection timeout (ms) */
 	@Env('DB_POSTGRESDB_CONNECTION_TIMEOUT')
-	connectionTimeoutMs: number = 20000;
+	connectionTimeoutMs: number = 20_000;
 
 	@Nested
 	ssl: PostgresSSLConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -47,7 +47,7 @@ describe('GlobalConfig', () => {
 				poolSize: 2,
 				port: 5432,
 				schema: 'public',
-				connectionTimeoutMs: 1000,
+				connectionTimeoutMs: 20000,
 				ssl: {
 					ca: '',
 					cert: '',

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -47,7 +47,7 @@ describe('GlobalConfig', () => {
 				poolSize: 2,
 				port: 5432,
 				schema: 'public',
-				connectionTimeoutMs: 20000,
+				connectionTimeoutMs: 20_000,
 				ssl: {
 					ca: '',
 					cert: '',


### PR DESCRIPTION
## Summary

The 1s default connection timeout for Postgres was chosen to encourage colocated DB + n8n server, but it turns out this default is too low.

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C035KBDA917/p1725607802538479

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
