### PR TITLE
fix(editor): Allow SSO login focus outlines to draw fully (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/SSOLogin.vue
+++ b/packages/editor-ui/src/components/SSOLogin.vue
@@ -53,7 +53,8 @@ const onSSOLogin = async () => {
 	span {
 		position: relative;
 		display: inline-block;
-		padding: var(--spacing-xl) var(--spacing-l);
+		margin: var(--spacing-2xs) auto;
+		padding: var(--spacing-l);
 		background: var(--color-background-xlight);
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a small visual glitch where the link and button focus outlines around the divider are cut in half. Adds a slight margin to allow the button outlines to draw fully while retaining the divider size unchanged.

Before:
<img width="427" alt="Screenshot 2024-10-10 at 09 45 42" src="https://github.com/user-attachments/assets/9aace46e-6231-468c-9d78-038cac21bd77">

After:
<img width="393" alt="Screenshot 2024-10-10 at 09 45 15" src="https://github.com/user-attachments/assets/cc6c2606-8844-40bb-9065-b85e28e70351">

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
