### PR TITLE
fix(editor): Toolbar, layering, and label rendering improvements on new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -74,14 +74,28 @@ const edgeStyle = computed(() => ({
 	stroke: isHovered.value ? 'var(--color-primary)' : edgeColor.value,
 }));
 
-const edgeLabelStyle = computed(() => ({ color: edgeColor.value }));
+const edgeClasses = computed(() => ({
+	[$style.edge]: true,
+	hovered: isHovered.value,
+}));
+
+const edgeLabelStyle = computed(() => ({
+	color: edgeColor.value,
+}));
 
 const edgeToolbarStyle = computed(() => {
 	const [, labelX, labelY] = path.value;
 	return {
 		transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+		...(isHovered.value ? { zIndex: 1 } : {}),
 	};
 });
+
+const edgeToolbarClasses = computed(() => ({
+	[$style.edgeLabelWrapper]: true,
+	'vue-flow__edge-label': true,
+	selected: props.selected,
+}));
 
 const path = computed(() =>
 	getCustomPath(props, {
@@ -108,7 +122,7 @@ function onDelete() {
 <template>
 	<BaseEdge
 		:id="id"
-		:class="$style.edge"
+		:class="edgeClasses"
 		:style="edgeStyle"
 		:path="path[0]"
 		:marker-end="markerEnd"
@@ -122,7 +136,7 @@ function onDelete() {
 			:data-target-node-name="targetNode?.label"
 			:data-edge-status="status"
 			:style="edgeToolbarStyle"
-			:class="$style.edgeLabelWrapper"
+			:class="edgeToolbarClasses"
 			@mouseenter="isHovered = true"
 			@mouseleave="isHovered = false"
 		>

--- a/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/CanvasNodeToolbar.vue
@@ -126,7 +126,7 @@ function onOpenContextMenu(event: MouseEvent) {
 
 <style lang="scss" module>
 .canvasNodeToolbar {
-	padding-bottom: var(--spacing-2xs);
+	padding-bottom: var(--spacing-xs);
 	display: flex;
 	justify-content: flex-end;
 	width: 100%;
@@ -137,6 +137,7 @@ function onOpenContextMenu(event: MouseEvent) {
 	align-items: center;
 	justify-content: center;
 	background-color: var(--color-canvas-background);
+	border-radius: var(--border-radius-base);
 
 	:global(.button) {
 		--button-font-color: var(--color-text-light);

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -102,12 +102,3 @@
 	margin-left: calc(-1 * var(--spacing-2xs));
 	padding: var(--spacing-2xs);
 }
-
-/**
- * Edges
- */
-
-.vue-flow__edges,
-.vue-flow__edge-labels {
-	z-index: 1 !important;
-}

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -108,8 +108,3 @@
 .vue-flow__edge-label.selected {
 	z-index: 1 !important;
 }
-
-//.vue-flow__edges:hover,
-//.vue-flow__edges:has(:hover) {
-//		z-index: 1 !important;
-//}

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -83,10 +83,6 @@
 		cursor: grabbing;
 	}
 
-	&.selected {
-		z-index: 1 !important;
-	}
-
 	&:has(.sticky--active) {
 		z-index: 1 !important;
 	}

--- a/packages/editor-ui/src/styles/plugins/_vueflow.scss
+++ b/packages/editor-ui/src/styles/plugins/_vueflow.scss
@@ -98,3 +98,18 @@
 	margin-left: calc(-1 * var(--spacing-2xs));
 	padding: var(--spacing-2xs);
 }
+
+/**
+ * Edges
+ */
+
+.vue-flow__edges:has(.selected),
+.vue-flow__edges:has(.hovered),
+.vue-flow__edge-label.selected {
+	z-index: 1 !important;
+}
+
+//.vue-flow__edges:hover,
+//.vue-flow__edges:has(:hover) {
+//		z-index: 1 !important;
+//}


### PR DESCRIPTION
## Summary

<img width="1244" alt="Screenshot 2024-10-24 at 15 29 42" src="https://github.com/user-attachments/assets/45e08f2a-96a3-49d5-9f66-e2f2ab2a6ea8">

- No longer bring selected stickies to front
- No longer bring edges to front unless hovered or selected
- Add border-radius to node toolbar and increase padding

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-267/connector-label-should-appear-on-top-of-connector


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
