### PR TITLE
refactor(core): Include self-sending and debouncing in pubsub commands

### DIFF
--- a/packages/cli/src/scaling/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/publisher.service.test.ts
@@ -52,7 +52,7 @@ describe('Publisher', () => {
 
 			expect(client.publish).toHaveBeenCalledWith(
 				'n8n.commands',
-				JSON.stringify({ ...msg, senderId: queueModeId }),
+				JSON.stringify({ ...msg, senderId: queueModeId, selfSend: false, debounce: true }),
 			);
 		});
 	});

--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -7,3 +7,17 @@ export const COMMAND_PUBSUB_CHANNEL = 'n8n.commands';
 
 /** Pubsub channel for messages sent by workers in response to commands from main processes. */
 export const WORKER_RESPONSE_PUBSUB_CHANNEL = 'n8n.worker-response';
+
+/**
+ * Commands that should be sent to the sender as well, e.g. during workflow activation and
+ * deactivation in multi-main setup. */
+export const SELF_SEND_COMMANDS = new Set([
+	'add-webhooks-triggers-and-pollers',
+	'remove-triggers-and-pollers',
+]);
+
+/**
+ * Commands that should not be debounced when received, e.g. during webhook handling in
+ * multi-main setup.
+ */
+export const IMMEDIATE_COMMANDS = new Set(['relay-execution-lifecycle-event']);

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -22,6 +22,12 @@ export namespace PubSub {
 		senderId: string;
 		targets?: string[];
 		command: CommandKey;
+
+		/** Whether the command should be sent to the sender as well. */
+		selfSend?: boolean;
+
+		/** Whether the command should be debounced when received. */
+		debounce?: boolean;
 	} & (PubSubCommandMap[CommandKey] extends never
 		? { payload?: never } // some commands carry no payload
 		: { payload: PubSubCommandMap[CommandKey] });

--- a/packages/cli/src/services/orchestration/main/handle-command-message-main.ts
+++ b/packages/cli/src/services/orchestration/main/handle-command-message-main.ts
@@ -27,17 +27,11 @@ export async function handleCommandMessageMain(messageString: string) {
 			`RedisCommandHandler(main): Received command message ${message.command} from ${message.senderId}`,
 		);
 
-		const selfSendingAllowed = [
-			'add-webhooks-triggers-and-pollers',
-			'remove-triggers-and-pollers',
-		].includes(message.command);
-
 		if (
-			!selfSendingAllowed &&
+			!message.selfSend &&
 			(message.senderId === queueModeId ||
 				(message.targets && !message.targets.includes(queueModeId)))
 		) {
-			// Skipping command message because it's not for this instance
 			logger.debug(
 				`Skipping command message ${message.command} because it's not for this instance.`,
 			);


### PR DESCRIPTION
In the final part of the pubsub overhaul, we will migrate the pubsub setup in the main process to an event emitter pattern. This will require taking care of two edge cases:

- pubsub commands where self-sending is allowed (e.g. for workflow activation and deactivation in multi-main flow), and
- pubsub commands that should not be debounced (e.g. for relaying lifecycle events during webhook handling where one main creates the webhook and another handles it).

This PR includes these two new flags in pubsub commands, as setup for the upcoming final part.

https://linear.app/n8n/issue/PAY-2023