### PR TITLE
fix(Todoist Node): Fix listSearch filter bug in Todoist Node

### DIFF
--- a/packages/nodes-base/nodes/Todoist/v2/Service.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/Service.ts
@@ -54,6 +54,11 @@ export interface Service {
 	execute(ctx: Context, operation: OperationType, itemIndex: number): Promise<TodoistResponse>;
 }
 
+export interface TodoistProjectType {
+	id: number;
+	name: string;
+}
+
 export interface TodoistResponse {
 	success?: boolean;
 	data?: IDataObject;

--- a/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
+++ b/packages/nodes-base/nodes/Todoist/v2/TodoistV2.node.ts
@@ -13,7 +13,7 @@ import {
 
 import { todoistApiRequest } from '../GenericFunctions';
 
-import type { OperationType } from './Service';
+import type { OperationType, TodoistProjectType } from './Service';
 import { TodoistService } from './Service';
 
 // interface IBodyCreateTask {
@@ -610,22 +610,24 @@ export class TodoistV2 implements INodeType {
 
 	methods = {
 		listSearch: {
-			async searchProjects(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
-				const projects = await todoistApiRequest.call(this, 'GET', '/projects');
+			async searchProjects(
+				this: ILoadOptionsFunctions,
+				filter?: string,
+			): Promise<INodeListSearchResult> {
+				const projects: TodoistProjectType[] = await todoistApiRequest.call(
+					this,
+					'GET',
+					'/projects',
+				);
 				return {
-					results: projects.map((project: IDataObject) => ({
-						name: project.name,
-						value: project.id,
-					})),
-				};
-			},
-			async searchLabels(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
-				const labels = await todoistApiRequest.call(this, 'GET', '/labels');
-				return {
-					results: labels.map((label: IDataObject) => ({
-						name: label.name,
-						value: label.name,
-					})),
+					results: projects
+						.filter(
+							(project) => !filter || project.name.toLowerCase().includes(filter.toLowerCase()),
+						)
+						.map((project) => ({
+							name: project.name,
+							value: project.id,
+						})),
 				};
 			},
 		},
@@ -636,12 +638,9 @@ export class TodoistV2 implements INodeType {
 				const returnData: INodePropertyOptions[] = [];
 				const projects = await todoistApiRequest.call(this, 'GET', '/projects');
 				for (const project of projects) {
-					const projectName = project.name;
-					const projectId = project.id;
-
 					returnData.push({
-						name: projectName,
-						value: projectId,
+						name: project.name,
+						value: project.id,
 					});
 				}
 
@@ -666,12 +665,9 @@ export class TodoistV2 implements INodeType {
 					const qs: IDataObject = { project_id: projectId };
 					const sections = await todoistApiRequest.call(this, 'GET', '/sections', {}, qs);
 					for (const section of sections) {
-						const sectionName = section.name;
-						const sectionId = section.id;
-
 						returnData.push({
-							name: sectionName,
-							value: sectionId,
+							name: section.name,
+							value: section.id,
 						});
 					}
 				}
@@ -706,12 +702,9 @@ export class TodoistV2 implements INodeType {
 
 					const items = await todoistApiRequest.call(this, 'GET', '/tasks', {}, qs);
 					for (const item of items) {
-						const itemContent = item.content;
-						const itemId = item.id;
-
 						returnData.push({
-							name: itemContent,
-							value: itemId,
+							name: item.content,
+							value: item.id,
 						});
 					}
 				}
@@ -726,10 +719,9 @@ export class TodoistV2 implements INodeType {
 				const labels = await todoistApiRequest.call(this, 'GET', '/labels');
 
 				for (const label of labels) {
-					const labelName = label.name;
 					returnData.push({
-						name: labelName,
-						value: labelName,
+						name: label.name,
+						value: label.name,
 					});
 				}
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Todoist Node's `listSearch` by adding a filter option for project names. The bug was that when searching for a project in the Todoist Node's, the filter did not apply causing all projects to be returned to the options instead of the filtered results. 

It also removes redundant variable declarations. 

![image](https://github.com/user-attachments/assets/52404da6-c976-4b39-877a-8da8be2293cf)

## Related Linear tickets, Github issues, and Community forum posts

[NODE-857](https://linear.app/n8n/issue/NODE-857/bug-filter-bug-in-todoist-node)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
