### PR TITLE
fix(Chat Trigger Node): Fix Allowed Origins paramter

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -241,16 +241,14 @@ export class ChatTrigger extends Node {
 				default: {},
 				options: [
 					// CORS parameters are only valid for when chat is used in hosted or webhook mode
-					...(Array.isArray(commonCORSParameters)
-						? commonCORSParameters.map((p: INodeProperties) => ({
-								...p,
-								displayOptions: {
-									show: {
-										'/mode': ['hostedChat', 'webhook'],
-									},
-								},
-							}))
-						: []),
+					...commonCORSParameters.map((p) => ({
+						...p,
+						displayOptions: {
+							show: {
+								'/mode': ['hostedChat', 'webhook'],
+							},
+						},
+					})),
 					{
 						...allowFileUploadsOption,
 						displayOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -1,4 +1,6 @@
-import { Node, NodeConnectionType } from 'n8n-workflow';
+import type { BaseChatMemory } from '@langchain/community/memory/chat_memory';
+import { pick } from 'lodash';
+import { Node, NodeConnectionType, commonCORSParameters } from 'n8n-workflow';
 import type {
 	IDataObject,
 	IWebhookFunctions,
@@ -10,10 +12,8 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
-import { pick } from 'lodash';
-import type { BaseChatMemory } from '@langchain/community/memory/chat_memory';
-import { createPage } from './templates';
 import { validateAuth } from './GenericFunctions';
+import { createPage } from './templates';
 import type { LoadPreviousSessionChatOption } from './types';
 
 const CHAT_TRIGGER_PATH_IDENTIFIER = 'chat';
@@ -56,7 +56,6 @@ export class ChatTrigger extends Node {
 				],
 			},
 		},
-		supportsCORS: true,
 		maxNodes: 1,
 		inputs: `={{ (() => {
 			if (!['hostedChat', 'webhook'].includes($parameter.mode)) {
@@ -241,6 +240,17 @@ export class ChatTrigger extends Node {
 				placeholder: 'Add Field',
 				default: {},
 				options: [
+					// CORS parameters are only valid for when chat is used in hosted or webhook mode
+					...(Array.isArray(commonCORSParameters)
+						? commonCORSParameters.map((p: INodeProperties) => ({
+								...p,
+								displayOptions: {
+									show: {
+										'/mode': ['hostedChat', 'webhook'],
+									},
+								},
+							}))
+						: []),
 					{
 						...allowFileUploadsOption,
 						displayOptions: {

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -1,5 +1,5 @@
 import type { Response } from 'express';
-import { Workflow, NodeHelpers } from 'n8n-workflow';
+import { Workflow, NodeHelpers, CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { INode, IWebhookData, IHttpRequestMethods } from 'n8n-workflow';
 import { Service } from 'typedi';
 
@@ -47,12 +47,18 @@ export class LiveWebhooks implements IWebhookManager {
 			select: ['nodes'],
 		});
 
+		const isChatWebhookNode = (type: string, webhookId?: string) =>
+			type === CHAT_TRIGGER_NODE_TYPE && `${webhookId}/chat` === path;
+
 		const nodes = workflowData?.nodes;
 		const webhookNode = nodes?.find(
-			({ type, parameters, typeVersion }) =>
-				parameters?.path === path &&
-				(parameters?.httpMethod ?? 'GET') === httpMethod &&
-				'webhook' in this.nodeTypes.getByNameAndVersion(type, typeVersion),
+			({ type, parameters, typeVersion, webhookId }) =>
+				(parameters?.path === path &&
+					(parameters?.httpMethod ?? 'GET') === httpMethod &&
+					'webhook' in this.nodeTypes.getByNameAndVersion(type, typeVersion)) ||
+				// Chat Trigger has doesn't have configurable path and is always using POST, so
+				// we need to use webhookId for matching
+				isChatWebhookNode(type, webhookId),
 		);
 		return webhookNode?.parameters?.options as WebhookAccessControlOptions;
 	}

--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -259,7 +259,7 @@ const commonPollingParameters: INodeProperties[] = [
 	},
 ];
 
-const commonCORSParameters: INodeProperties[] = [
+export const commonCORSParameters: INodeProperties[] = [
 	{
 		displayName: 'Allowed Origins (CORS)',
 		name: 'allowedOrigins',


### PR DESCRIPTION
## Summary

This PR addresses issues with the Chat Trigger node's CORS settings and the parameter matching:

- Corrects the display of the `allowedOrigins` option, ensuring it appears only for hosted and webhook modes.
- Fixes the webhook matching logic for Chat Trigger nodes, which previously didn't work due to path and method matching limitations.
- Exposes commonCORSParameters from the workflow package for reuse.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
