### PR TITLE
fix(Set Node): Fix issue with UI properties not being hidden

### DIFF
--- a/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
+++ b/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
@@ -178,6 +178,7 @@ const versionDescription: INodeTypeDescription = {
 			displayOptions: {
 				show: {
 					include: ['selected'],
+					'/includeOtherFields': [true],
 				},
 			},
 		},
@@ -193,6 +194,7 @@ const versionDescription: INodeTypeDescription = {
 			displayOptions: {
 				show: {
 					include: ['except'],
+					'/includeOtherFields': [true],
 				},
 			},
 		},

--- a/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
+++ b/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
@@ -178,7 +178,42 @@ const versionDescription: INodeTypeDescription = {
 			displayOptions: {
 				show: {
 					include: ['selected'],
+					'@version': [3, 3.1, 3.2],
+				},
+			},
+		},
+		{
+			displayName: 'Fields to Exclude',
+			name: 'excludeFields',
+			type: 'string',
+			default: '',
+			placeholder: 'e.g. fieldToExclude1,fieldToExclude2',
+			description:
+				'Comma-separated list of the field names you want to exclude from the output. You can drag the selected fields from the input panel.',
+			requiresDataPath: 'multiple',
+			displayOptions: {
+				show: {
+					include: ['except'],
+					'@version': [3, 3.1, 3.2],
+				},
+			},
+		},
+		{
+			displayName: 'Fields to Include',
+			name: 'includeFields',
+			type: 'string',
+			default: '',
+			placeholder: 'e.g. fieldToInclude1,fieldToInclude2',
+			description:
+				'Comma-separated list of the field names you want to include in the output. You can drag the selected fields from the input panel.',
+			requiresDataPath: 'multiple',
+			displayOptions: {
+				show: {
+					include: ['selected'],
 					'/includeOtherFields': [true],
+				},
+				hide: {
+					'@version': [3, 3.1, 3.2],
 				},
 			},
 		},
@@ -195,6 +230,9 @@ const versionDescription: INodeTypeDescription = {
 				show: {
 					include: ['except'],
 					'/includeOtherFields': [true],
+				},
+				hide: {
+					'@version': [3, 3.1, 3.2],
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
This hides the exclude / include fields box when `include other input fields` is disabled.

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/bugreport-editfields-node-not-properly-hiding-input-field/57647

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
