### PR TITLE
fix(editor): Don't render pinned icon for disabled nodes

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.spec.ts
@@ -18,6 +18,18 @@ describe('CanvasNodeStatusIcons', () => {
 		expect(getByTestId('canvas-node-status-pinned')).toBeInTheDocument();
 	});
 
+	it('should not render pinned icon when disabled', () => {
+		const { queryByTestId } = renderComponent({
+			global: {
+				provide: createCanvasNodeProvide({
+					data: { disabled: true, pinnedData: { count: 5, visible: true } },
+				}),
+			},
+		});
+
+		expect(queryByTestId('canvas-node-status-pinned')).not.toBeInTheDocument();
+	});
+
 	it('should render correctly for a running node', () => {
 		const { getByTestId } = renderComponent({
 			global: {

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -15,6 +15,7 @@ const {
 	executionRunning,
 	hasRunData,
 	runDataIterations,
+	isDisabled,
 } = useCanvasNode();
 
 const hideNodeIssues = computed(() => false); // @TODO Implement this
@@ -45,7 +46,7 @@ const hideNodeIssues = computed(() => false); // @TODO Implement this
 		</N8nTooltip>
 	</div>
 	<div
-		v-else-if="hasPinnedData && !nodeHelpers.isProductionExecutionPreview.value"
+		v-else-if="hasPinnedData && !nodeHelpers.isProductionExecutionPreview.value && !isDisabled"
 		data-test-id="canvas-node-status-pinned"
 		:class="[$style.status, $style.pinnedData]"
 	>


### PR DESCRIPTION
## Summary

| Before | After |
| ------------- | ------------- |
| <img width="303" alt="image" src="https://github.com/user-attachments/assets/c19d0584-0688-4876-a397-2755f39f64e4"> | <img width="303" alt="image" src="https://github.com/user-attachments/assets/ae5a751b-cb16-4222-be3e-dbd42f6c1a7d">  |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7683/decativated-pinned-node-still-shows-icon

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
