### PR TITLE
feat(OpenAI Node): Allow to specify thread ID for Assistant -> Message operation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -1,30 +1,27 @@
+import type { BaseMessage } from '@langchain/core/messages';
 import { AgentExecutor } from 'langchain/agents';
-
-import { OpenAIAssistantRunnable } from 'langchain/experimental/openai_assistant';
 import type { OpenAIToolType } from 'langchain/dist/experimental/openai_assistant/schema';
-import { OpenAI as OpenAIClient } from 'openai';
-
-import {
-	ApplicationError,
-	NodeConnectionType,
-	NodeOperationError,
-	updateDisplayOptions,
-} from 'n8n-workflow';
+import { OpenAIAssistantRunnable } from 'langchain/experimental/openai_assistant';
+import type { BufferWindowMemory } from 'langchain/memory';
+import omit from 'lodash/omit';
 import type {
 	IDataObject,
 	IExecuteFunctions,
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-
-import type { BufferWindowMemory } from 'langchain/memory';
-import omit from 'lodash/omit';
-import type { BaseMessage } from '@langchain/core/messages';
-import { formatToOpenAIAssistantTool } from '../../helpers/utils';
-import { assistantRLC } from '../descriptions';
+import {
+	ApplicationError,
+	NodeConnectionType,
+	NodeOperationError,
+	updateDisplayOptions,
+} from 'n8n-workflow';
+import { OpenAI as OpenAIClient } from 'openai';
 
 import { getConnectedTools } from '../../../../../utils/helpers';
 import { getTracingConfig } from '../../../../../utils/tracing';
+import { formatToOpenAIAssistantTool } from '../../helpers/utils';
+import { assistantRLC } from '../descriptions';
 
 const properties: INodeProperties[] = [
 	assistantRLC,
@@ -60,6 +57,46 @@ const properties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				prompt: ['define'],
+			},
+		},
+	},
+	{
+		displayName: 'Memory',
+		name: 'memory',
+		type: 'options',
+		options: [
+			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+				name: 'Use memory connector',
+				value: 'connector',
+				description: 'Connect one of the supported memory nodes',
+			},
+			{
+				// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+				name: 'Use thread ID',
+				value: 'threadId',
+				description: 'Specify the ID of the thread to continue',
+			},
+		],
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.6 } }],
+			},
+		},
+		default: 'connector',
+	},
+	{
+		displayName: 'Thread ID',
+		name: 'threadId',
+		type: 'string',
+		default: '',
+		placeholder: '',
+		description: 'The ID of the thread to continue, a new thread will be created if not specified',
+		hint: 'If the thread ID is empty or undefined a new thread will be created and included in the response',
+		displayOptions: {
+			show: {
+				'@version': [{ _cnd: { gte: 1.6 } }],
+				memory: ['threadId'],
 			},
 		},
 	},
@@ -201,9 +238,19 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		tools: tools ?? [],
 	});
 
-	const memory = (await this.getInputConnectionData(NodeConnectionType.AiMemory, 0)) as
-		| BufferWindowMemory
-		| undefined;
+	const useMemoryConnector =
+		nodeVersion >= 1.6 && this.getNodeParameter('memory', i) === 'connector';
+	const memory =
+		useMemoryConnector || nodeVersion < 1.6
+			? ((await this.getInputConnectionData(NodeConnectionType.AiMemory, 0)) as
+					| BufferWindowMemory
+					| undefined)
+			: undefined;
+
+	const threadId =
+		nodeVersion >= 1.6 && !useMemoryConnector
+			? (this.getNodeParameter('threadId', i) as string)
+			: undefined;
 
 	const chainValues: IDataObject = {
 		content: input,
@@ -231,6 +278,8 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 			chainValues.threadId = thread.id;
 		}
+	} else if (threadId) {
+		chainValues.threadId = threadId;
 	}
 
 	let filteredResponse: IDataObject = {};
