### PR TITLE
fix(Google Vertex Chat Model Node): Clean service account private key

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
@@ -12,6 +12,7 @@ import {
 import { ChatVertexAI } from '@langchain/google-vertexai';
 import type { SafetySetting } from '@google/generative-ai';
 import { ProjectsClient } from '@google-cloud/resource-manager';
+import { formatPrivateKey } from 'n8n-nodes-base/dist/utils/utilities';
 import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
 import { N8nLlmTracing } from '../N8nLlmTracing';
 import { additionalOptions } from '../gemini-common/additional-options';
@@ -97,7 +98,7 @@ export class LmChatGoogleVertex implements INodeType {
 				const results: Array<{ name: string; value: string }> = [];
 
 				const credentials = await this.getCredentials('googleApi');
-				const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
+				const privateKey = formatPrivateKey(credentials.privateKey as string);
 				const email = (credentials.email as string).trim();
 
 				const client = new ProjectsClient({
@@ -125,7 +126,7 @@ export class LmChatGoogleVertex implements INodeType {
 
 	async supplyData(this: IExecuteFunctions, itemIndex: number): Promise<SupplyData> {
 		const credentials = await this.getCredentials('googleApi');
-		const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
+		const privateKey = formatPrivateKey(credentials.privateKey as string);
 		const email = (credentials.email as string).trim();
 
 		const modelName = this.getNodeParameter('modelName', itemIndex) as string;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatGoogleVertex/LmChatGoogleVertex.node.ts
@@ -97,11 +97,13 @@ export class LmChatGoogleVertex implements INodeType {
 				const results: Array<{ name: string; value: string }> = [];
 
 				const credentials = await this.getCredentials('googleApi');
+				const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
+				const email = (credentials.email as string).trim();
 
 				const client = new ProjectsClient({
 					credentials: {
-						client_email: credentials.email as string,
-						private_key: credentials.privateKey as string,
+						client_email: email,
+						private_key: privateKey,
 					},
 				});
 
@@ -123,6 +125,8 @@ export class LmChatGoogleVertex implements INodeType {
 
 	async supplyData(this: IExecuteFunctions, itemIndex: number): Promise<SupplyData> {
 		const credentials = await this.getCredentials('googleApi');
+		const privateKey = (credentials.privateKey as string).replace(/\\n/g, '\n').trim();
+		const email = (credentials.email as string).trim();
 
 		const modelName = this.getNodeParameter('modelName', itemIndex) as string;
 
@@ -153,8 +157,8 @@ export class LmChatGoogleVertex implements INodeType {
 				authOptions: {
 					projectId,
 					credentials: {
-						client_email: credentials.email as string,
-						private_key: credentials.privateKey as string,
+						client_email: email,
+						private_key: privateKey,
 					},
 				},
 				model: modelName,


### PR DESCRIPTION
## Summary

This PR addresses an issue with Google Service Account credentials: https://github.com/n8n-io/n8n/issues/10347
When copying private key from JSON file, the key contains serialized line endings ("\n"). We need to replace them with actual line ending characters before using.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/10347
https://linear.app/n8n/issue/AI-276/google-vertex-community-issue-error1e08010cdecoder-routinesunsupported

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
