### PR TITLE
fix(core): Add missing primary key to execution annotation tags table

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.9'
 services:
   mysql:
     image: mysql:5.7
-    command: --sql_require_primary_key=ON
     environment:
       - MYSQL_DATABASE=n8n
       - MYSQL_ROOT_PASSWORD=password

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.9'
 services:
   mysql:
     image: mysql:5.7
+    command: --sql_require_primary_key=ON
     environment:
       - MYSQL_DATABASE=n8n
       - MYSQL_ROOT_PASSWORD=password

--- a/packages/cli/src/databases/migrations/common/1724753530828-CreateExecutionAnnotationTables.ts
+++ b/packages/cli/src/databases/migrations/common/1724753530828-CreateExecutionAnnotationTables.ts
@@ -25,7 +25,10 @@ export class CreateAnnotationTables1724753530828 implements ReversibleMigration 
 			.withIndexOn('name', true).withTimestamps;
 
 		await createTable(annotationTagMappingsTableName)
-			.withColumns(column('annotationId').int.notNull, column('tagId').varchar(24).notNull)
+			.withColumns(
+				column('annotationId').int.notNull.primary,
+				column('tagId').varchar(24).notNull.primary,
+			)
 			.withForeignKey('annotationId', {
 				tableName: annotationsTableName,
 				columnName: 'id',

--- a/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,12 +1,25 @@
+import { ApplicationError } from 'n8n-workflow';
+
 import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
 
 export class AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644
 	implements IrreversibleMigration
 {
 	async up({ queryRunner, tablePrefix }: MigrationContext) {
-		await queryRunner.createPrimaryKey(`${tablePrefix}execution_annotation_tags`, [
-			'annotationId',
-			'tagId',
-		]);
+		// Check if the primary key already exists
+		const table = await queryRunner.getTable(`${tablePrefix}execution_annotation_tags`);
+
+		if (!table) {
+			throw new ApplicationError('execution_annotation_tags table not found');
+		}
+
+		const hasPrimaryKey = table.primaryColumns.length > 0;
+
+		if (!hasPrimaryKey) {
+			await queryRunner.createPrimaryKey(`${tablePrefix}execution_annotation_tags`, [
+				'annotationId',
+				'tagId',
+			]);
+		}
 	}
 }

--- a/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,0 +1,12 @@
+import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
+
+export class AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644
+	implements IrreversibleMigration
+{
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
+		await queryRunner.createPrimaryKey(`${tablePrefix}execution_annotation_tags`, [
+			'annotationId',
+			'tagId',
+		]);
+	}
+}

--- a/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from 'n8n-workflow';
+import assert from 'node:assert';
 
 import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
 
@@ -9,9 +9,7 @@ export class AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644
 		// Check if the primary key already exists
 		const table = await queryRunner.getTable(`${tablePrefix}execution_annotation_tags`);
 
-		if (!table) {
-			throw new ApplicationError('execution_annotation_tags table not found');
-		}
+		assert(table, 'execution_annotation_tags table not found');
 
 		const hasPrimaryKey = table.primaryColumns.length > 0;
 

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -66,6 +66,7 @@ import { CreateAnnotationTables1724753530828 } from '../common/1724753530828-Cre
 import { AddApiKeysTable1724951148974 } from '../common/1724951148974-AddApiKeysTable';
 import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-CreateProcessedDataTable';
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
+import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -134,4 +135,5 @@ export const mysqlMigrations: Migration[] = [
 	AddApiKeysTable1724951148974,
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
+	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -66,6 +66,7 @@ import { CreateAnnotationTables1724753530828 } from '../common/1724753530828-Cre
 import { AddApiKeysTable1724951148974 } from '../common/1724951148974-AddApiKeysTable';
 import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-CreateProcessedDataTable';
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
+import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -134,4 +135,5 @@ export const postgresMigrations: Migration[] = [
 	AddApiKeysTable1724951148974,
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
+	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from 'n8n-workflow';
+import assert from 'node:assert';
 
 import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
 
@@ -17,9 +17,7 @@ export class AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644
 		// Check if the primary key already exists
 		const table = await queryRunner.getTable(`${tablePrefix}execution_annotation_tags`);
 
-		if (!table) {
-			throw new ApplicationError('execution_annotation_tags table not found');
-		}
+		assert(table, 'execution_annotation_tags table not found');
 
 		const hasPrimaryKey = table.primaryColumns.length > 0;
 

--- a/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,0 +1,63 @@
+import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
+
+const annotationsTableName = 'execution_annotations';
+const annotationTagsTableName = 'annotation_tag_entity';
+const annotationTagMappingsTableName = 'execution_annotation_tags';
+
+export class AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644
+	implements IrreversibleMigration
+{
+	async up({
+		queryRunner,
+		tablePrefix,
+		schemaBuilder: { createTable, column, dropIndex },
+	}: MigrationContext) {
+		await queryRunner.createPrimaryKey(`${tablePrefix}${annotationTagMappingsTableName}`, [
+			'annotationId',
+			'tagId',
+		]);
+
+		// SQLite doesn't support adding a primary key to an existing table
+		// So we have to do the following steps:
+
+		// 1. Rename the existing table
+		await queryRunner.query(
+			`ALTER TABLE ${tablePrefix}${annotationTagMappingsTableName} RENAME TO ${tablePrefix}${annotationTagMappingsTableName}_tmp;`,
+		);
+
+		// 1.1 Drop the existing indices
+		await dropIndex(`${annotationTagMappingsTableName}_tmp`, ['tagId'], {
+			customIndexName: 'IDX_a3697779b366e131b2bbdae297',
+		});
+		await dropIndex(`${annotationTagMappingsTableName}_tmp`, ['annotationId'], {
+			customIndexName: 'IDX_c1519757391996eb06064f0e7c',
+		});
+
+		// 	2. Create a new table with the desired structure
+		await createTable(annotationTagMappingsTableName)
+			.withColumns(
+				column('annotationId').int.notNull.primary,
+				column('tagId').varchar(24).notNull.primary,
+			)
+			.withForeignKey('annotationId', {
+				tableName: annotationsTableName,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withIndexOn('tagId')
+			.withIndexOn('annotationId')
+			.withForeignKey('tagId', {
+				tableName: annotationTagsTableName,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			});
+
+		// 3. Copy data from the old table to the new one
+		await queryRunner.query(
+			`INSERT INTO ${tablePrefix}${annotationTagMappingsTableName} SELECT * FROM ${tablePrefix}${annotationTagMappingsTableName}_tmp;`,
+		);
+
+		// 4. Drop the old table
+		await queryRunner.dropTable(`${tablePrefix}${annotationTagMappingsTableName}_tmp`, true);
+	}
+}

--- a/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from 'n8n-workflow/src';
+import { ApplicationError } from 'n8n-workflow';
 
 import type { IrreversibleMigration, MigrationContext } from '@/databases/types';
 

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -38,6 +38,7 @@ import { ExecutionSoftDelete1693491613982 } from './1693491613982-ExecutionSoftD
 import { DropRoleMapping1705429061930 } from './1705429061930-DropRoleMapping';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddApiKeysTable1724951148974 } from './1724951148974-AddApiKeysTable';
+import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from './1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -128,6 +129,7 @@ const sqliteMigrations: Migration[] = [
 	AddApiKeysTable1724951148974,
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
+	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -563,10 +563,10 @@ describe('ExecutionService', () => {
 					{
 						...summaryShape,
 						annotation: {
-							tags: [
+							tags: expect.arrayContaining([
 								expect.objectContaining({ name: 'tag1' }),
 								expect.objectContaining({ name: 'tag2' }),
-							],
+							]),
 							vote: 'up',
 						},
 					},
@@ -646,10 +646,10 @@ describe('ExecutionService', () => {
 				{
 					...summaryShape,
 					annotation: {
-						tags: [
+						tags: expect.arrayContaining([
 							expect.objectContaining({ name: 'tag1' }),
 							expect.objectContaining({ name: 'tag2' }),
-						],
+						]),
 						vote: 'up',
 					},
 				},
@@ -691,10 +691,10 @@ describe('ExecutionService', () => {
 				{
 					...summaryShape,
 					annotation: {
-						tags: [
+						tags: expect.arrayContaining([
 							expect.objectContaining({ name: 'tag1' }),
 							expect.objectContaining({ name: 'tag2' }),
-						],
+						]),
 						vote: 'up',
 					},
 				},


### PR DESCRIPTION
## Summary

This PR adds missing composite primary index to the table `execution_annotation_tags`.
It uses typeorm method for MySQL and PostgreSQL, but since sqlite does not support adding primary keys to existing tables, it creates a new table and copy existing data.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-384/community-issue-unable-to-create-or-change-a-table-without-a-primary
- https://github.com/n8n-io/n8n/issues/11123

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
