### PR TITLE
fix(editor): Fix getInitials when Intl.Segmenter is not supported

### DIFF
--- a/packages/design-system/src/utils/labelUtil.spec.ts
+++ b/packages/design-system/src/utils/labelUtil.spec.ts
@@ -1,3 +1,5 @@
+import type { MockInstance } from 'vitest';
+
 import { getInitials } from './labelUtil';
 
 describe('labelUtil.getInitials', () => {
@@ -25,5 +27,30 @@ describe('labelUtil.getInitials', () => {
 		['👩‍⚕️D 👩‍⚕️D', '👩‍⚕️👩‍⚕️'],
 	])('turns "%s" into "%s"', (input, output) => {
 		expect(getInitials(input)).toBe(output);
+	});
+
+	describe('when Intl.Segmenter is not supported', () => {
+		let intlSpy: MockInstance;
+
+		beforeEach(() => {
+			// No Intl.Segmenter support
+			intlSpy = vi.spyOn(globalThis, 'Intl', 'get');
+			intlSpy.mockImplementation(() => ({}));
+		});
+
+		it.each([
+			['', ''],
+
+			// simple words
+			['Hello', 'He'],
+			['Hello World', 'HW'],
+			['H', 'H'],
+
+			// multiple spaces
+			['Double  Space', 'DS'],
+			['        ', ''],
+		])('turns "%s" into "%s"', (input, output) => {
+			expect(getInitials(input)).toBe(output);
+		});
 	});
 });

--- a/packages/design-system/src/utils/labelUtil.ts
+++ b/packages/design-system/src/utils/labelUtil.ts
@@ -1,29 +1,3 @@
-// export const getInitials = (label: string): string => {
-// 	const words = label
-// 		.split(' ')
-// 		.filter((word) => word !== '')
-// 		.map((word) => [...new Intl.Segmenter().segment(word)]);
-
-// 	if (words.length === 0) {
-// 		return '';
-// 	} else if (words.length === 1) {
-// 		// first two segments of the first word
-// 		return (
-// 			words
-// 				.at(0)
-// 				?.slice(0, 2)
-// 				.map((grapheme) => grapheme.segment)
-// 				.join('') ?? ''
-// 		);
-// 	} else {
-// 		// first segment ok the first two words
-// 		return words
-// 			.slice(0, 2)
-// 			.map((word) => word.at(0)?.segment ?? '')
-// 			.join('');
-// 	}
-// };
-
 export const getInitials = (label: string): string => {
 	const isSegmenterSupported = typeof Intl !== 'undefined' && 'Segmenter' in Intl;
 

--- a/packages/design-system/src/utils/labelUtil.ts
+++ b/packages/design-system/src/utils/labelUtil.ts
@@ -1,25 +1,45 @@
-export const getInitials = (label: string): string => {
-	const words = label
-		.split(' ')
-		.filter((word) => word !== '')
-		.map((word) => [...new Intl.Segmenter().segment(word)]);
+// export const getInitials = (label: string): string => {
+// 	const words = label
+// 		.split(' ')
+// 		.filter((word) => word !== '')
+// 		.map((word) => [...new Intl.Segmenter().segment(word)]);
 
-	if (words.length === 0) {
-		return '';
-	} else if (words.length === 1) {
-		// first two segments of the first word
-		return (
-			words
-				.at(0)
-				?.slice(0, 2)
-				.map((grapheme) => grapheme.segment)
-				.join('') ?? ''
-		);
-	} else {
-		// first segment ok the first two words
-		return words
-			.slice(0, 2)
-			.map((word) => word.at(0)?.segment ?? '')
-			.join('');
-	}
+// 	if (words.length === 0) {
+// 		return '';
+// 	} else if (words.length === 1) {
+// 		// first two segments of the first word
+// 		return (
+// 			words
+// 				.at(0)
+// 				?.slice(0, 2)
+// 				.map((grapheme) => grapheme.segment)
+// 				.join('') ?? ''
+// 		);
+// 	} else {
+// 		// first segment ok the first two words
+// 		return words
+// 			.slice(0, 2)
+// 			.map((word) => word.at(0)?.segment ?? '')
+// 			.join('');
+// 	}
+// };
+
+export const getInitials = (label: string): string => {
+	const isSegmenterSupported = typeof Intl !== 'undefined' && 'Segmenter' in Intl;
+
+	const segmentWord = (word: string): string[] => {
+		if (isSegmenterSupported) {
+			return [...new Intl.Segmenter().segment(word)].map((s) => s.segment);
+		}
+		return word.split('');
+	};
+
+	const getFirstSegment = (word: string[]): string => word[0] || '';
+	const getFirstTwoSegments = (word: string[]): string => word.slice(0, 2).join('');
+
+	const words = label.split(' ').filter(Boolean).map(segmentWord);
+
+	if (words.length === 0) return '';
+	if (words.length === 1) return getFirstTwoSegments(words[0]);
+	return words.slice(0, 2).map(getFirstSegment).join('');
 };


### PR DESCRIPTION
## Summary

Fix getInitials when Intl.Segmenter is not supported

from Sentry issue

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1819/typeerror-intlsegmenter-is-not-a-constructor

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
