### PR TITLE
fix(core): Ensure error reporter does not promote `info` to `error` messages

### DIFF
--- a/packages/workflow/src/ErrorReporterProxy.ts
+++ b/packages/workflow/src/ErrorReporterProxy.ts
@@ -35,7 +35,7 @@ export const error = (e: unknown, options?: ReportingOptions) => {
 
 export const info = (msg: string, options?: ReportingOptions) => {
 	Logger.info(msg);
-	instance.report(msg, options);
+	instance.report(msg, { ...options, level: 'info' });
 };
 
 export const warn = (warning: Error | string, options?: ReportingOptions) =>


### PR DESCRIPTION
https://n8nio.slack.com/archives/C069HS026UF/p1728898929568559?thread_ts=1728896820.536419&cid=C069HS026UF