### PR TITLE
refactor(core): Report potentially unused job processor branch

### DIFF
--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -1,7 +1,12 @@
 import type { RunningJobSummary } from '@n8n/api-types';
 import { InstanceSettings, WorkflowExecute } from 'n8n-core';
-import { BINARY_ENCODING, ApplicationError, Workflow } from 'n8n-workflow';
 import type { ExecutionStatus, IExecuteResponsePromiseData, IRun } from 'n8n-workflow';
+import {
+	BINARY_ENCODING,
+	ApplicationError,
+	Workflow,
+	ErrorReporterProxy as ErrorReporter,
+} from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 import { Service } from 'typedi';
 
@@ -143,6 +148,7 @@ export class JobProcessor {
 			workflowExecute = new WorkflowExecute(additionalData, execution.mode, execution.data);
 			workflowRun = workflowExecute.processRunExecutionData(workflow);
 		} else {
+			ErrorReporter.info(`Worker found execution ${executionId} without data`);
 			// Execute all nodes
 			// Can execute without webhook so go on
 			workflowExecute = new WorkflowExecute(additionalData, execution.mode);


### PR DESCRIPTION
As explained [here](https://linear.app/n8n/issue/PAY-2100/cannot-read-properties-of-undefined-reading-node#comment-6882ab4d), I have a theory that the second branch in the core of the job processor is not being executed, either currently or back in 2021. Since this logic is ancient and has no tests or documentation or anyone who can help confirm, I'd like to validate this theory and better understand this logic by reporting uses of this branch to Sentry.