### PR TITLE
fix(core): Do not debounce webhooks, triggers and pollers activation

### DIFF
--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -20,4 +20,7 @@ export const SELF_SEND_COMMANDS = new Set([
  * Commands that should not be debounced when received, e.g. during webhook handling in
  * multi-main setup.
  */
-export const IMMEDIATE_COMMANDS = new Set(['relay-execution-lifecycle-event']);
+export const IMMEDIATE_COMMANDS = new Set([
+	'add-webhooks-triggers-and-pollers',
+	'relay-execution-lifecycle-event',
+]);


### PR DESCRIPTION
In multi-main setup, activating a webhook-based workflow on any main sends a message `add-webhooks-triggers-and-pollers` into the pubsub command channel, so that in response the leader main can activate the webhook. 

When normalizing debounce values, https://github.com/n8n-io/n8n/pull/11156 expanded the debounce window on this message by an extra 200ms. This delay has seemingly no effect on normal use, but we believe it is causing our benchmarking setup to fail, so remove the debouncing for this specific message. If this is correct, I'll later add tests to ensure the debounce value for this message does not change.

Context: https://n8nio.slack.com/archives/C03MZF137FV/p1729245210142909?thread_ts=1729231259.216589&cid=C03MZF137FV