### PR TITLE
perf(Google Sheets Node): Don't load whole spreadsheet dataset to determine columns when appending data

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -226,7 +226,9 @@ export async function execute(
 		keyRowIndex = locationDefine.headerRow as number;
 	}
 
-	const sheetData = await sheet.getData(range, 'FORMATTED_VALUE');
+	const [sheetNameForKeyRow] = range.split('!');
+	const sheetNameWithRangeForKeyRow = `${sheetNameForKeyRow}!1:${keyRowIndex}`;
+	const sheetData = await sheet.getData(sheetNameWithRangeForKeyRow, 'FORMATTED_VALUE');
 
 	if (sheetData === undefined || !sheetData.length) {
 		dataMode = 'autoMapInputData';


### PR DESCRIPTION
## Summary

This change reduces the amount of data that will be loaded to identify columns when appending new rows to a google sheet. 

### Explanation

Before this change was the whole data set of the spreadsheet loaded, but only a few rows were needed to identity the columns.  The problem is that the provided "range" parameter of the execute function only contains the sheet name without any range annotations. In case there would be any range annotations in the range, I extract the sheet name from it.

## Related Linear tickets, Github issues, and Community forum posts

Github issue #11234 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
