### PR TITLE
fix(Chat Trigger Node): Fix auth in "Embedded Chat" mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -460,20 +460,19 @@ export class ChatTrigger extends Node {
 		const mode = ctx.getMode() === 'manual' ? 'test' : 'production';
 		const bodyData = ctx.getBodyData() ?? {};
 
-		if (nodeMode === 'hostedChat') {
-			try {
-				await validateAuth(ctx);
-			} catch (error) {
-				if (error) {
-					res.writeHead((error as IDataObject).responseCode as number, {
-						'www-authenticate': 'Basic realm="Webhook"',
-					});
-					res.end((error as IDataObject).message as string);
-					return { noWebhookResponse: true };
-				}
-				throw error;
+		try {
+			await validateAuth(ctx);
+		} catch (error) {
+			if (error) {
+				res.writeHead((error as IDataObject).responseCode as number, {
+					'www-authenticate': 'Basic realm="Webhook"',
+				});
+				res.end((error as IDataObject).message as string);
+				return { noWebhookResponse: true };
 			}
-
+			throw error;
+		}
+		if (nodeMode === 'hostedChat') {
 			// Show the chat on GET request
 			if (webhookName === 'setup') {
 				const webhookUrlRaw = ctx.getNodeWebhookUrl('default') as string;


### PR DESCRIPTION
## Summary

This PR fixes an issue with Chat Trigger Node where the request wouldn't be adequately validated in "Embedded Chat" mode due to validation try/catch nested in `nodeMode === 'hostedChat'` guard

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
