### PR TITLE
fix(editor): Credentials scopes and n8n scopes mix up

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -279,9 +279,12 @@ const requiredPropertiesFilled = computed(() => {
 });
 
 const credentialPermissions = computed(() => {
+	/**
+	 * Credentials don't have permissions until the have been created on the BE
+	 * credential:update allows the users modify the form fields at least until the credential is saved
+	 */
 	return getResourcePermissions(
-		((credentialId.value ? currentCredential.value : credentialData.value) as ICredentialsResponse)
-			?.scopes,
+		(currentCredential.value as ICredentialsResponse)?.scopes ?? ['credential:update'],
 	).credential;
 });
 
@@ -341,11 +344,8 @@ onMounted(async () => {
 			credentialTypeName: defaultCredentialTypeName.value,
 		});
 
-		const scopes = homeProject.value?.scopes ?? [];
-
 		credentialData.value = {
 			...credentialData.value,
-			scopes,
 			...(homeProject.value ? { homeProject: homeProject.value } : {}),
 		};
 	} else {

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -279,16 +279,8 @@ const requiredPropertiesFilled = computed(() => {
 });
 
 const credentialPermissions = computed(() => {
-	/**
-	 * Credentials don't have permissions until they have been created on the BE
-	 * credential:update allows the users modify the form fields at least until the credential is saved
-	 * credential:share allows the users to share not saved credentials
-	 */
 	return getResourcePermissions(
-		(currentCredential.value as ICredentialsResponse)?.scopes ?? [
-			'credential:update',
-			'credential:share',
-		],
+		(currentCredential.value as ICredentialsResponse)?.scopes ?? homeProject.value?.scopes,
 	).credential;
 });
 

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -280,11 +280,15 @@ const requiredPropertiesFilled = computed(() => {
 
 const credentialPermissions = computed(() => {
 	/**
-	 * Credentials don't have permissions until the have been created on the BE
+	 * Credentials don't have permissions until they have been created on the BE
 	 * credential:update allows the users modify the form fields at least until the credential is saved
+	 * credential:share allows the users to share not saved credentials
 	 */
 	return getResourcePermissions(
-		(currentCredential.value as ICredentialsResponse)?.scopes ?? ['credential:update'],
+		(currentCredential.value as ICredentialsResponse)?.scopes ?? [
+			'credential:update',
+			'credential:share',
+		],
 	).credential;
 });
 


### PR DESCRIPTION
## Summary

N8n scopes and credential scopes where being mixed, causing the malfunction

![image](https://github.com/user-attachments/assets/97487b0f-76c1-474b-aa42-b08c620c63b5)

sharing is also enabled before persisting the credentials - no regression
![image](https://github.com/user-attachments/assets/48612516-0300-4b44-aee0-c799f39c7a8e)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/PAY-1931/community-issue-google-service-account-api-crash-during-set-up-of-http

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
