### PR TITLE
fix(core): Fix sentry de-duplication by migrating from event-processors to beforeSend (no-changelog)

### DIFF
--- a/packages/cli/src/error-reporting.ts
+++ b/packages/cli/src/error-reporting.ts
@@ -29,7 +29,7 @@ export const initErrorHandling = async () => {
 		DEPLOYMENT_NAME: serverName,
 	} = process.env;
 
-	const { init, captureException, addEventProcessor } = await import('@sentry/node');
+	const { init, captureException } = await import('@sentry/node');
 
 	const { RewriteFrames } = await import('@sentry/integrations');
 	const { Integrations } = await import('@sentry/node');
@@ -41,6 +41,8 @@ export const initErrorHandling = async () => {
 		'OnUnhandledRejection',
 		'ContextLines',
 	];
+	const seenErrors = new Set<string>();
+
 	init({
 		dsn,
 		release,
@@ -62,34 +64,32 @@ export const initErrorHandling = async () => {
 				},
 			}),
 		],
-	});
+		beforeSend(event, { originalException }) {
+			if (!originalException) return null;
 
-	const seenErrors = new Set<string>();
-	addEventProcessor((event, { originalException }) => {
-		if (!originalException) return null;
+			if (
+				originalException instanceof QueryFailedError &&
+				['SQLITE_FULL', 'SQLITE_IOERR'].some((errMsg) => originalException.message.includes(errMsg))
+			) {
+				return null;
+			}
 
-		if (
-			originalException instanceof QueryFailedError &&
-			['SQLITE_FULL', 'SQLITE_IOERR'].some((errMsg) => originalException.message.includes(errMsg))
-		) {
-			return null;
-		}
+			if (originalException instanceof ApplicationError) {
+				const { level, extra, tags } = originalException;
+				if (level === 'warning') return null;
+				event.level = level;
+				if (extra) event.extra = { ...event.extra, ...extra };
+				if (tags) event.tags = { ...event.tags, ...tags };
+			}
 
-		if (originalException instanceof ApplicationError) {
-			const { level, extra, tags } = originalException;
-			if (level === 'warning') return null;
-			event.level = level;
-			if (extra) event.extra = { ...event.extra, ...extra };
-			if (tags) event.tags = { ...event.tags, ...tags };
-		}
+			if (originalException instanceof Error && originalException.stack) {
+				const eventHash = createHash('sha1').update(originalException.stack).digest('base64');
+				if (seenErrors.has(eventHash)) return null;
+				seenErrors.add(eventHash);
+			}
 
-		if (originalException instanceof Error && originalException.stack) {
-			const eventHash = createHash('sha1').update(originalException.stack).digest('base64');
-			if (seenErrors.has(eventHash)) return null;
-			seenErrors.add(eventHash);
-		}
-
-		return event;
+			return event;
+		},
 	});
 
 	ErrorReporterProxy.init({


### PR DESCRIPTION
## Summary
Our current Sentry events de-duplication code uses event-processors, which don't seem to work on cloud instance for some reason.
This PR switches to `beforeSend` to run the de-duplication check at the every end, just before sending the event to Sentry. This should hopefully fix the issue on cloud.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive