### PR TITLE
fix(core)!: Bind worker server to IPv4

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -6,9 +6,13 @@ class HealthConfig {
 	@Env('QUEUE_HEALTH_CHECK_ACTIVE')
 	active: boolean = false;
 
-	/** Port for worker to respond to health checks requests on, if enabled. */
+	/** Port for worker server to listen on. */
 	@Env('QUEUE_HEALTH_CHECK_PORT')
 	port: number = 5678;
+
+	/** IP address for worker server to listen on. */
+	@Env('N8N_WORKER_SERVER_ADDRESS')
+	address: string = '0.0.0.0';
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -198,6 +198,7 @@ describe('GlobalConfig', () => {
 			health: {
 				active: false,
 				port: 5678,
+				address: '0.0.0.0',
 			},
 			bull: {
 				redis: {

--- a/packages/cli/BREAKING-CHANGES.md
+++ b/packages/cli/BREAKING-CHANGES.md
@@ -2,6 +2,16 @@
 
 This list shows all the versions which include breaking changes and how to upgrade.
 
+# 1.63.0
+
+### What changed?
+
+The worker server used to bind to IPv6 by default. It now binds to IPv4 by default.
+
+### When is action necessary?
+
+If you experience a port conflict error when starting a worker server using its default port, set a different port for the worker server with `QUEUE_HEALTH_CHECK_PORT`.
+
 ## 1.57.0
 
 ### What changed?

--- a/packages/cli/src/errors/port-taken.error.ts
+++ b/packages/cli/src/errors/port-taken.error.ts
@@ -1,9 +1,0 @@
-import { ApplicationError } from 'n8n-workflow';
-
-export class PortTakenError extends ApplicationError {
-	constructor(port: number) {
-		super(
-			`Port ${port} is already in use. Do you already have the n8n main process running on that port?`,
-		);
-	}
-}


### PR DESCRIPTION
Looking into why a worker server was not throwing `EADDRINUSE` when started after a main process server in localhost despite both being on the same protocol and address and port, I found that the worker server defaults to IPv6 while the main process listens on IPv4 by default. This is surprising behavior.

```
lsof -i :5678
COMMAND  PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    6147 ivov   23u  IPv4 0xfcce9321579ad135      0t0  TCP *:rrac (LISTEN)
node    6260 ivov   26u  IPv6 0xfcce9326201028e5      0t0  TCP *:rrac (LISTEN)
```

This PR adjusts the worker server to bind by default to IPv4 to stay consistent with the main process server.