### PR TITLE
fix: Fix transaction handling for 'revert' command

### DIFF
--- a/packages/cli/src/commands/db/revert.ts
+++ b/packages/cli/src/commands/db/revert.ts
@@ -55,7 +55,9 @@ export async function main(
 		return;
 	}
 
-	await connection.undoLastMigration();
+	await connection.undoLastMigration({
+		transaction: lastMigrationInstance.transaction === false ? 'none' : 'each',
+	});
 	await connection.destroy();
 }
 


### PR DESCRIPTION
## Summary

If a migration has `transaction = false`, we should not let the MigrationExecutor start a transaction

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
