### PR TITLE
fix(core): Make execution and its data creation atomic

### DIFF
--- a/packages/cli/src/databases/repositories/execution-data.repository.ts
+++ b/packages/cli/src/databases/repositories/execution-data.repository.ts
@@ -1,4 +1,6 @@
 import { DataSource, In, Repository } from '@n8n/typeorm';
+import type { EntityManager } from '@n8n/typeorm';
+import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { Service } from 'typedi';
 
 import { ExecutionData } from '../entities/execution-data';
@@ -7,6 +9,13 @@ import { ExecutionData } from '../entities/execution-data';
 export class ExecutionDataRepository extends Repository<ExecutionData> {
 	constructor(dataSource: DataSource) {
 		super(ExecutionData, dataSource.manager);
+	}
+
+	async createExecutionDataForExecution(
+		data: QueryDeepPartialEntity<ExecutionData>,
+		transactionManager: EntityManager,
+	) {
+		return await transactionManager.insert(ExecutionData, data);
 	}
 
 	async findByExecutionIds(executionIds: string[]) {

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -304,16 +304,34 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	 * Insert a new execution and its execution data using a transaction.
 	 */
 	async createNewExecution(execution: CreateExecutionPayload): Promise<string> {
-		const { data, workflowData, ...rest } = execution;
-		const { identifiers: inserted } = await this.insert({ ...rest, createdAt: new Date() });
-		const { id: executionId } = inserted[0] as { id: string };
-		const { connections, nodes, name, settings } = workflowData ?? {};
-		await this.executionDataRepository.insert({
-			executionId,
-			workflowData: { connections, nodes, name, settings, id: workflowData.id },
-			data: stringify(data),
-		});
-		return String(executionId);
+		const { data: dataObj, workflowData: currentWorkflow, ...rest } = execution;
+		const { connections, nodes, name, settings } = currentWorkflow ?? {};
+		const workflowData = { connections, nodes, name, settings, id: currentWorkflow.id };
+		const data = stringify(dataObj);
+
+		const { type: dbType, sqlite: sqliteConfig } = this.globalConfig.database;
+		if (dbType === 'sqlite' && sqliteConfig.poolSize === 0) {
+			// TODO: Delete this block of code once the sqlite legacy (non-pooling) driver is dropped.
+			// In the non-pooling sqlite driver we can't use transactions, because that creates nested transactions under highly concurrent loads, leading to errors in the database
+			const { identifiers: inserted } = await this.insert({ ...rest, createdAt: new Date() });
+			const { id: executionId } = inserted[0] as { id: string };
+			await this.executionDataRepository.insert({ executionId, workflowData, data });
+			return String(executionId);
+		} else {
+			// All other database drivers should create executions and execution-data atomically
+			return await this.manager.transaction(async (transactionManager) => {
+				const { identifiers: inserted } = await transactionManager.insert(ExecutionEntity, {
+					...rest,
+					createdAt: new Date(),
+				});
+				const { id: executionId } = inserted[0] as { id: string };
+				await this.executionDataRepository.createExecutionDataForExecution(
+					{ executionId, workflowData, data },
+					transactionManager,
+				);
+				return String(executionId);
+			});
+		}
 	}
 
 	async markAsCrashed(executionIds: string | string[]) {

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '@n8n/config';
 import Container from 'typedi';
 
 import { ExecutionDataRepository } from '@/databases/repositories/execution-data.repository';
@@ -53,6 +54,39 @@ describe('ExecutionRepository', () => {
 				settings: workflow.settings,
 			});
 			expect(executionData?.data).toEqual('[{"resultData":"1"},{}]');
+		});
+
+		it('should not create execution if execution data insert fails', async () => {
+			const { type: dbType, sqlite: sqliteConfig } = Container.get(GlobalConfig).database;
+			// Do not run this test for the legacy sqlite driver
+			if (dbType === 'sqlite' && sqliteConfig.poolSize === 0) return;
+
+			const executionRepo = Container.get(ExecutionRepository);
+			const executionDataRepo = Container.get(ExecutionDataRepository);
+
+			const workflow = await createWorkflow({ settings: { executionOrder: 'v1' } });
+			jest
+				.spyOn(executionDataRepo, 'createExecutionDataForExecution')
+				.mockRejectedValueOnce(new Error());
+
+			await expect(
+				async () =>
+					await executionRepo.createNewExecution({
+						workflowId: workflow.id,
+						data: {
+							//@ts-expect-error This is not needed for tests
+							resultData: {},
+						},
+						workflowData: workflow,
+						mode: 'manual',
+						startedAt: new Date(),
+						status: 'new',
+						finished: false,
+					}),
+			).rejects.toThrow();
+
+			const executionEntities = await executionRepo.find();
+			expect(executionEntities).toBeEmptyArray();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR re-implements #10276, except the original "no-transactions" code is still used for the legacy sqlite driver.

## Related Linear tickets, Github issues, and Community forum posts

[CAT-255](https://linear.app/n8n/issue/CAT-255/)
(edit by ivov) https://linear.app/n8n/issue/PAY-2152

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
