### PR TITLE
feat(editor): Add undo/redo for importing workflow data on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1370,7 +1370,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 	function addConnections(
 		connections: CanvasConnectionCreateData[] | CanvasConnection[],
-		{ trackBulk = true, trackHistory = false },
+		{ trackBulk = true, trackHistory = false } = {},
 	) {
 		if (trackBulk) {
 			historyStore.startRecordingUndo();

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1368,26 +1368,40 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		return targetNodeHasInputConnectionOfType;
 	}
 
-	function addConnections(connections: CanvasConnectionCreateData[] | CanvasConnection[]) {
+	function addConnections(
+		connections: CanvasConnectionCreateData[] | CanvasConnection[],
+		{ trackBulk = true, trackHistory = false },
+	) {
+		if (trackBulk) {
+			historyStore.startRecordingUndo();
+		}
+
 		for (const { source, target, data } of connections) {
-			createConnection({
-				source,
-				sourceHandle: createCanvasConnectionHandleString({
-					mode: CanvasConnectionMode.Output,
-					type: isValidNodeConnectionType(data?.source.type)
-						? data?.source.type
-						: NodeConnectionType.Main,
-					index: data?.source.index ?? 0,
-				}),
-				target,
-				targetHandle: createCanvasConnectionHandleString({
-					mode: CanvasConnectionMode.Input,
-					type: isValidNodeConnectionType(data?.target.type)
-						? data?.target.type
-						: NodeConnectionType.Main,
-					index: data?.target.index ?? 0,
-				}),
-			});
+			createConnection(
+				{
+					source,
+					sourceHandle: createCanvasConnectionHandleString({
+						mode: CanvasConnectionMode.Output,
+						type: isValidNodeConnectionType(data?.source.type)
+							? data?.source.type
+							: NodeConnectionType.Main,
+						index: data?.source.index ?? 0,
+					}),
+					target,
+					targetHandle: createCanvasConnectionHandleString({
+						mode: CanvasConnectionMode.Input,
+						type: isValidNodeConnectionType(data?.target.type)
+							? data?.target.type
+							: NodeConnectionType.Main,
+						index: data?.target.index ?? 0,
+					}),
+				},
+				{ trackHistory },
+			);
+		}
+
+		if (trackBulk) {
+			historyStore.stopRecordingUndo();
 		}
 	}
 
@@ -1454,6 +1468,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 	async function addImportedNodesToWorkflow(
 		data: IWorkflowDataUpdate,
+		{ trackBulk = true, trackHistory = false } = {},
 	): Promise<IWorkflowDataUpdate> {
 		// Because nodes with the same name maybe already exist, it could
 		// be needed that they have to be renamed. Also could it be possible
@@ -1596,17 +1611,23 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		}
 
 		// Add the nodes with the changed node names, expressions and connections
-		historyStore.startRecordingUndo();
+		if (trackBulk) {
+			historyStore.startRecordingUndo();
+		}
 
-		await addNodes(Object.values(tempWorkflow.nodes));
+		await addNodes(Object.values(tempWorkflow.nodes), { trackBulk: false, trackHistory: true });
 		addConnections(
 			mapLegacyConnectionsToCanvasConnections(
 				tempWorkflow.connectionsBySourceNode,
 				Object.values(tempWorkflow.nodes),
 			),
+			{ trackBulk: false, trackHistory },
 		);
 
-		historyStore.stopRecordingUndo();
+		if (trackBulk) {
+			historyStore.stopRecordingUndo();
+		}
+
 		uiStore.stateIsDirty = true;
 
 		return {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/111de21a-20bf-422c-9b38-42087e4b6de7



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7713/undo-does-not-reset-copypasted-multiple-nodes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
