### PR TITLE
fix(core): Remove subworkflow license check

### DIFF
--- a/packages/cli/src/subworkflows/__tests__/subworkflow-policy-checker.test.ts
+++ b/packages/cli/src/subworkflows/__tests__/subworkflow-policy-checker.test.ts
@@ -107,24 +107,6 @@ describe('SubworkflowPolicyChecker', () => {
 	});
 
 	describe('`any` caller policy', () => {
-		it('if no sharing, should be overriden to `workflows-from-same-owner`', async () => {
-			license.isSharingEnabled.mockReturnValueOnce(false);
-
-			const parentWorkflow = mock<WorkflowEntity>();
-			const subworkflowId = 'subworkflow-id';
-			const subworkflow = mock<Workflow>({ id: subworkflowId, settings: { callerPolicy: 'any' } }); // should be overridden
-
-			const parentWorkflowProject = mock<Project>({ id: uuid() });
-			const subworkflowProject = mock<Project>({ id: uuid(), type: 'team' });
-
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(parentWorkflowProject);
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(subworkflowProject);
-
-			const check = checker.check(subworkflow, parentWorkflow.id);
-
-			await expect(check).rejects.toThrowError(SubworkflowPolicyDenialError);
-		});
-
 		it('should not throw on a regular subworkflow call', async () => {
 			const parentWorkflow = mock<WorkflowEntity>({ id: uuid() });
 			const subworkflow = mock<Workflow>({ settings: { callerPolicy: 'any' } });

--- a/packages/cli/src/subworkflows/__tests__/subworkflow-policy-checker.test.ts
+++ b/packages/cli/src/subworkflows/__tests__/subworkflow-policy-checker.test.ts
@@ -10,7 +10,6 @@ import {
 	SUBWORKFLOW_DENIAL_BASE_DESCRIPTION,
 	SubworkflowPolicyDenialError,
 } from '@/errors/subworkflow-policy-denial.error';
-import type { License } from '@/license';
 import type { AccessService } from '@/services/access.service';
 import { OwnershipService } from '@/services/ownership.service';
 import type { UrlService } from '@/services/url.service';
@@ -20,7 +19,6 @@ import { SubworkflowPolicyChecker } from '../subworkflow-policy-checker.service'
 
 describe('SubworkflowPolicyChecker', () => {
 	const ownershipService = mockInstance(OwnershipService);
-	const license = mock<License>();
 	const globalConfig = mock<GlobalConfig>({
 		workflows: { callerPolicyDefaultOption: 'workflowsFromSameOwner' },
 	});
@@ -29,16 +27,11 @@ describe('SubworkflowPolicyChecker', () => {
 
 	const checker = new SubworkflowPolicyChecker(
 		mock(),
-		license,
 		ownershipService,
 		globalConfig,
 		accessService,
 		urlService,
 	);
-
-	beforeEach(() => {
-		license.isSharingEnabled.mockReturnValue(true);
-	});
 
 	afterEach(() => {
 		jest.restoreAllMocks();

--- a/packages/cli/src/subworkflows/subworkflow-policy-checker.service.ts
+++ b/packages/cli/src/subworkflows/subworkflow-policy-checker.service.ts
@@ -82,10 +82,8 @@ export class SubworkflowPolicyChecker {
 	 * Find the subworkflow's caller policy.
 	 */
 	private findPolicy(subworkflow: Workflow): WorkflowSettings.CallerPolicy {
-		if (!this.license.isSharingEnabled()) return 'workflowsFromSameOwner';
-
 		return (
-			subworkflow.settings?.callerPolicy ?? this.globalConfig.workflows.callerPolicyDefaultOption
+			subworkflow.settings.callerPolicy ?? this.globalConfig.workflows.callerPolicyDefaultOption
 		);
 	}
 

--- a/packages/cli/src/subworkflows/subworkflow-policy-checker.service.ts
+++ b/packages/cli/src/subworkflows/subworkflow-policy-checker.service.ts
@@ -5,7 +5,6 @@ import { Service } from 'typedi';
 
 import type { Project } from '@/databases/entities/project';
 import { SubworkflowPolicyDenialError } from '@/errors/subworkflow-policy-denial.error';
-import { License } from '@/license';
 import { Logger } from '@/logger';
 import { AccessService } from '@/services/access.service';
 import { OwnershipService } from '@/services/ownership.service';
@@ -18,7 +17,6 @@ type DenialPolicy = Exclude<Policy, 'any'>;
 export class SubworkflowPolicyChecker {
 	constructor(
 		private readonly logger: Logger,
-		private readonly license: License,
 		private readonly ownershipService: OwnershipService,
 		private readonly globalConfig: GlobalConfig,
 		private readonly accessService: AccessService,
@@ -137,7 +135,6 @@ export class SubworkflowPolicyChecker {
 			reason: this.denialReasons[policy],
 			parentWorkflowId,
 			subworkflowId,
-			isSharingEnabled: this.license.isSharingEnabled(),
 		});
 	}
 }


### PR DESCRIPTION
## Summary

This led constantly to issues when the license got out of sync between the main instance and the worker.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1902

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
