### PR TITLE
fix(core): On unhandled rejections, extract the original exception correctly

### DIFF
--- a/packages/cli/src/error-reporting.ts
+++ b/packages/cli/src/error-reporting.ts
@@ -66,8 +66,12 @@ export const initErrorHandling = async () => {
 				},
 			}),
 		],
-		beforeSend(event, { originalException }) {
+		async beforeSend(event, { originalException }) {
 			if (!originalException) return null;
+
+			if (originalException instanceof Promise) {
+				originalException = await originalException.catch((error) => error as Error);
+			}
 
 			if (originalException instanceof AxiosError) return null;
 


### PR DESCRIPTION
## Summary
When `beforeSend` is called on unhandled rejections, `hint.originalException` is not the actual error, but is the rejected promise that wraps around the error.
This PR changes `beforeSend` to extract the error out of the promise before doing any further processing.

[Context](https://n8nio.slack.com/archives/C069HS026UF/p1729768831509029)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
