### PR TITLE
fix(editor): Fix design system form component sizing

### DIFF
--- a/packages/design-system/src/components/N8nFormInput/FormInput.vue
+++ b/packages/design-system/src/components/N8nFormInput/FormInput.vue
@@ -193,6 +193,7 @@ defineExpose({ inputRef });
 		:label="label"
 		:tooltip-text="tooltipText"
 		:required="required && showRequiredAsterisk"
+		:size="labelSize"
 	>
 		<template #content>
 			{{ tooltipText }}
@@ -210,6 +211,7 @@ defineExpose({ inputRef });
 		:label="label"
 		:tooltip-text="tooltipText"
 		:required="required && showRequiredAsterisk"
+		:size="labelSize"
 	>
 		<div :class="showErrors ? $style.errorInput : ''" @keydown.stop @keydown.enter="onEnter">
 			<slot v-if="hasDefaultSlot" />
@@ -223,6 +225,7 @@ defineExpose({ inputRef });
 				:disabled="disabled"
 				:name="name"
 				:teleported="teleported"
+				:size="tagSize"
 				@update:model-value="onUpdateModelValue"
 				@focus="onFocus"
 				@blur="onBlur"
@@ -246,6 +249,7 @@ defineExpose({ inputRef });
 				:maxlength="maxlength"
 				:autocomplete="autocomplete"
 				:disabled="disabled"
+				:size="tagSize"
 				@update:model-value="onUpdateModelValue"
 				@blur="onBlur"
 				@focus="onFocus"

--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -5,7 +5,7 @@ import N8nIcon from '../N8nIcon';
 import N8nText from '../N8nText';
 import N8nTooltip from '../N8nTooltip';
 
-const SIZE = ['small', 'medium'] as const;
+const SIZE = ['small', 'medium', 'large'] as const;
 
 interface InputLabelProps {
 	compact?: boolean;


### PR DESCRIPTION
## Summary

Some design system form components accepting props for sizing but they're not utilizing them

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1992](https://linear.app/n8n/issue/PAY-1992/fix-design-system-forminput-component-sizing)

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
