### PR TITLE
fix(editor): Show docs link in credential modal when docs sidebar is hidden

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialConfig.vue
@@ -266,7 +266,10 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 			/>
 
 			<template v-if="credentialPermissions.update">
-				<n8n-notice v-if="documentationUrl && credentialProperties.length && !docs" theme="warning">
+				<n8n-notice
+					v-if="documentationUrl && credentialProperties.length && !showCredentialDocs"
+					theme="warning"
+				>
 					{{ $locale.baseText('credentialEdit.credentialConfig.needHelpFillingOutTheseFields') }}
 					<span class="ml-4xs">
 						<n8n-link :to="documentationUrl" size="small" bold @click="onDocumentationUrlClick">


### PR DESCRIPTION
## Summary

Show docs link in credential modal when docs sidebar is hidden

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/164b1ec5-93b2-4fa7-b9a4-7a15e374b11a">

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/15b8803e-0e48-4962-a907-18568e46a5e7">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1707/show-docs-link-for-credentials-in-ab-test

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
