### PR TITLE
fix(core): Prevent shutdown error in regular mode

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -9,7 +9,6 @@ import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus'
 import { LogStreamingEventRelay } from '@/events/log-streaming-event-relay';
 import { JobProcessor } from '@/scaling/job-processor';
 import type { ScalingService } from '@/scaling/scaling.service';
-import { WorkerServer } from '@/scaling/worker-server';
 import { OrchestrationHandlerWorkerService } from '@/services/orchestration/worker/orchestration.handler.worker.service';
 import { OrchestrationWorkerService } from '@/services/orchestration/worker/orchestration.worker.service';
 import type { RedisServicePubSubSubscriber } from '@/services/redis/redis-service-pub-sub-subscriber';
@@ -167,6 +166,7 @@ export class Worker extends BaseCommand {
 			this.globalConfig.queue.health.active ||
 			this.globalConfig.credentials.overwrite.endpoint !== ''
 		) {
+			const { WorkerServer } = await import('@/scaling/worker-server');
 			await Container.get(WorkerServer).init();
 		}
 


### PR DESCRIPTION
Dynamically import `WorkerServer` to prevent `ScalingService` from being registered in the DI container when running a main in regular mode.

```
ComponentShutdownError: Failed to shutdown gracefully
    at ShutdownService.shutdownComponent (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:113:29)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at /Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:99:41
    at async Promise.allSettled (index 0)
    at ShutdownService.startShutdown (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:98:4)
    at ShutdownService.waitForShutdown (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:88:3)
    at /Users/ivov/Development/n8n/packages/cli/src/commands/base-command.ts:329:4 {
  level: 'error',
  tags: { packageName: 'cli' },
  extra: { component: 'ScalingService.stop()' },
  [cause]: TypeError: Cannot read properties of undefined (reading 'pause')
      at ScalingService.stop (/Users/ivov/Development/n8n/packages/cli/src/scaling/scaling.service.ts:91:20)
      at ShutdownService.shutdownComponent (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:110:17)
      at /Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:99:52
      at Array.map (<anonymous>)
      at ShutdownService.startShutdown (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:99:18)
      at ShutdownService.shutdown (/Users/ivov/Development/n8n/packages/cli/src/shutdown/shutdown.service.ts:79:31)
      at /Users/ivov/Development/n8n/packages/cli/src/commands/base-command.ts:327:25
      at ReadStream.<anonymous> (/Users/ivov/Development/n8n/packages/cli/src/commands/start.ts:335:45)
      at ReadStream.emit (node:events:519:28)
      at ReadStream.emit (node:domain:488:12)
} { component: 'ScalingService.stop()' }
```

