### PR TITLE
fix(editor): Respect tag querystring filter when listing workflows

### DIFF
--- a/cypress/e2e/1-workflows.cy.ts
+++ b/cypress/e2e/1-workflows.cy.ts
@@ -73,4 +73,28 @@ describe('Workflows', () => {
 
 		WorkflowsPage.getters.newWorkflowButtonCard().should('be.visible');
 	});
+
+	it('should respect tag querystring filter when listing workflows', () => {
+		WorkflowsPage.getters.newWorkflowButtonCard().click();
+
+		cy.createFixtureWorkflow('Test_workflow_2.json', getUniqueWorkflowName('My New Workflow'));
+
+		cy.visit(WorkflowsPage.url);
+
+		WorkflowsPage.getters.createWorkflowButton().click();
+
+		cy.createFixtureWorkflow('Test_workflow_1.json', 'Empty State Card Workflow');
+
+		cy.visit(WorkflowsPage.url);
+
+		WorkflowsPage.getters.workflowFilterButton().click();
+
+		WorkflowsPage.getters.workflowTagsDropdown().click();
+
+		WorkflowsPage.getters.workflowTagItem('some-tag-1').click();
+
+		cy.reload();
+
+		WorkflowsPage.getters.workflowCards().should('have.length', 1);
+	});
 });

--- a/packages/editor-ui/src/components/WorkflowTagsDropdown.vue
+++ b/packages/editor-ui/src/components/WorkflowTagsDropdown.vue
@@ -52,9 +52,6 @@ function handleEsc() {
 function handleBlur() {
 	emit('blur');
 }
-
-// Fetch all tags when the component is created
-void tagsStore.fetchAll();
 </script>
 
 <template>

--- a/packages/editor-ui/src/components/WorkflowTagsDropdown.vue
+++ b/packages/editor-ui/src/components/WorkflowTagsDropdown.vue
@@ -52,6 +52,9 @@ function handleEsc() {
 function handleBlur() {
 	emit('blur');
 }
+
+// Fetch all tags when the component is created
+void tagsStore.fetchAll();
 </script>
 
 <template>

--- a/packages/editor-ui/src/views/WorkflowsView.test.ts
+++ b/packages/editor-ui/src/views/WorkflowsView.test.ts
@@ -22,6 +22,7 @@ describe('WorkflowsView', () => {
 	let projectsStore: ReturnType<typeof useProjectsStore>;
 
 	const routerReplaceMock = vi.fn();
+	const routerPushMock = vi.fn();
 
 	const renderComponent = createComponentRenderer(WorkflowsView, {
 		global: {
@@ -32,6 +33,7 @@ describe('WorkflowsView', () => {
 				},
 				$router: {
 					replace: routerReplaceMock,
+					push: routerPushMock,
 				},
 			},
 		},

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -152,6 +152,9 @@ const WorkflowsView = defineComponent({
 	},
 	async mounted() {
 		this.documentTitle.set(this.$locale.baseText('workflows.heading'));
+
+		await this.tagsStore.fetchAll();
+
 		await this.setFiltersFromQueryString();
 
 		void this.usersStore.showPersonalizationSurvey();

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -298,6 +298,16 @@ const WorkflowsView = defineComponent({
 				filtersToApply.status = status === 'true';
 			}
 
+			// remove all empty filters in the querystring
+			await this.$router.push({
+				query: {
+					...(tags && { tags }),
+					...(status && { status }),
+					...(search && { search }),
+					...(homeProject && { homeProject }),
+				},
+			});
+
 			if (Object.keys(filtersToApply).length) {
 				this.filters = {
 					...this.filters,

--- a/packages/editor-ui/src/views/WorkflowsView.vue
+++ b/packages/editor-ui/src/views/WorkflowsView.vue
@@ -26,6 +26,8 @@ interface Filters {
 	tags: string[];
 }
 
+type QueryFilters = Partial<Filters>;
+
 const StatusFilter = {
 	ACTIVE: true,
 	DEACTIVATED: false,
@@ -266,10 +268,20 @@ const WorkflowsView = defineComponent({
 		isValidProjectId(projectId: string) {
 			return this.projectsStore.availableProjects.some((project) => project.id === projectId);
 		},
+		async removeInvalidQueryFiltersFromUrl(filtersToApply: QueryFilters) {
+			await this.$router.push({
+				query: {
+					...(filtersToApply.tags && { tags: filtersToApply.tags?.join(',') }),
+					...(filtersToApply.status && { status: filtersToApply.status?.toString() }),
+					...(filtersToApply.search && { search: filtersToApply.search }),
+					...(filtersToApply.homeProject && { homeProject: filtersToApply.homeProject }),
+				},
+			});
+		},
 		async setFiltersFromQueryString() {
 			const { tags, status, search, homeProject } = this.$route.query;
 
-			const filtersToApply: { [key: string]: string | string[] | boolean } = {};
+			const filtersToApply: QueryFilters = {};
 
 			if (homeProject && typeof homeProject === 'string') {
 				await this.projectsStore.getAvailableProjects();
@@ -298,15 +310,7 @@ const WorkflowsView = defineComponent({
 				filtersToApply.status = status === 'true';
 			}
 
-			// remove all empty filters in the querystring
-			await this.$router.push({
-				query: {
-					...(tags && { tags }),
-					...(status && { status }),
-					...(search && { search }),
-					...(homeProject && { homeProject }),
-				},
-			});
+			await this.removeInvalidQueryFiltersFromUrl(filtersToApply);
 
 			if (Object.keys(filtersToApply).length) {
 				this.filters = {


### PR DESCRIPTION
## Summary

Before: 

https://share.cleanshot.com/3L7WJ8CP

Now:

https://share.cleanshot.com/YHzDqbdW

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2366/homepage-the-filter-status-set-in-the-url-query-params-is-lost-if-i

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
