### PR TITLE
fix(Microsoft SQL Node): Fix execute query to allow for non select query to run

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Sql/GenericFunctions.ts
@@ -1,8 +1,11 @@
+import type { IResult } from 'mssql';
+import mssql from 'mssql';
 import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
-import mssql from 'mssql';
-import type { ITables, OperationInputData } from './interfaces';
+
 import { chunk, flatten } from '@utils/utilities';
+
+import type { ITables, OperationInputData } from './interfaces';
 
 /**
  * Returns a copy of the item which only contains the json data and
@@ -233,4 +236,37 @@ export async function deleteOperation(tables: ITables, pool: mssql.ConnectionPoo
 			(acc += resp.rowsAffected.reduce((sum, val) => (sum += val))),
 		0,
 	);
+}
+
+export async function executeSqlQueryAndPrepareResults(
+	pool: mssql.ConnectionPool,
+	rawQuery: string,
+	itemIndex: number,
+): Promise<INodeExecutionData[]> {
+	const rawResult: IResult<any> = await pool.request().query(rawQuery);
+	const { recordsets, rowsAffected } = rawResult;
+	if (Array.isArray(recordsets) && recordsets.length > 0) {
+		const result: IDataObject[] = recordsets.length > 1 ? flatten(recordsets) : recordsets[0];
+
+		return result.map((entry) => ({
+			json: entry,
+			pairedItem: [{ item: itemIndex }],
+		}));
+	} else if (rowsAffected && rowsAffected.length > 0) {
+		// Handle non-SELECT queries (e.g., INSERT, UPDATE, DELETE)
+		return rowsAffected.map((affectedRows, idx) => ({
+			json: {
+				message: `Query ${idx + 1} executed successfully`,
+				rowsAffected: affectedRows,
+			},
+			pairedItem: [{ item: itemIndex }],
+		}));
+	} else {
+		return [
+			{
+				json: { message: 'Query executed successfully, but no rows were affected' },
+				pairedItem: [{ item: itemIndex }],
+			},
+		];
+	}
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue in MS SQL Node execute query operation as it only worked for select queries before.
mssql returns the result as an object of type 
```
export interface IResult<T> {
    recordsets: T extends any[] ? { [P in keyof T]: IRecordSet<T[P]> } : Array<IRecordSet<T>>;
    recordset: IRecordSet<T extends any[] ? T[0] : T>;
    rowsAffected: number[];
    output: { [key: string]: any };
}
```
by extracting recordsets and rowsAffected the execute query operation now supports all queries not just select queries. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1794/community-issue-mssql-result-is-not-iterable-internal-error
https://github.com/n8n-io/n8n/issues/11033

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
