### PR TITLE
fix(editor): Color scheme for a markdown code blocks in dark mode

### DIFF
--- a/packages/@n8n/chat/src/css/markdown.scss
+++ b/packages/@n8n/chat/src/css/markdown.scss
@@ -1,4 +1,10 @@
-@import 'highlight.js/styles/github.css';
+@use "sass:meta";
+
+@include meta.load-css("highlight.js/styles/github.css");
+
+body[data-theme="dark"] {
+	@include meta.load-css("highlight.js/styles/github-dark-dimmed.css");
+}
 
 // https://github.com/pxlrbt/markdown-css
 .chat-message-markdown {
@@ -561,7 +567,6 @@
 
 	kbd, /* different style for kbd? */
 	code {
-		background: #eee;
 		padding: 0.1em 0.25em;
 		border-radius: 0.2rem;
 		-webkit-box-decoration-break: clone;

--- a/packages/@n8n/chat/src/css/markdown.scss
+++ b/packages/@n8n/chat/src/css/markdown.scss
@@ -1,9 +1,9 @@
-@use "sass:meta";
+@use 'sass:meta';
 
-@include meta.load-css("highlight.js/styles/github.css");
+@include meta.load-css('highlight.js/styles/github.css');
 
-body[data-theme="dark"] {
-	@include meta.load-css("highlight.js/styles/github-dark-dimmed.css");
+body[data-theme='dark'] {
+	@include meta.load-css('highlight.js/styles/github-dark-dimmed.css');
 }
 
 // https://github.com/pxlrbt/markdown-css

--- a/packages/@n8n/chat/src/css/markdown.scss
+++ b/packages/@n8n/chat/src/css/markdown.scss
@@ -2,8 +2,18 @@
 
 @include meta.load-css('highlight.js/styles/github.css');
 
-body[data-theme='dark'] {
+@mixin hljs-dark-theme {
 	@include meta.load-css('highlight.js/styles/github-dark-dimmed.css');
+}
+
+body {
+	&[data-theme='dark'] {
+		@include hljs-dark-theme;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		@include hljs-dark-theme;
+	}
 }
 
 // https://github.com/pxlrbt/markdown-css

--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
@@ -145,6 +145,13 @@ watchDebounced(
 	color: var(--color-text-base);
 	font-size: var(--font-size-2xs);
 	padding: var(--spacing-2xs);
+
+	code {
+		font-size: var(--font-size-3xs);
+		background: var(--color-background-base);
+		padding: var(--spacing-5xs);
+		border-radius: var(--border-radius-base);
+	}
 }
 
 .content {
@@ -163,13 +170,6 @@ watchDebounced(
 
 .text {
 	display: inline;
-}
-
-code {
-	font-size: var(--font-size-3xs);
-	background: var(--color-background-base);
-	padding: var(--spacing-5xs);
-	border-radius: var(--border-radius-base);
 }
 
 .pill {

--- a/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
@@ -680,6 +680,9 @@ onMounted(() => {
 	[data-theme='dark'] & {
 		--chat--input--text-color: var(--input-font-color, var(--color-text-dark));
 	}
+	@media (prefers-color-scheme: dark) {
+		--chat--input--text-color: var(--input-font-color, var(--color-text-dark));
+	}
 
 	border-bottom-right-radius: var(--border-radius-base);
 	border-top-right-radius: var(--border-radius-base);


### PR DESCRIPTION
## Summary

This PR fixes the code highlighting in markdown section for dark mode

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-331/color-scheme-for-a-code-blocks-in-dark-mode

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
