### PR TITLE
fix(Edit Image Node): Fix text option 

### DIFF
--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -264,6 +264,22 @@ const nodeOperationOptions: INodeProperties[] = [
 		description: 'Text to write on the image',
 	},
 	{
+		displayName: 'Font Name or ID',
+		name: 'font',
+		type: 'options',
+		displayOptions: {
+			show: {
+				operation: ['text'],
+			},
+		},
+		typeOptions: {
+			loadOptionsMethod: 'getFonts',
+		},
+		default: '',
+		description:
+			'The font to use. Choose from the list, or specify the local file path to the font using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+	},
+	{
 		displayName: 'Font Size',
 		name: 'fontSize',
 		type: 'number',
@@ -837,22 +853,6 @@ export class EditImage implements INodeType {
 								default: '',
 							},
 							...nodeOperationOptions,
-							{
-								displayName: 'Font Name or ID',
-								name: 'font',
-								type: 'options',
-								displayOptions: {
-									show: {
-										operation: ['text'],
-									},
-								},
-								typeOptions: {
-									loadOptionsMethod: 'getFonts',
-								},
-								default: 'default',
-								description:
-									'The font to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
-							},
 						],
 					},
 				],
@@ -877,22 +877,6 @@ export class EditImage implements INodeType {
 						type: 'string',
 						default: '',
 						description: 'File name to set in binary data',
-					},
-					{
-						displayName: 'Font Name or ID',
-						name: 'font',
-						type: 'options',
-						displayOptions: {
-							show: {
-								'/operation': ['text'],
-							},
-						},
-						typeOptions: {
-							loadOptionsMethod: 'getFonts',
-						},
-						default: 'default',
-						description:
-							'The font to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Format',
@@ -975,11 +959,6 @@ export class EditImage implements INodeType {
 						return 1;
 					}
 					return 0;
-				});
-
-				returnData.unshift({
-					name: 'default',
-					value: 'default',
 				});
 
 				return returnData;
@@ -1233,8 +1212,6 @@ export class EditImage implements INodeType {
 
 						// Combine the lines to a single string
 						const renderText = lines.join('\n');
-
-						// const font = options.font || operationData.font;
 
 						gmInstance = gmInstance!
 							.fill(operationData.fontColor as string)

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -1234,14 +1234,11 @@ export class EditImage implements INodeType {
 						// Combine the lines to a single string
 						const renderText = lines.join('\n');
 
-						const font = options.font || operationData.font;
-
-						if (font && font !== 'default') {
-							gmInstance = gmInstance!.font(font as string);
-						}
+						// const font = options.font || operationData.font;
 
 						gmInstance = gmInstance!
 							.fill(operationData.fontColor as string)
+							.font(operationData.font as string)
 							.fontSize(operationData.fontSize as number)
 							.drawText(
 								operationData.positionX as number,

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -276,8 +276,7 @@ const nodeOperationOptions: INodeProperties[] = [
 			loadOptionsMethod: 'getFonts',
 		},
 		default: '',
-		description:
-			'The font to use. Choose from the list, or specify the local file path to the font using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		description: 'The font to use. Choose from the list, or specify the local file path to the font using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Font Size',

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -276,7 +276,8 @@ const nodeOperationOptions: INodeProperties[] = [
 			loadOptionsMethod: 'getFonts',
 		},
 		default: '',
-		description: 'The font to use. Choose from the list, or specify the local file path to the font using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+		description:
+			'The font to use. Choose from the list, or specify the local file path to the font using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Font Size',


### PR DESCRIPTION
## Summary

Edit Image node's text operation isn't working due to the font not being set. This PR fixes this by making 'font' a node parameter instead of an option. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1521/edit-image-text-option-is-not-working
https://community.n8n.io/t/edit-image-node-adding-text-doesnt-work/50593/2

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
