### PR TITLE
fix(API): `PUT /credentials/:id` should move the specified credential, not the first one in the database

### DIFF
--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -140,11 +140,7 @@ export declare namespace CredentialRequest {
 
 	type Delete = AuthenticatedRequest<{ id: string }, {}, {}, Record<string, string>>;
 
-	type Transfer = AuthenticatedRequest<
-		{ workflowId: string },
-		{},
-		{ destinationProjectId: string }
-	>;
+	type Transfer = AuthenticatedRequest<{ id: string }, {}, { destinationProjectId: string }>;
 }
 
 export type OperationID = 'getUsers' | 'getUser';

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.handler.ts
@@ -53,7 +53,7 @@ export = {
 
 			await Container.get(EnterpriseCredentialsService).transferOne(
 				req.user,
-				req.params.workflowId,
+				req.params.id,
 				body.destinationProjectId,
 			);
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Before this using the public API to move a credential would ignore the credential id in the path, due to a type error, and move the first credential it finds in the database that the user has access to.

This PR fixes this by fixing the type error and adding a test.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
