### PR TITLE
ci(editor): Use eslint-plugin-prettier for vue files during development (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/frontend.js
+++ b/packages/@n8n_io/eslint-config/frontend.js
@@ -1,3 +1,5 @@
+const isCI = process.env.CI === 'true';
+
 /**
  * @type {import('@types/eslint').ESLint.ConfigData}
  */
@@ -21,58 +23,78 @@ module.exports = {
 				'import/no-extraneous-dependencies': 'off',
 			},
 		},
+		{
+			files: ['**/*.vue'],
+			plugins: isCI ? [] : ['eslint-plugin-prettier'],
+			rules: {
+				'vue/no-deprecated-slot-attribute': 'error',
+				'vue/no-deprecated-slot-scope-attribute': 'error',
+				'vue/no-multiple-template-root': 'error',
+				'vue/v-slot-style': 'error',
+				'vue/no-unused-components': 'error',
+				'vue/multi-word-component-names': 'off',
+				'vue/component-name-in-template-casing': [
+					'error',
+					'PascalCase',
+					{
+						registeredComponentsOnly: true,
+					},
+				],
+				'vue/no-reserved-component-names': [
+					'error',
+					{
+						disallowVueBuiltInComponents: true,
+						disallowVue3BuiltInComponents: false,
+					},
+				],
+				'vue/prop-name-casing': ['error', 'camelCase'],
+				'vue/attribute-hyphenation': ['error', 'always'],
+				'vue/define-emits-declaration': ['error', 'type-literal'],
+				'vue/require-macro-variable-name': [
+					'error',
+					{
+						defineProps: 'props',
+						defineEmits: 'emit',
+						defineSlots: 'slots',
+						useSlots: 'slots',
+						useAttrs: 'attrs',
+					},
+				],
+				'vue/block-order': [
+					'error',
+					{
+						order: ['script', 'template', 'style'],
+					},
+				],
+				'vue/no-v-html': 'error',
+
+				...(isCI
+					? {}
+					: {
+							'prettier/prettier': ['error', { endOfLine: 'auto' }],
+							'arrow-body-style': 'off',
+							'prefer-arrow-callback': 'off',
+						}),
+
+				// TODO: remove these
+				'vue/no-mutating-props': 'warn',
+				'vue/no-side-effects-in-computed-properties': 'warn',
+				'vue/no-v-text-v-html-on-component': 'warn',
+				'vue/return-in-computed-property': 'warn',
+			},
+		},
 	],
 
 	rules: {
-		'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-		'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+		'no-console': 'warn',
+		'no-debugger': isCI ? 'error' : 'off',
 		semi: [2, 'always'],
 		'comma-dangle': ['error', 'always-multiline'],
 		'no-tabs': 0,
 		'no-labels': 0,
-		'vue/no-deprecated-slot-attribute': 'error',
-		'vue/no-deprecated-slot-scope-attribute': 'error',
-		'vue/no-multiple-template-root': 'error',
-		'vue/v-slot-style': 'error',
-		'vue/no-unused-components': 'error',
-		'vue/multi-word-component-names': 'off',
 		'@typescript-eslint/no-use-before-define': 'off',
 		'@typescript-eslint/no-explicit-any': 'error',
-		'vue/component-name-in-template-casing': [
-			'error',
-			'PascalCase',
-			{
-				registeredComponentsOnly: true,
-			},
-		],
-		'vue/no-reserved-component-names': [
-			'error',
-			{
-				disallowVueBuiltInComponents: true,
-				disallowVue3BuiltInComponents: false,
-			},
-		],
-		'vue/prop-name-casing': ['error', 'camelCase'],
-		'vue/attribute-hyphenation': ['error', 'always'],
 		'import/no-extraneous-dependencies': 'warn',
-		'vue/define-emits-declaration': ['error', 'type-literal'],
-		'vue/require-macro-variable-name': [
-			'error',
-			{
-				defineProps: 'props',
-				defineEmits: 'emit',
-				defineSlots: 'slots',
-				useSlots: 'slots',
-				useAttrs: 'attrs',
-			},
-		],
-		'vue/block-order': [
-			'error',
-			{
-				order: ['script', 'template', 'style'],
-			},
-		],
-		'vue/no-v-html': 'error',
 
 		// TODO: fix these
 		'@typescript-eslint/no-unsafe-call': 'off',
@@ -84,10 +106,6 @@ module.exports = {
 		'@typescript-eslint/no-unsafe-member-access': 'off',
 
 		// TODO: remove these
-		'vue/no-mutating-props': 'warn',
-		'vue/no-side-effects-in-computed-properties': 'warn',
-		'vue/no-v-text-v-html-on-component': 'warn',
-		'vue/return-in-computed-property': 'warn',
 		'n8n-local-rules/no-plain-errors': 'off',
 	},
 };

--- a/packages/@n8n_io/eslint-config/package.json
+++ b/packages/@n8n_io/eslint-config/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-lodash": "^7.4.0",
     "eslint-plugin-n8n-local-rules": "^1.0.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^51.0.1",
     "eslint-plugin-unused-imports": "^3.1.0",
     "eslint-plugin-vue": "^9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,9 @@ importers:
       eslint-plugin-n8n-local-rules:
         specifier: ^1.0.0
         version: 1.0.0
+      eslint-plugin-prettier:
+        specifier: ^5.1.3
+        version: 5.1.3(@types/eslint@8.56.5)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
       eslint-plugin-unicorn:
         specifier: ^51.0.1
         version: 51.0.1(eslint@8.57.0)


### PR DESCRIPTION
## Summary

This PR brings back eslint-plugin-prettier to be able to auto-format `.vue` files in the IDE when saved.

## Review / Merge checklist

- [x] PR title and summary are descriptive