### PR TITLE
build: Disable `node-param-collection-type-unsorted-items` for langchain nodes (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/.eslintrc.js
+++ b/packages/@n8n/nodes-langchain/.eslintrc.js
@@ -76,7 +76,6 @@ module.exports = {
 				'n8n-nodes-base/node-execute-block-wrong-error-thrown': 'error',
 				'n8n-nodes-base/node-filename-against-convention': 'error',
 				'n8n-nodes-base/node-param-array-type-assertion': 'error',
-				'n8n-nodes-base/node-param-collection-type-unsorted-items': 'error',
 				'n8n-nodes-base/node-param-color-type-unused': 'error',
 				'n8n-nodes-base/node-param-default-missing': 'error',
 				'n8n-nodes-base/node-param-default-wrong-for-boolean': 'error',


### PR DESCRIPTION
## Summary
Follow-up to #10779, disable `node-param-collection-type-unsorted-items` rule in nodes-langchain package

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
