### PR TITLE
Revert "perf(Google Sheets Node): Don't load whole spreadsheet dataset to determine columns when appending data"

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/append.operation.ts
@@ -226,9 +226,7 @@ export async function execute(
 		keyRowIndex = locationDefine.headerRow as number;
 	}
 
-	const [sheetNameForKeyRow] = range.split('!');
-	const sheetNameWithRangeForKeyRow = `${sheetNameForKeyRow}!1:${keyRowIndex}`;
-	const sheetData = await sheet.getData(sheetNameWithRangeForKeyRow, 'FORMATTED_VALUE');
+	const sheetData = await sheet.getData(range, 'FORMATTED_VALUE');
 
 	if (!sheetData?.length) {
 		dataMode = 'autoMapInputData';


### PR DESCRIPTION
Reverts n8n-io/n8n#11235
the change caused an issue in the append as we lost track of the last row in the sheet 

Related Linear Tickets 
https://linear.app/n8n/issue/NODE-1892/google-sheet-append-no-longer-works-correctly