### PR TITLE
refactor(core): Have `WorkerServer` use `InstanceSettings`

### DIFF
--- a/packages/cli/src/scaling/worker-server.ts
+++ b/packages/cli/src/scaling/worker-server.ts
@@ -1,12 +1,12 @@
 import { GlobalConfig } from '@n8n/config';
 import express from 'express';
+import { InstanceSettings } from 'n8n-core';
 import { ensureError } from 'n8n-workflow';
 import { strict as assert } from 'node:assert';
 import http from 'node:http';
 import type { Server } from 'node:http';
 import { Service } from 'typedi';
 
-import config from '@/config';
 import { CredentialsOverwrites } from '@/credentials-overwrites';
 import * as Db from '@/db';
 import { CredentialsOverwritesAlreadySetError } from '@/errors/credentials-overwrites-already-set.error';
@@ -40,8 +40,9 @@ export class WorkerServer {
 		private readonly scalingService: ScalingService,
 		private readonly credentialsOverwrites: CredentialsOverwrites,
 		private readonly externalHooks: ExternalHooks,
+		private readonly instanceSettings: InstanceSettings,
 	) {
-		assert(config.getEnv('generic.instanceType') === 'worker');
+		assert(this.instanceSettings.instanceType === 'worker');
 
 		const app = express();
 


### PR DESCRIPTION
## Summary

Have `WorkerServer` use `InstanceSettings` instead of `config`. The [underlying PR](https://github.com/n8n-io/n8n/pull/10640) was merged soon before and we do not require PRs to be up to date with master, which broke CI.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
