### PR TITLE
feat(editor): New option '1' to selector of how many items of output display at once (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nDatatable/Datatable.vue
+++ b/packages/design-system/src/components/N8nDatatable/Datatable.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const rowsPerPageOptions = ref([10, 25, 50, 100]);
+const rowsPerPageOptions = ref([1, 10, 25, 50, 100]);
 
 const $style = useCssModule();
 

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -200,7 +200,7 @@ export default defineComponent({
 			MAX_DISPLAY_ITEMS_AUTO_ALL,
 			currentPage: 1,
 			pageSize: 10,
-			pageSizes: [10, 25, 50, 100],
+			pageSizes: [1, 10, 25, 50, 100],
 
 			pinDataDiscoveryTooltipVisible: false,
 			isControlledPinDataTooltip: false,


### PR DESCRIPTION
## Summary

Added new option '1' to selector of how many items of output display at once
![image](https://github.com/user-attachments/assets/04cddd49-d484-4938-997c-684bc60ba8e3)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1604/add-page-size-of-1-to-options-in-ndv