### PR TITLE
fix(editor): Make schema view search copy more clear

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2043,7 +2043,7 @@
 	"ndv.trigger.webhookBasedNode.action": "Pull in events from {name}",
 	"ndv.search.placeholder.output": "Search output",
 	"ndv.search.placeholder.input": "Search selected node",
-	"ndv.search.placeholder.input.schema": "Search previous nodes",
+	"ndv.search.placeholder.input.schema": "Search previous nodes' fields",
 	"ndv.search.noMatch.title": "No matching items",
 	"ndv.search.noNodeMatch.title": "No matching nodes",
 	"ndv.search.noMatch.description": "Try changing or {link} the filter to see more",


### PR DESCRIPTION
## Summary

Make schema view search copy more clear

<img width="705" alt="image" src="https://github.com/user-attachments/assets/6a41335c-7e26-4115-9149-366cb9ecb803">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1716/expression-editor-previous-nodes-filter-broken

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
