### PR TITLE
feat(editor): Improve new canvas discovery design by specifying ALPHA version (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
+++ b/packages/design-system/src/components/N8nActionDropdown/ActionDropdown.vue
@@ -118,7 +118,9 @@ defineExpose({ open, close });
 								{{ item.label }}
 							</span>
 							<span v-if="item.badge">
-								<N8nBadge theme="primary" size="xsmall">{{ item.badge }}</N8nBadge>
+								<N8nBadge theme="primary" size="xsmall" v-bind="item.badgeProps">
+									{{ item.badge }}
+								</N8nBadge>
 							</span>
 							<N8nKeyboardShortcut
 								v-if="item.shortcut"

--- a/packages/design-system/src/types/action-dropdown.ts
+++ b/packages/design-system/src/types/action-dropdown.ts
@@ -4,6 +4,7 @@ export interface ActionDropdownItem {
 	id: string;
 	label: string;
 	badge?: string;
+	badgeProps?: Record<string, unknown>;
 	icon?: string;
 	divided?: boolean;
 	disabled?: boolean;

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -189,9 +189,18 @@ const workflowMenuItems = computed<ActionDropdownItem[]>(() => {
 
 	actions.push({
 		id: WORKFLOW_MENU_ACTIONS.SWITCH_NODE_VIEW_VERSION,
-		...(nodeViewSwitcherDiscovered.value || nodeViewVersion.value === '2'
+		...(nodeViewVersion.value === '2'
 			? {}
-			: { badge: locale.baseText('menuActions.badge.new') }),
+			: nodeViewSwitcherDiscovered.value
+				? {
+						badge: locale.baseText('menuActions.badge.alpha'),
+						badgeProps: {
+							theme: 'tertiary',
+						},
+					}
+				: {
+						badge: locale.baseText('menuActions.badge.new'),
+					}),
 		label:
 			nodeViewVersion.value === '2'
 				? locale.baseText('menuActions.switchToOldNodeViewVersion')
@@ -735,7 +744,7 @@ function showCreateWorkflowSuccessToast(id?: string) {
 					data-test-id="workflow-import-input"
 					@change="handleFileImport()"
 				/>
-				<N8nTooltip dismissible :visible="isNodeViewDiscoveryTooltipVisible">
+				<N8nTooltip :visible="isNodeViewDiscoveryTooltipVisible">
 					<N8nActionDropdown
 						:items="workflowMenuItems"
 						data-test-id="workflow-menu"
@@ -743,6 +752,9 @@ function showCreateWorkflowSuccessToast(id?: string) {
 						@visible-change="onWorkflowMenuOpen"
 					/>
 					<template #content>
+						<div class="mb-4xs">
+							<N8nBadge>{{ $locale.baseText('menuActions.badge.alpha') }}</N8nBadge>
+						</div>
 						{{ $locale.baseText('menuActions.nodeViewDiscovery.tooltip') }}
 						<N8nIcon
 							:class="$style.closeNodeViewDiscovery"

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -908,6 +908,7 @@
 	"menuActions.switchToNewNodeViewVersion": "Switch to new canvas",
 	"menuActions.switchToOldNodeViewVersion": "Switch to old canvas",
 	"menuActions.badge.new": "NEW",
+	"menuActions.badge.alpha": "ALPHA",
 	"menuActions.nodeViewDiscovery.tooltip": "Try our new, more performant canvas",
 	"multipleParameter.addItem": "Add item",
 	"multipleParameter.currentlyNoItemsExist": "Currently no items exist",


### PR DESCRIPTION
## Summary

<img width="216" alt="Screenshot 2024-10-23 at 16 22 34" src="https://github.com/user-attachments/assets/85e45dd4-aebe-45a7-b900-06c81d0de343">
<img width="389" alt="Screenshot 2024-10-23 at 16 22 16" src="https://github.com/user-attachments/assets/079c3446-2397-48b8-8b2f-51ba6b5eb8b7">
<img width="224" alt="Screenshot 2024-10-23 at 16 22 23" src="https://github.com/user-attachments/assets/c16c915b-94f5-4e18-b99f-3de0c588a5ac">



## Related Linear tickets, Github issues, and Community forum posts

N/A 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
