### PR TITLE
fix(Telegram Trigger Node): Use timing-safe string comparison (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type {
 	IHookFunctions,
 	IWebhookFunctions,
@@ -233,7 +234,11 @@ export class TelegramTrigger implements INodeType {
 		const nodeVersion = this.getNode().typeVersion;
 		if (nodeVersion > 1) {
 			const secret = getSecretToken.call(this);
-			if (secret !== headerData['x-telegram-bot-api-secret-token']) {
+			const secretBuffer = Buffer.from(secret);
+			const headerSecretBuffer = Buffer.from(
+				String(headerData['x-telegram-bot-api-secret-token'] ?? ''),
+			);
+			if (!crypto.timingSafeEqual(secretBuffer, headerSecretBuffer)) {
 				const res = this.getResponseObject();
 				res.status(403).json({ message: 'Provided secret is not valid' });
 				return {


### PR DESCRIPTION
## Summary

This PR Uses crypto.timingSafeEqual, a timing-safe string comparison function built into NodeJS

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1684/a-timing-attack-might-allow-hackers-to-bruteforce-passwords-high

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
