### PR TITLE
fix: Fix task runner default n8n uri and auth endpoint (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/authenticator.ts
+++ b/packages/@n8n/task-runner/src/authenticator.ts
@@ -11,7 +11,7 @@ export type AuthOpts = {
  */
 export async function authenticate(opts: AuthOpts) {
 	try {
-		const authEndpoint = `http://${opts.n8nUri}/rest/runners/auth`;
+		const authEndpoint = `http://${opts.n8nUri}/runners/auth`;
 		const response = await fetch(authEndpoint, {
 			method: 'POST',
 			headers: {

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -20,7 +20,7 @@ function readAndParseConfig(): Config {
 	}
 
 	return {
-		n8nUri: process.env.N8N_RUNNERS_N8N_URI ?? 'localhost:5678',
+		n8nUri: process.env.N8N_RUNNERS_N8N_URI ?? 'localhost:5679',
 		authToken,
 		grantToken,
 	};

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -20,7 +20,7 @@ function readAndParseConfig(): Config {
 	}
 
 	return {
-		n8nUri: process.env.N8N_RUNNERS_N8N_URI ?? 'localhost:5679',
+		n8nUri: process.env.N8N_RUNNERS_N8N_URI ?? '127.0.0.1:5679',
 		authToken,
 		grantToken,
 	};


### PR DESCRIPTION
## Summary

Fix task runner default n8n uri and auth endpoint

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
