### PR TITLE
fix(Contentful Node): Add missing additional fields to entry > get

### DIFF
--- a/packages/nodes-base/nodes/Contentful/EntryDescription.ts
+++ b/packages/nodes-base/nodes/Contentful/EntryDescription.ts
@@ -177,6 +177,19 @@ export const fields: INodeProperties[] = [
 		],
 	},
 	{
+		displayName: 'Entry ID',
+		name: 'entryId',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [resource.value],
+				operation: ['get'],
+			},
+		},
+	},
+	{
 		displayName: 'Additional Fields',
 		name: 'additionalFields',
 		type: 'collection',
@@ -197,18 +210,5 @@ export const fields: INodeProperties[] = [
 				description: 'Whether the data should be returned RAW instead of parsed',
 			},
 		],
-	},
-	{
-		displayName: 'Entry ID',
-		name: 'entryId',
-		type: 'string',
-		default: '',
-		required: true,
-		displayOptions: {
-			show: {
-				resource: [resource.value],
-				operation: ['get'],
-			},
-		},
 	},
 ];

--- a/packages/nodes-base/nodes/Contentful/EntryDescription.ts
+++ b/packages/nodes-base/nodes/Contentful/EntryDescription.ts
@@ -177,6 +177,28 @@ export const fields: INodeProperties[] = [
 		],
 	},
 	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: [resource.value],
+				operation: ['get'],
+			},
+		},
+		options: [
+			{
+				displayName: 'RAW Data',
+				name: 'rawData',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the data should be returned RAW instead of parsed',
+			},
+		],
+	},
+	{
 		displayName: 'Entry ID',
 		name: 'entryId',
 		type: 'string',


### PR DESCRIPTION
## Summary
Entry > Get was missing additional Fields which was stopping the resource operation / action from working. Not added test as it is a missing UI option.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/unable-to-configure-contentful-node-to-get-entry-by-entryid/53442
https://linear.app/n8n/issue/NODE-1728/contentful-additional-fields-missing
