### PR TITLE
refactor(core): Move frontend settings to @n8n/api-types (no-changelog)

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -15,6 +15,7 @@
     "start": "cd ..; pnpm start"
   },
   "devDependencies": {
+    "@n8n/api-types": "workspace:*",
     "@types/lodash": "catalog:",
     "eslint-plugin-cypress": "^3.3.0",
     "n8n-workflow": "workspace:*"

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,6 @@
 import 'cypress-real-events';
 import FakeTimers from '@sinonjs/fake-timers';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 import { WorkflowPage } from '../pages';
 import {
 	BACKEND_BASE_URL,
@@ -86,8 +86,8 @@ Cypress.Commands.add('signout', () => {
 	cy.getCookie(N8N_AUTH_COOKIE).should('not.exist');
 });
 
-export let settings: Partial<IN8nUISettings>;
-Cypress.Commands.add('overrideSettings', (value: Partial<IN8nUISettings>) => {
+export let settings: Partial<FrontendSettings>;
+Cypress.Commands.add('overrideSettings', (value: Partial<FrontendSettings>) => {
 	settings = value;
 });
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,7 +1,7 @@
 // Load type definitions that come with Cypress module
 /// <reference types="cypress" />
 
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 
 Cypress.Keyboard.defaults({
 	keystrokeDelay: 0,
@@ -45,7 +45,7 @@ declare global {
 			 */
 			signinAsMember(index?: number): void;
 			signout(): void;
-			overrideSettings(value: Partial<IN8nUISettings>): void;
+			overrideSettings(value: Partial<FrontendSettings>): void;
 			enableFeature(feature: string): void;
 			disableFeature(feature: string): void;
 			enableQueueMode(): void;

--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -1,0 +1,172 @@
+import type { ExpressionEvaluatorType, LogLevel, WorkflowSettings } from 'n8n-workflow';
+
+export interface IVersionNotificationSettings {
+	enabled: boolean;
+	endpoint: string;
+	infoUrl: string;
+}
+
+export interface ITelemetryClientConfig {
+	url: string;
+	key: string;
+}
+
+export interface ITelemetrySettings {
+	enabled: boolean;
+	config?: ITelemetryClientConfig;
+}
+
+export type AuthenticationMethod = 'email' | 'ldap' | 'saml';
+
+export interface IUserManagementSettings {
+	quota: number;
+	showSetupOnFirstLoad?: boolean;
+	smtpSetup: boolean;
+	authenticationMethod: AuthenticationMethod;
+}
+
+export interface FrontendSettings {
+	isDocker?: boolean;
+	databaseType: 'sqlite' | 'mariadb' | 'mysqldb' | 'postgresdb';
+	endpointForm: string;
+	endpointFormTest: string;
+	endpointFormWaiting: string;
+	endpointWebhook: string;
+	endpointWebhookTest: string;
+	saveDataErrorExecution: WorkflowSettings.SaveDataExecution;
+	saveDataSuccessExecution: WorkflowSettings.SaveDataExecution;
+	saveManualExecutions: boolean;
+	saveExecutionProgress: boolean;
+	executionTimeout: number;
+	maxExecutionTimeout: number;
+	workflowCallerPolicyDefaultOption: WorkflowSettings.CallerPolicy;
+	oauthCallbackUrls: {
+		oauth1: string;
+		oauth2: string;
+	};
+	timezone: string;
+	urlBaseWebhook: string;
+	urlBaseEditor: string;
+	versionCli: string;
+	nodeJsVersion: string;
+	concurrency: number;
+	authCookie: {
+		secure: boolean;
+	};
+	binaryDataMode: 'default' | 'filesystem' | 's3';
+	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev';
+	n8nMetadata?: {
+		userId?: string;
+		[key: string]: string | number | undefined;
+	};
+	versionNotifications: IVersionNotificationSettings;
+	instanceId: string;
+	telemetry: ITelemetrySettings;
+	posthog: {
+		enabled: boolean;
+		apiHost: string;
+		apiKey: string;
+		autocapture: boolean;
+		disableSessionRecording: boolean;
+		debug: boolean;
+	};
+	personalizationSurveyEnabled: boolean;
+	defaultLocale: string;
+	userManagement: IUserManagementSettings;
+	sso: {
+		saml: {
+			loginLabel: string;
+			loginEnabled: boolean;
+		};
+		ldap: {
+			loginLabel: string;
+			loginEnabled: boolean;
+		};
+	};
+	publicApi: {
+		enabled: boolean;
+		latestVersion: number;
+		path: string;
+		swaggerUi: {
+			enabled: boolean;
+		};
+	};
+	workflowTagsDisabled: boolean;
+	logLevel: LogLevel;
+	hiringBannerEnabled: boolean;
+	previewMode: boolean;
+	templates: {
+		enabled: boolean;
+		host: string;
+	};
+	missingPackages?: boolean;
+	executionMode: 'regular' | 'queue';
+	pushBackend: 'sse' | 'websocket';
+	communityNodesEnabled: boolean;
+	aiAssistant: {
+		enabled: boolean;
+	};
+	deployment: {
+		type: string;
+	};
+	isNpmAvailable: boolean;
+	allowedModules: {
+		builtIn?: string[];
+		external?: string[];
+	};
+	enterprise: {
+		sharing: boolean;
+		ldap: boolean;
+		saml: boolean;
+		logStreaming: boolean;
+		advancedExecutionFilters: boolean;
+		variables: boolean;
+		sourceControl: boolean;
+		auditLogs: boolean;
+		externalSecrets: boolean;
+		showNonProdBanner: boolean;
+		debugInEditor: boolean;
+		binaryDataS3: boolean;
+		workflowHistory: boolean;
+		workerView: boolean;
+		advancedPermissions: boolean;
+		projects: {
+			team: {
+				limit: number;
+			};
+		};
+	};
+	hideUsagePage: boolean;
+	license: {
+		planName?: string;
+		consumerId: string;
+		environment: 'development' | 'production' | 'staging';
+	};
+	variables: {
+		limit: number;
+	};
+	expressions: {
+		evaluator: ExpressionEvaluatorType;
+	};
+	mfa: {
+		enabled: boolean;
+	};
+	banners: {
+		dismissed: string[];
+	};
+	ai: {
+		enabled: boolean;
+	};
+	workflowHistory: {
+		pruneTime: number;
+		licensePruneTime: number;
+	};
+	pruning: {
+		isEnabled: boolean;
+		maxAge: number;
+		maxCount: number;
+	};
+	security: {
+		blockFileAccessToN8nFiles: boolean;
+	};
+}

--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -1,6 +1,7 @@
+export type * from './datetime';
 export type * from './push';
 export type * from './scaling';
-export type * from './datetime';
+export type * from './frontend-settings';
 export type * from './user';
 
 export type { Collaborator } from './push/collaboration';

--- a/packages/cli/src/events/relay-event-map.ts
+++ b/packages/cli/src/events/relay-event-map.ts
@@ -1,5 +1,5 @@
+import type { AuthenticationMethod } from '@n8n/api-types';
 import type {
-	AuthenticationMethod,
 	IPersonalizationSurveyAnswersV4,
 	IRun,
 	IWorkflowBase,

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -239,12 +239,6 @@ export interface IExternalHooksFunctions {
 	};
 }
 
-export interface IVersionNotificationSettings {
-	enabled: boolean;
-	endpoint: string;
-	infoUrl: string;
-}
-
 export interface IPersonalizationSurveyAnswers {
 	email: string | null;
 	codingSkill: string | null;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,10 +1,10 @@
+import type { FrontendSettings } from '@n8n/api-types';
 import { exec as callbackExec } from 'child_process';
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import { access as fsAccess } from 'fs/promises';
 import helmet from 'helmet';
 import { InstanceSettings } from 'n8n-core';
-import type { IN8nUISettings } from 'n8n-workflow';
 import { resolve } from 'path';
 import { Container, Service } from 'typedi';
 import { promisify } from 'util';
@@ -252,7 +252,7 @@ export class Server extends AbstractServer {
 			this.app.get(
 				`/${this.restEndpoint}/settings`,
 				ResponseHelper.send(
-					async (req: express.Request): Promise<IN8nUISettings> =>
+					async (req: express.Request): Promise<FrontendSettings> =>
 						frontendService.getSettings(req.headers['push-ref'] as string),
 				),
 			);

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -1,14 +1,10 @@
+import type { FrontendSettings, ITelemetrySettings } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import { createWriteStream } from 'fs';
 import { mkdir } from 'fs/promises';
 import uniq from 'lodash/uniq';
 import { InstanceSettings } from 'n8n-core';
-import type {
-	ICredentialType,
-	IN8nUISettings,
-	INodeTypeBaseDescription,
-	ITelemetrySettings,
-} from 'n8n-workflow';
+import type { ICredentialType, INodeTypeBaseDescription } from 'n8n-workflow';
 import fs from 'node:fs';
 import path from 'path';
 import { Container, Service } from 'typedi';
@@ -37,7 +33,7 @@ import { UrlService } from './url.service';
 
 @Service()
 export class FrontendService {
-	settings: IN8nUISettings;
+	settings: FrontendSettings;
 
 	private communityPackagesService?: CommunityPackagesService;
 
@@ -247,7 +243,7 @@ export class FrontendService {
 		this.writeStaticJSON('credentials', credentials);
 	}
 
-	getSettings(pushRef?: string): IN8nUISettings {
+	getSettings(pushRef?: string): FrontendSettings {
 		this.eventService.emit('session-started', { pushRef });
 
 		const restEndpoint = this.globalConfig.endpoints.rest;

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -1,7 +1,12 @@
 import type { Component } from 'vue';
 import type { NotificationOptions as ElementNotificationOptions } from 'element-plus';
 import type { Connection } from '@jsplumb/core';
-import type { Iso8601DateTimeString } from '@n8n/api-types';
+import type {
+	FrontendSettings,
+	Iso8601DateTimeString,
+	IUserManagementSettings,
+	IVersionNotificationSettings,
+} from '@n8n/api-types';
 import type { Scope } from '@n8n/permissions';
 import type { IMenuItem, NodeCreatorTag } from 'n8n-design-system';
 import type {
@@ -31,10 +36,8 @@ import type {
 	FeatureFlags,
 	ExecutionStatus,
 	ITelemetryTrackProperties,
-	IUserManagementSettings,
 	WorkflowSettings,
 	IUserSettings,
-	IN8nUISettings,
 	BannerName,
 	INodeExecutionData,
 	INodeProperties,
@@ -494,12 +497,6 @@ export interface IUser extends IUserResponse {
 	fullName?: string;
 	createdAt?: string;
 	mfaEnabled: boolean;
-}
-
-export interface IVersionNotificationSettings {
-	enabled: boolean;
-	endpoint: string;
-	infoUrl: string;
 }
 
 export interface IUserListAction {
@@ -1090,7 +1087,7 @@ export interface INodeCreatorState {
 
 export interface ISettingsState {
 	initialized: boolean;
-	settings: IN8nUISettings;
+	settings: FrontendSettings;
 	userManagement: IUserManagementSettings;
 	templatesEndpointHealthy: boolean;
 	api: {
@@ -1643,7 +1640,7 @@ export type EnterpriseEditionFeatureKey =
 	| 'WorkerView'
 	| 'AdvancedPermissions';
 
-export type EnterpriseEditionFeatureValue = keyof Omit<IN8nUISettings['enterprise'], 'projects'>;
+export type EnterpriseEditionFeatureValue = keyof Omit<FrontendSettings['enterprise'], 'projects'>;
 
 export interface IN8nPromptResponse {
 	updated: boolean;

--- a/packages/editor-ui/src/__tests__/defaults.ts
+++ b/packages/editor-ui/src/__tests__/defaults.ts
@@ -1,6 +1,6 @@
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 
-export const defaultSettings: IN8nUISettings = {
+export const defaultSettings: FrontendSettings = {
 	databaseType: 'sqlite',
 	isDocker: false,
 	pruning: {

--- a/packages/editor-ui/src/api/settings.ts
+++ b/packages/editor-ui/src/api/settings.ts
@@ -1,9 +1,9 @@
 import type { IRestApiContext, IN8nPrompts, IN8nPromptResponse } from '../Interface';
 import { makeRestApiRequest, get, post } from '@/utils/apiUtils';
 import { N8N_IO_BASE_URL, NPM_COMMUNITY_NODE_SEARCH_API_URL } from '@/constants';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 
-export async function getSettings(context: IRestApiContext): Promise<IN8nUISettings> {
+export async function getSettings(context: IRestApiContext): Promise<FrontendSettings> {
 	return await makeRestApiRequest(context, 'GET', '/settings');
 }
 

--- a/packages/editor-ui/src/components/Telemetry.vue
+++ b/packages/editor-ui/src/components/Telemetry.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
+import type { ITelemetrySettings } from '@n8n/api-types';
 import { useRootStore } from '@/stores/root.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
-import type { ITelemetrySettings } from 'n8n-workflow';
 import { useProjectsStore } from '@/stores/projects.store';
 import { computed, onMounted, watch, ref } from 'vue';
 import { useTelemetry } from '@/composables/useTelemetry';

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'vue';
-import type { ITelemetrySettings, ITelemetryTrackProperties, IDataObject } from 'n8n-workflow';
+import type { ITelemetrySettings } from '@n8n/api-types';
+import type { ITelemetryTrackProperties, IDataObject } from 'n8n-workflow';
 import type { RouteLocation } from 'vue-router';
 
 import type { INodeCreateElement, IUpdateInformation } from '@/Interface';

--- a/packages/editor-ui/src/stores/__tests__/posthog.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/posthog.test.ts
@@ -4,12 +4,12 @@ import { useUsersStore } from '@/stores/users.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useRootStore } from '@/stores/root.store';
 import { useTelemetryStore } from '@/stores/telemetry.store';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 import { LOCAL_STORAGE_EXPERIMENT_OVERRIDES } from '@/constants';
 import { nextTick } from 'vue';
 import { defaultSettings } from '../../__tests__/defaults';
 
-export const DEFAULT_POSTHOG_SETTINGS: IN8nUISettings['posthog'] = {
+export const DEFAULT_POSTHOG_SETTINGS: FrontendSettings['posthog'] = {
 	enabled: true,
 	apiHost: 'host',
 	apiKey: 'key',
@@ -20,13 +20,13 @@ export const DEFAULT_POSTHOG_SETTINGS: IN8nUISettings['posthog'] = {
 const CURRENT_USER_ID = '1';
 const CURRENT_INSTANCE_ID = '456';
 
-function setSettings(overrides?: Partial<IN8nUISettings>) {
+function setSettings(overrides?: Partial<FrontendSettings>) {
 	useSettingsStore().setSettings({
 		...defaultSettings,
 		posthog: DEFAULT_POSTHOG_SETTINGS,
 		instanceId: CURRENT_INSTANCE_ID,
 		...overrides,
-	} as IN8nUISettings);
+	} as FrontendSettings);
 
 	useRootStore().setInstanceId(CURRENT_INSTANCE_ID);
 }

--- a/packages/editor-ui/src/stores/__tests__/sso.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/sso.test.ts
@@ -3,12 +3,12 @@ import { useSettingsStore } from '@/stores/settings.store';
 import { useSSOStore } from '@/stores/sso.store';
 import { merge } from 'lodash-es';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 
 let ssoStore: ReturnType<typeof useSSOStore>;
 let settingsStore: ReturnType<typeof useSettingsStore>;
 
-const DEFAULT_SETTINGS: IN8nUISettings = SETTINGS_STORE_DEFAULT_STATE.settings;
+const DEFAULT_SETTINGS: FrontendSettings = SETTINGS_STORE_DEFAULT_STATE.settings;
 
 describe('SSO store', () => {
 	beforeEach(() => {

--- a/packages/editor-ui/src/stores/__tests__/workflowHistory.store.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/workflowHistory.store.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 import { useWorkflowHistoryStore } from '@/stores/workflowHistory.store';
 import { useSettingsStore } from '@/stores/settings.store';
 
@@ -26,7 +26,7 @@ describe('Workflow history store', () => {
 					pruneTime,
 					licensePruneTime,
 				},
-			} as IN8nUISettings;
+			} as FrontendSettings;
 
 			expect(workflowHistoryStore.shouldUpgrade).toBe(shouldUpgrade);
 		},

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import Bowser from 'bowser';
+import type { IUserManagementSettings, FrontendSettings } from '@n8n/api-types';
 
 import * as publicApiApi from '@/api/api-keys';
 import * as ldapApi from '@/api/ldap';
@@ -8,12 +9,7 @@ import { testHealthEndpoint } from '@/api/templates';
 import type { ILdapConfig } from '@/Interface';
 import { STORES, INSECURE_CONNECTION_WARNING } from '@/constants';
 import { UserManagementAuthenticationMethod } from '@/Interface';
-import type {
-	IDataObject,
-	IN8nUISettings,
-	WorkflowSettings,
-	IUserManagementSettings,
-} from 'n8n-workflow';
+import type { IDataObject, WorkflowSettings } from 'n8n-workflow';
 import { ExpressionEvaluatorProxy } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useRootStore } from './root.store';
@@ -27,7 +23,7 @@ import { i18n } from '@/plugins/i18n';
 
 export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 	const initialized = ref(false);
-	const settings = ref<IN8nUISettings>({} as IN8nUISettings);
+	const settings = ref<FrontendSettings>({} as FrontendSettings);
 	const userManagement = ref<IUserManagementSettings>({
 		quota: -1,
 		showSetupOnFirstLoad: false,
@@ -164,7 +160,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const isDevRelease = computed(() => settings.value.releaseChannel === 'dev');
 
-	const setSettings = (newSettings: IN8nUISettings) => {
+	const setSettings = (newSettings: FrontendSettings) => {
 		settings.value = newSettings;
 		userManagement.value = newSettings.userManagement;
 		if (userManagement.value) {
@@ -208,7 +204,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		}
 	};
 
-	const setAllowedModules = (allowedModules: IN8nUISettings['allowedModules']) => {
+	const setAllowedModules = (allowedModules: FrontendSettings['allowedModules']) => {
 		settings.value.allowedModules = allowedModules;
 	};
 
@@ -367,7 +363,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 	};
 
 	const reset = () => {
-		settings.value = {} as IN8nUISettings;
+		settings.value = {} as FrontendSettings;
 	};
 
 	return {

--- a/packages/editor-ui/src/stores/versions.store.ts
+++ b/packages/editor-ui/src/stores/versions.store.ts
@@ -1,6 +1,7 @@
+import type { IVersionNotificationSettings } from '@n8n/api-types';
 import * as versionsApi from '@/api/versions';
 import { STORES, VERSIONS_MODAL_KEY } from '@/constants';
-import type { IVersion, IVersionNotificationSettings } from '@/Interface';
+import type { IVersion } from '@/Interface';
 import { defineStore } from 'pinia';
 import { useRootStore } from './root.store';
 import { useToast } from '@/composables/useToast';

--- a/packages/editor-ui/src/views/ProjectSettings.test.ts
+++ b/packages/editor-ui/src/views/ProjectSettings.test.ts
@@ -10,7 +10,7 @@ import { VIEWS } from '@/constants';
 import { useUsersStore } from '@/stores/users.store';
 import { createProjectListItem } from '@/__tests__/data/projects';
 import { useSettingsStore } from '@/stores/settings.store';
-import type { IN8nUISettings } from 'n8n-workflow';
+import type { FrontendSettings } from '@n8n/api-types';
 import { ProjectTypes } from '@/types/projects.types';
 
 vi.mock('vue-router', () => {
@@ -63,7 +63,7 @@ describe('ProjectSettings', () => {
 					},
 				},
 			},
-		} as IN8nUISettings);
+		} as FrontendSettings);
 		projectsStore.setCurrentProject({
 			id: '123',
 			type: 'team',

--- a/packages/workflow/src/Authentication.ts
+++ b/packages/workflow/src/Authentication.ts
@@ -1,1 +1,0 @@
-export type AuthenticationMethod = 'email' | 'ldap' | 'saml';

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -10,7 +10,6 @@ import type { URLSearchParams } from 'url';
 import type { RequestBodyMatcher } from 'nock';
 import type { Client as SSHClient } from 'ssh2';
 
-import type { AuthenticationMethod } from './Authentication';
 import type { CODE_EXECUTION_MODES, CODE_LANGUAGES, LOG_LEVELS } from './Constants';
 import type { IDeferredPromise } from './DeferredPromise';
 import type { ExecutionStatus } from './ExecutionStatus';
@@ -2407,16 +2406,6 @@ export interface INodesGraphResult {
 	webhookNodeNames: string[];
 }
 
-export interface ITelemetryClientConfig {
-	url: string;
-	key: string;
-}
-
-export interface ITelemetrySettings {
-	enabled: boolean;
-	config?: ITelemetryClientConfig;
-}
-
 export interface FeatureFlags {
 	[featureFlag: string]: string | boolean | undefined;
 }
@@ -2598,19 +2587,6 @@ export interface ExecutionFilters {
 	workflowId?: number | string;
 }
 
-export interface IVersionNotificationSettings {
-	enabled: boolean;
-	endpoint: string;
-	infoUrl: string;
-}
-
-export interface IUserManagementSettings {
-	quota: number;
-	showSetupOnFirstLoad?: boolean;
-	smtpSetup: boolean;
-	authenticationMethod: AuthenticationMethod;
-}
-
 export type NpsSurveyRespondedState = { lastShownAt: number; responded: true };
 export type NpsSurveyWaitingState = {
 	lastShownAt: number;
@@ -2628,157 +2604,9 @@ export interface IUserSettings {
 	npsSurvey?: NpsSurveyState;
 }
 
-export interface IPublicApiSettings {
-	enabled: boolean;
-	latestVersion: number;
-	path: string;
-	swaggerUi: {
-		enabled: boolean;
-	};
-}
-
 export type ExpressionEvaluatorType = 'tmpl' | 'tournament';
 
 export type N8nAIProviderType = 'openai' | 'unknown';
-
-export interface IN8nUISettings {
-	isDocker?: boolean;
-	databaseType: 'sqlite' | 'mariadb' | 'mysqldb' | 'postgresdb';
-	endpointForm: string;
-	endpointFormTest: string;
-	endpointFormWaiting: string;
-	endpointWebhook: string;
-	endpointWebhookTest: string;
-	saveDataErrorExecution: WorkflowSettings.SaveDataExecution;
-	saveDataSuccessExecution: WorkflowSettings.SaveDataExecution;
-	saveManualExecutions: boolean;
-	saveExecutionProgress: boolean;
-	executionTimeout: number;
-	maxExecutionTimeout: number;
-	workflowCallerPolicyDefaultOption: WorkflowSettings.CallerPolicy;
-	oauthCallbackUrls: {
-		oauth1: string;
-		oauth2: string;
-	};
-	timezone: string;
-	urlBaseWebhook: string;
-	urlBaseEditor: string;
-	versionCli: string;
-	nodeJsVersion: string;
-	concurrency: number;
-	authCookie: {
-		secure: boolean;
-	};
-	binaryDataMode: 'default' | 'filesystem' | 's3';
-	releaseChannel: 'stable' | 'beta' | 'nightly' | 'dev';
-	n8nMetadata?: {
-		userId?: string;
-		[key: string]: string | number | undefined;
-	};
-	versionNotifications: IVersionNotificationSettings;
-	instanceId: string;
-	telemetry: ITelemetrySettings;
-	posthog: {
-		enabled: boolean;
-		apiHost: string;
-		apiKey: string;
-		autocapture: boolean;
-		disableSessionRecording: boolean;
-		debug: boolean;
-	};
-	personalizationSurveyEnabled: boolean;
-	defaultLocale: string;
-	userManagement: IUserManagementSettings;
-	sso: {
-		saml: {
-			loginLabel: string;
-			loginEnabled: boolean;
-		};
-		ldap: {
-			loginLabel: string;
-			loginEnabled: boolean;
-		};
-	};
-	publicApi: IPublicApiSettings;
-	workflowTagsDisabled: boolean;
-	logLevel: LogLevel;
-	hiringBannerEnabled: boolean;
-	previewMode: boolean;
-	templates: {
-		enabled: boolean;
-		host: string;
-	};
-	missingPackages?: boolean;
-	executionMode: 'regular' | 'queue';
-	pushBackend: 'sse' | 'websocket';
-	communityNodesEnabled: boolean;
-	aiAssistant: {
-		enabled: boolean;
-	};
-	deployment: {
-		type: string | 'default' | 'n8n-internal' | 'cloud' | 'desktop_mac' | 'desktop_win';
-	};
-	isNpmAvailable: boolean;
-	allowedModules: {
-		builtIn?: string[];
-		external?: string[];
-	};
-	enterprise: {
-		sharing: boolean;
-		ldap: boolean;
-		saml: boolean;
-		logStreaming: boolean;
-		advancedExecutionFilters: boolean;
-		variables: boolean;
-		sourceControl: boolean;
-		auditLogs: boolean;
-		externalSecrets: boolean;
-		showNonProdBanner: boolean;
-		debugInEditor: boolean;
-		binaryDataS3: boolean;
-		workflowHistory: boolean;
-		workerView: boolean;
-		advancedPermissions: boolean;
-		projects: {
-			team: {
-				limit: number;
-			};
-		};
-	};
-	hideUsagePage: boolean;
-	license: {
-		planName?: string;
-		consumerId: string;
-		environment: 'development' | 'production' | 'staging';
-	};
-	variables: {
-		limit: number;
-	};
-	expressions: {
-		evaluator: ExpressionEvaluatorType;
-	};
-	mfa: {
-		enabled: boolean;
-	};
-	banners: {
-		dismissed: string[];
-	};
-	ai: {
-		enabled: boolean;
-	};
-	workflowHistory: {
-		pruneTime: number;
-		licensePruneTime: number;
-	};
-	pruning: {
-		isEnabled: boolean;
-		maxAge: number;
-		maxCount: number;
-	};
-	security: {
-		blockFileAccessToN8nFiles: boolean;
-	};
-}
 
 export interface SecretsHelpersBase {
 	update(): Promise<void>;

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -6,7 +6,6 @@ import * as ObservableObject from './ObservableObject';
 import * as TelemetryHelpers from './TelemetryHelpers';
 
 export * from './errors';
-export * from './Authentication';
 export * from './Constants';
 export * from './Cron';
 export * from './DeferredPromise';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5
     devDependencies:
+      '@n8n/api-types':
+        specifier: workspace:*
+        version: link:../packages/@n8n/api-types
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.14.195


### PR DESCRIPTION
## Summary
This is a continuation of #10742 to keep moving stuff out of `n8n-workflow`.

## Review / Merge checklist

- [x] PR title and summary are descriptive