### PR TITLE
fix(Google Calendar Node): Mode to add or replace attendees in event update

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
@@ -841,6 +841,58 @@ export const eventFields: INodeProperties[] = [
 			},
 			{
 				displayName: 'Attendees',
+				name: 'attendeesUi',
+				type: 'fixedCollection',
+				placeholder: 'Add Attendees',
+				default: {
+					values: {
+						mode: 'add',
+						attendees: [],
+					},
+				},
+				options: [
+					{
+						displayName: 'Values',
+						name: 'values',
+						values: [
+							{
+								displayName: 'Mode',
+								name: 'mode',
+								type: 'options',
+								default: 'add',
+								options: [
+									{
+										name: 'Add Attendees Below [Default]',
+										value: 'add',
+									},
+									{
+										name: 'Replace Attendees with Those Below',
+										value: 'replace',
+									},
+								],
+							},
+							{
+								displayName: 'Attendees',
+								name: 'attendees',
+								type: 'string',
+								typeOptions: {
+									multipleValues: true,
+									multipleValueButtonText: 'Add Attendee',
+								},
+								default: '',
+								description: 'The attendees of the event. Multiple ones can be separated by comma.',
+							},
+						],
+					},
+				],
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 1.2 } }],
+					},
+				},
+			},
+			{
+				displayName: 'Attendees',
 				name: 'attendees',
 				type: 'string',
 				typeOptions: {
@@ -849,6 +901,11 @@ export const eventFields: INodeProperties[] = [
 				},
 				default: '',
 				description: 'The attendees of the event. Multiple ones can be separated by comma.',
+				displayOptions: {
+					show: {
+						'@version': [1, 1.1],
+					},
+				},
 			},
 			{
 				displayName: 'Color Name or ID',

--- a/packages/nodes-base/nodes/Google/Calendar/test/node/event.update.test.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/test/node/event.update.test.ts
@@ -1,0 +1,128 @@
+import type { MockProxy } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
+import type { INode, IExecuteFunctions } from 'n8n-workflow';
+
+import { GoogleCalendar } from '../../GoogleCalendar.node';
+
+import * as genericFunctions from '../../GenericFunctions';
+
+jest.mock('../../GenericFunctions', () => ({
+	getTimezones: jest.fn(),
+	googleApiRequest: jest.fn(),
+	googleApiRequestAllItems: jest.fn(),
+	addTimezoneToDate: jest.fn(),
+	addNextOccurrence: jest.fn(),
+	encodeURIComponentOnce: jest.fn(),
+}));
+
+describe('RespondToWebhook Node', () => {
+	let googleCalendar: GoogleCalendar;
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		googleCalendar = new GoogleCalendar();
+		mockExecuteFunctions = mock<IExecuteFunctions>({
+			getInputData: jest.fn(),
+			getNode: jest.fn(),
+			getNodeParameter: jest.fn(),
+			getTimezone: jest.fn(),
+			helpers: {
+				constructExecutionMetaData: jest.fn().mockReturnValue([]),
+			},
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Google Calendar > Event > Update', () => {
+		it('should update replace attendees in version 1.1', async () => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('event');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('update');
+			mockExecuteFunctions.getTimezone.mockReturnValueOnce('Europe/Berlin');
+			mockExecuteFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.1 }));
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myCalendar');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myEvent');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(true);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({
+				attendees: ['email1@mail.com'],
+			});
+
+			await googleCalendar.execute.call(mockExecuteFunctions);
+
+			expect(genericFunctions.googleApiRequest).toHaveBeenCalledWith(
+				'PATCH',
+				'/calendar/v3/calendars/undefined/events/myEvent',
+				{ attendees: [{ email: 'email1@mail.com' }] },
+				{},
+			);
+		});
+
+		it('should update replace attendees', async () => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('event');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('update');
+			mockExecuteFunctions.getTimezone.mockReturnValueOnce('Europe/Berlin');
+			mockExecuteFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.2 }));
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myCalendar');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myEvent');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(true);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({
+				attendeesUi: {
+					values: {
+						mode: 'replace',
+						attendees: ['email1@mail.com'],
+					},
+				},
+			});
+
+			await googleCalendar.execute.call(mockExecuteFunctions);
+
+			expect(genericFunctions.googleApiRequest).toHaveBeenCalledWith(
+				'PATCH',
+				'/calendar/v3/calendars/undefined/events/myEvent',
+				{ attendees: [{ email: 'email1@mail.com' }] },
+				{},
+			);
+		});
+
+		it('should update add attendees', async () => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('event');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('update');
+			mockExecuteFunctions.getTimezone.mockReturnValueOnce('Europe/Berlin');
+			mockExecuteFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.2 }));
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myCalendar');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('myEvent');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce(true);
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({
+				attendeesUi: {
+					values: {
+						mode: 'add',
+						attendees: ['email1@mail.com'],
+					},
+				},
+			});
+			(genericFunctions.googleApiRequest as jest.Mock).mockResolvedValueOnce({
+				attendees: [{ email: 'email2@mail.com' }],
+			});
+
+			await googleCalendar.execute.call(mockExecuteFunctions);
+
+			expect(genericFunctions.googleApiRequest).toHaveBeenCalledTimes(2);
+
+			expect(genericFunctions.googleApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/calendar/v3/calendars/undefined/events/myEvent',
+			);
+			expect(genericFunctions.googleApiRequest).toHaveBeenCalledWith(
+				'PATCH',
+				'/calendar/v3/calendars/undefined/events/myEvent',
+				{ attendees: [{ email: 'email2@mail.com' }, { email: 'email1@mail.com' }] },
+				{},
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

updated option attendees to allow adding or replacing attendees when updating event

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1682/google-calendar-adding-attendees-to-event-doesnt-work
https://community.n8n.io/t/google-calendar-attendees/27530
