### PR TITLE
fix(core): Fix resolving of $fromAI expression via `evaluateExpression`

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -3758,14 +3758,14 @@ export function getExecuteFunctions(
 			continueOnFail: () => {
 				return continueOnFail(node);
 			},
-			evaluateExpression: (expression: string, itemIndex: number) => {
+			evaluateExpression(expression: string, itemIndex: number) {
 				return workflow.expression.resolveSimpleParameterValue(
 					`=${expression}`,
 					{},
 					runExecutionData,
 					runIndex,
 					itemIndex,
-					node.name,
+					this.getNode().name,
 					connectionInputData,
 					mode,
 					getAdditionalKeys(additionalData, mode, runExecutionData),

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2856,6 +2856,8 @@ async function getInputConnectionData(
 				connectedNode.typeVersion,
 			);
 
+			// TODO: create a new context object here based on the type of `connectedNode`, and avoid using `Object.assign` on context objects
+			// https://linear.app/n8n/issue/CAT-269
 			const context = Object.assign({}, this);
 
 			context.getNodeParameter = (
@@ -3765,6 +3767,8 @@ export function getExecuteFunctions(
 					runExecutionData,
 					runIndex,
 					itemIndex,
+					// TODO: revert this back to `node.name` when we stop using `IExecuteFunctions` as the context object in AI nodes.
+					// https://linear.app/n8n/issue/CAT-269
 					this.getNode().name,
 					connectionInputData,
 					mode,


### PR DESCRIPTION
## Summary
This fixes an issue with resolving `$fromAI` expression when combined with `noDataExpression` and `evaluateExpression`. Because we're calling `.execute` of the wrapped tool node directly, the execute functions(`getExecuteFunctions`) would get created with references to the root node, and the root node's name would be passed in `evaluateExpression`. 
To fix this, I changed `evaluateExpression` to be a named function so that it could access the current node's context and use `this.getNode().name` to get the node's name to resolve the expression.

## Related Linear tickets, Github issues, and Community forum posts
- https://github.com/n8n-io/n8n/issues/11209

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
