### PR TITLE
fix: Incorrect error message on calling wrong webhook method

### DIFF
--- a/packages/cli/src/errors/response-errors/webhook-not-found.error.ts
+++ b/packages/cli/src/errors/response-errors/webhook-not-found.error.ts
@@ -47,10 +47,13 @@ export class WebhookNotFoundError extends NotFoundError {
 	) {
 		const errorMsg = webhookNotFoundErrorMessage({ path, httpMethod, webhookMethods });
 
-		const hintMsg =
-			hint === 'default'
-				? "Click the 'Test workflow' button on the canvas, then try again. (In test mode, the webhook only works for one call after you click this button)"
-				: "The workflow must be active for a production URL to run successfully. You can activate the workflow using the toggle in the top-right of the editor. Note that unlike test URL calls, production URL calls aren't shown on the canvas (only in the executions list)";
+		let hintMsg = '';
+		if (!webhookMethods?.length) {
+			hintMsg =
+				hint === 'default'
+					? "Click the 'Test workflow' button on the canvas, then try again. (In test mode, the webhook only works for one call after you click this button)"
+					: "The workflow must be active for a production URL to run successfully. You can activate the workflow using the toggle in the top-right of the editor. Note that unlike test URL calls, production URL calls aren't shown on the canvas (only in the executions list)";
+		}
 
 		super(errorMsg, hintMsg);
 	}

--- a/packages/cli/src/webhooks/live-webhooks.ts
+++ b/packages/cli/src/webhooks/live-webhooks.ts
@@ -160,8 +160,9 @@ export class LiveWebhooks implements IWebhookManager {
 		}
 
 		const webhook = await this.webhookService.findWebhook(httpMethod, path);
+		const webhookMethods = await this.getWebhookMethods(path);
 		if (webhook === null) {
-			throw new WebhookNotFoundError({ path, httpMethod }, { hint: 'production' });
+			throw new WebhookNotFoundError({ path, httpMethod, webhookMethods }, { hint: 'production' });
 		}
 
 		return webhook;


### PR DESCRIPTION
## Summary

show message describing issue

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1763/webhook-incorrect-error-message-on-calling-webhook
