### PR TITLE
fix(editor): Address edge toolbar rendering glitches

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -7,7 +7,6 @@ import type {
 	ConnectStartEvent,
 } from '@/types';
 import type {
-	EdgeMouseEvent,
 	Connection,
 	XYPosition,
 	ViewportTransform,
@@ -31,6 +30,7 @@ import { isPresent } from '@/utils/typesUtils';
 import { GRID_SIZE } from '@/utils/nodeViewUtils';
 import { CanvasKey } from '@/constants';
 import { onKeyDown, onKeyUp } from '@vueuse/core';
+import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
 
 const $style = useCssModule();
 
@@ -261,19 +261,7 @@ function onClickConnectionAdd(connection: Connection) {
 	emit('click:connection:add', connection);
 }
 
-/**
- * Connection hover
- */
-
-const hoveredEdges = ref<Record<string, boolean>>({});
-
-function onMouseEnterEdge(event: EdgeMouseEvent) {
-	hoveredEdges.value[event.edge.id] = true;
-}
-
-function onMouseLeaveEdge(event: EdgeMouseEvent) {
-	hoveredEdges.value[event.edge.id] = false;
-}
+const arrowHeadMarkerId = ref('custom-arrow-head');
 
 /**
  * Executions
@@ -511,8 +499,6 @@ provide(CanvasKey, {
 		:selection-key-code="selectionKeyCode"
 		:pan-activation-key-code="panningKeyCode"
 		data-test-id="canvas"
-		@edge-mouse-enter="onMouseEnterEdge"
-		@edge-mouse-leave="onMouseLeaveEdge"
 		@connect-start="onConnectStart"
 		@connect="onConnect"
 		@connect-end="onConnectEnd"
@@ -543,8 +529,8 @@ provide(CanvasKey, {
 		<template #edge-canvas-edge="canvasEdgeProps">
 			<Edge
 				v-bind="canvasEdgeProps"
+				:marker-end="`url(#${arrowHeadMarkerId})`"
 				:read-only="readOnly"
-				:hovered="hoveredEdges[canvasEdgeProps.id]"
 				@add="onClickConnectionAdd"
 				@delete="onDeleteConnection"
 			/>
@@ -553,6 +539,8 @@ provide(CanvasKey, {
 		<template #connection-line="connectionLineProps">
 			<CanvasConnectionLine v-bind="connectionLineProps" />
 		</template>
+
+		<CanvasArrowHeadMarker :id="arrowHeadMarkerId" />
 
 		<Background data-test-id="canvas-background" pattern-color="#aaa" :gap="GRID_SIZE" />
 

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasArrowHeadMarker.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasArrowHeadMarker.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+defineProps<{ id: string }>();
+</script>
+
+<template>
+	<svg>
+		<defs>
+			<marker
+				:id="id"
+				viewBox="-10 -10 20 20"
+				refX="0"
+				refY="0"
+				markerWidth="12.5"
+				markerHeight="12.5"
+				markerUnits="strokeWidth"
+				orient="auto-start-reverse"
+			>
+				<polyline
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					points="-5,-4 0,0 -5,4 -5,-4"
+					stroke-width="2"
+					stroke="context-stroke"
+					fill="context-stroke"
+				/>
+			</marker>
+		</defs>
+	</svg>
+</template>

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.spec.ts
@@ -1,10 +1,10 @@
-import { fireEvent } from '@testing-library/vue';
 import CanvasEdge, { type CanvasEdgeProps } from './CanvasEdge.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { Position } from '@vue-flow/core';
 import { NodeConnectionType } from 'n8n-workflow';
+import userEvent from '@testing-library/user-event';
 
 const DEFAULT_PROPS = {
 	sourceX: 0,
@@ -31,18 +31,21 @@ beforeEach(() => {
 describe('CanvasEdge', () => {
 	it('should emit delete event when toolbar delete is clicked', async () => {
 		const { emitted, getByTestId } = renderComponent();
+		await userEvent.hover(getByTestId('edge-label-wrapper'));
 		const deleteButton = getByTestId('delete-connection-button');
 
-		await fireEvent.click(deleteButton);
+		await userEvent.click(deleteButton);
 
 		expect(emitted()).toHaveProperty('delete');
 	});
 
 	it('should emit add event when toolbar add is clicked', async () => {
 		const { emitted, getByTestId } = renderComponent();
+		await userEvent.hover(getByTestId('edge-label-wrapper'));
+
 		const addButton = getByTestId('add-connection-button');
 
-		await fireEvent.click(addButton);
+		await userEvent.click(addButton);
 
 		expect(emitted()).toHaveProperty('add');
 	});
@@ -53,6 +56,8 @@ describe('CanvasEdge', () => {
 				readOnly: true,
 			},
 		});
+
+		await userEvent.hover(getByTestId('edge-label-wrapper'));
 
 		expect(() => getByTestId('add-connection-button')).toThrow();
 		expect(() => getByTestId('delete-connection-button')).toThrow();

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -70,4 +70,8 @@ function onDelete() {
 	--button-background-color: var(--color-background-base);
 	--button-hover-background-color: var(--color-background-light);
 }
+
+.canvas-edge-toolbar-button {
+	border-width: 2px;
+}
 </style>


### PR DESCRIPTION
## Summary

Increase hit area around connectors
Prevent hovering glitches
Add label background
Arrow marker inherits parent path colors
properly toggle label and toolbar

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/N8N-7616/nodeconnector-rendering-glitches

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
