### PR TITLE
docs: Add end of service notice for Line (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Line/Line.node.ts
+++ b/packages/nodes-base/nodes/Line/Line.node.ts
@@ -39,6 +39,13 @@ export class Line implements INodeType {
 		],
 		properties: [
 			{
+				displayName:
+					'End of service: LINE Notify will be discontinued from April 1st 2025, You can find more information <a href="https://notify-bot.line.me/closing-announce" target="_blank">here</a>',
+				name: 'notice',
+				type: 'notice',
+				default: '',
+			},
+			{
 				displayName: 'Resource',
 				name: 'resource',
 				type: 'options',


### PR DESCRIPTION
## Summary
Adds notice to line node to mention the service is closing down.

![image](https://github.com/user-attachments/assets/f8898564-0d04-4dba-98d0-3d8ef8bc6199)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1827/line-node-handle-apis-deprecation-march-31-2025

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
