### PR TITLE
fix: Workflow deactivation error should not block deactivation (no-changelog)

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -51,6 +51,7 @@ import {
 	sleep,
 	ExecutionCancelledError,
 	Node,
+	TriggerCloseError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 import Container from 'typedi';
@@ -1606,8 +1607,14 @@ export class WorkflowExecute {
 
 								if (runNodeData.closeFunction) {
 									// Explanation why we do this can be found in n8n-workflow/Workflow.ts -> runNode
-
-									closeFunction = runNodeData.closeFunction();
+									try {
+										closeFunction = runNodeData.closeFunction();
+									} catch (error) {
+										throw new TriggerCloseError(executionNode, {
+											cause: error as Error,
+											level: 'warning',
+										});
+									}
 								}
 							}
 

--- a/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Kafka/KafkaTrigger.node.ts
@@ -9,7 +9,7 @@ import type {
 	ITriggerResponse,
 	IRun,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, TriggerCloseError } from 'n8n-workflow';
 
 export class KafkaTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -295,9 +295,14 @@ export class KafkaTrigger implements INodeType {
 
 		// The "closeFunction" function gets called by n8n whenever
 		// the workflow gets deactivated and can so clean up.
-		async function closeFunction() {
-			await consumer.disconnect();
-		}
+		const closeFunction = async () => {
+			try {
+				await consumer.disconnect();
+			} catch (error) {
+				// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+				throw new TriggerCloseError(this.getNode(), { cause: error as Error, level: 'warning' });
+			}
+		};
 
 		// The "manualTriggerFunction" function gets called by n8n
 		// when a user is in the workflow editor and starts the

--- a/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
+++ b/packages/nodes-base/nodes/LocalFileTrigger/LocalFileTrigger.node.ts
@@ -6,6 +6,7 @@ import {
 	type INodeTypeDescription,
 	type ITriggerResponse,
 	NodeConnectionType,
+	TriggerCloseError,
 } from 'n8n-workflow';
 
 export class LocalFileTrigger implements INodeType {
@@ -241,9 +242,14 @@ export class LocalFileTrigger implements INodeType {
 			watcher.on(eventName, (pathString) => executeTrigger(eventName, pathString as string));
 		}
 
-		async function closeFunction() {
-			return await watcher.close();
-		}
+		const closeFunction = async () => {
+			try {
+				return await watcher.close();
+			} catch (error) {
+				// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+				throw new TriggerCloseError(this.getNode(), { cause: error as Error, level: 'warning' });
+			}
+		};
 
 		return {
 			closeFunction,

--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQTrigger.node.ts
@@ -10,7 +10,7 @@ import type {
 	ITriggerFunctions,
 	ITriggerResponse,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, TriggerCloseError } from 'n8n-workflow';
 
 import { rabbitDefaultOptions } from './DefaultOptions';
 import { MessageTracker, rabbitmqConnectQueue, parseMessage } from './GenericFunctions';
@@ -228,9 +228,14 @@ export class RabbitMQTrigger implements INodeType {
 			};
 
 			const closeFunction = async () => {
-				await channel.close();
-				await channel.connection.close();
-				return;
+				try {
+					await channel.close();
+					await channel.connection.close();
+					return;
+				} catch (error) {
+					// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+					throw new TriggerCloseError(this.getNode(), { cause: error as Error, level: 'warning' });
+				}
 			};
 
 			return {

--- a/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
+++ b/packages/nodes-base/nodes/Redis/RedisTrigger.node.ts
@@ -4,7 +4,7 @@ import type {
 	INodeTypeDescription,
 	ITriggerResponse,
 } from 'n8n-workflow';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, TriggerCloseError } from 'n8n-workflow';
 
 import type { RedisCredential } from './types';
 import { redisConnectionTest, setupRedisClient } from './utils';
@@ -111,10 +111,15 @@ export class RedisTrigger implements INodeType {
 			await client.pSubscribe(channels, onMessage);
 		}
 
-		async function closeFunction() {
-			await client.pUnsubscribe();
-			await client.quit();
-		}
+		const closeFunction = async () => {
+			try {
+				await client.pUnsubscribe();
+				await client.quit();
+			} catch (error) {
+				// eslint-disable-next-line n8n-nodes-base/node-execute-block-wrong-error-thrown
+				throw new TriggerCloseError(this.getNode(), { cause: error as Error, level: 'warning' });
+			}
+		};
 
 		return {
 			closeFunction,


### PR DESCRIPTION
## Summary
This PR fixes Trigger nodes so that workflow deactivation error does not block deactivation, by throwing TriggerCloseError in the following Trigger nodes:

- AmqpTrigger
- KafkaTrigger
- LocalFileTrigger
- MqttTrigger
- RabbitMqTrigger
- RedisTrigger

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1699/workflow-deactivation-error-should-not-block-deactivation

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
