### PR TITLE
feat: Implement auth for task runners

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -7,5 +7,8 @@ export class TaskRunnersConfig {
 	disabled: boolean = true;
 
 	@Env('N8N_RUNNERS_PATH')
-	path: string = '/runners/_ws';
+	path: string = '/runners';
+
+	@Env('N8N_RUNNERS_AUTH_TOKEN')
+	authToken: string = '';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -220,9 +220,9 @@ describe('GlobalConfig', () => {
 			},
 		},
 		taskRunners: {
-			disabled: false,
-			path: '/runners/_ws',
-			authToken: 'token',
+			disabled: true,
+			path: '/runners',
+			authToken: '',
 		},
 	};
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -222,6 +222,7 @@ describe('GlobalConfig', () => {
 		taskRunners: {
 			disabled: false,
 			path: '/runners/_ws',
+			authToken: 'token',
 		},
 	};
 

--- a/packages/@n8n/task-runner-node-js/src/authenticator.ts
+++ b/packages/@n8n/task-runner-node-js/src/authenticator.ts
@@ -1,0 +1,38 @@
+export type AuthOpts = {
+	n8nUri: string;
+	authToken: string;
+};
+
+/**
+ * Requests a one-time token that can be used to establish a task runner connection
+ */
+export async function authenticate(opts: AuthOpts) {
+	try {
+		const authEndpoint = `http://${opts.n8nUri}/rest/runners/auth`;
+		const response = await fetch(authEndpoint, {
+			method: 'POST',
+			headers: {
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				token: opts.authToken,
+			}),
+		});
+
+		if (!response.ok) {
+			throw new Error(`Invalid response status ${response.status}: ${await response.text()}`);
+		}
+
+		const { token: grantToken } = (await response.json()) as { token: string };
+
+		return grantToken;
+	} catch (e) {
+		console.error(e);
+		const error = e as Error;
+
+		throw new Error(`Could not connect to n8n message broker ${opts.n8nUri}: ${error.message}`, {
+			cause: error,
+		});
+	}
+}

