### PR TITLE
fix: Don't show pinned data tooltip for pinned nodes

### DIFF
--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -243,7 +243,7 @@ describe('Data pinning', () => {
 		});
 	});
 
-	it('should show pinned data tooltip', () => {
+	it('should not show pinned data tooltip', () => {
 		cy.createFixtureWorkflow('Pinned_webhook_node.json', 'Test');
 		workflowPage.actions.executeWorkflow();
 

--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -218,7 +218,11 @@ describe('Data pinning', () => {
 	});
 
 	it('should show pinned data tooltip', () => {
-		const { callEndpoint } = simpleWebhookCall({ method: 'GET', webhookPath: nanoid(), executeNow: false });
+		const { callEndpoint } = simpleWebhookCall({
+			method: 'GET',
+			webhookPath: nanoid(),
+			executeNow: false,
+		});
 
 		ndv.actions.close();
 		workflowPage.actions.executeWorkflow();
@@ -230,7 +234,12 @@ describe('Data pinning', () => {
 		callEndpoint((response) => {
 			expect(response.status).to.eq(200);
 			getVisiblePopper().should('have.length', 1);
-			getVisiblePopper().eq(0).should('have.text', 'You can pin this output instead of waiting for a test event. Open node to do so.')
+			getVisiblePopper()
+				.eq(0)
+				.should(
+					'have.text',
+					'You can pin this output instead of waiting for a test event. Open node to do so.',
+				);
 		});
 	});
 

--- a/cypress/e2e/13-pinning.cy.ts
+++ b/cypress/e2e/13-pinning.cy.ts
@@ -1,3 +1,6 @@
+import { nanoid } from 'nanoid';
+
+import { simpleWebhookCall, waitForWebhook } from './16-webhook-node.cy';
 import {
 	HTTP_REQUEST_NODE_NAME,
 	MANUAL_TRIGGER_NODE_NAME,
@@ -7,6 +10,7 @@ import {
 } from '../constants';
 import { WorkflowPage, NDV } from '../pages';
 import { errorToast } from '../pages/notifications';
+import { getVisiblePopper } from '../utils';
 
 const workflowPage = new WorkflowPage();
 const ndv = new NDV();
@@ -211,6 +215,33 @@ describe('Data pinning', () => {
 				});
 			},
 		);
+	});
+
+	it('should show pinned data tooltip', () => {
+		const { callEndpoint } = simpleWebhookCall({ method: 'GET', webhookPath: nanoid(), executeNow: false });
+
+		ndv.actions.close();
+		workflowPage.actions.executeWorkflow();
+		cy.wait(waitForWebhook);
+
+		// hide other visible popper on workflow execute button
+		workflowPage.getters.canvasNodes().eq(0).click();
+
+		callEndpoint((response) => {
+			expect(response.status).to.eq(200);
+			getVisiblePopper().should('have.length', 1);
+			getVisiblePopper().eq(0).should('have.text', 'You can pin this output instead of waiting for a test event. Open node to do so.')
+		});
+	});
+
+	it('should show pinned data tooltip', () => {
+		cy.createFixtureWorkflow('Pinned_webhook_node.json', 'Test');
+		workflowPage.actions.executeWorkflow();
+
+		// hide other visible popper on workflow execute button
+		workflowPage.getters.canvasNodes().eq(0).click();
+
+		getVisiblePopper().should('have.length', 0);
 	});
 });
 

--- a/cypress/e2e/16-webhook-node.cy.ts
+++ b/cypress/e2e/16-webhook-node.cy.ts
@@ -67,7 +67,7 @@ export const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
 
 	const callEndpoint = (cb: (response: Cypress.Response<unknown>) => void) => {
 		cy.request(method, `${BACKEND_BASE_URL}/webhook-test/${webhookPath}`).then(cb);
-	}
+	};
 
 	if (executeNow) {
 		ndv.actions.execute();
@@ -81,7 +81,7 @@ export const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
 
 	return {
 		callEndpoint,
-	}
+	};
 };
 
 describe('Webhook Trigger node', () => {

--- a/cypress/e2e/16-webhook-node.cy.ts
+++ b/cypress/e2e/16-webhook-node.cy.ts
@@ -9,7 +9,7 @@ const workflowPage = new WorkflowPage();
 const ndv = new NDV();
 const credentialsModal = new CredentialsModal();
 
-const waitForWebhook = 500;
+export const waitForWebhook = 500;
 
 interface SimpleWebhookCallOptions {
 	method: string;
@@ -21,7 +21,7 @@ interface SimpleWebhookCallOptions {
 	authentication?: string;
 }
 
-const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
+export const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
 	const {
 		authentication,
 		method,
@@ -65,14 +65,22 @@ const simpleWebhookCall = (options: SimpleWebhookCallOptions) => {
 		getVisibleSelect().find('.option-headline').contains(responseData).click();
 	}
 
+	const callEndpoint = (cb: (response: Cypress.Response<unknown>) => void) => {
+		cy.request(method, `${BACKEND_BASE_URL}/webhook-test/${webhookPath}`).then(cb);
+	}
+
 	if (executeNow) {
 		ndv.actions.execute();
 		cy.wait(waitForWebhook);
 
-		cy.request(method, `${BACKEND_BASE_URL}/webhook-test/${webhookPath}`).then((response) => {
+		callEndpoint((response) => {
 			expect(response.status).to.eq(200);
 			ndv.getters.outputPanel().contains('headers');
 		});
+	}
+
+	return {
+		callEndpoint,
 	}
 };
 

--- a/cypress/fixtures/Pinned_webhook_node.json
+++ b/cypress/fixtures/Pinned_webhook_node.json
@@ -1,0 +1,39 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "path": "FwrbSiaua2Xmvn6-Z-7CQ",
+        "options": {}
+      },
+      "id": "8fcc7e5f-2cef-4938-9564-eea504c20aa0",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        360,
+        220
+      ],
+      "webhookId": "9c778f2a-e882-46ed-a0e4-c8e2f76ccd65"
+    }
+  ],
+  "connections": {},
+  "pinData": {
+    "Webhook": [
+      {
+        "headers": {
+          "connection": "keep-alive",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+          "accept": "*/*",
+          "cookie": "n8n-auth=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjNiM2FhOTE5LWRhZDgtNDE5MS1hZWZiLTlhZDIwZTZkMjJjNiIsImhhc2giOiJ1ZVAxR1F3U2paIiwiaWF0IjoxNzI4OTE1NTQyLCJleHAiOjE3Mjk1MjAzNDJ9.fV02gpUnSiUoMxHwfB0npBjcjct7Mv9vGfj-jRTT3-I",
+          "host": "localhost:5678",
+          "accept-encoding": "gzip, deflate"
+        },
+        "params": {},
+        "query": {},
+        "body": {},
+        "webhookUrl": "http://localhost:5678/webhook-test/FwrbSiaua2Xmvn6-Z-7CQ",
+        "executionMode": "test"
+      }
+    ]
+  }
+}

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -524,7 +524,7 @@ function showPinDataDiscoveryTooltip(dataItemsCount: number): void {
 		isScheduledGroup.value ||
 		uiStore.isAnyModalOpen ||
 		dataItemsCount === 0 ||
-		pinnedData.hasData
+		pinnedData.hasData.value
 	)
 		return;
 

--- a/packages/editor-ui/src/components/Node.vue
+++ b/packages/editor-ui/src/components/Node.vue
@@ -523,7 +523,8 @@ function showPinDataDiscoveryTooltip(dataItemsCount: number): void {
 		isManualTypeNode.value ||
 		isScheduledGroup.value ||
 		uiStore.isAnyModalOpen ||
-		dataItemsCount === 0
+		dataItemsCount === 0 ||
+		pinnedData.hasData
 	)
 		return;
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Don't show tooltip for pinned nodes
![image](https://github.com/user-attachments/assets/6c0d2392-4725-46cc-a2c9-76c3b402bd88)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
