### PR TITLE
fix(core): Do not serialize CredentialsEntity.shared anymore (no-changelog)

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -113,13 +113,6 @@ export class CredentialsService {
 				);
 			}
 
-			credentials.forEach((c) => {
-				// @ts-expect-error: This is to emulate the old behaviour of removing the shared
-				// field as part of `addOwnedByAndSharedWith`. We need this field in `addScopes`
-				// though. So to avoid leaking the information we just delete it.
-				delete c.shared;
-			});
-
 			return credentials;
 		}
 
@@ -164,13 +157,6 @@ export class CredentialsService {
 		if (options.includeScopes) {
 			credentials = credentials.map((c) => this.roleService.addScopes(c, user, projectRelations!));
 		}
-
-		credentials.forEach((c) => {
-			// @ts-expect-error: This is to emulate the old behaviour of removing the shared
-			// field as part of `addOwnedByAndSharedWith`. We need this field in `addScopes`
-			// though. So to avoid leaking the information we just delete it.
-			delete c.shared;
-		});
 
 		return credentials;
 	}

--- a/packages/cli/src/databases/entities/credentials-entity.ts
+++ b/packages/cli/src/databases/entities/credentials-entity.ts
@@ -26,4 +26,9 @@ export class CredentialsEntity extends WithTimestampsAndStringId implements ICre
 
 	@OneToMany('SharedCredentials', 'credentials')
 	shared: SharedCredentials[];
+
+	toJSON() {
+		const { shared, ...rest } = this;
+		return rest;
+	}
 }

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -515,7 +515,6 @@ describe('GET /credentials/:id', () => {
 		expect(response.statusCode).toBe(200);
 		expect(response.body.data).toMatchObject({
 			id: savedCredential.id,
-			shared: [{ projectId: teamProject.id, role: 'credential:owner' }],
 			homeProject: {
 				id: teamProject.id,
 			},


### PR DESCRIPTION
## Summary
Frontend doesn't seem to use `.shared` on credentials anymore since RBAC changes.
This PR removes the `.shared` field from serialized credentials that get returned to the frontend.


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SEC-10

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included