### PR TITLE
fix(benchmark): Simplify binary data scenario setup and use larger binary file

### DIFF
--- a/packages/@n8n/benchmark/scenarios/binary-data/binary-data.script.js
+++ b/packages/@n8n/benchmark/scenarios/binary-data/binary-data.script.js
@@ -3,9 +3,9 @@ import { check } from 'k6';
 
 const apiBaseUrl = __ENV.API_BASE_URL;
 
-// This creates a ~2MB JSON file
-const file = JSON.stringify(Array.from({ length: 100 * 1024 }, () => Math.random()));
-const filename = 'test.json';
+// This creates a 2MB file (16 * 128 * 1024 = 2 * 1024 * 1024 = 2MB)
+const file = Array.from({ length: 128 * 1024 }, () => Math.random().toString().slice(2)).join('');
+const filename = 'test.bin';
 
 export default function () {
 	const data = {

--- a/packages/@n8n/benchmark/scenarios/binary-data/binary-data.script.js
+++ b/packages/@n8n/benchmark/scenarios/binary-data/binary-data.script.js
@@ -3,8 +3,9 @@ import { check } from 'k6';
 
 const apiBaseUrl = __ENV.API_BASE_URL;
 
-const file = open(__ENV.SCRIPT_FILE_PATH, 'b');
-const filename = String(__ENV.SCRIPT_FILE_PATH).split('/').pop();
+// This creates a ~2MB JSON file
+const file = JSON.stringify(Array.from({ length: 100 * 1024 }, () => Math.random()));
+const filename = 'test.json';
 
 export default function () {
 	const data = {

--- a/packages/@n8n/benchmark/src/test-execution/k6-executor.ts
+++ b/packages/@n8n/benchmark/src/test-execution/k6-executor.ts
@@ -77,7 +77,6 @@ export function handleSummary(data) {
 			env: {
 				API_BASE_URL: this.opts.n8nApiBaseUrl,
 				K6_CLOUD_TOKEN: this.opts.k6ApiToken,
-				SCRIPT_FILE_PATH: augmentedTestScriptPath,
 			},
 			stdio: 'inherit',
 		})`${k6ExecutablePath} run ${flattedFlags} ${augmentedTestScriptPath}`;


### PR DESCRIPTION
## Summary

The binary data scenario has been failing on the VM. This simplifies the setup and uses a larger binary file.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
