### PR TITLE
fix(Elasticsearch Node): Fix issue with self signed certificates not working

### DIFF
--- a/packages/nodes-base/nodes/Elastic/Elasticsearch/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Elastic/Elasticsearch/GenericFunctions.ts
@@ -80,7 +80,7 @@ export async function elasticsearchApiRequest(
 	}
 
 	try {
-		return await this.helpers.requestWithAuthentication.call(this, 'elasticsearchApi', options);
+		return await this.helpers.httpRequestWithAuthentication.call(this, 'elasticsearchApi', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}


### PR DESCRIPTION
## Summary
The request was being made with `requestWithAuthentication` which has different options to `httpRequestWithAuthentication`, Updated and tested against a test Elastic instance.

With tests I need to look to see if there is a way we can test if the option actually works with Nock, took a quick look and couldn't find anything so leaving for tech debt week.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/elasticsearch-ignore-ssl-issues-not-working-in-version-1-55-3/52345
https://linear.app/n8n/issue/NODE-1618/elasticsearch-ignore-ssl-issues-not-working-in-version-1553

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
