### PR TITLE
feat(editor): Improve new canvas discovery process (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -56,6 +56,7 @@ import { useTelemetry } from '@/composables/useTelemetry';
 import type { BaseTextKey } from '@/plugins/i18n';
 import { useNpsSurveyStore } from '@/stores/npsSurvey.store';
 import { useNodeViewVersionSwitcher } from '@/composables/useNodeViewVersionSwitcher';
+import N8nIconButton from 'n8n-design-system/components/N8nIconButton/IconButton.vue';
 
 const props = defineProps<{
 	readOnly?: boolean;
@@ -189,7 +190,7 @@ const workflowMenuItems = computed<ActionDropdownItem[]>(() => {
 
 	actions.push({
 		id: WORKFLOW_MENU_ACTIONS.SWITCH_NODE_VIEW_VERSION,
-		...(nodeViewSwitcherDiscovered.value
+		...(nodeViewSwitcherDiscovered.value || nodeViewVersion.value === '2'
 			? {}
 			: { badge: locale.baseText('menuActions.badge.new') }),
 		label:
@@ -398,8 +399,8 @@ async function handleFileImport(): Promise<void> {
 	}
 }
 
-function onWorkflowMenuOpen() {
-	setNodeViewSwitcherDropdownOpened();
+function onWorkflowMenuOpen(visible: boolean) {
+	setNodeViewSwitcherDropdownOpened(visible);
 }
 
 async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void> {
@@ -735,7 +736,7 @@ function showCreateWorkflowSuccessToast(id?: string) {
 					data-test-id="workflow-import-input"
 					@change="handleFileImport()"
 				/>
-				<N8nTooltip :visible="isNodeViewDiscoveryTooltipVisible">
+				<N8nTooltip dismissible :visible="isNodeViewDiscoveryTooltipVisible">
 					<N8nActionDropdown
 						:items="workflowMenuItems"
 						data-test-id="workflow-menu"
@@ -744,6 +745,11 @@ function showCreateWorkflowSuccessToast(id?: string) {
 					/>
 					<template #content>
 						{{ $locale.baseText('menuActions.nodeViewDiscovery.tooltip') }}
+						<N8nIcon
+							:class="$style.closeNodeViewDiscovery"
+							icon="times-circle"
+							@click="setNodeViewSwitcherDiscovered"
+						/>
 					</template>
 				</N8nTooltip>
 			</div>
@@ -833,5 +839,12 @@ $--header-spacing: 20px;
 
 .disabledShareButton {
 	cursor: not-allowed;
+}
+
+.closeNodeViewDiscovery {
+	position: absolute;
+	right: var(--spacing-xs);
+	top: var(--spacing-xs);
+	cursor: pointer;
 }
 </style>

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -56,7 +56,6 @@ import { useTelemetry } from '@/composables/useTelemetry';
 import type { BaseTextKey } from '@/plugins/i18n';
 import { useNpsSurveyStore } from '@/stores/npsSurvey.store';
 import { useNodeViewVersionSwitcher } from '@/composables/useNodeViewVersionSwitcher';
-import N8nIconButton from 'n8n-design-system/components/N8nIconButton/IconButton.vue';
 
 const props = defineProps<{
 	readOnly?: boolean;

--- a/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
+++ b/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
@@ -1,25 +1,28 @@
-import { computed, ref } from 'vue';
-import { useLocalStorage } from '@vueuse/core';
+import { computed } from 'vue';
+import { useLocalStorage, debouncedRef } from '@vueuse/core';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useWorkflowsStore } from '@/stores/workflows.store';
-import { debouncedRef } from '@vueuse/core';
+import { useNDVStore } from '@/stores/ndv.store';
 
 export function useNodeViewVersionSwitcher() {
+	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
 	const settingsStore = useSettingsStore();
 	const telemetry = useTelemetry();
 
 	const isNewUser = computed(() => workflowsStore.activeWorkflows.length === 0);
+	const isNewUserDebounced = debouncedRef(isNewUser, 3000);
 
 	const nodeViewVersion = useLocalStorage(
 		'NodeView.version',
 		settingsStore.deploymentType === 'n8n-internal' ? '2' : '1',
 	);
 
-	const nodeViewSwitcherDropdownOpened = ref(false);
-	function setNodeViewSwitcherDropdownOpened() {
-		nodeViewSwitcherDropdownOpened.value = true;
+	function setNodeViewSwitcherDropdownOpened(visible: boolean) {
+		if (!visible) {
+			setNodeViewSwitcherDiscovered();
+		}
 	}
 
 	const nodeViewSwitcherDiscovered = useLocalStorage('NodeView.switcher.discovered', false);
@@ -27,19 +30,11 @@ export function useNodeViewVersionSwitcher() {
 		nodeViewSwitcherDiscovered.value = true;
 	}
 
-	const isNodeViewDiscoveryTooltipVisibleRaw = computed(
+	const isNodeViewDiscoveryTooltipVisible = computed(
 		() =>
+			!ndvStore.activeNodeName &&
 			nodeViewVersion.value !== '2' &&
-			!(
-				isNewUser.value ||
-				nodeViewSwitcherDropdownOpened.value ||
-				nodeViewSwitcherDiscovered.value
-			),
-	);
-
-	const isNodeViewDiscoveryTooltipVisible = debouncedRef(
-		isNodeViewDiscoveryTooltipVisibleRaw,
-		3000,
+			!(isNewUserDebounced.value || nodeViewSwitcherDiscovered.value),
 	);
 
 	function switchNodeViewVersion() {


### PR DESCRIPTION
## Summary

<img width="219" alt="image" src="https://github.com/user-attachments/assets/39348293-2169-48f4-a781-16d8f3342aaf">


- Set as discovered after workflow menu is opened
- Hide while NDV is open
- Add close button

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
