### PR TITLE
fix(Strava Trigger Node): Fix issue with webhook not being deleted

### DIFF
--- a/packages/nodes-base/nodes/Strava/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strava/GenericFunctions.ts
@@ -36,14 +36,13 @@ export async function stravaApiRequest(
 
 		if (this.getNode().type.includes('Trigger') && resource.includes('/push_subscriptions')) {
 			const credentials = await this.getCredentials('stravaOAuth2Api');
-			if (method === 'GET') {
+			if (method === 'GET' || method === 'DELETE') {
 				qs.client_id = credentials.clientId;
 				qs.client_secret = credentials.clientSecret;
 			} else {
 				body.client_id = credentials.clientId;
 				body.client_secret = credentials.clientSecret;
 			}
-
 			return await this.helpers?.request(options);
 		} else {
 			return await this.helpers.requestOAuth2.call(this, 'stravaOAuth2Api', options, {

--- a/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
+++ b/packages/nodes-base/nodes/Strava/StravaTrigger.node.ts
@@ -112,7 +112,7 @@ export class StravaTrigger implements INodeType {
 						default: false,
 						// eslint-disable-next-line n8n-nodes-base/node-param-description-boolean-without-whether
 						description:
-							'Strava allows just one subscription at all times. If you want to delete the current subscription to make room for a new subcription with the current parameters, set this parameter to true. Keep in mind this is a destructive operation.',
+							'Strava allows just one subscription at all times. If you want to delete the current subscription to make room for a new subscription with the current parameters, set this parameter to true. Keep in mind this is a destructive operation.',
 					},
 				],
 			},
@@ -155,9 +155,8 @@ export class StravaTrigger implements INodeType {
 				try {
 					responseData = await stravaApiRequest.call(this, 'POST', endpoint, body);
 				} catch (error) {
-					const apiErrorResponse = error.cause.response;
-					if (apiErrorResponse?.body?.errors) {
-						const errors = apiErrorResponse.body.errors;
+					if (error?.cause?.error) {
+						const errors = error?.cause?.error?.errors;
 						for (error of errors) {
 							// if there is a subscription already created
 							if (error.resource === 'PushSubscription' && error.code === 'already exists') {
@@ -177,6 +176,7 @@ export class StravaTrigger implements INodeType {
 										'DELETE',
 										`/push_subscriptions/${webhooks[0].id}`,
 									);
+
 									// now there is room create a subscription with the n8n data
 									const requestBody = {
 										callback_url: webhookUrl,
@@ -190,7 +190,7 @@ export class StravaTrigger implements INodeType {
 										requestBody,
 									);
 								} else {
-									error.message = `A subscription already exists [${webhooks[0].callback_url}]. If you want to delete this subcription and create a new one with the current parameters please go to options and set delete if exist to true`;
+									error.message = `A subscription already exists [${webhooks[0].callback_url}]. If you want to delete this subscription and create a new one with the current parameters please go to options and set delete if exist to true`;
 									throw error;
 								}
 							}


### PR DESCRIPTION
## Summary
We were not checking the correct error value or sending the id and secret as url params on a delete. We now show a more useful error message and we delete the webhook when we should.

![image](https://github.com/user-attachments/assets/e3831cbc-f033-4c00-8a12-508199fed00b)


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1848/strava-trigger-node-unable-to-activate-the-trigger
https://community.n8n.io/t/bad-request-when-activating-strava-trigger-node/54306/3
https://community.n8n.io/t/strava-trigger-is-not-working/57201


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
