### PR TITLE
ci: Use `tsc-watch` across all backend packages (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "run-script-os": "^1.0.7",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.1",
-    "tsc-alias": "^1.8.7",
-    "tsc-watch": "^6.0.4",
+    "tsc-alias": "^1.8.10",
+    "tsc-watch": "^6.2.0",
     "turbo": "2.1.2",
     "typescript": "*",
     "zx": "^8.1.4"

--- a/packages/@n8n/benchmark/package.json
+++ b/packages/@n8n/benchmark/package.json
@@ -17,7 +17,7 @@
     "benchmark-locally": "pnpm benchmark --env local",
     "provision-cloud-env": "zx scripts/provision-cloud-env.mjs",
     "destroy-cloud-env": "zx scripts/destroy-cloud-env.mjs",
-    "watch": "concurrently \"tsc -w -p tsconfig.build.json\" \"tsc-alias -w -p tsconfig.build.json\""
+    "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\""
   },
   "engines": {
     "node": ">=20.10"
@@ -41,10 +41,7 @@
   },
   "devDependencies": {
     "@types/convict": "^6.1.1",
-    "@types/k6": "^0.52.0",
-    "@types/node": "^20.14.8",
-    "tsc-alias": "^1.8.7",
-    "typescript": "^5.5.2"
+    "@types/k6": "^0.52.0"
   },
   "bin": {
     "n8n-benchmark": "./bin/n8n-benchmark"

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -13,7 +13,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint . --quiet",
     "lintfix": "eslint . --fix",
-    "watch": "concurrently \"tsc -w -p tsconfig.build.json\" \"tsc-alias -w -p tsconfig.build.json\""
+    "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\""
   },
   "main": "dist/start.js",
   "module": "src/start.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "test:sqlite": "N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest",
     "test:postgres": "N8N_LOG_LEVEL=silent DB_TYPE=postgresdb DB_POSTGRESDB_SCHEMA=alt_schema DB_TABLE_PREFIX=test_ jest --no-coverage",
     "test:mysql": "N8N_LOG_LEVEL=silent DB_TYPE=mysqldb DB_TABLE_PREFIX=test_ jest --no-coverage",
-    "watch": "concurrently \"tsc -w -p tsconfig.build.json\" \"tsc-alias -w -p tsconfig.build.json\""
+    "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\""
   },
   "bin": {
     "n8n": "./bin/n8n"

--- a/packages/nodes-base/tsconfig.json
+++ b/packages/nodes-base/tsconfig.json
@@ -15,12 +15,5 @@
 		{ "path": "../@n8n/imap/tsconfig.build.json" },
 		{ "path": "../workflow/tsconfig.build.json" },
 		{ "path": "../core/tsconfig.build.json" }
-	],
-	"tsc-alias": {
-		"replacers": {
-			"base-url": {
-				"enabled": false
-			}
-		}
-	}
+	]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,11 +184,11 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.24.0)(@jest/types@29.6.1)(babel-jest@29.6.2(@babel/core@7.24.0))(jest@29.6.2(@types/node@18.16.16)(ts-node@10.9.2(@types/node@18.16.16)(typescript@5.6.2)))(typescript@5.6.2)
       tsc-alias:
-        specifier: ^1.8.7
-        version: 1.8.7
+        specifier: ^1.8.10
+        version: 1.8.10
       tsc-watch:
-        specifier: ^6.0.4
-        version: 6.0.4(typescript@5.6.2)
+        specifier: ^6.2.0
+        version: 6.2.0(typescript@5.6.2)
       turbo:
         specifier: 2.1.2
         version: 2.1.2
@@ -279,15 +279,6 @@ importers:
       '@types/k6':
         specifier: ^0.52.0
         version: 0.52.0
-      '@types/node':
-        specifier: ^18.16.16
-        version: 18.16.16
-      tsc-alias:
-        specifier: ^1.8.7
-        version: 1.8.7
-      typescript:
-        specifier: ^5.6.2
-        version: 5.6.2
 
   packages/@n8n/chat:
     dependencies:
@@ -11618,12 +11609,12 @@ packages:
     peerDependencies:
       ts-toolbelt: ^9.6.0
 
-  tsc-alias@1.8.7:
-    resolution: {integrity: sha512-59Q/zUQa3miTf99mLbSqaW0hi1jt4WoG8Uhe5hSZJHQpSoFW9eEwvW7jlKMHXWvT+zrzy3SN9PE/YBhQ+WVydA==}
+  tsc-alias@1.8.10:
+    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
     hasBin: true
 
-  tsc-watch@6.0.4:
-    resolution: {integrity: sha512-cHvbvhjO86w2aGlaHgSCeQRl+Aqw6X6XN4sQMPZKF88GoP30O+oTuh5lRIJr5pgFWrRpF1AgXnJJ2DoFEIPHyg==}
+  tsc-watch@6.2.0:
+    resolution: {integrity: sha512-2LBhf9kjKXnz7KQ/puLHlozMzzUNHAdYBNMkg3eksQJ9GBAgMg8czznM83T5PmsoUvDnXzfIeQn2lNcIYDr8LA==}
     engines: {node: '>=12.12.0'}
     hasBin: true
     peerDependencies:
@@ -24976,7 +24967,7 @@ snapshots:
       tslib: 2.6.2
       typedarray-dts: 1.0.0
 
-  tsc-alias@1.8.7:
+  tsc-alias@1.8.10:
     dependencies:
       chokidar: 4.0.1
       commander: 9.4.1
@@ -24985,7 +24976,7 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.4.1
 
-  tsc-watch@6.0.4(typescript@5.6.2):
+  tsc-watch@6.2.0(typescript@5.6.2):
     dependencies:
       cross-spawn: 7.0.3
       node-cleanup: 2.1.2


### PR DESCRIPTION
## Summary
using `tsc-alias` via `concurrently` have always had issues, but they got significantly worse in the last month. This PR updates all backend/nodes packages to use `tsc-watch` for the `watch` command instead, to ensure that `tsc-alias` only executes once after every compilation is successful, instead of running it in watch more, where it tries to race with `tsc`.  

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
