### PR TITLE
fix: Add missing Node.js natives to task runners (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -283,7 +283,7 @@ describe('JsTaskRunner', () => {
 		});
 
 		it('should allow access to Node.js Buffers', async () => {
-			const outcome = await execTaskWithParams({
+			const outcomeAll = await execTaskWithParams({
 				task: newTaskWithSettings({
 					code: 'return { val: Buffer.from("test-buffer").toString() }',
 					nodeMode: 'runOnceForAllItems',
@@ -293,7 +293,21 @@ describe('JsTaskRunner', () => {
 				}),
 			});
 
-			expect(outcome.result).toEqual([wrapIntoJson({ val: 'test-buffer' })]);
+			expect(outcomeAll.result).toEqual([wrapIntoJson({ val: 'test-buffer' })]);
+
+			const outcomePer = await execTaskWithParams({
+				task: newTaskWithSettings({
+					code: 'return { val: Buffer.from("test-buffer").toString() }',
+					nodeMode: 'runOnceForEachItem',
+				}),
+				taskData: newAllCodeTaskData(inputItems.map(wrapIntoJson), {
+					envProviderState: undefined,
+				}),
+			});
+
+			expect(outcomePer.result).toEqual([
+				{ ...wrapIntoJson({ val: 'test-buffer' }), pairedItem: { item: 0 } },
+			]);
 		});
 	});
 

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -164,6 +164,25 @@ export class JsTaskRunner extends TaskRunner {
 		};
 	}
 
+	private getNativeVariables() {
+		return {
+			// Exposed Node.js globals in vm2
+			Buffer,
+			Function,
+			eval,
+			setTimeout,
+			setInterval,
+			setImmediate,
+			clearTimeout,
+			clearInterval,
+			clearImmediate,
+
+			// Missing JS natives
+			btoa,
+			atob,
+		};
+	}
+
 	/**
 	 * Executes the requested code for all items in a single run
 	 */
@@ -181,19 +200,9 @@ export class JsTaskRunner extends TaskRunner {
 			require: this.requireResolver,
 			module: {},
 			console: customConsole,
-
-			// Exposed Node.js globals in vm2
-			Buffer,
-			Function,
-			eval,
-			setTimeout,
-			setInterval,
-			setImmediate,
-			clearTimeout,
-			clearInterval,
-			clearImmediate,
-
 			items: inputItems,
+
+			...this.getNativeVariables(),
 			...dataProxy,
 			...this.buildRpcCallObject(taskId),
 		};
@@ -243,6 +252,7 @@ export class JsTaskRunner extends TaskRunner {
 				console: customConsole,
 				item,
 
+				...this.getNativeVariables(),
 				...dataProxy,
 				...this.buildRpcCallObject(taskId),
 			};


### PR DESCRIPTION
## Summary

When adding these last time, I missed the once for each item mode. This adds the natives to that mode, and also centralises them.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
