### PR TITLE
fix(AI Agent Node): Preserve `intermediateSteps` when using output parser with non-tool agent

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/Agent.node.ts
@@ -251,7 +251,7 @@ export class Agent implements INodeType {
 		icon: 'fa:robot',
 		iconColor: 'black',
 		group: ['transform'],
-		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
 		description: 'Generates an action plan and executes it. Can use external tools.',
 		subtitle:
 			"={{ {	toolsAgent: 'Tools Agent', conversationalAgent: 'Conversational Agent', openAiFunctionsAgent: 'OpenAI Functions Agent', reActAgent: 'ReAct Agent', sqlAgent: 'SQL Agent', planAndExecuteAgent: 'Plan and Execute Agent' }[$parameter.agent] }}",

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -14,6 +14,7 @@ import {
 import { getOptionalOutputParsers } from '../../../../../utils/output_parsers/N8nOutputParser';
 import { throwIfToolSchema } from '../../../../../utils/schemaParsing';
 import { getTracingConfig } from '../../../../../utils/tracing';
+import { extractParsedOutput } from '../utils';
 
 export async function conversationalAgentExecute(
 	this: IExecuteFunctions,
@@ -102,12 +103,12 @@ export async function conversationalAgentExecute(
 				input = (await prompt.invoke({ input })).value;
 			}
 
-			let response = await agentExecutor
+			const response = await agentExecutor
 				.withConfig(getTracingConfig(this))
 				.invoke({ input, outputParsers });
 
 			if (outputParser) {
-				response = { output: await outputParser.parse(response.output as string) };
+				response.output = await extractParsedOutput(this, outputParser, response.output as string);
 			}
 
 			returnData.push({ json: response });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/OpenAiFunctionsAgent/execute.ts
@@ -15,6 +15,7 @@ import {
 import { getConnectedTools, getPromptInputByType } from '../../../../../utils/helpers';
 import { getOptionalOutputParsers } from '../../../../../utils/output_parsers/N8nOutputParser';
 import { getTracingConfig } from '../../../../../utils/tracing';
+import { extractParsedOutput } from '../utils';
 
 export async function openAiFunctionsAgentExecute(
 	this: IExecuteFunctions,
@@ -103,12 +104,12 @@ export async function openAiFunctionsAgentExecute(
 				input = (await prompt.invoke({ input })).value;
 			}
 
-			let response = await agentExecutor
+			const response = await agentExecutor
 				.withConfig(getTracingConfig(this))
 				.invoke({ input, outputParsers });
 
 			if (outputParser) {
-				response = { output: await outputParser.parse(response.output as string) };
+				response.output = await extractParsedOutput(this, outputParser, response.output as string);
 			}
 
 			returnData.push({ json: response });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
@@ -14,6 +14,7 @@ import { getConnectedTools, getPromptInputByType } from '../../../../../utils/he
 import { getOptionalOutputParsers } from '../../../../../utils/output_parsers/N8nOutputParser';
 import { throwIfToolSchema } from '../../../../../utils/schemaParsing';
 import { getTracingConfig } from '../../../../../utils/tracing';
+import { extractParsedOutput } from '../utils';
 
 export async function planAndExecuteAgentExecute(
 	this: IExecuteFunctions,
@@ -79,12 +80,12 @@ export async function planAndExecuteAgentExecute(
 				input = (await prompt.invoke({ input })).value;
 			}
 
-			let response = await agentExecutor
+			const response = await agentExecutor
 				.withConfig(getTracingConfig(this))
 				.invoke({ input, outputParsers });
 
 			if (outputParser) {
-				response = { output: await outputParser.parse(response.output as string) };
+				response.output = await extractParsedOutput(this, outputParser, response.output as string);
 			}
 
 			returnData.push({ json: response });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -19,6 +19,7 @@ import {
 import { getOptionalOutputParsers } from '../../../../../utils/output_parsers/N8nOutputParser';
 import { throwIfToolSchema } from '../../../../../utils/schemaParsing';
 import { getTracingConfig } from '../../../../../utils/tracing';
+import { extractParsedOutput } from '../utils';
 
 export async function reActAgentAgentExecute(
 	this: IExecuteFunctions,
@@ -103,12 +104,12 @@ export async function reActAgentAgentExecute(
 				input = (await prompt.invoke({ input })).value;
 			}
 
-			let response = await agentExecutor
+			const response = await agentExecutor
 				.withConfig(getTracingConfig(this))
 				.invoke({ input, outputParsers });
 
 			if (outputParser) {
-				response = { output: await outputParser.parse(response.output as string) };
+				response.output = await extractParsedOutput(this, outputParser, response.output as string);
 			}
 
 			returnData.push({ json: response });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/utils.ts
@@ -1,0 +1,19 @@
+import type { BaseOutputParser } from '@langchain/core/output_parsers';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+export async function extractParsedOutput(
+	ctx: IExecuteFunctions,
+	outputParser: BaseOutputParser<unknown>,
+	output: string,
+): Promise<Record<string, unknown> | undefined> {
+	const parsedOutput = (await outputParser.parse(output)) as {
+		output: Record<string, unknown>;
+	};
+
+	if (ctx.getNode().typeVersion <= 1.6) {
+		return parsedOutput;
+	}
+	// For 1.7 and above, we try to extract the output from the parsed output
+	// with fallback to the original output if it's not present
+	return parsedOutput?.output ?? parsedOutput;
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where `intermediateSteps` are discarded when using an output parser with a non-tool agent.
This happenes because we would re-assign the `response` as the output of the parsers, effectively removing `intermediateSteps`. To fix this, we only re-assign `response.output` to the parsed output. It also fixes double-wrapping of the output as `output.output` but only for the latest version of the node to preserve backward compatibility. 

Agent Node v1.7
![CleanShot 2024-10-23 at 11 22 03](https://github.com/user-attachments/assets/811000c7-c51a-40dd-a56e-c0c7716d03e3)
Agent Node v1.6 with fix but preserved `output.output` wrapping
![CleanShot 2024-10-23 at 11 21 55](https://github.com/user-attachments/assets/f679f7e9-a2be-48d9-b0f9-4672c3190728)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
