### PR TITLE
fix(Azure OpenAI Chat Model Node): Add response format option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -7,7 +7,6 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
-import type { ClientOptions } from '@langchain/openai';
 import { ChatOpenAI } from '@langchain/openai';
 import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
 import { N8nLlmTracing } from '../N8nLlmTracing';
@@ -52,6 +51,18 @@ export class LmChatAzureOpenAi implements INodeType {
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionType.AiChain, NodeConnectionType.AiAgent]),
 			{
+				displayName:
+					'If using JSON response format, you must include word "json" in the prompt in your chain or agent. Also, make sure to select latest models released post November 2023.',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						'/options.responseFormat': ['json_object'],
+					},
+				},
+			},
+			{
 				displayName: 'Model (Deployment) Name',
 				name: 'model',
 				type: 'string',
@@ -85,6 +96,25 @@ export class LmChatAzureOpenAi implements INodeType {
 						typeOptions: {
 							maxValue: 32768,
 						},
+					},
+					{
+						displayName: 'Response Format',
+						name: 'responseFormat',
+						default: 'text',
+						type: 'options',
+						options: [
+							{
+								name: 'Text',
+								value: 'text',
+								description: 'Regular text response',
+							},
+							{
+								name: 'JSON',
+								value: 'json_object',
+								description:
+									'Enables JSON mode, which should guarantee the message the model generates is valid JSON',
+							},
+						],
 					},
 					{
 						displayName: 'Presence Penalty',
@@ -148,9 +178,8 @@ export class LmChatAzureOpenAi implements INodeType {
 			presencePenalty?: number;
 			temperature?: number;
 			topP?: number;
+			responseFormat?: 'text' | 'json_object';
 		};
-
-		const configuration: ClientOptions = {};
 
 		const model = new ChatOpenAI({
 			azureOpenAIApiDeploymentName: modelName,
@@ -160,8 +189,12 @@ export class LmChatAzureOpenAi implements INodeType {
 			...options,
 			timeout: options.timeout ?? 60000,
 			maxRetries: options.maxRetries ?? 2,
-			configuration,
 			callbacks: [new N8nLlmTracing(this)],
+			modelKwargs: options.responseFormat
+				? {
+						response_format: { type: options.responseFormat },
+					}
+				: undefined,
 		});
 
 		return {


### PR DESCRIPTION
## Summary

This PR adds an option to specify the desired response format of the model output.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/10816
https://linear.app/n8n/issue/AI-351/community-issue-response-format-option-for-azure-openai-chat-model

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
