### PR TITLE
fix(core): Deep merge the generic pagination request options

### DIFF
--- a/packages/workflow/src/RoutingNode.ts
+++ b/packages/workflow/src/RoutingNode.ts
@@ -688,7 +688,7 @@ export class RoutingNode {
 						// Make the HTTP request
 						tempResponseData = await this.rawRoutingRequest(
 							executeSingleFunctions,
-							{ ...requestData, options: { ...requestData.options, ...paginateRequestData } },
+							{ ...requestData, options: merge({}, requestData.options, paginateRequestData) },
 							credentialType,
 							credentialsDecrypted,
 						);


### PR DESCRIPTION
## Summary

Deep merge the request options for pagination in a declarative node.
For example if a cursor is sent in the request body for pagination with additional node body parameters: 
```
requestData.options: {
  body: {
    otherProperty: 'value1'
  }
},
paginateRequestData: {
  body: {
    cursor: 'abc123'
  }
}
```

**Is:**
```
{
  body: {
    cursor: 'abc123'
  }
}
```

**Should:**
```
{
  body: {
    otherProperty: 'value1'
    cursor: 'abc123'
  }
}
```

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
