### PR TITLE
fix(Gitlab Node): Author name and email not being set

### DIFF
--- a/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/Gitlab.node.ts
@@ -1606,7 +1606,13 @@ export class Gitlab implements INodeType {
 						body.commit_message = this.getNodeParameter('commitMessage', i) as string;
 
 						if (additionalParameters.author) {
-							body.author = additionalParameters.author;
+							const author = additionalParameters.author as IDataObject;
+							if (author.name) {
+								body.author_name = author.name;
+							}
+							if (author.email) {
+								body.author_email = author.email;
+							}
 						}
 						if (
 							additionalParameters.branchStart &&
@@ -1648,7 +1654,13 @@ export class Gitlab implements INodeType {
 							{},
 						) as IDataObject;
 						if (additionalParameters.author) {
-							body.author = additionalParameters.author;
+							const author = additionalParameters.author as IDataObject;
+							if (author.name) {
+								body.author_name = author.name;
+							}
+							if (author.email) {
+								body.author_email = author.email;
+							}
 						}
 						body.branch = this.getNodeParameter('branch', i) as string;
 						body.commit_message = this.getNodeParameter('commitMessage', i) as string;


### PR DESCRIPTION
## Summary

This fixes a bug in the node where an author object was sent, but the Gitlab API is expecting two params `author_name` and `author_email`. See https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository.

**Before** when providing author email and name:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/85ee3b0b-5f9e-4dd2-8f7d-bc95c2b07a06">

**After** when providing author email and name:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/cd5b5830-58c2-4d75-b94b-d669eae8bb62">

## Related Linear tickets, Github issues, and Community forum posts
None

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
