### PR TITLE
fix(core): Wrap nodes for tool use at a suitable time

### DIFF
--- a/packages/cli/src/__tests__/node-types.test.ts
+++ b/packages/cli/src/__tests__/node-types.test.ts
@@ -1,0 +1,100 @@
+import { mock } from 'jest-mock-extended';
+import type { INodeType, IVersionedNodeType } from 'n8n-workflow';
+
+import type { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+
+import { NodeTypes } from '../node-types';
+
+describe('NodeTypes', () => {
+	let nodeTypes: NodeTypes;
+	const loadNodesAndCredentials = mock<LoadNodesAndCredentials>();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		nodeTypes = new NodeTypes(loadNodesAndCredentials);
+	});
+
+	describe('getByNameAndVersion', () => {
+		const nodeTypeName = 'n8n-nodes-base.testNode';
+
+		it('should throw an error if the node-type does not exist', () => {
+			const nodeTypeName = 'unknownNode';
+
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.loadedNodes = {};
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.knownNodes = {};
+
+			expect(() => nodeTypes.getByNameAndVersion(nodeTypeName)).toThrow(
+				'Unrecognized node type: unknownNode',
+			);
+		});
+
+		it('should return a regular node-type without version', () => {
+			const nodeType = mock<INodeType>();
+
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.loadedNodes = {
+				[nodeTypeName]: { type: nodeType },
+			};
+
+			const result = nodeTypes.getByNameAndVersion(nodeTypeName);
+
+			expect(result).toEqual(nodeType);
+		});
+
+		it('should return a regular node-type with version', () => {
+			const nodeTypeV1 = mock<INodeType>();
+			const nodeType = mock<IVersionedNodeType>({
+				nodeVersions: { 1: nodeTypeV1 },
+				getNodeType: () => nodeTypeV1,
+			});
+
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.loadedNodes = {
+				[nodeTypeName]: { type: nodeType },
+			};
+
+			const result = nodeTypes.getByNameAndVersion(nodeTypeName);
+
+			expect(result).toEqual(nodeTypeV1);
+		});
+
+		it('should throw when a node-type is requested as tool, but does not support being used as one', () => {
+			const nodeType = mock<INodeType>();
+
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.loadedNodes = {
+				[nodeTypeName]: { type: nodeType },
+			};
+
+			expect(() => nodeTypes.getByNameAndVersion(`${nodeTypeName}Tool`)).toThrow(
+				'Node cannot be used as a tool',
+			);
+		});
+
+		it('should return the tool node-type when requested as tool', () => {
+			const nodeType = mock<INodeType>();
+			// @ts-expect-error can't use a mock here
+			nodeType.description = {
+				name: nodeTypeName,
+				displayName: 'TestNode',
+				usableAsTool: true,
+				properties: [],
+			};
+
+			// @ts-expect-error overwriting a readonly property
+			loadNodesAndCredentials.loadedNodes = {
+				[nodeTypeName]: { type: nodeType },
+			};
+
+			const result = nodeTypes.getByNameAndVersion(`${nodeTypeName}Tool`);
+			expect(result).not.toEqual(nodeType);
+			expect(result.description.name).toEqual('n8n-nodes-base.testNodeTool');
+			expect(result.description.displayName).toEqual('TestNode Tool');
+			expect(result.description.codex?.categories).toContain('AI');
+			expect(result.description.inputs).toEqual([]);
+			expect(result.description.outputs).toEqual(['ai_tool']);
+		});
+	});
+});

--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -44,15 +44,7 @@ export class NodeTypes implements INodeTypes {
 	}
 
 	getByNameAndVersion(nodeType: string, version?: number): INodeType {
-		const versionedNodeType = NodeHelpers.getVersionedNodeType(
-			this.getNode(nodeType).type,
-			version,
-		);
-		if (versionedNodeType.description.usableAsTool) {
-			return NodeHelpers.convertNodeToAiTool(versionedNodeType);
-		}
-
-		return versionedNodeType;
+		return NodeHelpers.getVersionedNodeType(this.getNode(nodeType).type, version);
 	}
 
 	/* Some nodeTypes need to get special parameters applied like the polling nodes the polling times */
@@ -79,6 +71,11 @@ export class NodeTypes implements INodeTypes {
 			NodeHelpers.applySpecialNodeParameters(loaded);
 
 			loadedNodes[type] = { sourcePath, type: loaded };
+			if (loaded.description.usableAsTool) {
+				const clone = structuredClone(loaded);
+				const tool = NodeHelpers.convertNodeToAiTool(clone);
+				loadedNodes[type + 'Tool'] = { sourcePath, type: tool };
+			}
 			return loadedNodes[type];
 		}
 

--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -52,10 +52,10 @@ export class NodeTypes implements INodeTypes {
 		}
 
 		const node = this.getNode(nodeType);
-		const versionedNode = NodeHelpers.getVersionedNodeType(node.type, version);
-		if (!toolRequested) return versionedNode;
+		const versionedNodeType = NodeHelpers.getVersionedNodeType(node.type, version);
+		if (!toolRequested) return versionedNodeType;
 
-		if (!versionedNode.description.usableAsTool)
+		if (!versionedNodeType.description.usableAsTool)
 			throw new ApplicationError('Node cannot be used as a tool', { extra: { nodeType } });
 
 		const { loadedNodes } = this.loadNodesAndCredentials;
@@ -65,12 +65,12 @@ export class NodeTypes implements INodeTypes {
 
 		// Instead of modifying the existing type, we extend it into a new type object
 		const clonedProperties = Object.create(
-			versionedNode.description.properties,
+			versionedNodeType.description.properties,
 		) as INodeTypeDescription['properties'];
-		const clonedDescription = Object.create(versionedNode.description, {
+		const clonedDescription = Object.create(versionedNodeType.description, {
 			properties: { value: clonedProperties },
 		}) as INodeTypeDescription;
-		const clonedNode = Object.create(versionedNode, {
+		const clonedNode = Object.create(versionedNodeType, {
 			description: { value: clonedDescription },
 		}) as INodeType;
 		const tool = NodeHelpers.convertNodeToAiTool(clonedNode);


### PR DESCRIPTION
## Summary

This bug was accidentally introduced in https://github.com/n8n-io/n8n/pull/10641.
Because of the way we were creating descriptions for "Tool" version of the nodes that can be used as tools, we were modifying the existing description, instead of creating a new one.
This PR uses prototype-chanining to create a new description, and a new properties array for the Tool version of the node.

In the long run however we should update `generate-ui-types` to create these pseudo-nodes, and avoid having to modify or extend the regular nodes types at runtime. 

## Related Linear tickets, Github issues, and Community forum posts

- PAY-2099
- https://github.com/n8n-io/n8n/issues/11233
- https://github.com/n8n-io/n8n/issues/11220
- https://github.com/n8n-io/n8n/issues/11265
- https://community.n8n.io/t/psa-upgrading-from-v1-55-x-to-v1-62-x-be-careful/57372
- https://community.n8n.io/t/postgres-fails-when-error-output-is-enabled/57397/2

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
