### PR TITLE
fix(editor): Reset selection keycode to force selection mode after tab change on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -145,11 +145,11 @@ const disableKeyBindings = computed(() => !props.keyBindings);
 
 const isPanningEnabled = ref(false);
 const panningKeyCode = ' ';
-const selectionKeyCode = ref(true);
+const selectionKeyCode = ref<true | null>(true);
 
 onKeyDown(panningKeyCode, () => {
 	isPanningEnabled.value = true;
-	selectionKeyCode.value = false;
+	selectionKeyCode.value = null;
 });
 
 onKeyUp(panningKeyCode, () => {
@@ -193,7 +193,7 @@ useKeybindings(keyMap, { disabled: disableKeyBindings });
  * @issue https://linear.app/n8n/issue/N8N-7843/selection-keycode-gets-unset-when-changing-tabs
  */
 function resetSelectionKeyCode() {
-	selectionKeyCode.value = false;
+	selectionKeyCode.value = null;
 	void nextTick(() => {
 		selectionKeyCode.value = true;
 	});


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/62a46e6b-8cee-4c5e-a600-8edc950bcf3d



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7843/selection-keycode-gets-unset-when-changing-tabs

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
