### PR TITLE
fix(core): WorkflowDataProxy: deepCopy node execution data to prevent mutation

### DIFF
--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -255,11 +255,11 @@ export class WorkflowDataProxy {
 		shortSyntax?: boolean;
 	}) {
 		try {
-			return this.getNodeExecutionData(nodeName, shortSyntax, branchIndex, runIndex);
+			return deepCopy(this.getNodeExecutionData(nodeName, shortSyntax, branchIndex, runIndex));
 		} catch (e) {
 			const pinData = getPinDataIfManualExecution(this.workflow, nodeName, this.mode);
 			if (pinData) {
-				return pinData;
+				return deepCopy(pinData);
 			}
 
 			throw e;
@@ -412,7 +412,6 @@ export class WorkflowDataProxy {
 							nodeName,
 							shortSyntax,
 						});
-
 						if (executionData.length === 0) {
 							if (that.workflow.getParentNodes(nodeName).length === 0) {
 								throw new ExpressionError('No execution data available', {
@@ -958,7 +957,7 @@ export class WorkflowDataProxy {
 				});
 			}
 
-			return taskData.data!.main[previousNodeOutput]![pairedItem.item];
+			return deepCopy(taskData.data!.main[previousNodeOutput]![pairedItem.item]);
 		};
 
 		const base = {
@@ -1228,7 +1227,7 @@ export class WorkflowDataProxy {
 						return () => {
 							const result = that.connectionInputData;
 							if (result.length) {
-								return result;
+								return deepCopy(result);
 							}
 							return [];
 						};

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -208,6 +208,20 @@ describe('WorkflowDataProxy', () => {
 				name: 'test workflow',
 			});
 		});
+
+		test('should not be able to modify previous node data', () => {
+			proxy.$json.data = 'updated!';
+			expect(proxy.$json.data).toEqual(105);
+
+			proxy.$('Function').item.json.initialName = 'updated!';
+			expect(proxy.$('Function').item.json.initialName).toEqual(105);
+
+			proxy.$input.all()[1].json.data = 'updated!';
+			expect(proxy.$input.all()[1].json.data).toEqual(160);
+
+			proxy.$('Rename').first().json.data = 'updated!';
+			expect(proxy.$('Rename').first().json.data).toEqual(105);
+		});
 	});
 
 	describe('Errors', () => {


### PR DESCRIPTION
## Summary

Expressions being allowed to mutate source data causes many bugs, this PR is an attempt to fix that.

`deepCopy` does come with a performance cost, but maybe it's better to be slow and correct.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1517/expression-extensions-typing-reverse-crashes-fe

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
