### PR TITLE
feat(core): Allow customizing max file size in form-data payloads for webhooks

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -65,6 +65,10 @@ export class EndpointsConfig {
 	@Env('N8N_PAYLOAD_SIZE_MAX')
 	payloadSizeMax: number = 16;
 
+	/** Max payload size for files in form-data webhook payloads in MiB */
+	@Env('N8N_FORMDATA_FILE_SIZE_MAX')
+	formDataFileSizeMax: number = 200;
+
 	@Nested
 	metrics: PrometheusMetricsConfig;
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -176,6 +176,7 @@ describe('GlobalConfig', () => {
 			formTest: 'form-test',
 			formWaiting: 'form-waiting',
 			payloadSizeMax: 16,
+			formDataFileSizeMax: 200,
 			rest: 'rest',
 			webhook: 'webhook',
 			webhookTest: 'webhook-test',

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -6,6 +6,7 @@
 /* eslint-disable prefer-spread */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+import { GlobalConfig } from '@n8n/config';
 import type express from 'express';
 import formidable from 'formidable';
 import get from 'lodash/get';
@@ -214,9 +215,11 @@ export async function executeWebhook(
 		if (!binaryData) {
 			const { contentType, encoding } = req;
 			if (contentType === 'multipart/form-data') {
+				const { formDataFileSizeMax } = Container.get(GlobalConfig).endpoints;
 				const form = formidable({
 					multiples: true,
 					encoding: encoding as formidable.BufferEncoding,
+					maxFileSize: formDataFileSizeMax,
 					// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 				});
 				req.body = await new Promise((resolve) => {


### PR DESCRIPTION
## Summary
Formidable by default only allows files up to 200MiB. This PR adds a config option to let users customize this value.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/n8n-webhook-upload-limit-when-using-form-data/54021

## Review / Merge checklist

- [x] PR title and summary are descriptive