### PR TITLE
feat(editor): Do not show error for remote options when credentials aren't specified

### DIFF
--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -674,6 +674,23 @@ describe('NDV', () => {
 		ndv.getters.parameterInput('operation').find('input').should('have.value', 'Delete');
 	});
 
+	it('Should show a notice when remote options cannot be fetched because of missing credentials', () => {
+		cy.intercept('POST', '/rest/dynamic-node-parameters/options', { statusCode: 403 }).as(
+			'parameterOptions',
+		);
+
+		workflowPage.actions.addInitialNodeToCanvas(NOTION_NODE_NAME, {
+			keepNdvOpen: true,
+			action: 'Update a database page',
+		});
+
+		ndv.actions.addItemToFixedCollection('propertiesUi');
+		ndv.getters
+			.parameterInput('key')
+			.find('input')
+			.should('have.value', 'Set up credential to see options');
+	});
+
 	it('Should show error state when remote options cannot be fetched', () => {
 		cy.intercept('POST', '/rest/dynamic-node-parameters/options', { statusCode: 500 }).as(
 			'parameterOptions',
@@ -694,23 +711,6 @@ describe('NDV', () => {
 			.parameterInput('key')
 			.find('input')
 			.should('have.value', 'Error fetching options from Notion');
-	});
-
-	it('Should show a notice when remote options cannot be fetched because of missing credentials', () => {
-		cy.intercept('POST', '/rest/dynamic-node-parameters/options', { statusCode: 403 }).as(
-			'parameterOptions',
-		);
-
-		workflowPage.actions.addInitialNodeToCanvas(NOTION_NODE_NAME, {
-			keepNdvOpen: true,
-			action: 'Update a database page',
-		});
-
-		ndv.actions.addItemToFixedCollection('propertiesUi');
-		ndv.getters
-			.parameterInput('key')
-			.find('input')
-			.should('have.value', 'Set up credential to see options');
 	});
 
 	it('Should open appropriate node creator after clicking on connection hint link', () => {

--- a/cypress/e2e/5-ndv.cy.ts
+++ b/cypress/e2e/5-ndv.cy.ts
@@ -684,11 +684,33 @@ describe('NDV', () => {
 			action: 'Update a database page',
 		});
 
+		clickCreateNewCredential();
+		setCredentialValues({
+			apiKey: 'sk_test_123',
+		});
+
 		ndv.actions.addItemToFixedCollection('propertiesUi');
 		ndv.getters
 			.parameterInput('key')
 			.find('input')
 			.should('have.value', 'Error fetching options from Notion');
+	});
+
+	it('Should show a notice when remote options cannot be fetched because of missing credentials', () => {
+		cy.intercept('POST', '/rest/dynamic-node-parameters/options', { statusCode: 403 }).as(
+			'parameterOptions',
+		);
+
+		workflowPage.actions.addInitialNodeToCanvas(NOTION_NODE_NAME, {
+			keepNdvOpen: true,
+			action: 'Update a database page',
+		});
+
+		ndv.actions.addItemToFixedCollection('propertiesUi');
+		ndv.getters
+			.parameterInput('key')
+			.find('input')
+			.should('have.value', 'Set up credential to see options');
 	});
 
 	it('Should open appropriate node creator after clicking on connection hint link', () => {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -177,6 +177,15 @@ const displayValue = computed(() => {
 		if (!nodeType.value || nodeType.value?.codex?.categories?.includes(CORE_NODES_CATEGORY)) {
 			return i18n.baseText('parameterInput.loadOptionsError');
 		}
+
+		if (nodeType.value?.credentials?.length > 0) {
+			const credentialsType = nodeType.value?.credentials[0];
+
+			if (credentialsType.required && !node.value.credentials) {
+				return i18n.baseText('parameterInput.loadOptionsCredentialsRequired');
+			}
+		}
+
 		return i18n.baseText('parameterInput.loadOptionsErrorService', {
 			interpolate: { service: nodeType.value.displayName },
 		});

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -178,10 +178,10 @@ const displayValue = computed(() => {
 			return i18n.baseText('parameterInput.loadOptionsError');
 		}
 
-		if (nodeType.value?.credentials?.length > 0) {
+		if (nodeType.value?.credentials && nodeType.value?.credentials?.length > 0) {
 			const credentialsType = nodeType.value?.credentials[0];
 
-			if (credentialsType.required && !node.value.credentials) {
+			if (credentialsType.required && !node.value?.credentials) {
 				return i18n.baseText('parameterInput.loadOptionsCredentialsRequired');
 			}
 		}

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -1258,6 +1258,7 @@ onUpdated(async () => {
 					"
 					:title="displayTitle"
 					:placeholder="getPlaceholder()"
+					data-test-id="parameter-input-field"
 					@update:model-value="(valueChanged($event) as undefined) && onUpdateTextInput($event)"
 					@keydown.stop
 					@focus="setFocus"

--- a/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
@@ -173,7 +173,8 @@ describe('ParameterInput.vue', () => {
 			throw new Error('Node does not have any credentials set');
 		});
 
-		mockNodeTypesState.getNodeType = vi.fn(() => ({
+		// @ts-expect-error Readonly property
+		mockNodeTypesState.getNodeType = vi.fn().mockReturnValue({
 			displayName: 'Test',
 			credentials: [
 				{
@@ -181,7 +182,7 @@ describe('ParameterInput.vue', () => {
 					required: true,
 				},
 			],
-		}));
+		});
 
 		const { emitted, container, getByTestId } = renderComponent(ParameterInput, {
 			pinia: createTestingPinia(),

--- a/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/__tests__/ParameterInput.test.ts
@@ -167,4 +167,46 @@ describe('ParameterInput.vue', () => {
 		// Nothing should be emitted
 		expect(emitted('update')).toBeUndefined();
 	});
+
+	test('should show message when can not load options without credentials', async () => {
+		mockNodeTypesState.getNodeParameterOptions = vi.fn(async () => {
+			throw new Error('Node does not have any credentials set');
+		});
+
+		mockNodeTypesState.getNodeType = vi.fn(() => ({
+			displayName: 'Test',
+			credentials: [
+				{
+					name: 'openAiApi',
+					required: true,
+				},
+			],
+		}));
+
+		const { emitted, container, getByTestId } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'columns',
+				parameter: {
+					displayName: 'Columns',
+					name: 'columns',
+					type: 'options',
+					typeOptions: { loadOptionsMethod: 'getColumnsMultiOptions' },
+				},
+				modelValue: 'id',
+			},
+		});
+
+		await waitFor(() => expect(getByTestId('parameter-input-field')).toBeInTheDocument());
+
+		const input = container.querySelector('input') as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+
+		expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalled();
+
+		expect(input.value.toLowerCase()).not.toContain('error');
+		expect(input).toHaveValue('Set up credential to see options');
+
+		expect(emitted('update')).toBeUndefined();
+	});
 });

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1358,6 +1358,7 @@
 	"parameterInput.loadingOptions": "Loading options...",
 	"parameterInput.loadOptionsErrorService": "Error fetching options from {service}",
 	"parameterInput.loadOptionsError": "Error fetching options",
+	"parameterInput.loadOptionsCredentialsRequired": "Set up credential to see options",
 	"parameterInput.openEditWindow": "Open Edit Window",
 	"parameterInput.parameter": "Parameter: \"{shortPath}\"",
 	"parameterInput.parameterHasExpression": "Parameter: \"{shortPath}\" has an expression",


### PR DESCRIPTION
## Summary

For newly inserted nodes, if they have parameters with remote options and credentials aren't set yet, we shouldn't show an error. Change this to the "Set up credential to see options" notice.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-309/openai-model-selector-dont-show-error-if-cred-is-missing

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
