### PR TITLE
feat(editor): Show strikethrough line for all single main input and single main output nodes in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.spec.ts
@@ -4,7 +4,7 @@ import { NodeConnectionType } from 'n8n-workflow';
 import { createCanvasNodeProvide } from '@/__tests__/data';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
-import { CanvasNodeRenderType } from '@/types';
+import { CanvasConnectionMode, CanvasNodeRenderType } from '@/types';
 
 const renderComponent = createComponentRenderer(CanvasNodeDefault);
 
@@ -157,6 +157,36 @@ describe('CanvasNodeDefault', () => {
 				},
 			});
 			expect(getByText('Test Node').closest('.node')).not.toHaveClass('disabled');
+		});
+
+		it('should render strike-through when node is disabled and has node input and output handles', () => {
+			const { container } = renderComponent({
+				global: {
+					provide: {
+						...createCanvasNodeProvide({
+							data: {
+								disabled: true,
+								inputs: [{ type: NodeConnectionType.Main, index: 0 }],
+								outputs: [{ type: NodeConnectionType.Main, index: 0 }],
+								connections: {
+									[CanvasConnectionMode.Input]: {
+										[NodeConnectionType.Main]: [
+											[{ node: 'node', type: NodeConnectionType.Main, index: 0 }],
+										],
+									},
+									[CanvasConnectionMode.Output]: {
+										[NodeConnectionType.Main]: [
+											[{ node: 'node', type: NodeConnectionType.Main, index: 0 }],
+										],
+									},
+								},
+							},
+						}),
+					},
+				},
+			});
+
+			expect(container.querySelector('.disabledStrikeThrough')).toBeVisible();
 		});
 	});
 

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -30,7 +30,14 @@ const {
 	hasIssues,
 	render,
 } = useCanvasNode();
