### PR TITLE
refactor(core): Convey error stack from job failure to main

### DIFF
--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -114,6 +114,7 @@ export class ScalingService {
 			executionId,
 			workerId: config.getEnv('redis.queueModeId'),
 			errorMsg: error.message,
+			errorStack: error.stack ?? '',
 		};
 
 		await job.progress(msg);
@@ -295,12 +296,18 @@ export class ScalingService {
 					});
 					break;
 				case 'job-failed':
-					this.logger.error(`Execution ${msg.executionId} (job ${jobId}) failed`, {
-						workerId: msg.workerId,
-						errorMsg: msg.errorMsg,
-						executionId: msg.executionId,
-						jobId,
-					});
+					this.logger.error(
+						[
+							`Execution ${msg.executionId} (job ${jobId}) failed`,
+							msg.errorStack ? `\n${msg.errorStack}\n` : '',
+						].join(''),
+						{
+							workerId: msg.workerId,
+							errorMsg: msg.errorMsg,
+							executionId: msg.executionId,
+							jobId,
+						},
+					);
 					break;
 				case 'abort-job':
 					break; // only for worker

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -56,6 +56,7 @@ export type JobFailedMessage = {
 	executionId: string;
 	workerId: string;
 	errorMsg: string;
+	errorStack: string;
 };
 
 /** Message sent by main to worker to abort a job. */


### PR DESCRIPTION
Currently, if a job fails due to a job processing issue like [this](https://linear.app/n8n/issue/PAY-2100), the worker conveys only the error message for display in the main process, not its stack trace. This results in main displaying the error message followed by a rather obscure stack trace from Bull's job failed event.

```
10:39:33.850   info    Enqueued execution 243 (job 1774) { "scope": "scaling", "executionId": "243", "jobId": "1774", "file": "scaling.service.js", "function": "addJob" }
10:39:33.852   debug   Started execution of workflow "Webhook" from webhook with execution ID 243 { "executionId": "243", "file": "webhook-helpers.js", "function": "executeWebhook" }
10:39:33.979   error   Execution 243 (job 1774) failed { "scope": "scaling", "workerId": "worker-eWnl4zNMa6P6IgnH", "errorMsg": "Cannot read properties of undefined (reading 'node')", "executionId": "243", "jobId": "1774", "file": "scaling.service.js" }
10:39:33.984   error   Problem with execution 243: Cannot read properties of undefined (reading 'node'). Aborting. { "file": "workflow-runner.js" }
10:39:33.986   error   Cannot read properties of undefined (reading 'node') (execution 243)
Error: Cannot read properties of undefined (reading 'node')
    at Queue.onFailed (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/job.js:516:18)
    at Queue.emit (node:events:519:28)
    at Queue.emit (node:domain:488:12)
    at Object.module.exports.emitSafe (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/utils.js:50:20)
    at EventEmitter.messageHandler (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/queue.js:476:15)
    at EventEmitter.emit (node:events:519:28)
    at DataHandler.handleSubscriberReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:80:32)
    at DataHandler.returnReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:47:18)
    at JavascriptRedisParser.returnReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:21:22)
    at JavascriptRedisParser.execute (/Users/ivov/Development/n8n/node_modules/.pnpm/redis-parser@3.0.0/node_modules/redis-parser/lib/parser.js:544:14)
 { "scope": "scaling", "file": "LoggerProxy.js", "function": "exports.error" }
```

This PR makes it so we convey to main the worker's stack trace from the original error, for easier debugging. The obscure Bull stack trace is preserved for now.

```
10:28:18.140   info    Enqueued execution 242 (job 1773) { "scope": "scaling", "executionId": "242", "jobId": "1773", "file": "scaling.service.js", "function": "addJob" }
10:28:18.141   debug   Started execution of workflow "Webhook" from webhook with execution ID 242 { "executionId": "242", "file": "webhook-helpers.js", "function": "executeWebhook" }
10:28:18.231   error   Execution 242 (job 1773) failed
TypeError: Cannot read properties of undefined (reading 'node')
    at WorkflowExecute.processRunExecutionData (/Users/ivov/Development/n8n/packages/core/src/WorkflowExecute.ts:896:80)
    at JobProcessor.processJob (/Users/ivov/Development/n8n/packages/cli/src/scaling/job-processor.ts:146:34)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Queue.<anonymous> (/Users/ivov/Development/n8n/packages/cli/src/scaling/scaling.service.ts:94:5)
 { "scope": "scaling", "workerId": "worker-htlmualyL1t4MahB", "errorMsg": "Cannot read properties of undefined (reading 'node')", "executionId": "242", "jobId": "1773", "file": "scaling.service.js" }
10:28:18.235   error   Problem with execution 242: Cannot read properties of undefined (reading 'node'). Aborting. { "file": "workflow-runner.js" }
10:28:18.238   error   Cannot read properties of undefined (reading 'node') (execution 242)
Error: Cannot read properties of undefined (reading 'node')
    at Queue.onFailed (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/job.js:516:18)
    at Queue.emit (node:events:519:28)
    at Queue.emit (node:domain:488:12)
    at Object.module.exports.emitSafe (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/utils.js:50:20)
    at EventEmitter.messageHandler (/Users/ivov/Development/n8n/node_modules/.pnpm/bull@4.12.1/node_modules/bull/lib/queue.js:476:15)
    at EventEmitter.emit (node:events:519:28)
    at DataHandler.handleSubscriberReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:80:32)
    at DataHandler.returnReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:47:18)
    at JavascriptRedisParser.returnReply (/Users/ivov/Development/n8n/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/DataHandler.js:21:22)
    at JavascriptRedisParser.execute (/Users/ivov/Development/n8n/node_modules/.pnpm/redis-parser@3.0.0/node_modules/redis-parser/lib/parser.js:544:14)
 { "scope": "scaling", "file": "LoggerProxy.js", "function": "exports.error" }
```

Follow-up to #11244