### PR TITLE
ci(benchmark): Run 3 times a night to account for fluctuations

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -3,7 +3,7 @@ run-name: Benchmark ${{ inputs.n8n_tag || 'nightly' }}
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '30 1,2,3 * * *'
   workflow_dispatch:
     inputs:
       debug:


### PR DESCRIPTION

## Summary

Run nightly benchmark 3 times a night to account for fluctuations. Also don't run at hour sharp, since GH might delay and drop queued runs if there's high demand, and GH recommends using something other than that.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
