### PR TITLE
fix(editor): Fix Adding nodes one after the other also adds connections (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -56,6 +56,7 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 		<div :class="$style.canvas">
 			<Canvas
 				v-if="workflow"
+				:id="id"
 				:nodes="mappedNodes"
 				:connections="mappedConnections"
 				:event-bus="eventBus"

--- a/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
+++ b/packages/editor-ui/src/composables/__tests__/useCanvasOperations.spec.ts
@@ -613,6 +613,28 @@ describe('useCanvasOperations', () => {
 			expect(setNodePositionByIdSpy).toHaveBeenCalledWith(nodes[1].id, expect.any(Object));
 			expect(setNodePositionByIdSpy).toHaveBeenCalledWith(nodes[2].id, expect.any(Object));
 		});
+
+		it('should return newly added nodes', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const nodeTypesStore = useNodeTypesStore();
+			const nodeTypeName = 'type';
+			const nodes = [
+				mockNode({ name: 'Node 1', type: nodeTypeName, position: [30, 40] }),
+				mockNode({ name: 'Node 2', type: nodeTypeName, position: [100, 240] }),
+			];
+
+			workflowsStore.getCurrentWorkflow.mockReturnValue(
+				createTestWorkflowObject(workflowsStore.workflow),
+			);
+
+			nodeTypesStore.nodeTypes = {
+				[nodeTypeName]: { 1: mockNodeTypeDescription({ name: nodeTypeName }) },
+			};
+
+			const { addNodes } = useCanvasOperations({ router });
+			const added = await addNodes(nodes, {});
+			expect(added.length).toBe(2);
+		});
 	});
 
 	describe('revertAddNode', () => {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -494,6 +494,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 	) {
 		let insertPosition = options.position;
 		let lastAddedNode: INodeUi | undefined;
+		const addedNodes: INodeUi[] = [];
 
 		const nodesWithTypeVersion = nodes.map((node) => {
 			const typeVersion =
@@ -516,7 +517,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 
 			try {
-				lastAddedNode = addNode(
+				const newNode = addNode(
 					{
 						...node,
 						position,
@@ -528,6 +529,8 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 						isAutoAdd,
 					},
 				);
+				lastAddedNode = newNode;
+				addedNodes.push(newNode);
 			} catch (error) {
 				toast.showError(error, i18n.baseText('error'));
 				console.error(error);
@@ -552,6 +555,8 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		if (!options.keepPristine) {
 			uiStore.stateIsDirty = true;
 		}
+
+		return addedNodes;
 	}
 
 	function updatePositionForNodeWithMultipleInputs(node: INodeUi) {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -610,6 +610,10 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			historyStore.pushCommandToUndo(new AddNodeCommand(nodeData));
 		}
 
+		if (!options.isAutoAdd) {
+			createConnectionToLastInteractedWithNode(nodeData, options);
+		}
+
 		void nextTick(() => {
 			workflowsStore.setNodePristine(nodeData.name, true);
 
@@ -617,10 +621,6 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			nodeHelpers.updateNodeParameterIssues(nodeData);
 			nodeHelpers.updateNodeCredentialIssues(nodeData);
 			nodeHelpers.updateNodeInputIssues(nodeData);
-
-			if (!options.isAutoAdd) {
-				createConnectionToLastInteractedWithNode(nodeData, options);
-			}
 
 			if (options.telemetry) {
 				trackAddNode(nodeData, options);

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -858,10 +858,6 @@ async function onAddNodesAndConnections(
 		return;
 	}
 
-	const { onNodesInitialized, addSelectedNodes, findNode } = useVueFlow({
-		id: editableWorkflow.value.id,
-	});
-
 	const addedNodes = await addNodes(nodes, {
 		dragAndDrop,
 		position,
@@ -891,18 +887,10 @@ async function onAddNodesAndConnections(
 		};
 	});
 
-	const { off } = onNodesInitialized(() => {
-		addConnections(mappedConnections);
+	addConnections(mappedConnections);
 
-		const lastAddedNode = addedNodes.at(-1);
-		const uiNode = lastAddedNode?.id ? findNode(lastAddedNode.id) : undefined;
-		if (lastAddedNode && uiNode) {
-			setNodeSelected(lastAddedNode.id);
-			addSelectedNodes([uiNode]);
-		}
-
-		off();
-	});
+	uiStore.resetLastInteractedWith();
+	selectNodes([addedNodes[addedNodes.length - 1].id]);
 }
 
 async function onRevertAddNode({ node }: { node: INodeUi }) {

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -39,7 +39,6 @@ import type {
 	ViewportTransform,
 	XYPosition as VueFlowXYPosition,
 } from '@vue-flow/core';
-import { useVueFlow } from '@vue-flow/core';
 import type {
 	CanvasConnectionCreateData,
 	CanvasEventBusEvents,


### PR DESCRIPTION
## Summary

How to reproduce

1. Select one node
2. Open node selector
3. Add a node
Both nodes should be connected
Last added node should be selected

Repeat step 3, the behaviour should be the same

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/c56a1536-9166-4089-990b-0ad6a571f0ed) | ![image](https://github.com/user-attachments/assets/ec6e3ce2-1e31-4b95-b422-b45e6e48ab90) |


## Related Linear tickets, Github issues, and Community forum posts

[N8N-7814](https://linear.app/n8n/issue/N8N-7814/adding-nodes-multiple-times-while-keeping-a-node-selected-only-adds)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
