### PR TITLE
fix: Fix console log handling in JS task runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -1,4 +1,4 @@
-import type { CodeExecutionMode, IDataObject, WorkflowExecuteMode } from 'n8n-workflow';
+import type { CodeExecutionMode, IDataObject } from 'n8n-workflow';
 
 import { ValidationError } from '@/js-task-runner/errors/validation-error';
 import {
@@ -31,30 +31,13 @@ describe('JsTaskRunner', () => {
 	});
 
 	describe('console', () => {
-		test.each<[CodeExecutionMode, WorkflowExecuteMode]>([
-			['runOnceForAllItems', 'cli'],
-			['runOnceForAllItems', 'error'],
-			['runOnceForAllItems', 'integrated'],
-			['runOnceForAllItems', 'internal'],
-			['runOnceForAllItems', 'retry'],
-			['runOnceForAllItems', 'trigger'],
-			['runOnceForAllItems', 'webhook'],
-			['runOnceForEachItem', 'cli'],
-			['runOnceForEachItem', 'error'],
-			['runOnceForEachItem', 'integrated'],
-			['runOnceForEachItem', 'internal'],
-			['runOnceForEachItem', 'retry'],
-			['runOnceForEachItem', 'trigger'],
-			['runOnceForEachItem', 'webhook'],
-		])(
-			'should make an rpc call for console log in %s mode when workflow mode is %s',
-			async (nodeMode, workflowMode) => {
-				jest.spyOn(console, 'log').mockImplementation(() => {});
+		test.each<[CodeExecutionMode]>([['runOnceForAllItems'], ['runOnceForEachItem']])(
+			'should make an rpc call for console log in %s mode',
+			async (nodeMode) => {
 				jest.spyOn(jsTaskRunner, 'makeRpcCall').mockResolvedValue(undefined);
 				const task = newTaskWithSettings({
 					code: "console.log('Hello', 'world!'); return {}",
 					nodeMode,
-					workflowMode,
 				});
 
 				await execTaskWithParams({
@@ -62,32 +45,9 @@ describe('JsTaskRunner', () => {
 					taskData: newAllCodeTaskData([wrapIntoJson({})]),
 				});
 
-				expect(console.log).toHaveBeenCalledWith('[JS Code]', 'Hello world!');
 				expect(jsTaskRunner.makeRpcCall).toHaveBeenCalledWith(task.taskId, 'logNodeOutput', [
 					'Hello world!',
 				]);
-			},
-		);
-
-		test.each<[CodeExecutionMode, WorkflowExecuteMode]>([
-			['runOnceForAllItems', 'manual'],
-			['runOnceForEachItem', 'manual'],
-		])(
-			"shouldn't make an rpc call for console log in %s mode when workflow mode is %s",
-			async (nodeMode, workflowMode) => {
-				jest.spyOn(jsTaskRunner, 'makeRpcCall').mockResolvedValue(undefined);
-				const task = newTaskWithSettings({
-					code: "console.log('Hello', 'world!'); return {}",
-					nodeMode,
-					workflowMode,
-				});
-
-				await execTaskWithParams({
-					task,
-					taskData: newAllCodeTaskData([wrapIntoJson({})]),
-				});
-
-				expect(jsTaskRunner.makeRpcCall).not.toHaveBeenCalled();
 			},
 		);
 	});

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -74,8 +74,6 @@ type CustomConsole = {
 	log: (...args: unknown[]) => void;
 };
 
-const noop = () => {};
-
 export class JsTaskRunner extends TaskRunner {
 	constructor(
 		taskType: string,
@@ -110,16 +108,14 @@ export class JsTaskRunner extends TaskRunner {
 		});
 
 		const customConsole = {
-			log:
-				settings.workflowMode === 'manual'
-					? noop
-					: (...args: unknown[]) => {
-							const logOutput = args
-								.map((arg) => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg))
-								.join(' ');
-							console.log('[JS Code]', logOutput);
-							void this.makeRpcCall(task.taskId, 'logNodeOutput', [logOutput]);
-						},
+			// Send log output back to the main process. It will take care of forwarding
+			// it to the UI or printing to console.
+			log: (...args: unknown[]) => {
+				const logOutput = args
+					.map((arg) => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg))
+					.join(' ');
+				void this.makeRpcCall(task.taskId, 'logNodeOutput', [logOutput]);
+			},
 		};
 
 		const result =


### PR DESCRIPTION

## Summary

`NodeExecuteFunctions` take care of routing the logs to the correct place.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
