### PR TITLE
fix(Google Calendar Node): Fix issue with conference data types not loading

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/EventDescription.ts
@@ -216,7 +216,7 @@ export const eventFields: INodeProperties[] = [
 								description:
 									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 								typeOptions: {
-									loadOptionsMethod: 'getConferenceSolutations',
+									loadOptionsMethod: 'getConferenceSolutions',
 									loadOptionsDependsOn: ['calendar'],
 								},
 								default: '',

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -91,7 +91,7 @@ export class GoogleCalendar implements INodeType {
 			// select them easily
 			async getConferenceSolutations(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const calendar = this.getCurrentNodeParameter('calendar') as string;
+				const calendar = this.getCurrentNodeParameter('calendar', { extractValue: true }) as string;
 				const posibleSolutions: IDataObject = {
 					eventHangout: 'Google Hangout',
 					eventNamedHangout: 'Google Hangout Classic',

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -89,10 +89,10 @@ export class GoogleCalendar implements INodeType {
 		loadOptions: {
 			// Get all the calendars to display them to user so that they can
 			// select them easily
-			async getConferenceSolutations(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+			async getConferenceSolutions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				const calendar = this.getCurrentNodeParameter('calendar', { extractValue: true }) as string;
-				const posibleSolutions: IDataObject = {
+				const possibleSolutions: IDataObject = {
 					eventHangout: 'Google Hangout',
 					eventNamedHangout: 'Google Hangout Classic',
 					hangoutsMeet: 'Google Meet',
@@ -106,7 +106,7 @@ export class GoogleCalendar implements INodeType {
 				);
 				for (const solution of allowedConferenceSolutionTypes) {
 					returnData.push({
-						name: posibleSolutions[solution] as string,
+						name: possibleSolutions[solution] as string,
 						value: solution,
 					});
 				}


### PR DESCRIPTION
## Summary
This node uses the the RLC and we were not extracting the value from it, I have not added a test as I am not sure if there is one for this 🤔

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1842/community-issue-meet-on-node-google-calendar-does-not-work
https://github.com/n8n-io/n8n/issues/11183

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
