### PR TITLE
fix(core): Override executions mode if `regular` during worker startup

### DIFF
--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -61,6 +61,10 @@ export class Worker extends BaseCommand {
 	constructor(argv: string[], cmdConfig: Config) {
 		if (!process.env.N8N_ENCRYPTION_KEY) throw new WorkerMissingEncryptionKey();
 
+		if (config.getEnv('executions.mode') !== 'queue') {
+			config.set('executions.mode', 'queue');
+		}
+
 		super(argv, cmdConfig);
 
 		this.logger = Container.get(Logger).withScope('scaling');

--- a/packages/cli/test/integration/commands/worker.cmd.test.ts
+++ b/packages/cli/test/integration/commands/worker.cmd.test.ts
@@ -39,6 +39,8 @@ mockInstance(Push);
 const command = setupTestCommand(Worker);
 
 test('worker initializes all its components', async () => {
+	config.set('executions.mode', 'regular'); // should be overridden
+
 	const worker = await command.run();
 	expect(worker.queueModeId).toBeDefined();
 	expect(worker.queueModeId).toContain('worker');
@@ -53,4 +55,6 @@ test('worker initializes all its components', async () => {
 	expect(logStreamingEventRelay.init).toHaveBeenCalledTimes(1);
 	expect(orchestrationWorkerService.init).toHaveBeenCalledTimes(1);
 	expect(messageEventBus.send).toHaveBeenCalledTimes(1);
+
+	expect(config.getEnv('executions.mode')).toBe('queue');
 });


### PR DESCRIPTION
## Summary

A worker process is intended only for scaling mode and should not be started in regular mode. This has been allowed for a long time and disallowed only recently, so we should override any `EXECUTIONS_MODE=regular` for workers until we can make the breaking change in v2.

## Related Linear tickets, Github issues, and Community forum posts

#11247

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
