### PR TITLE
feat(editor): Adjust selection rectangle to include node selection box on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -44,7 +44,7 @@ const connectionType = computed(() =>
 		: NodeConnectionType.Main,
 );
 
-const renderToolbar = computed(() => (props.selected || isHovered.value) && !props.readOnly);
+const renderToolbar = computed(() => isHovered.value && !props.readOnly);
 
 const isMainConnection = computed(() => data.value.source.type === NodeConnectionType.Main);
 

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -51,9 +51,7 @@ const isMainConnection = computed(() => data.value.source.type === NodeConnectio
 const status = computed(() => props.data.status);
 
 const edgeColor = computed(() => {
-	if (props.selected) {
-		return 'var(--color-background-dark)';
-	} else if (status.value === 'success') {
+	if (status.value === 'success') {
 		return 'var(--color-success)';
 	} else if (status.value === 'pinned') {
 		return 'var(--color-secondary)';
@@ -61,6 +59,8 @@ const edgeColor = computed(() => {
 		return 'var(--color-primary)';
 	} else if (!isMainConnection.value) {
 		return 'var(--node-type-supplemental-color)';
+	} else if (props.selected) {
+		return 'var(--color-background-dark)';
 	} else {
 		return 'var(--color-foreground-xdark)';
 	}

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -1,3 +1,7 @@
+/**
+ * Resizer
+ */
+
 .vue-flow__resize-control.line {
 	border-color: transparent;
 	z-index: 1;
@@ -32,6 +36,10 @@
 	z-index: 1;
 }
 
+/**
+ * Minimap
+ */
+
 .vue-flow__minimap {
 	height: 120px;
 	overflow: hidden;
@@ -50,12 +58,20 @@
 	}
 }
 
+/**
+ * Pane
+ */
+
 .vue-flow__pane {
 	&,
 	&.draggable {
 		cursor: default;
 	}
 }
+
+/**
+ * Node
+ */
 
 .vue-flow__node {
 	&,
@@ -70,4 +86,14 @@
 	&:has(.sticky--active) {
 		z-index: 1 !important;
 	}
+}
+
+/**
+ * Selection
+ */
+.vue-flow__nodesselection-rect {
+	box-sizing: content-box;
+	margin-top: calc(-1 * var(--spacing-2xs));
+	margin-left: calc(-1 * var(--spacing-2xs));
+	padding: var(--spacing-2xs);
 }

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -91,6 +91,7 @@
 /**
  * Selection
  */
+
 .vue-flow__nodesselection-rect {
 	box-sizing: content-box;
 	margin-top: calc(-1 * var(--spacing-2xs));


### PR DESCRIPTION
## Summary

<img width="1594" alt="Screenshot 2024-10-04 at 11 26 41" src="https://github.com/user-attachments/assets/bb4cae51-3abf-476f-9cc5-e675a1cc2c6c">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7634/selection-box-when-multiple-nodes-are-selected-tweaks

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
