### PR TITLE
fix(core): Fix race condition when resolving post-execute promise

### DIFF
--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -108,6 +108,15 @@ describe('ActiveExecutions', () => {
 		expect(activeExecutions.getActiveExecutions().length).toBe(0);
 	});
 
+	test('Should not try to resolve a post-execute promise for an inactive execution', async () => {
+		// @ts-expect-error Private method
+		const getExecutionSpy = jest.spyOn(activeExecutions, 'getExecution');
+
+		activeExecutions.finalizeExecution('inactive-execution-id', mockFullRunData());
+
+		expect(getExecutionSpy).not.toHaveBeenCalled();
+	});
+
 	test('Should resolve post execute promise on removal', async () => {
 		const newExecution = mockExecutionData();
 		const executionId = await activeExecutions.add(newExecution);

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -154,6 +154,7 @@ export class ActiveExecutions {
 
 	/** Resolve the post-execution promise in an execution. */
 	finalizeExecution(executionId: string, fullRunData?: IRun) {
+		if (!this.has(executionId)) return;
 		const execution = this.getExecution(executionId);
 		execution.postExecutePromise.resolve(fullRunData);
 		this.logger.debug('Execution finalized', { executionId });


### PR DESCRIPTION
On starting an execution, we add it to active executions, which means registering the active execution in memory and creating a deferred post-execute promise, which in its `finally` block will deregister the active execution. We later resolve this promise on execution success or failure, or reject the promise on execution cancellation.

Currently we have [this high-frequency Sentry error](https://n8nio.sentry.io/issues/5908604134/) in [this story](https://linear.app/n8n/issue/PAY-2137) being thrown. This means that sometimes, on execution failure, the execution is already deregistered by the time we try to resolve the deferred promise. The only spot where we deregister an active execution is in the above `finally` block, so this means we are trying to resolve the promise twice.

My theory is that there is a race condition:

1. Execution encounters error.
2. The `catch` block in the execution `PCancelable` triggers `WorkflowRunner.processError` [here](https://github.com/n8n-io/n8n/blob/83ca7f8e90ec95fdd455788a645b6b8ded13d334/packages/cli/src/workflow-runner.ts#L342), which calls `ActiveExecutions.finalizeExecution`, which resolves the post-execute promise, which triggers the `finally` block [here](https://github.com/n8n-io/n8n/blob/3a9c65e1cbafca1d2c75dc85c0644ee34bfdfa3c/packages/cli/src/active-executions.ts#L112) which deregisters the execution.
3. Simultaneously, the rest of `WorkflowRunner.processError` continues running and calls `finalizeExecution` again [here](https://github.com/n8n-io/n8n/blob/83ca7f8e90ec95fdd455788a645b6b8ded13d334/packages/cli/src/workflow-runner.ts#L104), which tries to re-resolve the post-execute promise but finds that the execution is no longer registered as active.

`WorkflowRunner` cannot be safely refactored at this time, so we can either 

- add a check in `WorkflowRunner` to ensure the execution is registered as active before we attempt any `finalizeExecution` call, or
- add that check in `finalizeExecution` instead.

I find the latter preferable to centralize the check. I have not been able to reproduce this error locally, but from what I can tell, there is no scenario where we would allow calling `finalizeExecution` on an inactive execution whose post-execute promise is already settled.