### PR TITLE
fix(benchmark): Fix single webhook script path in manifest

### DIFF
--- a/packages/@n8n/benchmark/scenarios/single-webhook/single-webhook.manifest.json
+++ b/packages/@n8n/benchmark/scenarios/single-webhook/single-webhook.manifest.json
@@ -3,5 +3,5 @@
 	"name": "SingleWebhook",
 	"description": "A single webhook trigger that responds with a 200 status code",
 	"scenarioData": { "workflowFiles": ["single-webhook.json"] },
-	"scriptPath": "single-webhook.script.ts"
+	"scriptPath": "single-webhook.script.js"
 }


### PR DESCRIPTION

## Summary

The file was changed to .js in #11290

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
