### PR TITLE
fix(core): Support CIFS permission restrictions in source control

### DIFF
--- a/packages/cli/src/environments/source-control/__tests__/source-control-preferences.service.test.ts
+++ b/packages/cli/src/environments/source-control/__tests__/source-control-preferences.service.test.ts
@@ -1,0 +1,30 @@
+import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
+import fsp from 'node:fs/promises';
+
+import { SourceControlPreferencesService } from '../source-control-preferences.service.ee';
+
+describe('SourceControlPreferencesService', () => {
+	const service = new SourceControlPreferencesService(
+		mock<InstanceSettings>({ n8nFolder: 'test' }),
+		mock(),
+		mock(),
+	);
+
+	describe('getPrivateKeyPath', () => {
+		it('should return the path to the private key file', async () => {
+			fsp.writeFile = jest.fn();
+
+			// @ts-expect-error Private method
+			jest.spyOn(service, 'getPrivateKeyFromDatabase').mockResolvedValue('private-key');
+
+			await service.getPrivateKeyPath();
+
+			expect(fsp.writeFile).toHaveBeenCalledWith(
+				expect.stringContaining('ssh_private_key_temp'),
+				'private-key',
+				{ mode: 0o600, encoding: 'utf8' },
+			);
+		});
+	});
+});

--- a/packages/cli/src/environments/source-control/source-control-preferences.service.ee.ts
+++ b/packages/cli/src/environments/source-control/source-control-preferences.service.ee.ts
@@ -3,7 +3,7 @@ import { validate } from 'class-validator';
 import { rm as fsRm } from 'fs/promises';
 import { Cipher, InstanceSettings } from 'n8n-core';
 import { ApplicationError, jsonParse } from 'n8n-workflow';
-import { writeFile, chmod, readFile } from 'node:fs/promises';
+import { writeFile, readFile } from 'node:fs/promises';
 import path from 'path';
 import Container, { Service } from 'typedi';
 
@@ -97,9 +97,10 @@ export class SourceControlPreferencesService {
 
 		const tempFilePath = path.join(this.instanceSettings.n8nFolder, 'ssh_private_key_temp');
 
-		await writeFile(tempFilePath, dbPrivateKey);
-
-		await chmod(tempFilePath, 0o600);
+		await writeFile(tempFilePath, dbPrivateKey, {
+			mode: 0o600, // required by OpenSSH login client
+			encoding: 'utf8',
+		});
 
 		return tempFilePath;
 	}


### PR DESCRIPTION
CIFS filesystems [disallow changing file permissions after mount](https://sysadmins.tech/linux-and-cifs-files-permissions/), hence set the permissions for the SSH private key on creation instead of using `chmod`.

Context: https://n8nio.slack.com/archives/C04B1GZ4T0U/p1726665721479049