### PR TITLE
fix(editor): Fix chat crashing when rendering output-parsed content

### DIFF
--- a/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
@@ -384,7 +384,12 @@ function extractResponseMessage(responseData?: IDataObject) {
 
 	if (!matchedPath) return JSON.stringify(responseData, null, 2);
 
-	return get(responseData, matchedPath) as string;
+	const matchedOutput = get(responseData, matchedPath);
+	if (typeof matchedOutput === 'object') {
+		return '```json\n' + JSON.stringify(matchedOutput, null, 4) + '\n```';
+	}
+
+	return matchedOutput?.toString() ?? '';
 }
 
 async function sendMessage(message: string, files?: File[]) {

--- a/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
@@ -386,7 +386,7 @@ function extractResponseMessage(responseData?: IDataObject) {
 
 	const matchedOutput = get(responseData, matchedPath);
 	if (typeof matchedOutput === 'object') {
-		return '```json\n' + JSON.stringify(matchedOutput, null, 4) + '\n```';
+		return '```json\n' + JSON.stringify(matchedOutput, null, 2) + '\n```';
 	}
 
 	return matchedOutput?.toString() ?? '';


### PR DESCRIPTION
## Summary

Fix an issue where editor-ui would crash when rendering output-parsed content, for example, Agent with output parser. Before pushing the message to the chat stack, we convert it to a Markdown JSON string and stringify it to render it nicely in the chat window.
![CleanShot 2024-10-10 at 15 20 56](https://github.com/user-attachments/assets/309b484b-f606-469e-a991-fccbf91086f9)

## Related Linear tickets, Github issues, and Community forum posts
- Sentry: 5973225157
- Sentry: 5941300808
## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
