### PR TITLE
fix: Make sure errors are transferred correctly from js task runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/errors/__tests__/execution-error.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/__tests__/execution-error.test.ts
@@ -1,0 +1,53 @@
+import { ExecutionError } from '../execution-error';
+
+describe('ExecutionError', () => {
+	const defaultStack = `TypeError: a.unknown is not a function
+    at VmCodeWrapper (evalmachine.<anonymous>:2:3)
+    at evalmachine.<anonymous>:7:2
+    at Script.runInContext (node:vm:148:12)
+    at Script.runInNewContext (node:vm:153:17)
+    at runInNewContext (node:vm:309:38)
+    at JsTaskRunner.runForAllItems (/n8n/packages/@n8n/task-runner/dist/js-task-runner/js-task-runner.js:90:65)
+    at JsTaskRunner.executeTask (/n8n/packages/@n8n/task-runner/dist/js-task-runner/js-task-runner.js:71:26)
+    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+    at async JsTaskRunner.receivedSettings (/n8n/packages/@n8n/task-runner/dist/task-runner.js:190:26)`;
+
+	it('should parse error details from stack trace without itemIndex', () => {
+		const error = new Error('a.unknown is not a function');
+		error.stack = defaultStack;
+
+		const executionError = new ExecutionError(error);
+		expect(executionError.message).toBe('a.unknown is not a function [line 2]');
+		expect(executionError.lineNumber).toBe(2);
+		expect(executionError.description).toBe('TypeError');
+		expect(executionError.context).toBeUndefined();
+	});
+
+	it('should parse error details from stack trace with itemIndex', () => {
+		const error = new Error('a.unknown is not a function');
+		error.stack = defaultStack;
+
+		const executionError = new ExecutionError(error, 1);
+		expect(executionError.message).toBe('a.unknown is not a function [line 2, for item 1]');
+		expect(executionError.lineNumber).toBe(2);
+		expect(executionError.description).toBe('TypeError');
+		expect(executionError.context).toEqual({ itemIndex: 1 });
+	});
+
+	it('should serialize correctly', () => {
+		const error = new Error('a.unknown is not a function');
+		error.stack = defaultStack;
+
+		const executionError = new ExecutionError(error, 1);
+
+		expect(JSON.stringify(executionError)).toBe(
+			JSON.stringify({
+				message: 'a.unknown is not a function [line 2, for item 1]',
+				description: 'TypeError',
+				itemIndex: 1,
+				context: { itemIndex: 1 },
+				lineNumber: 2,
+			}),
+		);
+	});
+});

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/error-like.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/error-like.ts
@@ -1,0 +1,12 @@
+export interface ErrorLike {
+	message: string;
+	stack?: string;
+}
+
+export function isErrorLike(value: unknown): value is ErrorLike {
+	if (typeof value !== 'object' || value === null) return false;
+
+	const errorLike = value as ErrorLike;
+
+	return typeof errorLike.message === 'string';
+}

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/serializable-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/serializable-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Error that has its message property serialized as well. Used to transport
+ * errors over the wire.
+ */
+export abstract class SerializableError extends Error {
+	constructor(message: string) {
+		super(message);
+
+		// So it is serialized as well
+		this.makeMessageEnumerable();
+	}
+
+	private makeMessageEnumerable() {
+		Object.defineProperty(this, 'message', {
+			value: this.message,
+			enumerable: true, // This makes the message property enumerable
+			writable: true,
+			configurable: true,
+		});
+	}
+}

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/validation-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/validation-error.ts
@@ -1,6 +1,6 @@
-import { ApplicationError } from 'n8n-workflow';
+import { SerializableError } from './serializable-error';
 
