### PR TITLE
Added 'delete all empty rows' function to Google Sheets node

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/router.ts
@@ -52,9 +52,6 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 				case 'create':
 					sheetName = spreadsheetId;
 					break;
-				case 'delete':
-					sheetName = sheetId;
-					break;
 				case 'remove':
 					sheetName = `${spreadsheetId}||${sheetId}`;
 					break;


### PR DESCRIPTION
## Summary
Adds ability to delete empty rows in a google sheet.
In addition to the new code in delete.operations.ts, I only needed to make one minor change to router whereby sheetName was being set to sheetId. This wasn't necessary as the execute function in delete.operation.ts receives both sheetName and sheetId. I have made minimal alterations to the existing code and confirmed all preexisting functionality still works as normal.


## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/setting-the-amount-of-loops-for-a-loop-over-items-node/53866/4

As discussed in the above thread, the present method to achieve this functionality is very redundant and better workflows can be achieved by adding the Delete Empty Rows feature.


## Review / Merge checklist
Confirm regular delete by rows/columns still functions normally.
Confirm delete all empty rows works.