### PR TITLE
test(core): Fix license mock in worker test

### DIFF
--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -21,7 +21,7 @@ mockInstance(LoadNodesAndCredentials);
 const binaryDataService = mockInstance(BinaryDataService);
 const externalHooks = mockInstance(ExternalHooks);
 const externalSecretsManager = mockInstance(ExternalSecretsManager);
-const license = mockInstance(License);
+const license = mockInstance(License, { loadCertStr: async () => '' });
 const messageEventBus = mockInstance(MessageEventBus);
 const logStreamingEventRelay = mockInstance(LogStreamingEventRelay);
 const orchestrationHandlerWorkerService = mockInstance(OrchestrationHandlerWorkerService);


### PR DESCRIPTION
Fix this error when running `worker` command tests locally:

```
> n8n@1.59.0 test:sqlite /Users/ivov/Development/n8n/packages/cli
> N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest "--" "worker"

 FAIL  test/integration/commands/worker.cmd.test.ts
  ✕ worker initializes all its components (11 ms)

  ● worker initializes all its components

    TypeError: Cannot read properties of undefined (reading 'length')

      284 |
      285 | 		if (activationKey) {
    > 286 | 			const hasCert = (await this.license.loadCertStr()).length > 0;
          | 			                                                   ^
      287 |
      288 | 			if (hasCert) {
      289 | 				return this.logger.debug('Skipping license activation');

      at Worker.initLicense (src/commands/base-command.ts:286:55)
      at Worker.init (src/commands/worker.ts:102:3)
      at Object.run (test/integration/shared/utils/test-command.ts:39:3)
      at Object.<anonymous> (test/integration/commands/worker.cmd.test.ts:33:17)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        4.341 s
Ran all test suites matching /worker/i.
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Test failed. See above for more details.
```