### PR TITLE
fix(core): Prevent backend from loading duplicate copies of nodes packages

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -18,6 +18,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeHelpers, ApplicationError, ErrorReporterProxy as ErrorReporter } from 'n8n-workflow';
 import path from 'path';
+import picocolors from 'picocolors';
 import { Container, Service } from 'typedi';
 
 import {
@@ -146,6 +147,7 @@ export class LoadNodesAndCredentials {
 					path.join(nodeModulesDir, packagePath),
 				);
 			} catch (error) {
+				this.logger.error((error as Error).message);
 				ErrorReporter.error(error);
 			}
 		}
@@ -258,6 +260,13 @@ export class LoadNodesAndCredentials {
 		dir: string,
 	) {
 		const loader = new constructor(dir, this.excludeNodes, this.includeNodes);
+		if (loader.packageName in this.loaders) {
+			throw new ApplicationError(
+				picocolors.red(
+					`nodes package ${loader.packageName} is already loaded.\n Please delete this second copy at path ${dir}`,
+				),
+			);
+		}
 		await loader.loadAll();
 		this.loaders[loader.packageName] = loader;
 		return loader;

--- a/packages/core/src/DirectoryLoader.ts
+++ b/packages/core/src/DirectoryLoader.ts
@@ -1,5 +1,6 @@
 import glob from 'fast-glob';
-import { readFile } from 'fs/promises';
+import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import type {
 	CodexData,
 	DocumentationLink,
@@ -350,18 +351,11 @@ export class CustomDirectoryLoader extends DirectoryLoader {
  * e.g. /nodes-base or community packages.
  */
 export class PackageDirectoryLoader extends DirectoryLoader {
-	packageName = '';
+	packageJson: n8n.PackageJson = this.readJSONSync('package.json');
 
-	packageJson!: n8n.PackageJson;
-
-	async readPackageJson() {
-		this.packageJson = await this.readJSON('package.json');
-		this.packageName = this.packageJson.name;
-	}
+	packageName = this.packageJson.name;
 
 	override async loadAll() {
-		await this.readPackageJson();
-
 		const { n8n } = this.packageJson;
 		if (!n8n) return;
 
@@ -391,6 +385,17 @@ export class PackageDirectoryLoader extends DirectoryLoader {
 		});
 	}
 
+	protected readJSONSync<T>(file: string): T {
+		const filePath = this.resolvePath(file);
+		const fileString = readFileSync(filePath, 'utf8');
+
+		try {
+			return jsonParse<T>(fileString);
+		} catch (error) {
+			throw new ApplicationError('Failed to parse JSON', { extra: { filePath } });
+		}
+	}
+
 	protected async readJSON<T>(file: string): Promise<T> {
 		const filePath = this.resolvePath(file);
 		const fileString = await readFile(filePath, 'utf8');
@@ -408,8 +413,6 @@ export class PackageDirectoryLoader extends DirectoryLoader {
  */
 export class LazyPackageDirectoryLoader extends PackageDirectoryLoader {
 	override async loadAll() {
-		await this.readPackageJson();
-
 		try {
 			const knownNodes: typeof this.known.nodes = await this.readJSON('dist/known/nodes.json');
 			for (const nodeName in knownNodes) {


### PR DESCRIPTION
## Summary
Right now it's possible for someone to install `n8n-nodes-base` or `@n8n/n8n-nodes-langchain` as a community nodes, which starts messing up the n8n instance after they upgrade n8n, but older version of these packages are still around and being loaded into the app.

This PR
1. Updates `PackageDirectoryLoader` to read the package name in the constructor, so that `loader.packageName` is available before we load any nodes/modules
2. Updates `LoadNodesAndCredentials` to never load a package if a loader for the same package name is already in memory.  

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/webhook-errors-after-updating/55083

## Review / Merge checklist

- [x] PR title and summary are descriptive