### PR TITLE
refactor(editor): Stop importing Vue compiler macros

### DIFF
--- a/packages/design-system/src/components/AskAssistantLoadingMessage/AssistantLoadingMessage.vue
+++ b/packages/design-system/src/components/AskAssistantLoadingMessage/AssistantLoadingMessage.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { defineProps, withDefaults } from 'vue';
-
 import AssistantAvatar from '../AskAssistantAvatar/AssistantAvatar.vue';
 
 withDefaults(

--- a/packages/editor-ui/src/components/AnnotationTagsContainer.vue
+++ b/packages/editor-ui/src/components/AnnotationTagsContainer.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, defineProps, defineEmits } from 'vue';
+import { computed } from 'vue';
 import TagsContainer from './TagsContainer.vue';
 import { useAnnotationTagsStore } from '@/stores/tags.store';
 import type { ITag } from '@/Interface';

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { withDefaults, defineProps, defineEmits, ref, computed } from 'vue';
+import { ref, computed } from 'vue';
 import {
 	WEBHOOK_NODE_TYPE,
 	MANUAL_TRIGGER_NODE_TYPE,

--- a/packages/editor-ui/src/components/executions/ExecutionsTime.vue
+++ b/packages/editor-ui/src/components/executions/ExecutionsTime.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, defineProps } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useI18n } from '@/composables/useI18n';
 
 const props = defineProps<{

--- a/packages/editor-ui/src/components/executions/workflow/VoteButtons.vue
+++ b/packages/editor-ui/src/components/executions/workflow/VoteButtons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, defineEmits } from 'vue';
+import { defineProps } from 'vue';
 import type { AnnotationVote } from 'n8n-workflow';
 
 defineProps<{

--- a/packages/editor-ui/src/components/executions/workflow/VoteButtons.vue
+++ b/packages/editor-ui/src/components/executions/workflow/VoteButtons.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { defineProps } from 'vue';
 import type { AnnotationVote } from 'n8n-workflow';
 
 defineProps<{


### PR DESCRIPTION
## Summary

We do not need to import `defineEmits`, `defineProps` and `withDefaults` because they are compiler macros.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
