### PR TITLE
fix(Pinecone Vector Store Node): Prevent populating of vectors after manually stopping the execution

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -1,5 +1,7 @@
 /* eslint-disable n8n-nodes-base/node-filename-against-convention */
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
+import type { Document } from '@langchain/core/documents';
+import type { Embeddings } from '@langchain/core/embeddings';
 import type { VectorStore } from '@langchain/core/vectorstores';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import type {
@@ -15,14 +17,13 @@ import type {
 	Icon,
 	INodePropertyOptions,
 } from 'n8n-workflow';
-import type { Embeddings } from '@langchain/core/embeddings';
-import type { Document } from '@langchain/core/documents';
-import { logWrapper } from '../../../utils/logWrapper';
-import { N8nJsonLoader } from '../../../utils/N8nJsonLoader';
-import type { N8nBinaryLoader } from '../../../utils/N8nBinaryLoader';
-import { getMetadataFiltersValues, logAiEvent } from '../../../utils/helpers';
-import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
+
 import { processDocument } from './processDocuments';
+import { getMetadataFiltersValues, logAiEvent } from '../../../utils/helpers';
+import { logWrapper } from '../../../utils/logWrapper';
+import type { N8nBinaryLoader } from '../../../utils/N8nBinaryLoader';
+import { N8nJsonLoader } from '../../../utils/N8nJsonLoader';
+import { getConnectionHintNoticeField } from '../../../utils/sharedFields';
 
 type NodeOperationMode = 'insert' | 'load' | 'retrieve' | 'update';
 
@@ -296,6 +297,9 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 
 				const resultData = [];
 				for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+					if (this.getExecutionCancelSignal()?.aborted) {
+						break;
+					}
 					const itemData = items[itemIndex];
 					const { processedDocuments, serializedDocuments } = await processDocument(
 						documentInput,


### PR DESCRIPTION
## Summary

This PR fixes an issue where vectors would continue to be processed even after the execution was stopped. To fix this, we need to check in the main processing loop if the AbortSignal was aborted and, if so, break out of the loop.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
