### PR TITLE
fix(editor): Hide data mapping tooltip in credential edit modal

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionTip.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { useI18n } from '@/composables/useI18n';
-import { useNDVStore } from '@/stores/ndv.store';
-import { computed, onBeforeUnmount, ref, watch } from 'vue';
-import { EditorSelection, EditorState, type SelectionRange } from '@codemirror/state';
-import { type Completion, CompletionContext } from '@codemirror/autocomplete';
-import { datatypeCompletions } from '@/plugins/codemirror/completions/datatype.completions';
-import { watchDebounced } from '@vueuse/core';
 import { FIELDS_SECTION } from '@/plugins/codemirror/completions/constants';
+import { datatypeCompletions } from '@/plugins/codemirror/completions/datatype.completions';
 import { isCompletionSection } from '@/plugins/codemirror/completions/utils';
+import { useNDVStore } from '@/stores/ndv.store';
+import { type Completion, CompletionContext } from '@codemirror/autocomplete';
+import { EditorSelection, EditorState, type SelectionRange } from '@codemirror/state';
+import { watchDebounced } from '@vueuse/core';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 
 type TipId = 'executePrevious' | 'drag' | 'default' | 'dotObject' | 'dotPrimitive';
 
@@ -36,7 +36,11 @@ const canDragToFocusedInput = computed(
 const emptyExpression = computed(() => props.unresolvedExpression.trim().length === 0);
 
 const tip = computed<TipId>(() => {
-	if (!ndvStore.hasInputData && ndvStore.isInputParentOfActiveNode) {
+	if (
+		!ndvStore.hasInputData &&
+		ndvStore.isInputParentOfActiveNode &&
+		ndvStore.focusedMappableInput
+	) {
 		return 'executePrevious';
 	}
 

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -539,7 +539,8 @@ const showDragnDropTip = computed(
 		!isDropDisabled.value &&
 		(!ndvStore.hasInputData || !isInputDataEmpty.value) &&
 		!ndvStore.isMappingOnboarded &&
-		ndvStore.isInputParentOfActiveNode,
+		ndvStore.isInputParentOfActiveNode &&
+		!props.isForCredential,
 );
 
 const shouldCaptureForPosthog = computed(() => {


### PR DESCRIPTION
## Summary

data mapping tooltip would show up in credential modal:

![image](https://github.com/user-attachments/assets/64e79630-1893-4bfb-b988-d37c9a78bf67)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1835/data-mapping-tooltip-appears-in-cred-fields

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
