### PR TITLE
feat(editor): Add route for create / edit / share credentials

### DIFF
--- a/packages/editor-ui/src/components/CredentialCard.vue
+++ b/packages/editor-ui/src/components/CredentialCard.vue
@@ -135,7 +135,7 @@ function moveResource() {
 </script>
 
 <template>
-	<n8n-card :class="$style.cardLink" @click="onClick">
+	<n8n-card :class="$style.cardLink" @click.stop="onClick">
 		<template #prepend>
 			<CredentialIcon :credential-type-name="credentialType?.name ?? ''" />
 		</template>

--- a/packages/editor-ui/src/components/CredentialCard.vue
+++ b/packages/editor-ui/src/components/CredentialCard.vue
@@ -21,6 +21,10 @@ const CREDENTIAL_LIST_ITEM_ACTIONS = {
 	MOVE: 'move',
 };
 
+const emit = defineEmits<{
+	click: [credentialId: string];
+}>();
+
 const props = withDefaults(
 	defineProps<{
 		data: ICredentialsResponse;
@@ -83,7 +87,7 @@ const formattedCreatedAtDate = computed(() => {
 });
 
 function onClick() {
-	uiStore.openExistingCredential(props.data.id);
+	emit('click', props.data.id);
 }
 
 async function onAction(action: string) {

--- a/packages/editor-ui/src/routes/projects.routes.ts
+++ b/packages/editor-ui/src/routes/projects.routes.ts
@@ -18,7 +18,8 @@ const commonChildRoutes: RouteRecordRaw[] = [
 		},
 	},
 	{
-		path: 'credentials',
+		path: 'credentials/:credentialId?',
+		props: true,
 		components: {
 			default: CredentialsView,
 			sidebar: MainSidebar,

--- a/packages/editor-ui/src/views/CredentialsView.test.ts
+++ b/packages/editor-ui/src/views/CredentialsView.test.ts
@@ -1,84 +1,141 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
-import type { Scope } from '@n8n/permissions';
 import { useCredentialsStore } from '@/stores/credentials.store';
-import type { ProjectSharingData } from '@/types/projects.types';
 import CredentialsView from '@/views/CredentialsView.vue';
-import ResourcesListLayout from '@/components/layouts/ResourcesListLayout.vue';
+import { useUIStore } from '@/stores/ui.store';
+import { mockedStore } from '@/__tests__/utils';
+import { waitFor, within, fireEvent } from '@testing-library/vue';
+import { CREDENTIAL_SELECT_MODAL_KEY } from '@/constants';
+import userEvent from '@testing-library/user-event';
+import { STORES } from '@/constants';
+import { useProjectsStore } from '@/stores/projects.store';
+import type { Project } from '@/types/projects.types';
 
-vi.mock('@/components/layouts/ResourcesListLayout.vue', async (importOriginal) => {
-	const original = await importOriginal<typeof ResourcesListLayout>();
+const mockRoutePush = vi.fn();
+const mockRouteReplace = vi.fn();
+vi.mock('vue-router', async (importOriginal) => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const actual = await importOriginal<typeof import('vue-router')>();
 	return {
-		default: {
-			...original.default,
-			render: vi.fn(),
-			setup: vi.fn(),
+		...actual,
+		// your mocked methods
+		useRouter: () => {
+			return {
+				push: mockRoutePush,
+				replace: mockRouteReplace,
+			};
 		},
 	};
 });
 
+const initialState = {
+	[STORES.SETTINGS]: {
+		settings: { enterprise: { variables: true, projects: { team: { limit: -1 } } } },
+	},
+};
+
 const renderComponent = createComponentRenderer(CredentialsView);
 
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
 describe('CredentialsView', () => {
-	describe('with fake stores', () => {
-		let credentialsStore: ReturnType<typeof useCredentialsStore>;
-
-		beforeEach(() => {
-			createTestingPinia();
-			credentialsStore = useCredentialsStore();
-		});
-
-		afterAll(() => {
-			vi.resetAllMocks();
-		});
-		it('should have ResourcesListLayout render with necessary keys from credential object', () => {
-			const homeProject: ProjectSharingData = {
+	it('should render credentials', () => {
+		createTestingPinia({ initialState });
+		const credentialsStore = mockedStore(useCredentialsStore);
+		credentialsStore.allCredentials = [
+			{
 				id: '1',
 				name: 'test',
-				type: 'personal',
+				type: 'test',
 				createdAt: '2021-05-05T00:00:00Z',
 				updatedAt: '2021-05-05T00:00:00Z',
-			};
-			const scopes: Scope[] = ['credential:move', 'credential:delete'];
-			const sharedWithProjects: ProjectSharingData[] = [
-				{
-					id: '2',
-					name: 'test 2',
-					type: 'personal',
-					createdAt: '2021-05-05T00:00:00Z',
-					updatedAt: '2021-05-05T00:00:00Z',
-				},
-			];
-			vi.spyOn(credentialsStore, 'allCredentials', 'get').mockReturnValue([
+			},
+		];
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.isProjectHome = false;
+		const { getByTestId } = renderComponent();
+		expect(getByTestId('resources-list-item')).toBeInTheDocument();
+	});
+
+	it('should disable cards based on permissions', () => {
+		createTestingPinia({ initialState });
+		const credentialsStore = mockedStore(useCredentialsStore);
+		credentialsStore.allCredentials = [
+			{
+				id: '1',
+				name: 'test',
+				type: 'test',
+				createdAt: '2021-05-05T00:00:00Z',
+				updatedAt: '2021-05-05T00:00:00Z',
+				scopes: ['credential:update'],
+			},
+			{
+				id: '2',
+				name: 'test2',
+				type: 'test2',
+				createdAt: '2021-05-05T00:00:00Z',
+				updatedAt: '2021-05-05T00:00:00Z',
+			},
+		];
+		const projectsStore = mockedStore(useProjectsStore);
+		projectsStore.isProjectHome = false;
+		const { getAllByTestId } = renderComponent();
+
+		const items = getAllByTestId('resources-list-item');
+		expect(items.length).toBe(2);
+
+		expect(within(items[1]).getByText('Read only')).toBeInTheDocument();
+	});
+
+	describe('create credential', () => {
+		it('should show modal based on route param', async () => {
+			createTestingPinia({ initialState });
+			const uiStore = mockedStore(useUIStore);
+			renderComponent({ props: { credentialId: 'create' } });
+			expect(uiStore.openModal).toHaveBeenCalledWith(CREDENTIAL_SELECT_MODAL_KEY);
+		});
+
+		it('should update credentialId route param to create', async () => {
+			createTestingPinia({ initialState });
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.isProjectHome = false;
+			projectsStore.currentProject = { scopes: ['credential:create'] } as Project;
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.allCredentials = [
 				{
 					id: '1',
 					name: 'test',
 					type: 'test',
 					createdAt: '2021-05-05T00:00:00Z',
 					updatedAt: '2021-05-05T00:00:00Z',
-					homeProject,
-					scopes,
-					sharedWithProjects,
 				},
-			]);
-			renderComponent();
-			expect(ResourcesListLayout.setup).toHaveBeenCalledWith(
-				expect.objectContaining({
-					resources: [
-						expect.objectContaining({
-							type: 'test',
-							homeProject,
-							scopes,
-							sharedWithProjects,
-						}),
-					],
-				}),
-				null,
+			];
+			const { getByTestId } = renderComponent();
+
+			await userEvent.click(getByTestId('resources-list-add'));
+			await waitFor(() =>
+				expect(mockRouteReplace).toHaveBeenCalledWith({ params: { credentialId: 'create' } }),
 			);
 		});
+	});
 
-		it('should disable cards based on permissions', () => {
-			vi.spyOn(credentialsStore, 'allCredentials', 'get').mockReturnValue([
+	describe('open existing credential', () => {
+		it('should show modal based on route param', async () => {
+			createTestingPinia({ initialState });
+			const uiStore = mockedStore(useUIStore);
+			renderComponent({ props: { credentialId: 'credential-id' } });
+			expect(uiStore.openExistingCredential).toHaveBeenCalledWith('credential-id');
+		});
+
+		it('should update credentialId route param to create', async () => {
+			createTestingPinia({ initialState });
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.isProjectHome = false;
+			projectsStore.currentProject = { scopes: ['credential:read'] } as Project;
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.allCredentials = [
 				{
 					id: '1',
 					name: 'test',
@@ -87,28 +144,15 @@ describe('CredentialsView', () => {
 					updatedAt: '2021-05-05T00:00:00Z',
 					scopes: ['credential:update'],
 				},
-				{
-					id: '2',
-					name: 'test2',
-					type: 'test2',
-					createdAt: '2021-05-05T00:00:00Z',
-					updatedAt: '2021-05-05T00:00:00Z',
-				},
-			]);
+			];
+			const { getByTestId } = renderComponent();
 
-			renderComponent();
-			expect(ResourcesListLayout.setup).toHaveBeenCalledWith(
-				expect.objectContaining({
-					resources: [
-						expect.objectContaining({
-							readOnly: false,
-						}),
-						expect.objectContaining({
-							readOnly: true,
-						}),
-					],
-				}),
-				null,
+			/**
+			 * userEvent DOES NOT work here
+			 */
+			await fireEvent.click(getByTestId('resources-list-item'));
+			await waitFor(() =>
+				expect(mockRouteReplace).toHaveBeenCalledWith({ params: { credentialId: '1' } }),
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

Access credentials by Id
![image](https://github.com/user-attachments/assets/02f27b24-7b92-4b4f-8672-8a8420059473)


## Related Linear tickets, Github issues, and Community forum posts

[PAY-2062](https://linear.app/n8n/issue/PAY-2062/update-credentials-router)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
