### PR TITLE
fix(editor): Fix filter execution by "Queued"

### DIFF
--- a/packages/editor-ui/src/utils/__tests__/executionUtils.spec.ts
+++ b/packages/editor-ui/src/utils/__tests__/executionUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { displayForm, openPopUpWindow } from '../executionUtils';
+import { displayForm, openPopUpWindow, executionFilterToQueryFilter } from '../executionUtils';
 import type { INode, IRunData, IPinData } from 'n8n-workflow';
 
 const FORM_TRIGGER_NODE_TYPE = 'formTrigger';
@@ -124,5 +124,13 @@ describe('displayForm', () => {
 		});
 
 		expect(openPopUpWindow).not.toHaveBeenCalled();
+	});
+
+	describe('executionFilterToQueryFilter()', () => {
+		it('adds "new" to the filter', () => {
+			expect(executionFilterToQueryFilter({ status: 'new' }).status).toStrictEqual(
+				expect.arrayContaining(['new']),
+			);
+		});
 	});
 });

--- a/packages/editor-ui/src/utils/executionUtils.ts
+++ b/packages/editor-ui/src/utils/executionUtils.ts
@@ -64,6 +64,9 @@ export const executionFilterToQueryFilter = (
 		case 'canceled':
 			queryFilter.status = ['canceled'];
 			break;
+		case 'new':
+			queryFilter.status = ['new'];
+			break;
 	}
 
 	return queryFilter;


### PR DESCRIPTION
## Summary

Filtering by "Queued" in the UI would have no effect since the "new" status was being ignored

## Related Linear tickets, Github issues, and Community forum posts
[PAY-2005](https://linear.app/n8n/issue/PAY-2005/queued-executions-filter-broken)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
