### PR TITLE
fix(editor): Disable Ask AI button in deprecated nodes (no-changelog)

### DIFF
--- a/packages/design-system/src/components/AskAssistantChat/__tests__/__snapshots__/AskAssistantChat.spec.ts.snap
+++ b/packages/design-system/src/components/AskAssistantChat/__tests__/__snapshots__/AskAssistantChat.spec.ts.snap
@@ -848,6 +848,7 @@ exports[`AskAssistantChat > renders default placeholder chat correctly 1`] = `
             For specific tasks, you’ll see the 
             <button
               class="button"
+              data-test-id="ask-assistant-button"
               style="height: 18px;"
               tabindex="-1"
             >
@@ -1090,6 +1091,7 @@ exports[`AskAssistantChat > renders end of session chat correctly 1`] = `
             </span>
             <button
               class="button"
+              data-test-id="ask-assistant-button"
               style="height: 18px;"
               tabindex="-1"
             >

--- a/packages/design-system/src/components/InlineAskAssistantButton/InlineAskAssistantButton.vue
+++ b/packages/design-system/src/components/InlineAskAssistantButton/InlineAskAssistantButton.vue
@@ -50,6 +50,7 @@ const onClick = () => {
 		:style="{ height: sizes[size].height }"
 		:disabled="asked"
 		:tabindex="static ? '-1' : ''"
+		data-test-id="ask-assistant-button"
 		@click="onClick"
 	>
 		<div>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -384,8 +384,9 @@ function copySuccess() {
 	});
 }
 
-function nodeInExclusionList() {
-	return ['n8n-nodes-base.function'].includes(node.value.type);
+function nodeIsHidden() {
+	const nodeType = nodeTypesStore.getNodeType(node?.value.type);
+	return nodeType?.hidden ?? false;
 }
 
 async function onAskAssistantClick() {
@@ -432,7 +433,7 @@ async function onAskAssistantClick() {
 				v-n8n-html="getErrorDescription()"
 			></div>
 			<div
-				v-if="isAskAssistantAvailable && !nodeInExclusionList()"
+				v-if="isAskAssistantAvailable && !nodeIsHidden()"
 				class="node-error-view__assistant-button"
 				data-test-id="node-error-view-ask-assistant-button"
 			>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -121,7 +121,8 @@ const isAskAssistantAvailable = computed(() => {
 		return false;
 	}
 	const isCustomNode = node.value.type === undefined || isCommunityPackageName(node.value.type);
-	return assistantStore.canShowAssistantButtonsOnCanvas && !isCustomNode;
+
+	return assistantStore.canShowAssistantButtonsOnCanvas && !isCustomNode && !nodeIsHidden();
 });
 
 const assistantAlreadyAsked = computed(() => {
@@ -433,7 +434,7 @@ async function onAskAssistantClick() {
 				v-n8n-html="getErrorDescription()"
 			></div>
 			<div
-				v-if="isAskAssistantAvailable && !nodeIsHidden()"
+				v-if="isAskAssistantAvailable"
 				class="node-error-view__assistant-button"
 				data-test-id="node-error-view-ask-assistant-button"
 			>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -384,6 +384,10 @@ function copySuccess() {
 	});
 }
 
+function nodeInExclusionList() {
+	return ['n8n-nodes-base.function'].includes(node.value.type);
+}
+
 async function onAskAssistantClick() {
 	const { message, lineNumber, description } = props.error;
 	const sessionInProgress = !assistantStore.isSessionEnded;
@@ -428,7 +432,7 @@ async function onAskAssistantClick() {
 				v-n8n-html="getErrorDescription()"
 			></div>
 			<div
-				v-if="isAskAssistantAvailable"
+				v-if="isAskAssistantAvailable && !nodeInExclusionList()"
 				class="node-error-view__assistant-button"
 				data-test-id="node-error-view-ask-assistant-button"
 			>

--- a/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
+++ b/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
@@ -1,9 +1,10 @@
 import { createComponentRenderer } from '@/__tests__/render';
-import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
+import { mockedStore, SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import NodeErrorView from '@/components/Error/NodeErrorView.vue';
 import { STORES } from '@/constants';
 import { createTestingPinia } from '@pinia/testing';
 import { type INode } from 'n8n-workflow';
+import { useAssistantStore } from '@/stores/assistant.store';
 
 const DEFAULT_SETUP = {
 	pinia: createTestingPinia({
@@ -62,5 +63,28 @@ describe('NodeErrorView.vue', () => {
 		const errorMessage = getByTestId('node-error-message');
 
 		expect(errorMessage).toHaveTextContent('Unexpected identifier [line 1]');
+	});
+
+	it('should not render AI assistant button when error happens in deprecated function node', async () => {
+		const aiAssistantStore = useAssistantStore(DEFAULT_SETUP.pinia);
+
+		//@ts-expect-error
+		aiAssistantStore.canShowAssistantButtonsOnCanvas = true;
+
+		const { queryByTestId } = renderComponent({
+			props: {
+				error: {
+					node: {
+						...mockNode,
+						type: 'n8n-nodes-base.function',
+						typeVersion: 1,
+					},
+				},
+			},
+		});
+
+		const aiAssistantButton = queryByTestId('ask-assistant-button');
+
+		expect(aiAssistantButton).toBeNull();
 	});
 });

--- a/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
+++ b/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
@@ -1,5 +1,5 @@
 import { createComponentRenderer } from '@/__tests__/render';
-import { mockedStore, SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
+import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import NodeErrorView from '@/components/Error/NodeErrorView.vue';
 import { STORES } from '@/constants';
 import { createTestingPinia } from '@pinia/testing';

--- a/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
+++ b/packages/editor-ui/src/components/Error/__tests__/NodeErrorView.test.ts
@@ -5,6 +5,7 @@ import { STORES } from '@/constants';
 import { createTestingPinia } from '@pinia/testing';
 import { type INode } from 'n8n-workflow';
 import { useAssistantStore } from '@/stores/assistant.store';
+import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 
 const DEFAULT_SETUP = {
 	pinia: createTestingPinia({
@@ -67,6 +68,14 @@ describe('NodeErrorView.vue', () => {
 
 	it('should not render AI assistant button when error happens in deprecated function node', async () => {
 		const aiAssistantStore = useAssistantStore(DEFAULT_SETUP.pinia);
+		const nodeTypeStore = useNodeTypesStore(DEFAULT_SETUP.pinia);
+
+		//@ts-expect-error
+		nodeTypeStore.getNodeType = vi.fn(() => ({
+			type: 'n8n-nodes-base.function',
+			typeVersion: 1,
+			hidden: true,
+		}));
 
 		//@ts-expect-error
 		aiAssistantStore.canShowAssistantButtonsOnCanvas = true;


### PR DESCRIPTION
## Summary

Title self explanatory

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2437/disable-ask-ai-button-in-old-function-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
