### PR TITLE
fix(Gmail Trigger Node): Change Gmail Trigger dedupe logic

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -361,7 +361,7 @@ export class GmailTrigger implements INodeType {
 		const nextPollPossibleDuplicates = (responseData as IDataObject[]).reduce(
 			(duplicates, { json }) => {
 				const emailDate = getEmailDateAsSeconds(json as IDataObject);
-				return emailDate === lastEmailDate
+				return emailDate <= lastEmailDate
 					? duplicates.concat((json as IDataObject).id as string)
 					: duplicates;
 			},


### PR DESCRIPTION
## Summary
This PR changes how GMail Trigger node handles duplicate email by changing the comparison against latest email date

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1601/community-issue-gmail-trigger-fetching-duplicate-emails-again
https://github.com/n8n-io/n8n/issues/10470


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
