### PR TITLE
feat(editor): Remove manual chunking from vite (no-changelog)

### DIFF
--- a/packages/editor-ui/vite.config.mts
+++ b/packages/editor-ui/vite.config.mts
@@ -3,40 +3,10 @@ import { resolve } from 'path';
 import { defineConfig, mergeConfig } from 'vite';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 
-import packageJSON from './package.json';
 import { vitestConfig } from '../design-system/vite.config.mts';
 import icons from 'unplugin-icons/vite';
 import iconsResolver from 'unplugin-icons/resolver';
 import components from 'unplugin-vue-components/vite';
-
-const vendorChunks = ['vue', 'vue-router'];
-const n8nChunks = ['n8n-workflow', 'n8n-design-system', '@n8n/chat'];
-const ignoreChunks = [
-	'@fontsource/open-sans',
-	'@vueuse/components',
-	// TODO: remove this. It's currently required by xml2js in NodeErrors
-	'stream-browserify',
-	'vue-markdown-render',
-];
-
-const isScopedPackageToIgnore = (str: string) => /@codemirror\//.test(str);
-
-function renderChunks() {
-	const { dependencies } = packageJSON;
-	const chunks: Record<string, string[]> = {};
-
-	Object.keys(dependencies).forEach((key) => {
-		if ([...vendorChunks, ...n8nChunks, ...ignoreChunks].includes(key)) {
-			return;
-		}
-
-		if (isScopedPackageToIgnore(key)) return;
-
-		chunks[key] = [key];
-	});
-
-	return chunks;
-}
 
 const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
@@ -124,19 +94,8 @@ export default mergeConfig(
 			},
 		},
 		build: {
-			assetsInlineLimit: 0,
 			minify: !!release,
 			sourcemap: !!release,
-			rollupOptions: {
-				treeshake: !!release,
-				output: {
-					manualChunks: {
-						vendor: vendorChunks,
-						n8n: n8nChunks,
-						...renderChunks(),
-					},
-				},
-			},
 		},
 	}),
 	vitestConfig,


### PR DESCRIPTION
## Summary

Removed manually picking chunks, allowing Vite to split the code as necessary.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
