### PR TITLE
feat: Add support for $env in the js task runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -26,5 +26,8 @@
     "n8n-core": "workspace:*",
     "nanoid": "^3.3.6",
     "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "luxon": "catalog:"
   }
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
@@ -119,6 +119,11 @@ export const newAllCodeTaskData = (
 		siblingParameters: {},
 		mode: 'manual',
 		selfData: {},
+		envProviderState: {
+			env: {},
+			isEnvAccessBlocked: true,
+			isProcessAvailable: true,
+		},
 		additionalData: {
 			executionId: 'exec-id',
 			instanceBaseUrl: '',

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
@@ -65,6 +65,9 @@ export const newAllCodeTaskData = (
 	const manualTriggerNode = newNode({
 		name: 'Trigger',
 		type: 'n8n-nodes-base.manualTrigger',
+		parameters: {
+			manualTriggerParam: 'empty',
+		},
 	});
 
 	return {
@@ -117,14 +120,26 @@ export const newAllCodeTaskData = (
 		mode: 'manual',
 		selfData: {},
 		additionalData: {
-			formWaitingBaseUrl: '',
+			executionId: 'exec-id',
 			instanceBaseUrl: '',
 			restartExecutionId: '',
 			restApiUrl: '',
-			webhookBaseUrl: '',
-			webhookTestBaseUrl: '',
-			webhookWaitingBaseUrl: '',
-			variables: {},
+			formWaitingBaseUrl: 'http://formWaitingBaseUrl',
+			webhookBaseUrl: 'http://webhookBaseUrl',
+			webhookTestBaseUrl: 'http://webhookTestBaseUrl',
+			webhookWaitingBaseUrl: 'http://webhookWaitingBaseUrl',
+			variables: {
+				var: 'value',
+			},
+		},
+		executeData: {
+			node: codeNode,
+			data: {
+				main: [codeNodeInputData],
+			},
+			source: {
+				main: [{ previousNode: manualTriggerNode.name }],
+			},
 		},
 		...opts,
 	};

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -17,6 +17,7 @@ import type {
 	INodeParameters,
 	IRunExecutionData,
 	WorkflowExecuteMode,
+	EnvProviderState,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { runInNewContext, type Context } from 'node:vm';
@@ -63,6 +64,7 @@ export interface AllCodeTaskData {
 	connectionInputData: INodeExecutionData[];
 	siblingParameters: INodeParameters;
 	mode: WorkflowExecuteMode;
+	envProviderState?: EnvProviderState;
 	executeData?: IExecuteData;
 	defaultReturnRunIndex: number;
 	selfData: IDataObject;
@@ -262,6 +264,13 @@ export class JsTaskRunner extends TaskRunner {
 			allData.defaultReturnRunIndex,
 			allData.selfData,
 			allData.contextNodeName,
+			// Make sure that even if we don't receive the envProviderState for
+			// whatever reason, we don't expose the task runner's env to the code
+			allData.envProviderState ?? {
+				env: {},
+				isEnvAccessBlocked: false,
+				isProcessAvailable: true,
+			},
 		).getDataProxy();
 	}
 

--- a/packages/cli/src/runners/task-managers/task-manager.ts
+++ b/packages/cli/src/runners/task-managers/task-manager.ts
@@ -1,16 +1,17 @@
-import {
-	type IExecuteFunctions,
-	type Workflow,
-	type IRunExecutionData,
-	type INodeExecutionData,
-	type ITaskDataConnections,
-	type INode,
-	type WorkflowParameters,
-	type INodeParameters,
-	type WorkflowExecuteMode,
-	type IExecuteData,
-	type IDataObject,
-	type IWorkflowExecuteAdditionalData,
+import type {
+	EnvProviderState,
+	IExecuteFunctions,
+	Workflow,
+	IRunExecutionData,
+	INodeExecutionData,
+	ITaskDataConnections,
+	INode,
+	WorkflowParameters,
+	INodeParameters,
+	WorkflowExecuteMode,
+	IExecuteData,
+	IDataObject,
+	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 
@@ -42,6 +43,7 @@ export interface TaskData {
 	connectionInputData: INodeExecutionData[];
 	siblingParameters: INodeParameters;
 	mode: WorkflowExecuteMode;
+	envProviderState: EnvProviderState;
 	executeData?: IExecuteData;
 	defaultReturnRunIndex: number;
 	selfData: IDataObject;
@@ -76,6 +78,7 @@ export interface AllCodeTaskData {
 	connectionInputData: INodeExecutionData[];
 	siblingParameters: INodeParameters;
 	mode: WorkflowExecuteMode;
+	envProviderState: EnvProviderState;
 	executeData?: IExecuteData;
 	defaultReturnRunIndex: number;
 	selfData: IDataObject;
@@ -137,6 +140,7 @@ export class TaskManager {
 		connectionInputData: INodeExecutionData[],
 		siblingParameters: INodeParameters,
 		mode: WorkflowExecuteMode,
+		envProviderState: EnvProviderState,
 		executeData?: IExecuteData,
 		defaultReturnRunIndex = -1,
 		selfData: IDataObject = {},
@@ -153,6 +157,7 @@ export class TaskManager {
 			itemIndex,
 			siblingParameters,
 			mode,
+			envProviderState,
 			executeData,
 			defaultReturnRunIndex,
 			selfData,
@@ -311,6 +316,7 @@ export class TaskManager {
 				contextNodeName: jd.contextNodeName,
 				defaultReturnRunIndex: jd.defaultReturnRunIndex,
 				mode: jd.mode,
+				envProviderState: jd.envProviderState,
 				node: jd.node,
 				runExecutionData: jd.runExecutionData,
 				runIndex: jd.runIndex,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -6,6 +6,13 @@
 import type { PushType } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import { WorkflowExecute } from 'n8n-core';
+import {
+	ApplicationError,
+	ErrorReporterProxy as ErrorReporter,
+	NodeOperationError,
+	Workflow,
+	WorkflowHooks,
+} from 'n8n-workflow';
 import type {
 	IDataObject,
 	IExecuteData,
@@ -28,13 +35,7 @@ import type {
 	ITaskDataConnections,
 	ExecuteWorkflowOptions,
 	IWorkflowExecutionDataProcess,
-} from 'n8n-workflow';
-import {
-	ApplicationError,
-	ErrorReporterProxy as ErrorReporter,
-	NodeOperationError,
-	Workflow,
-	WorkflowHooks,
+	EnvProviderState,
 } from 'n8n-workflow';
 import { Container } from 'typedi';
 
@@ -1008,6 +1009,7 @@ export async function getBase(
 			connectionInputData: INodeExecutionData[],
 			siblingParameters: INodeParameters,
 			mode: WorkflowExecuteMode,
+			envProviderState: EnvProviderState,
 			executeData?: IExecuteData,
 			defaultReturnRunIndex?: number,
 			selfData?: IDataObject,
@@ -1028,6 +1030,7 @@ export async function getBase(
 				connectionInputData,
 				siblingParameters,
 				mode,
+				envProviderState,
 				executeData,
 				defaultReturnRunIndex,
 				selfData,

--- a/packages/core/src/Agent/index.ts
+++ b/packages/core/src/Agent/index.ts
@@ -11,6 +11,7 @@ import type {
 	IExecuteData,
 	IDataObject,
 } from 'n8n-workflow';
+import { createEnvProviderState } from 'n8n-workflow';
 
 export const createAgentStartJob = (
 	additionalData: IWorkflowExecuteAdditionalData,
@@ -49,6 +50,7 @@ export const createAgentStartJob = (
 			connectionInputData,
 			siblingParameters,
 			mode,
+			createEnvProviderState(),
 			executeData,
 			defaultReturnRunIndex,
 			selfData,

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -22,6 +22,7 @@ import type { WorkflowActivationError } from './errors/workflow-activation.error
 import type { WorkflowOperationError } from './errors/workflow-operation.error';
 import type { ExecutionStatus } from './ExecutionStatus';
 import type { Workflow } from './Workflow';
+import type { EnvProviderState } from './WorkflowDataProxyEnvProvider';
 import type { WorkflowHooks } from './WorkflowHooks';
 
 export interface IAdditionalCredentialOptions {
@@ -2256,6 +2257,7 @@ export interface IWorkflowExecuteAdditionalData {
 		connectionInputData: INodeExecutionData[],
 		siblingParameters: INodeParameters,
 		mode: WorkflowExecuteMode,
+		envProviderState: EnvProviderState,
 		executeData?: IExecuteData,
 		defaultReturnRunIndex?: number,
 		selfData?: IDataObject,

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -30,6 +30,8 @@ import {
 import * as NodeHelpers from './NodeHelpers';
 import { deepCopy } from './utils';
 import type { Workflow } from './Workflow';
+import type { EnvProviderState } from './WorkflowDataProxyEnvProvider';
+import { createEnvProvider, createEnvProviderState } from './WorkflowDataProxyEnvProvider';
 import { getPinDataIfManualExecution } from './WorkflowDataProxyHelpers';
 
 export function isResourceLocatorValue(value: unknown): value is INodeParameterResourceLocator {
@@ -66,6 +68,7 @@ export class WorkflowDataProxy {
 		private defaultReturnRunIndex = -1,
 		private selfData: IDataObject = {},
 		private contextNodeName: string = activeNodeName,
+		private envProviderState?: EnvProviderState,
 	) {
 		this.runExecutionData = isScriptingNode(this.contextNodeName, workflow)
 			? runExecutionData !== null
@@ -482,40 +485,6 @@ export class WorkflowDataProxy {
 					}
 
 					return Reflect.get(target, name, receiver);
-				},
-			},
-		);
-	}
-
-	/**
-	 * Returns a proxy to query data from the environment
-	 *
-	 * @private
-	 */
-	private envGetter() {
-		const that = this;
-		return new Proxy(
-			{},
-			{
-				has: () => true,
-				get(_, name) {
-					if (name === 'isProxy') return true;
-
-					if (typeof process === 'undefined') {
-						throw new ExpressionError('not accessible via UI, please run node', {
-							runIndex: that.runIndex,
-							itemIndex: that.itemIndex,
-						});
-					}
-					if (process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true') {
-						throw new ExpressionError('access to env vars denied', {
-							causeDetailed:
-								'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
-							runIndex: that.runIndex,
-							itemIndex: that.itemIndex,
-						});
-					}
-					return process.env[name.toString()];
 				},
 			},
 		);
@@ -1303,7 +1272,11 @@ export class WorkflowDataProxy {
 
 			$binary: {}, // Placeholder
 			$data: {}, // Placeholder
-			$env: this.envGetter(),
+			$env: createEnvProvider(
+				that.runIndex,
+				that.itemIndex,
+				that.envProviderState ?? createEnvProviderState(),
+			),
 			$evaluateExpression: (expression: string, itemIndex?: number) => {
 				itemIndex = itemIndex || that.itemIndex;
 				return that.workflow.expression.getParameterValue(

--- a/packages/workflow/src/WorkflowDataProxyEnvProvider.ts
+++ b/packages/workflow/src/WorkflowDataProxyEnvProvider.ts
@@ -1,0 +1,75 @@
+import { ExpressionError } from './errors/expression.error';
+
+export type EnvProviderState = {
+	isProcessAvailable: boolean;
+	isEnvAccessBlocked: boolean;
+	env: Record<string, string>;
+};
+
+/**
+ * Captures a snapshot of the environment variables and configuration
+ * that can be used to initialize an environment provider.
+ */
+export function createEnvProviderState(): EnvProviderState {
+	const isProcessAvailable = typeof process !== 'undefined';
+	const isEnvAccessBlocked = isProcessAvailable
+		? process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE === 'true'
+		: false;
+	const env: Record<string, string> =
+		!isProcessAvailable || isEnvAccessBlocked ? {} : (process.env as Record<string, string>);
+
+	return {
+		isProcessAvailable,
+		isEnvAccessBlocked,
+		env,
+	};
+}
+
+/**
+ * Creates a proxy that provides access to the environment variables
+ * in the `WorkflowDataProxy`. Use the `createEnvProviderState` to
+ * create the default state object that is needed for the proxy,
+ * unless you need something specific.
+ *
+ * @example
+ * createEnvProvider(
+ *   runIndex,
+ *   itemIndex,
+ *   createEnvProviderState(),
+ * )
+ */
+export function createEnvProvider(
+	runIndex: number,
+	itemIndex: number,
+	providerState: EnvProviderState,
+): Record<string, string> {
+	return new Proxy(
+		{},
+		{
+			has() {
+				return true;
+			},
+
+			get(_, name) {
+				if (name === 'isProxy') return true;
+
+				if (!providerState.isProcessAvailable) {
+					throw new ExpressionError('not accessible via UI, please run node', {
+						runIndex,
+						itemIndex,
+					});
+				}
+				if (providerState.isEnvAccessBlocked) {
+					throw new ExpressionError('access to env vars denied', {
+						causeDetailed:
+							'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
+						runIndex,
+						itemIndex,
+					});
+				}
+
+				return providerState.env[name.toString()];
+			},
+		},
+	);
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -18,6 +18,7 @@ export * from './NodeHelpers';
 export * from './RoutingNode';
 export * from './Workflow';
 export * from './WorkflowDataProxy';
+export * from './WorkflowDataProxyEnvProvider';
 export * from './WorkflowHooks';
 export * from './VersionedNodeType';
 export * from './TypeValidation';

--- a/packages/workflow/test/WorkflowDataProxyEnvProvider.test.ts
+++ b/packages/workflow/test/WorkflowDataProxyEnvProvider.test.ts
@@ -1,0 +1,87 @@
+import { ExpressionError } from '../src/errors/expression.error';
+import { createEnvProvider, createEnvProviderState } from '../src/WorkflowDataProxyEnvProvider';
+
+describe('createEnvProviderState', () => {
+	afterEach(() => {
+		delete process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE;
+	});
+
+	it('should return the state with process available and env access allowed', () => {
+		expect(createEnvProviderState()).toEqual({
+			isProcessAvailable: true,
+			isEnvAccessBlocked: false,
+			env: process.env,
+		});
+	});
+
+	it('should block env access when N8N_BLOCK_ENV_ACCESS_IN_NODE is set to "true"', () => {
+		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
+
+		expect(createEnvProviderState()).toEqual({
+			isProcessAvailable: true,
+			isEnvAccessBlocked: true,
+			env: {},
+		});
+	});
+
+	it('should handle process not being available', () => {
+		const originalProcess = global.process;
+		try {
+			// @ts-expect-error process is read-only
+			global.process = undefined;
+
+			expect(createEnvProviderState()).toEqual({
+				isProcessAvailable: false,
+				isEnvAccessBlocked: false,
+				env: {},
+			});
+		} finally {
+			global.process = originalProcess;
+		}
+	});
+});
+
+describe('createEnvProvider', () => {
+	it('should return true when checking for a property using "has"', () => {
+		const proxy = createEnvProvider(0, 0, createEnvProviderState());
+		expect('someProperty' in proxy).toBe(true);
+	});
+
+	it('should return the value from process.env if access is allowed', () => {
+		process.env.TEST_ENV_VAR = 'test_value';
+		const proxy = createEnvProvider(0, 0, createEnvProviderState());
+		expect(proxy.TEST_ENV_VAR).toBe('test_value');
+	});
+
+	it('should throw ExpressionError when process is unavailable', () => {
+		const originalProcess = global.process;
+		// @ts-expect-error process is read-only
+		global.process = undefined;
+		try {
+			const proxy = createEnvProvider(1, 1, createEnvProviderState());
+
+			expect(() => proxy.someEnvVar).toThrowError(
+				new ExpressionError('not accessible via UI, please run node', {
+					runIndex: 1,
+					itemIndex: 1,
+				}),
+			);
+		} finally {
+			global.process = originalProcess;
+		}
+	});
+
+	it('should throw ExpressionError when env access is blocked', () => {
+		process.env.N8N_BLOCK_ENV_ACCESS_IN_NODE = 'true';
+		const proxy = createEnvProvider(1, 1, createEnvProviderState());
+
+		expect(() => proxy.someEnvVar).toThrowError(
+			new ExpressionError('access to env vars denied', {
+				causeDetailed:
+					'If you need access please contact the administrator to remove the environment variable ‘N8N_BLOCK_ENV_ACCESS_IN_NODE‘',
+				runIndex: 1,
+				itemIndex: 1,
+			}),
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,10 @@ importers:
       ws:
         specifier: '>=8.17.1'
         version: 8.17.1
+    devDependencies:
+      luxon:
+        specifier: 'catalog:'
+        version: 3.4.4
 
   packages/@n8n_io/eslint-config:
     devDependencies:


### PR DESCRIPTION
## Summary

#### Add support for $env in JS task runner 

$env provides access to the instance's environment variables unless
it has been explicitly blocked. This commit adds functionality to pass
the environment variables to the JS task runner if needed.

I think ideally we wouldn't want to pass the entire env to the task
runner, but instead request them on-demand. However since we can't
make the Proxy code async, we can't do that for now. This shouldn't be
an issues tho since the env access is something you would want to
use only in a local installation.

Also adds tests for many of the other built-ins

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2061/make-sure-all-the-built-in-methods-and-variables-are-available-in-the

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
