### PR TITLE
fix(Postgres PGVector Store Node): Fix filtering in retriever mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -1,14 +1,17 @@
-import { type INodeProperties } from 'n8n-workflow';
 import {
 	PGVectorStore,
 	type DistanceStrategy,
 	type PGVectorStoreArgs,
 } from '@langchain/community/vectorstores/pgvector';
-import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/v2/transport';
+import type { Callbacks } from '@langchain/core/callbacks/manager';
+import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
+import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/v2/transport';
+import type { IDataObject, INodeProperties } from 'n8n-workflow';
 import type pg from 'pg';
-import { createVectorStoreNode } from '../shared/createVectorStoreNode';
+
 import { metadataFilterField } from '../../../utils/sharedFields';
+import { createVectorStoreNode } from '../shared/createVectorStoreNode';
 
 type CollectionOptions = {
 	useCollection?: boolean;
@@ -177,6 +180,39 @@ const retrieveFields: INodeProperties[] = [
 	},
 ];
 
+/**
+ * Extended PGVectorStore class to handle custom filtering.
+ * This wrapper is necessary because when used as a retriever,
+ * similaritySearchVectorWithScore should use this.filter instead of
+ * expecting it from the parameter
+ */
+class ExtendedPGVectorStore extends PGVectorStore {
+	static async initialize(
+		embeddings: EmbeddingsInterface,
+		args: PGVectorStoreArgs & { dimensions?: number },
+	): Promise<ExtendedPGVectorStore> {
+		const { dimensions, ...rest } = args;
+		const postgresqlVectorStore = new this(embeddings, rest);
+
+		await postgresqlVectorStore._initializeClient();
+		await postgresqlVectorStore.ensureTableInDatabase(dimensions);
+		if (postgresqlVectorStore.collectionTableName) {
+			await postgresqlVectorStore.ensureCollectionTableInDatabase();
+		}
+
+		return postgresqlVectorStore;
+	}
+
+	async similaritySearchVectorWithScore(
+		query: number[],
+		k: number,
+		filter?: PGVectorStore['FilterType'],
+	) {
+		const mergedFilter = { ...this.filter, ...filter };
+		return await super.similaritySearchVectorWithScore(query, k, mergedFilter);
+	}
+}
+
 export const VectorStorePGVector = createVectorStoreNode({
 	meta: {
 		description: 'Work with your data in Postgresql with the PGVector extension',
@@ -236,7 +272,7 @@ export const VectorStorePGVector = createVectorStoreNode({
 			'cosine',
 		) as DistanceStrategy;
 
-		return await PGVectorStore.initialize(embeddings, config);
+		return await ExtendedPGVectorStore.initialize(embeddings, config);
 	},
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		// NOTE: if you are to create the HNSW index before use, you need to consider moving the distanceStrategy field to

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -3,11 +3,10 @@ import {
 	type DistanceStrategy,
 	type PGVectorStoreArgs,
 } from '@langchain/community/vectorstores/pgvector';
-import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/v2/transport';
-import type { IDataObject, INodeProperties } from 'n8n-workflow';
+import type { INodeProperties } from 'n8n-workflow';
 import type pg from 'pg';
 
 import { metadataFilterField } from '../../../utils/sharedFields';

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -218,7 +218,7 @@ export const VectorStorePGVector = createVectorStoreNode({
 		icon: 'file:postgres.svg',
 		displayName: 'Postgres PGVector Store',
 		docsUrl:
-			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase/',
+			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector/',
 		name: 'vectorStorePGVector',
 		credentials: [
 			{


### PR DESCRIPTION
## Summary
This PR fixes PG Vector filtering when used in the retriever mode. Similar to what we do for QDrant VS, we extend the original class and merge instance filters with filters passed as arguments to `similaritySearchVectorWithScore`.

## Related Linear tickets, Github issues, and Community forum posts
- https://github.com/n8n-io/n8n/issues/11061

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
