### PR TITLE
fix(core): Allow loading nodes from multiple custom directories

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -260,7 +260,7 @@ export class LoadNodesAndCredentials {
 		dir: string,
 	) {
 		const loader = new constructor(dir, this.excludeNodes, this.includeNodes);
-		if (loader.packageName in this.loaders) {
+		if (loader instanceof PackageDirectoryLoader && loader.packageName in this.loaders) {
 			throw new ApplicationError(
 				picocolors.red(
 					`nodes package ${loader.packageName} is already loaded.\n Please delete this second copy at path ${dir}`,


### PR DESCRIPTION
## Summary
In #10979 we added a check to prevent n8n instances from overwriting existing nodes. But that check did not exclude custom nodes. This PR fixes that issue, allowing people to load custom nodes from multiple directories again.

This entire file needs unit tests so that we can prevent regressions like these in the future.

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Tests included
- [x] PR Labeled with `release/backport`