### PR TITLE
fix(Supabase Node): Fix issue with delete not always working

### DIFF
--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -186,8 +186,8 @@ export class Supabase implements INodeType {
 			if (operation === 'delete') {
 				const tableId = this.getNodeParameter('tableId', 0) as string;
 				const filterType = this.getNodeParameter('filterType', 0) as string;
-				let endpoint = `/${tableId}`;
 				for (let i = 0; i < length; i++) {
+					let endpoint = `/${tableId}`;
 					if (filterType === 'manual') {
 						const matchType = this.getNodeParameter('matchType', 0) as string;
 						const keys = this.getNodeParameter('filters.conditions', i, []) as IDataObject[];


### PR DESCRIPTION
## Summary
Fixes an issue with the endpoint URL not being reset on each item loop this resulted in the filter being appended to the URL and only the first item being impacted on the delete.

Will handle tests for this node during tech debt week.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1574/detele-row-of-supabase-node-only-runs-for-first-item

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
