### PR TITLE
feat(editor): Bring selected nodes and edges to front on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -107,6 +107,7 @@
  * Edges
  */
 
-.vue-flow__edges {
+.vue-flow__edges,
+.vue-flow__edge-labels {
 	z-index: 1 !important;
 }

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -83,6 +83,10 @@
 		cursor: grabbing;
 	}
 
+	&.selected {
+		z-index: 1 !important;
+	}
+
 	&:has(.sticky--active) {
 		z-index: 1 !important;
 	}
@@ -97,4 +101,8 @@
 	margin-top: calc(-1 * var(--spacing-2xs));
 	margin-left: calc(-1 * var(--spacing-2xs));
 	padding: var(--spacing-2xs);
+}
+
+.vue-flow__edges {
+	z-index: 1 !important;
 }

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -70,7 +70,7 @@
 }
 
 /**
- * Node
+ * Nodes
  */
 
 .vue-flow__node {
@@ -102,6 +102,10 @@
 	margin-left: calc(-1 * var(--spacing-2xs));
 	padding: var(--spacing-2xs);
 }
+
+/**
+ * Edges
+ */
 
 .vue-flow__edges {
 	z-index: 1 !important;


### PR DESCRIPTION
## Summary

- Brings connections to front
- Brings selected nodes to front


https://github.com/user-attachments/assets/c4c95e0e-4e8c-4b80-90e1-d41700c56f7f



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7779/connectors-get-covered-by-nodes-sometimes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
