### PR TITLE
fix(editor): Fix render key for dynamic number of handles on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/handles/CanvasHandleRenderer.vue
+++ b/packages/editor-ui/src/components/canvas/elements/handles/CanvasHandleRenderer.vue
@@ -11,7 +11,6 @@ import CanvasHandleMainOutput from '@/components/canvas/elements/handles/render-
 import CanvasHandleNonMainInput from '@/components/canvas/elements/handles/render-types/CanvasHandleNonMainInput.vue';
 import CanvasHandleNonMainOutput from '@/components/canvas/elements/handles/render-types/CanvasHandleNonMainOutput.vue';
 import { CanvasNodeHandleKey } from '@/constants';
-import { createCanvasConnectionHandleString } from '@/utils/canvasUtilsV2';
 import { useCanvasNode } from '@/composables/useCanvasNode';
 
 const props = defineProps<
@@ -44,14 +43,6 @@ const style = useCssModule();
 
 const handleType = computed(() =>
 	props.mode === CanvasConnectionMode.Input ? 'target' : 'source',
-);
-
-const handleString = computed(() =>
-	createCanvasConnectionHandleString({
-		mode: props.mode,
-		type: props.type,
-		index: props.index,
-	}),
 );
 
 const handleClasses = computed(() => [style.handle, style[props.type], style[props.mode]]);
@@ -121,7 +112,7 @@ const RenderType = () => {
  */
 
 function onAdd() {
-	emit('add', handleString.value);
+	emit('add', props.handleId);
 }
 
 /**
@@ -152,7 +143,7 @@ provide(CanvasNodeHandleKey, {
 <template>
 	<Handle
 		v-bind="$attrs"
-		:id="handleString"
+		:id="handleId"
 		:class="handleClasses"
 		:type="handleType"
 		:position="position"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNode.vue
@@ -260,7 +260,10 @@ onBeforeUnmount(() => {
 		:class="[$style.canvasNode, { [$style.showToolbar]: showToolbar }]"
 		data-test-id="canvas-node"
 	>
-		<template v-for="source in mappedOutputs" :key="source.handleId">
+		<template
+			v-for="source in mappedOutputs"
+			:key="`${source.handleId}(${source.index + 1}/${mappedOutputs.length})`"
+		>
 			<CanvasHandleRenderer
 				v-bind="source"
 				:mode="CanvasConnectionMode.Output"
@@ -271,7 +274,10 @@ onBeforeUnmount(() => {
 			/>
 		</template>
 
-		<template v-for="target in mappedInputs" :key="target.handleId">
+		<template
+			v-for="target in mappedInputs"
+			:key="`${target.handleId}(${target.index + 1}/${mappedInputs.length})`"
+		>
 			<CanvasHandleRenderer
 				v-bind="target"
 				:mode="CanvasConnectionMode.Input"


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/e4b8baa7-d5b8-48ee-bedb-40595ca6c9fc



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7761/switch-connection-handles-start-from-wrong-position-after-changing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
