### PR TITLE
refactor(core): Deregistering cronjobs should also release them (no-changelog)

### DIFF
--- a/packages/core/src/ScheduledTaskManager.ts
+++ b/packages/core/src/ScheduledTaskManager.ts
@@ -30,8 +30,9 @@ export class ScheduledTaskManager {
 
 	deregisterCrons(workflowId: string) {
 		const cronJobs = this.cronJobs.get(workflowId) ?? [];
-		for (const cronJob of cronJobs) {
-			cronJob.stop();
+		while (cronJobs.length) {
+			const cronJob = cronJobs.pop();
+			if (cronJob) cronJob.stop();
 		}
 	}
 

--- a/packages/core/test/ScheduledTaskManager.test.ts
+++ b/packages/core/test/ScheduledTaskManager.test.ts
@@ -56,7 +56,12 @@ describe('ScheduledTaskManager', () => {
 		scheduledTaskManager.registerCron(workflow, everyMinute, onTick);
 		scheduledTaskManager.registerCron(workflow, everyMinute, onTick);
 		scheduledTaskManager.registerCron(workflow, everyMinute, onTick);
+
+		expect(scheduledTaskManager.cronJobs.get(workflow.id)?.length).toBe(3);
+
 		scheduledTaskManager.deregisterCrons(workflow.id);
+
+		expect(scheduledTaskManager.cronJobs.get(workflow.id)?.length).toBe(0);
 
 		expect(onTick).not.toHaveBeenCalled();
 		jest.advanceTimersByTime(10 * 60 * 1000); // 10 minutes


### PR DESCRIPTION
## Summary
This PR ensures that when we deregister a cron job, we also stop holding any references to it, so that the GC can collect it, preventing any memory leaks.

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