--- a/packages/@n8n/task-runner-node-js/src/authenticator.ts
+++ b/packages/@n8n/task-runner-node-js/src/authenticator.ts
@@ -1,3 +1,5 @@
+import * as a from 'node:assert/strict';
+
 export type AuthOpts = {
 	n8nUri: string;
 	authToken: string;
@@ -24,7 +26,9 @@ export async function authenticate(opts: AuthOpts) {
 			throw new Error(`Invalid response status ${response.status}: ${await response.text()}`);
 		}
 
-		const { token: grantToken } = (await response.json()) as { token: string };
+		const { data } = (await response.json()) as { data: { token: string } };
+		const grantToken = data.token;
+		a.ok(grantToken);
 
 		return grantToken;
 	} catch (e) {

--- a/packages/@n8n/task-runner-node-js/src/code.ts
+++ b/packages/@n8n/task-runner-node-js/src/code.ts
@@ -51,8 +51,14 @@ const getAdditionalKeys = (): IWorkflowDataProxyAdditionalKeys => {
 };
 
 export class JsTaskRunner extends TaskRunner {
-	constructor(taskType: string, wsUrl: string, maxConcurrency: number, name?: string) {
-		super(taskType, wsUrl, maxConcurrency, name ?? 'Test Runner');
+	constructor(
+		taskType: string,
+		wsUrl: string,
+		grantToken: string,
+		maxConcurrency: number,
+		name?: string,
+	) {
+		super(taskType, wsUrl, grantToken, maxConcurrency, name ?? 'Test Runner');
 	}
 
 	async executeTask(task: Task<JSExecSettings>): Promise<TaskResultData> {

--- a/packages/@n8n/task-runner-node-js/src/start.ts
+++ b/packages/@n8n/task-runner-node-js/src/start.ts
@@ -28,7 +28,7 @@ void (async function start() {
 		n8nUri: config.n8nUri,
 	});
 
-	const wsUrl = `ws://${config.n8nUri}/rest/runners/_ws?token=${grantToken}`;
+	const wsUrl = `ws://${config.n8nUri}/rest/runners/_ws`;
 
-	_runner = new JsTaskRunner('javascript', wsUrl, 5);
+	_runner = new JsTaskRunner('javascript', wsUrl, grantToken, 5);
 })();

--- a/packages/@n8n/task-runner-node-js/src/start.ts
+++ b/packages/@n8n/task-runner-node-js/src/start.ts
@@ -1,3 +1,34 @@
-import { JsTaskRunner } from './code';
+import * as a from 'node:assert/strict';
 
-new JsTaskRunner('javascript', 'ws://localhost:5678/rest/runners/_ws', 5);
+import { JsTaskRunner } from './code';
+import { authenticate } from './authenticator';
+
+let _runner: JsTaskRunner;
+
+type Config = {
+	n8nUri: string;
+	authToken: string;
+};
+
+function readAndParseConfig(): Config {
+	const authToken = process.env.N8N_RUNNERS_AUTH_TOKEN;
+	a.ok(authToken, 'Missing task runner auth token. Use N8N_RUNNERS_AUTH_TOKEN to configure it');
+
+	return {
+		n8nUri: 'localhost:5678',
+		authToken,
+	};
+}
+
+void (async function start() {
+	const config = readAndParseConfig();
+
+	const grantToken = await authenticate({
+		authToken: config.authToken,
+		n8nUri: config.n8nUri,
+	});
+
+	const wsUrl = `ws://${config.n8nUri}/rest/runners/_ws?token=${grantToken}`;
+
+	_runner = new JsTaskRunner('javascript', wsUrl, 5);
+})();

--- a/packages/@n8n/task-runner-node-js/src/task-runner.ts
+++ b/packages/@n8n/task-runner-node-js/src/task-runner.ts
@@ -1,5 +1,7 @@
-import { type MessageEvent, WebSocket } from 'ws';
+import { URL } from 'node:url';
 import { nanoid } from 'nanoid';
+import { type MessageEvent, WebSocket } from 'ws';
+
 import {
 	RPC_ALLOW_LIST,
 	type RunnerMessage,
@@ -57,12 +59,15 @@ export class TaskRunner {
 
 	constructor(
 		public taskType: string,
-		private wsUrl: string,
+		wsUrl: string,
 		private maxConcurrency: number,
 		public name?: string,
 	) {
 		this.id = nanoid();
-		this.ws = new WebSocket(this.wsUrl + '?id=' + this.id);
+
+		const url = new URL(wsUrl);
+		url.searchParams.append('id', this.id);
+		this.ws = new WebSocket(url.toString());
 		this.ws.addEventListener('message', this._wsMessage);
 		this.ws.addEventListener('close', this.stopTaskOffers);
 	}

--- a/packages/@n8n/task-runner-node-js/src/task-runner.ts
+++ b/packages/@n8n/task-runner-node-js/src/task-runner.ts
@@ -60,6 +60,7 @@ export class TaskRunner {
 	constructor(
 		public taskType: string,
 		wsUrl: string,
+		grantToken: string,
 		private maxConcurrency: number,
 		public name?: string,
 	) {
@@ -67,7 +68,12 @@ export class TaskRunner {
 
 		const url = new URL(wsUrl);
 		url.searchParams.append('id', this.id);
-		this.ws = new WebSocket(url.toString());
+		this.ws = new WebSocket(url.toString(), {
+			headers: {
+				authorization: `Bearer ${grantToken}`,
+			},
+		});
+		console.log('1');
 		this.ws.addEventListener('message', this._wsMessage);
 		this.ws.addEventListener('close', this.stopTaskOffers);
 	}

--- a/packages/cli/src/runners/__tests__/task-broker.test.ts
+++ b/packages/cli/src/runners/__tests__/task-broker.test.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended';
-import type { INodeExecutionData } from 'n8n-workflow';
 
-import type { RunnerMessage } from '../runner-types';
+import type { RunnerMessage, TaskResultData } from '../runner-types';
 import { TaskBroker, TaskRejectError } from '../task-broker.service';
 import type { TaskOffer, TaskRequest, TaskRunner } from '../task-broker.service';
 
@@ -371,7 +370,7 @@ describe('TaskBroker', () => {
 			const runnerId = 'runner1';
 			const taskId = 'task1';
 			const requesterId = 'requester1';
-			const data = mock<INodeExecutionData[]>();
+			const data = mock<TaskResultData>();
 
 			const message: RunnerMessage.ToN8n.TaskDone = {
 				type: 'runner:taskdone',

--- a/packages/cli/src/runners/auth/__tests__/task-runner-auth.controller.test.ts
+++ b/packages/cli/src/runners/auth/__tests__/task-runner-auth.controller.test.ts
@@ -72,7 +72,9 @@ describe('TaskRunnerAuthController', () => {
 
 		const createMockReqWithToken = (token?: string) =>
 			mock<TaskRunnerServerInitRequest>({
-				query: { token },
+				headers: {
+					authorization: `Bearer ${token}`,
+				},
 			});
 
 		beforeEach(() => {
@@ -80,7 +82,7 @@ describe('TaskRunnerAuthController', () => {
 		});
 
 		it('should respond with 401 when grant token is missing', async () => {
-			const req = createMockReqWithToken();
+			const req = mock<TaskRunnerServerInitRequest>({});
 
 			await authController.authMiddleware(req, res, next);
 

--- a/packages/cli/src/runners/auth/__tests__/task-runner-auth.controller.test.ts
+++ b/packages/cli/src/runners/auth/__tests__/task-runner-auth.controller.test.ts
@@ -1,0 +1,113 @@
+import { GlobalConfig } from '@n8n/config';
+import type { NextFunction, Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import { CacheService } from '@/services/cache/cache.service';
+import { mockInstance } from '@test/mocking';
+
+import { BadRequestError } from '../../../errors/response-errors/bad-request.error';
+import { ForbiddenError } from '../../../errors/response-errors/forbidden.error';
+import type { AuthlessRequest } from '../../../requests';
+import type { TaskRunnerServerInitRequest } from '../../runner-types';
+import { TaskRunnerAuthController } from '../task-runner-auth.controller';
+import { TaskRunnerAuthService } from '../task-runner-auth.service';
+
+describe('TaskRunnerAuthController', () => {
+	const globalConfig = mockInstance(GlobalConfig, {
+		cache: {
+			backend: 'memory',
+			memory: {
+				maxSize: 1024,
+				ttl: 9999,
+			},
+		},
+		taskRunners: {
+			authToken: 'random-secret',
+		},
+	});
+	const TTL = 100;
+	const cacheService = new CacheService(globalConfig);
+	const authService = new TaskRunnerAuthService(globalConfig, cacheService, TTL);
+	const authController = new TaskRunnerAuthController(authService);
+
+	const createMockGrantTokenReq = (token?: string) =>
+		({
+			body: {
+				token,
+			},
+		}) as unknown as AuthlessRequest;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('createGrantToken', () => {
+		it('should throw BadRequestError when auth token is missing', async () => {
+			const req = createMockGrantTokenReq();
+
+			// Act
+			await expect(authController.createGrantToken(req)).rejects.toThrowError(BadRequestError);
+		});
+
+		it('should throw ForbiddenError when auth token is invalid', async () => {
+			const req = createMockGrantTokenReq('invalid');
+
+			// Act
+			await expect(authController.createGrantToken(req)).rejects.toThrowError(ForbiddenError);
+		});
+
+		it('should return rant token when auth token is valid', async () => {
+			const req = createMockGrantTokenReq('random-secret');
+
+			// Act
+			await expect(authController.createGrantToken(req)).resolves.toStrictEqual({
+				token: expect.any(String),
+			});
+		});
+	});
+
+	describe('authMiddleware', () => {
+		const res = mock<Response>();
+		const next = jest.fn() as NextFunction;
+
+		const createMockReqWithToken = (token?: string) =>
+			mock<TaskRunnerServerInitRequest>({
+				query: { token },
+			});
+
+		beforeEach(() => {
+			res.status.mockReturnThis();
+		});
+
+		it('should respond with 401 when grant token is missing', async () => {
+			const req = createMockReqWithToken();
+
+			await authController.authMiddleware(req, res, next);
+
+			expect(next).not.toHaveBeenCalled();
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(res.json).toHaveBeenCalledWith({ code: 401, message: 'Unauthorized' });
+		});
+
+		it('should respond with 403 when grant token is invalid', async () => {
+			const req = createMockReqWithToken('invalid');
+
+			await authController.authMiddleware(req, res, next);
+
+			expect(next).not.toHaveBeenCalled();
+			expect(res.status).toHaveBeenCalledWith(403);
+			expect(res.json).toHaveBeenCalledWith({ code: 403, message: 'Forbidden' });
+		});
+
+		it('should call next() when grant token is valid', async () => {
+			const { token: validToken } = await authController.createGrantToken(
+				createMockGrantTokenReq('random-secret'),
+			);
+
+			await authController.authMiddleware(createMockReqWithToken(validToken), res, next);
+
+			expect(next).toHaveBeenCalled();
+			expect(res.status).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/runners/auth/__tests__/task-runner-auth.service.test.ts
+++ b/packages/cli/src/runners/auth/__tests__/task-runner-auth.service.test.ts
@@ -1,0 +1,92 @@
+import { GlobalConfig } from '@n8n/config';
+import { sleep } from 'n8n-workflow';
+
+import config from '@/config';
+import { CacheService } from '@/services/cache/cache.service';
+
+import { mockInstance } from '../../../../test/shared/mocking';
+import { TaskRunnerAuthService } from '../task-runner-auth.service';
+
+describe('TaskRunnerAuthService', () => {
+	config.set('taskRunners.authToken', 'random-secret');
+
+	const globalConfig = mockInstance(GlobalConfig, {
+		cache: {
+			backend: 'memory',
+			memory: {
+				maxSize: 1024,
+				ttl: 9999,
+			},
+		},
+		taskRunners: {
+			authToken: 'random-secret',
+		},
+	});
+	const TTL = 100;
+	const cacheService = new CacheService(globalConfig);
+	const authService = new TaskRunnerAuthService(globalConfig, cacheService, TTL);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('isValidAuthToken', () => {
+		it('should be valid for the configured token', () => {
+			expect(authService.isValidAuthToken('random-secret'));
+		});
+
+		it('should be invalid for anything else', () => {
+			expect(authService.isValidAuthToken('!random-secret'));
+		});
+	});
+
+	describe('createGrantToken', () => {
+		it('should generate a random token', async () => {
+			expect(typeof (await authService.createGrantToken())).toBe('string');
+		});
+
+		it('should store the generated token in cache', async () => {
+			// Arrange
+			const cacheSetSpy = jest.spyOn(cacheService, 'set');
+
+			// Act
+			const token = await authService.createGrantToken();
+
+			// Assert
+			expect(cacheSetSpy).toHaveBeenCalledWith(`grant-token:${token}`, '1', TTL);
+		});
+	});
+
+	describe('tryConsumeGrantToken', () => {
+		it('should return false for an invalid grant token', async () => {
+			expect(await authService.tryConsumeGrantToken('random-secret')).toBe(false);
+		});
+
+		it('should return true for a valid grant token', async () => {
+			// Arrange
+			const grantToken = await authService.createGrantToken();
+
+			// Act
+			expect(await authService.tryConsumeGrantToken(grantToken)).toBe(true);
+		});
+
+		it('should return false for a already used grant token', async () => {
+			// Arrange
+			const grantToken = await authService.createGrantToken();
+
+			// Act
+			expect(await authService.tryConsumeGrantToken(grantToken)).toBe(true);
+			expect(await authService.tryConsumeGrantToken(grantToken)).toBe(false);
+		});
+
+		it('should return false for an expired grant token', async () => {
+			// Arrange
+			const grantToken = await authService.createGrantToken();
+
+			// Act
+			await sleep(TTL + 1);
+
+			expect(await authService.tryConsumeGrantToken(grantToken)).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/runners/auth/task-runner-auth.controller.ts
+++ b/packages/cli/src/runners/auth/task-runner-auth.controller.ts
@@ -1,0 +1,61 @@
+import type { NextFunction, Response } from 'express';
+import { Service } from 'typedi';
+
+import type { AuthlessRequest } from '@/requests';
+
+import { taskRunnerAuthRequestBodySchema } from './task-runner-auth.schema';
+import { TaskRunnerAuthService } from './task-runner-auth.service';
+import { BadRequestError } from '../../errors/response-errors/bad-request.error';
+import { ForbiddenError } from '../../errors/response-errors/forbidden.error';
+import type { TaskRunnerServerInitRequest } from '../runner-types';
+
+/**
+ * Controller responsible for authenticating Task Runner connections
+ */
+@Service()
+export class TaskRunnerAuthController {
+	constructor(private readonly taskRunnerAuthService: TaskRunnerAuthService) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		this.authMiddleware = this.authMiddleware.bind(this);
+	}
+
+	/**
+	 * Validates the provided auth token and creates and responds with a grant token,
+	 * which can be used to initiate a task runner connection.
+	 */
+	async createGrantToken(req: AuthlessRequest) {
+		const result = await taskRunnerAuthRequestBodySchema.safeParseAsync(req.body);
+		if (!result.success) {
+			throw new BadRequestError(result.error.errors[0].code);
+		}
+
+		const { token: authToken } = result.data;
+		if (!this.taskRunnerAuthService.isValidAuthToken(authToken)) {
+			throw new ForbiddenError();
+		}
+
+		const grantToken = await this.taskRunnerAuthService.createGrantToken();
+		return {
+			token: grantToken,
+		};
+	}
+
+	/**
+	 * Middleware to authenticate task runner init requests
+	 */
+	async authMiddleware(req: TaskRunnerServerInitRequest, res: Response, next: NextFunction) {
+		const grantToken = req.query.token;
+		if (!grantToken) {
+			res.status(401).json({ code: 401, message: 'Unauthorized' });
+			return;
+		}
+
+		const isConsumed = await this.taskRunnerAuthService.tryConsumeGrantToken(grantToken);
+		if (!isConsumed) {
+			res.status(403).json({ code: 403, message: 'Forbidden' });
+			return;
+		}
+
+		next();
+	}
+}

--- a/packages/cli/src/runners/auth/task-runner-auth.controller.ts
+++ b/packages/cli/src/runners/auth/task-runner-auth.controller.ts
@@ -44,12 +44,13 @@ export class TaskRunnerAuthController {
 	 * Middleware to authenticate task runner init requests
 	 */
 	async authMiddleware(req: TaskRunnerServerInitRequest, res: Response, next: NextFunction) {
-		const grantToken = req.query.token;
-		if (!grantToken) {
+		const authHeader = req.headers.authorization;
+		if (typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
 			res.status(401).json({ code: 401, message: 'Unauthorized' });
 			return;
 		}
 
+		const grantToken = authHeader.slice('Bearer '.length);
 		const isConsumed = await this.taskRunnerAuthService.tryConsumeGrantToken(grantToken);
 		if (!isConsumed) {
 			res.status(403).json({ code: 403, message: 'Forbidden' });

--- a/packages/cli/src/runners/auth/task-runner-auth.schema.ts
+++ b/packages/cli/src/runners/auth/task-runner-auth.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const taskRunnerAuthRequestBodySchema = z.object({
+	token: z.string().min(1),
+});

--- a/packages/cli/src/runners/auth/task-runner-auth.service.ts
+++ b/packages/cli/src/runners/auth/task-runner-auth.service.ts
@@ -1,0 +1,56 @@
+import { GlobalConfig } from '@n8n/config';
+import { randomBytes } from 'crypto';
+import { Service } from 'typedi';
+
+import { Time } from '@/constants';
+import { CacheService } from '@/services/cache/cache.service';
+
+const GRANT_TOKEN_TTL = 15 * Time.seconds.toMilliseconds;
+
+@Service()
+export class TaskRunnerAuthService {
+	constructor(
+		private readonly globalConfig: GlobalConfig,
+		private readonly cacheService: CacheService,
+		// For unit testing purposes
+		private readonly grantTokenTtl = GRANT_TOKEN_TTL,
+	) {}
+
+	isValidAuthToken(token: string) {
+		return token === this.globalConfig.taskRunners.authToken;
+	}
+
+	/**
+	 * @returns grant token that can be used to establish a task runner connection
+	 */
+	async createGrantToken() {
+		const grantToken = this.generateGrantToken();
+
+		const key = this.cacheKeyForGrantToken(grantToken);
+		await this.cacheService.set(key, '1', this.grantTokenTtl);
+
+		return grantToken;
+	}
+
+	/**
+	 * Checks if the given `grantToken` is a valid token and marks it as
+	 * used.
+	 */
+	async tryConsumeGrantToken(grantToken: string) {
+		const key = this.cacheKeyForGrantToken(grantToken);
+		const consumed = await this.cacheService.get<string>(key);
+		// Not found from cache --> Invalid token
+		if (consumed === undefined) return false;
+
+		await this.cacheService.delete(key);
+		return true;
+	}
+
+	private generateGrantToken() {
+		return randomBytes(32).toString('hex');
+	}
+
+	private cacheKeyForGrantToken(grantToken: string) {
+		return `grant-token:${grantToken}`;
+	}
+}

--- a/packages/cli/src/runners/runner-types.ts
+++ b/packages/cli/src/runners/runner-types.ts
@@ -1,4 +1,9 @@
+import type { Response } from 'express';
 import type { INodeExecutionData } from 'n8n-workflow';
+import type WebSocket from 'ws';
+
+import type { TaskRunner } from './task-broker.service';
+import type { AuthlessRequest } from '../requests';
 
 export type DataRequestType = 'input' | 'node' | 'all';
 
@@ -6,6 +11,13 @@ export interface TaskResultData {
 	result: INodeExecutionData[];
 	customData?: Record<string, string>;
 }
+
+export interface TaskRunnerServerInitRequest
+	extends AuthlessRequest<{}, {}, {}, { id: TaskRunner['id']; token?: string }> {
+	ws: WebSocket;
+}
+
+export type TaskRunnerServerInitResponse = Response & { req: TaskRunnerServerInitRequest };
 
 export namespace N8nMessage {
 	export namespace ToRunner {

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -89,6 +89,9 @@ export class CacheService extends TypedEmitter<CacheEvents> {
 	//             storing
 	// ----------------------------------
 
+	/**
+	 * @param ttl Time to live in milliseconds
+	 */
 	async set(key: string, value: unknown, ttl?: number) {
 		if (!this.cache) await this.init();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20952,11 +20952,18 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.6)
 
+  babel-preset-jest@29.5.0(@babel/core@7.24.0):
+    dependencies:
+      '@babel/core': 7.24.6
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.6)
+
   babel-preset-jest@29.5.0(@babel/core@7.24.6):
     dependencies:
       '@babel/core': 7.24.6
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.6)
+    optional: true
 
   babel-walk@3.0.0-canary-5:
     dependencies:


### PR DESCRIPTION

## Summary

Authentication works in two steps:

1. `POST /rest/runners/auth` with `{ "token": "auth_token" }` to create a one-time use grant token
2. `/rest/runners/_ws?id=<runnerId>&token=<grant_token>` to initiate a task runner connection

The reason for this two phase auth mechanism is that in the next steps we can have a shim process that takes care of the first step and starts the task runner only with the one-time use grant token. That way the actual auth token is protected from anyone gaining access to the task runner.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-1967/task-runner-to-broker-authentication

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
