### PR TITLE
fix(RSS Feed Trigger Node): Fix regression on missing timestamps

### DIFF
--- a/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
@@ -78,14 +78,15 @@ export class RssFeedReadTrigger implements INodeType {
 				return [this.helpers.returnJsonArray(feed.items[0])];
 			}
 			feed.items.forEach((item) => {
-				if (Date.parse(item.isoDate as string) > dateToCheck) {
+				if (item.isoDate && Date.parse(item.isoDate) > dateToCheck) {
 					returnData.push(item);
 				}
 			});
 
 			if (feed.items.length) {
-				const maxIsoDate = Math.max(...feed.items.map(({ isoDate }) => Date.parse(isoDate!)));
-				pollData.lastItemDate = new Date(maxIsoDate).toISOString();
+				pollData.lastItemDate = feed.items.reduce((a, b) =>
+					new Date(a.isoDate!) > new Date(b.isoDate!) ? a : b,
+				).isoDate;
 			}
 		}
 

--- a/packages/nodes-base/nodes/RssFeedRead/test/RssFeedRead.test.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/test/RssFeedRead.test.ts
@@ -46,6 +46,20 @@ describe('RssFeedReadTrigger', () => {
 			expect(pollData.lastItemDate).toEqual(newItemDate);
 		});
 
+		it('should gracefully handle missing timestamps', async () => {
+			const pollData = mock();
+			pollFunctions.getNodeParameter.mockReturnValue(feedUrl);
+			pollFunctions.getWorkflowStaticData.mockReturnValue(pollData);
+			(Parser.prototype.parseURL as jest.Mock).mockResolvedValue({ items: [{}, {}] });
+
+			const result = await node.poll.call(pollFunctions);
+
+			expect(result).toEqual(null);
+			expect(pollFunctions.getWorkflowStaticData).toHaveBeenCalledWith('node');
+			expect(pollFunctions.getNodeParameter).toHaveBeenCalledWith('feedUrl');
+			expect(Parser.prototype.parseURL).toHaveBeenCalledWith(feedUrl);
+		});
+
 		it('should return null if the feed is empty', async () => {
 			const pollData = mock({ lastItemDate });
 			pollFunctions.getNodeParameter.mockReturnValue(feedUrl);


### PR DESCRIPTION
## Summary
In #10855 [I changed how we determined the max isoDate](https://github.com/n8n-io/n8n/pull/10855/files#diff-ee91417349b6fa488efcf4552f57be8c6799e93fdc38e8e01bc3e261b56e11d9L80-L83), assuming that all RSS feeds would contain valid timestamps on every item.  
Turns out that's not the case, since RSS feeds can be hand-crafted to not align with the spec.

This PR reverts back that code, and adds a test to prevent this regression from happening again.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #10986
GHC-260

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
