### PR TITLE
refactor: Remove unused disable directives from `nodes-base`

### DIFF
--- a/packages/nodes-base/nodes/AiTransform/AiTransform.node.ts
+++ b/packages/nodes-base/nodes/AiTransform/AiTransform.node.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-dirname-against-convention */
 import {
 	NodeOperationError,
 	NodeConnectionType,

--- a/packages/nodes-base/nodes/CompareDatasets/CompareDatasets.node.ts
+++ b/packages/nodes-base/nodes/CompareDatasets/CompareDatasets.node.ts
@@ -22,11 +22,11 @@ export class CompareDatasets implements INodeType {
 		version: [1, 2, 2.1, 2.2, 2.3],
 		description: 'Compare two inputs for changes',
 		defaults: { name: 'Compare Datasets' },
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [NodeConnectionType.Main, NodeConnectionType.Main],
 		inputNames: ['Input A', 'Input B'],
 		requiredInputs: 1,
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+
 		outputs: [
 			NodeConnectionType.Main,
 			NodeConnectionType.Main,

--- a/packages/nodes-base/nodes/Cron/Cron.node.ts
+++ b/packages/nodes-base/nodes/Cron/Cron.node.ts
@@ -23,7 +23,7 @@ export class Cron implements INodeType {
 			name: 'Cron',
 			color: '#29a568',
 		},
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [],
 		outputs: [NodeConnectionType.Main],
 		properties: [

--- a/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
@@ -82,7 +82,7 @@ const versionDescription: INodeTypeDescription = {
 		activationHint:
 			"Once you’ve finished building your workflow, <a data-key='activate'>activate</a> it to have it also listen continuously (you just won’t see those executions here).",
 	},
-	// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 	inputs: [],
 	outputs: [NodeConnectionType.Main],
 	credentials: [

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -86,7 +86,7 @@ const versionDescription: INodeTypeDescription = {
 		activationHint:
 			"Once you’ve finished building your workflow, <a data-key='activate'>activate</a> it to have it also listen continuously (you just won’t see those executions here).",
 	},
-	// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 	inputs: [],
 	outputs: [NodeConnectionType.Main],
 	credentials: [

--- a/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Form/v1/FormTriggerV1.node.ts
@@ -27,7 +27,7 @@ const descriptionV1: INodeTypeDescription = {
 	defaults: {
 		name: 'n8n Form Trigger',
 	},
-	// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 	inputs: [],
 	outputs: [NodeConnectionType.Main],
 	webhooks: [

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -38,7 +38,7 @@ const descriptionV2: INodeTypeDescription = {
 	defaults: {
 		name: 'n8n Form Trigger',
 	},
-	// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 	inputs: [],
 	outputs: [NodeConnectionType.Main],
 	webhooks: [

--- a/packages/nodes-base/nodes/Google/Analytics/v1/GoogleAnalyticsV1.node.ts
+++ b/packages/nodes-base/nodes/Google/Analytics/v1/GoogleAnalyticsV1.node.ts
@@ -1,4 +1,3 @@
-/* eslint-disable n8n-nodes-base/node-filename-against-convention */
 import {
 	type IExecuteFunctions,
 	type IDataObject,

--- a/packages/nodes-base/nodes/Interval/Interval.node.ts
+++ b/packages/nodes-base/nodes/Interval/Interval.node.ts
@@ -22,7 +22,7 @@ export class Interval implements INodeType {
 			name: 'Interval',
 			color: '#00FF00',
 		},
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [],
 		outputs: [NodeConnectionType.Main],
 		properties: [

--- a/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
@@ -20,7 +20,7 @@ export class SplitInBatchesV2 implements INodeType {
 			color: '#007755',
 		},
 		inputs: [NodeConnectionType.Main],
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+
 		outputs: [NodeConnectionType.Main, NodeConnectionType.Main],
 		outputNames: ['loop', 'done'],
 		properties: [

--- a/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v3/SplitInBatchesV3.node.ts
@@ -21,7 +21,7 @@ export class SplitInBatchesV3 implements INodeType {
 			color: '#007755',
 		},
 		inputs: [NodeConnectionType.Main],
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+
 		outputs: [NodeConnectionType.Main, NodeConnectionType.Main],
 		outputNames: ['done', 'loop'],
 		properties: [

--- a/packages/nodes-base/nodes/Start/Start.node.ts
+++ b/packages/nodes-base/nodes/Start/Start.node.ts
@@ -20,7 +20,7 @@ export class Start implements INodeType {
 			name: 'Start',
 			color: '#00e000',
 		},
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [],
 		outputs: [NodeConnectionType.Main],
 		properties: [

--- a/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
+++ b/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
@@ -17,9 +17,9 @@ export class StickyNote implements INodeType {
 			name: 'Sticky Note',
 			color: '#FFD233',
 		},
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [],
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+
 		outputs: [],
 		properties: [
 			{

--- a/packages/nodes-base/nodes/StopAndError/StopAndError.node.ts
+++ b/packages/nodes-base/nodes/StopAndError/StopAndError.node.ts
@@ -26,7 +26,7 @@ export class StopAndError implements INodeType {
 			color: '#ff0000',
 		},
 		inputs: [NodeConnectionType.Main],
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-outputs-wrong
+
 		outputs: [],
 		properties: [
 			{

--- a/packages/nodes-base/nodes/Webflow/V1/WebflowTriggerV1.node.ts
+++ b/packages/nodes-base/nodes/Webflow/V1/WebflowTriggerV1.node.ts
@@ -26,7 +26,7 @@ export class WebflowTriggerV1 implements INodeType {
 			defaults: {
 				name: 'Webflow Trigger',
 			},
-			// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 			inputs: [],
 			outputs: [NodeConnectionType.Main],
 			credentials: [

--- a/packages/nodes-base/nodes/Webflow/V2/WebflowTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Webflow/V2/WebflowTriggerV2.node.ts
@@ -26,7 +26,7 @@ export class WebflowTriggerV2 implements INodeType {
 			defaults: {
 				name: 'Webflow Trigger',
 			},
-			// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 			inputs: [],
 			outputs: [NodeConnectionType.Main],
 			credentials: [

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -65,7 +65,7 @@ export class Webhook extends Node {
 			activationHint:
 				"Once you've finished building your workflow, run it without having to click this button by using the production webhook URL.",
 		},
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-inputs-wrong-regular-node
+
 		inputs: [],
 		outputs: `={{(${configuredOutputs})($parameter)}}`,
 		credentials: credentialsProperty(this.authPropertyName),

--- a/packages/nodes-base/utils/descriptions.ts
+++ b/packages/nodes-base/utils/descriptions.ts
@@ -43,7 +43,6 @@ export const looseTypeValidationProperty: INodeProperties = {
 };
 
 export const appendAttributionOption: INodeProperties = {
-	// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
 	displayName: 'Append n8n Attribution',
 	name: 'appendAttribution',
 	type: 'boolean',


### PR DESCRIPTION
Lintfix with `--report-unused-disable-directives​​` to remove stale exemptions no longer required by the nodelinter.