### PR TITLE
fix(editor): Increase connector snap radius

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -501,6 +501,7 @@ provide(CanvasKey, {
 		:edges="connections"
 		:apply-changes="false"
 		:connection-line-options="{ markerEnd: MarkerType.ArrowClosed }"
+		:connection-radius="60"
 		pan-on-scroll
 		snap-to-grid
 		:snap-grid="[GRID_SIZE, GRID_SIZE]"


### PR DESCRIPTION
## Summary

Added VueFlow configuration to increase connector's snap radius to mimic V1 behaviour

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/N8N-7678/make-connector-snap-to-handle-with-a-bigger-target-area

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
