### PR TITLE
fix(core): Handle Redis disconnects gracefully

### DIFF
--- a/packages/cli/src/decorators/debounce.ts
+++ b/packages/cli/src/decorators/debounce.ts
@@ -1,5 +1,20 @@
 import debounce from 'lodash/debounce';
 
+/**
+ * Debounce a class method using `lodash/debounce`.
+ *
+ * @param waitMs - Number of milliseconds to debounce method by.
+ *
+ * @example
+ * ```
+ * class MyClass {
+ *   @Debounce(1000)
+ *   async myMethod() {
+ *     // debounced
+ *   }
+ * }
+ * ```
+ */
 export const Debounce =
 	(waitMs: number): MethodDecorator =>
 	<T>(

--- a/packages/cli/src/decorators/debounce.ts
+++ b/packages/cli/src/decorators/debounce.ts
@@ -1,0 +1,22 @@
+import debounce from 'lodash/debounce';
+
+export const Debounce =
+	(waitMs: number): MethodDecorator =>
+	<T>(
+		_: object,
+		methodName: string,
+		originalDescriptor: PropertyDescriptor,
+	): TypedPropertyDescriptor<T> => ({
+		configurable: true,
+
+		get() {
+			const debouncedFn = debounce(originalDescriptor.value, waitMs);
+
+			Object.defineProperty(this, methodName, {
+				configurable: false,
+				value: debouncedFn,
+			});
+
+			return debouncedFn as T;
+		},
+	});

--- a/packages/cli/src/scaling/pubsub/publisher.service.ts
+++ b/packages/cli/src/scaling/pubsub/publisher.service.ts
@@ -24,8 +24,6 @@ export class Publisher {
 		if (config.getEnv('executions.mode') !== 'queue') return;
 
 		this.client = this.redisClientService.createClient({ type: 'publisher(n8n)' });
-
-		this.client.on('error', (error) => this.logger.error(error.message));
 	}
 
 	getClient() {

--- a/packages/cli/src/scaling/pubsub/subscriber.service.ts
+++ b/packages/cli/src/scaling/pubsub/subscriber.service.ts
@@ -27,8 +27,6 @@ export class Subscriber {
 
 		this.client = this.redisClientService.createClient({ type: 'subscriber(n8n)' });
 
-		this.client.on('error', (error) => this.logger.error(error.message));
-
 		this.client.on('message', (channel: PubSub.Channel, message) => {
 			this.handlers.get(channel)?.(message);
 		});

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -27,10 +27,10 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 
 		/** How long (in ms) to wait before resetting the cumulative timeout. */
 		resetLength: 30_000,
-
-		/** Whether any client has lost connection to Redis. */
-		lostConnection: false,
 	};
+
+	/** Whether any client has lost connection to Redis. */
+	private lostConnection = false;
 
 	constructor(
 		private readonly logger: Logger,
@@ -53,9 +53,9 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		});
 
 		client.on('ready', () => {
-			if (this.config.lostConnection) {
+			if (this.lostConnection) {
 				this.emit('connection-recovered');
-				this.config.lostConnection = false;
+				this.lostConnection = false;
 			}
 		});
 
@@ -212,7 +212,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 
 			this.logger.warn(`Lost Redis connection. ${reconnectionMsg} (${timeoutDetails})`);
 
-			this.config.lostConnection = true;
+			this.lostConnection = true;
 		});
 
 		this.on('connection-recovered', () => {

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -202,11 +202,11 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 	private registerListeners() {
 		const { maxTimeout: maxTimeoutMs, retryInterval: retryIntervalMs } = this.config;
 
-		const retryInterval = Math.round(retryIntervalMs / 1000) + 's';
-		const maxTimeout = Math.round(maxTimeoutMs / 1000) + 's';
+		const retryInterval = this.formatTimeout(retryIntervalMs);
+		const maxTimeout = this.formatTimeout(maxTimeoutMs);
 
 		this.on('connection-lost', (cumulativeTimeoutMs) => {
-			const cumulativeTimeout = Math.round(cumulativeTimeoutMs / 1000) + 's';
+			const cumulativeTimeout = this.formatTimeout(cumulativeTimeoutMs);
 			const reconnectionMsg = `Trying to reconnect in ${retryInterval}...`;
 			const timeoutDetails = `${cumulativeTimeout}/${maxTimeout}`;
 
@@ -218,5 +218,12 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 		this.on('connection-recovered', () => {
 			this.logger.info('Recovered Redis connection');
 		});
+	}
+
+	private formatTimeout(timeoutMs: number) {
+		const timeoutSeconds = timeoutMs / 1000;
+		const roundedTimeout = Math.round(timeoutSeconds * 10) / 10;
+
+		return roundedTimeout + 's';
 	}
 }

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -3,24 +3,61 @@ import ioRedis from 'ioredis';
 import type { Cluster, RedisOptions } from 'ioredis';
 import { Service } from 'typedi';
 
+import { Debounce } from '@/decorators/debounce';
 import { Logger } from '@/logger';
+import { TypedEmitter } from '@/typed-emitter';
 
 import type { RedisClientType } from '../scaling/redis/redis.types';
 
+type RedisEventMap = {
+	'connection-lost': number;
+	'connection-recovered': never;
+};
+
 @Service()
-export class RedisClientService {
+export class RedisClientService extends TypedEmitter<RedisEventMap> {
 	private readonly clients = new Set<ioRedis | Cluster>();
+
+	private readonly config = {
+		/** How long (in ms) to try to reconnect for before exiting. */
+		maxTimeout: this.globalConfig.queue.bull.redis.timeoutThreshold,
+
+		/** How long (in ms) to wait between reconnection attempts. */
+		retryInterval: 1000,
+
+		/** How long (in ms) to wait before resetting the cumulative timeout. */
+		resetLength: 30_000,
+
+		/** Whether any client has lost connection to Redis. */
+		lostConnection: false,
+	};
 
 	constructor(
 		private readonly logger: Logger,
 		private readonly globalConfig: GlobalConfig,
-	) {}
+	) {
+		super();
+		this.registerListeners();
+	}
 
 	createClient(arg: { type: RedisClientType; extraOptions?: RedisOptions }) {
 		const client =
 			this.clusterNodes().length > 0
 				? this.createClusterClient(arg)
 				: this.createRegularClient(arg);
+
+		client.on('error', (error) => {
+			if ('code' in error && error.code === 'ECONNREFUSED') return; // handled by retryStrategy
+
+			this.logger.error(`[Redis client] ${error.message}`, { error });
+		});
+
+		client.on('ready', () => {
+			if (this.config.lostConnection) {
+				this.emit('connection-recovered');
+				this.config.lostConnection = false;
+			}
+		});
 
 		this.clients.add(client);
 
@@ -118,32 +155,29 @@ export class RedisClientService {
 	 * Reset the cumulative timeout if >30s between reconnection attempts.
 	 */
 	private retryStrategy() {
-		const RETRY_INTERVAL = 500; // ms
-		const RESET_LENGTH = 30_000; // ms
-		const MAX_TIMEOUT = this.globalConfig.queue.bull.redis.timeoutThreshold;
-
 		let lastAttemptTs = 0;
 		let cumulativeTimeout = 0;
 
 		return () => {
 			const nowTs = Date.now();
 
-			if (nowTs - lastAttemptTs > RESET_LENGTH) {
+			if (nowTs - lastAttemptTs > this.config.resetLength) {
 				cumulativeTimeout = 0;
 				lastAttemptTs = nowTs;
 			} else {
 				cumulativeTimeout += nowTs - lastAttemptTs;
 				lastAttemptTs = nowTs;
-				if (cumulativeTimeout > MAX_TIMEOUT) {
-					this.logger.error(`[Redis] Unable to connect after max timeout of ${MAX_TIMEOUT} ms`);
-					this.logger.error('Exiting process...');
+				if (cumulativeTimeout > this.config.maxTimeout) {
+					const maxTimeout = Math.round(this.config.maxTimeout / 1000) + 's';
+					this.logger.error(`Unable to connect to Redis after trying to connect for ${maxTimeout}`);
+					this.logger.error('Exiting process due to Redis connection error');
 					process.exit(1);
 				}
 			}
 
-			this.logger.warn('Redis unavailable - trying to reconnect...');
+			this.emit('connection-lost', cumulativeTimeout);
 
-			return RETRY_INTERVAL;
+			return this.config.retryInterval;
 		};
 	}
 
@@ -155,5 +189,34 @@ export class RedisClientService {
 				const [host, port] = pair.split(':');
 				return { host, port: parseInt(port) };
 			});
+	}
+
+	@Debounce(1000)
+	emit<Event extends keyof RedisEventMap>(
+		event: Event,
+		...args: Array<RedisEventMap[Event]>
+	): boolean {
+		return super.emit(event, ...args);
+	}
+
+	private registerListeners() {
+		const { maxTimeout: maxTimeoutMs, retryInterval: retryIntervalMs } = this.config;
+
+		const retryInterval = Math.round(retryIntervalMs / 1000) + 's';
+		const maxTimeout = Math.round(maxTimeoutMs / 1000) + 's';
+
+		this.on('connection-lost', (cumulativeTimeoutMs) => {
+			const cumulativeTimeout = Math.round(cumulativeTimeoutMs / 1000) + 's';
+			const reconnectionMsg = `Trying to reconnect in ${retryInterval}...`;
+			const timeoutDetails = `${cumulativeTimeout}/${maxTimeout}`;
+
+			this.logger.warn(`Lost Redis connection. ${reconnectionMsg} (${timeoutDetails})`);
+
+			this.config.lostConnection = true;
+		});
+
+		this.on('connection-recovered', () => {
+			this.logger.info('Recovered Redis connection');
+		});
 	}
 }


### PR DESCRIPTION
Currently a Redis disconnect triggers [all manner of logs](https://n8nio.slack.com/archives/C069HS026UF/p1723618011118889) from multiple related services and from all six Redis clients simultaneously. This PR handles Redis this scenario [more gracefully](https://share.cleanshot.com/hhLH2Vc7).