### PR TITLE
test(core): Allow Jest to exit cleanly in `worker` command test

### DIFF
--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -10,6 +10,7 @@ import { ExternalHooks } from '@/external-hooks';
 import { ExternalSecretsManager } from '@/external-secrets/external-secrets-manager.ee';
 import { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { ScalingService } from '@/scaling/scaling.service';
 import { OrchestrationHandlerWorkerService } from '@/services/orchestration/worker/orchestration.handler.worker.service';
 import { OrchestrationWorkerService } from '@/services/orchestration/worker/orchestration.worker.service';
@@ -29,12 +30,12 @@ const logStreamingEventRelay = mockInstance(LogStreamingEventRelay);
 const orchestrationHandlerWorkerService = mockInstance(OrchestrationHandlerWorkerService);
 const scalingService = mockInstance(ScalingService);
 const orchestrationWorkerService = mockInstance(OrchestrationWorkerService);
+mockInstance(Publisher);
 
 const command = setupTestCommand(Worker);
 
 test('worker initializes all its components', async () => {
 	const worker = await command.run();
-
 	expect(worker.queueModeId).toBeDefined();
 	expect(worker.queueModeId).toContain('worker');
 	expect(worker.queueModeId.length).toBeGreaterThan(15);


### PR DESCRIPTION
Noticed this while working on workers:

```
> pnpm test:sqlite "--" "worker.cmd"


> n8n@1.62.1 test:sqlite /Users/ivov/Development/n8n/packages/cli
> N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest "--" "worker.cmd"

 PASS  test/integration/commands/worker.cmd.test.ts
  ✓ worker initializes all its components (28 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.309 s, estimated 4 s
Ran all test suites matching /worker.cmd/i.
Jest did not exit one second after the test run has completed.

'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```