### PR TITLE
fix(OpenAI Node): Fix tool parameter parsing issue

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -278,7 +278,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			for (const tool of externalTools ?? []) {
 				if (tool.name === functionName) {
 					const parsedArgs: { input: string } = jsonParse(functionArgs);
-					const functionInput = parsedArgs.input ?? functionArgs;
+					const functionInput = parsedArgs.input ?? parsedArgs ?? functionArgs;
 					functionResponse = await tool.invoke(functionInput);
 				}
 			}


### PR DESCRIPTION
## Summary

This PR adds a fix to the OpenAI Node's tool parameter parsing logic. It should improve reliability of the tool calling.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-385/community-issue-http-tool-does-not-work-correctly-with-openai-node
https://community.n8n.io/t/issue-with-http-request-tool/56719

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
