### PR TITLE
fix(editor): Add striped background to readonly canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.spec.ts
+++ b/packages/editor-ui/src/components/canvas/Canvas.spec.ts
@@ -207,4 +207,17 @@ describe('Canvas', () => {
 			await waitFor(() => expect(getByTestId('canvas-minimap')).not.toBeVisible());
 		});
 	});
+
+	describe('background', () => {
+		it('should render default background', () => {
+			const { container } = renderComponent();
+			expect(container.querySelector('#pattern-canvas')).toBeInTheDocument();
+		});
+
+		it('should render striped background', () => {
+			const { container } = renderComponent({ props: { readOnly: true } });
+			expect(container.querySelector('#pattern-canvas')).not.toBeInTheDocument();
+			expect(container.querySelector('#diagonalHatch')).toBeInTheDocument();
+		});
+	});
 });

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -32,6 +32,7 @@ import { CanvasKey } from '@/constants';
 import { onKeyDown, onKeyUp, useDebounceFn } from '@vueuse/core';
 import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
 import { CanvasNodeRenderType } from '@/types';
+import CanvasBackgroundStripedPattern from './elements/CanvasBackgroundStripedPattern.vue';
 
 const $style = useCssModule();
 
@@ -110,6 +111,7 @@ const {
 	onPaneReady,
 	findNode,
 	onNodesInitialized,
+	viewport,
 } = useVueFlow({ id: props.id, deleteKeyCode: null });
 
 const isPaneReady = ref(false);
@@ -562,7 +564,12 @@ provide(CanvasKey, {
 
 		<CanvasArrowHeadMarker :id="arrowHeadMarkerId" />
 
-		<Background data-test-id="canvas-background" pattern-color="#aaa" :gap="GRID_SIZE" />
+		<Background data-test-id="canvas-background" pattern-color="#aaa" :gap="GRID_SIZE">
+			<template #pattern-container>
+				<CanvasBackgroundStripedPattern :x="viewport.x" :y="viewport.y" :zoom="viewport.zoom" />
+			</template>
+			<rect v-if="readOnly" x="0" y="0" width="100%" height="100%" fill="url(#diagonalHatch)" />
+		</Background>
 
 		<Transition name="minimap">
 			<MiniMap

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -565,10 +565,10 @@ provide(CanvasKey, {
 		<CanvasArrowHeadMarker :id="arrowHeadMarkerId" />
 
 		<Background data-test-id="canvas-background" pattern-color="#aaa" :gap="GRID_SIZE">
-			<template #pattern-container>
+			<template v-if="readOnly" #pattern-container>
 				<CanvasBackgroundStripedPattern :x="viewport.x" :y="viewport.y" :zoom="viewport.zoom" />
+				<rect x="0" y="0" width="100%" height="100%" fill="url(#diagonalHatch)" />
 			</template>
-			<rect v-if="readOnly" x="0" y="0" width="100%" height="100%" fill="url(#diagonalHatch)" />
 		</Background>
 
 		<Transition name="minimap">

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -567,7 +567,6 @@ provide(CanvasKey, {
 		<Background data-test-id="canvas-background" pattern-color="#aaa" :gap="GRID_SIZE">
 			<template v-if="readOnly" #pattern-container>
 				<CanvasBackgroundStripedPattern :x="viewport.x" :y="viewport.y" :zoom="viewport.zoom" />
-				<rect x="0" y="0" width="100%" height="100%" fill="url(#diagonalHatch)" />
 			</template>
 		</Background>
 

--- a/packages/editor-ui/src/components/canvas/elements/CanvasBackgroundStripedPattern.vue
+++ b/packages/editor-ui/src/components/canvas/elements/CanvasBackgroundStripedPattern.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+/* eslint-disable vue/no-multiple-template-root */
 /**
  * @see https://github.com/bcakmakoglu/vue-flow/blob/master/packages/background/src/Background.vue
  */
@@ -25,6 +26,7 @@ const patternOffset = computed(() => scaledGap.value / 2);
 	>
 		<path :d="`M0 ${scaledGap / 2} H${scaledGap}`" :stroke-width="scaledGap / 2" />
 	</pattern>
+	<rect x="0" y="0" width="100%" height="100%" fill="url(#diagonalHatch)" />
 </template>
 
 <style scoped>

--- a/packages/editor-ui/src/components/canvas/elements/CanvasBackgroundStripedPattern.vue
+++ b/packages/editor-ui/src/components/canvas/elements/CanvasBackgroundStripedPattern.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+/**
+ * @see https://github.com/bcakmakoglu/vue-flow/blob/master/packages/background/src/Background.vue
+ */
+import { computed } from 'vue';
+const props = defineProps<{
+	x: number;
+	y: number;
+	zoom: number;
+}>();
+
+const scaledGap = computed(() => 20 * props.zoom || 1);
+const patternOffset = computed(() => scaledGap.value / 2);
+</script>
+
+<template>
+	<pattern
+		id="diagonalHatch"
+		patternUnits="userSpaceOnUse"
+		:x="x % scaledGap"
+		:y="y % scaledGap"
+		:width="scaledGap"
+		:height="scaledGap"
+		:patternTransform="`rotate(135) translate(-${patternOffset},-${patternOffset})`"
+	>
+		<path :d="`M0 ${scaledGap / 2} H${scaledGap}`" :stroke-width="scaledGap / 2" />
+	</pattern>
+</template>
+
+<style scoped>
+path {
+	stroke: var(--color-canvas-read-only-line);
+}
+</style>


### PR DESCRIPTION
## Summary

Add striped background to canvas readonly mode
![image](https://github.com/user-attachments/assets/50dd5cf2-066c-460a-83e4-d7102a74e6bd)
![image](https://github.com/user-attachments/assets/cac33c28-68c0-4dd1-b572-c101ad463760)


## Related Linear tickets, Github issues, and Community forum posts

[N8N-7782](https://linear.app/n8n/issue/N8N-7782/canvas-background-on-executions-tab-is-same-as-in-the-editor-tab-not)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
