### PR TITLE
feat(editor): Add lint for $('Node').item in runOnceForAllItems mode

### DIFF
--- a/cypress/e2e/6-code-node.cy.ts
+++ b/cypress/e2e/6-code-node.cy.ts
@@ -38,6 +38,51 @@ describe('Code node', () => {
 
 			successToast().contains('Node executed successfully');
 		});
+
+		it('should show lint errors in `runOnceForAllItems` mode', () => {
+			const getParameter = () => ndv.getters.parameterInput('jsCode').should('be.visible');
+			const getEditor = () => getParameter().find('.cm-content').should('exist');
+
+			getEditor().type('{selectall}').paste(`$input.itemMatching()
+$input.item
+$('When clicking ‘Test workflow’').item
+$input.first(1)
+
+for (const item of $input.all()) {
+  item.foo
+}
+
+return
+`);
+			getParameter().get('.cm-lint-marker-error').should('have.length', 6);
+			getParameter().contains('itemMatching').realHover();
+			cy.get('.cm-tooltip-lint').should(
+				'have.text',
+				'`.itemMatching()` expects an item index to be passed in as its argument.',
+			);
+		});
+
+		it('should show lint errors in `runOnceForEachItem` mode', () => {
+			const getParameter = () => ndv.getters.parameterInput('jsCode').should('be.visible');
+			const getEditor = () => getParameter().find('.cm-content').should('exist');
+
+			ndv.getters.parameterInput('mode').click();
+			ndv.actions.selectOptionInParameterDropdown('mode', 'Run Once for Each Item');
+			getEditor().type('{selectall}').paste(`$input.itemMatching()
+$input.all()
+$input.first()
+$input.item()
+
+return []
+`);
+
+			getParameter().get('.cm-lint-marker-error').should('have.length', 5);
+			getParameter().contains('all').realHover();
+			cy.get('.cm-tooltip-lint').should(
+				'have.text',
+				"Method `$input.all()` is only available in the 'Run Once for All Items' mode.",
+			);
+		});
 	});
 
 	describe('Ask AI', () => {

--- a/packages/editor-ui/src/components/CodeNodeEditor/linter.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/linter.ts
@@ -2,7 +2,7 @@ import type { Diagnostic } from '@codemirror/lint';
 import { linter } from '@codemirror/lint';
 import type { EditorView } from '@codemirror/view';
 import * as esprima from 'esprima-next';
-import type { Node } from 'estree';
+import type { Node, MemberExpression } from 'estree';
 import type { CodeExecutionMode, CodeNodeEditorLanguage } from 'n8n-workflow';
 import { toValue, type MaybeRefOrGetter } from 'vue';
 
@@ -153,13 +153,20 @@ export const useLinter = (
 		if (toValue(mode) === 'runOnceForAllItems') {
 			type TargetNode = RangeNode & { property: RangeNode };
 
+			const isInputIdentifier = (node: Node) =>
+				node.type === 'Identifier' && node.name === '$input';
+			const isPreviousNodeCall = (node: Node) =>
+				node.type === 'CallExpression' &&
+				node.callee.type === 'Identifier' &&
+				node.callee.name === '$';
+			const isDirectMemberExpression = (node: Node): node is MemberExpression =>
+				node.type === 'MemberExpression' && !node.computed;
+			const isItemIdentifier = (node: Node) => node.type === 'Identifier' && node.name === 'item';
+
 			const isUnavailableInputItemAccess = (node: Node) =>
-				node.type === 'MemberExpression' &&
-				!node.computed &&
-				node.object.type === 'Identifier' &&
-				node.object.name === '$input' &&
-				node.property.type === 'Identifier' &&
-				node.property.name === 'item';
+				isDirectMemberExpression(node) &&
+				(isInputIdentifier(node.object) || isPreviousNodeCall(node.object)) &&
+				isItemIdentifier(node.property);
 
 			walk<TargetNode>(ast, isUnavailableInputItemAccess).forEach((node) => {
 				const [start, end] = getRange(node.property);

--- a/packages/editor-ui/src/styles/plugins/_codemirror.scss
+++ b/packages/editor-ui/src/styles/plugins/_codemirror.scss
@@ -95,10 +95,16 @@
 }
 
 .cm-editor .cm-tooltip.cm-completionInfo,
-.cm-editor .cm-tooltip.cm-cursorInfo {
+.cm-editor .cm-tooltip.cm-cursorInfo,
+.cm-editor .cm-tooltip-hover {
 	// Add padding when infobox only contains text
 	&:not(:has(div)) {
 		padding: var(--spacing-xs);
+	}
+
+	&:has(.cm-tooltip-lint) {
+		padding: 0;
+		overflow: hidden;
 	}
 
 	.autocomplete-info-container {

--- a/packages/editor-ui/src/styles/plugins/_codemirror.scss
+++ b/packages/editor-ui/src/styles/plugins/_codemirror.scss
@@ -95,8 +95,7 @@
 }
 
 .cm-editor .cm-tooltip.cm-completionInfo,
-.cm-editor .cm-tooltip.cm-cursorInfo,
-.cm-editor .cm-tooltip-hover {
+.cm-editor .cm-tooltip.cm-cursorInfo {
 	// Add padding when infobox only contains text
 	&:not(:has(div)) {
 		padding: var(--spacing-xs);


### PR DESCRIPTION
## Summary

<img width="948" alt="image" src="https://github.com/user-attachments/assets/49bee3c2-b6d9-41cc-8bdb-856c52e10287">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1588/code-node-throw-an-error-when-using-dollaritem-in-run-once-for-all

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
