### PR TITLE
feat: Fail all tasks for a disconnected Task Runner (no-changelog)

### DIFF
--- a/packages/cli/src/runners/__tests__/task-broker.test.ts
+++ b/packages/cli/src/runners/__tests__/task-broker.test.ts
@@ -5,6 +5,8 @@ import type { RunnerMessage, TaskResultData } from '../runner-types';
 import { TaskBroker } from '../task-broker.service';
 import type { TaskOffer, TaskRequest, TaskRunner } from '../task-broker.service';
 
+const createValidUntil = (ms: number) => process.hrtime.bigint() + BigInt(ms * 1_000_000);
+
 describe('TaskBroker', () => {
 	let taskBroker: TaskBroker;
 
@@ -15,14 +17,12 @@ describe('TaskBroker', () => {
 
 	describe('expireTasks', () => {
 		it('should remove expired task offers and keep valid task offers', () => {
-			const now = process.hrtime.bigint();
-
 			const validOffer: TaskOffer = {
 				offerId: 'valid',
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000), // 1 second in the future
+				validUntil: createValidUntil(1000), // 1 second in the future
 			};
 
 			const expiredOffer1: TaskOffer = {
@@ -30,7 +30,7 @@ describe('TaskBroker', () => {
 				runnerId: 'runner2',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now - BigInt(1000 * 1_000_000), // 1 second in the past
+				validUntil: createValidUntil(-1000), // 1 second in the past
 			};
 
 			const expiredOffer2: TaskOffer = {
@@ -38,7 +38,7 @@ describe('TaskBroker', () => {
 				runnerId: 'runner3',
 				taskType: 'taskType1',
 				validFor: 2000,
-				validUntil: now - BigInt(2000 * 1_000_000), // 2 seconds in the past
+				validUntil: createValidUntil(-2000), // 2 seconds in the past
 			};
 
 			taskBroker.setPendingTaskOffers([validOffer, expiredOffer1, expiredOffer2]);
@@ -102,6 +102,55 @@ describe('TaskBroker', () => {
 
 			expect(runnerIds).toHaveLength(0);
 		});
+
+		it('should remove any pending offers for that runner', () => {
+			const runnerId = 'runner1';
+			const runner = mock<TaskRunner>({ id: runnerId });
+			const messageCallback = jest.fn();
+
+			taskBroker.registerRunner(runner, messageCallback);
+			taskBroker.taskOffered({
+				offerId: 'offer1',
+				runnerId,
+				taskType: 'mock',
+				validFor: 1000,
+				validUntil: createValidUntil(1000),
+			});
+			taskBroker.taskOffered({
+				offerId: 'offer1',
+				runnerId: 'runner2',
+				taskType: 'mock',
+				validFor: 1000,
+				validUntil: createValidUntil(1000),
+			});
+			taskBroker.deregisterRunner(runnerId);
+
+			const offers = taskBroker.getPendingTaskOffers();
+			expect(offers).toHaveLength(1);
+			expect(offers.filter((o) => o.runnerId !== runnerId)).toHaveLength(1);
+		});
+
+		it('should fail any running tasks for that runner', () => {
+			const runnerId = 'runner1';
+			const runner = mock<TaskRunner>({ id: runnerId });
+			const messageCallback = jest.fn();
+
+			const taskId = 'task1';
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const failSpy = jest.spyOn(taskBroker as any, 'failTask');
+			const rejectSpy = jest.spyOn(taskBroker, 'handleRunnerReject');
+
+			taskBroker.registerRunner(runner, messageCallback);
+			taskBroker.setTasks({
+				[taskId]: { id: taskId, requesterId: 'requester1', runnerId, taskType: 'mock' },
+				task2: { id: 'task2', requesterId: 'requester1', runnerId: 'runner2', taskType: 'mock' },
+			});
+			taskBroker.deregisterRunner(runnerId);
+
+			expect(failSpy).toBeCalledWith(taskId, 'The Task Runner has disconnected');
+			expect(rejectSpy).toBeCalledWith(taskId, 'The Task Runner has disconnected');
+		});
 	});
 
 	describe('deregisterRequester', () => {
@@ -121,14 +170,12 @@ describe('TaskBroker', () => {
 
 	describe('taskRequested', () => {
 		it('should match a pending offer to an incoming request', async () => {
-			const now = process.hrtime.bigint();
-
 			const offer: TaskOffer = {
 				offerId: 'offer1',
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000),
+				validUntil: createValidUntil(1000),
 			};
 
 			taskBroker.setPendingTaskOffers([offer]);
@@ -150,8 +197,6 @@ describe('TaskBroker', () => {
 
 	describe('taskOffered', () => {
 		it('should match a pending request to an incoming offer', () => {
-			const now = process.hrtime.bigint();
-
 			const request: TaskRequest = {
 				requestId: 'request1',
 				requesterId: 'requester1',
@@ -166,7 +211,7 @@ describe('TaskBroker', () => {
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000),
+				validUntil: createValidUntil(1000),
 			};
 
 			jest.spyOn(taskBroker, 'acceptOffer').mockResolvedValue(); // allow Jest to exit cleanly
@@ -180,14 +225,12 @@ describe('TaskBroker', () => {
 
 	describe('settleTasks', () => {
 		it('should match task offers with task requests by task type', () => {
-			const now = process.hrtime.bigint();
-
 			const offer1: TaskOffer = {
 				offerId: 'offer1',
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000),
+				validUntil: createValidUntil(1000),
 			};
 
 			const offer2: TaskOffer = {
@@ -195,7 +238,7 @@ describe('TaskBroker', () => {
 				runnerId: 'runner2',
 				taskType: 'taskType2',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000),
+				validUntil: createValidUntil(1000),
 			};
 
 			const request1: TaskRequest = {
@@ -235,14 +278,12 @@ describe('TaskBroker', () => {
 		});
 
 		it('should not match a request whose acceptance is in progress', () => {
-			const now = process.hrtime.bigint();
-
 			const offer: TaskOffer = {
 				offerId: 'offer1',
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000),
+				validUntil: createValidUntil(1000),
 			};
 
 			const request: TaskRequest = {
@@ -271,14 +312,12 @@ describe('TaskBroker', () => {
 		});
 
 		it('should expire tasks before settling', () => {
-			const now = process.hrtime.bigint();
-
 			const validOffer: TaskOffer = {
 				offerId: 'valid',
 				runnerId: 'runner1',
 				taskType: 'taskType1',
 				validFor: 1000,
-				validUntil: now + BigInt(1000 * 1_000_000), // 1 second in the future
+				validUntil: createValidUntil(1000), // 1 second in the future
 			};
 
 			const expiredOffer: TaskOffer = {
@@ -286,7 +325,7 @@ describe('TaskBroker', () => {
 				runnerId: 'runner2',
 				taskType: 'taskType2', // will be removed before matching
 				validFor: 1000,
-				validUntil: now - BigInt(1000 * 1_000_000), // 1 second in the past
+				validUntil: createValidUntil(-1000), // 1 second in the past
 			};
 
 			const request1: TaskRequest = {

--- a/packages/cli/src/runners/__tests__/task-broker.test.ts
+++ b/packages/cli/src/runners/__tests__/task-broker.test.ts
@@ -117,7 +117,7 @@ describe('TaskBroker', () => {
 				validUntil: createValidUntil(1000),
 			});
 			taskBroker.taskOffered({
-				offerId: 'offer1',
+				offerId: 'offer2',
 				runnerId: 'runner2',
 				taskType: 'mock',
 				validFor: 1000,
@@ -127,7 +127,7 @@ describe('TaskBroker', () => {
 
 			const offers = taskBroker.getPendingTaskOffers();
 			expect(offers).toHaveLength(1);
-			expect(offers.filter((o) => o.runnerId !== runnerId)).toHaveLength(1);
+			expect(offers[0].runnerId).toBe('runner2');
 		});
 
 		it('should fail any running tasks for that runner', () => {
@@ -148,8 +148,8 @@ describe('TaskBroker', () => {
 			});
 			taskBroker.deregisterRunner(runnerId);
 
-			expect(failSpy).toBeCalledWith(taskId, 'The Task Runner has disconnected');
-			expect(rejectSpy).toBeCalledWith(taskId, 'The Task Runner has disconnected');
+			expect(failSpy).toBeCalledWith(taskId, `The Task Runner (${runnerId}) has disconnected`);
+			expect(rejectSpy).toBeCalledWith(taskId, `The Task Runner (${runnerId}) has disconnected`);
 		});
 	});
 

--- a/packages/cli/src/runners/task-broker.service.ts
+++ b/packages/cli/src/runners/task-broker.service.ts
@@ -75,15 +75,11 @@ export class TaskBroker {
 
 	expireTasks() {
 		const now = process.hrtime.bigint();
-		const invalidOffers: number[] = [];
-		for (let i = 0; i < this.pendingTaskOffers.length; i++) {
-			if (this.pendingTaskOffers[i].validUntil < now) {
-				invalidOffers.push(i);
+		for (let i = this.pendingTaskOffers.length; i >= 0; i--) {
+			if (this.pendingTaskOffers[i]?.validUntil < now) {
+				this.pendingTaskOffers.splice(i, 1);
 			}
 		}
-
-		// We reverse the list so the later indexes are valid after deleting earlier ones
-		invalidOffers.reverse().forEach((i) => this.pendingTaskOffers.splice(i, 1));
 	}
 
 	registerRunner(runner: TaskRunner, messageCallback: MessageCallback) {
@@ -92,6 +88,21 @@ export class TaskBroker {
 
 	deregisterRunner(runnerId: string) {
 		this.knownRunners.delete(runnerId);
+
+		// Remove any pending offers
+		for (let i = this.pendingTaskOffers.length; i >= 0; i--) {
+			if (this.pendingTaskOffers[i]?.runnerId === runnerId) {
+				this.pendingTaskOffers.splice(i, 1);
+			}
+		}
+
+		// Fail any tasks
+		for (const task of this.tasks.values()) {
+			if (task.runnerId === runnerId) {
+				void this.failTask(task.id, 'The Task Runner has disconnected');
+				this.handleRunnerReject(task.id, 'The Task Runner has disconnected');
+			}
+		}
 	}
 
 	registerRequester(requesterId: string, messageCallback: RequesterMessageCallback) {

--- a/packages/cli/src/runners/task-broker.service.ts
+++ b/packages/cli/src/runners/task-broker.service.ts
@@ -75,8 +75,8 @@ export class TaskBroker {
 
 	expireTasks() {
 		const now = process.hrtime.bigint();
-		for (let i = this.pendingTaskOffers.length; i >= 0; i--) {
-			if (this.pendingTaskOffers[i]?.validUntil < now) {
+		for (let i = this.pendingTaskOffers.length - 1; i >= 0; i--) {
+			if (this.pendingTaskOffers[i].validUntil < now) {
 				this.pendingTaskOffers.splice(i, 1);
 			}
 		}
@@ -90,8 +90,8 @@ export class TaskBroker {
 		this.knownRunners.delete(runnerId);
 
 		// Remove any pending offers
-		for (let i = this.pendingTaskOffers.length; i >= 0; i--) {
-			if (this.pendingTaskOffers[i]?.runnerId === runnerId) {
+		for (let i = this.pendingTaskOffers.length - 1; i >= 0; i--) {
+			if (this.pendingTaskOffers[i].runnerId === runnerId) {
 				this.pendingTaskOffers.splice(i, 1);
 			}
 		}
@@ -99,8 +99,8 @@ export class TaskBroker {
 		// Fail any tasks
 		for (const task of this.tasks.values()) {
 			if (task.runnerId === runnerId) {
-				void this.failTask(task.id, 'The Task Runner has disconnected');
-				this.handleRunnerReject(task.id, 'The Task Runner has disconnected');
+				void this.failTask(task.id, `The Task Runner (${runnerId}) has disconnected`);
+				this.handleRunnerReject(task.id, `The Task Runner (${runnerId}) has disconnected`);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When a Task Runner disconnects, the Task Broker should kill all pending Tasks and Task Offers, so that the workflow fails gracefully.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
