### PR TITLE
fix(editor): Use correct output for connected nodes in schema view

### DIFF
--- a/packages/editor-ui/src/components/__tests__/__snapshots__/RunDataSchema.test.ts.snap
+++ b/packages/editor-ui/src/components/__tests__/__snapshots__/RunDataSchema.test.ts.snap
@@ -1,5 +1,1059 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`RunDataSchema.vue > renders schema for correct output branch 1`] = `
+<div
+  class="schema animated"
+  data-test-id="run-data-schema-node-schema"
+  data-v-46dade00=""
+>
+  <div
+    class="innerSchema"
+    data-v-46dade00=""
+  >
+    <div
+      class="item"
+      data-test-id="run-data-schema-item"
+      data-v-46dade00=""
+    >
+      <div
+        class="itemContent"
+      >
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <!--v-if-->
+      <!--v-if-->
+      <div
+        class="sub"
+      >
+        <div
+          class="innerSub"
+        >
+          
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="string"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="name"
+                  data-path=".name"
+                  data-target="mappable"
+                  data-value="{{ $json.name }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                    data-icon="font"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      name
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    John
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="number"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="age"
+                  data-path=".age"
+                  data-target="mappable"
+                  data-value="{{ $json.age }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-hashtag fa-w-14 fa-sm"
+                    data-icon="hashtag"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M440.667 182.109l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l14.623-81.891C377.123 38.754 371.468 32 363.997 32h-40.632a12 12 0 0 0-11.813 9.891L296.175 128H197.54l14.623-81.891C213.477 38.754 207.822 32 200.35 32h-40.632a12 12 0 0 0-11.813 9.891L132.528 128H53.432a12 12 0 0 0-11.813 9.891l-7.143 40C33.163 185.246 38.818 192 46.289 192h74.81L98.242 320H19.146a12 12 0 0 0-11.813 9.891l-7.143 40C-1.123 377.246 4.532 384 12.003 384h74.81L72.19 465.891C70.877 473.246 76.532 480 84.003 480h40.632a12 12 0 0 0 11.813-9.891L151.826 384h98.634l-14.623 81.891C234.523 473.246 240.178 480 247.65 480h40.632a12 12 0 0 0 11.813-9.891L315.472 384h79.096a12 12 0 0 0 11.813-9.891l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l22.857-128h79.096a12 12 0 0 0 11.813-9.891zM261.889 320h-98.634l22.857-128h98.634l-22.857 128z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      age
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    22
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="array"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="hobbies"
+                  data-path=".hobbies"
+                  data-target="mappable"
+                  data-value="{{ $json.hobbies }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-list fa-w-16 fa-sm"
+                    data-icon="list"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      hobbies
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <!--v-if-->
+            </div>
+            <input
+              id="set_1-hobbies"
+              inert=""
+              type="checkbox"
+            />
+            <label
+              class="toggle"
+              for="set_1-hobbies"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-angle-right fa-w-8"
+                data-icon="angle-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 256 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  fill="currentColor"
+                />
+              </svg>
+            </label>
+            <div
+              class="sub"
+            >
+              <div
+                class="innerSub"
+              >
+                
+                <div
+                  class="item"
+                  data-test-id="run-data-schema-item"
+                >
+                  <div
+                    class="itemContent"
+                  >
+                    <div
+                      class="pill mappable"
+                      title="string"
+                    >
+                      <span
+                        class="label"
+                        data-depth="2"
+                        data-name="string[0]"
+                        data-path=".hobbies[0]"
+                        data-target="mappable"
+                        data-value="{{ $json.hobbies[0] }}"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                          data-icon="font"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class=""
+                            d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            hobbies
+                          </span>
+                          
+                        </span>
+                        <span
+                          class="content arrayIndex"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            [0]
+                          </span>
+                          
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      class="text"
+                      data-test-id="run-data-schema-item-value"
+                    >
+                      
+                      
+                      <!--v-if-->
+                      <span
+                        class="content"
+                      >
+                        
+                        <span>
+                          <!--v-if-->
+                          surfing
+                        </span>
+                        
+                      </span>
+                      
+                      
+                    </span>
+                  </div>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </div>
+                <div
+                  class="item"
+                  data-test-id="run-data-schema-item"
+                >
+                  <div
+                    class="itemContent"
+                  >
+                    <div
+                      class="pill mappable"
+                      title="string"
+                    >
+                      <span
+                        class="label"
+                        data-depth="2"
+                        data-name="string[1]"
+                        data-path=".hobbies[1]"
+                        data-target="mappable"
+                        data-value="{{ $json.hobbies[1] }}"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                          data-icon="font"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class=""
+                            d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            hobbies
+                          </span>
+                          
+                        </span>
+                        <span
+                          class="content arrayIndex"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            [1]
+                          </span>
+                          
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      class="text"
+                      data-test-id="run-data-schema-item-value"
+                    >
+                      
+                      
+                      <!--v-if-->
+                      <span
+                        class="content"
+                      >
+                        
+                        <span>
+                          <!--v-if-->
+                          traveling
+                        </span>
+                        
+                      </span>
+                      
+                      
+                    </span>
+                  </div>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDataSchema.vue > renders schema for correct output branch 2`] = `
+<div
+  class="schema animated"
+  data-test-id="run-data-schema-node-schema"
+  data-v-46dade00=""
+>
+  <div
+    class="innerSchema"
+    data-v-46dade00=""
+  >
+    <div
+      class="item"
+      data-test-id="run-data-schema-item"
+      data-v-46dade00=""
+    >
+      <div
+        class="itemContent"
+      >
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <!--v-if-->
+      <!--v-if-->
+      <div
+        class="sub"
+      >
+        <div
+          class="innerSub"
+        >
+          
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="string"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="name"
+                  data-path=".name"
+                  data-target="mappable"
+                  data-value="{{ $('Set2').item.json.name }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                    data-icon="font"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      name
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    John
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="number"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="age"
+                  data-path=".age"
+                  data-target="mappable"
+                  data-value="{{ $('Set2').item.json.age }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-hashtag fa-w-14 fa-sm"
+                    data-icon="hashtag"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M440.667 182.109l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l14.623-81.891C377.123 38.754 371.468 32 363.997 32h-40.632a12 12 0 0 0-11.813 9.891L296.175 128H197.54l14.623-81.891C213.477 38.754 207.822 32 200.35 32h-40.632a12 12 0 0 0-11.813 9.891L132.528 128H53.432a12 12 0 0 0-11.813 9.891l-7.143 40C33.163 185.246 38.818 192 46.289 192h74.81L98.242 320H19.146a12 12 0 0 0-11.813 9.891l-7.143 40C-1.123 377.246 4.532 384 12.003 384h74.81L72.19 465.891C70.877 473.246 76.532 480 84.003 480h40.632a12 12 0 0 0 11.813-9.891L151.826 384h98.634l-14.623 81.891C234.523 473.246 240.178 480 247.65 480h40.632a12 12 0 0 0 11.813-9.891L315.472 384h79.096a12 12 0 0 0 11.813-9.891l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l22.857-128h79.096a12 12 0 0 0 11.813-9.891zM261.889 320h-98.634l22.857-128h98.634l-22.857 128z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      age
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    22
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="array"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="hobbies"
+                  data-path=".hobbies"
+                  data-target="mappable"
+                  data-value="{{ $('Set2').item.json.hobbies }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-list fa-w-16 fa-sm"
+                    data-icon="list"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      hobbies
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <!--v-if-->
+            </div>
+            <input
+              id="set_2-hobbies"
+              inert=""
+              type="checkbox"
+            />
+            <label
+              class="toggle"
+              for="set_2-hobbies"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-angle-right fa-w-8"
+                data-icon="angle-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 256 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class=""
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  fill="currentColor"
+                />
+              </svg>
+            </label>
+            <div
+              class="sub"
+            >
+              <div
+                class="innerSub"
+              >
+                
+                <div
+                  class="item"
+                  data-test-id="run-data-schema-item"
+                >
+                  <div
+                    class="itemContent"
+                  >
+                    <div
+                      class="pill mappable"
+                      title="string"
+                    >
+                      <span
+                        class="label"
+                        data-depth="2"
+                        data-name="string[0]"
+                        data-path=".hobbies[0]"
+                        data-target="mappable"
+                        data-value="{{ $('Set2').item.json.hobbies[0] }}"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                          data-icon="font"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class=""
+                            d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            hobbies
+                          </span>
+                          
+                        </span>
+                        <span
+                          class="content arrayIndex"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            [0]
+                          </span>
+                          
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      class="text"
+                      data-test-id="run-data-schema-item-value"
+                    >
+                      
+                      
+                      <!--v-if-->
+                      <span
+                        class="content"
+                      >
+                        
+                        <span>
+                          <!--v-if-->
+                          surfing
+                        </span>
+                        
+                      </span>
+                      
+                      
+                    </span>
+                  </div>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </div>
+                <div
+                  class="item"
+                  data-test-id="run-data-schema-item"
+                >
+                  <div
+                    class="itemContent"
+                  >
+                    <div
+                      class="pill mappable"
+                      title="string"
+                    >
+                      <span
+                        class="label"
+                        data-depth="2"
+                        data-name="string[1]"
+                        data-path=".hobbies[1]"
+                        data-target="mappable"
+                        data-value="{{ $('Set2').item.json.hobbies[1] }}"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                          data-icon="font"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 448 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class=""
+                            d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            hobbies
+                          </span>
+                          
+                        </span>
+                        <span
+                          class="content arrayIndex"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            [1]
+                          </span>
+                          
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      class="text"
+                      data-test-id="run-data-schema-item-value"
+                    >
+                      
+                      
+                      <!--v-if-->
+                      <span
+                        class="content"
+                      >
+                        
+                        <span>
+                          <!--v-if-->
+                          traveling
+                        </span>
+                        
+                      </span>
+                      
+                      
+                    </span>
+                  </div>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDataSchema.vue > renders schema for correct output branch 3`] = `
+<div
+  class="schema animated"
+  data-test-id="run-data-schema-node-schema"
+  data-v-46dade00=""
+>
+  <div
+    class="innerSchema"
+    data-v-46dade00=""
+  >
+    <div
+      class="item"
+      data-test-id="run-data-schema-item"
+      data-v-46dade00=""
+    >
+      <div
+        class="itemContent"
+      >
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <!--v-if-->
+      <!--v-if-->
+      <div
+        class="sub"
+      >
+        <div
+          class="innerSub"
+        >
+          
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="number"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="id"
+                  data-path=".id"
+                  data-target="mappable"
+                  data-value="{{ $('If').item.json.id }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-hashtag fa-w-14 fa-sm"
+                    data-icon="hashtag"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M440.667 182.109l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l14.623-81.891C377.123 38.754 371.468 32 363.997 32h-40.632a12 12 0 0 0-11.813 9.891L296.175 128H197.54l14.623-81.891C213.477 38.754 207.822 32 200.35 32h-40.632a12 12 0 0 0-11.813 9.891L132.528 128H53.432a12 12 0 0 0-11.813 9.891l-7.143 40C33.163 185.246 38.818 192 46.289 192h74.81L98.242 320H19.146a12 12 0 0 0-11.813 9.891l-7.143 40C-1.123 377.246 4.532 384 12.003 384h74.81L72.19 465.891C70.877 473.246 76.532 480 84.003 480h40.632a12 12 0 0 0 11.813-9.891L151.826 384h98.634l-14.623 81.891C234.523 473.246 240.178 480 247.65 480h40.632a12 12 0 0 0 11.813-9.891L315.472 384h79.096a12 12 0 0 0 11.813-9.891l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l22.857-128h79.096a12 12 0 0 0 11.813-9.891zM261.889 320h-98.634l22.857-128h98.634l-22.857 128z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      id
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    1
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          <div
+            class="item"
+            data-test-id="run-data-schema-item"
+          >
+            <div
+              class="itemContent"
+            >
+              <div
+                class="pill mappable"
+                title="string"
+              >
+                <span
+                  class="label"
+                  data-depth="1"
+                  data-name="name"
+                  data-path=".name"
+                  data-target="mappable"
+                  data-value="{{ $('If').item.json.name }}"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                    data-icon="font"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class=""
+                      d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      name
+                    </span>
+                    
+                  </span>
+                </span>
+              </div>
+              <span
+                class="text"
+                data-test-id="run-data-schema-item-value"
+              >
+                
+                
+                <!--v-if-->
+                <span
+                  class="content"
+                >
+                  
+                  <span>
+                    <!--v-if-->
+                    John
+                  </span>
+                  
+                </span>
+                
+                
+              </span>
+            </div>
+            <!--v-if-->
+            <!--v-if-->
+            <!--v-if-->
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`RunDataSchema.vue > renders schema for data 1`] = `
 <div
   class="schema animated"
