### PR TITLE
chore: Anonymise ip addresses in rudderstack events

### DIFF
--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -267,6 +267,44 @@ describe('Telemetry', () => {
 			expect(execBuffer['2'].prod_success?.first).toEqual(execTime1);
 		});
 	});
+
+	describe('Rudderstack', () => {
+		test("should call rudderStack.identify() with a fake IP address to instruct Rudderstack to not use the user's IP address", () => {
+			const traits = {
+				name: 'Test User',
+				age: 30,
+				isActive: true,
+			};
+
+			telemetry.identify(traits);
+
+			const expectedArgs = {
+				userId: instanceId,
+				traits: { ...traits, instanceId },
+				context: {
+					ip: '0.0.0.0', // RudderStack anonymized IP
+				},
+			};
+
+			expect(mockRudderStack.identify).toHaveBeenCalledWith(expectedArgs);
+		});
+
+		test("should call rudderStack.track() with a fake IP address to instruct Rudderstack to not use the user's IP address", () => {
+			const eventName = 'Test Event';
+			const properties = { user_id: '1234' };
+
+			telemetry.track(eventName, properties);
+
+			expect(mockRudderStack.track).toHaveBeenCalledWith(
+				expect.objectContaining({
+					event: eventName,
+					context: {
+						ip: '0.0.0.0', // RudderStack anonymized IP
+					},
+				}),
+			);
+		});
+	});
 });
 
 const fakeJestSystemTime = (dateTime: string | Date): Date => {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -188,6 +188,10 @@ export class Telemetry {
 		this.rudderStack.identify({
 			userId: instanceId,
 			traits: { ...traits, instanceId },
+			context: {
+				// provide a fake IP address to instruct RudderStack to not use the user's IP address
+				ip: '0.0.0.0',
+			},
 		});
 	}
 
@@ -212,13 +216,18 @@ export class Telemetry {
 			userId: `${instanceId}${user_id ? `#${user_id}` : ''}`,
 			event: eventName,
 			properties: updatedProperties,
+			context: {},
 		};
 
 		if (withPostHog) {
 			this.postHog?.track(payload);
 		}
 
-		return this.rudderStack.track(payload);
+		return this.rudderStack.track({
+			...payload,
+			// provide a fake IP address to instruct RudderStack to not use the user's IP address
+			context: { ...payload.context, ip: '0.0.0.0' },
+		});
 	}
 
 	// test helpers

