### PR TITLE
fix(core): Clean run data correctly for the new partial execution flow (no-changelog)

### DIFF
--- a/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
+++ b/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
@@ -125,6 +125,32 @@ export class DirectedGraph {
 		return directChildren;
 	}
 
+	private getChildrenRecursive(node: INode, children: Set<INode>) {
+		const directChildren = this.getDirectChildren(node);
+
+		for (const directChild of directChildren) {
+			// Break out if we found a cycle.
+			if (children.has(directChild.to)) {
+				continue;
+			}
+			children.add(directChild.to);
+			this.getChildrenRecursive(directChild.to, children);
+		}
+
+		return children;
+	}
+
+	/**
+	 * Returns all nodes that are children of the node that is passed as an
+	 * argument.
+	 *
+	 * If the node being passed in is a child of itself (e.g. is part of a
+	 * cylce), the return set will contain it as well.
+	 */
+	getChildren(node: INode) {
+		return this.getChildrenRecursive(node, new Set());
+	}
+
 	getDirectParents(node: INode) {
 		const nodeExists = this.nodes.get(node.name) === node;
 		a.ok(nodeExists);

--- a/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
@@ -38,4 +38,52 @@ describe('DirectedGraph', () => {
 			graph,
 		);
 	});
+
+	describe('getChildren', () => {
+		// ┌─────┐    ┌─────┐   ┌─────┐
+		// │node1├───►│node2├──►│node3│
+		// └─────┘    └─────┘   └─────┘
+		test('returns all children', () => {
+			// ARRANGE
+			const node1 = createNodeData({ name: 'Node1' });
+			const node2 = createNodeData({ name: 'Node2' });
+			const node3 = createNodeData({ name: 'Node3' });
+			const graph = new DirectedGraph()
+				.addNodes(node1, node2, node3)
+				.addConnections({ from: node1, to: node2 }, { from: node2, to: node3 });
+
+			// ACT
+			const children = graph.getChildren(node1);
+
+			// ASSERT
+			expect(children.size).toBe(2);
+			expect(children).toEqual(new Set([node2, node3]));
+		});
+
+		//     ┌─────┐    ┌─────┐   ┌─────┐
+		//  ┌─►│node1├───►│node2├──►│node3├─┐
+		//  │  └─────┘    └─────┘   └─────┘ │
+		//  │                               │
+		//  └───────────────────────────────┘
+		test('terminates when finding a cycle', () => {
+			// ARRANGE
+			const node1 = createNodeData({ name: 'Node1' });
+			const node2 = createNodeData({ name: 'Node2' });
+			const node3 = createNodeData({ name: 'Node3' });
+			const graph = new DirectedGraph()
+				.addNodes(node1, node2, node3)
+				.addConnections(
+					{ from: node1, to: node2 },
+					{ from: node2, to: node3 },
+					{ from: node3, to: node1 },
+				);
+
+			// ACT
+			const children = graph.getChildren(node1);
+
+			// ASSERT
+			expect(children.size).toBe(3);
+			expect(children).toEqual(new Set([node1, node2, node3]));
+		});
+	});
 });

--- a/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
@@ -17,8 +17,8 @@ describe('cleanRunData', () => {
 			.addConnections({ from: node1, to: node2 }, { from: node2, to: node3 });
 		const runData: IRunData = {
 			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 2 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 3 } }])],
 		};
 
 		// ACT
@@ -41,8 +41,8 @@ describe('cleanRunData', () => {
 			.addConnections({ from: node1, to: node2 }, { from: node2, to: node3 });
 		const runData: IRunData = {
 			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 2 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 3 } }])],
 		};
 
 		// ACT
@@ -72,8 +72,8 @@ describe('cleanRunData', () => {
 
 		const runData: IRunData = {
 			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
-			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 2 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 3 } }])],
 		};
 
 		// ACT

