### PR TITLE
refactor(core): Remove dead pubsub code

### DIFF
--- a/packages/cli/src/controllers/orchestration.controller.ts
+++ b/packages/cli/src/controllers/orchestration.controller.ts
@@ -28,11 +28,4 @@ export class OrchestrationController {
 		if (!this.licenseService.isWorkerViewLicensed()) return;
 		return await this.orchestrationService.getWorkerStatus();
 	}
-
-	@GlobalScope('orchestration:list')
-	@Post('/worker/ids')
-	async getWorkerIdsAll() {
-		if (!this.licenseService.isWorkerViewLicensed()) return;
-		return await this.orchestrationService.getWorkerIds();
-	}
 }

--- a/packages/cli/src/events/maps/pub-sub.event-map.ts
+++ b/packages/cli/src/events/maps/pub-sub.event-map.ts
@@ -80,25 +80,5 @@ export type PubSubCommandMap = {
 };
 
 export type PubSubWorkerResponseMap = {
-	// #region Lifecycle
-
-	'restart-event-bus': {
-		result: 'success' | 'error';
-		error?: string;
-	};
-
-	'reload-external-secrets-providers': {
-		result: 'success' | 'error';
-		error?: string;
-	};
-
-	// #endregion
-
-	// #region Worker view
-
-	'get-worker-id': never;
-
 	'get-worker-status': WorkerStatus;
-
-	// #endregion
 };

--- a/packages/cli/src/scaling/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/publisher.service.test.ts
@@ -61,7 +61,7 @@ describe('Publisher', () => {
 		it('should publish worker response into `n8n.worker-response` pubsub channel', async () => {
 			const publisher = new Publisher(mock(), redisClientService);
 			const msg = mock<PubSub.WorkerResponse>({
-				command: 'reload-external-secrets-providers',
+				command: 'get-worker-status',
 			});
 
 			await publisher.publishWorkerResponse(msg);

--- a/packages/cli/src/scaling/__tests__/pubsub-handler.test.ts
+++ b/packages/cli/src/scaling/__tests__/pubsub-handler.test.ts
@@ -195,7 +195,6 @@ describe('PubSubHandler', () => {
 				'community-package-update': expect.any(Function),
 				'community-package-uninstall': expect.any(Function),
 				'get-worker-status': expect.any(Function),
-				'get-worker-id': expect.any(Function),
 			});
 		});
 
@@ -265,26 +264,6 @@ describe('PubSubHandler', () => {
 			eventService.emit('get-worker-status');
 
 			expect(workerStatus.generateStatus).toHaveBeenCalled();
-		});
-
-		it('should get worker ID on `get-worker-id` event', () => {
-			new PubSubHandler(
-				eventService,
-				instanceSettings,
-				license,
-				eventbus,
-				externalSecretsManager,
-				communityPackagesService,
-				publisher,
-				workerStatus,
-			).init();
-
-			eventService.emit('get-worker-id');
-
-			expect(publisher.publishWorkerResponse).toHaveBeenCalledWith({
-				workerId: expect.any(String),
-				command: 'get-worker-id',
-			});
 		});
 	});
 });

--- a/packages/cli/src/scaling/pubsub/pubsub-handler.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub-handler.ts
@@ -43,11 +43,6 @@ export class PubSubHandler {
 							command: 'get-worker-status',
 							payload: this.workerStatus.generateStatus(),
 						}),
-					'get-worker-id': async () =>
-						await this.publisher.publishWorkerResponse({
-							workerId: config.getEnv('redis.queueModeId'),
-							command: 'get-worker-id',
-						}),
 				});
 				break;
 			case 'main':

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -87,17 +87,9 @@ export namespace PubSub {
 	>;
 
 	namespace WorkerResponses {
-		export type RestartEventBus = ToWorkerResponse<'restart-event-bus'>;
-		export type ReloadExternalSecretsProviders =
-			ToWorkerResponse<'reload-external-secrets-providers'>;
-		export type GetWorkerId = ToWorkerResponse<'get-worker-id'>;
 		export type GetWorkerStatus = ToWorkerResponse<'get-worker-status'>;
 	}
 
 	/** Response sent via the `n8n.worker-response` pubsub channel. */
-	export type WorkerResponse =
-		| WorkerResponses.RestartEventBus
-		| WorkerResponses.ReloadExternalSecretsProviders
-		| WorkerResponses.GetWorkerId
-		| WorkerResponses.GetWorkerStatus;
+	export type WorkerResponse = WorkerResponses.GetWorkerStatus;
 }

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -86,10 +86,6 @@ export namespace PubSub {
 		_ToWorkerResponse<WorkerResponseKey>
 	>;
 
-	namespace WorkerResponses {
-		export type GetWorkerStatus = ToWorkerResponse<'get-worker-status'>;
-	}
-
 	/** Response sent via the `n8n.worker-response` pubsub channel. */
-	export type WorkerResponse = WorkerResponses.GetWorkerStatus;
+	export type WorkerResponse = ToWorkerResponse<'get-worker-status'>;
 }

--- a/packages/cli/src/services/orchestration.service.ts
+++ b/packages/cli/src/services/orchestration.service.ts
@@ -128,16 +128,6 @@ export class OrchestrationService {
 		});
 	}
 
-	async getWorkerIds() {
-		if (!this.sanityCheck()) return;
-
-		const command = 'get-worker-id';
-
-		this.logger.debug(`Sending "${command}" to command channel`);
-
-		await this.publisher.publishCommand({ command });
-	}
-
 	// ----------------------------------
 	//           activations
 	// ----------------------------------

--- a/packages/cli/src/services/orchestration/main/handle-worker-response-message-main.ts
+++ b/packages/cli/src/services/orchestration/main/handle-worker-response-message-main.ts
@@ -4,6 +4,7 @@ import Container from 'typedi';
 import { Logger } from '@/logging/logger.service';
 import { WORKER_RESPONSE_PUBSUB_CHANNEL } from '@/scaling/constants';
 import type { PubSub } from '@/scaling/pubsub/pubsub.types';
+import { assertNever } from '@/utils';
 
 import type { MainResponseReceivedHandlerOptions } from './types';
 import { Push } from '../../../push';
@@ -32,12 +33,8 @@ export async function handleWorkerResponseMessageMain(
 				status: workerResponse.payload,
 			});
 			break;
-		case 'get-worker-id':
-			break;
 		default:
-			Container.get(Logger).debug(
-				`Received worker response ${workerResponse.command} from ${workerResponse.workerId}`,
-			);
+			assertNever(workerResponse.command);
 	}
 
 	return workerResponse;


### PR DESCRIPTION
- Remove unused endpoint `POST /orchestration/worker/ids` - never called by FE
- Remove unused method `OrchestrationService.getWorkerIds` - used only by endpoint above
- Remove worker sending of response to `get-worker-id` - command never sent
- Remove worker response type `get-worker-id` - used only for response to command above
- Remove `get-worker-id` handler stub - main process does nothing with this response
- Remove other unused worker response types: `restart-event-bus`, `reload-external-secrets-providers` - these responses are never sent by workers

Worker view [continues to work](https://github.com/user-attachments/assets/f3d5c8a1-92f9-42ac-8dfc-4b172acd81e2)

Extracted from #11156
