### PR TITLE
fix: Deregister task runner when connection closes

### DIFF
--- a/packages/cli/src/runners/runner-ws-server.ts
+++ b/packages/cli/src/runners/runner-ws-server.ts
@@ -118,6 +118,7 @@ export class TaskRunnerService {
 
 	removeConnection(id: TaskRunner['id']) {
 		if (id in this.runnerConnections) {
+			this.taskBroker.deregisterRunner(id);
 			this.runnerConnections[id].close();
 			delete this.runnerConnections[id];
 		}


### PR DESCRIPTION
## Summary

Deregister a task runner when it disconnects

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
