### PR TITLE
fix(core): Fix webhook binary data max size configuration

### DIFF
--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -219,7 +219,7 @@ export async function executeWebhook(
 				const form = formidable({
 					multiples: true,
 					encoding: encoding as formidable.BufferEncoding,
-					maxFileSize: formDataFileSizeMax,
+					maxFileSize: formDataFileSizeMax * 1024 * 1024,
 					// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 				});
 				req.body = await new Promise((resolve) => {


### PR DESCRIPTION
## Summary

Webhook binary data max size was made configurable in #10857. Unfortunately that had a mistake in its logic. Formidable [takes the max file size in bytes, not in MBs](https://github.com/node-formidable/formidable/blob/master/src/Formidable.js#L25).

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/10892

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
