### PR TITLE
fix(editor): Close Push connection in NodeView v2 (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1536,7 +1536,10 @@ onBeforeUnmount(() => {
 	removeImportEventBindings();
 	removeExecutionOpenedEventBindings();
 	unregisterCustomActions();
-	collaborationStore.terminate();
+	if (!isDemoRoute.value) {
+		collaborationStore.terminate();
+		pushConnectionStore.pushDisconnect();
+	}
 });
 </script>
 


### PR DESCRIPTION
## Summary
NodeView v2 should close the push connection on unmount, just like v1 does.


## Review / Merge checklist

- [x] PR title and summary are descriptive