### PR TITLE
fix(editor): Update Usage page for Community edition

### DIFF
--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1797,6 +1797,7 @@
 	"settings.usageAndPlan.license.activation.error.title": "Activation failed",
 	"settings.usageAndPlan.license.activation.success.title": "License activated",
 	"settings.usageAndPlan.license.activation.success.message": "Your {name} {type} has been successfully activated.",
+	"settings.usageAndPlan.license.communityRegistered.tooltip": "You have registered your email to unlock additional features on your community plan",
 	"settings.externalSecrets.title": "External Secrets",
 	"settings.externalSecrets.info": "Connect external secrets tools for centralized credentials management across environments, and to enhance system security.",
 	"settings.externalSecrets.info.link": "More info",

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -18,8 +18,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
-let usageStore: ReturnType<typeof mockedStore<useUsageStore>>;
-let settingsStore: ReturnType<typeof mockedStore<useSettingsStore>>;
+let usageStore: ReturnType<typeof mockedStore<typeof useUsageStore>>;
+let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -4,6 +4,7 @@ import { mockedStore } from '@/__tests__/utils';
 import { useUsageStore } from '@/stores/usage.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import SettingsUsageAndPlan from '@/views/SettingsUsageAndPlan.vue';
+import { FrontendSettings } from '@n8n/api-types/src';
 
 vi.mock('vue-router', () => {
 	return {
@@ -32,11 +33,10 @@ describe('SettingsUsageAndPlan', () => {
 		settingsStore.settings = {
 			instanceId: 'instance-id',
 			license: {
-				consumerId: 'consumer-id',
 				environment: 'production',
 			},
 			versionCli: '0.0.0',
-		};
+		} as FrontendSettings;
 	});
 
 	it('should not throw errors when rendering', async () => {

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -1,0 +1,60 @@
+import { createTestingPinia } from '@pinia/testing';
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { useUsageStore } from '@/stores/usage.store';
+import { useSettingsStore } from '@/stores/settings.store';
+import SettingsUsageAndPlan from '@/views/SettingsUsageAndPlan.vue';
+
+vi.mock('vue-router', () => {
+	return {
+		useRoute: () => ({
+			query: {},
+		}),
+		useRouter: () => ({
+			replace: vi.fn(),
+		}),
+		RouterLink: {
+			template: '<a><slot /></a>',
+		},
+	};
+});
+let usageStore: ReturnType<typeof mockedStore<ReturnType<typeof useUsageStore>>>;
+let settingsStore: ReturnType<typeof mockedStore<ReturnType<typeof useSettingsStore>>>;
+
+const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
+
+describe('SettingsUsageAndPlan', () => {
+	beforeEach(() => {
+		createTestingPinia();
+		usageStore = mockedStore(useUsageStore);
+		settingsStore = mockedStore(useSettingsStore);
+
+		settingsStore.settings = {
+			instanceId: 'instance-id',
+			license: {
+				environment: 'production',
+			},
+			versionCli: '0.0.0',
+		};
+	});
+
+	it('should not throw errors when rendering', async () => {
+		expect(() => renderComponent()).not.toThrow();
+	});
+
+	it('should render the title only while loading', async () => {
+		const { getByRole } = renderComponent();
+		expect(getByRole('heading', { level: 2 })).toBeInTheDocument();
+		expect(getByRole('heading').nextElementSibling).toBeNull();
+	});
+
+	it('should show community registered badge', async () => {
+		usageStore.isLoading = false;
+		usageStore.subscriptionAppUrl = 'https://example.com';
+		usageStore.planName = 'Community registered';
+		const { getByRole, container } = renderComponent();
+		expect(getByRole('heading', { level: 3 })).toHaveTextContent('Community Edition');
+		expect(getByRole('heading', { level: 3 })).toContain(container.querySelector('.n8n-badge'));
+		expect(container.querySelector('.n8n-badge')).toHaveTextContent('registered');
+	});
+});

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -2,9 +2,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import { useUsageStore } from '@/stores/usage.store';
-import { useSettingsStore } from '@/stores/settings.store';
 import SettingsUsageAndPlan from '@/views/SettingsUsageAndPlan.vue';
-import { FrontendSettings } from '@n8n/api-types/src';
 
 vi.mock('vue-router', () => {
 	return {
@@ -19,8 +17,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
+
 let usageStore: ReturnType<typeof mockedStore<typeof useUsageStore>>;
-let settingsStore: ReturnType<typeof mockedStore<typeof useSettingsStore>>;
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 
@@ -28,15 +26,6 @@ describe('SettingsUsageAndPlan', () => {
 	beforeEach(() => {
 		createTestingPinia();
 		usageStore = mockedStore(useUsageStore);
-		settingsStore = mockedStore(useSettingsStore);
-
-		settingsStore.settings = {
-			instanceId: 'instance-id',
-			license: {
-				environment: 'production',
-			},
-			versionCli: '0.0.0',
-		} as FrontendSettings;
 	});
 
 	it('should not throw errors when rendering', async () => {
@@ -51,7 +40,8 @@ describe('SettingsUsageAndPlan', () => {
 
 	it('should show community registered badge', async () => {
 		usageStore.isLoading = false;
-		usageStore.subscriptionAppUrl = 'https://example.com';
+		usageStore.viewPlansUrl = 'https://subscription.n8n.io';
+		usageStore.managePlanUrl = 'https://subscription.n8n.io';
 		usageStore.planName = 'Community registered';
 		const { getByRole, container } = renderComponent();
 		expect(getByRole('heading', { level: 3 })).toHaveTextContent('Community Edition');

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -18,8 +18,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
-let usageStore: Parameters<typeof mockedStore>[0];
-let settingsStore: Parameters<typeof mockedStore>[0];
+let usageStore: ReturnType<typeof mockedStore<useUsageStore>>;
+let settingsStore: ReturnType<typeof mockedStore<useSettingsStore>>;
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -32,6 +32,7 @@ describe('SettingsUsageAndPlan', () => {
 		settingsStore.settings = {
 			instanceId: 'instance-id',
 			license: {
+				consumerId: 'consumer-id',
 				environment: 'production',
 			},
 			versionCli: '0.0.0',

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -18,8 +18,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
-let usageStore: ReturnType<typeof mockedStore<ReturnType<typeof useUsageStore>>>;
-let settingsStore: ReturnType<typeof mockedStore<ReturnType<typeof useSettingsStore>>>;
+let usageStore;
+let settingsStore;
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -18,8 +18,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
-let usageStore: ReturnType<typeof useUsageStore>;
-let settingsStore: ReturnType<typeof useSettingsStore>;
+let usageStore: Parameters<typeof mockedStore>[0];
+let settingsStore: Parameters<typeof mockedStore>[0];
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.test.ts
@@ -18,8 +18,8 @@ vi.mock('vue-router', () => {
 		},
 	};
 });
-let usageStore;
-let settingsStore;
+let usageStore: ReturnType<typeof useUsageStore>;
+let settingsStore: ReturnType<typeof useSettingsStore>;
 
 const renderComponent = createComponentRenderer(SettingsUsageAndPlan);
 

--- a/packages/editor-ui/src/views/SettingsUsageAndPlan.vue
+++ b/packages/editor-ui/src/views/SettingsUsageAndPlan.vue
@@ -32,6 +32,18 @@ const canUserActivateLicense = computed(() =>
 	hasPermission(['rbac'], { rbac: { scope: 'license:manage' } }),
 );
 
+const badgedPlanName = computed(() => {
+	const [name, badge] = usageStore.planName.split(' ');
+	return {
+		name,
+		badge,
+	};
+});
+
+const isCommunityEditionRegistered = computed(
+	() => usageStore.planName.toLowerCase() === 'community registered',
+);
+
 const showActivationSuccess = () => {
 	toast.showMessage({
 		type: 'success',
@@ -125,11 +137,15 @@ const onDialogOpened = () => {
 
 <template>
 	<div class="settings-usage-and-plan">
-		<n8n-heading size="2xlarge">{{ locale.baseText('settings.usageAndPlan.title') }}</n8n-heading>
+		<n8n-heading tag="h2" size="2xlarge">{{
+			locale.baseText('settings.usageAndPlan.title')
+		}}</n8n-heading>
 		<div v-if="!usageStore.isLoading">
-			<n8n-heading :class="$style.title" size="large">
+			<n8n-heading tag="h3" :class="$style.title" size="large">
 				<i18n-t keypath="settings.usageAndPlan.description" tag="span">
-					<template #name>{{ usageStore.planName }}</template>
+					<template #name>{{
+						badgedPlanName.badge ? badgedPlanName.name : usageStore.planName
+					}}</template>
 					<template #type>
 						<span v-if="usageStore.planId">{{
 							locale.baseText('settings.usageAndPlan.plan')
@@ -137,6 +153,18 @@ const onDialogOpened = () => {
 						<span v-else>{{ locale.baseText('settings.usageAndPlan.edition') }}</span>
 					</template>
 				</i18n-t>
+				<span :class="$style.titleTooltip">
+					<N8nTooltip v-if="badgedPlanName.badge" placement="top">
+						<template #content>
+							<i18n-t
+								v-if="isCommunityEditionRegistered"
+								keypath="settings.usageAndPlan.license.communityRegistered.tooltip"
+							>
+							</i18n-t>
+						</template>
+						<N8nBadge>{{ badgedPlanName.badge }}</N8nBadge>
+					</N8nTooltip>
+				</span>
 			</n8n-heading>
 
 			<div :class="$style.quota">
@@ -239,7 +267,8 @@ const onDialogOpened = () => {
 }
 
 .title {
-	display: block;
+	display: flex;
+	align-items: center;
 	padding: var(--spacing-2xl) 0 var(--spacing-m);
 }
 
@@ -308,6 +337,12 @@ const onDialogOpened = () => {
 div[class*='info'] > span > span:last-child {
 	line-height: 1.4;
 	padding: 0 0 0 var(--spacing-4xs);
+}
+
+.titleTooltip {
+	display: flex;
+	align-items: center;
+	margin: 0 0 0 var(--spacing-2xs);
 }
 </style>
 


### PR DESCRIPTION
## Summary

Show a registered badge if users unlock additional features on the Community edition. 

## Related Linear tickets, Github issues, and Community forum posts

[PAY-1933](https://linear.app/n8n/issue/PAY-1933/add-new-styling-and-messaging-to-usage-page-plan-title#comment-adb133be)

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.