### PR TITLE
fix(editor): Add safety to prevent undefined errors

### DIFF
--- a/packages/editor-ui/src/composables/useWorkflowHelpers.ts
+++ b/packages/editor-ui/src/composables/useWorkflowHelpers.ts
@@ -694,7 +694,7 @@ export function useWorkflowHelpers(options: { router: ReturnType<typeof useRoute
 		}
 
 		const workflowId = workflowsStore.workflowId;
-		const path = getWebhookExpressionValue(webhookData, 'path', true, node.name);
+		const path = getWebhookExpressionValue(webhookData, 'path', true, node.name) ?? '';
 		const isFullPath =
 			(getWebhookExpressionValue(
 				webhookData,

--- a/packages/editor-ui/src/utils/__tests__/expressions.test.ts
+++ b/packages/editor-ui/src/utils/__tests__/expressions.test.ts
@@ -1,5 +1,9 @@
 import { ExpressionError } from 'n8n-workflow';
-import { stringifyExpressionResult, unwrapExpression } from '../expressions';
+import {
+	removeExpressionPrefix,
+	stringifyExpressionResult,
+	unwrapExpression,
+} from '../expressions';
 
 describe('Utils: Expressions', () => {
 	describe('stringifyExpressionResult()', () => {
@@ -41,6 +45,16 @@ describe('Utils: Expressions', () => {
 	describe('unwrapExpression', () => {
 		it('should remove the brackets around an expression', () => {
 			expect(unwrapExpression('{{ $json.foo }}')).toBe('$json.foo');
+		});
+	});
+
+	describe('removeExpressionPrefix', () => {
+		it.each([
+			['=expression', 'expression'],
+			['notAnExpression', 'notAnExpression'],
+			[undefined, ''],
+		])('turns "%s" into "%s"', (input, output) => {
+			expect(removeExpressionPrefix(input)).toBe(output);
 		});
 	});
 });

--- a/packages/editor-ui/src/utils/expressions.ts
+++ b/packages/editor-ui/src/utils/expressions.ts
@@ -16,8 +16,8 @@ export const unwrapExpression = (expr: string) => {
 	return expr.replace(/\{\{(.*)\}\}/, '$1').trim();
 };
 
-export const removeExpressionPrefix = (expr: string) => {
-	return expr.startsWith('=') ? expr.slice(1) : expr;
+export const removeExpressionPrefix = (expr: string | null | undefined) => {
+	return expr?.startsWith('=') ? expr.slice(1) : (expr ?? '');
 };
 
 export const isTestableExpression = (expr: string) => {


### PR DESCRIPTION
## Summary

Fix 2 sentry issues related to undefined

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1817/typeerror-undefined-is-not-an-object-evaluating-exprstartswith

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
