### PR TITLE
fix(editor): Fix `DataTable` markup (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/RunDataTable.vue
+++ b/packages/editor-ui/src/components/RunDataTable.vue
@@ -390,25 +390,27 @@ export default defineComponent({
 <template>
 	<div :class="[$style.dataDisplay, { [$style.highlight]: highlight }]">
 		<table v-if="tableData.columns && tableData.columns.length === 0" :class="$style.table">
-			<tr>
-				<th :class="$style.emptyCell"></th>
-				<th :class="$style.tableRightMargin"></th>
-			</tr>
-			<tr
-				v-for="(_, index1) in tableData.data"
-				:key="index1"
-				:class="{ [$style.hoveringRow]: isHoveringRow(index1) }"
-			>
-				<td
-					:data-row="index1"
-					:data-col="0"
-					@mouseenter="onMouseEnterCell"
-					@mouseleave="onMouseLeaveCell"
+			<tbody>
+				<tr>
+					<th :class="$style.emptyCell"></th>
+					<th :class="$style.tableRightMargin"></th>
+				</tr>
+				<tr
+					v-for="(_, index1) in tableData.data"
+					:key="index1"
+					:class="{ [$style.hoveringRow]: isHoveringRow(index1) }"
 				>
-					<n8n-info-tip>{{ $locale.baseText('runData.emptyItemHint') }}</n8n-info-tip>
-				</td>
-				<td :class="$style.tableRightMargin"></td>
-			</tr>
+					<td
+						:data-row="index1"
+						:data-col="0"
+						@mouseenter="onMouseEnterCell"
+						@mouseleave="onMouseLeaveCell"
+					>
+						<n8n-info-tip>{{ $locale.baseText('runData.emptyItemHint') }}</n8n-info-tip>
+					</td>
+					<td :class="$style.tableRightMargin"></td>
+				</tr>
+			</tbody>
 		</table>
 		<table v-else :class="$style.table">
 			<thead>

--- a/packages/editor-ui/src/components/RunDataTable.vue
+++ b/packages/editor-ui/src/components/RunDataTable.vue
@@ -390,11 +390,13 @@ export default defineComponent({
 <template>
 	<div :class="[$style.dataDisplay, { [$style.highlight]: highlight }]">
 		<table v-if="tableData.columns && tableData.columns.length === 0" :class="$style.table">
-			<tbody>
+			<thead>
 				<tr>
 					<th :class="$style.emptyCell"></th>
 					<th :class="$style.tableRightMargin"></th>
 				</tr>
+			</thead>
+			<tbody>
 				<tr
 					v-for="(_, index1) in tableData.data"
 					:key="index1"


### PR DESCRIPTION
## Summary
Addressing the following Vite warning:
```
11:53:03 AM [vite] warning: <tr> cannot be child of <table>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
n8n-editor-ui:dev: 391|         <div :class="[$style.dataDisplay, { [$style.highlight]: highlight }]">
n8n-editor-ui:dev: 392|                 <table v-if="tableData.columns && tableData.columns.length === 0" :class="$style.table">
n8n-editor-ui:dev: 393|                         <tr>
n8n-editor-ui:dev:    |     ^^^^
n8n-editor-ui:dev: 394|                                 <th :class="$style.emptyCell"></th>
n8n-editor-ui:dev:    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
n8n-editor-ui:dev: 395|                                 <th :class="$style.tableRightMargin"></th>
n8n-editor-ui:dev:    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
n8n-editor-ui:dev: 396|                         </tr>
n8n-editor-ui:dev:    |  ^^^^^^^^
n8n-editor-ui:dev:   Plugin: vite:vue
```