### PR TITLE
fix(core): fix lifecycle issue when cancelling manual executions

### DIFF
--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -145,6 +145,18 @@ export class ActiveExecutions {
 		this.postExecuteCleanup(executionId);
 	}
 
+	cancelExecution(executionId: string): void {
+		const execution = this.activeExecutions[executionId];
+		if (execution === undefined) {
+			// There is no execution running with that id
+			return;
+		}
+
+		console.log(new Date().toISOString(), 'cancel execution');
+		execution.workflowExecution!.cancel();
+		console.log(new Date().toISOString(), 'cancelled execution');
+	}
+
 	/**
 	 * Forces an execution to stop
 	 */
@@ -163,6 +175,12 @@ export class ActiveExecutions {
 			promise.reject(reason);
 		}
 
+		// FIXME: Option 2: Don't clean up the execution. Because we cancelled it
+		// above, which means the time a node finishes the execution will stop and
+		// the WorkflowRunner will remove it from the active executions.
+		// Given that this function is called from many places this is probably not
+		// a good fix.
+		//
 		this.postExecuteCleanup(executionId);
 	}
 

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -252,7 +252,7 @@ export class ActiveExecutions {
 				await this.concurrencyControl.removeAll(this.activeExecutions);
 			}
 
-			executionIds.forEach((executionId) => this.stopExecution(executionId));
+			executionIds.forEach((executionId) => this.cancelExecution(executionId));
 		}
 
 		let count = 0;

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -450,8 +450,19 @@ export class ExecutionService {
 			return await this.executionRepository.stopBeforeRun(execution);
 		}
 
+		// NOTE: old code
+		// NOTE: Should this actually stop the execution?
+		// Maybe this should just get the execution from the active executions,
+		// then cancel it and then let the workflow execute and workflow runner
+		// take care of the rest?
+		//if (this.activeExecutions.has(execution.id)) {
+		//	this.activeExecutions.stopExecution(execution.id);
+		//}
+
+		// NOTE: new code
+		// FIXME: Option 3
 		if (this.activeExecutions.has(execution.id)) {
-			this.activeExecutions.stopExecution(execution.id);
+			this.activeExecutions.cancelExecution(execution.id);
 		}
 
 		if (this.waitTracker.has(execution.id)) {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -318,11 +318,23 @@ export class WorkflowRunner {
 			workflowExecution
 				.then((fullRunData) => {
 					clearTimeout(executionTimeout);
+					// NOTE: old code
 					if (workflowExecution.isCanceled) {
 						fullRunData.finished = false;
 					}
 					fullRunData.status = this.activeExecutions.getStatus(executionId);
 					this.activeExecutions.remove(executionId, fullRunData);
+
+					// NOTE: new code
+					// FIXME: Option 1: Don't call `getStatus` if the execution was
+					// already cancelled.
+					//if (workflowExecution.isCanceled) {
+					//	fullRunData.finished = false;
+					//	this.activeExecutions.remove(executionId, fullRunData);
+					//} else {
+					//	// if the execution was canceled it was already removed from the active executions
+					//	fullRunData.status = this.activeExecutions.getStatus(executionId);
+					//}
 				})
 				.catch(
 					async (error) =>

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -311,7 +311,7 @@ export class WorkflowRunner {
 			if (workflowTimeout > 0) {
 				const timeout = Math.min(workflowTimeout, config.getEnv('executions.maxTimeout')) * 1000; // as seconds
 				executionTimeout = setTimeout(() => {
-					void this.activeExecutions.stopExecution(executionId);
+					void this.activeExecutions.cancelExecution(executionId);
 				}, timeout);
 			}
 

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -515,7 +515,11 @@ export class Wait extends Webhook {
 			// we just check the database every 60 seconds.
 			return await new Promise((resolve) => {
 				const timer = setTimeout(() => resolve([context.getInputData()]), waitValue);
-				context.onExecutionCancellation(() => clearTimeout(timer));
+				context.onExecutionCancellation(() => {
+					clearTimeout(timer);
+					// FIXME: Don't let the promise dangle
+					resolve([context.getInputData()]);
+				});
 			});
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The fix in https://github.com/n8n-io/n8n/pull/9992 introduced a lifecycle issue with executions where an execution would be removed multiple times from the `ActiveExecution`s.

Normally the flow would be like this:
```mermaid
sequenceDiagram
  Actor Customer as User
  participant AE as Active Executions
  participant WR as Workflow Runner
  participant WE as Workflow Execute
  participant Node

  Customer ->>+ WR: run workflow
  WR ->>+ AE: register execution
  activate AE
  WR ->>+ WE: execute worfklow
  WE ->>+ Node: run node
  Node ->>- WE: done
  WE ->>- WR: done
  WR ->> AE: get status
  AE ->> WR: send status
  WR ->> AE: unregister execution
  deactivate AE
  WR ->>- Customer: done
```

When cancelling this would happen (unless for the wait node):
```mermaid
sequenceDiagram
  Actor Customer as User
  participant ES as Execution Service
  participant AE as Active Executions
  participant WR as Workflow Runner
  participant WE as Workflow Execute
  participant Node

  Customer ->>+ WR: run workflow
  WR ->>+ AE: register execution
  activate AE
  WR ->>+ WE: execute worfklow
  
  WE ->>+ Node: run node

  %% cancel execution
  Customer ->>+ ES: cancel workflow run
  ES ->> WE: cancel execution
  WE -x Node: cancel execution
  ES ->> AE: unregister execution
  deactivate AE
  ES ->>- Customer: done

  %% finish execution anyways
  Node ->>- WE: done
  WE ->>- WR: done, because cancelled
  WR ->> AE: get status BOOM
  deactivate WR
```

<details>
<summary>Wait Node</summary>
The wait node would never resolve, so it would look like this:

```mermaid
sequenceDiagram
  Actor Customer as User
  participant ES as Execution Service
  participant AE as Active Executions
  participant WR as Workflow Runner
  participant WE as Workflow Execute
  participant Node

  Customer ->>+ WR: run workflow
  WR ->>+ AE: register execution
  activate AE
  WR ->>+ WE: execute worfklow
  
  WE ->>+ Node: run node

  %% cancel execution
  Customer ->>+ ES: cancel workflow run
  ES ->> WE: cancel execution
  WE ->> Node: cancel execution
  ES ->> AE: unregister execution
  deactivate AE
  ES ->>- Customer: done

  deactivate WE
  deactivate WR
  deactivate Node
```


</details>

Before https://github.com/n8n-io/n8n/pull/9992 the flow was like this. And I think it should be like that again.
```mermaid
sequenceDiagram
  Actor Customer as User
  participant ES as Execution Service
  participant AE as Active Executions
  participant WR as Workflow Runner
  participant WE as Workflow Execute
  participant Node

  Customer ->>+ WR: run workflow
  WR ->>+ AE: register execution
  activate AE
  WR ->>+ WE: execute worfklow
  
  WE ->>+ Node: run node

  %% cancel execution
  Customer ->>+ ES: cancel workflow run
  ES ->> WE: cancel execution
  WE -x Node: cancel execution
  ES ->>- Customer: done

  %% finish execution anyways
  Node ->>- WE: done
  WE ->>- WR: done, because cancelled
  WR ->> AE: get status
  AE ->> WR: send status
  WR ->> AE: unregister execution
  deactivate AE
  WR ->>- Customer: done
```

So while I have 3 solutions in this PR I prefer Option 3, which concentrates the responsibility for registering and unregistering active executions again within the `WorkflowRunner`.

Once I've decided on a solution I'll write tests and refactor the rest of the code.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1554/error-no-active-execution-found

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
