### PR TITLE
feat(Iterable Node): Add support for EDC and USDC selection

### DIFF
--- a/packages/nodes-base/credentials/IterableApi.credentials.ts
+++ b/packages/nodes-base/credentials/IterableApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class IterableApi implements ICredentialType {
 	name = 'iterableApi';
@@ -15,5 +20,38 @@ export class IterableApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Region',
+			name: 'region',
+			type: 'options',
+			options: [
+				{
+					name: 'EDC',
+					value: 'https://api.eu.iterable.com',
+				},
+				{
+					name: 'USDC',
+					value: 'https://api.iterable.com',
+				},
+			],
+			default: 'https://api.iterable.com',
+		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Api_Key: '={{$credentials.apiKey}}',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials?.region}}',
+			url: '/api/webhooks',
+			method: 'GET',
+		},
+	};
 }

--- a/packages/nodes-base/nodes/Iterable/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Iterable/GenericFunctions.ts
@@ -2,8 +2,8 @@ import type {
 	IDataObject,
 	IExecuteFunctions,
 	IHttpRequestMethods,
+	IHttpRequestOptions,
 	ILoadOptionsFunctions,
-	IRequestOptions,
 	JsonObject,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
@@ -12,7 +12,6 @@ export async function iterableApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
-
 	body: any = {},
 	qs: IDataObject = {},
 	uri?: string,
@@ -20,15 +19,14 @@ export async function iterableApiRequest(
 ): Promise<any> {
 	const credentials = await this.getCredentials('iterableApi');
 
-	const options: IRequestOptions = {
+	const options: IHttpRequestOptions = {
 		headers: {
 			'Content-Type': 'application/json',
-			Api_Key: credentials.apiKey,
 		},
 		method,
 		body,
 		qs,
-		uri: uri || `https://api.iterable.com/api${resource}`,
+		url: uri || `${credentials.region}/api${resource}`,
 		json: true,
 	};
 	try {
@@ -38,8 +36,7 @@ export async function iterableApiRequest(
 		if (Object.keys(body as IDataObject).length === 0) {
 			delete options.body;
 		}
-		//@ts-ignore
-		return await this.helpers.request.call(this, options);
+		return await this.helpers.httpRequestWithAuthentication.call(this, 'iterableApi', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}


### PR DESCRIPTION
## Summary
Updates the Iterable node to allow region selection between EDC and USDC, Defaults to USDC to prevent a breaking change. Also moves auth to the credential so it can be used with the HTTP Request node.

Tests to follow in a future PR.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1741/iterable-update-urls

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
