### PR TITLE
fix(Clockify Node): Partial clockify trigger fix plus workaround

### DIFF
--- a/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
@@ -43,7 +43,7 @@ export class ClockifyTrigger implements INodeType {
 				name: 'workspaceId',
 				type: 'options',
 				description:
-					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>',
 				typeOptions: {
 					loadOptionsMethod: 'listWorkspaces',
 				},
@@ -59,6 +59,10 @@ export class ClockifyTrigger implements INodeType {
 					{
 						name: 'New Time Entry',
 						value: EntryTypeEnum.NEW_TIME_ENTRY,
+					},
+					{
+						name: 'Fetch All Time Entries',
+						value: EntryTypeEnum.FETCH_ALL_TIME_ENTRIES,
 					},
 				],
 				required: true,
@@ -105,6 +109,12 @@ export class ClockifyTrigger implements INodeType {
 		let result = null;
 
 		switch (triggerField) {
+			// TODO
+			case EntryTypeEnum.FETCH_ALL_TIME_ENTRIES:
+				resource = `workspaces/${workspaceId}/user/${webhookData.userId}/time-entries`;
+				qs.hydrated = true;
+				qs['in-progress'] = false;
+				break;
 			case EntryTypeEnum.NEW_TIME_ENTRY:
 			default:
 				const workflowTimezone = this.getTimezone();
@@ -117,9 +127,9 @@ export class ClockifyTrigger implements INodeType {
 		}
 
 		result = await clockifyApiRequest.call(this, 'GET', resource, {}, qs);
-		webhookData.lastTimeChecked = qs.end;
 
 		if (Array.isArray(result) && result.length !== 0) {
+			if (triggerField === EntryTypeEnum.NEW_TIME_ENTRY) webhookData.lastTimeChecked = qs.end;
 			return [this.helpers.returnJsonArray(result)];
 		}
 		return null;

--- a/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
+++ b/packages/nodes-base/nodes/Clockify/ClockifyTrigger.node.ts
@@ -109,7 +109,6 @@ export class ClockifyTrigger implements INodeType {
 		let result = null;
 
 		switch (triggerField) {
-			// TODO
 			case EntryTypeEnum.FETCH_ALL_TIME_ENTRIES:
 				resource = `workspaces/${workspaceId}/user/${webhookData.userId}/time-entries`;
 				qs.hydrated = true;
@@ -129,7 +128,9 @@ export class ClockifyTrigger implements INodeType {
 		result = await clockifyApiRequest.call(this, 'GET', resource, {}, qs);
 
 		if (Array.isArray(result) && result.length !== 0) {
-			if (triggerField === EntryTypeEnum.NEW_TIME_ENTRY) webhookData.lastTimeChecked = qs.end;
+			if (triggerField === EntryTypeEnum.NEW_TIME_ENTRY) {
+				webhookData.lastTimeChecked = result[0].end;
+			}
 			return [this.helpers.returnJsonArray(result)];
 		}
 		return null;

--- a/packages/nodes-base/nodes/Clockify/EntryTypeEnum.ts
+++ b/packages/nodes-base/nodes/Clockify/EntryTypeEnum.ts
@@ -1,3 +1,4 @@
 export const enum EntryTypeEnum {
 	NEW_TIME_ENTRY,
+	FETCH_ALL_TIME_ENTRIES = 1,
 }


### PR DESCRIPTION
## Summary

Fixes some aspects of the "new time entry" clockify trigger, as well as adding support for periodically fetching all entries for entry updating workaround. 

**Problem**: This issue stems from a fundamental problem within the [Clockify API](https://docs.developer.clockify.me/#tag/Time-entry/operation/getTimeEntries), which does not allow access to most recent time entry submissions by date submitted (or finalized/created or stopped). Furthermore, Clockify only allows one to retrieve entries through start date (registered by the user) and end date (also inputted by the user) [plus a bit more irrelevant options]. The prior code seemed to have been treating the "start date" as submission/stop/finalization date (that's at least what it looks like, not sure if it was intentional), which caused problems such as discarding entries that have start dates prior to the latest checked date (so if it checked a minute ago, it would only fetch items from the current minute, then move onto the next minute). 

**Solution**: Only set the "last checked"/"lastTimeChecked" variable when data is retrieved, then update the "lastTimeChecked" to the current time to skip already processed data. However, this doesn't update or account for modifications and/or additions after the "last checked" time is updated. This is why the new feature for polling all events is added, to support updating previous records, etc, though costly (meant to be used along with the fixed "new time entry" trigger, except at a slower interval). 

**Purpose**: To put into place a system that gives a real time "feel" to clockify API updates while not requiring the use of webhooks and port forwarding. (this is useful for home servers)

Illustrations: 
*note: I use task and time entry interchangeably here*
### Previous method 
![image](https://github.com/user-attachments/assets/643d2eee-9053-4869-8dba-1fb73739a471)

### New method
![image](https://github.com/user-attachments/assets/72cc45fc-c3bb-4452-825d-5e657ec74f63)

### Update/manual insert workaround
![image](https://github.com/user-attachments/assets/70eb6a63-4f19-4d28-8267-5add335da1ff)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
[Community post](https://community.n8n.io/t/polling-not-working-or-am-i-doing-something-wrong/10576/2)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (In progress) 
- [ ] Tests included. (In progress)
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported) N/A
