### PR TITLE
fix(editor): Make sure deactivated status shows even for nodes with long names on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -126,7 +126,9 @@ function openContextMenu(event: MouseEvent) {
 		<div :class="$style.description">
 			<div v-if="label" :class="$style.label">
 				{{ label }}
-				<div v-if="isDisabled">({{ i18n.baseText('node.disabled') }})</div>
+			</div>
+			<div v-if="isDisabled" :class="$style.disabledLabel">
+				({{ i18n.baseText('node.disabled') }})
 			</div>
 			<div v-if="subtitle" :class="$style.subtitle">{{ subtitle }}</div>
 		</div>
@@ -265,7 +267,8 @@ function openContextMenu(event: MouseEvent) {
 	align-items: center;
 }
 
-.label {
+.label,
+.disabledLabel {
 	font-size: var(--font-size-m);
 	text-align: center;
 	text-overflow: ellipsis;

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/__snapshots__/CanvasNodeDefault.spec.ts.snap
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/__snapshots__/CanvasNodeDefault.spec.ts.snap
@@ -17,9 +17,9 @@ exports[`CanvasNodeDefault > configurable > should render configurable node corr
     <div
       class="label"
     >
-      Test Node 
-      <!--v-if-->
+      Test Node
     </div>
+    <!--v-if-->
     <div
       class="subtitle"
     >
@@ -46,9 +46,9 @@ exports[`CanvasNodeDefault > configuration > should render configurable configur
     <div
       class="label"
     >
-      Test Node 
-      <!--v-if-->
+      Test Node
     </div>
+    <!--v-if-->
     <div
       class="subtitle"
     >
@@ -75,9 +75,9 @@ exports[`CanvasNodeDefault > configuration > should render configuration node co
     <div
       class="label"
     >
-      Test Node 
-      <!--v-if-->
+      Test Node
     </div>
+    <!--v-if-->
     <div
       class="subtitle"
     >
@@ -104,9 +104,9 @@ exports[`CanvasNodeDefault > should render node correctly 1`] = `
     <div
       class="label"
     >
-      Test Node 
-      <!--v-if-->
+      Test Node
     </div>
+    <!--v-if-->
     <div
       class="subtitle"
     >
@@ -156,9 +156,9 @@ exports[`CanvasNodeDefault > trigger > should render trigger node correctly 1`] 
     <div
       class="label"
     >
-      Test Node 
-      <!--v-if-->
+      Test Node
     </div>
+    <!--v-if-->
     <div
       class="subtitle"
     >


### PR DESCRIPTION
## Summary

<img width="634" alt="Screenshot 2024-10-07 at 16 21 45" src="https://github.com/user-attachments/assets/cc927f3b-0ec7-474d-b9d2-086dacc142d2">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7797/cannot-see-full-node-name-here-and-deactivated-its-important-to-show

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