@@ -257,7 +306,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				tools: assistantTools,
 			});
 		}
-		filteredResponse = omit(response, ['signal', 'timeout']) as IDataObject;
+		filteredResponse = omit(response, ['signal', 'timeout', 'content', 'runId']) as IDataObject;
 	} catch (error) {
 		if (!(error instanceof ApplicationError)) {
 			throw new NodeOperationError(this.getNode(), error.message, { itemIndex: i });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -306,7 +306,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				tools: assistantTools,
 			});
 		}
-		// Exclude configuration and runId properties from the response
+		// Remove configuration properties and runId added by Langchain that are not relevant to the user
 		filteredResponse = omit(response, ['signal', 'timeout', 'content', 'runId']) as IDataObject;
 	} catch (error) {
 		if (!(error instanceof ApplicationError)) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -306,6 +306,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				tools: assistantTools,
 			});
 		}
+		// Exclude configuration and runId properties from the response
 		filteredResponse = omit(response, ['signal', 'timeout', 'content', 'runId']) as IDataObject;
 	} catch (error) {
 		if (!(error instanceof ApplicationError)) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
@@ -1,5 +1,5 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
-import type { INodeTypeDescription } from 'n8n-workflow';
+import type { INodeInputConfiguration, INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionType } from 'n8n-workflow';
 
 import * as assistant from './assistant';
@@ -42,13 +42,21 @@ const prettifyOperation = (resource: string, operation: string) => {
 	return `${capitalize(operation)} ${capitalize(resource)}`;
 };
 
-const configureNodeInputs = (resource: string, operation: string, hideTools: string) => {
+const configureNodeInputs = (
+	resource: string,
+	operation: string,
+	hideTools: string,
+	memory: string | undefined,
+) => {
 	if (resource === 'assistant' && operation === 'message') {
-		return [
+		const inputs: INodeInputConfiguration[] = [
 			{ type: NodeConnectionType.Main },
-			{ type: NodeConnectionType.AiMemory, displayName: 'Memory', maxConnections: 1 },
 			{ type: NodeConnectionType.AiTool, displayName: 'Tools' },
 		];
+		if (memory !== 'threadId') {
+			inputs.push({ type: NodeConnectionType.AiMemory, displayName: 'Memory', maxConnections: 1 });
+		}
+		return inputs;
 	}
 	if (resource === 'text' && operation === 'message') {
 		if (hideTools === 'hide') {
@@ -69,7 +77,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'openAi',
 	icon: { light: 'file:openAi.svg', dark: 'file:openAi.dark.svg' },
 	group: ['transform'],
-	version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
+	version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
 	subtitle: `={{(${prettifyOperation})($parameter.resource, $parameter.operation)}}`,
 	description: 'Message an assistant or GPT, analyze images, generate audio, etc.',
 	defaults: {
@@ -89,7 +97,7 @@ export const versionDescription: INodeTypeDescription = {
 			],
 		},
 	},
-	inputs: `={{(${configureNodeInputs})($parameter.resource, $parameter.operation, $parameter.hideTools)}}`,
+	inputs: `={{(${configureNodeInputs})($parameter.resource, $parameter.operation, $parameter.hideTools, $parameter.memory ?? undefined)}}`,
 	outputs: [NodeConnectionType.Main],
 	credentials: [
 		{


### PR DESCRIPTION
## Summary

This PR adds two new fields to OpenAI's Assitant Node: `memory` and `threadId`. In version 1.6 of the node, users can specify whether they want to use the default memory connector to provide memory to their assistant or specify a thread ID instead.
![CleanShot 2024-10-03 at 14 26 08@2x](https://github.com/user-attachments/assets/61827524-625b-4411-a506-c490b56a7de7)

## Related Linear tickets, Github issues, and Community forum posts
- https://community.n8n.io/t/enhanced-openai-assistant-node/34291/9

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
