### PR TITLE
fix(core): Ensure `LoggerProxy` is not scoped

### DIFF
--- a/packages/cli/src/logging/__tests__/logger.service.test.ts
+++ b/packages/cli/src/logging/__tests__/logger.service.test.ts
@@ -1,10 +1,42 @@
+jest.mock('n8n-workflow', () => ({
+	...jest.requireActual('n8n-workflow'),
+	LoggerProxy: { init: jest.fn() },
+}));
+
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
+import { LoggerProxy } from 'n8n-workflow';
 
 import { Logger } from '@/logging/logger.service';
 
 describe('Logger', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('constructor', () => {
+		const globalConfig = mock<GlobalConfig>({
+			logging: {
+				level: 'info',
+				outputs: ['console'],
+				scopes: [],
+			},
+		});
+
+		test('if root, should initialize `LoggerProxy` with instance', () => {
+			const logger = new Logger(globalConfig, mock<InstanceSettings>(), { isRoot: true });
+
+			expect(LoggerProxy.init).toHaveBeenCalledWith(logger);
+		});
+
+		test('if scoped, should not initialize `LoggerProxy`', () => {
+			new Logger(globalConfig, mock<InstanceSettings>(), { isRoot: false });
+
+			expect(LoggerProxy.init).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('transports', () => {
 		test('if `console` selected, should set console transport', () => {
 			const globalConfig = mock<GlobalConfig>({

--- a/packages/cli/src/logging/logger.service.ts
+++ b/packages/cli/src/logging/logger.service.ts
@@ -30,6 +30,7 @@ export class Logger {
 	constructor(
 		private readonly globalConfig: GlobalConfig,
 		private readonly instanceSettings: InstanceSettings,
+		{ isRoot }: { isRoot?: boolean } = { isRoot: true },
 	) {
 		this.level = this.globalConfig.logging.level;
 
@@ -51,7 +52,7 @@ export class Logger {
 			this.scopes = new Set(scopes);
 		}
 
-		LoggerProxy.init(this);
+		if (isRoot) LoggerProxy.init(this);
 	}
 
 	private setInternalLogger(internalLogger: winston.Logger) {
@@ -61,7 +62,7 @@ export class Logger {
 	/** Create a logger that injects the given scopes into its log metadata. */
 	scoped(scopes: LogScope | LogScope[]) {
 		scopes = Array.isArray(scopes) ? scopes : [scopes];
-		const scopedLogger = new Logger(this.globalConfig, this.instanceSettings);
+		const scopedLogger = new Logger(this.globalConfig, this.instanceSettings, { isRoot: false });
 		const childLogger = this.internalLogger.child({ scopes });
 
 		scopedLogger.setInternalLogger(childLogger);


### PR DESCRIPTION
Currently we initialize a `Logger` singleton shared by most services. More recently, we allowed some services to use `Logger.scoped` to instantiate a scoped logger to auto-inject scopes like `'waiting-executions'` into the scoped logger's log metadata. 

In `Logger.constructor` we also initialize a `LoggerProxy` for use by `workflow` and `core` packages. Since `Logger.scoped` calls `Logger.constructor` we are unintentionally re-initializing `LoggerProxy` on every `Logger.scoped` call, which causes `LoggerProxy` to [end up with the scopes](https://share.cleanshot.com/tHQ8PHt2) of the last `Logger.scoped` call, e.g. `LoggerProxy` in `core` in regular mode is currently auto-injecting the `waiting-executions` scope.

This PR ensures `LoggerProxy` is only initialized by the root `Logger.constructor` so that `LoggerProxy` does not receive scopes from further constructor calls.

