### PR TITLE
fix: Include error in the message in JS task runner sandbox (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
+++ b/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
@@ -66,8 +66,6 @@ export class JsTaskRunnerSandbox {
 			throw new WrappedExecutionError(error);
 		}
 
-		throw new ApplicationError('Unknown error', {
-			cause: error,
-		});
+		throw new ApplicationError(`Unknown error: ${JSON.stringify(error)}`);
 	}
 }


### PR DESCRIPTION
## Summary

So users can see what the underlying issue might be

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
