### PR TITLE
fix(editor): Set document title when renaming and loading workflow (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -367,6 +367,7 @@ async function onNameSubmit({
 	if (saved) {
 		isNameEditEnabled.value = false;
 		showCreateWorkflowSuccessToast(id);
+		workflowHelpers.setDocumentTitle(newName, 'IDLE');
 	}
 	uiStore.removeActiveAction('workflowSaving');
 	onSubmit(saved);

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -372,7 +372,7 @@ async function initializeWorkspaceForExistingWorkflow(id: string) {
 
 async function openWorkflow(data: IWorkflowDb) {
 	resetWorkspace();
-	workflowHelpers.setDocumentTitle(editableWorkflow.value.name, 'IDLE');
+	workflowHelpers.setDocumentTitle(data.name, 'IDLE');
 
 	await initializeWorkspace(data);
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/22cbe33c-8d3c-4b30-9874-dc5a23c99fc9



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7715/update-page-title-when-workflow-is-renamed

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
