### PR TITLE
Paypal updates - Transaction Search

### DIFF
--- a/packages/nodes-base/nodes/PayPal/PayPal.node.ts
+++ b/packages/nodes-base/nodes/PayPal/PayPal.node.ts
@@ -16,6 +16,7 @@ import {
 	payoutItemOperations,
 	payoutOperations,
 } from './PaymentDescription';
+import { transactionOperations, transactionFields } from './TransactionDescription';
 import type {
 	IAmount,
 	IItem,
@@ -62,6 +63,10 @@ export class PayPal implements INodeType {
 						name: 'Payout Item',
 						value: 'payoutItem',
 					},
+					{
+						name: 'Transaction Search',
+						value: 'transactionSearch',
+					},
 				],
 				default: 'payout',
 			},
@@ -71,6 +76,9 @@ export class PayPal implements INodeType {
 			...payoutItemOperations,
 			...payoutFields,
 			...payoutItemFields,
+			// Transaction Search
+			...transactionOperations,
+			...transactionFields,
 		],
 	};
 
@@ -212,7 +220,9 @@ export class PayPal implements INodeType {
 							responseData = responseData.items;
 						}
 					}
-				} else if (resource === 'payoutItem') {
+				}
+
+				if (resource === 'payoutItem') {
 					if (operation === 'get') {
 						const payoutItemId = this.getNodeParameter('payoutItemId', i) as string;
 						responseData = await payPalApiRequest.call(
@@ -232,6 +242,101 @@ export class PayPal implements INodeType {
 							{},
 							qs,
 						);
+					}
+				}
+				if (resource === 'transactionSearch') {
+					if (operation === 'listtransactions') {
+						const transaction_id = this.getNodeParameter('transaction_id', i) as string;
+						const transaction_type = this.getNodeParameter('transaction_type', i) as string;
+						const transaction_status = this.getNodeParameter('transaction_status', i) as string;
+						const transaction_amount = this.getNodeParameter('transaction_amount', i) as string;
+						const transaction_currency = this.getNodeParameter('transaction_currency', i) as string;
+						const start_date = this.getNodeParameter('start_date', i) as string;
+						const end_date = this.getNodeParameter('end_date', i) as string;
+						const payment_instrument_type = this.getNodeParameter(
+							'payment_instrument_type',
+							i,
+						) as string;
+						const store_id = this.getNodeParameter('store_id', i) as string;
+						const terminal_id = this.getNodeParameter('terminal_id', i) as string;
+						const fields = this.getNodeParameter('fields', i) as string;
+						const balance_affecting_records_only = this.getNodeParameter(
+							'balance_affecting_records_only',
+							i,
+						) as string;
+
+						/*				        const qs = {
+				          transaction_id,
+				          transaction_type,
+				          transaction_status,
+				          transaction_amount,
+				          transaction_currency,
+				          start_date: new Date(start_date).toISOString(),
+				          end_date: new Date(end_date).toISOString(),
+				          payment_instrument_type,
+				          store_id,
+				          terminal_id,
+				          fields,
+				          balance_affecting_records_only,
+				        };*/
+
+						qs.start_date = new Date(start_date).toISOString();
+						qs.end_date = new Date(end_date).toISOString();
+
+						if (transaction_id) {
+							qs.transaction_id = transaction_id;
+						}
+						if (transaction_type) {
+							qs.transaction_type = transaction_type;
+						}
+						if (transaction_status) {
+							qs.transaction_status = transaction_status;
+						}
+						if (transaction_amount) {
+							qs.transaction_amount = transaction_amount;
+						}
+						if (transaction_currency) {
+							qs.transaction_currency = transaction_currency;
+						}
+						if (payment_instrument_type) {
+							qs.payment_instrument_type = payment_instrument_type;
+						}
+						if (store_id) {
+							qs.store_id = store_id;
+						}
+						if (terminal_id) {
+							qs.terminal_id = terminal_id;
+						}
+						if (fields) {
+							qs.fields = fields;
+						}
+						if (balance_affecting_records_only) {
+							qs.balance_affecting_records_only = balance_affecting_records_only;
+						}
+
+						responseData = await payPalApiRequest.call(
+							this,
+							'/reporting/transactions',
+							'GET',
+							{},
+							qs,
+						);
+					}
+					if (operation === 'listAllBalances') {
+						const as_of_time = this.getNodeParameter('as_of_time', 0) as string;
+						const currency_code = this.getNodeParameter('currency_code', 0) as string;
+
+						// Ensure dates are in the correct ISO 8601 format with timezone
+						const formattedas_of_time = new Date(as_of_time).toISOString();
+
+						// Construct request parameters
+						const qs = {
+							as_of_time: formattedas_of_time,
+							currency_code: currency_code,
+						};
+
+						// Make the API request
+						responseData = await payPalApiRequest.call(this, '/reporting/balances', 'GET', {}, qs);
 					}
 				}
 

--- a/packages/nodes-base/nodes/PayPal/TransactionDescription.ts
+++ b/packages/nodes-base/nodes/PayPal/TransactionDescription.ts
@@ -1,0 +1,251 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const transactionOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+			},
+		},
+		options: [
+			{
+				name: 'List transactions',
+				value: 'listtransactions',
+				description:
+					'Specify one or more query parameters to filter the transaction that appear in the response.',
+				action: 'Get a list of transactions.',
+			},
+			{
+				name: 'List all balances',
+				value: 'listAllBalances',
+				description:
+					'Specify date time to list balances for that time that appear in the response.',
+				action: 'Get a list of all balances',
+			},
+		],
+		default: 'listtransactions',
+	},
+];
+
+export const transactionFields: INodeProperties[] = [
+	/* -------------------------------------------------------------------------- */
+	/*              Transaction Search: List Transactions                         */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Transaction ID',
+		name: 'transaction_id',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a PayPal transaction ID. A valid transaction ID is 17 characters long, except for an order ID, which is 19 characters long.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Transaction Type',
+		name: 'transaction_type',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a PayPal transaction event code. See Transaction event codes.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Transaction Status',
+		name: 'transaction_status',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a PayPal transaction status code. Value is: D,P,S,V',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Transaction Amount',
+		name: 'transaction_amount',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a gross transaction amount range. Specify the range as <start-range> TO <end-range>, where <start-range> is the lower limit of the gross PayPal transaction amount and <end-range> is the upper limit of the gross transaction amount. Specify the amounts in lower denominations. For example, to search for transactions from $5.00 to $10.05, specify [500 TO 1005].',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Transaction Currency',
+		name: 'transaction_currency',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a three-character ISO-4217 currency code for the PayPal transaction currency.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Start Date',
+		name: 'start_date',
+		type: 'dateTime',
+		default: '',
+		required: true,
+		description:
+			'Filters the transactions in the response by a start date and time, in Internet date and time format. Seconds are required. Fractional seconds are optional.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'End Date (Max Range: 31 days)',
+		name: 'end_date',
+		type: 'dateTime',
+		default: '',
+		required: true,
+		description:
+			'Filters the transactions in the response by an end date and time, in Internet date and time format. Seconds are required. Fractional seconds are optional. The maximum supported range is 31 days.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Payment Instrument Type',
+		name: 'payment_instrument_type',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Filters the transactions in the response by a payment instrument type. Value is either: CREDITCARD or DEBITCARD. If you omit this parameter, the API does not apply this filter.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Store ID',
+		name: 'store_id',
+		type: 'string',
+		default: '',
+		required: false,
+		description: 'Filters the transactions in the response by a store ID.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Terminal ID',
+		name: 'terminal_id',
+		type: 'string',
+		default: '',
+		required: false,
+		description: 'Filters the transactions in the response by a terminal ID.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Fields',
+		name: 'fields',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Indicates which fields appear in the response. Value is a single field or a comma-separated list of fields. The transaction_info value returns only the transaction details in the response. To include all fields in the response, specify fields=all.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+	{
+		displayName: 'Balance Affecting Records Only',
+		name: 'balance_affecting_records_only',
+		type: 'string',
+		default: '',
+		required: false,
+		description:
+			'Indicates whether the response includes only balance-impacting transactions or all transactions. Value is either: Y,N',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listtransactions'],
+			},
+		},
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*            Transaction Search: List All Balances                           */
+	/* -------------------------------------------------------------------------- */
+
+	{
+		displayName: 'As of Time',
+		name: 'as_of_time',
+		type: 'dateTime',
+		default: '',
+		required: true,
+		description:
+			'Lists balances in the response at the date time provided. Will return the last refreshed balance in the system when not provided.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listAllBalances'],
+			},
+		},
+	},
+	{
+		displayName: 'Currency Code',
+		name: 'currency_code',
+		type: 'string',
+		default: 'ALL',
+		required: true,
+		description:
+			'Filters the transactions in the response by a three-character ISO-4217 currency code for the PayPal transaction currency.',
+		displayOptions: {
+			show: {
+				resource: ['transactionSearch'],
+				operation: ['listAllBalances'],
+			},
+		},
+	},
+];


### PR DESCRIPTION
Transaction Search - List Transactions and List All Balances

## Summary

I add "Transaction Search" on the PayPal node
- List Transactions 
- - transaction_id
- - transaction_type
- - transaction_status
- - transaction_amount
- - transaction_currency
- - start_date
- - end_date
- - payment_instrument_type
- - store_id
- - terminal_id
- - fields
- - balance_affecting_records_only
- List All Balances
- - as_of_time
- - currency_code

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/paypal-integration-got-created/30

https://community.n8n.io/t/need-a-node-for-paypal-transaction/14594 

https://community.n8n.io/t/extend-paypal-node-functions/12073