### PR TITLE
fix(editor): Out of memory toast properly renders html

### DIFF
--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -437,6 +437,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 							message: runDataExecutedErrorMessage,
 							type: 'error',
 							duration: 0,
+							dangerouslyUseHTMLString: true,
 						});
 					}
 				}


### PR DESCRIPTION
## Summary

| Before  | After |
| ------------- | ------------- |
| <img width="376" alt="image" src="https://github.com/user-attachments/assets/59937903-bda9-436e-aba9-07477e20634f"> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/94fd2090-9619-480e-afea-d0178b8469d2">  |

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1929](https://linear.app/n8n/issue/PAY-1929/community-issue-[low-priorty-bugui]-html-message-status-response-not)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
