### PR TITLE
fix(editor): Minimap Show nodes outside viewport

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -567,7 +567,6 @@ provide(CanvasKey, {
 				pannable
 				zoomable
 				:node-class-name="minimapNodeClassnameFn"
-				mask-color="var(--color-background-base)"
 				:node-border-radius="16"
 				@mouseenter="onMinimapMouseEnter"
 				@mouseleave="onMinimapMouseLeave"


### PR DESCRIPTION
## Summary

Due to the selected color palette event though nodes outside the viewport were rendered in the minimap it was imposible to distinguish them from the background 

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/567de9e5-c21e-4d49-9d54-12977a04aa08) | ![image](https://github.com/user-attachments/assets/72979895-c8e0-4554-bff2-2bbb7df9f0f3)  |


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/N8N-7692/minimap-isnt-useful-since-doesnt-show-nodes-outside-the-viewport

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