-export class ValidationError extends ApplicationError {
+export class ValidationError extends SerializableError {
 	description = '';
 
 	itemIndex: number | undefined = undefined;

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -25,6 +25,8 @@ import { runInNewContext, type Context } from 'node:vm';
 import type { TaskResultData } from '@/runner-types';
 import { type Task, TaskRunner } from '@/task-runner';
 
+import { isErrorLike } from './errors/error-like';
+import { ExecutionError } from './errors/execution-error';
 import type { RequireResolver } from './require-resolver';
 import { createRequireResolver } from './require-resolver';
 import { validateRunForAllItemsOutput, validateRunForEachItemOutput } from './result-validation';
@@ -186,7 +188,7 @@ export class JsTaskRunner extends TaskRunner {
 
 		try {
 			const result = (await runInNewContext(
-				`module.exports = async function() {${settings.code}\n}()`,
+				`module.exports = async function VmCodeWrapper() {${settings.code}\n}()`,
 				context,
 			)) as TaskResultData['result'];
 
@@ -195,12 +197,14 @@ export class JsTaskRunner extends TaskRunner {
 			}
 
 			return validateRunForAllItemsOutput(result);
-		} catch (error) {
+		} catch (e) {
+			// Errors thrown by the VM are not instances of Error, so map them to an ExecutionError
+			const error = this.toExecutionErrorIfNeeded(e);
+
 			if (settings.continueOnFail) {
-				return [{ json: { error: this.getErrorMessageFromVmError(error) } }];
+				return [{ json: { error: error.message } }];
 			}
 
-			(error as Record<string, unknown>).node = allData.node;
 			throw error;
 		}
 	}
@@ -233,7 +237,7 @@ export class JsTaskRunner extends TaskRunner {
 
 			try {
 				let result = (await runInNewContext(
-					`module.exports = async function() {${settings.code}\n}()`,
+					`module.exports = async function VmCodeWrapper() {${settings.code}\n}()`,
 					context,
 				)) as INodeExecutionData | undefined;
 
@@ -257,14 +261,16 @@ export class JsTaskRunner extends TaskRunner {
 								},
 					);
 				}
-			} catch (error) {
+			} catch (e) {
+				// Errors thrown by the VM are not instances of Error, so map them to an ExecutionError
+				const error = this.toExecutionErrorIfNeeded(e);
+
 				if (!settings.continueOnFail) {
-					(error as Record<string, unknown>).node = allData.node;
 					throw error;
 				}
 
 				returnData.push({
-					json: { error: this.getErrorMessageFromVmError(error) },
+					json: { error: error.message },
 					pairedItem: {
 						item: index,
 					},
@@ -304,11 +310,15 @@ export class JsTaskRunner extends TaskRunner {
 		).getDataProxy();
 	}
 
-	private getErrorMessageFromVmError(error: unknown): string {
-		if (typeof error === 'object' && !!error && 'message' in error) {
-			return error.message as string;
+	private toExecutionErrorIfNeeded(error: unknown): Error {
+		if (error instanceof Error) {
+			return error;
 		}
 
-		return JSON.stringify(error);
+		if (isErrorLike(error)) {
+			return new ExecutionError(error);
+		}
+
+		return new ExecutionError({ message: JSON.stringify(error) });
 	}
 }

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -1,4 +1,4 @@
-import { ApplicationError, ensureError } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 import { URL } from 'node:url';
 import { type MessageEvent, WebSocket } from 'ws';
@@ -256,8 +256,7 @@ export abstract class TaskRunner {
 		try {
 			const data = await this.executeTask(task);
 			this.taskDone(taskId, data);
-		} catch (e) {
-			const error = ensureError(e);
+		} catch (error) {
 			this.taskErrored(taskId, error);
 		}
 	}

--- a/packages/core/src/Agent/index.ts
+++ b/packages/core/src/Agent/index.ts
@@ -10,6 +10,7 @@ import type {
 	INodeParameters,
 	IExecuteData,
 	IDataObject,
+	Result,
 } from 'n8n-workflow';
 import { createEnvProviderState } from 'n8n-workflow';
 
@@ -29,13 +30,13 @@ export const createAgentStartJob = (
 	selfData?: IDataObject,
 	contextNodeName?: string,
 ): IExecuteFunctions['startJob'] => {
-	return async function startJob<T = unknown>(
+	return async function startJob<T = unknown, E = unknown>(
 		this: IExecuteFunctions,
 		jobType: string,
 		settings: unknown,
 		itemIndex: number,
-	): Promise<T> {
-		return await additionalData.startAgentJob<T>(
+	): Promise<Result<T, E>> {
+		return await additionalData.startAgentJob<T, E>(
 			additionalData,
 			jobType,
 			settings,

--- a/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
+++ b/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
@@ -1,16 +1,13 @@
 import {
-	ensureError,
+	ApplicationError,
 	type CodeExecutionMode,
 	type IExecuteFunctions,
 	type INodeExecutionData,
 	type WorkflowExecuteMode,
 } from 'n8n-workflow';
 
-import { ExecutionError } from './ExecutionError';
-import {
-	mapItemsNotDefinedErrorIfNeededForRunForAll,
-	validateNoDisallowedMethodsInRunForEach,
-} from './JsCodeValidator';
+import { isWrappableError, WrappedExecutionError } from './errors/WrappedExecutionError';
+import { validateNoDisallowedMethodsInRunForEach } from './JsCodeValidator';
 
 /**
  * JS Code execution sandbox that executes the JS code using task runner.
@@ -23,70 +20,54 @@ export class JsTaskRunnerSandbox {
 		private readonly executeFunctions: IExecuteFunctions,
 	) {}
 
-	async runCode<T = unknown>(): Promise<T> {
-		const itemIndex = 0;
-
-		try {
-			const executionResult = (await this.executeFunctions.startJob<T>(
-				'javascript',
-				{
-					code: this.jsCode,
-					nodeMode: this.nodeMode,
-					workflowMode: this.workflowMode,
-				},
-				itemIndex,
-			)) as T;
-			return executionResult;
-		} catch (e) {
-			const error = ensureError(e);
-			throw new ExecutionError(error);
-		}
-	}
-
 	async runCodeAllItems(): Promise<INodeExecutionData[]> {
 		const itemIndex = 0;
 
-		return await this.executeFunctions
-			.startJob<INodeExecutionData[]>(
-				'javascript',
-				{
-					code: this.jsCode,
-					nodeMode: this.nodeMode,
-					workflowMode: this.workflowMode,
-					continueOnFail: this.executeFunctions.continueOnFail(),
-				},
-				itemIndex,
-			)
-			.catch((e) => {
-				const error = ensureError(e);
-				// anticipate user expecting `items` to pre-exist as in Function Item node
-				mapItemsNotDefinedErrorIfNeededForRunForAll(this.jsCode, error);
+		const executionResult = await this.executeFunctions.startJob<INodeExecutionData[]>(
+			'javascript',
+			{
+				code: this.jsCode,
+				nodeMode: this.nodeMode,
+				workflowMode: this.workflowMode,
+				continueOnFail: this.executeFunctions.continueOnFail(),
+			},
+			itemIndex,
+		);
 
-				throw new ExecutionError(error);
-			});
+		return executionResult.ok
+			? executionResult.result
+			: this.throwExecutionError(executionResult.error);
 	}
 
 	async runCodeForEachItem(): Promise<INodeExecutionData[]> {
 		validateNoDisallowedMethodsInRunForEach(this.jsCode, 0);
 		const itemIndex = 0;
 
-		return await this.executeFunctions
-			.startJob<INodeExecutionData[]>(
-				'javascript',
-				{
-					code: this.jsCode,
-					nodeMode: this.nodeMode,
-					workflowMode: this.workflowMode,
-					continueOnFail: this.executeFunctions.continueOnFail(),
-				},
-				itemIndex,
-			)
-			.catch((e) => {
-				const error = ensureError(e);
-				// anticipate user expecting `items` to pre-exist as in Function Item node
-				mapItemsNotDefinedErrorIfNeededForRunForAll(this.jsCode, error);
+		const executionResult = await this.executeFunctions.startJob<INodeExecutionData[]>(
+			'javascript',
+			{
+				code: this.jsCode,
+				nodeMode: this.nodeMode,
+				workflowMode: this.workflowMode,
+				continueOnFail: this.executeFunctions.continueOnFail(),
+			},
+			itemIndex,
+		);
 
-				throw new ExecutionError(error);
-			});
+		return executionResult.ok
+			? executionResult.result
+			: this.throwExecutionError(executionResult.error);
+	}
+
+	private throwExecutionError(error: unknown): never {
+		// The error coming from task runner is not an instance of error,
+		// so we need to wrap it in an error instance.
+		if (isWrappableError(error)) {
+			throw new WrappedExecutionError(error);
+		}
+
+		throw new ApplicationError('Unknown error', {
+			cause: error,
+		});
 	}
 }

--- a/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
+++ b/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
@@ -1,0 +1,35 @@
+import { ApplicationError } from 'n8n-workflow';
+
+export type WrappableError = Record<string, unknown>;
+
+/**
+ * Errors received from the task runner are not instances of Error.
+ * This class wraps them in an Error instance and makes all their
+ * properties available.
+ */
+export class WrappedExecutionError extends ApplicationError {
+	[key: string]: unknown;
+
+	constructor(error: WrappableError) {
+		const message = typeof error.message === 'string' ? error.message : 'Unknown error';
+		super(message, {
+			cause: error,
+		});
+
+		this.copyErrorProperties(error);
+	}
+
+	private copyErrorProperties(error: WrappableError) {
+		for (const key of Object.getOwnPropertyNames(error)) {
+			if (key === 'message' || key === 'stack') {
+				continue;
+			}
+
+			this[key] = error[key];
+		}
+	}
+}
+
+export function isWrappableError(error: unknown): error is WrappableError {
+	return typeof error === 'object' && error !== null;
+}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -21,6 +21,7 @@ import type { NodeOperationError } from './errors/node-operation.error';
 import type { WorkflowActivationError } from './errors/workflow-activation.error';
 import type { WorkflowOperationError } from './errors/workflow-operation.error';
 import type { ExecutionStatus } from './ExecutionStatus';
+import type { Result } from './result';
 import type { Workflow } from './Workflow';
 import type { EnvProviderState } from './WorkflowDataProxyEnvProvider';
 import type { WorkflowHooks } from './WorkflowHooks';
@@ -954,7 +955,11 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 
 		getParentCallbackManager(): CallbackManager | undefined;
 
-		startJob<T = unknown>(jobType: string, settings: unknown, itemIndex: number): Promise<T>;
+		startJob<T = unknown, E = unknown>(
+			jobType: string,
+			settings: unknown,
+			itemIndex: number,
+		): Promise<Result<T, E>>;
 	};
 
 export interface IExecuteSingleFunctions extends BaseExecutionFunctions {
@@ -2242,7 +2247,7 @@ export interface IWorkflowExecuteAdditionalData {
 	secretsHelpers: SecretsHelpersBase;
 	logAiEvent: (eventName: AiEvent, payload: AiEventPayload) => void;
 	parentCallbackManager?: CallbackManager;
-	startAgentJob<T>(
+	startAgentJob<T, E = unknown>(
 		additionalData: IWorkflowExecuteAdditionalData,
 		jobType: string,
 		settings: unknown,
@@ -2262,7 +2267,7 @@ export interface IWorkflowExecuteAdditionalData {
 		defaultReturnRunIndex?: number,
 		selfData?: IDataObject,
 		contextNodeName?: string,
-	): Promise<T>;
+	): Promise<Result<T, E>>;
 }
 
 export type WorkflowExecuteMode =
@@ -2668,8 +2673,6 @@ export type BannerName =
 	| 'EMAIL_CONFIRMATION';
 
 export type Functionality = 'regular' | 'configuration-node' | 'pairedItem';
-
-export type Result<T, E> = { ok: true; result: T } | { ok: false; error: E };
 
 export type CallbackManager = CallbackManagerLC;
 

--- a/packages/workflow/src/NodeParameters/FilterParameter.ts
+++ b/packages/workflow/src/NodeParameters/FilterParameter.ts
@@ -7,10 +7,10 @@ import type {
 	FilterOptionsValue,
 	FilterValue,
 	INodeProperties,
-	Result,
 	ValidationResult,
 } from '../Interfaces';
 import * as LoggerProxy from '../LoggerProxy';
+import type { Result } from '../result';
 import { validateFieldType } from '../TypeValidation';
 
 type FilterConditionMetadata = {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -22,6 +22,7 @@ export * from './WorkflowDataProxyEnvProvider';
 export * from './WorkflowHooks';
 export * from './VersionedNodeType';
 export * from './TypeValidation';
+export * from './result';
 export { LoggerProxy, NodeHelpers, ObservableObject, TelemetryHelpers };
 export {
 	isObjectEmpty,

--- a/packages/workflow/src/result.ts
+++ b/packages/workflow/src/result.ts
@@ -1,0 +1,13 @@
+export type ResultOk<T> = { ok: true; result: T };
+export type ResultError<E> = { ok: false; error: E };
+export type Result<T, E> = ResultOk<T> | ResultError<E>;
+
+export const createResultOk = <T>(data: T): ResultOk<T> => ({
+	ok: true,
+	result: data,
+});
+
+export const createResultError = <E = unknown>(error: E): ResultError<E> => ({
+	ok: false,
+	error,
+});


### PR DESCRIPTION

## Summary

Before:

![image](https://github.com/user-attachments/assets/3bf11d41-3caa-43e2-83d5-24b3c356cd57)


After:

![image](https://github.com/user-attachments/assets/7ca92a64-686d-49bd-805e-6c86d9afbbae)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
