### PR TITLE
fix(editor): Use `:focus-visible` instead for `:focus` for buttons

### DIFF
--- a/packages/design-system/src/components/N8nButton/Button.scss
+++ b/packages/design-system/src/components/N8nButton/Button.scss
@@ -53,7 +53,7 @@
 		}
 	}
 
-	&:focus:not(:active, .active) {
+	&:focus-visible:not(:active, .active) {
 		color: $button-focus-font-color unquote($important);
 		border-color: $button-focus-border-color unquote($important);
 		background-color: $button-focus-background-color unquote($important);
@@ -68,7 +68,7 @@
 		&,
 		&:hover,
 		&:active,
-		&:focus {
+		&:focus-visible {
 			color: $button-disabled-font-color;
 			border-color: $button-disabled-border-color;
 			background-color: $button-disabled-background-color;
@@ -83,7 +83,7 @@
 		&,
 		&:hover,
 		&:active,
-		&:focus {
+		&:focus-visible {
 			color: $button-loading-font-color;
 			border-color: $button-loading-border-color;
 			background-color: $button-loading-background-color;


### PR DESCRIPTION
## Summary
Uses `:focus-visible` for button focus state. This should prevent applying focused styling to buttons when they are interacted with by mouse.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
