### PR TITLE
fix(YouTube Node): Fix Date filters

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/YouTube.node.ts
@@ -10,6 +10,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, BINARY_ENCODING, NodeOperationError } from 'n8n-workflow';
 
+import { DateTime } from 'luxon';
 import { googleApiRequest, googleApiRequestAllItems } from './GenericFunctions';
 
 import { channelFields, channelOperations } from './ChannelDescription';
@@ -762,6 +763,28 @@ export class YouTube implements INodeType {
 						qs.type = 'video';
 
 						qs.forMine = true;
+						if (filters.publishedAfter) {
+							const publishedAfter = DateTime.fromISO(filters.publishedAfter as string);
+							if (publishedAfter.isValid) {
+								filters.publishedAfter = publishedAfter.setZone(this.getTimezone()).toISO();
+							} else {
+								throw new NodeOperationError(
+									this.getNode(),
+									`The value "${filters.publishedAfter as string}" is not a valid DateTime.`,
+								);
+							}
+						}
+						if (filters.publishedBefore) {
+							const publishedBefore = DateTime.fromISO(filters.publishedBefore as string);
+							if (publishedBefore.isValid) {
+								filters.publishedAfter = publishedBefore.setZone(this.getTimezone()).toISO();
+							} else {
+								throw new NodeOperationError(
+									this.getNode(),
+									`The value "${filters.publishedBefore as string}" is not a valid DateTime.`,
+								);
+							}
+						}
 
 						Object.assign(qs, options, filters);
 


### PR DESCRIPTION
## Summary
This PR fixes the date format for published before and published after filters to include timezones

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1288/youtube-published-after-published-before-date-filters-error

https://github.com/n8n-io/n8n/issues/9007

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
