### PR TITLE
fix(editor): Prevent node name input in NDV to expand unnecessarily

### DIFF
--- a/packages/editor-ui/src/components/NodeSettings.vue
+++ b/packages/editor-ui/src/components/NodeSettings.vue
@@ -1147,10 +1147,10 @@ onBeforeUnmount(() => {
 		padding: var(--spacing-s) var(--spacing-s) var(--spacing-s) var(--spacing-s);
 		font-size: var(--font-size-l);
 		display: flex;
+		justify-content: space-between;
 
 		.node-name {
 			padding-top: var(--spacing-5xs);
-			flex-grow: 1;
 		}
 	}
 


### PR DESCRIPTION
## Summary
Preventing node name input in NDV header from taking the full header width unless necessary.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
