### PR TITLE
fix(editor): When cloud users click on "How to update your n8n version"  auto-login them before redirecting to the dashboard (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/UpdatesPanel.vue
+++ b/packages/editor-ui/src/components/UpdatesPanel.vue
@@ -1,39 +1,28 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 
 import ModalDrawer from './ModalDrawer.vue';
 import TimeAgo from './TimeAgo.vue';
 import VersionCard from './VersionCard.vue';
 import { VERSIONS_MODAL_KEY } from '../constants';
-import { mapStores } from 'pinia';
 import { useVersionsStore } from '@/stores/versions.store';
-import type { IVersion } from '@/Interface';
+import { useI18n } from '@/composables/useI18n';
+import { useUIStore } from '@/stores/ui.store';
 
-export default defineComponent({
-	name: 'UpdatesPanel',
-	components: {
-		ModalDrawer,
-		VersionCard,
-		TimeAgo,
-	},
-	computed: {
-		...mapStores(useVersionsStore),
-		nextVersions(): IVersion[] {
-			return this.versionsStore.nextVersions;
-		},
-		currentVersion(): IVersion | undefined {
-			return this.versionsStore.currentVersion;
-		},
-		infoUrl(): string {
-			return this.versionsStore.infoUrl;
-		},
-	},
-	data() {
-		return {
-			VERSIONS_MODAL_KEY,
-		};
-	},
-});
+const versionsStore = useVersionsStore();
+const uiStore = useUIStore();
+
+const i18n = useI18n();
+
+const nextVersions = computed(() => versionsStore.nextVersions);
+
+const currentVersion = computed(() => versionsStore.currentVersion);
+
+const infoUrl = computed(() => versionsStore.infoUrl);
+
+const onInfoUrlClick = async () => {
+	uiStore.goToVersions();
+};
 </script>
 
 <template>
@@ -45,24 +34,24 @@ export default defineComponent({
 	>
 		<template #header>
 			<span :class="$style.title">
-				{{ $locale.baseText('updatesPanel.weVeBeenBusy') }}
+				{{ i18n.baseText('updatesPanel.weVeBeenBusy') }}
 			</span>
 		</template>
 		<template #content>
 			<section :class="$style['description']">
 				<p v-if="currentVersion">
 					{{
-						$locale.baseText('updatesPanel.youReOnVersion', {
+						i18n.baseText('updatesPanel.youReOnVersion', {
 							interpolate: { currentVersionName: currentVersion.name },
 						})
 					}}
 					<strong>
 						<TimeAgo :date="currentVersion.createdAt" />
 					</strong>
-					{{ $locale.baseText('updatesPanel.andIs') }}
+					{{ i18n.baseText('updatesPanel.andIs') }}
 					<strong>
 						{{
-							$locale.baseText('updatesPanel.version', {
+							i18n.baseText('updatesPanel.version', {
 								interpolate: {
 									numberOfVersions: nextVersions.length,
 									howManySuffix: nextVersions.length > 1 ? 's' : '',
@@ -70,15 +59,23 @@ export default defineComponent({
 							})
 						}}
 					</strong>
-					{{ $locale.baseText('updatesPanel.behindTheLatest') }}
+					{{ i18n.baseText('updatesPanel.behindTheLatest') }}
 				</p>
 
-				<n8n-link v-if="infoUrl" :to="infoUrl" :bold="true">
+				<n8n-button
+					v-if="infoUrl"
+					:text="true"
+					type="primary"
+					size="large"
+					:class="$style['link']"
+					:bold="true"
+					@click="onInfoUrlClick"
+				>
 					<font-awesome-icon icon="info-circle" class="mr-2xs" />
 					<span>
-						{{ $locale.baseText('updatesPanel.howToUpdateYourN8nVersion') }}
+						{{ i18n.baseText('updatesPanel.howToUpdateYourN8nVersion') }}
 					</span>
-				</n8n-link>
+				</n8n-button>
 			</section>
 			<section :class="$style.versions">
 				<div v-for="version in nextVersions" :key="version.name" :class="$style['versions-card']">
@@ -113,6 +110,15 @@ export default defineComponent({
 
 	div {
 		padding-top: 20px;
+	}
+
+	.link {
+		padding-left: 0px;
+	}
+
+	.link:hover {
+		color: var(--prim-color-primary);
+		text-decoration: none;
 	}
 }
 

--- a/packages/editor-ui/src/stores/__tests__/ui.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/ui.test.ts
@@ -1,9 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import {
-	generateCloudDashboardAutoLoginLink,
-	generateUpgradeLink,
-	useUIStore,
-} from '@/stores/ui.store';
+import { generateUpgradeLink, useUIStore } from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
 import { merge } from 'lodash-es';

--- a/packages/editor-ui/src/stores/__tests__/ui.test.ts
+++ b/packages/editor-ui/src/stores/__tests__/ui.test.ts
@@ -1,5 +1,9 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { generateUpgradeLinkUrl, useUIStore } from '@/stores/ui.store';
+import {
+	generateCloudDashboardAutoLoginLink,
+	generateUpgradeLink,
+	useUIStore,
+} from '@/stores/ui.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useUsersStore } from '@/stores/users.store';
 import { merge } from 'lodash-es';
@@ -98,7 +102,7 @@ describe('UI store', () => {
 			'https://n8n.io/pricing?utm_campaign=utm-test-campaign&source=test_source',
 		],
 	])(
-		'"generateUpgradeLinkUrl" should generate the correct URL for "%s" deployment and "%s" license environment and user role "%s"',
+		'"generateUpgradeLink" should generate the correct URL for "%s" deployment and "%s" license environment and user role "%s"',
 		async (type, environment, role, expectation) => {
 			setUser(role as IRole);
 
@@ -115,7 +119,7 @@ describe('UI store', () => {
 				}),
 			);
 
-			const updateLinkUrl = await generateUpgradeLinkUrl('test_source', 'utm-test-campaign', type);
+			const updateLinkUrl = await generateUpgradeLink('test_source', 'utm-test-campaign', type);
 
 			expect(updateLinkUrl).toBe(expectation);
 		},


### PR DESCRIPTION
## Summary

Title self explanatory.

PR also migrates upgradePanel component to composition API.

![image](https://github.com/user-attachments/assets/0d55d645-417d-4068-a3be-d4e14b67376a)


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2616/bug-when-cloud-users-click-on-update-info-url-they-dont-get-auto

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
