### PR TITLE
fix: JS Task Runner not having access to Buffer (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -281,6 +281,20 @@ describe('JsTaskRunner', () => {
 				expect(outcome.result).toEqual([wrapIntoJson({ val: undefined })]);
 			});
 		});
+
+		it('should allow access to Node.js Buffers', async () => {
+			const outcome = await execTaskWithParams({
+				task: newTaskWithSettings({
+					code: 'return { val: Buffer.from("test-buffer").toString() }',
+					nodeMode: 'runOnceForAllItems',
+				}),
+				taskData: newAllCodeTaskData(inputItems.map(wrapIntoJson), {
+					envProviderState: undefined,
+				}),
+			});
+
+			expect(outcome.result).toEqual([wrapIntoJson({ val: 'test-buffer' })]);
+		});
 	});
 
 	describe('runOnceForAllItems', () => {
@@ -755,8 +769,6 @@ describe('JsTaskRunner', () => {
 					},
 				}),
 			);
-
-			console.log('DONE');
 		}, 1000);
 	});
 });

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -181,6 +181,17 @@ export class JsTaskRunner extends TaskRunner {
 			module: {},
 			console: customConsole,
 
+			// Exposed Node.js globals in vm2
+			Buffer,
+			Function,
+			eval,
+			setTimeout,
+			setInterval,
+			setImmediate,
+			clearTimeout,
+			clearInterval,
+			clearImmediate,
+
 			items: inputItems,
 			...dataProxy,
 			...this.buildRpcCallObject(taskId),
@@ -188,7 +199,7 @@ export class JsTaskRunner extends TaskRunner {
 
 		try {
 			const result = (await runInNewContext(
-				`module.exports = async function VmCodeWrapper() {${settings.code}\n}()`,
+				`globalThis.global = globalThis; module.exports = async function VmCodeWrapper() {${settings.code}\n}()`,
 				context,
 			)) as TaskResultData['result'];
 


### PR DESCRIPTION
## Summary

Gives the JS Task Runner access to Buffer and some other JS/Node builtins that the vm2 Code node has access to.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