--- a/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
@@ -1,0 +1,86 @@
+import type { IRunData } from 'n8n-workflow';
+import { cleanRunData } from '../cleanRunData';
+import { DirectedGraph } from '../DirectedGraph';
+import { createNodeData, toITaskData } from './helpers';
+
+describe('cleanRunData', () => {
+	// ┌─────┐    ┌─────┐   ┌─────┐
+	// │node1├───►│node2├──►│node3│
+	// └─────┘    └─────┘   └─────┘
+	test('deletes all run data of all children and the node being passed in', () => {
+		// ARRANGE
+		const node1 = createNodeData({ name: 'Node1' });
+		const node2 = createNodeData({ name: 'Node2' });
+		const node3 = createNodeData({ name: 'Node3' });
+		const graph = new DirectedGraph()
+			.addNodes(node1, node2, node3)
+			.addConnections({ from: node1, to: node2 }, { from: node2, to: node3 });
+		const runData: IRunData = {
+			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+		};
+
+		// ACT
+		const newRunData = cleanRunData(runData, graph, [node1]);
+
+		// ASSERT
+		expect(newRunData).toEqual({});
+	});
+
+	// ┌─────┐    ┌─────┐   ┌─────┐
+	// │node1├───►│node2├──►│node3│
+	// └─────┘    └─────┘   └─────┘
+	test('retains the run data of parent nodes of the node being passed in', () => {
+		// ARRANGE
+		const node1 = createNodeData({ name: 'Node1' });
+		const node2 = createNodeData({ name: 'Node2' });
+		const node3 = createNodeData({ name: 'Node3' });
+		const graph = new DirectedGraph()
+			.addNodes(node1, node2, node3)
+			.addConnections({ from: node1, to: node2 }, { from: node2, to: node3 });
+		const runData: IRunData = {
+			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+		};
+
+		// ACT
+		const newRunData = cleanRunData(runData, graph, [node2]);
+
+		// ASSERT
+		expect(newRunData).toEqual({ [node1.name]: runData[node1.name] });
+	});
+
+	//     ┌─────┐    ┌─────┐   ┌─────┐
+	//  ┌─►│node1├───►│node2├──►│node3├─┐
+	//  │  └─────┘    └─────┘   └─────┘ │
+	//  │                               │
+	//  └───────────────────────────────┘
+	test('terminates when finding a cycle', () => {
+		// ARRANGE
+		const node1 = createNodeData({ name: 'Node1' });
+		const node2 = createNodeData({ name: 'Node2' });
+		const node3 = createNodeData({ name: 'Node3' });
+		const graph = new DirectedGraph()
+			.addNodes(node1, node2, node3)
+			.addConnections(
+				{ from: node1, to: node2 },
+				{ from: node2, to: node3 },
+				{ from: node3, to: node1 },
+			);
+
+		const runData: IRunData = {
+			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 1 } }])],
+		};
+
+		// ACT
+		const newRunData = cleanRunData(runData, graph, [node2]);
+
+		// ASSERT
+		// TODO: Find out if this is a desirable result in milestone 2
+		expect(newRunData).toEqual({});
+	});
+});

--- a/packages/core/src/PartialExecutionUtils/cleanRunData.ts
+++ b/packages/core/src/PartialExecutionUtils/cleanRunData.ts
@@ -1,0 +1,26 @@
+import type { INode, IRunData } from 'n8n-workflow';
+import type { DirectedGraph } from './DirectedGraph';
+
+/**
+ * Returns new run data that does not contain data for any node that is a child
+ * of any start node.
+ * This does not mutate the `runData` being passed in.
+ */
+export function cleanRunData(
+	runData: IRunData,
+	graph: DirectedGraph,
+	startNodes: INode[],
+): IRunData {
+	const newRunData: IRunData = { ...runData };
+
+	for (const startNode of startNodes) {
+		delete newRunData[startNode.name];
+		const children = graph.getChildren(startNode);
+
+		for (const child of children) {
+			delete newRunData[child.name];
+		}
+	}
+
+	return newRunData;
+}

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -58,6 +58,7 @@ import {
 	findSubgraph,
 	findTriggerForPartialExecution,
 } from './PartialExecutionUtils';
+import { cleanRunData } from './PartialExecutionUtils/cleanRunData';
 
 export class WorkflowExecute {
 	private status: ExecutionStatus = 'new';
@@ -347,7 +348,8 @@ export class WorkflowExecute {
 		}
 
 		// 2. Find the Subgraph
-		const subgraph = findSubgraph(DirectedGraph.fromWorkflow(workflow), destinationNode, trigger);
+		const graph = DirectedGraph.fromWorkflow(workflow);
+		const subgraph = findSubgraph(graph, destinationNode, trigger);
 		const filteredNodes = subgraph.getNodes();
 
 		// 3. Find the Start Nodes
@@ -362,7 +364,7 @@ export class WorkflowExecute {
 		}
 
 		// 6. Clean Run Data
-		// TODO:
+		const newRunData: IRunData = cleanRunData(runData, graph, startNodes);
 
 		// 7. Recreate Execution Stack
 		const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
@@ -376,7 +378,7 @@ export class WorkflowExecute {
 				runNodeFilter: Array.from(filteredNodes.values()).map((node) => node.name),
 			},
 			resultData: {
-				runData,
+				runData: newRunData,
 				pinData,
 			},
 			executionData: {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This cleans the run data correctly:

Before:

https://github.com/user-attachments/assets/8e21e3b1-48e9-4e94-951d-ef00ae0abdf7



After:

https://github.com/user-attachments/assets/4e2dccc7-57a6-4bed-a198-746af21e9191


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1978

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
