### PR TITLE
fix(editor): Fix floating nodes sorting (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NDVFloatingNodes.vue
+++ b/packages/editor-ui/src/components/NDVFloatingNodes.vue
@@ -73,7 +73,7 @@ const connectedNodes = computed<
 		),
 		[FloatingNodePosition.right]: getINodesFromNames(
 			workflow.getChildNodes(rootName, NodeConnectionType.Main, 1),
-		),
+		).reverse(),
 		[FloatingNodePosition.left]: getINodesFromNames(
 			workflow.getParentNodes(rootName, NodeConnectionType.Main, 1),
 		),


### PR DESCRIPTION
## Summary

Test case
![image](https://github.com/user-attachments/assets/6f05993b-c06c-40ad-93c8-d70a9afcd2da)
| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/2f771fd0-d619-4a46-9531-4848a0c63783)  | ![image](https://github.com/user-attachments/assets/3ef8e797-76f2-4808-8f7b-bf57623ca5bc)  |






[CAT-83](https://linear.app/n8n/issue/CAT-83/output-connector-previews-do-not-reflect-node-positions-on-canvas)



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
