### PR TITLE
chore: Document file-upload properties for `@n8n/chat` (no-changelog)

### DIFF
--- a/packages/@n8n/chat/README.md
+++ b/packages/@n8n/chat/README.md
@@ -184,6 +184,16 @@ createChat({
 - **Type**: `string[]`
 - **Description**: The initial messages to be displayed in the Chat window.
 
+### `allowFileUploads`
+- **Type**: `Ref<boolean> | boolean`
+- **Default**: `false`
+- **Description**: Whether to allow file uploads in the chat. If set to `true`, users will be able to upload files through the chat interface.
+
+### `allowedFilesMimeTypes`
+- **Type**: `Ref<string> | string`
+- **Default**: `''`
+- **Description**: A comma-separated list of allowed MIME types for file uploads. Only applicable if `allowFileUploads` is set to `true`. If left empty, all file types are allowed. For example: `'image/*,application/pdf'`.
+
 ## Customization
 The Chat window is entirely customizable using CSS variables.
 


### PR DESCRIPTION
## Summary
Add Chat SDK docs about `allowFileUploads` and `allowedFilesMimeTypes`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
