### PR TITLE
fix(OpenAI Node, Basic LLM Chain Node, Tool Agent Node): Better OpenAI API rate limit errors

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -35,7 +35,10 @@ import {
 	isChatInstance,
 } from '../../../utils/helpers';
 import { getTracingConfig } from '../../../utils/tracing';
-import { getCustomErrorMessage } from '../../vendors/OpenAi/helpers/error-handling';
+import {
+	getCustomErrorMessage as getCustomOpenAiErrorMessage,
+	isOpenAiError,
+} from '../../vendors/OpenAi/helpers/error-handling';
 
 interface MessagesTemplate {
 	type: string;
@@ -586,12 +589,12 @@ export class ChainLlm implements INodeType {
 					});
 				});
 			} catch (error) {
-				if (error instanceof NodeApiError) {
-					// If the error is an OpenAI's rate limit error, we want to handle it differently
-					// because OpenAI has multiple different rate limit errors
+				// If the error is an OpenAI's rate limit error, we want to handle it differently
+				// because OpenAI has multiple different rate limit errors
+				if (error instanceof NodeApiError && isOpenAiError(error.cause)) {
 					const openAiErrorCode: string | undefined = (error.cause as any).error?.code;
 					if (openAiErrorCode) {
-						const customMessage = getCustomErrorMessage(openAiErrorCode);
+						const customMessage = getCustomOpenAiErrorMessage(openAiErrorCode);
 						if (customMessage) {
 							error.message = customMessage;
 						}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -5,11 +5,15 @@ import {
 	type INodeType,
 	type INodeTypeDescription,
 	type SupplyData,
+	type JsonObject,
+	NodeApiError,
 } from 'n8n-workflow';
 
 import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
 import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
 import { N8nLlmTracing } from '../N8nLlmTracing';
+import { RateLimitError } from 'openai';
+import { getCustomErrorMessage } from '../../vendors/OpenAi/helpers/error-handling';
 
 export class LmChatOpenAi implements INodeType {
 	description: INodeTypeDescription = {
@@ -272,6 +276,25 @@ export class LmChatOpenAi implements INodeType {
 						response_format: { type: options.responseFormat },
 					}
 				: undefined,
+			onFailedAttempt: (error: any) => {
+				// If the error is a rate limit error, we want to handle it differently
+				// because OpenAI has multiple different rate limit errors
+				if (error instanceof RateLimitError) {
+					const errorCode = error?.code;
+					if (errorCode) {
+						const customErrorMessage = getCustomErrorMessage(errorCode);
+
+						const apiError = new NodeApiError(this.getNode(), error as unknown as JsonObject);
+						if (customErrorMessage) {
+							apiError.message = customErrorMessage;
+						}
+
+						throw apiError;
+					}
+				}
+
+				throw error;
+			},
 		});
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/router.ts
@@ -12,6 +12,7 @@ import * as image from './image';
 import * as text from './text';
 
 import type { OpenAiType } from './node.type';
+import { getCustomErrorMessage } from '../helpers/error-handling';
 
 export async function router(this: IExecuteFunctions) {
 	const returnData: INodeExecutionData[] = [];
@@ -61,6 +62,15 @@ export async function router(this: IExecuteFunctions) {
 			}
 
 			if (error instanceof NodeApiError) {
+				// If the error is a rate limit error, we want to handle it differently
+				const errorCode: string | undefined = (error.cause as any).error?.error?.code;
+				if (errorCode) {
+					const customErrorMessage = getCustomErrorMessage(errorCode);
+					if (customErrorMessage) {
+						error.message = customErrorMessage;
+					}
+				}
+
 				error.context = {
 					itemIndex: i,
 				};

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
@@ -1,0 +1,8 @@
+const errorMap: Record<string, string> = {
+	insufficient_quota: 'OpenAI: Insufficient quota',
+	rate_limit_exceeded: 'OpenAI: Rate limit reached',
+};
+
+export function getCustomErrorMessage(errorCode: string): string | undefined {
+	return errorMap[errorCode];
+}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/error-handling.ts
@@ -1,3 +1,5 @@
+import { OpenAIError } from 'openai/error';
+
 const errorMap: Record<string, string> = {
 	insufficient_quota: 'OpenAI: Insufficient quota',
 	rate_limit_exceeded: 'OpenAI: Rate limit reached',
@@ -5,4 +7,8 @@ const errorMap: Record<string, string> = {
 
 export function getCustomErrorMessage(errorCode: string): string | undefined {
 	return errorMap[errorCode];
+}
+
+export function isOpenAiError(error: any): error is OpenAIError {
+	return error instanceof OpenAIError;
 }


### PR DESCRIPTION
## Summary

In this PR some custom handling for the OpenAI rate limit errors is introduced.
According to OpenAI's docs, there might be two sets of errors ending up with 429 HTTP response: rate limit errors and insufficient quota errors (https://platform.openai.com/docs/guides/error-codes/api-errors)
We can look at the code in the response to see what kind of error it was.

Also, we override a default message for those errors with a more descriptive and openai-specific ones.
This should also help with the issue, when a long poorly formatted text is displayed in some cases of rate limit errors.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-313/openai-is-returning-429-errors-quite-often
https://linear.app/n8n/issue/AI-342/bad-error-in-openai-node

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
