### PR TITLE
feat(FTP Node): Add FTP node to Core Nodes > Other (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Ftp/Ftp.node.json
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.json
@@ -17,6 +17,6 @@
 	},
 	"alias": ["SFTP", "FTP", "Binary", "File", "Transfer"],
 	"subcategories": {
-		"Core Nodes": ["Helpers"]
+		"Core Nodes": ["Files", "Helpers"]
 	}
 }

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.json
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.json
@@ -17,6 +17,6 @@
 	},
 	"alias": ["SFTP", "FTP", "Binary", "File", "Transfer"],
 	"subcategories": {
-		"Core Nodes": ["Files"]
+		"Core Nodes": ["Helpers"]
 	}
 }


### PR DESCRIPTION
## Summary
Adds the FTP node to Core Nodes so it can be found.

![image](https://github.com/user-attachments/assets/91271ae6-764b-495b-b89c-7cff20105004)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1634/ftp-node-add-it-to-core-other-in-the-nodes-panel

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