-const { mainOutputs, mainInputs, nonMainInputs, requiredNonMainInputs } = useNodeConnections({
+const {
+	mainOutputs,
+	mainOutputConnections,
+	mainInputs,
+	mainInputConnections,
+	nonMainInputs,
+	requiredNonMainInputs,
+} = useNodeConnections({
 	inputs,
 	outputs,
 	connections,
@@ -86,6 +93,15 @@ const dataTestId = computed(() => {
 	return `canvas-${type}-node`;
 });
 
+const isStrikethroughVisible = computed(() => {
+	const isSingleMainInputNode =
+		mainInputs.value.length === 1 && mainInputConnections.value.length <= 1;
+	const isSingleMainOutputNode =
+		mainOutputs.value.length === 1 && mainOutputConnections.value.length <= 1;
+
+	return isDisabled.value && isSingleMainInputNode && isSingleMainOutputNode;
+});
+
 function openContextMenu(event: MouseEvent) {
 	emit('open:contextmenu', event);
 }
@@ -103,7 +119,7 @@ function openContextMenu(event: MouseEvent) {
 			</div>
 		</N8nTooltip>
 		<CanvasNodeStatusIcons :class="$style.statusIcons" />
-		<CanvasNodeDisabledStrikeThrough v-if="isDisabled" />
+		<CanvasNodeDisabledStrikeThrough v-if="isStrikethroughVisible" />
 		<div :class="$style.description">
 			<div v-if="label" :class="$style.label">
 				{{ label }}

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.spec.ts
@@ -1,38 +1,12 @@
 import CanvasNodeDisabledStrikeThrough from '@/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue';
 import { createComponentRenderer } from '@/__tests__/render';
-import { NodeConnectionType } from 'n8n-workflow';
-import { createCanvasNodeProvide } from '@/__tests__/data';
-import { CanvasConnectionMode } from '@/types';
 
 const renderComponent = createComponentRenderer(CanvasNodeDisabledStrikeThrough);
 
 describe('CanvasNodeDisabledStrikeThrough', () => {
 	it('should render node correctly', () => {
-		const { container } = renderComponent({
-			global: {
-				provide: {
-					...createCanvasNodeProvide({
-						data: {
-							inputs: [{ type: NodeConnectionType.Main, index: 0 }],
-							outputs: [{ type: NodeConnectionType.Main, index: 0 }],
-							connections: {
-								[CanvasConnectionMode.Input]: {
-									[NodeConnectionType.Main]: [
-										[{ node: 'node', type: NodeConnectionType.Main, index: 0 }],
-									],
-								},
-								[CanvasConnectionMode.Output]: {
-									[NodeConnectionType.Main]: [
-										[{ node: 'node', type: NodeConnectionType.Main, index: 0 }],
-									],
-								},
-							},
-						},
-					}),
-				},
-			},
-		});
+		const { container } = renderComponent();
 
-		expect(container.firstChild).toBeVisible();
+		expect(container.firstChild).toHaveClass('disabledStrikeThrough');
 	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.spec.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.spec.ts
@@ -13,6 +13,8 @@ describe('CanvasNodeDisabledStrikeThrough', () => {
 				provide: {
 					...createCanvasNodeProvide({
 						data: {
+							inputs: [{ type: NodeConnectionType.Main, index: 0 }],
+							outputs: [{ type: NodeConnectionType.Main, index: 0 }],
 							connections: {
 								[CanvasConnectionMode.Input]: {
 									[NodeConnectionType.Main]: [

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
@@ -1,27 +1,7 @@
 <script setup lang="ts">
 import { computed, useCssModule } from 'vue';
-import { useNodeConnections } from '@/composables/useNodeConnections';
-import { useCanvasNode } from '@/composables/useCanvasNode';
 
 const $style = useCssModule();
-
-const { inputs, outputs, connections } = useCanvasNode();
-const { mainInputConnections, mainInputs, mainOutputConnections, mainOutputs } = useNodeConnections(
-	{
-		inputs,
-		outputs,
-		connections,
-	},
-);
-
-const isVisible = computed(() => {
-	const isSingleMainInputNode =
-		mainInputs.value.length === 1 && mainInputConnections.value.length <= 1;
-	const isSingleMainOutputNode =
-		mainOutputs.value.length === 1 && mainOutputConnections.value.length <= 1;
-
-	return isSingleMainInputNode && isSingleMainOutputNode;
-});
 
 const isSuccessStatus = computed(
 	() => false,
@@ -38,7 +18,7 @@ const classes = computed(() => {
 </script>
 
 <template>
-	<div v-if="isVisible" :class="classes"></div>
+	<div :class="classes"></div>
 </template>
 
 <style lang="scss" module>

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
@@ -15,11 +15,12 @@ const { mainInputConnections, mainInputs, mainOutputConnections, mainOutputs } =
 );
 
 const isVisible = computed(() => {
-	const isSingleInputNode = mainInputs.value.length === 1 && mainInputConnections.value.length <= 1;
-	const isSingleOutputNode =
+	const isSingleMainInputNode =
+		mainInputs.value.length === 1 && mainInputConnections.value.length <= 1;
+	const isSingleMainOutputNode =
 		mainOutputs.value.length === 1 && mainOutputConnections.value.length <= 1;
 
-	return isSingleInputNode && isSingleOutputNode;
+	return isSingleMainInputNode && isSingleMainOutputNode;
 });
 
 const isSuccessStatus = computed(

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.vue
@@ -6,15 +6,21 @@ import { useCanvasNode } from '@/composables/useCanvasNode';
 const $style = useCssModule();
 
 const { inputs, outputs, connections } = useCanvasNode();
-const { mainInputConnections, mainOutputConnections } = useNodeConnections({
-	inputs,
-	outputs,
-	connections,
-});
-
-const isVisible = computed(
-	() => mainInputConnections.value.length === 1 && mainOutputConnections.value.length === 1,
+const { mainInputConnections, mainInputs, mainOutputConnections, mainOutputs } = useNodeConnections(
+	{
+		inputs,
+		outputs,
+		connections,
+	},
 );
+
+const isVisible = computed(() => {
+	const isSingleInputNode = mainInputs.value.length === 1 && mainInputConnections.value.length <= 1;
+	const isSingleOutputNode =
+		mainOutputs.value.length === 1 && mainOutputConnections.value.length <= 1;
+
+	return isSingleInputNode && isSingleOutputNode;
+});
 
 const isSuccessStatus = computed(
 	() => false,


### PR DESCRIPTION
## Summary

<img width="1504" alt="Screenshot 2024-09-23 at 12 07 33" src="https://github.com/user-attachments/assets/43413d4f-edf9-495e-a796-b6ca67e31a0c">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7607/deactivating-a-node-does-not-display-a-strikethrough-line

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
