### PR TITLE
fix(HTTP Request Tool Node): Remove default user agent header

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
@@ -276,7 +276,8 @@ export class ToolHttpRequest implements INodeType {
 			url: this.getNodeParameter('url', itemIndex) as string,
 			qs: {},
 			headers: {
-				// FIXME: This is a workaround to prevent the node from sending a default User-Agent (`n8n`) when the header is not set
+				// FIXME: This is a workaround to prevent the node from sending a default User-Agent (`n8n`) when the header is not set.
+				//  Needs to be replaced with a proper fix after NODE-1777 is resolved
 				'User-Agent': undefined,
 			},
 			body: {},

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
@@ -275,7 +275,10 @@ export class ToolHttpRequest implements INodeType {
 			method: this.getNodeParameter('method', itemIndex, 'GET') as IHttpRequestMethods,
 			url: this.getNodeParameter('url', itemIndex) as string,
 			qs: {},
-			headers: {},
+			headers: {
+				// FIXME: This is a workaround to prevent the node from sending a default User-Agent (`n8n`) when the header is not set
+				'User-Agent': undefined,
+			},
 			body: {},
 		};
 


### PR DESCRIPTION
## Summary

As HTTP Tool node uses newer `helper.httpRequest` and normal HTTP node uses deprecated `helper.request`, they have slightly different in handling user agent header.
This PR adds a workaround so that HTTP Tool node behaves the same way as normal HTTP tool (not sending a default `n8n` user agent header).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-354/change-default-user-agent-in-http-tool-to-the-default-http-node-user

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
