### PR TITLE
fix(Github Document Loader Node): Pass through apiUrl from credentials & fix log output

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/document_loaders/DocumentGithubLoader/DocumentGithubLoader.node.ts
@@ -109,17 +109,22 @@ export class DocumentGithubLoader implements INodeType {
 			0,
 		)) as CharacterTextSplitter | undefined;
 
+		const { index } = this.addInputData(NodeConnectionType.AiDocument, [
+			[{ json: { repository, branch, ignorePaths, recursive } }],
+		]);
 		const docs = new GithubRepoLoader(repository, {
 			branch,
 			ignorePaths: (ignorePaths ?? '').split(',').map((p) => p.trim()),
 			recursive,
 			accessToken: (credentials.accessToken as string) || '',
+			apiUrl: credentials.server as string,
 		});
 
 		const loadedDocs = textSplitter
 			? await textSplitter.splitDocuments(await docs.load())
 			: await docs.load();
 
+		this.addOutputData(NodeConnectionType.AiDocument, index, [[{ json: { loadedDocs } }]]);
 		return {
 			response: logWrapper(loadedDocs, this),
 		};


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Github loader wouldn't be usable with other than the default Github API URL. I also added
`addInputData` and `addOutputData` calls to make sure we show the items in the AI logs.
![CleanShot 2024-10-02 at 09 41 34@2x](https://github.com/user-attachments/assets/1d81ad39-3ad0-4855-ab99-9ab024d31434)


## Related Linear tickets, Github issues, and Community forum posts
- https://github.com/n8n-io/n8n/issues/11037

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
