### PR TITLE
fix(MySQL Node): Fix "Maximum call stack size exceeded" error when handling a large number of rows

### DIFF
--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -215,16 +215,16 @@ export function configureQueryRunner(
 		const connection = await pool.getConnection();
 
 		if (mode === BATCH_MODE.SINGLE) {
-			const formatedQueries = queries.map(({ query, values }) => connection.format(query, values));
+			const formattedQueries = queries.map(({ query, values }) => connection.format(query, values));
 			try {
-				//releasing connection after formating queries, otherwise pool.query() will fail with timeout
+				//releasing connection after formatting queries, otherwise pool.query() will fail with timeout
 				connection.release();
 
 				let singleQuery = '';
-				if (formatedQueries.length > 1) {
-					singleQuery = formatedQueries.map((query) => query.trim().replace(/;$/, '')).join(';');
+				if (formattedQueries.length > 1) {
+					singleQuery = formattedQueries.map((query) => query.trim().replace(/;$/, '')).join(';');
 				} else {
-					singleQuery = formatedQueries[0];
+					singleQuery = formattedQueries[0];
 				}
 
 				let response: IDataObject | IDataObject[] = (
@@ -249,7 +249,7 @@ export function configureQueryRunner(
 					response = [response];
 				}
 
-				//because single query is used in this mode mapping itemIndex not posible, setting all items as paired
+				//because single query is used in this mode mapping itemIndex not possible, setting all items as paired
 				const pairedItem = generatePairedItemData(queries.length);
 
 				returnData.push(
@@ -262,24 +262,24 @@ export function configureQueryRunner(
 					),
 				);
 			} catch (err) {
-				const error = parseMySqlError.call(this, err, 0, formatedQueries);
+				const error = parseMySqlError.call(this, err, 0, formattedQueries);
 
 				if (!this.continueOnFail()) throw error;
 				returnData.push({ json: { message: error.message, error: { ...error } } });
 			}
 		} else {
 			if (mode === BATCH_MODE.INDEPENDENTLY) {
-				let formatedQuery = '';
+				let formattedQuery = '';
 				for (const [index, queryWithValues] of queries.entries()) {
 					try {
 						const { query, values } = queryWithValues;
-						formatedQuery = connection.format(query, values);
+						formattedQuery = connection.format(query, values);
 
 						let statements;
 						if ((options?.nodeVersion as number) <= 2.3) {
-							statements = formatedQuery.split(';').map((q) => q.trim());
+							statements = formattedQuery.split(';').map((q) => q.trim());
 						} else {
-							statements = splitQueryToStatements(formatedQuery, false);
+							statements = splitQueryToStatements(formattedQuery, false);
 						}
 
 						const responses: IDataObject[] = [];
@@ -300,7 +300,7 @@ export function configureQueryRunner(
 							),
 						);
 					} catch (err) {
-						const error = parseMySqlError.call(this, err, index, [formatedQuery]);
+						const error = parseMySqlError.call(this, err, index, [formattedQuery]);
 
 						if (!this.continueOnFail()) {
 							connection.release();
@@ -314,17 +314,17 @@ export function configureQueryRunner(
 			if (mode === BATCH_MODE.TRANSACTION) {
 				await connection.beginTransaction();
 
-				let formatedQuery = '';
+				let formattedQuery = '';
 				for (const [index, queryWithValues] of queries.entries()) {
 					try {
 						const { query, values } = queryWithValues;
-						formatedQuery = connection.format(query, values);
+						formattedQuery = connection.format(query, values);
 
 						let statements;
 						if ((options?.nodeVersion as number) <= 2.3) {
-							statements = formatedQuery.split(';').map((q) => q.trim());
+							statements = formattedQuery.split(';').map((q) => q.trim());
 						} else {
-							statements = splitQueryToStatements(formatedQuery, false);
+							statements = splitQueryToStatements(formattedQuery, false);
 						}
 
 						const responses: IDataObject[] = [];
@@ -345,7 +345,7 @@ export function configureQueryRunner(
 							),
 						);
 					} catch (err) {
-						const error = parseMySqlError.call(this, err, index, [formatedQuery]);
+						const error = parseMySqlError.call(this, err, index, [formattedQuery]);
 
 						if (connection) {
 							await connection.rollback();

--- a/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/MySql/v2/helpers/utils.ts
@@ -209,7 +209,7 @@ export function configureQueryRunner(
 			return [];
 		}
 
-		const returnData: INodeExecutionData[] = [];
+		let returnData: INodeExecutionData[] = [];
 		const mode = (options.queryBatching as QueryMode) || BATCH_MODE.SINGLE;
 
 		const connection = await pool.getConnection();
@@ -252,8 +252,8 @@ export function configureQueryRunner(
 				//because single query is used in this mode mapping itemIndex not possible, setting all items as paired
 				const pairedItem = generatePairedItemData(queries.length);
 
-				returnData.push(
-					...prepareOutput(
+				returnData = returnData.concat(
+					prepareOutput(
 						response,
 						options,
 						statements,
@@ -290,8 +290,8 @@ export function configureQueryRunner(
 							responses.push(response);
 						}
 
-						returnData.push(
-							...prepareOutput(
+						returnData = returnData.concat(
+							prepareOutput(
 								responses,
 								options,
 								statements,
@@ -335,8 +335,8 @@ export function configureQueryRunner(
 							responses.push(response);
 						}
 
-						returnData.push(
-							...prepareOutput(
+						returnData = returnData.concat(
+							prepareOutput(
 								responses,
 								options,
 								statements,


### PR DESCRIPTION
## Summary
In #10965 I missed these three occurrences.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/mysql-maximum-call-stack-size-exceeded-again/57514

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
