### PR TITLE
fix(editor): Set correct connection type when auto-adding nodes in new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -859,6 +859,7 @@ async function onAddNodesAndConnections(
 	const mappedConnections: CanvasConnectionCreateData[] = connections.map(({ from, to }) => {
 		const fromNode = editableWorkflow.value.nodes[offsetIndex + from.nodeIndex];
 		const toNode = editableWorkflow.value.nodes[offsetIndex + to.nodeIndex];
+		const type = from.type ?? to.type ?? NodeConnectionType.Main;
 
 		return {
 			source: fromNode.id,
@@ -866,11 +867,11 @@ async function onAddNodesAndConnections(
 			data: {
 				source: {
 					index: from.outputIndex ?? 0,
-					type: NodeConnectionType.Main,
+					type,
 				},
 				target: {
 					index: to.inputIndex ?? 0,
-					type: NodeConnectionType.Main,
+					type,
 				},
 			},
 		};


### PR DESCRIPTION
## Summary

<img width="737" alt="image" src="https://github.com/user-attachments/assets/f6d2b546-6df1-402c-b141-22cb710ca74d">

Known issue: insert position is incorrect. Will fix separately.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7718/incorrect-node-position-when-auto-adding-chat-trigger-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
