### PR TITLE
fix: Load sentry for task runner server only if configured (no-changelog)

### DIFF
--- a/packages/cli/src/runners/task-runner-server.ts
+++ b/packages/cli/src/runners/task-runner-server.ts
@@ -125,11 +125,13 @@ export class TaskRunnerServer {
 		const { app } = this;
 
 		// Augment errors sent to Sentry
-		const {
-			Handlers: { requestHandler, errorHandler },
-		} = await import('@sentry/node');
-		app.use(requestHandler());
-		app.use(errorHandler());
+		if (this.globalConfig.sentry.backendDsn) {
+			const {
+				Handlers: { requestHandler, errorHandler },
+			} = await import('@sentry/node');
+			app.use(requestHandler());
+			app.use(errorHandler());
+		}
 	}
 
 	private setupCommonMiddlewares() {


### PR DESCRIPTION


## Summary

Load sentry for task runner server only if configured


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
