### PR TITLE
fix(benchmark): Always print out container logs after run

### DIFF
--- a/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
+++ b/packages/@n8n/benchmark/scripts/run-for-n8n-setup.mjs
@@ -105,9 +105,8 @@ async function main() {
 		console.error(error.message);
 		console.error('');
 		await printContainerStatus(dockerComposeClient);
-		console.error('');
-		await dumpLogs(dockerComposeClient);
 	} finally {
+		await dumpLogs(dockerComposeClient);
 		await dockerComposeClient.$('down');
 	}
 }
@@ -118,7 +117,7 @@ async function printContainerStatus(dockerComposeClient) {
 }
 
 async function dumpLogs(dockerComposeClient) {
-	console.error('Container logs:');
+	console.info('Container logs:');
 	await dockerComposeClient.$('logs');
 }
 


### PR DESCRIPTION
## Summary

Always print out container logs after run

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
