### PR TITLE
fix(editor): Allow custom git repo urls in source control settings

### DIFF
--- a/packages/editor-ui/src/views/SettingsSourceControl.test.ts
+++ b/packages/editor-ui/src/views/SettingsSourceControl.test.ts
@@ -182,8 +182,7 @@ describe('SettingsSourceControl', () => {
 
 			await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
 
-			const repoUrlInput = container.querySelector('input[name="repoUrl"]');
-			expect(repoUrlInput).toBeInTheDocument();
+			const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
 
 			await userEvent.click(repoUrlInput);
 			await userEvent.type(repoUrlInput, url);

--- a/packages/editor-ui/src/views/SettingsSourceControl.test.ts
+++ b/packages/editor-ui/src/views/SettingsSourceControl.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import {expect, vi} from 'vitest';
 import { screen, waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createPinia, setActivePinia } from 'pinia';
@@ -170,6 +170,8 @@ describe('SettingsSourceControl', () => {
 			['git@192.168.1.101:2222:user/repo', true],
 			['git@ssh.dev.azure.com:v3/User/repo/directory', true],
 			['ssh://git@mydomain.example:2224/gitolite-admin', true],
+			['gituser@192.168.1.1:ABC/Repo4.git', true],
+			['root@192.168.1.1/repo.git', true],
 			['http://github.com/user/repository', false],
 			['https://github.com/user/repository', false],
 		])('%s', async (url: string, isValid: boolean) => {
@@ -180,7 +182,8 @@ describe('SettingsSourceControl', () => {
 
 			await waitFor(() => expect(sourceControlStore.preferences.publicKey).not.toEqual(''));
 
-			const repoUrlInput = container.querySelector('input[name="repoUrl"]')!;
+			const repoUrlInput = container.querySelector('input[name="repoUrl"]');
+			expect(repoUrlInput).toBeInTheDocument();
 
 			await userEvent.click(repoUrlInput);
 			await userEvent.type(repoUrlInput, url);

--- a/packages/editor-ui/src/views/SettingsSourceControl.test.ts
+++ b/packages/editor-ui/src/views/SettingsSourceControl.test.ts
@@ -1,4 +1,4 @@
-import {expect, vi} from 'vitest';
+import { vi } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createPinia, setActivePinia } from 'pinia';

--- a/packages/editor-ui/src/views/SettingsSourceControl.vue
+++ b/packages/editor-ui/src/views/SettingsSourceControl.vue
@@ -131,7 +131,7 @@ const repoUrlValidationRules: Array<Rule | RuleGroup> = [
 		name: 'MATCH_REGEX',
 		config: {
 			regex:
-				/^(ssh:\/\/)?git@(?:\[[0-9a-fA-F:]+\]|(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+)(?::[0-9]+)*:(?:v[0-9]+\/)?[a-zA-Z0-9_.\-\/]+(\.git)?(?:\/[a-zA-Z0-9_.\-\/]+)*$/,
+				/^(?:git@|ssh:\/\/git@|[\w-]+@)(?:[\w.-]+|\[[0-9a-fA-F:]+])(?::\d+)?[:\/][\w\-~]+(?:\/[\w\-~]+)*(?:\.git)?(?:\/.*)?$/,
 			message: locale.baseText('settings.sourceControl.repoUrlInvalid'),
 		},
 	},


### PR DESCRIPTION
## Summary

Allow custom git repo urls in source control settings

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1963](https://linear.app/n8n/issue/PAY-1963/bug-enterprise-customer-familienservice-valid-gitea-ssh-url-is#comment-ee3c36a9)

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
