### PR TITLE
ci: Skip running pre-commit hooks on rebase and merge (no-changelog)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,7 +4,13 @@ pre-commit:
       glob: 'packages/**/*.{js,ts,json}'
       run: ./node_modules/.bin/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
+      skip:
+        - merge
+        - rebase
     prettier_check:
       glob: 'packages/**/*.{vue,yml,md}'
       run: ./node_modules/.bin/prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
+      skip:
+        - merge
+        - rebase


### PR DESCRIPTION
PR title says it all

[Lefthook docs](https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#skip)