--- a/packages/editor-ui/src/plugins/__tests__/telemetry.test.ts
+++ b/packages/editor-ui/src/plugins/__tests__/telemetry.test.ts
@@ -38,9 +38,11 @@ describe('telemetry', () => {
 
 			telemetry.identify(userId, instanceId);
 			expect(identifyFunction).toHaveBeenCalledTimes(1);
-			expect(identifyFunction).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
-				instance_id: instanceId,
-			});
+			expect(identifyFunction).toHaveBeenCalledWith(
+				`${instanceId}#${userId}`,
+				{ instance_id: instanceId },
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 
 		it('Rudderstack identify method should be called when proving userId and versionCli ', () => {
@@ -60,10 +62,14 @@ describe('telemetry', () => {
 
 			telemetry.identify(userId, instanceId, versionCli);
 			expect(identifyFunction).toHaveBeenCalledTimes(1);
-			expect(identifyFunction).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
-				instance_id: instanceId,
-				version_cli: versionCli,
-			});
+			expect(identifyFunction).toHaveBeenCalledWith(
+				`${instanceId}#${userId}`,
+				{
+					instance_id: instanceId,
+					version_cli: versionCli,
+				},
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 
 		it('Rudderstack identify method should be called when proving userId and versionCli and projectId', () => {
@@ -84,10 +90,14 @@ describe('telemetry', () => {
 
 			telemetry.identify(userId, instanceId, versionCli, projectId);
 			expect(identifyFunction).toHaveBeenCalledTimes(1);
-			expect(identifyFunction).toHaveBeenCalledWith(`${instanceId}#${userId}#${projectId}`, {
-				instance_id: instanceId,
-				version_cli: versionCli,
-			});
+			expect(identifyFunction).toHaveBeenCalledWith(
+				`${instanceId}#${userId}#${projectId}`,
+				{
+					instance_id: instanceId,
+					version_cli: versionCli,
+				},
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 
 		it('Rudderstack identify method should be called when proving userId and deployment type is cloud ', () => {
@@ -111,11 +121,15 @@ describe('telemetry', () => {
 
 			telemetry.identify(userId, instanceId, versionCli);
 			expect(identifyFunction).toHaveBeenCalledTimes(1);
-			expect(identifyFunction).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
-				instance_id: instanceId,
-				version_cli: versionCli,
-				user_cloud_id: userCloudId,
-			});
+			expect(identifyFunction).toHaveBeenCalledWith(
+				`${instanceId}#${userId}`,
+				{
+					instance_id: instanceId,
+					version_cli: versionCli,
+					user_cloud_id: userCloudId,
+				},
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 
 		it('Rudderstack identify method should be called when proving userId and deployment type is cloud', () => {
@@ -139,11 +153,15 @@ describe('telemetry', () => {
 
 			telemetry.identify(userId, instanceId, versionCli);
 			expect(identifyFunction).toHaveBeenCalledTimes(1);
-			expect(identifyFunction).toHaveBeenCalledWith(`${instanceId}#${userId}`, {
-				instance_id: instanceId,
-				version_cli: versionCli,
-				user_cloud_id: userCloudId,
-			});
+			expect(identifyFunction).toHaveBeenCalledWith(
+				`${instanceId}#${userId}`,
+				{
+					instance_id: instanceId,
+					version_cli: versionCli,
+					user_cloud_id: userCloudId,
+				},
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 
 		it('Rudderstack reset method should be called when proving userId and deployment type is cloud', () => {
@@ -175,10 +193,14 @@ describe('telemetry', () => {
 			telemetry.track(event, properties, options);
 
 			expect(trackFunction).toHaveBeenCalledTimes(1);
-			expect(trackFunction).toHaveBeenCalledWith(event, {
-				...properties,
-				version_cli: MOCK_VERSION_CLI,
-			});
+			expect(trackFunction).toHaveBeenCalledWith(
+				event,
+				{
+					...properties,
+					version_cli: MOCK_VERSION_CLI,
+				},
+				{ context: { ip: '0.0.0.0' } },
+			);
 		});
 	});
 });

--- a/packages/editor-ui/src/plugins/telemetry/index.ts
+++ b/packages/editor-ui/src/plugins/telemetry/index.ts
@@ -94,6 +94,12 @@ export class Telemetry {
 			this.rudderStack?.identify(
 				`${instanceId}#${userId}${projectId ? '#' + projectId : ''}`,
 				traits,
+				{
+					context: {
+						// provide a fake IP address to instruct RudderStack to not use the user's IP address
+						ip: '0.0.0.0',
+					},
+				},
 			);
 		} else {
 			this.rudderStack?.reset();
@@ -112,7 +118,12 @@ export class Telemetry {
 			version_cli: useRootStore().versionCli,
 		};
 
-		this.rudderStack.track(event, updatedProperties);
+		this.rudderStack.track(event, updatedProperties, {
+			context: {
+				// provide a fake IP address to instruct RudderStack to not use the user's IP address
+				ip: '0.0.0.0',
+			},
+		});
 
 		if (options.withPostHog) {
 			usePostHog().capture(event, updatedProperties);
@@ -136,7 +147,12 @@ export class Telemetry {
 			properties.theme = useUIStore().appliedTheme;
 
 			const category = route.meta?.telemetry?.pageCategory || 'Editor';
-			this.rudderStack.page(category, pageName, properties);
+			this.rudderStack.page(category, pageName, properties, {
+				context: {
+					// provide a fake IP address to instruct RudderStack to not use the user's IP address
+					ip: '0.0.0.0',
+				},
+			});
 		} else {
 			this.pageEventQueue.push({
 				route,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Provides a fake IP address (`0.0.0.0`) to Rudderstack when emitting telemetry events to instruct Rudderstack to not fetch the actual IP address of the users when processing the telemetry event.

In fact, according to [these Rudderstack docs](https://www.rudderstack.com/docs/event-spec/standard-events/common-fields/#how-rudderstack-collects-ip-address), the Rudderstack backend will not fetch the user's IP address if an IP address was already provided as part of the event context.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

- [ADO-2384](https://linear.app/n8n/issue/ADO-2384/anonymise-ip-addresses-in-rudderstack-events)
- [ADO-2433](https://linear.app/n8n/issue/ADO-2433/override-ip-in-n8n-fe-and-be)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
