### PR TITLE
fix(editor): Run external hooks after settings have been initialized

### DIFF
--- a/packages/editor-ui/src/App.vue
+++ b/packages/editor-ui/src/App.vue
@@ -8,7 +8,6 @@ import Modals from '@/components/Modals.vue';
 import Telemetry from '@/components/Telemetry.vue';
 import AskAssistantFloatingButton from '@/components/AskAssistant/AskAssistantFloatingButton.vue';
 import { loadLanguage } from '@/plugins/i18n';
-import { useExternalHooks } from '@/composables/useExternalHooks';
 import { APP_MODALS_ELEMENT_ID, HIRING_BANNER, VIEWS } from '@/constants';
 import { useRootStore } from '@/stores/root.store';
 import { useAssistantStore } from '@/stores/assistant.store';
@@ -46,7 +45,6 @@ watch(defaultLocale, (newLocale) => {
 onMounted(async () => {
 	setAppZIndexes();
 	logHiringBanner();
-	void useExternalHooks().run('app.mount');
 	loading.value = false;
 	window.addEventListener('resize', updateGridWidth);
 	await updateGridWidth();

--- a/packages/editor-ui/src/init.ts
+++ b/packages/editor-ui/src/init.ts
@@ -4,6 +4,7 @@ import { useRootStore } from '@/stores/root.store';
 import { useSettingsStore } from '@/stores/settings.store';
 import { useSourceControlStore } from '@/stores/sourceControl.store';
 import { useUsersStore } from '@/stores/users.store';
+import { useExternalHooks } from '@/composables/useExternalHooks';
 import { initializeCloudHooks } from '@/hooks/register';
 import { useVersionsStore } from '@/stores/versions.store';
 import { useProjectsStore } from '@/stores/projects.store';
@@ -26,6 +27,9 @@ export async function initializeCore() {
 	const versionsStore = useVersionsStore();
 
 	await settingsStore.initialize();
+
+	void useExternalHooks().run('app.mount');
+
 	if (!settingsStore.isPreviewMode) {
 		await usersStore.initialize();
 


### PR DESCRIPTION
## Summary
Since external hooks often use values from the settings store, all external hooks should run after the settings store has been initialized.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
