### PR TITLE
fix(Postgres Node): Falsy query parameters ignored

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
@@ -46,6 +46,9 @@ const createMockExecuteFunction = (nodeParameters: IDataObject) => {
 			node.parameters = { ...node.parameters, ...(nodeParameters as INodeParameters) };
 			return node;
 		},
+		evaluateExpression(str: string, _: number) {
+			return str.replace('{{', '').replace('}}', '');
+		},
 	} as unknown as IExecuteFunctions;
 	return fakeExecuteFunction;
 };
@@ -289,6 +292,26 @@ describe('Test PostgresV2, executeQuery operation', () => {
 			items,
 			nodeOptions,
 		);
+	});
+
+	it('should call runQueries with falsy query replacements', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'executeQuery',
+			query: 'SELECT *\nFROM users\nWHERE username IN ($1, $2, $3)',
+			options: {
+				queryReplacement: '={{ 0 }}, {{ null }}, {{ 0 }}',
+			},
+		};
+		const nodeOptions = nodeParameters.options as IDataObject;
+
+		expect(async () => {
+			await executeQuery.execute.call(
+				createMockExecuteFunction(nodeParameters),
+				runQueries,
+				items,
+				nodeOptions,
+			);
+		}).not.toThrow();
 	});
 });
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -80,7 +80,7 @@ export async function execute(
 			const rawReplacements = (node.parameters.options as IDataObject)?.queryReplacement as string;
 
 			const stringToArray = (str: NodeParameterValueType | undefined) => {
-				if (!str) return [];
+				if (str === undefined) return [];
 				return String(str)
 					.split(',')
 					.filter((entry) => entry)


### PR DESCRIPTION
## Summary

Postgres Node: v2.5 ignores falsey (0, null, maybe others) value query parameters.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1627/postgres-node-v25-ignores-falsey-0-null-maybe-others-value-query
https://community.n8n.io/t/postgres-node-2-5-ignores-falsey-query-parameters/52141