### PR TITLE
fix(editor):  Shorten overflowing Node Label in InputLabels on hover and focus

### DIFF
--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -47,7 +47,15 @@ const addTargetBlank = (html: string) =>
 			}"
 		>
 			<div v-if="label" :class="$style.title">
-				<N8nText :bold="bold" :size="size" :compact="compact" :color="color">
+				<N8nText
+					:bold="bold"
+					:size="size"
+					:compact="compact"
+					:color="color"
+					:class="{
+						[$style.textEllipses]: showOptions,
+					}"
+				>
 					{{ label }}
 					<N8nText v-if="required" color="primary" :bold="bold" :size="size">*</N8nText>
 				</N8nText>
@@ -105,6 +113,11 @@ const addTargetBlank = (html: string) =>
 	.overlay {
 		opacity: 1;
 		transition: opacity 100ms ease-in; // transition on hover in
+	}
+
+	.title > span {
+		text-overflow: ellipsis;
+		overflow: hidden;
 	}
 }
 
@@ -168,6 +181,11 @@ const addTargetBlank = (html: string) =>
 .overflow {
 	overflow-x: hidden;
 	overflow-y: clip;
+}
+
+.textEllipses {
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .heading {

--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -33,7 +33,14 @@ const addTargetBlank = (html: string) =>
 </script>
 
 <template>
-	<div :class="$style.container" v-bind="$attrs" data-test-id="input-label">
+	<div
+		:class="{
+			[$style.container]: true,
+			[$style.withOptions]: $slots.options,
+		}"
+		v-bind="$attrs"
+		data-test-id="input-label"
+	>
 		<label
 			v-if="label || $slots.options"
 			:for="inputName"
@@ -116,7 +123,8 @@ const addTargetBlank = (html: string) =>
 		opacity: 1;
 		transition: opacity 100ms ease-in; // transition on hover in
 	}
-
+}
+.withOptions:hover {
 	.title > span {
 		text-overflow: ellipsis;
 		overflow: hidden;

--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -50,6 +50,7 @@ const addTargetBlank = (html: string) =>
 				[$style.heading]: !!label,
 				[$style.underline]: underline,
 				[$style[size]]: true,
+				[$style.overflow]: !!$slots.options,
 			}"
 		>
 			<div v-if="label" :class="$style.title">
@@ -100,9 +101,6 @@ const addTargetBlank = (html: string) =>
 }
 .inputLabel {
 	display: block;
-
-	overflow-x: hidden;
-	overflow-y: clip;
 }
 .container:hover,
 .inputLabel:hover {
@@ -186,6 +184,11 @@ const addTargetBlank = (html: string) =>
 
 .visible {
 	opacity: 1;
+}
+
+.overflow {
+	overflow-x: hidden;
+	overflow-y: clip;
 }
 
 .textEllipses {

--- a/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -43,7 +43,6 @@ const addTargetBlank = (html: string) =>
 				[$style.heading]: !!label,
 				[$style.underline]: underline,
 				[$style[size]]: true,
-				[$style.overflow]: !!$slots.options,
 			}"
 		>
 			<div v-if="label" :class="$style.title">
@@ -94,6 +93,9 @@ const addTargetBlank = (html: string) =>
 }
 .inputLabel {
 	display: block;
+
+	overflow-x: hidden;
+	overflow-y: clip;
 }
 .container:hover,
 .inputLabel:hover {
@@ -176,11 +178,6 @@ const addTargetBlank = (html: string) =>
 
 .visible {
 	opacity: 1;
-}
-
-.overflow {
-	overflow-x: hidden;
-	overflow-y: clip;
 }
 
 .textEllipses {

--- a/packages/design-system/src/components/N8nInputLabel/__tests__/InputLabel.spec.ts
+++ b/packages/design-system/src/components/N8nInputLabel/__tests__/InputLabel.spec.ts
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/vue';
+
+import InputLabel from '../InputLabel.vue';
+
+describe('component', () => {
+	describe('Text overflow behavior', () => {
+		it('displays full text without options', () => {
+			const { container } = render(InputLabel, {
+				props: {
+					label: 'a label',
+				},
+			});
+
+			expect(container.querySelectorAll('.textEllipses').length).eq(0);
+
+			expect(container).toMatchSnapshot();
+		});
+
+		it('displays ellipsis with options', () => {
+			const { container } = render(InputLabel, {
+				props: {
+					label: 'a label',
+					showOptions: true,
+				},
+			});
+
+			expect(container.querySelectorAll('.textEllipses').length).eq(1);
+
+			expect(container).toMatchSnapshot();
+		});
+	});
+});

--- a/packages/design-system/src/components/N8nInputLabel/__tests__/__snapshots__/InputLabel.spec.ts.snap
+++ b/packages/design-system/src/components/N8nInputLabel/__tests__/__snapshots__/InputLabel.spec.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`component > Text overflow behavior > displays ellipsis with options 1`] = `
+<div>
+  <div
+    class="container"
+    data-test-id="input-label"
+  >
+    <label
+      class="n8n-input-label inputLabel heading medium"
+    >
+      <div
+        class="title"
+      >
+        <span
+          class="n8n-text size-medium bold textEllipses textEllipses"
+        >
+          
+          a label 
+          <!--v-if-->
+          
+        </span>
+      </div>
+      <!--v-if-->
+      <!--v-if-->
+      <!--v-if-->
+    </label>
+    
+    
+  </div>
+</div>
+`;
+
+exports[`component > Text overflow behavior > displays full text without options 1`] = `
+<div>
+  <div
+    class="container"
+    data-test-id="input-label"
+  >
+    <label
+      class="n8n-input-label inputLabel heading medium"
+    >
+      <div
+        class="title"
+      >
+        <span
+          class="n8n-text size-medium bold"
+        >
+          
+          a label 
+          <!--v-if-->
+          
+        </span>
+      </div>
+      <!--v-if-->
+      <!--v-if-->
+      <!--v-if-->
+    </label>
+    
+    
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary

Shorten the label on InputLabel on hover and on focus if options are in use.

Before:
<img width="283" alt="Screenshot 2024-10-04 at 16 38 03" src="https://github.com/user-attachments/assets/e22cbfd4-a949-4b97-851a-124acb1af2cd">

After:
<img width="338" alt="Screenshot 2024-10-04 at 16 39 38" src="https://github.com/user-attachments/assets/a668b824-72e3-4d84-bfaf-fb5af5cf318a">



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2626/display-name-of-ndv-parameters-should-wrap-and-not-overlap-with



## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
