### PR TITLE
feat(GitHub Node): Add workflow resource operations

### DIFF
--- a/packages/nodes-base/nodes/Github/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Github/GenericFunctions.ts
@@ -119,3 +119,13 @@ export function isBase64(content: string) {
 	const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 	return base64regex.test(content);
 }
+
+export function validateJSON(json: string | undefined): any {
+	let result;
+	try {
+		result = JSON.parse(json!);
+	} catch (exception) {
+		result = undefined;
+	}
+	return result;
+}

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -14,9 +14,9 @@ import {
 	githubApiRequest,
 	githubApiRequestAllItems,
 	isBase64,
+	validateJSON,
 } from './GenericFunctions';
 import { getRepositories, getUsers, getWorkflows } from './SearchFunctions';
-import { validateJSON } from '../ClickUp/GenericFunctions';
 
 export class Github implements INodeType {
 	description: INodeTypeDescription = {


### PR DESCRIPTION
## Summary

Add the ability to use GitHub workflows as Nodes:
- Disable a workflow
- Dispatch a workflow event
- Enable a workflow
- Get a workflow
- Get the usage of a workflow
- List workflows

Following [GitHub's API](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28).

It enhances the integration between n8n and GitHub Actions Workflows, enabling greater automation by using GitHub nodes instead of HTTP nodes.

<img width="390" alt="Screenshot 2024-09-09 at 20 03 31" src="https://github.com/user-attachments/assets/fe773d9f-8519-4789-bd33-3395ecc07446">

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created (https://github.com/n8n-io/n8n-docs/pull/2463)
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
