### PR TITLE
feat(OpenAI Node, Agent Node, Basic LLM Chain Node): Update title of an error when missing chatInput

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -181,10 +181,14 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	}
 
 	if (input === undefined) {
-		throw new NodeOperationError(this.getNode(), 'No prompt specified', {
-			description:
-				"Expected to find the prompt in an input field called 'chatInput' (this is what the chat trigger node outputs). To use something else, change the 'Prompt' parameter",
-		});
+		throw new NodeOperationError(
+			this.getNode(),
+			"Could not automatically set prompt from previous node. Please select 'Define below' in the Prompt parameter",
+			{
+				description:
+					"Expected to find the prompt in an input field called 'chatInput' (this is what the chat trigger node outputs). To use something else, change the 'Prompt' parameter",
+			},
+		);
 	}
 
 	const assistantId = this.getNodeParameter('assistantId', i, '', { extractValue: true }) as string;

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -98,10 +98,14 @@ export function getPromptInputByType(options: {
 	}
 
 	if (input === undefined) {
-		throw new NodeOperationError(ctx.getNode(), 'No prompt specified', {
-			description:
-				"Expected to find the prompt in an input field called 'chatInput' (this is what the chat trigger node outputs). To use something else, change the 'Prompt' parameter",
-		});
+		throw new NodeOperationError(
+			ctx.getNode(),
+			"Could not automatically set prompt from previous node. Please select 'Define below' in the Prompt parameter",
+			{
+				description:
+					"Expected to find the prompt in an input field called 'chatInput' (this is what the chat trigger node outputs). To use something else, change the 'Prompt' parameter",
+			},
+		);
 	}
 
 	return input;


### PR DESCRIPTION
Update title of an error when "Take from previous node automatically" mode is selected and `={{ $json.chatInput }}` couldn't resolve.

![image](https://github.com/user-attachments/assets/be857264-3fc0-427e-b413-5be12b418d13)

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
