### PR TITLE
feat(Slack Node): Add option to hide workflow link on message update

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -983,7 +983,30 @@ export const messageFields: INodeProperties[] = [
 			},
 		],
 	},
-
+	{
+		displayName: 'Options',
+		name: 'otherOptions',
+		type: 'collection',
+		displayOptions: {
+			show: {
+				operation: ['update'],
+				resource: ['message'],
+			},
+		},
+		default: {},
+		description: 'Other options to set',
+		placeholder: 'Add option',
+		options: [
+			{
+				displayName: 'Include Link to Workflow',
+				name: 'includeLinkToWorkflow',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to append a link to this workflow at the end of the message. This is helpful if you have many workflows sending Slack messages.',
+			},
+		],
+	},
 	/* ----------------------------------------------------------------------- */
 	/*                                 message:delete
 	/* ----------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
Adds the `Include Link to Workflow` option to Message > Update without this when updating a message without the link we were adding it again with no way for the user to control it.

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/9803
https://linear.app/n8n/issue/NODE-1423/slack-allow-removing-automated-with-n8n-footer-in-update-operation

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
