### PR TITLE
fix: Expressions display actual result of evaluating expression inside string

### DIFF
--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -383,7 +383,7 @@ export const useExpressionEditor = ({
 					if (/\[Object:\s(\{.+\}|\{\})\]/.test(resolved)) {
 						resolved = resolved.replace(/(\[Object: |\]$)/g, '');
 						try {
-							resolved = String(JSON.parse(resolved as string));
+							resolved = String(JSON.parse(resolved));
 						} catch (error) {}
 					}
 

--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -352,6 +352,12 @@ export const useExpressionEditor = ({
 	 * - `This is a {{ [] }} test` displays as `This is a test`.
 	 * - `{{ [] }}` displays as `[Array: []]`.
 	 *
+	 * - `This is a {{ {} }} test` displays as `This is a [object Object] test`.
+	 * - `{{ {} }}` displays as `[Object: {}]`.
+	 *
+	 * - `This is a {{ [{}] }} test` displays as `This is a [object Object] test`.
+	 * - `{{ [] }}` displays as `[Array: []]`.
+	 *
 	 * Some segments display differently based on context:
 	 *
 	 * Date displays as
@@ -366,13 +372,29 @@ export const useExpressionEditor = ({
 			.map((s) => {
 				if (cachedSegments.length <= 1 || s.kind !== 'resolvable') return s;
 
-				if (typeof s.resolved === 'string' && /\[Object: "\d{4}-\d{2}-\d{2}T/.test(s.resolved)) {
-					const utcDateString = s.resolved.replace(/(\[Object: "|\"\])/g, '');
-					s.resolved = new Date(utcDateString).toString();
-				}
+				if (typeof s.resolved === 'string') {
+					let resolved = s.resolved;
 
-				if (typeof s.resolved === 'string' && /\[Array:\s\[.+\]\]/.test(s.resolved)) {
-					s.resolved = s.resolved.replace(/(\[Array: \[|\])/g, '');
+					if (/\[Object: "\d{4}-\d{2}-\d{2}T/.test(resolved)) {
+						const utcDateString = resolved.replace(/(\[Object: "|\"\])/g, '');
+						resolved = new Date(utcDateString).toString();
+					}
+
+					if (/\[Object:\s(\{.+\}|\{\})\]/.test(resolved)) {
+						resolved = resolved.replace(/(\[Object: |\]$)/g, '');
+						try {
+							resolved = String(JSON.parse(resolved as string));
+						} catch (error) {}
+					}
+
+					if (/\[Array:\s\[.+\]\]/.test(resolved)) {
+						resolved = resolved.replace(/(\[Array: |\]$)/g, '');
+						try {
+							resolved = String(JSON.parse(resolved as string));
+						} catch (error) {}
+					}
+
+					s.resolved = resolved;
 				}
 
 				return s;

--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -390,7 +390,7 @@ export const useExpressionEditor = ({
 					if (/\[Array:\s\[.+\]\]/.test(resolved)) {
 						resolved = resolved.replace(/(\[Array: |\]$)/g, '');
 						try {
-							resolved = String(JSON.parse(resolved as string));
+							resolved = String(JSON.parse(resolved));
 						} catch (error) {}
 					}
 


### PR DESCRIPTION
## Summary

actual result would be displayed in preview instead of parsed preview:
![image](https://github.com/user-attachments/assets/91fb17b3-2a58-4491-9d51-2065fefe28c9)
instead of `test [Array: [{"id": 1},[],{}]]`

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/10180
https://linear.app/n8n/issue/NODE-1742/community-issue-expressions-map-function-producing-invalid-json-body
