### PR TITLE
refactor(editor): Migrate community nodes modals to composition api (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CommunityPackageInstallModal.vue
+++ b/packages/editor-ui/src/components/CommunityPackageInstallModal.vue
@@ -17,7 +17,7 @@ const communityNodesStore = useCommunityNodesStore();
 
 const toast = useToast();
 const telemetry = useTelemetry();
-const locale = useI18n();
+const i18n = useI18n();
 
 const modalBus = createEventBus();
 
@@ -47,14 +47,14 @@ const onInstallClick = async () => {
 			loading.value = false;
 			modalBus.emit('close');
 			toast.showMessage({
-				title: locale.baseText('settings.communityNodes.messages.install.success'),
+				title: i18n.baseText('settings.communityNodes.messages.install.success'),
 				type: 'success',
 			});
 		} catch (error) {
 			if (error.httpStatusCode && error.httpStatusCode === 400) {
 				infoTextErrorMessage.value = error.message;
 			} else {
-				toast.showError(error, locale.baseText('settings.communityNodes.messages.install.error'));
+				toast.showError(error, i18n.baseText('settings.communityNodes.messages.install.error'));
 			}
 		} finally {
 			loading.value = false;
@@ -89,7 +89,7 @@ const onLearnMoreLinkClick = () => {
 	<Modal
 		width="540px"
 		:name="COMMUNITY_PACKAGE_INSTALL_MODAL_KEY"
-		:title="$locale.baseText('settings.communityNodes.installModal.title')"
+		:title="i18n.baseText('settings.communityNodes.installModal.title')"
 		:event-bus="modalBus"
 		:center="true"
 		:before-close="onModalClose"
@@ -99,15 +99,15 @@ const onLearnMoreLinkClick = () => {
 			<div :class="[$style.descriptionContainer, 'p-s']">
 				<div>
 					<n8n-text>
-						{{ $locale.baseText('settings.communityNodes.installModal.description') }}
+						{{ i18n.baseText('settings.communityNodes.installModal.description') }}
 					</n8n-text>
 					{{ ' ' }}
 					<n8n-link :to="COMMUNITY_NODES_INSTALLATION_DOCS_URL" @click="onMoreInfoTopClick">
-						{{ $locale.baseText('generic.moreInfo') }}
+						{{ i18n.baseText('generic.moreInfo') }}
 					</n8n-link>
 				</div>
 				<n8n-button
-					:label="$locale.baseText('settings.communityNodes.browseButton.label')"
+					:label="i18n.baseText('settings.communityNodes.browseButton.label')"
 					icon="external-link-alt"
 					:class="$style.browseButton"
 					@click="openNPMPage"
@@ -116,9 +116,9 @@ const onLearnMoreLinkClick = () => {
 			<div :class="[$style.formContainer, 'mt-m']">
 				<n8n-input-label
 					:class="$style.labelTooltip"
-					:label="$locale.baseText('settings.communityNodes.installModal.packageName.label')"
+					:label="i18n.baseText('settings.communityNodes.installModal.packageName.label')"
 					:tooltip-text="
-						$locale.baseText('settings.communityNodes.installModal.packageName.tooltip', {
+						i18n.baseText('settings.communityNodes.installModal.packageName.tooltip', {
 							interpolate: { npmURL: NPM_KEYWORD_SEARCH_URL },
 						})
 					"
@@ -130,7 +130,7 @@ const onLearnMoreLinkClick = () => {
 						data-test-id="package-name-input"
 						:maxlength="214"
 						:placeholder="
-							$locale.baseText('settings.communityNodes.installModal.packageName.placeholder')
+							i18n.baseText('settings.communityNodes.installModal.packageName.placeholder')
 						"
 						:required="true"
 						:disabled="loading"
@@ -152,10 +152,10 @@ const onLearnMoreLinkClick = () => {
 					@update:model-value="onCheckboxChecked"
 				>
 					<n8n-text>
-						{{ $locale.baseText('settings.communityNodes.installModal.checkbox.label') }} </n8n-text
+						{{ i18n.baseText('settings.communityNodes.installModal.checkbox.label') }} </n8n-text
 					><br />
 					<n8n-link :to="COMMUNITY_NODES_RISKS_DOCS_URL" @click="onLearnMoreLinkClick">{{
-						$locale.baseText('generic.moreInfo')
+						i18n.baseText('generic.moreInfo')
 					}}</n8n-link>
 				</el-checkbox>
 			</div>
@@ -166,8 +166,8 @@ const onLearnMoreLinkClick = () => {
 				:disabled="!userAgreed || packageName === '' || loading"
 				:label="
 					loading
-						? $locale.baseText('settings.communityNodes.installModal.installButton.label.loading')
-						: $locale.baseText('settings.communityNodes.installModal.installButton.label')
+						? i18n.baseText('settings.communityNodes.installModal.installButton.label.loading')
+						: i18n.baseText('settings.communityNodes.installModal.installButton.label')
 				"
 				size="large"
 				float="right"

--- a/packages/editor-ui/src/components/CommunityPackageInstallModal.vue
+++ b/packages/editor-ui/src/components/CommunityPackageInstallModal.vue
@@ -127,6 +127,7 @@ const onLearnMoreLinkClick = () => {
 						v-model="packageName"
 						name="packageNameInput"
 						type="text"
+						data-test-id="package-name-input"
 						:maxlength="214"
 						:placeholder="
 							$locale.baseText('settings.communityNodes.installModal.packageName.placeholder')

--- a/packages/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
+++ b/packages/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
@@ -1,163 +1,137 @@
-<script>
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import Modal from '@/components/Modal.vue';
 import { COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY, COMMUNITY_PACKAGE_MANAGE_ACTIONS } from '@/constants';
 import { useToast } from '@/composables/useToast';
-import { mapStores } from 'pinia';
 import { useCommunityNodesStore } from '@/stores/communityNodes.store';
 import { createEventBus } from 'n8n-design-system/utils';
+import { useI18n } from '@/composables/useI18n';
+import { useTelemetry } from '@/composables/useTelemetry';
+import { computed, ref } from 'vue';
 
-export default defineComponent({
-	name: 'CommunityPackageManageConfirmModal',
-	components: {
-		Modal,
-	},
-	props: {
-		modalName: {
-			type: String,
-			required: true,
-		},
-		activePackageName: {
-			type: String,
-			required: true,
-		},
-		mode: {
-			type: String,
-		},
-	},
-	setup() {
+export type CommunityPackageManageMode = 'uninstall' | 'update' | 'view-documentation';
+
+interface Props {
+	modalName: string;
+	activePackageName: string;
+	mode: CommunityPackageManageMode;
+}
+
+const props = defineProps<Props>();
+
+const communityNodesStore = useCommunityNodesStore();
+
+const modalBus = createEventBus();
+
+const toast = useToast();
+const locale = useI18n();
+const telemetry = useTelemetry();
+
+const loading = ref(false);
+
+const activePackage = computed(
+	() => communityNodesStore.installedPackages[props.activePackageName],
+);
+
+const getModalContent = computed(() => {
+	if (props.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL) {
 		return {
-			...useToast(),
+			title: locale.baseText('settings.communityNodes.confirmModal.uninstall.title'),
+			message: locale.baseText('settings.communityNodes.confirmModal.uninstall.message', {
+				interpolate: {
+					packageName: props.activePackageName,
+				},
+			}),
+			buttonLabel: locale.baseText('settings.communityNodes.confirmModal.uninstall.buttonLabel'),
+			buttonLoadingLabel: locale.baseText(
+				'settings.communityNodes.confirmModal.uninstall.buttonLoadingLabel',
+			),
 		};
-	},
-	data() {
-		return {
-			loading: false,
-			modalBus: createEventBus(),
-			COMMUNITY_PACKAGE_CONFIRM_MODAL_KEY,
-			COMMUNITY_PACKAGE_MANAGE_ACTIONS,
-		};
-	},
-	computed: {
-		...mapStores(useCommunityNodesStore),
-		activePackage() {
-			return this.communityNodesStore.installedPackages[this.activePackageName];
-		},
-		getModalContent() {
-			if (this.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL) {
-				return {
-					title: this.$locale.baseText('settings.communityNodes.confirmModal.uninstall.title'),
-					message: this.$locale.baseText('settings.communityNodes.confirmModal.uninstall.message', {
-						interpolate: {
-							packageName: this.activePackageName,
-						},
-					}),
-					buttonLabel: this.$locale.baseText(
-						'settings.communityNodes.confirmModal.uninstall.buttonLabel',
-					),
-					buttonLoadingLabel: this.$locale.baseText(
-						'settings.communityNodes.confirmModal.uninstall.buttonLoadingLabel',
-					),
-				};
-			}
-			return {
-				title: this.$locale.baseText('settings.communityNodes.confirmModal.update.title', {
-					interpolate: {
-						packageName: this.activePackageName,
-					},
-				}),
-				description: this.$locale.baseText(
-					'settings.communityNodes.confirmModal.update.description',
-				),
-				message: this.$locale.baseText('settings.communityNodes.confirmModal.update.message', {
-					interpolate: {
-						packageName: this.activePackageName,
-						version: this.activePackage.updateAvailable,
-					},
-				}),
-				buttonLabel: this.$locale.baseText(
-					'settings.communityNodes.confirmModal.update.buttonLabel',
-				),
-				buttonLoadingLabel: this.$locale.baseText(
-					'settings.communityNodes.confirmModal.update.buttonLoadingLabel',
-				),
-			};
-		},
-	},
-	methods: {
-		onModalClose() {
-			return !this.loading;
-		},
-		async onConfirmButtonClick() {
-			if (this.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL) {
-				await this.onUninstall();
-			} else if (this.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UPDATE) {
-				await this.onUpdate();
-			}
-		},
-		async onUninstall() {
-			try {
-				this.$telemetry.track('user started cnr package deletion', {
-					package_name: this.activePackage.packageName,
-					package_node_names: this.activePackage.installedNodes.map((node) => node.name),
-					package_version: this.activePackage.installedVersion,
-					package_author: this.activePackage.authorName,
-					package_author_email: this.activePackage.authorEmail,
-				});
-				this.loading = true;
-				await this.communityNodesStore.uninstallPackage(this.activePackageName);
-				this.showMessage({
-					title: this.$locale.baseText('settings.communityNodes.messages.uninstall.success.title'),
-					type: 'success',
-				});
-			} catch (error) {
-				this.showError(
-					error,
-					this.$locale.baseText('settings.communityNodes.messages.uninstall.error'),
-				);
-			} finally {
-				this.loading = false;
-				this.modalBus.emit('close');
-			}
-		},
-		async onUpdate() {
-			try {
-				this.$telemetry.track('user started cnr package update', {
-					package_name: this.activePackage.packageName,
-					package_node_names: this.activePackage.installedNodes.map((node) => node.name),
-					package_version_current: this.activePackage.installedVersion,
-					package_version_new: this.activePackage.updateAvailable,
-					package_author: this.activePackage.authorName,
-					package_author_email: this.activePackage.authorEmail,
-				});
-				this.loading = true;
-				const updatedVersion = this.activePackage.updateAvailable;
-				await this.communityNodesStore.updatePackage(this.activePackageName);
-				this.showMessage({
-					title: this.$locale.baseText('settings.communityNodes.messages.update.success.title'),
-					message: this.$locale.baseText(
-						'settings.communityNodes.messages.update.success.message',
-						{
-							interpolate: {
-								packageName: this.activePackageName,
-								version: updatedVersion,
-							},
-						},
-					),
-					type: 'success',
-				});
-			} catch (error) {
-				this.showError(
-					error,
-					this.$locale.baseText('settings.communityNodes.messages.update.error.title'),
-				);
-			} finally {
-				this.loading = false;
-				this.modalBus.emit('close');
-			}
-		},
-	},
+	}
+	return {
+		title: locale.baseText('settings.communityNodes.confirmModal.update.title', {
+			interpolate: {
+				packageName: props.activePackageName,
+			},
+		}),
+		description: locale.baseText('settings.communityNodes.confirmModal.update.description'),
+		message: locale.baseText('settings.communityNodes.confirmModal.update.message', {
+			interpolate: {
+				packageName: props.activePackageName,
+				version: activePackage.value.updateAvailable ?? '',
+			},
+		}),
+		buttonLabel: locale.baseText('settings.communityNodes.confirmModal.update.buttonLabel'),
+		buttonLoadingLabel: locale.baseText(
+			'settings.communityNodes.confirmModal.update.buttonLoadingLabel',
+		),
+	};
 });
+
+const onModalClose = () => {
+	return !loading.value;
+};
+
+const onConfirmButtonClick = async () => {
+	if (props.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL) {
+		await onUninstall();
+	} else if (props.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UPDATE) {
+		await onUpdate();
+	}
+};
+
+const onUninstall = async () => {
+	try {
+		telemetry.track('user started cnr package deletion', {
+			package_name: activePackage.value.packageName,
+			package_node_names: activePackage.value.installedNodes.map((node) => node.name),
+			package_version: activePackage.value.installedVersion,
+			package_author: activePackage.value.authorName,
+			package_author_email: activePackage.value.authorEmail,
+		});
+		loading.value = true;
+		await communityNodesStore.uninstallPackage(props.activePackageName);
+		toast.showMessage({
+			title: locale.baseText('settings.communityNodes.messages.uninstall.success.title'),
+			type: 'success',
+		});
+	} catch (error) {
+		toast.showError(error, locale.baseText('settings.communityNodes.messages.uninstall.error'));
+	} finally {
+		loading.value = false;
+		modalBus.emit('close');
+	}
+};
+
+const onUpdate = async () => {
+	try {
+		telemetry.track('user started cnr package update', {
+			package_name: activePackage.value.packageName,
+			package_node_names: activePackage.value.installedNodes.map((node) => node.name),
+			package_version_current: activePackage.value.installedVersion,
+			package_version_new: activePackage.value.updateAvailable,
+			package_author: activePackage.value.authorName,
+			package_author_email: activePackage.value.authorEmail,
+		});
+		loading.value = true;
+		const updatedVersion = activePackage.value.updateAvailable;
+		await communityNodesStore.updatePackage(props.activePackageName);
+		toast.showMessage({
+			title: locale.baseText('settings.communityNodes.messages.update.success.title'),
+			message: locale.baseText('settings.communityNodes.messages.update.success.message', {
+				interpolate: {
+					packageName: props.activePackageName,
+					version: updatedVersion ?? '',
+				},
+			}),
+			type: 'success',
+		});
+	} catch (error) {
+		toast.showError(error, locale.baseText('settings.communityNodes.messages.update.error.title'));
+	} finally {
+		loading.value = false;
+		modalBus.emit('close');
+	}
+};
 </script>
 
 <template>

--- a/packages/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
+++ b/packages/editor-ui/src/components/CommunityPackageManageConfirmModal.vue
@@ -23,7 +23,7 @@ const communityNodesStore = useCommunityNodesStore();
 const modalBus = createEventBus();
 
 const toast = useToast();
-const locale = useI18n();
+const i18n = useI18n();
 const telemetry = useTelemetry();
 
 const loading = ref(false);
@@ -35,33 +35,33 @@ const activePackage = computed(
 const getModalContent = computed(() => {
 	if (props.mode === COMMUNITY_PACKAGE_MANAGE_ACTIONS.UNINSTALL) {
 		return {
-			title: locale.baseText('settings.communityNodes.confirmModal.uninstall.title'),
-			message: locale.baseText('settings.communityNodes.confirmModal.uninstall.message', {
+			title: i18n.baseText('settings.communityNodes.confirmModal.uninstall.title'),
+			message: i18n.baseText('settings.communityNodes.confirmModal.uninstall.message', {
 				interpolate: {
 					packageName: props.activePackageName,
 				},
 			}),
-			buttonLabel: locale.baseText('settings.communityNodes.confirmModal.uninstall.buttonLabel'),
-			buttonLoadingLabel: locale.baseText(
+			buttonLabel: i18n.baseText('settings.communityNodes.confirmModal.uninstall.buttonLabel'),
+			buttonLoadingLabel: i18n.baseText(
 				'settings.communityNodes.confirmModal.uninstall.buttonLoadingLabel',
 			),
 		};
 	}
 	return {
-		title: locale.baseText('settings.communityNodes.confirmModal.update.title', {
+		title: i18n.baseText('settings.communityNodes.confirmModal.update.title', {
 			interpolate: {
 				packageName: props.activePackageName,
 			},
 		}),
-		description: locale.baseText('settings.communityNodes.confirmModal.update.description'),
-		message: locale.baseText('settings.communityNodes.confirmModal.update.message', {
+		description: i18n.baseText('settings.communityNodes.confirmModal.update.description'),
+		message: i18n.baseText('settings.communityNodes.confirmModal.update.message', {
 			interpolate: {
 				packageName: props.activePackageName,
 				version: activePackage.value.updateAvailable ?? '',
 			},
 		}),
-		buttonLabel: locale.baseText('settings.communityNodes.confirmModal.update.buttonLabel'),
-		buttonLoadingLabel: locale.baseText(
+		buttonLabel: i18n.baseText('settings.communityNodes.confirmModal.update.buttonLabel'),
+		buttonLoadingLabel: i18n.baseText(
 			'settings.communityNodes.confirmModal.update.buttonLoadingLabel',
 		),
 	};
@@ -91,11 +91,11 @@ const onUninstall = async () => {
 		loading.value = true;
 		await communityNodesStore.uninstallPackage(props.activePackageName);
 		toast.showMessage({
-			title: locale.baseText('settings.communityNodes.messages.uninstall.success.title'),
+			title: i18n.baseText('settings.communityNodes.messages.uninstall.success.title'),
 			type: 'success',
 		});
 	} catch (error) {
-		toast.showError(error, locale.baseText('settings.communityNodes.messages.uninstall.error'));
+		toast.showError(error, i18n.baseText('settings.communityNodes.messages.uninstall.error'));
 	} finally {
 		loading.value = false;
 		modalBus.emit('close');
@@ -116,8 +116,8 @@ const onUpdate = async () => {
 		const updatedVersion = activePackage.value.updateAvailable;
 		await communityNodesStore.updatePackage(props.activePackageName);
 		toast.showMessage({
-			title: locale.baseText('settings.communityNodes.messages.update.success.title'),
-			message: locale.baseText('settings.communityNodes.messages.update.success.message', {
+			title: i18n.baseText('settings.communityNodes.messages.update.success.title'),
+			message: i18n.baseText('settings.communityNodes.messages.update.success.message', {
 				interpolate: {
 					packageName: props.activePackageName,
 					version: updatedVersion ?? '',
@@ -126,7 +126,7 @@ const onUpdate = async () => {
 			type: 'success',
 		});
 	} catch (error) {
-		toast.showError(error, locale.baseText('settings.communityNodes.messages.update.error.title'));
+		toast.showError(error, i18n.baseText('settings.communityNodes.messages.update.error.title'));
 	} finally {
 		loading.value = false;
 		modalBus.emit('close');

--- a/packages/editor-ui/src/components/__tests__/CommunityPackageInstallModal.spec.ts
+++ b/packages/editor-ui/src/components/__tests__/CommunityPackageInstallModal.spec.ts
@@ -45,7 +45,10 @@ describe('CommunityPackageInstallModal', () => {
 
 		await retry(() => expect(getByTestId('communityPackageInstall-modal')).toBeInTheDocument());
 
+		const packageNameInput = getByTestId('package-name-input');
 		const installButton = getByTestId('install-community-package-button');
+
+		await userEvent.type(packageNameInput, 'n8n-nodes-test');
 
 		expect(installButton).toBeDisabled();
 


### PR DESCRIPTION
Migrating `CommunityPackageInstallModal` and `CommunityPackageManageConfirmModal` to composition api.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
