### PR TITLE
fix(editor): Change tooltip for workflow with execute workflow trigger

### DIFF
--- a/packages/editor-ui/src/components/WorkflowActivator.test.ts
+++ b/packages/editor-ui/src/components/WorkflowActivator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import WorkflowActivator from '@/components/WorkflowActivator.vue';
+import userEvent from '@testing-library/user-event';
+
+import { useWorkflowsStore } from '@/stores/workflows.store';
+
+import { createTestingPinia } from '@pinia/testing';
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } from '@/constants';
+
+const renderComponent = createComponentRenderer(WorkflowActivator);
+let mockWorkflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+
+describe('WorkflowActivator', () => {
+	beforeEach(() => {
+		createTestingPinia();
+
+		mockWorkflowsStore = mockedStore(useWorkflowsStore);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders correctly', () => {
+		const renderOptions = {
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		};
+
+		const { getByTestId, getByRole } = renderComponent(renderOptions);
+		expect(getByTestId('workflow-activator-status')).toBeInTheDocument();
+		expect(getByRole('switch')).toBeInTheDocument();
+	});
+
+	it('display an inactive tooltip when there are no nodes available', async () => {
+		mockWorkflowsStore.workflowId = '1';
+
+		const { getByTestId, getByRole } = renderComponent({
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		});
+
+		await userEvent.hover(getByRole('switch'));
+		expect(getByRole('tooltip')).toBeInTheDocument();
+
+		expect(getByRole('tooltip')).toHaveTextContent(
+			'This workflow has no trigger nodes that require activation',
+		);
+		expect(getByTestId('workflow-activator-status')).toHaveTextContent('Inactive');
+	});
+
+	it('display an inactive tooltip when only execute workflow trigger is available', async () => {
+		mockWorkflowsStore.workflowId = '1';
+		mockWorkflowsStore.workflowTriggerNodes = [
+			{ type: EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, disabled: false } as never,
+		];
+
+		const { getByTestId, getByRole } = renderComponent({
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		});
+
+		await userEvent.hover(getByRole('switch'));
+		expect(getByRole('tooltip')).toBeInTheDocument();
+
+		expect(getByRole('tooltip')).toHaveTextContent(
+			"Execute Workflow Trigger' doesn't require activation as it is triggered by another workflow",
+		);
+		expect(getByTestId('workflow-activator-status')).toHaveTextContent('Inactive');
+	});
+});

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -7,7 +7,7 @@ import type { VNode } from 'vue';
 import { computed, h } from 'vue';
 import { useI18n } from '@/composables/useI18n';
 import type { PermissionsRecord } from '@/permissions';
-import { PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
+import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 import WorkflowActivationErrorMessage from './WorkflowActivationErrorMessage.vue';
 
 const props = defineProps<{
@@ -41,6 +41,17 @@ const isCurrentWorkflow = computed((): boolean => {
 const containsTrigger = computed((): boolean => {
 	const foundTriggers = getActivatableTriggerNodes(workflowsStore.workflowTriggerNodes);
 	return foundTriggers.length > 0;
+});
+
+const containsOnlyExecuteWorkflowTrigger = computed((): boolean => {
+	const foundActiveTriggers = workflowsStore.workflowTriggerNodes.filter(
+		(trigger) => !trigger.disabled,
+	);
+	const foundTriggers = foundActiveTriggers.filter(
+		(trigger) => trigger.type === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	);
+
+	return foundTriggers.length > 0 && foundTriggers.length === foundActiveTriggers.length;
 });
 
 const isNewWorkflow = computed(
@@ -109,7 +120,13 @@ async function displayActivationError() {
 		<n8n-tooltip :disabled="!disabled" placement="bottom">
 			<template #content>
 				<div>
-					{{ i18n.baseText('workflowActivator.thisWorkflowHasNoTriggerNodes') }}
+					{{
+						i18n.baseText(
+							containsOnlyExecuteWorkflowTrigger
+								? 'workflowActivator.thisWorkflowHasOnlyOneExecuteWorkflowTriggerNode'
+								: 'workflowActivator.thisWorkflowHasNoTriggerNodes',
+						)
+					}}
 				</div>
 			</template>
 			<el-switch

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2101,6 +2101,7 @@
 	"workflowActivator.showMessage.displayActivationError.title": "Problem activating workflow",
 	"workflowActivator.theWorkflowIsSetToBeActiveBut": "The workflow is activated but could not be started.<br />Click to display error message.",
 	"workflowActivator.thisWorkflowHasNoTriggerNodes": "This workflow has no trigger nodes that require activation",
+	"workflowActivator.thisWorkflowHasOnlyOneExecuteWorkflowTriggerNode": "'Execute Workflow Trigger' doesn't require activation as it is triggered by another workflow",
 	"workflowDetails.share": "Share",
 	"workflowDetails.active": "Active",
 	"workflowDetails.addTag": "Add tag",


### PR DESCRIPTION
## Summary

If a workflow cannot be triggered because the only trigger is an ‘Execute Workflow Trigger’ node, the tooltip on the disabled activation button should display: ‘The Execute Workflow Trigger does not require activation as it is triggered by another workflow.
Right now what the tooltip says "This workflow has no trigger", which is not correct.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2574/activating-a-workflow-with-an-execute-workflow-trigger-it-says-theres

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
