### PR TITLE
fix(Convert to File Node): Fix issue with end date always being day+1 when all day

### DIFF
--- a/packages/nodes-base/nodes/ICalendar/createEvent.operation.ts
+++ b/packages/nodes-base/nodes/ICalendar/createEvent.operation.ts
@@ -289,7 +289,7 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 				end = start;
 			}
 
-			end = allDay ? moment(end).utc().add(1, 'day').format() : end;
+			end = allDay ? moment(end).utc().set({ hour: 23, minute: 59, second: 59 }).format() : end;
 
 			const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i);
 			const options = this.getNodeParameter('additionalFields', i);

--- a/packages/nodes-base/nodes/ICalendar/test/node/ICalendar.test.ts
+++ b/packages/nodes-base/nodes/ICalendar/test/node/ICalendar.test.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-loop-func */
-import type { WorkflowTestData } from '@test/nodes/types';
-
+import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import {
 	getResultNodeData,
 	setup,
 	readJsonFileSync,
 	initBinaryDataService,
 } from '@test/nodes/Helpers';
-import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
+import type { WorkflowTestData } from '@test/nodes/types';
 
 describe('Execute iCalendar Node', () => {
 	beforeEach(async () => {
@@ -32,9 +31,9 @@ describe('Execute iCalendar Node', () => {
 										mimeType: 'text/calendar',
 										fileType: 'text',
 										fileExtension: 'ics',
-										data: 'QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQ0FMU0NBTEU6R1JFR09SSUFODQpQUk9ESUQ6YWRhbWdpYmJvbnMvaWNzDQpNRVRIT0Q6UFVCTElTSA0KWC1XUi1DQUxOQU1FOmRlZmF1bHQNClgtUFVCTElTSEVELVRUTDpQVDFIDQpCRUdJTjpWRVZFTlQNClVJRDpMWC1zckVYdkI1MXA1ZUxNS1gwTnkNClNVTU1BUlk6bmV3IGV2ZW50DQpEVFNUQU1QOjIwMjMwMjEwVDA5MzYwMFoNCkRUU1RBUlQ7VkFMVUU9REFURToyMDIzMDIyOA0KRFRFTkQ7VkFMVUU9REFURToyMDIzMDMwMQ0KQVRURU5ERUU7UlNWUD1GQUxTRTtDTj1QZXJzb246bWFpbHRvOnBlcnNvbjFAZW1haWwuY29tDQpFTkQ6VkVWRU5UDQpFTkQ6VkNBTEVOREFSDQo=',
+										data: 'QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQ0FMU0NBTEU6R1JFR09SSUFODQpQUk9ESUQ6YWRhbWdpYmJvbnMvaWNzDQpNRVRIT0Q6UFVCTElTSA0KWC1XUi1DQUxOQU1FOmRlZmF1bHQNClgtUFVCTElTSEVELVRUTDpQVDFIDQpCRUdJTjpWRVZFTlQNClVJRDp2ck1SekhmaXFveFBlajJhQWRvTzINClNVTU1BUlk6bmV3IGV2ZW50DQpEVFNUQU1QOjIwMjQxMDEwVDEzMTAwMFoNCkRUU1RBUlQ7VkFMVUU9REFURToyMDIzMDIyNw0KQVRURU5ERUU7UlNWUD1GQUxTRTtDTj1QZXJzb246bWFpbHRvOnBlcnNvbjFAZW1haWwuY29tDQpFTkQ6VkVWRU5UDQpFTkQ6VkNBTEVOREFSDQo=',
 										fileName: 'event.ics',
-										fileSize: '359 B',
+										fileSize: '332 B',
 									},
 								},
 							},


### PR DESCRIPTION
## Summary
Fixes an issue where the end date was always `end +1`, We now set this to midnight which is dropped from the event file later in the execution but loads in ical and google cal as a an all day event.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1845/community-issue-wrong-end-date-output-for-full-day-events-with-convert
https://github.com/n8n-io/n8n/issues/11192

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