@@ -871,6 +1925,443 @@ exports[`RunDataSchema.vue > renders schema for data 2`] = `
 `;
 
 exports[`RunDataSchema.vue > renders schema for in output pane 1`] = `
+<div>
+  <div
+    class="schemaWrapper"
+    data-v-46dade00=""
+  >
+    <div
+      class="schema"
+      data-test-id="run-data-schema-node-schema"
+      data-v-46dade00=""
+    >
+      <div
+        class="item"
+        data-test-id="run-data-schema-item"
+        data-v-46dade00=""
+      >
+        <div
+          class="itemContent"
+        >
+          <!--v-if-->
+          <!--v-if-->
+        </div>
+        <!--v-if-->
+        <!--v-if-->
+        <div
+          class="sub"
+        >
+          <div
+            class="innerSub"
+          >
+            
+            <div
+              class="item"
+              data-test-id="run-data-schema-item"
+            >
+              <div
+                class="itemContent"
+              >
+                <div
+                  class="pill mappable"
+                  title="string"
+                >
+                  <span
+                    class="label"
+                    data-depth="1"
+                    data-name="name"
+                    data-path=".name"
+                    data-target="mappable"
+                    data-value="{{ $json.name }}"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                      data-icon="font"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class=""
+                        d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <!--v-if-->
+                    <span
+                      class="content"
+                    >
+                      
+                      <span>
+                        <!--v-if-->
+                        name
+                      </span>
+                      
+                    </span>
+                  </span>
+                </div>
+                <span
+                  class="text"
+                  data-test-id="run-data-schema-item-value"
+                >
+                  
+                  
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      John
+                    </span>
+                    
+                  </span>
+                  
+                  
+                </span>
+              </div>
+              <!--v-if-->
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+            <div
+              class="item"
+              data-test-id="run-data-schema-item"
+            >
+              <div
+                class="itemContent"
+              >
+                <div
+                  class="pill mappable"
+                  title="number"
+                >
+                  <span
+                    class="label"
+                    data-depth="1"
+                    data-name="age"
+                    data-path=".age"
+                    data-target="mappable"
+                    data-value="{{ $json.age }}"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-hashtag fa-w-14 fa-sm"
+                      data-icon="hashtag"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class=""
+                        d="M440.667 182.109l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l14.623-81.891C377.123 38.754 371.468 32 363.997 32h-40.632a12 12 0 0 0-11.813 9.891L296.175 128H197.54l14.623-81.891C213.477 38.754 207.822 32 200.35 32h-40.632a12 12 0 0 0-11.813 9.891L132.528 128H53.432a12 12 0 0 0-11.813 9.891l-7.143 40C33.163 185.246 38.818 192 46.289 192h74.81L98.242 320H19.146a12 12 0 0 0-11.813 9.891l-7.143 40C-1.123 377.246 4.532 384 12.003 384h74.81L72.19 465.891C70.877 473.246 76.532 480 84.003 480h40.632a12 12 0 0 0 11.813-9.891L151.826 384h98.634l-14.623 81.891C234.523 473.246 240.178 480 247.65 480h40.632a12 12 0 0 0 11.813-9.891L315.472 384h79.096a12 12 0 0 0 11.813-9.891l7.143-40c1.313-7.355-4.342-14.109-11.813-14.109h-74.81l22.857-128h79.096a12 12 0 0 0 11.813-9.891zM261.889 320h-98.634l22.857-128h98.634l-22.857 128z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <!--v-if-->
+                    <span
+                      class="content"
+                    >
+                      
+                      <span>
+                        <!--v-if-->
+                        age
+                      </span>
+                      
+                    </span>
+                  </span>
+                </div>
+                <span
+                  class="text"
+                  data-test-id="run-data-schema-item-value"
+                >
+                  
+                  
+                  <!--v-if-->
+                  <span
+                    class="content"
+                  >
+                    
+                    <span>
+                      <!--v-if-->
+                      22
+                    </span>
+                    
+                  </span>
+                  
+                  
+                </span>
+              </div>
+              <!--v-if-->
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+            <div
+              class="item"
+              data-test-id="run-data-schema-item"
+            >
+              <div
+                class="itemContent"
+              >
+                <div
+                  class="pill mappable"
+                  title="array"
+                >
+                  <span
+                    class="label"
+                    data-depth="1"
+                    data-name="hobbies"
+                    data-path=".hobbies"
+                    data-target="mappable"
+                    data-value="{{ $json.hobbies }}"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="svg-inline--fa fa-list fa-w-16 fa-sm"
+                      data-icon="list"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class=""
+                        d="M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                    <!--v-if-->
+                    <span
+                      class="content"
+                    >
+                      
+                      <span>
+                        <!--v-if-->
+                        hobbies
+                      </span>
+                      
+                    </span>
+                  </span>
+                </div>
+                <!--v-if-->
+              </div>
+              <input
+                id="output_object-0-0-hobbies"
+                inert=""
+                type="checkbox"
+              />
+              <label
+                class="toggle"
+                for="output_object-0-0-hobbies"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-angle-right fa-w-8"
+                  data-icon="angle-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 256 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    class=""
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </label>
+              <div
+                class="sub"
+              >
+                <div
+                  class="innerSub"
+                >
+                  
+                  <div
+                    class="item"
+                    data-test-id="run-data-schema-item"
+                  >
+                    <div
+                      class="itemContent"
+                    >
+                      <div
+                        class="pill mappable"
+                        title="string"
+                      >
+                        <span
+                          class="label"
+                          data-depth="2"
+                          data-name="string[0]"
+                          data-path=".hobbies[0]"
+                          data-target="mappable"
+                          data-value="{{ $json.hobbies[0] }}"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                            data-icon="font"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 448 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              class=""
+                              d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                          <span
+                            class="content"
+                          >
+                            
+                            <span>
+                              <!--v-if-->
+                              hobbies
+                            </span>
+                            
+                          </span>
+                          <span
+                            class="content arrayIndex"
+                          >
+                            
+                            <span>
+                              <!--v-if-->
+                              [0]
+                            </span>
+                            
+                          </span>
+                        </span>
+                      </div>
+                      <span
+                        class="text"
+                        data-test-id="run-data-schema-item-value"
+                      >
+                        
+                        
+                        <!--v-if-->
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            surfing
+                          </span>
+                          
+                        </span>
+                        
+                        
+                      </span>
+                    </div>
+                    <!--v-if-->
+                    <!--v-if-->
+                    <!--v-if-->
+                  </div>
+                  <div
+                    class="item"
+                    data-test-id="run-data-schema-item"
+                  >
+                    <div
+                      class="itemContent"
+                    >
+                      <div
+                        class="pill mappable"
+                        title="string"
+                      >
+                        <span
+                          class="label"
+                          data-depth="2"
+                          data-name="string[1]"
+                          data-path=".hobbies[1]"
+                          data-target="mappable"
+                          data-value="{{ $json.hobbies[1] }}"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-font fa-w-14 fa-sm"
+                            data-icon="font"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 448 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              class=""
+                              d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                          <span
+                            class="content"
+                          >
+                            
+                            <span>
+                              <!--v-if-->
+                              hobbies
+                            </span>
+                            
+                          </span>
+                          <span
+                            class="content arrayIndex"
+                          >
+                            
+                            <span>
+                              <!--v-if-->
+                              [1]
+                            </span>
+                            
+                          </span>
+                        </span>
+                      </div>
+                      <span
+                        class="text"
+                        data-test-id="run-data-schema-item-value"
+                      >
+                        
+                        
+                        <!--v-if-->
+                        <span
+                          class="content"
+                        >
+                          
+                          <span>
+                            <!--v-if-->
+                            traveling
+                          </span>
+                          
+                        </span>
+                        
+                        
+                      </span>
+                    </div>
+                    <!--v-if-->
+                    <!--v-if-->
+                    <!--v-if-->
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RunDataSchema.vue > renders schema in output pane 1`] = `
 <div>
   <div
     class="schemaWrapper"


### PR DESCRIPTION
## Summary

Use correct output for connected nodes in schema view

<img width="663" alt="image" src="https://github.com/user-attachments/assets/533b04b2-72dc-463f-bd25-5219c59f9114">
<img width="663" alt="image" src="https://github.com/user-attachments/assets/a98b8b03-3026-4bf6-b8c6-69bc61b545ce">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1642/schema-view-downstream-of-an-if-node-wrong-output-branch-is-used

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
