### PR TITLE
fix(editor): Don't report certain error types to Sentry (no-changelog)

### DIFF
--- a/packages/editor-ui/src/main.ts
+++ b/packages/editor-ui/src/main.ts
@@ -30,6 +30,7 @@ import { FontAwesomePlugin } from './plugins/icons';
 import { createPinia, PiniaVuePlugin } from 'pinia';
 import { JsPlumbPlugin } from '@/plugins/jsplumb';
 import { ChartJSPlugin } from '@/plugins/chartjs';
+import { AxiosError } from 'axios';
 
 const pinia = createPinia();
 
@@ -37,7 +38,22 @@ const app = createApp(App);
 
 if (window.sentry?.dsn) {
 	const { dsn, release, environment } = window.sentry;
-	Sentry.init({ app, dsn, release, environment });
+	Sentry.init({
+		app,
+		dsn,
+		release,
+		environment,
+		beforeSend(event, { originalException }) {
+			if (
+				!originalException ||
+				originalException instanceof AxiosError ||
+				(originalException instanceof Error && originalException.message.includes('ResizeObserver'))
+			) {
+				return null;
+			}
+			return event;
+		},
+	});
 }
 
 app.use(TelemetryPlugin);


### PR DESCRIPTION
## Summary

There isn't much we can do about axios related errors or errors related to ResizeObserver.
so, we should just ignore them.

## Review / Merge checklist

- [x] PR title and summary are descriptive
