### PR TITLE
fix(AwsS3 Node): Fix search only using first input parameters

### DIFF
--- a/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
@@ -216,7 +216,7 @@ export class AwsS3V2 implements INodeType {
 						const servicePath = bucketName.includes('.') ? 's3' : `${bucketName}.s3`;
 						const basePath = bucketName.includes('.') ? `/${bucketName}` : '';
 						const returnAll = this.getNodeParameter('returnAll', 0);
-						const additionalFields = this.getNodeParameter('additionalFields', 0);
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 
 						if (additionalFields.prefix) {
 							qs.prefix = additionalFields.prefix as string;


### PR DESCRIPTION
## Summary
Fixes issue with search using `0` instead of the item index for parameters.

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/issues/10996
https://linear.app/n8n/issue/NODE-1783/community-issue-aws-s3-repeats-first-item-in-search-with-prefix
