### PR TITLE
fix: Forbid access to files outside source control work directory

### DIFF
--- a/packages/cli/src/environments/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments/source-control/__tests__/source-control.service.test.ts
@@ -1,0 +1,46 @@
+import { mock } from 'jest-mock-extended';
+import { InstanceSettings } from 'n8n-core';
+
+import { SourceControlPreferencesService } from '@/environments/source-control/source-control-preferences.service.ee';
+import { SourceControlService } from '@/environments/source-control/source-control.service.ee';
+
+describe('SourceControlService', () => {
+	const preferencesService = new SourceControlPreferencesService(
+		new InstanceSettings(),
+		mock(),
+		mock(),
+	);
+	const sourceControlService = new SourceControlService(
+		mock(),
+		mock(),
+		preferencesService,
+		mock(),
+		mock(),
+		mock(),
+		mock(),
+	);
+
+	describe('pushWorkfolder', () => {
+		it('should throw an error if a file is given that is not in the workfolder', async () => {
+			jest.spyOn(sourceControlService, 'sanityCheck').mockResolvedValue(undefined);
+
+			await expect(
+				sourceControlService.pushWorkfolder({
+					fileNames: [
+						{
+							file: '/etc/passwd',
+							id: 'test',
+							name: 'secret-file',
+							type: 'file',
+							status: 'modified',
+							location: 'local',
+							conflict: false,
+							updatedAt: new Date().toISOString(),
+							pushed: false,
+						},
+					],
+				}),
+			).rejects.toThrow('File path /etc/passwd is invalid');
+		});
+	});
+});

--- a/packages/cli/src/environments/source-control/source-control.controller.ee.ts
+++ b/packages/cli/src/environments/source-control/source-control.controller.ee.ts
@@ -170,6 +170,7 @@ export class SourceControlController {
 		if (this.sourceControlPreferencesService.isBranchReadOnly()) {
 			throw new BadRequestError('Cannot push onto read-only branch.');
 		}
+
 		try {
 			await this.sourceControlService.setGitUserDetails(
 				`${req.user.firstName} ${req.user.lastName}`,

--- a/packages/cli/src/utils/__tests__/path-util.test.ts
+++ b/packages/cli/src/utils/__tests__/path-util.test.ts
@@ -1,0 +1,24 @@
+import { isContainedWithin } from '../path-util';
+
+describe('isContainedWithin', () => {
+	it('should return true when parent and child paths are the same', () => {
+		expect(isContainedWithin('/some/parent/folder', '/some/parent/folder')).toBe(true);
+	});
+
+	test.each([
+		['/some/parent/folder', '/some/parent/folder/subfolder/file.txt'],
+		['/some/parent/folder', '/some/parent/folder/../folder/subfolder/file.txt'],
+		['/some/parent/folder/', '/some/parent/folder/subfolder/file.txt'],
+		['/some/parent/folder', '/some/parent/folder/subfolder/'],
+	])('should return true for parent %s and child %s', (parent, child) => {
+		expect(isContainedWithin(parent, child)).toBe(true);
+	});
+
+	test.each([
+		['/some/parent/folder', '/some/other/folder/file.txt'],
+		['/some/parent/folder', '/some/parent/folder_but_not_really'],
+		['/one/path', '/another/path'],
+	])('should return false for parent %s and child %s', (parent, child) => {
+		expect(isContainedWithin(parent, child)).toBe(false);
+	});
+});

--- a/packages/cli/src/utils/path-util.ts
+++ b/packages/cli/src/utils/path-util.ts
@@ -1,0 +1,16 @@
+import * as path from 'node:path';
+
+/**
+ * Checks if the given childPath is contained within the parentPath. Resolves
+ * the paths before comparing them, so that relative paths are also supported.
+ */
+export function isContainedWithin(parentPath: string, childPath: string): boolean {
+	parentPath = path.resolve(parentPath);
+	childPath = path.resolve(childPath);
+
+	if (parentPath === childPath) {
+		return true;
+	}
+
+	return childPath.startsWith(parentPath + path.sep);
+}


### PR DESCRIPTION
## Summary

Forbid access to files outside source control work directory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-144/path-traversal-cwe-23

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
