### PR TITLE
fix(HTTP Request Node): Do not modify request object when sanitizing message for UI

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -1,11 +1,12 @@
 import type { SecureContextOptions } from 'tls';
-import type {
-	ICredentialDataDecryptedObject,
-	IDataObject,
-	INodeExecutionData,
-	INodeProperties,
-	IOAuth2Options,
-	IRequestOptions,
+import {
+	deepCopy,
+	type ICredentialDataDecryptedObject,
+	type IDataObject,
+	type INodeExecutionData,
+	type INodeProperties,
+	type IOAuth2Options,
+	type IRequestOptions,
 } from 'n8n-workflow';
 
 import set from 'lodash/set';
@@ -60,7 +61,12 @@ export function sanitizeUiMessage(
 	authDataKeys: IAuthDataSanitizeKeys,
 	secrets?: string[],
 ) {
-	let sendRequest = request as unknown as IDataObject;
+	const { body, ...rest } = request as IDataObject;
+
+	let sendRequest: IDataObject = { body };
+	for (const [key, value] of Object.entries(rest)) {
+		sendRequest[key] = deepCopy(value);
+	}
 
 	// Protect browser from sending large binary data
 	if (Buffer.isBuffer(sendRequest.body) && sendRequest.body.length > 250000) {

--- a/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/utils/utils.test.ts
@@ -93,7 +93,7 @@ describe('HTTP Node Utils', () => {
 			);
 		});
 
-		it('should remove keys that contain sensitive data', async () => {
+		it('should remove keys that contain sensitive data and do not modify requestOptions', async () => {
 			const requestOptions: IRequestOptions = {
 				method: 'POST',
 				uri: 'https://example.com',
@@ -115,6 +115,14 @@ describe('HTTP Node Utils', () => {
 				method: 'POST',
 				uri: 'https://example.com',
 			});
+
+			expect(requestOptions).toEqual({
+				method: 'POST',
+				uri: 'https://example.com',
+				body: { sessionToken: 'secret', other: 'foo' },
+				headers: { authorization: 'secret', other: 'foo' },
+				auth: { user: 'user', password: 'secret' },
+			});
 		});
 
 		it('should remove secrets', async () => {
@@ -125,7 +133,9 @@ describe('HTTP Node Utils', () => {
 				headers: { authorization: 'secretAccessToken', other: 'foo' },
 			};
 
-			expect(sanitizeUiMessage(requestOptions, {}, ['secretAccessToken'])).toEqual({
+			const sanitizedRequest = sanitizeUiMessage(requestOptions, {}, ['secretAccessToken']);
+
+			expect(sanitizedRequest).toEqual({
 				body: {
 					nested: {
 						secret: REDACTED,


### PR DESCRIPTION
## Summary

original request object should not be modified

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/http-errors-after-minor-n8n-upgrade/54664
https://linear.app/n8n/issue/NODE-1747/http-request-node-recent-change-to-sanitise-auth-headers-is-breaking
https://support.n8n.io/#ticket/zoom/7521

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
