### PR TITLE
fix(MySQL Node): Fix "Maximum call stack size exceeded" error when handling a large number of rows

### DIFF
--- a/packages/nodes-base/nodes/MySql/v1/MySqlV1.node.ts
+++ b/packages/nodes-base/nodes/MySql/v1/MySqlV1.node.ts
@@ -327,7 +327,7 @@ export class MySqlV1 implements INodeType {
 							{ itemData: { item: index } },
 						);
 
-						collection.push(...executionData);
+						collection = collection.concat(executionData);
 
 						return collection;
 					},

--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -141,7 +141,7 @@ export function prepareOutput(
 	) => NodeExecutionWithMetadata[],
 	itemData: IPairedItemData | IPairedItemData[],
 ) {
-	const returnData: INodeExecutionData[] = [];
+	let returnData: INodeExecutionData[] = [];
 
 	if (options.detailedOutput) {
 		response.forEach((entry, index) => {
@@ -154,7 +154,7 @@ export function prepareOutput(
 				itemData,
 			});
 
-			returnData.push(...executionData);
+			returnData = returnData.concat(executionData);
 		});
 	} else {
 		response
@@ -164,7 +164,7 @@ export function prepareOutput(
 					itemData: Array.isArray(itemData) ? itemData[index] : itemData,
 				});
 
-				returnData.push(...executionData);
+				returnData = returnData.concat(executionData);
 			});
 	}
 


### PR DESCRIPTION
## Summary

Previous similar fixes:

* Google Sheets Node #7384
* Microsoft SQL Node #8334
* MongoDB Node #8530
* FTP Node #8657

## Related tickets and issues

https://community.n8n.io/t/mysql-maximum-call-stack-size-exceeded/54970

## Review / Merge checklist
- [x] PR title and summary are descriptive