### PR TITLE
fix: Fix task runner error propagation (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -758,17 +758,20 @@ describe('JsTaskRunner', () => {
 
 			await runner.receivedSettings(taskId, task.settings);
 
-			expect(sendSpy).toHaveBeenCalledWith(
-				JSON.stringify({
-					type: 'runner:taskerror',
-					taskId,
-					error: {
-						message: 'unknown is not defined [line 1]',
-						description: 'ReferenceError',
-						lineNumber: 1,
-					},
-				}),
-			);
-		}, 1000);
+			expect(sendSpy).toHaveBeenCalled();
+			const calledWith = sendSpy.mock.calls[0][0] as string;
+			expect(typeof calledWith).toBe('string');
+			const calledObject = JSON.parse(calledWith);
+			expect(calledObject).toEqual({
+				type: 'runner:taskerror',
+				taskId,
+				error: {
+					stack: expect.any(String),
+					message: 'unknown is not defined [line 1]',
+					description: 'ReferenceError',
+					lineNumber: 1,
+				},
+			});
+		});
 	});
 });

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/__tests__/execution-error.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/__tests__/execution-error.test.ts
@@ -42,6 +42,7 @@ describe('ExecutionError', () => {
 
 		expect(JSON.stringify(executionError)).toBe(
 			JSON.stringify({
+				stack: defaultStack,
 				message: 'a.unknown is not a function [line 2, for item 1]',
 				description: 'TypeError',
 				itemIndex: 1,

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/serializable-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/serializable-error.ts
@@ -1,4 +1,25 @@
 /**
+ * Makes the given error's `message` and `stack` properties enumerable
+ * so they can be serialized with JSON.stringify
+ */
+export function makeSerializable(error: Error) {
+	Object.defineProperties(error, {
+		message: {
+			value: error.message,
+			enumerable: true,
+			configurable: true,
+		},
+		stack: {
+			value: error.stack,
+			enumerable: true,
+			configurable: true,
+		},
+	});
+
+	return error;
+}
+
+/**
  * Error that has its message property serialized as well. Used to transport
  * errors over the wire.
  */
@@ -6,16 +27,6 @@ export abstract class SerializableError extends Error {
 	constructor(message: string) {
 		super(message);
 
-		// So it is serialized as well
-		this.makeMessageEnumerable();
-	}
-
-	private makeMessageEnumerable() {
-		Object.defineProperty(this, 'message', {
-			value: this.message,
-			enumerable: true, // This makes the message property enumerable
-			writable: true,
-			configurable: true,
-		});
+		makeSerializable(this);
 	}
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -27,6 +27,7 @@ import { type Task, TaskRunner } from '@/task-runner';
 
 import { isErrorLike } from './errors/error-like';
 import { ExecutionError } from './errors/execution-error';
+import { makeSerializable } from './errors/serializable-error';
 import type { RequireResolver } from './require-resolver';
 import { createRequireResolver } from './require-resolver';
 import { validateRunForAllItemsOutput, validateRunForEachItemOutput } from './result-validation';
@@ -323,7 +324,7 @@ export class JsTaskRunner extends TaskRunner {
 
 	private toExecutionErrorIfNeeded(error: unknown): Error {
 		if (error instanceof Error) {
-			return error;
+			return makeSerializable(error);
 		}
 
 		if (isErrorLike(error)) {

--- a/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
+++ b/packages/nodes-base/nodes/Code/errors/WrappedExecutionError.ts
@@ -21,10 +21,6 @@ export class WrappedExecutionError extends ApplicationError {
 
 	private copyErrorProperties(error: WrappableError) {
 		for (const key of Object.getOwnPropertyNames(error)) {
-			if (key === 'message' || key === 'stack') {
-				continue;
-			}
-
 			this[key] = error[key];
 		}
 	}


### PR DESCRIPTION
## Summary

Make sure also errors thrown outside the sandbox are sent correctly to the task requester. Also include the original stack trace.

**Before**:

<img width="1485" alt="image" src="https://github.com/user-attachments/assets/6b1971bc-781c-4018-98c8-d86912cfb20c">


**After**:

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/6fd9a327-b2ba-4a36-bbdb-81539cb1594a">


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
