### PR TITLE
 test(editor): Set 'data-test-id' in design-system unit tests to match with editor-ui and cypress (no-changelog)

### DIFF
--- a/packages/design-system/src/__tests__/setup.ts
+++ b/packages/design-system/src/__tests__/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
-import { config } from '@vue/test-utils';
 import { configure } from '@testing-library/vue';
+import { config } from '@vue/test-utils';
 
 import { N8nPlugin } from 'n8n-design-system/plugin';
 

--- a/packages/design-system/src/__tests__/setup.ts
+++ b/packages/design-system/src/__tests__/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { configure, config } from '@vue/test-utils';
+import { config } from '@vue/test-utils';
+import { configure } from '@testing-library/vue';
 
 import { N8nPlugin } from 'n8n-design-system/plugin';
 

--- a/packages/design-system/src/__tests__/setup.ts
+++ b/packages/design-system/src/__tests__/setup.ts
@@ -1,7 +1,9 @@
 import '@testing-library/jest-dom';
-import { config } from '@vue/test-utils';
+import { configure, config } from '@vue/test-utils';
 
 import { N8nPlugin } from 'n8n-design-system/plugin';
+
+configure({ testIdAttribute: 'data-test-id' });
 
 config.global.plugins = [N8nPlugin];
 


### PR DESCRIPTION
## Summary

This tripped me up while trying to add more explicit unit tests to a `design-system` component. The same change was made for `editor-ui` 1.5 years ago: https://github.com/n8n-io/n8n/pull/5976

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
