### PR TITLE
fix(core): Change dedupe value column type from varchar(255) to text

### DIFF
--- a/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
+++ b/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
@@ -1,0 +1,45 @@
+import type { MigrationContext, ReversibleMigration } from '@/databases/types';
+
+const processedDataTableName = 'processed_data';
+
+export class UpdateProcessedDataValueColumnToText1729607673464 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, dropColumns, column }, runQuery }: MigrationContext) {
+		await addColumns(processedDataTableName, [column('value_temp').text.notNull]);
+
+		await runQuery(`
+		UPDATE ${processedDataTableName}
+		SET value_temp = value;
+	`);
+
+		await dropColumns(processedDataTableName, ['value']);
+
+		await addColumns(processedDataTableName, [column('value').text.notNull]);
+
+		await runQuery(`
+		UPDATE ${processedDataTableName}
+		SET value = value_temp;
+	`);
+
+		await dropColumns(processedDataTableName, ['value_temp']);
+	}
+
+	async down({ schemaBuilder: { addColumns, dropColumns, column }, runQuery }: MigrationContext) {
+		await addColumns(processedDataTableName, [column('value_temp').varchar(255).notNull]);
+
+		await runQuery(`
+		UPDATE ${processedDataTableName}
+		SET value_temp = value;
+	`);
+
+		await dropColumns(processedDataTableName, ['value']);
+
+		await addColumns(processedDataTableName, [column('value').varchar(255).notNull]);
+
+		await runQuery(`
+		UPDATE ${processedDataTableName}
+		SET value = value_temp;
+	`);
+
+		await dropColumns(processedDataTableName, ['value_temp']);
+	}
+}

--- a/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
+++ b/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
@@ -9,9 +9,7 @@ export class UpdateProcessedDataValueColumnToText1729607673464 implements Revers
 		await runQuery(`ALTER TABLE ${prefixedTableName} DROP COLUMN value;`);
 
 		if (isMysql) {
-			await runQuery(
-				`ALTER TABLE ${processedDataTableName} CHANGE value_temp value TEXT NOT NULL;`,
-			);
+			await runQuery(`ALTER TABLE ${prefixedTableName} CHANGE value_temp value TEXT NOT NULL;`);
 		} else {
 			await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);
 			await addNotNull(processedDataTableName, 'value');
@@ -26,7 +24,7 @@ export class UpdateProcessedDataValueColumnToText1729607673464 implements Revers
 
 		if (isMysql) {
 			await runQuery(
-				`ALTER TABLE ${processedDataTableName} CHANGE value_temp value VARCHAR(255) NOT NULL;`,
+				`ALTER TABLE ${prefixedTableName} CHANGE value_temp value VARCHAR(255) NOT NULL;`,
 			);
 		} else {
 			await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);

--- a/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
+++ b/packages/cli/src/databases/migrations/common/1729607673464-UpdateProcessedDataValueColumnToText.ts
@@ -2,41 +2,35 @@ import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 const processedDataTableName = 'processed_data';
 export class UpdateProcessedDataValueColumnToText1729607673464 implements ReversibleMigration {
-	async up({
-		schemaBuilder: { addNotNull, addColumns, dropColumns, column },
-		runQuery,
-		tablePrefix,
-	}: MigrationContext) {
+	async up({ schemaBuilder: { addNotNull }, isMysql, runQuery, tablePrefix }: MigrationContext) {
 		const prefixedTableName = `${tablePrefix}${processedDataTableName}`;
+		await runQuery(`ALTER TABLE ${prefixedTableName} ADD COLUMN value_temp TEXT;`);
+		await runQuery(`UPDATE ${prefixedTableName} SET value_temp = value;`);
+		await runQuery(`ALTER TABLE ${prefixedTableName} DROP COLUMN value;`);
 
-		await addColumns(processedDataTableName, [column('value_temp').text]);
-
-		await runQuery(`
-		UPDATE ${prefixedTableName}
-		SET value_temp = value;
-	`);
-
-		await dropColumns(processedDataTableName, ['value']);
-		await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);
-		await addNotNull(processedDataTableName, 'value');
+		if (isMysql) {
+			await runQuery(
+				`ALTER TABLE ${processedDataTableName} CHANGE value_temp value TEXT NOT NULL;`,
+			);
+		} else {
+			await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);
+			await addNotNull(processedDataTableName, 'value');
+		}
 	}
 
-	async down({
-		schemaBuilder: { addNotNull, addColumns, dropColumns, column },
-		runQuery,
-		tablePrefix,
-	}: MigrationContext) {
+	async down({ schemaBuilder: { addNotNull }, isMysql, runQuery, tablePrefix }: MigrationContext) {
 		const prefixedTableName = `${tablePrefix}${processedDataTableName}`;
+		await runQuery(`ALTER TABLE ${prefixedTableName} ADD COLUMN value_temp VARCHAR(255);`);
+		await runQuery(`UPDATE ${prefixedTableName} SET value_temp = value;`);
+		await runQuery(`ALTER TABLE ${prefixedTableName} DROP COLUMN value;`);
 
-		await addColumns(processedDataTableName, [column('value_temp').varchar(255)]);
-
-		await runQuery(`
-		UPDATE ${prefixedTableName}
-		SET value_temp = value;
-	`);
-
-		await dropColumns(processedDataTableName, ['value']);
-		await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);
-		await addNotNull(processedDataTableName, 'value');
+		if (isMysql) {
+			await runQuery(
+				`ALTER TABLE ${processedDataTableName} CHANGE value_temp value VARCHAR(255) NOT NULL;`,
+			);
+		} else {
+			await runQuery(`ALTER TABLE ${prefixedTableName} RENAME COLUMN value_temp TO value`);
+			await addNotNull(processedDataTableName, 'value');
+		}
 	}
 }

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -67,6 +67,7 @@ import { AddApiKeysTable1724951148974 } from '../common/1724951148974-AddApiKeys
 import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-CreateProcessedDataTable';
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
 import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
+import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -136,4 +137,5 @@ export const mysqlMigrations: Migration[] = [
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
+	UpdateProcessedDataValueColumnToText1729607673464,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -67,6 +67,7 @@ import { AddApiKeysTable1724951148974 } from '../common/1724951148974-AddApiKeys
 import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-CreateProcessedDataTable';
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
 import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
+import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -136,4 +137,5 @@ export const postgresMigrations: Migration[] = [
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
+	UpdateProcessedDataValueColumnToText1729607673464,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -64,6 +64,7 @@ import { RefactorExecutionIndices1723796243146 } from '../common/1723796243146-R
 import { CreateAnnotationTables1724753530828 } from '../common/1724753530828-CreateExecutionAnnotationTables';
 import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-CreateProcessedDataTable';
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
+import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -130,6 +131,7 @@ const sqliteMigrations: Migration[] = [
 	SeparateExecutionCreationFromStart1727427440136,
 	CreateProcessedDataTable1726606152711,
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
+	UpdateProcessedDataValueColumnToText1729607673464,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary
This PR changes the type of the value column from varchar(255) to text 
As sqlite has limited support for changing column, the change is done by adding and dropping columns only


## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1899/deduplication-node-throws-value-too-long-for-type-character

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
