### PR TITLE
fix(editor): Fix workflow executions list page redirection

### DIFF
--- a/cypress/e2e/20-workflow-executions.cy.ts
+++ b/cypress/e2e/20-workflow-executions.cy.ts
@@ -229,6 +229,33 @@ describe('Workflow Executions', () => {
 			cy.getByTestId('executions-filter-reset-button').should('be.visible').click();
 			executionsTab.getters.executionListItems().eq(11).should('be.visible');
 		});
+
+		it('should redirect back to editor after seeing a couple of execution using browser back button', () => {
+			createMockExecutions();
+			cy.intercept('GET', '/rest/executions?filter=*').as('getExecutions');
+
+			executionsTab.actions.switchToExecutionsTab();
+
+			cy.wait(['@getExecutions']);
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+
+			executionsTab.getters.executionListItems().eq(2).click();
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+			executionsTab.getters.executionListItems().eq(4).click();
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+			executionsTab.getters.executionListItems().eq(6).click();
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+
+			cy.go('back');
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+			cy.go('back');
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+			cy.go('back');
+			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
+			cy.go('back');
+
+			workflowPage.getters.nodeViewRoot().should('be.visible');
+		});
 	});
 
 	describe('when new workflow is not saved', () => {

--- a/cypress/e2e/20-workflow-executions.cy.ts
+++ b/cypress/e2e/20-workflow-executions.cy.ts
@@ -254,6 +254,8 @@ describe('Workflow Executions', () => {
 			executionsTab.getters.workflowExecutionPreviewIframe().should('exist');
 			cy.go('back');
 
+			cy.url().should('not.include', '/executions');
+			cy.url().should('include', '/workflow/');
 			workflowPage.getters.nodeViewRoot().should('be.visible');
 		});
 	});

--- a/packages/editor-ui/src/views/WorkflowExecutionsView.vue
+++ b/packages/editor-ui/src/views/WorkflowExecutionsView.vue
@@ -113,7 +113,7 @@ function onDocumentVisibilityChange() {
 async function initializeRoute() {
 	if (route.name === VIEWS.EXECUTION_HOME && executions.value.length > 0 && workflow.value) {
 		await router
-			.push({
+			.replace({
 				name: VIEWS.EXECUTION_PREVIEW,
 				params: { name: workflow.value.id, executionId: executions.value[0].id },
 			})


### PR DESCRIPTION
## Summary

The browser back button is not working in workflow executions view

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1988](https://linear.app/n8n/issue/PAY-1988/browser-back-button-broken-in-executions-view#comment-5b4d0aef)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included.
- [ ] PR Labeled with `release/backport`
