### PR TITLE
fix(Convert to File Node): Convert to ICS start date defaults to now

### DIFF
--- a/packages/nodes-base/nodes/ICalendar/createEvent.operation.ts
+++ b/packages/nodes-base/nodes/ICalendar/createEvent.operation.ts
@@ -28,7 +28,6 @@ export const description: INodeProperties[] = [
 		required: true,
 		description:
 			'Date and time at which the event begins. (For all-day events, the time will be ignored.).',
-		validateType: 'dateTime',
 	},
 	{
 		displayName: 'End',


### PR DESCRIPTION
## Summary
This PR fixes the start date of ICS event, the validation property seems to be causing the issue and it doesn't actually validate the value.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1452/convert-to-file-node-convert-to-ics-start-date-defaults-to-now
https://community.n8n.io/t/bug-in-ics-file-creation/49302
https://community.n8n.io/t/ics-calendar-creation-issue/52700
https://github.com/n8n-io/n8n/issues/11073

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
