### PR TITLE
fix(core): Print errors that happen before the execution starts on the worker instead of just on the main instance

### DIFF
--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -91,7 +91,7 @@ export class ScalingService {
 				// Errors thrown here will be sent to the main instance by bull. Logging
 				// them out and rethrowing them allows to find out which worker had the
 				// issue.
-				this.logger.error('[ScalingService] Executing a job errored', { job, error });
+				this.logger.error('[ScalingService] Executing a job errored', { jobId: job.id, error });
 				ErrorReporterProxy.error(error);
 				throw error;
 			}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -91,7 +91,11 @@ export class ScalingService {
 				// Errors thrown here will be sent to the main instance by bull. Logging
 				// them out and rethrowing them allows to find out which worker had the
 				// issue.
-				this.logger.error('[ScalingService] Executing a job errored', { jobId: job.id, error });
+				this.logger.error('[ScalingService] Executing a job errored', {
+					jobId: job.id,
+					executionId: job.data.executionId,
+					error,
+				});
 				ErrorReporterProxy.error(error);
 				throw error;
 			}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -88,6 +88,9 @@ export class ScalingService {
 			try {
 				await this.jobProcessor.processJob(job);
 			} catch (error: unknown) {
+				// Errors thrown here will be sent to the main instance by bull. Logging
+				// them out and rethrowing them allows to find out which worker had the
+				// issue.
 				this.logger.error('[ScalingService] Executing a job errored', { job, error });
 				ErrorReporterProxy.error(error);
 				throw error;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

A customer is facing intermittent database connection issues and its currently not possible to figure out if this comes from one worker or all workers because any error that is thrown and not caught will be caught by bull, then sent to the main instance and rethrown there. The workers won't print anything, not even that it received the job.

Their issue they are facing is probably related to the pg connection pool being depleted, but without finding the affected workers and if they recover or if they stay in that state it's impossible to hone in on the root cause. 

This PR catches errors that happen before the execution starts, logs them and rethrows them so the main instance's error handling code still runs.

I don't think this requires a test. But let me know if you disagree.

I provoked an error by throwing from inside `findSingleExecution`:

![image](https://github.com/user-attachments/assets/87b7ab46-344f-4fbc-b625-ccadd4c8481f)


Before

https://github.com/user-attachments/assets/4de081c9-3716-458b-a621-83785708a449

After

https://github.com/user-attachments/assets/811cefd8-6ecd-4134-b214-09f8c7f3e856

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/PAY-1949/investigate-execution-timeouts-and-connection-issues-in-logs

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] ~Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->~
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
