### PR TITLE
fix(OpenAI Chat Model Node, Ollama Chat Model Node): Change default model to a more up-to-date option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -79,7 +79,7 @@ export class EmbeddingsOpenAi implements INodeType {
 			},
 		],
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Use Embeddings OpenAI',
 		defaults: {
 			name: 'Embeddings OpenAI',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -128,7 +128,7 @@ export class LmChatOpenAi implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'gpt-4o',
+				default: 'gpt-4o-mini',
 			},
 			{
 				displayName:

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -128,7 +128,7 @@ export class LmChatOpenAi implements INodeType {
 						property: 'model',
 					},
 				},
-				default: 'gpt-3.5-turbo',
+				default: 'gpt-4o',
 			},
 			{
 				displayName:

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/description.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOllama/description.ts
@@ -17,7 +17,7 @@ export const ollamaModel: INodeProperties = {
 	displayName: 'Model',
 	name: 'model',
 	type: 'options',
-	default: 'llama2',
+	default: 'llama3.2',
 	description:
 		'The model which will generate the completion. To download models, visit <a href="https://ollama.ai/library">Ollama Models Library</a>.',
 	typeOptions: {

--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
@@ -26,7 +26,7 @@ type RunDetail = {
 	options: SerializedSecret | SerializedNotImplemented | SerializedFields;
 };
 
-const TIKTOKEN_ESTIMATE_MODEL = 'gpt-3.5-turbo';
+const TIKTOKEN_ESTIMATE_MODEL = 'gpt-4o';
 export class N8nLlmTracing extends BaseCallbackHandler {
 	name = 'N8nLlmTracing';
 


### PR DESCRIPTION
## Summary

This PR changes the models selected by default to a more up-to-date options.
- In OpenAI Chat Model Node it's `gpt-4o-mini`
- In Ollama Chat Model Node – `llama3.2`

It also makes `text-embedding-3-small` the default OpenAI embedding.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-252/select-up-to-date-models-by-default

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
