### PR TITLE
fix(editor): `utm_awc` with wrong value when redirecting to website templates (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainSidebar.vue
+++ b/packages/editor-ui/src/components/MainSidebar.vue
@@ -59,7 +59,7 @@ const userMenuItems = ref([
 	},
 ]);
 
-const mainMenuItems = ref([
+const mainMenuItems = computed(() => [
 	{
 		id: 'cloud-admin',
 		position: 'bottom',


### PR DESCRIPTION
## Summary

Makes the menu a computed property, so when the dependencies change (active workflows) the menu is re-render, with the proper values.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
