### PR TITLE
fix(core): Fix options validation

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2382,6 +2382,9 @@ export const validateValueAgainstSchema = (
 			parameterName,
 			parameterValue,
 			propertyDescription.validateType,
+			propertyDescription.validateType === 'options'
+				? { valueOptions: propertyDescription.options as INodePropertyOptions[] }
+				: undefined,
 		);
 	} else if (
 		propertyDescription.type === 'resourceMapper' &&


### PR DESCRIPTION
## Summary

Pass property options to `validateFieldType()` for validation. Currently the validation will fail on execution when using `validateType: 'options'`.
Note: this only effects options that are on the root level and not part of a collection.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
