### PR TITLE
fix(editor): Fit view when only  "Add first step" placeholder is visible (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -31,6 +31,7 @@ import { GRID_SIZE } from '@/utils/nodeViewUtils';
 import { CanvasKey } from '@/constants';
 import { onKeyDown, onKeyUp, useDebounceFn } from '@vueuse/core';
 import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
+import { CanvasNodeRenderType } from '@/types';
 
 const $style = useCssModule();
 
@@ -108,6 +109,7 @@ const {
 	nodes: graphNodes,
 	onPaneReady,
 	findNode,
+	onNodesInitialized,
 } = useVueFlow({ id: props.id, deleteKeyCode: null });
 
 const isPaneReady = ref(false);
@@ -477,6 +479,11 @@ onUnmounted(() => {
 onPaneReady(async () => {
 	await onFitView();
 	isPaneReady.value = true;
+});
+
+onNodesInitialized((nodes) => {
+	if (nodes.length !== 1 || nodes[0].data?.render.type !== CanvasNodeRenderType.AddNodes) return;
+	void onFitView();
 });
 
 watch(() => props.readOnly, setReadonly, {


### PR DESCRIPTION
## Summary

Fit view after deleting all nodes


https://github.com/user-attachments/assets/35d7aece-7491-4f13-b1aa-27499fbf3682


## Related Linear tickets, Github issues, and Community forum posts

[N8N-7677](https://linear.app/n8n/issue/N8N-7677/after-deleting-all-nodes-add-first-step-placeholder-appears-out-of-the)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
