### PR TITLE
fix(core): Enforce nodejs version consistently

### DIFF
--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -18,15 +18,15 @@ if (process.argv.length === 2) {
 	process.argv.push('start');
 }
 
-const ENFORCE_MIN_NODE_VERSION = process.env.E2E_TESTS !== 'true';
-if (ENFORCE_MIN_NODE_VERSION) {
+const ENFORCE_NODE_VERSION_RANGE = process.env.E2E_TESTS !== 'true';
+if (ENFORCE_NODE_VERSION_RANGE) {
 	const satisfies = require('semver/functions/satisfies');
 	const nodeVersion = process.versions.node;
 	const {
 		engines: { node: supportedNodeVersions },
 	} = require('../package.json');
 	if (!satisfies(nodeVersion, supportedNodeVersions)) {
-		console.log(`
+		console.error(`
 Your Node.js version ${nodeVersion} is currently not supported by n8n.
 Please use a Node.js version that satisfies the following version range: ${supportedNodeVersions}
 `);

--- a/packages/cli/bin/n8n
+++ b/packages/cli/bin/n8n
@@ -18,21 +18,20 @@ if (process.argv.length === 2) {
 	process.argv.push('start');
 }
 
-const nodeVersion = process.versions.node;
-const { major, gte } = require('semver');
-
-const MINIMUM_SUPPORTED_NODE_VERSION = '18.17.0';
 const ENFORCE_MIN_NODE_VERSION = process.env.E2E_TESTS !== 'true';
-
-if (
-	(ENFORCE_MIN_NODE_VERSION && !gte(nodeVersion, MINIMUM_SUPPORTED_NODE_VERSION)) ||
-	![18, 20, 22].includes(major(nodeVersion))
-) {
-	console.log(`
-	Your Node.js version ${nodeVersion} is currently not supported by n8n.
-	Please use Node.js v${MINIMUM_SUPPORTED_NODE_VERSION} (recommended), v20, or v22 instead!
-	`);
-	process.exit(1);
+if (ENFORCE_MIN_NODE_VERSION) {
+	const satisfies = require('semver/functions/satisfies');
+	const nodeVersion = process.versions.node;
+	const {
+		engines: { node: supportedNodeVersions },
+	} = require('../package.json');
+	if (!satisfies(nodeVersion, supportedNodeVersions)) {
+		console.log(`
+Your Node.js version ${nodeVersion} is currently not supported by n8n.
+Please use a Node.js version that satisfies the following version range: ${supportedNodeVersions}
+`);
+		process.exit(1);
+	}
 }
 
 // Disable nodejs custom inspection across the app

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "workflow"
   ],
   "engines": {
-    "node": ">=18.10"
+    "node": ">=18.17 <= 22"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary
Instead of maintaining 2 separate sources of truth about what versions of nodejs n8n supports, this PR updates `bin/n8n` to re-use the `engines` compatibility check from `package.json`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #11313
CAT-258

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
