### PR TITLE
fix(editor): Render image binary-data using img tags

### DIFF
--- a/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -63,6 +63,7 @@ onMounted(async () => {
 				<source :src="embedSource" :type="binaryData.mimeType" />
 				{{ $locale.baseText('binaryDataDisplay.yourBrowserDoesNotSupport') }}
 			</audio>
+			<img v-else-if="binaryData.fileType === 'image'" :src="embedSource" />
 			<VueJsonPretty
 				v-else-if="binaryData.fileType === 'json'"
 				:data="data"
@@ -76,13 +77,12 @@ onMounted(async () => {
 </template>
 
 <style lang="scss">
+img {
+	max-height: calc(100% - 1em);
+	max-width: calc(100% - 1em);
+}
 .binary-data {
 	background-color: var(--color-foreground-xlight);
-
-	&.image {
-		max-height: calc(100% - 1em);
-		max-width: calc(100% - 1em);
-	}
 
 	&.other,
 	&.pdf {

--- a/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
+++ b/packages/editor-ui/src/components/BinaryDataDisplayEmbed.vue
@@ -77,17 +77,16 @@ onMounted(async () => {
 </template>
 
 <style lang="scss">
-img {
-	max-height: calc(100% - 1em);
-	max-width: calc(100% - 1em);
+img,
+video {
+	max-height: 100%;
+	max-width: 100%;
 }
 .binary-data {
-	background-color: var(--color-foreground-xlight);
-
 	&.other,
 	&.pdf {
-		height: calc(100% - 1em);
-		width: calc(100% - 1em);
+		height: 100%;
+		width: 100%;
 	}
 }
 </style>


### PR DESCRIPTION
## Summary
render image binary data doesn't need to use the `embed` tag.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-1724

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
