### PR TITLE
fix: Prevent AI assistant session reset when workflow is saved

### DIFF
--- a/cypress/e2e/45-ai-assistant.cy.ts
+++ b/cypress/e2e/45-ai-assistant.cy.ts
@@ -1,3 +1,4 @@
+import { SCHEDULE_TRIGGER_NODE_NAME } from '../constants';
 import { NDV, WorkflowPage } from '../pages';
 import { AIAssistant } from '../pages/features/ai-assistant';
 
@@ -286,5 +287,19 @@ describe('AI Assistant::enabled', () => {
 		aiAssistant.actions.openChat();
 		// Now, session should be reset
 		aiAssistant.getters.placeholderMessage().should('be.visible');
+	});
+
+	it('Should not reset assistant session when workflow is saved', () => {
+		cy.intercept('POST', '/rest/ai-assistant/chat', {
+			statusCode: 200,
+			fixture: 'aiAssistant/simple_message_response.json',
+		}).as('chatRequest');
+		wf.actions.addInitialNodeToCanvas(SCHEDULE_TRIGGER_NODE_NAME);
+		aiAssistant.actions.openChat();
+		aiAssistant.actions.sendMessage('Hello');
+		wf.actions.openNode(SCHEDULE_TRIGGER_NODE_NAME);
+		ndv.getters.nodeExecuteButton().click();
+		wf.getters.isWorkflowSaved();
+		aiAssistant.getters.placeholderMessage().should('not.exist');
 	});
 });

--- a/packages/design-system/src/components/N8nAvatar/Avatar.vue
+++ b/packages/design-system/src/components/N8nAvatar/Avatar.vue
@@ -63,6 +63,10 @@ const getSize = (size: string): number => sizes[size];
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
+
+	svg {
+		border-radius: 50%;
+	}
 }
 
 .empty {

--- a/packages/editor-ui/src/stores/assistant.store.ts
+++ b/packages/editor-ui/src/stores/assistant.store.ts
@@ -1,5 +1,11 @@
 import { chatWithAssistant, replaceCode } from '@/api/assistant';
-import { VIEWS, EDITABLE_CANVAS_VIEWS, STORES, AI_ASSISTANT_EXPERIMENT } from '@/constants';
+import {
+	VIEWS,
+	EDITABLE_CANVAS_VIEWS,
+	STORES,
+	AI_ASSISTANT_EXPERIMENT,
+	PLACEHOLDER_EMPTY_WORKFLOW_ID,
+} from '@/constants';
 import type { ChatRequest } from '@/types/assistant.types';
 import type { ChatUI } from 'n8n-design-system/types/assistant';
 import { defineStore } from 'pinia';
@@ -116,7 +122,11 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 	watch(route, () => {
 		const activeWorkflowId = workflowsStore.workflowId;
-		if (!currentSessionId.value || currentSessionWorkflowId.value === activeWorkflowId) {
+		if (
+			!currentSessionId.value ||
+			currentSessionWorkflowId.value === PLACEHOLDER_EMPTY_WORKFLOW_ID ||
+			currentSessionWorkflowId.value === activeWorkflowId
+		) {
 			return;
 		}
 		resetAssistantChat();
@@ -276,6 +286,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				{
 					chat_session_id: currentSessionId.value,
 					task: isSupportChatSessionInProgress.value ? 'support' : 'error',
+					node_type: chatSessionError.value?.node.type,
 				},
 				{ withPostHog: true },
 			);


### PR DESCRIPTION
## Summary
1. Preventing AI assistant session reset when workflows are saved
2. Adding `node_type` to the `Assistant session started` telemetry event
3. Minor fix: Preventing user avatar from turning square when modals are open
<img width="168" alt="image" src="https://github.com/user-attachments/assets/62826c4e-873e-47b5-9445-1a09c815c89e">

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
