### PR TITLE
fix(editor): Add explicit max-width to handle label when connected on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
+++ b/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
@@ -76,9 +76,7 @@ function onClickAdd() {
 </script>
 <template>
 	<div :class="classes">
-		<div v-if="label" :class="outputLabelClasses">
-			{{ label }}
-		</div>
+		<div v-if="label" :class="outputLabelClasses">{{ label }}</div>
 		<div v-else-if="runData" :class="runDataLabelClasses">{{ runDataLabel }}</div>
 		<CanvasHandleDot :handle-classes="handleClasses" />
 		<Transition name="canvas-node-handle-main-output">

--- a/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
+++ b/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
@@ -20,6 +20,7 @@ const handleClasses = 'source';
 const classes = computed(() => ({
 	'canvas-node-handle-main-output': true,
 	[$style.handle]: true,
+	[$style.connected]: isConnected.value,
 	[$style.required]: isRequired.value,
 }));
 
@@ -51,6 +52,16 @@ const plusLineSize = computed(
 		})[(runDataTotal.value > 0 ? 'large' : renderOptions.value.outputs?.labelSize) ?? 'small'],
 );
 
+const outputLabelClasses = computed(() => ({
+	[$style.label]: true,
+	[$style.outputLabel]: true,
+}));
+
+const runDataLabelClasses = computed(() => ({
+	[$style.label]: true,
+	[$style.runDataLabel]: true,
+}));
+
 function onMouseEnter() {
 	isHovered.value = true;
 }
@@ -65,8 +76,10 @@ function onClickAdd() {
 </script>
 <template>
 	<div :class="classes">
-		<div v-if="label" :class="[$style.label, $style.outputLabel]">{{ label }}</div>
-		<div v-else-if="runData" :class="[$style.label, $style.runDataLabel]">{{ runDataLabel }}</div>
+		<div v-if="label" :class="outputLabelClasses">
+			{{ label }}
+		</div>
+		<div v-else-if="runData" :class="runDataLabelClasses">{{ runDataLabel }}</div>
 		<CanvasHandleDot :handle-classes="handleClasses" />
 		<Transition name="canvas-node-handle-main-output">
 			<CanvasHandlePlus
@@ -90,6 +103,10 @@ function onClickAdd() {
 	flex-direction: row;
 	align-items: center;
 	justify-content: center;
+
+	&.connected .label {
+		max-width: 96px;
+	}
 }
 
 .label {


### PR DESCRIPTION
## Summary

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/7a8ac780-6dfa-4bfb-9b3f-a19bcb4cdafb">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7825/main-output-label-not-showing-when-connected

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
