### PR TITLE
refactor: Move secrets provider imports (no-changelog)

### DIFF
--- a/packages/cli/src/external-secrets/providers/azure-key-vault/azure-key-vault.ts
+++ b/packages/cli/src/external-secrets/providers/azure-key-vault/azure-key-vault.ts
@@ -1,5 +1,4 @@
-import { ClientSecretCredential } from '@azure/identity';
-import { SecretClient } from '@azure/keyvault-secrets';
+import type { SecretClient } from '@azure/keyvault-secrets';
 import type { INodeProperties } from 'n8n-workflow';
 
 import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '@/external-secrets/constants';
@@ -71,6 +70,9 @@ export class AzureKeyVault implements SecretsProvider {
 
 	async connect() {
 		const { vaultName, tenantId, clientId, clientSecret } = this.settings;
+
+		const { ClientSecretCredential } = await import('@azure/identity');
+		const { SecretClient } = await import('@azure/keyvault-secrets');
 
 		try {
 			const credential = new ClientSecretCredential(tenantId, clientId, clientSecret);

--- a/packages/cli/src/external-secrets/providers/gcp-secrets-manager/gcp-secrets-manager.ts
+++ b/packages/cli/src/external-secrets/providers/gcp-secrets-manager/gcp-secrets-manager.ts
@@ -1,4 +1,4 @@
-import { SecretManagerServiceClient as GcpClient } from '@google-cloud/secret-manager';
+import type { SecretManagerServiceClient as GcpClient } from '@google-cloud/secret-manager';
 import { jsonParse, type INodeProperties } from 'n8n-workflow';
 
 import { DOCS_HELP_NOTICE, EXTERNAL_SECRETS_NAME_REGEX } from '@/external-secrets/constants';
@@ -44,6 +44,8 @@ export class GcpSecretsManager implements SecretsProvider {
 
 	async connect() {
 		const { projectId, privateKey, clientEmail } = this.settings;
+
+		const { SecretManagerServiceClient: GcpClient } = await import('@google-cloud/secret-manager');
 
 		try {
 			this.client = new GcpClient({


### PR DESCRIPTION
## Summary

Based on my testing, moving these two imports saves 20MB+ of RAM at rest (1 minute after startup). Most of those saving appear to come from moving GCP, but moving Azure save a few MB, so it's worth doing as well.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
