### PR TITLE
fix(editor): Fix completion on $input.item. in Code node

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/__tests__/itemField.completions.test.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/__tests__/itemField.completions.test.ts
@@ -1,0 +1,77 @@
+import { CompletionContext } from '@codemirror/autocomplete';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { useItemFieldCompletions } from '../itemField.completions';
+
+describe('inputMethodCompletions', () => {
+	test('should return completions for $input.item.|', () => {
+		const { inputMethodCompletions } = useItemFieldCompletions('javaScript');
+		expect(inputMethodCompletions(createContext('$input.item.|'))).toEqual({
+			from: 0,
+			options: [
+				{
+					info: 'Returns the JSON input data to the current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					label: '$input.item.json',
+					type: 'variable',
+				},
+
+				{
+					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					label: '$input.item.binary',
+					type: 'variable',
+				},
+			],
+		});
+	});
+
+	test('should return completions for $input.first().|', () => {
+		const { inputMethodCompletions } = useItemFieldCompletions('javaScript');
+		expect(inputMethodCompletions(createContext('$input.first().|'))).toEqual({
+			from: 0,
+			options: [
+				{
+					info: 'Returns the JSON input data to the current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					label: '$input.first().json',
+					type: 'variable',
+				},
+
+				{
+					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					label: '$input.first().binary',
+					type: 'variable',
+				},
+			],
+		});
+	});
+
+	test('should return completions for $input.all()[1].|', () => {
+		const { inputMethodCompletions } = useItemFieldCompletions('javaScript');
+		expect(inputMethodCompletions(createContext('$input.all()[1].|'))).toEqual({
+			from: 0,
+			options: [
+				{
+					info: 'Returns the JSON input data to thqe current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					label: '$input.all()[1].json',
+					type: 'variable',
+				},
+
+				{
+					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					label: '$input.all()[1].binary',
+					type: 'variable',
+				},
+			],
+		});
+	});
+});
+
+export function createContext(docWithCursor: string) {
+	const cursorPosition = docWithCursor.indexOf('|');
+
+	const doc = docWithCursor.slice(0, cursorPosition) + docWithCursor.slice(cursorPosition + 1);
+
+	return new CompletionContext(
+		EditorState.create({ doc, selection: EditorSelection.single(cursorPosition) }),
+		cursorPosition,
+		false,
+	);
+}

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/__tests__/itemField.completions.test.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/__tests__/itemField.completions.test.ts
@@ -9,13 +9,13 @@ describe('inputMethodCompletions', () => {
 			from: 0,
 			options: [
 				{
-					info: 'Returns the JSON input data to the current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					info: expect.any(Function),
 					label: '$input.item.json',
 					type: 'variable',
 				},
 
 				{
-					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					info: expect.any(Function),
 					label: '$input.item.binary',
 					type: 'variable',
 				},
@@ -29,13 +29,13 @@ describe('inputMethodCompletions', () => {
 			from: 0,
 			options: [
 				{
-					info: 'Returns the JSON input data to the current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					info: expect.any(Function),
 					label: '$input.first().json',
 					type: 'variable',
 				},
 
 				{
-					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					info: expect.any(Function),
 					label: '$input.first().binary',
 					type: 'variable',
 				},
@@ -49,13 +49,13 @@ describe('inputMethodCompletions', () => {
 			from: 0,
 			options: [
 				{
-					info: 'Returns the JSON input data to thqe current node, for the current item. Shorthand for <code>$input.item.json</code>.',
+					info: expect.any(Function),
 					label: '$input.all()[1].json',
 					type: 'variable',
 				},
 
 				{
-					info: 'Returns any binary input data to the current node, for the current item. Shorthand for <code>$input.item.binary</code>.',
+					info: expect.any(Function),
 					label: '$input.all()[1].binary',
 					type: 'variable',
 				},

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/itemField.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/itemField.completions.ts
@@ -54,7 +54,7 @@ export function useItemFieldCompletions(language: 'python' | 'javaScript') {
 		const patterns = {
 			first: new RegExp(`\\${prefix}input\\.first\\(\\)\\..*`),
 			last: new RegExp(`\\${prefix}input\\.last\\(\\)\\..*`),
-			item: new RegExp(`\\${prefix}item\\.first\\(\\)\\..*`),
+			item: new RegExp(`\\${prefix}input\\.item\\..*`),
 			all: /\$input\.all\(\)\[(?<index>\w+)\]\..*/,
 		};
 

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/itemField.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/itemField.completions.ts
@@ -1,4 +1,4 @@
-import { addVarType, escape } from '../utils';
+import { addInfoRenderer, addVarType, escape } from '../utils';
 import type { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { useI18n } from '@/composables/useI18n';
 
@@ -94,7 +94,7 @@ export function useItemFieldCompletions(language: 'python' | 'javaScript') {
 
 			return {
 				from: preCursor.from,
-				options: options.map(addVarType),
+				options: options.map(addVarType).map(addInfoRenderer),
 			};
 		}
 

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/package.json
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "completions",
-  "version": "1.0.0",
-  "dependencies": {
-  }
-}


### PR DESCRIPTION
## Summary

<img width="705" alt="image" src="https://github.com/user-attachments/assets/91c8a363-32e0-4e2a-a261-e44cf6c6e1b3">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1717/typing-dollarinputitem-does-not-show-binary-and-json-autocomplete

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
