### PR TITLE
fix: Resend invite operation on users list

### DIFF
--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -244,7 +244,13 @@ export declare namespace UserRequest {
 	>;
 
 	export type InviteResponse = {
-		user: { id: string; email: string; inviteAcceptUrl?: string; emailSent: boolean };
+		user: {
+			id: string;
+			email: string;
+			inviteAcceptUrl?: string;
+			emailSent: boolean;
+			role: AssignableRole;
+		};
 		error?: string;
 	};
 

--- a/packages/cli/src/services/user.service.ts
+++ b/packages/cli/src/services/user.service.ts
@@ -130,6 +130,7 @@ export class UserService {
 						email,
 						inviteAcceptUrl,
 						emailSent: false,
+						role,
 					},
 					error: '',
 				};

--- a/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
+++ b/packages/cli/test/integration/controllers/invitation/invitation.controller.integration.test.ts
@@ -246,6 +246,7 @@ describe('InvitationController', () => {
 			const { user } = response.body.data[0];
 
 			expect(user.inviteAcceptUrl).toBeDefined();
+			expect(user).toHaveProperty('role', 'global:member');
 
 			const inviteUrl = new URL(user.inviteAcceptUrl);
 

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -1189,6 +1189,7 @@ export interface IInviteResponse {
 		email: string;
 		emailSent: boolean;
 		inviteAcceptUrl: string;
+		role: IRole;
 	};
 	error?: string;
 }

--- a/packages/editor-ui/src/stores/users.store.test.ts
+++ b/packages/editor-ui/src/stores/users.store.test.ts
@@ -70,7 +70,7 @@ describe('users.store', () => {
 
 			inviteUsers.mockResolvedValueOnce([
 				{
-					user: { role: 'global:member', email: 'test@n8n.io', emailSent: true },
+					user: { id: 'random-id', email: 'test@n8n.io', emailSent: true },
 				},
 			]);
 

--- a/packages/editor-ui/src/stores/users.store.test.ts
+++ b/packages/editor-ui/src/stores/users.store.test.ts
@@ -2,15 +2,20 @@ import type { CurrentUserResponse } from '@/Interface';
 import { useUsersStore } from './users.store';
 import { createPinia, setActivePinia } from 'pinia';
 
-const { loginCurrentUser, identify } = vi.hoisted(() => {
+const { loginCurrentUser, identify, inviteUsers } = vi.hoisted(() => {
 	return {
 		loginCurrentUser: vi.fn(),
 		identify: vi.fn(),
+		inviteUsers: vi.fn(),
 	};
 });
 
 vi.mock('@/api/users', () => ({
 	loginCurrentUser,
+}));
+
+vi.mock('@/api/invitation', () => ({
+	inviteUsers,
 }));
 
 vi.mock('@/composables/useTelemetry', () => ({
@@ -56,6 +61,31 @@ describe('users.store', () => {
 			});
 
 			expect(identify).toHaveBeenCalledWith('test-instance-id', mockUser.id);
+		});
+	});
+
+	describe('inviteUsers', () => {
+		it('should add pending user to the store', async () => {
+			const usersStore = useUsersStore();
+
+			inviteUsers.mockResolvedValueOnce([
+				{
+					user: { role: 'global:member', email: 'test@n8n.io', emailSent: true },
+				},
+			]);
+
+			await usersStore.inviteUsers([{ email: 'test@n8n.io', role: 'global:admin' }]);
+
+			expect(usersStore.allUsers[0]).toMatchObject(
+				expect.objectContaining({
+					role: 'global:member',
+					isPending: true,
+					isDefaultUser: false,
+					isPendingUser: true,
+					fullName: undefined,
+					emailSent: true,
+				}),
+			);
 		});
 	});
 });

--- a/packages/editor-ui/src/stores/users.store.test.ts
+++ b/packages/editor-ui/src/stores/users.store.test.ts
@@ -70,14 +70,16 @@ describe('users.store', () => {
 
 			inviteUsers.mockResolvedValueOnce([
 				{
-					user: { id: 'random-id', email: 'test@n8n.io', emailSent: true },
+					user: { id: 'random-id', email: 'test@n8n.io', emailSent: true, role: 'global:member' },
 				},
 			]);
 
-			await usersStore.inviteUsers([{ email: 'test@n8n.io', role: 'global:admin' }]);
+			await usersStore.inviteUsers([{ email: 'test@n8n.io', role: 'global:member' }]);
 
 			expect(usersStore.allUsers[0]).toMatchObject(
 				expect.objectContaining({
+					id: 'random-id',
+					email: 'test@n8n.io',
 					role: 'global:member',
 					isPending: true,
 					isDefaultUser: false,

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -280,7 +280,7 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 		addUsers(
 			invitedUsers.map(({ user }, index) => ({
 				isPending: true,
-				globalRole: { name: params[index].role },
+				role: params[index].role,
 				...user,
 			})),
 		);

--- a/packages/editor-ui/src/stores/users.store.ts
+++ b/packages/editor-ui/src/stores/users.store.ts
@@ -278,9 +278,8 @@ export const useUsersStore = defineStore(STORES.USERS, () => {
 	const inviteUsers = async (params: Array<{ email: string; role: InvitableRoleName }>) => {
 		const invitedUsers = await invitationsApi.inviteUsers(rootStore.restApiContext, params);
 		addUsers(
-			invitedUsers.map(({ user }, index) => ({
+			invitedUsers.map(({ user }) => ({
 				isPending: true,
-				role: params[index].role,
 				...user,
 			})),
 		);


### PR DESCRIPTION
## Summary

Pending users were added into the store with the property `globalRole`, but when we return the users we save them in the store with the property `role` instead.

![image](https://github.com/user-attachments/assets/3206f870-3d2c-47c3-a876-50ca9273d753)


## Before

See video on ticket -> https://linear.app/n8n/issue/HELP-645/resend-invitation-link-does-not-work-anymore

## Now

![CleanShot 2024-10-22 at 16 10 25](https://github.com/user-attachments/assets/1a41705a-e7e5-4f46-85d2-478012fd0f3e)


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/HELP-645/resend-invitation-link-does-not-work-anymore

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
