### PR TITLE
fix: Task Runner Auth CI fail with busy event loop (no-changelog)

### DIFF
--- a/packages/cli/src/runners/auth/__tests__/task-runner-auth.service.test.ts
+++ b/packages/cli/src/runners/auth/__tests__/task-runner-auth.service.test.ts
@@ -3,6 +3,7 @@ import { sleep } from 'n8n-workflow';
 
 import config from '@/config';
 import { CacheService } from '@/services/cache/cache.service';
+import { retryUntil } from '@test-integration/retry-until';
 
 import { mockInstance } from '../../../../test/shared/mocking';
 import { TaskRunnerAuthService } from '../task-runner-auth.service';
@@ -86,7 +87,9 @@ describe('TaskRunnerAuthService', () => {
 			// Act
 			await sleep(TTL + 1);
 
-			expect(await authService.tryConsumeGrantToken(grantToken)).toBe(false);
+			await retryUntil(async () =>
+				expect(await authService.tryConsumeGrantToken(grantToken)).toBe(false),
+			);
 		});
 	});
 });

--- a/packages/cli/test/integration/shared/retry-until.ts
+++ b/packages/cli/test/integration/shared/retry-until.ts
@@ -1,0 +1,32 @@
+/**
+ * Retries the given assertion until it passes or the timeout is reached
+ *
+ * @example
+ * await retryUntil(
+ *   () => expect(service.someState).toBe(true)
+ * );
+ */
+export const retryUntil = async (
+	assertion: () => Promise<void> | void,
+	{ interval = 20, timeout = 1000 } = {},
+) => {
+	return await new Promise((resolve, reject) => {
+		const startTime = Date.now();
+
+		const tryAgain = () => {
+			setTimeout(async () => {
+				try {
+					resolve(await assertion());
+				} catch (error) {
+					if (Date.now() - startTime > timeout) {
+						reject(error);
+					} else {
+						tryAgain();
+					}
+				}
+			}, interval);
+		};
+
+		tryAgain();
+	});
+};


### PR DESCRIPTION
## Summary
The Task Runner Auth service tests can sometimes fail if the system is under heavy load. This is likely due to some issues internal to the `cache-manager` package when using the 'memory' store.

## Related Linear tickets, Github issues, and Community forum posts
https://github.com/n8n-io/n8n/actions/runs/11141035080/job/30961206638

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
