### PR TITLE
refactor: Every node class should have a distinct constructor name (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -19,7 +19,7 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-export const VectorStoreInMemory = createVectorStoreNode({
+export class VectorStoreInMemory extends createVectorStoreNode({
 	meta: {
 		displayName: 'In-Memory Vector Store',
 		name: 'vectorStoreInMemory',
@@ -56,4 +56,4 @@ export const VectorStoreInMemory = createVectorStoreNode({
 
 		void vectorStoreInstance.addDocuments(`${workflowId}__${memoryKey}`, documents, clearStore);
 	},
-});
+}) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -212,7 +212,7 @@ class ExtendedPGVectorStore extends PGVectorStore {
 	}
 }
 
-export const VectorStorePGVector = createVectorStoreNode({
+export class VectorStorePGVector extends createVectorStoreNode({
 	meta: {
 		description: 'Work with your data in Postgresql with the PGVector extension',
 		icon: 'file:postgres.svg',
@@ -308,4 +308,4 @@ export const VectorStorePGVector = createVectorStoreNode({
 
 		await PGVectorStore.fromDocuments(documents, embeddings, config);
 	},
-});
+}) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -49,7 +49,7 @@ const insertFields: INodeProperties[] = [
 	},
 ];
 
-export const VectorStorePinecone = createVectorStoreNode({
+export class VectorStorePinecone extends createVectorStoreNode({
 	meta: {
 		displayName: 'Pinecone Vector Store',
 		name: 'vectorStorePinecone',
@@ -132,4 +132,4 @@ export const VectorStorePinecone = createVectorStoreNode({
 			pineconeIndex,
 		});
 	},
-});
+}) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -78,7 +78,7 @@ const retrieveFields: INodeProperties[] = [
 	},
 ];
 
-export const VectorStoreQdrant = createVectorStoreNode({
+export class VectorStoreQdrant extends createVectorStoreNode({
 	meta: {
 		displayName: 'Qdrant Vector Store',
 		name: 'vectorStoreQdrant',
@@ -134,4 +134,4 @@ export const VectorStoreQdrant = createVectorStoreNode({
 
 		await QdrantVectorStore.fromDocuments(documents, embeddings, config);
 	},
-});
+}) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreSupabase/VectorStoreSupabase.node.ts
@@ -39,7 +39,7 @@ const retrieveFields: INodeProperties[] = [
 
 const updateFields: INodeProperties[] = [...insertFields];
 
-export const VectorStoreSupabase = createVectorStoreNode({
+export class VectorStoreSupabase extends createVectorStoreNode({
 	meta: {
 		description: 'Work with your data in Supabase Vector Store',
 		icon: 'file:supabase.svg',
@@ -109,4 +109,4 @@ export const VectorStoreSupabase = createVectorStoreNode({
 			}
 		}
 	},
-});
+}) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.ts
@@ -44,7 +44,7 @@ const retrieveFields: INodeProperties[] = [
 	},
 ];
 
-export const VectorStoreZep = createVectorStoreNode({
+export class VectorStoreZep extends createVectorStoreNode({
 	meta: {
 		displayName: 'Zep Vector Store',
 		name: 'vectorStoreZep',
@@ -130,4 +130,4 @@ export const VectorStoreZep = createVectorStoreNode({
 			throw new NodeOperationError(context.getNode(), error as Error, { itemIndex });
 		}
 	},
-});
+}) {}


### PR DESCRIPTION
## Summary
The current code that creates VectorStore node classes always names **all** the classes `VectorStoreNodeType`. This breaks the convention that 
1. all n8n nodes have a unique class name, and 
2. every node file has the same name as the class.

Extracted out of #11329

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
