### PR TITLE
refactor: Remove duplication of scope definitions (no-changelog)

### DIFF
--- a/packages/@n8n/permissions/src/types.ts
+++ b/packages/@n8n/permissions/src/types.ts
@@ -5,45 +5,33 @@ export type Resource = keyof typeof RESOURCES;
 
 export type ResourceScope<
 	R extends Resource,
-	Operation extends string = DefaultOperations,
+	Operation extends (typeof RESOURCES)[R][number] = (typeof RESOURCES)[R][number],
 > = `${R}:${Operation}`;
 
 export type WildcardScope = `${Resource}:*` | '*';
 
 export type AnnotationTagScope = ResourceScope<'annotationTag'>;
-export type AuditLogsScope = ResourceScope<'auditLogs', 'manage'>;
-export type BannerScope = ResourceScope<'banner', 'dismiss'>;
-export type CommunityScope = ResourceScope<'community', 'register'>;
-export type CommunityPackageScope = ResourceScope<
-	'communityPackage',
-	'install' | 'uninstall' | 'update' | 'list' | 'manage'
->;
-export type CredentialScope = ResourceScope<'credential', DefaultOperations | 'share' | 'move'>;
-export type ExternalSecretScope = ResourceScope<'externalSecret', 'list' | 'use'>;
-export type ExternalSecretProviderScope = ResourceScope<
-	'externalSecretsProvider',
-	DefaultOperations | 'sync'
->;
-export type EventBusDestinationScope = ResourceScope<
-	'eventBusDestination',
-	DefaultOperations | 'test'
->;
-export type LdapScope = ResourceScope<'ldap', 'manage' | 'sync'>;
-export type LicenseScope = ResourceScope<'license', 'manage'>;
-export type LogStreamingScope = ResourceScope<'logStreaming', 'manage'>;
-export type OrchestrationScope = ResourceScope<'orchestration', 'read' | 'list'>;
+export type AuditLogsScope = ResourceScope<'auditLogs'>;
+export type BannerScope = ResourceScope<'banner'>;
+export type CommunityScope = ResourceScope<'community'>;
+export type CommunityPackageScope = ResourceScope<'communityPackage'>;
+export type CredentialScope = ResourceScope<'credential'>;
+export type ExternalSecretScope = ResourceScope<'externalSecret'>;
+export type ExternalSecretProviderScope = ResourceScope<'externalSecretsProvider'>;
+export type EventBusDestinationScope = ResourceScope<'eventBusDestination'>;
+export type LdapScope = ResourceScope<'ldap'>;
+export type LicenseScope = ResourceScope<'license'>;
+export type LogStreamingScope = ResourceScope<'logStreaming'>;
+export type OrchestrationScope = ResourceScope<'orchestration'>;
 export type ProjectScope = ResourceScope<'project'>;
-export type SamlScope = ResourceScope<'saml', 'manage'>;
-export type SecurityAuditScope = ResourceScope<'securityAudit', 'generate'>;
-export type SourceControlScope = ResourceScope<'sourceControl', 'pull' | 'push' | 'manage'>;
+export type SamlScope = ResourceScope<'saml'>;
+export type SecurityAuditScope = ResourceScope<'securityAudit'>;
+export type SourceControlScope = ResourceScope<'sourceControl'>;
 export type TagScope = ResourceScope<'tag'>;
-export type UserScope = ResourceScope<'user', DefaultOperations | 'resetPassword' | 'changeRole'>;
+export type UserScope = ResourceScope<'user'>;
 export type VariableScope = ResourceScope<'variable'>;
-export type WorkersViewScope = ResourceScope<'workersView', 'manage'>;
-export type WorkflowScope = ResourceScope<
-	'workflow',
-	DefaultOperations | 'share' | 'execute' | 'move'
->;
+export type WorkersViewScope = ResourceScope<'workersView'>;
+export type WorkflowScope = ResourceScope<'workflow'>;
 
 export type Scope =
 	| AnnotationTagScope


### PR DESCRIPTION
## Summary

While adding a new definition I realised we could remove some duplication from the scope definitions. This PR removes the need to specify the possible resource scope operations after adding them to the `RESOURCES` constant.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
