### PR TITLE
fix(editor): Prevent setting sticky node as active node on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -22,7 +22,7 @@ import { useCredentialsStore } from '@/stores/credentials.store';
 import { waitFor } from '@testing-library/vue';
 import { createTestingPinia } from '@pinia/testing';
 import { mockedStore } from '@/__tests__/utils';
-import { SET_NODE_TYPE, STORES } from '@/constants';
+import { SET_NODE_TYPE, STICKY_NODE_TYPE, STORES } from '@/constants';
 import type { Connection } from '@vue-flow/core';
 import { useClipboard } from '@/composables/useClipboard';
 
@@ -251,6 +251,24 @@ describe('useCanvasOperations', () => {
 			);
 
 			await waitFor(() => expect(ndvStore.setActiveNodeName).toHaveBeenCalledWith('Test Name'));
+		});
+
+		it('should not set sticky node type as active node', async () => {
+			const ndvStore = useNDVStore();
+			const nodeTypeDescription = mockNodeTypeDescription({ name: STICKY_NODE_TYPE });
+
+			const { addNode } = useCanvasOperations({ router });
+			addNode(
+				{
+					type: STICKY_NODE_TYPE,
+					typeVersion: 1,
+					name: 'Test Name',
+				},
+				nodeTypeDescription,
+				{ openNDV: true },
+			);
+
+			await waitFor(() => expect(ndvStore.setActiveNodeName).not.toHaveBeenCalled());
 		});
 	});
 

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -610,10 +610,10 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 			if (nodeData.type !== STICKY_NODE_TYPE) {
 				void externalHooks.run('nodeView.addNodeButton', { nodeTypeName: nodeData.type });
-			}
 
-			if (options.openNDV && !preventOpeningNDV) {
-				ndvStore.setActiveNodeName(nodeData.name);
+				if (options.openNDV && !preventOpeningNDV) {
+					ndvStore.setActiveNodeName(nodeData.name);
+				}
 			}
 		});
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/f4de33fd-1441-41ef-8d34-9acfe65e7618



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7800/cannot-save-workflows-with-shortcut-if-theres-a-sticky

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
