### PR TITLE
fix(editor): Do not enqueue `executionFinished` message for cancelled executions

### DIFF
--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -277,6 +277,7 @@ export interface IPackageVersions {
 export type IPushDataType = IPushData['type'];
 
 export type IPushData =
+	| PushDataExecutionCanceled
 	| PushDataExecutionFinished
 	| PushDataExecutionStarted
 	| PushDataExecuteAfter
@@ -311,6 +312,11 @@ type PushDataWorkflowActivated = {
 type PushDataWorkflowDeactivated = {
 	data: IActiveWorkflowChanged;
 	type: 'workflowDeactivated';
+};
+
+export type PushDataExecutionCanceled = {
+	data: IPushDataExecutionCanceled;
+	type: 'executionCanceled';
 };
 
 export type PushDataExecutionRecovered = {
@@ -392,6 +398,10 @@ interface IActiveWorkflowChanged {
 interface IWorkflowFailedToActivate {
 	workflowId: Workflow['id'];
 	errorMessage: string;
+}
+
+export interface IPushDataExecutionCanceled {
+	executionId: string;
 }
 
 export interface IPushDataExecutionRecovered {

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -321,6 +321,11 @@ function hookFunctionsPush(): IWorkflowExecuteHooks {
 					return;
 				}
 
+				if (fullRunData.status === 'canceled') {
+					pushInstance.send('executionCanceled', { executionId }, pushRef);
+					return;
+				}
+
 				// Clone the object except the runData. That one is not supposed
 				// to be send. Because that data got send piece by piece after
 				// each node which finished executing

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -433,6 +433,7 @@ type PushDataWorkflowUsersChanged = {
 };
 
 export type IPushData =
+	| PushDataExecutionCanceled
 	| PushDataExecutionFinished
 	| PushDataExecutionStarted
 	| PushDataExecuteAfter
@@ -462,6 +463,11 @@ export type PushDataActiveWorkflowRemoved = {
 export type PushDataWorkflowFailedToActivate = {
 	data: IWorkflowFailedToActivate;
 	type: 'workflowFailedToActivate';
+};
+
+export type PushDataExecutionCanceled = {
+	data: IPushDataExecutionCanceled;
+	type: 'executionCanceled';
 };
 
 export type PushDataExecutionRecovered = {
@@ -527,6 +533,11 @@ export interface IPushDataExecutionStarted {
 	workflowId: string;
 	workflowName?: string;
 }
+
+export interface IPushDataExecutionCanceled {
+	executionId: string;
+}
+
 export interface IPushDataExecutionRecovered {
 	executionId: string;
 }

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -240,6 +240,19 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 			return true;
 		}
 
+		if (receivedData.type === 'executionCanceled') {
+			const { activeExecutionId } = workflowsStore;
+			if (activeExecutionId === receivedData.data.executionId) {
+				workflowsStore.executingNode.length = 0;
+				uiStore.removeActiveAction('workflowRunning');
+				toast.showMessage({
+					title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
+					type: 'success',
+				});
+				return true;
+			}
+		}
+
 		if (receivedData.type === 'executionFinished' || receivedData.type === 'executionRecovered') {
 			// The workflow finished executing
 			let pushData: IPushDataExecutionFinished;


### PR DESCRIPTION
## Summary
This PR updates the frontend to use a distinct `executionCanceled` push messages for cancelled executions, instead of `executionFinished`.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/CAT-168

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included