### PR TITLE
fix(editor): Show previous nodes autocomplete in AI tool nodes

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/utils.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/utils.test.ts
@@ -1,5 +1,17 @@
-import { expressionWithFirstItem } from '../utils';
+import { createTestNode, createTestWorkflowObject } from '@/__tests__/mocks';
+import * as workflowHelpers from '@/composables/useWorkflowHelpers';
 import { javascriptLanguage } from '@codemirror/lang-javascript';
+import { autocompletableNodeNames, expressionWithFirstItem } from '../utils';
+import type { MockInstance } from 'vitest';
+import { mockedStore } from '../../../../__tests__/utils';
+import * as ndvStore from '@/stores/ndv.store';
+import { NodeConnectionType, type IConnections } from 'n8n-workflow';
+
+vi.mock('@/composables/useWorkflowHelpers', () => ({
+	useWorkflowHelpers: vi.fn().mockReturnValue({
+		getCurrentWorkflow: vi.fn(),
+	}),
+}));
 
 describe('completion utils', () => {
 	describe('expressionWithFirstItem', () => {
@@ -41,6 +53,74 @@ describe('completion utils', () => {
 			const tree = javascriptLanguage.parser.parse(source);
 			const result = expressionWithFirstItem(tree, source);
 			expect(result).toBe(expected);
+		});
+	});
+
+	describe('autocompletableNodeNames', () => {
+		it('should work for normal nodes', () => {
+			const nodes = [
+				createTestNode({ name: 'Node 1' }),
+				createTestNode({ name: 'Node 2' }),
+				createTestNode({ name: 'Node 3' }),
+			];
+			const connections = {
+				[nodes[0].name]: {
+					[NodeConnectionType.Main]: [
+						[{ node: nodes[1].name, type: NodeConnectionType.Main, index: 0 }],
+					],
+				},
+				[nodes[1].name]: {
+					[NodeConnectionType.Main]: [
+						[{ node: nodes[2].name, type: NodeConnectionType.Main, index: 0 }],
+					],
+				},
+			};
+			const workflowObject = createTestWorkflowObject({
+				nodes,
+				connections,
+			});
+
+			const workflowHelpersMock: MockInstance = vi.spyOn(workflowHelpers, 'useWorkflowHelpers');
+			workflowHelpersMock.mockReturnValue({
+				getCurrentWorkflow: vi.fn(() => workflowObject),
+			});
+			const ndvStoreMock: MockInstance = vi.spyOn(ndvStore, 'useNDVStore');
+			ndvStoreMock.mockReturnValue({ activeNode: nodes[2] });
+
+			expect(autocompletableNodeNames()).toEqual(['Node 2', 'Node 1']);
+		});
+
+		it('should work for AI tool nodes', () => {
+			const nodes = [
+				createTestNode({ name: 'Normal Node' }),
+				createTestNode({ name: 'Agent' }),
+				createTestNode({ name: 'Tool' }),
+			];
+			const connections: IConnections = {
+				[nodes[0].name]: {
+					[NodeConnectionType.Main]: [
+						[{ node: nodes[1].name, type: NodeConnectionType.Main, index: 0 }],
+					],
+				},
+				[nodes[2].name]: {
+					[NodeConnectionType.AiMemory]: [
+						[{ node: nodes[1].name, type: NodeConnectionType.AiMemory, index: 0 }],
+					],
+				},
+			};
+			const workflowObject = createTestWorkflowObject({
+				nodes,
+				connections,
+			});
+
+			const workflowHelpersMock: MockInstance = vi.spyOn(workflowHelpers, 'useWorkflowHelpers');
+			workflowHelpersMock.mockReturnValue({
+				getCurrentWorkflow: vi.fn(() => workflowObject),
+			});
+			const ndvStoreMock: MockInstance = vi.spyOn(ndvStore, 'useNDVStore');
+			ndvStoreMock.mockReturnValue({ activeNode: nodes[2] });
+
+			expect(autocompletableNodeNames()).toEqual(['Normal Node']);
 		});
 	});
 });

--- a/packages/editor-ui/src/plugins/codemirror/completions/__tests__/utils.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/__tests__/utils.test.ts
@@ -3,7 +3,6 @@ import * as workflowHelpers from '@/composables/useWorkflowHelpers';
 import { javascriptLanguage } from '@codemirror/lang-javascript';
 import { autocompletableNodeNames, expressionWithFirstItem } from '../utils';
 import type { MockInstance } from 'vitest';
-import { mockedStore } from '../../../../__tests__/utils';
 import * as ndvStore from '@/stores/ndv.store';
 import { NodeConnectionType, type IConnections } from 'n8n-workflow';
 


### PR DESCRIPTION
## Summary

Show previous nodes autocomplete in AI tool nodes

<img width="869" alt="image" src="https://github.com/user-attachments/assets/83759348-eb19-4e08-9dcc-44b331f91559">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1798/autocomplete-does-not-work-inside-tool

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
