### PR TITLE
fix(GraphQL Node): Change default request format to json instead of graphql

### DIFF
--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -510,21 +510,16 @@ export class GraphQL implements INodeType {
 						},
 					});
 				} else {
-					if (
-						typeof response === 'string' &&
-						(JSON.parse(response) as IDataObject).errorMessage &&
-						requestFormat === 'graphql'
-					) {
-						throw new NodeOperationError(
-							this.getNode(),
-							'Error in GraphQL request. Please try using the Request format "JSON" instead.',
-						);
-					} else {
-						throw new NodeOperationError(
-							this.getNode(),
-							'Response body is not valid JSON. Change "Response Format" to "String"',
-							{ itemIndex },
-						);
+					if (typeof response === 'string') {
+						try {
+							response = JSON.parse(response);
+						} catch (error) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Response body is not valid JSON. Change "Response Format" to "String"',
+								{ itemIndex },
+							);
+						}
 					}
 
 					const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -19,7 +19,7 @@ export class GraphQL implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:graphql.png',
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Makes a GraphQL request and returns the received data',
 		defaults: {
 			name: 'GraphQL',
@@ -175,6 +175,30 @@ export class GraphQL implements INodeType {
 				required: true,
 				options: [
 					{
+						name: 'GraphQL (Raw)',
+						value: 'graphql',
+					},
+					{
+						name: 'JSON',
+						value: 'json',
+					},
+				],
+				displayOptions: {
+					show: {
+						requestMethod: ['POST'],
+						'@version': [1],
+					},
+				},
+				default: 'graphql',
+				description: 'The format for the query payload',
+			},
+			{
+				displayName: 'Request Format',
+				name: 'requestFormat',
+				type: 'options',
+				required: true,
+				options: [
+					{
 						name: 'JSON (Recommended)',
 						value: 'json',
 						description:
@@ -190,6 +214,7 @@ export class GraphQL implements INodeType {
 				displayOptions: {
 					show: {
 						requestMethod: ['POST'],
+						'@version': [{ _cnd: { gte: 1.1 } }],
 					},
 				},
 				default: 'json',

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -175,12 +175,16 @@ export class GraphQL implements INodeType {
 				required: true,
 				options: [
 					{
-						name: 'GraphQL (Raw)',
-						value: 'graphql',
+						name: 'JSON (Recommended)',
+						value: 'json',
+						description:
+							'JSON object with query, variables, and operationName properties. The standard and most widely supported format for GraphQL requests.',
 					},
 					{
-						name: 'JSON',
-						value: 'json',
+						name: 'GraphQL (Raw)',
+						value: 'graphql',
+						description:
+							'Raw GraphQL query string. Not all servers support this format. Use JSON for better compatibility.',
 					},
 				],
 				displayOptions: {
@@ -188,23 +192,26 @@ export class GraphQL implements INodeType {
 						requestMethod: ['POST'],
 					},
 				},
-				default: 'graphql',
-				description: 'The format for the query payload',
+				default: 'json',
+				description: 'The request format for the query payload',
 			},
 			{
 				displayName: 'Query',
 				name: 'query',
-				type: 'json',
+				type: 'string',
 				default: '',
 				description: 'GraphQL query',
 				required: true,
+				typeOptions: {
+					rows: 6,
+				},
 			},
 			{
 				displayName: 'Variables',
 				name: 'variables',
 				type: 'json',
 				default: '',
-				description: 'Query variables',
+				description: 'Query variables as JSON object',
 				displayOptions: {
 					show: {
 						requestFormat: ['json'],
@@ -350,11 +357,7 @@ export class GraphQL implements INodeType {
 					'POST',
 				) as IHttpRequestMethods;
 				const endpoint = this.getNodeParameter('endpoint', itemIndex, '') as string;
-				const requestFormat = this.getNodeParameter(
-					'requestFormat',
-					itemIndex,
-					'graphql',
-				) as string;
+				const requestFormat = this.getNodeParameter('requestFormat', itemIndex, 'json') as string;
 				const responseFormat = this.getNodeParameter('responseFormat', 0) as string;
 				const { parameter }: { parameter?: Array<{ name: string; value: string }> } =
 					this.getNodeParameter('headerParametersUi', itemIndex, {}) as IDataObject;
@@ -484,7 +487,20 @@ export class GraphQL implements INodeType {
 				} else {
 					if (typeof response === 'string') {
 						try {
-							response = JSON.parse(response);
+							if (typeof response === 'string') {
+								response = JSON.parse(response) as IDataObject;
+							}
+
+							// Check for errors in the response
+							if (response.errors && Array.isArray(response.errors)) {
+								// If the request format is 'graphql', throw an error suggesting to try JSON
+								if (requestFormat === 'graphql') {
+									throw new NodeOperationError(
+										this.getNode(),
+										'Error in GraphQL request. Please try using the Request format "JSON" instead.',
+									);
+								}
+							}
 						} catch (error) {
 							throw new NodeOperationError(
 								this.getNode(),

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -512,10 +512,7 @@ export class GraphQL implements INodeType {
 				} else {
 					if (typeof response === 'string') {
 						try {
-							if (typeof response === 'string') {
-								response = JSON.parse(response) as IDataObject;
-							}
-
+							response = JSON.parse(response) as IDataObject;
 							if (
 								response.errors &&
 								Array.isArray(response.errors) &&

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -478,7 +478,7 @@ export class GraphQL implements INodeType {
 						...requestOptions.body,
 						query: gqlQuery,
 						variables: parsedVariables,
-						operationName: this.getNodeParameter('operationName', itemIndex) as string,
+						operationName: this.getNodeParameter('operationName', itemIndex, '') as string,
 					};
 
 					if (jsonBody.operationName === '') {
@@ -516,15 +516,15 @@ export class GraphQL implements INodeType {
 								response = JSON.parse(response) as IDataObject;
 							}
 
-							// Check for errors in the response
-							if (response.errors && Array.isArray(response.errors)) {
-								// If the request format is 'graphql', throw an error suggesting to try JSON
-								if (requestFormat === 'graphql') {
-									throw new NodeOperationError(
-										this.getNode(),
-										'Error in GraphQL request. Please try using the Request format "JSON" instead.',
-									);
-								}
+							if (
+								response.errors &&
+								Array.isArray(response.errors) &&
+								requestFormat === 'graphql'
+							) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Error in GraphQL request. Please try using the Request format "JSON" instead.',
+								);
 							}
 						} catch (error) {
 							throw new NodeOperationError(

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -510,26 +510,21 @@ export class GraphQL implements INodeType {
 						},
 					});
 				} else {
-					if (typeof response === 'string') {
-						try {
-							response = JSON.parse(response) as IDataObject;
-							if (
-								response.errors &&
-								Array.isArray(response.errors) &&
-								requestFormat === 'graphql'
-							) {
-								throw new NodeOperationError(
-									this.getNode(),
-									'Error in GraphQL request. Please try using the Request format "JSON" instead.',
-								);
-							}
-						} catch (error) {
-							throw new NodeOperationError(
-								this.getNode(),
-								'Response body is not valid JSON. Change "Response Format" to "String"',
-								{ itemIndex },
-							);
-						}
+					if (
+						typeof response === 'string' &&
+						(JSON.parse(response) as IDataObject).errorMessage &&
+						requestFormat === 'graphql'
+					) {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Error in GraphQL request. Please try using the Request format "JSON" instead.',
+						);
+					} else {
+						throw new NodeOperationError(
+							this.getNode(),
+							'Response body is not valid JSON. Change "Response Format" to "String"',
+							{ itemIndex },
+						);
 					}
 
 					const executionData = this.helpers.constructExecutionMetaData(


### PR DESCRIPTION
## Summary

This PR attempts to make the current Graphql node less confusing by 
- setting the default request format content type to json instead of graphql (not many servers support this anymore) 
- throwing an error that prompts the user to change the request format from graphql to json 
- adding descriptions to these options for more clarity

https://linear.app/n8n/issue/NODE-1018/make-using-different-flavours-of-graphql-less-confusing

It also changes the Query field from type `json` to `string`: 
https://linear.app/n8n/issue/NODE-1050/bug-json-field-for-graphql-nodes-for-query-field-is-wrong

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
