### PR TITLE
fix(editor): Bring back the "Forgot password" link on SigninView

### DIFF
--- a/packages/editor-ui/src/views/SigninView.vue
+++ b/packages/editor-ui/src/views/SigninView.vue
@@ -47,6 +47,7 @@ const formConfig: IFormBoxConfig = reactive({
 	title: locale.baseText('auth.signin'),
 	buttonText: locale.baseText('auth.signin'),
 	redirectText: locale.baseText('forgotPassword'),
+	redirectLink: '/forgot-password',
 	inputs: [
 		{
 			name: 'email',


### PR DESCRIPTION
## Summary
This was accidentally removed [here](https://github.com/n8n-io/n8n/pull/10884/files#diff-d3ab92c04e0f51368ccf55f014bed93bec267703e10540894f9f24bacbd0ee91L46-L57). 
All versions after and including 1.61 are currently missing this link from the SigninView.

## Related Linear tickets, Github issues, and Community forum posts

[CP-1587](https://linear.app/n8n/issue/CP-1587)

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] PR Labeled with `release/backport`