### PR TITLE
fix(editor): Support middle click to scroll when using a mouse on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.spec.ts
+++ b/packages/editor-ui/src/components/canvas/Canvas.spec.ts
@@ -220,4 +220,20 @@ describe('Canvas', () => {
 			expect(container.querySelector('#diagonalHatch')).toBeInTheDocument();
 		});
 	});
+
+	describe('pane', () => {
+		describe('onPaneMouseDown', () => {
+			it('should enable panning when middle mouse button is pressed', async () => {
+				const { getByTestId } = renderComponent();
+				const canvas = getByTestId('canvas');
+				const pane = canvas.querySelector('.vue-flow__pane');
+
+				if (!pane) throw new Error('VueFlow pane not in the document');
+
+				await fireEvent.mouseDown(canvas, { button: 1, view: window });
+
+				expect(canvas).toHaveClass('draggable');
+			});
+		});
+	});
 });

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -109,8 +109,6 @@ const props = withDefaults(
 
 const {
 	vueFlowRef,
-	paneDragging,
-	panOnDrag,
 	getSelectedNodes: selectedNodes,
 	addSelectedNodes,
 	removeSelectedNodes,
@@ -189,7 +187,6 @@ const keyMap = computed(() => ({
 useKeybindings(keyMap, { disabled: disableKeyBindings });
 
 function setPanningEnabled(value: boolean) {
-	console.log('setPanningEnabled', value);
 	if (value) {
 		isPanningEnabled.value = true;
 		selectionKeyCode.value = null;

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -189,6 +189,7 @@ const keyMap = computed(() => ({
 useKeybindings(keyMap, { disabled: disableKeyBindings });
 
 function setPanningEnabled(value: boolean) {
+	console.log('setPanningEnabled', value);
 	if (value) {
 		isPanningEnabled.value = true;
 		selectionKeyCode.value = null;
@@ -674,6 +675,10 @@ provide(CanvasKey, {
 
 	&.draggable :global(.vue-flow__pane) {
 		cursor: grab;
+	}
+
+	:global(.vue-flow__pane) {
+		cursor: default;
 	}
 
 	:global(.vue-flow__pane.dragging) {

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -59,17 +59,6 @@
 }
 
 /**
- * Pane
- */
-
-.vue-flow__pane {
-	&,
-	&.draggable {
-		cursor: default;
-	}
-}
-
-/**
  * Nodes
  */
 

--- a/packages/editor-ui/src/utils/eventUtils.ts
+++ b/packages/editor-ui/src/utils/eventUtils.ts
@@ -1,0 +1,3 @@
+export function isMiddleMouseButton(event: MouseEvent) {
+	return event.which === 2 || event.button === 1;
+}


### PR DESCRIPTION
## Summary

Dirty fix, creating upstream issue to vueflow.

https://github.com/user-attachments/assets/808816c0-8575-41f7-b263-032cf73341f4


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7585/support-middle-click-to-scroll-when-using-a-mouse

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
