### PR TITLE
fix(editor): Select last added node after adding on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -610,6 +610,10 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			historyStore.pushCommandToUndo(new AddNodeCommand(nodeData));
 		}
 
+		if (!options.isAutoAdd) {
+			createConnectionToLastInteractedWithNode(nodeData, options);
+		}
+
 		void nextTick(() => {
 			workflowsStore.setNodePristine(nodeData.name, true);
 
@@ -617,10 +621,6 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			nodeHelpers.updateNodeParameterIssues(nodeData);
 			nodeHelpers.updateNodeCredentialIssues(nodeData);
 			nodeHelpers.updateNodeInputIssues(nodeData);
-
-			if (!options.isAutoAdd) {
-				createConnectionToLastInteractedWithNode(nodeData, options);
-			}
 
 			if (options.telemetry) {
 				trackAddNode(nodeData, options);

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -858,10 +858,6 @@ async function onAddNodesAndConnections(
 		return;
 	}
 
-	const { onNodesInitialized, addSelectedNodes, findNode } = useVueFlow({
-		id: editableWorkflow.value.id,
-	});
-
 	const addedNodes = await addNodes(nodes, {
 		dragAndDrop,
 		position,
@@ -891,17 +887,11 @@ async function onAddNodesAndConnections(
 		};
 	});
 
-	const { off } = onNodesInitialized(() => {
-		addConnections(mappedConnections);
+	addConnections(mappedConnections);
 
-		const lastAddedNode = addedNodes.at(-1);
-		const uiNode = lastAddedNode?.id ? findNode(lastAddedNode.id) : undefined;
-		if (lastAddedNode && uiNode) {
-			setNodeSelected(lastAddedNode.id);
-			addSelectedNodes([uiNode]);
-		}
-
-		off();
+	void nextTick(() => {
+		uiStore.resetLastInteractedWith();
+		selectNodes([addedNodes[addedNodes.length - 1].id]);
 	});
 }
 

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -889,10 +889,8 @@ async function onAddNodesAndConnections(
 
 	addConnections(mappedConnections);
 
-	void nextTick(() => {
-		uiStore.resetLastInteractedWith();
-		selectNodes([addedNodes[addedNodes.length - 1].id]);
-	});
+	uiStore.resetLastInteractedWith();
+	selectNodes([addedNodes[addedNodes.length - 1].id]);
 }
 
 async function onRevertAddNode({ node }: { node: INodeUi }) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7814/adding-nodes-multiple-times-while-keeping-a-node-selected-only-adds

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
