### PR TITLE
fix(core): Add 'user_id' to `license-community-plus-registered` telemetry event

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1061,6 +1061,7 @@ describe('TelemetryEventRelay', () => {
 	describe('Community+ registered', () => {
 		it('should track `license-community-plus-registered` event', () => {
 			const event: RelayEventMap['license-community-plus-registered'] = {
+				userId: 'user123',
 				email: 'user@example.com',
 				licenseKey: 'license123',
 			};
@@ -1068,6 +1069,7 @@ describe('TelemetryEventRelay', () => {
 			eventService.emit('license-community-plus-registered', event);
 
 			expect(telemetry.track).toHaveBeenCalledWith('User registered for license community plus', {
+				user_id: 'user123',
 				email: 'user@example.com',
 				licenseKey: 'license123',
 			});

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -8,7 +8,7 @@ import type {
 
 import type { AuthProviderType } from '@/databases/entities/auth-identity';
 import type { ProjectRole } from '@/databases/entities/project-relation';
-import type { GlobalRole } from '@/databases/entities/user';
+import type { GlobalRole, User } from '@/databases/entities/user';
 import type { IWorkflowDb } from '@/interfaces';
 
 import type { AiEventMap } from './ai.event-map';
@@ -421,6 +421,7 @@ export type RelayEventMap = {
 	};
 
 	'license-community-plus-registered': {
+		userId: User['id'];
 		email: string;
 		licenseKey: string;
 	};

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -236,10 +236,12 @@ export class TelemetryEventRelay extends EventRelay {
 	}
 
 	private licenseCommunityPlusRegistered({
+		userId,
 		email,
 		licenseKey,
 	}: RelayEventMap['license-community-plus-registered']) {
 		this.telemetry.track('User registered for license community plus', {
+			user_id: userId,
 			email,
 			licenseKey,
 		});

--- a/packages/cli/src/license/__tests__/license.service.test.ts
+++ b/packages/cli/src/license/__tests__/license.service.test.ts
@@ -94,6 +94,7 @@ describe('LicenseService', () => {
 				.spyOn(axios, 'post')
 				.mockResolvedValueOnce({ data: { title: 'Title', text: 'Text', licenseKey: 'abc-123' } });
 			const data = await licenseService.registerCommunityEdition({
+				userId: '123',
 				email: 'test@ema.il',
 				instanceId: '123',
 				instanceUrl: 'http://localhost',
@@ -102,6 +103,7 @@ describe('LicenseService', () => {
 
 			expect(data).toEqual({ title: 'Title', text: 'Text' });
 			expect(eventService.emit).toHaveBeenCalledWith('license-community-plus-registered', {
+				userId: '123',
 				email: 'test@ema.il',
 				licenseKey: 'abc-123',
 			});
@@ -111,6 +113,7 @@ describe('LicenseService', () => {
 			jest.spyOn(axios, 'post').mockRejectedValueOnce(new AxiosError('Failed'));
 			await expect(
 				licenseService.registerCommunityEdition({
+					userId: '123',
 					email: 'test@ema.il',
 					instanceId: '123',
 					instanceUrl: 'http://localhost',

--- a/packages/cli/src/license/license.controller.ts
+++ b/packages/cli/src/license/license.controller.ts
@@ -4,7 +4,7 @@ import { InstanceSettings } from 'n8n-core';
 
 import { Get, Post, RestController, GlobalScope, Body } from '@/decorators';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { AuthenticatedRequest, AuthlessRequest, LicenseRequest } from '@/requests';
+import { AuthenticatedRequest, LicenseRequest } from '@/requests';
 import { UrlService } from '@/services/url.service';
 
 import { LicenseService } from './license.service';
@@ -41,11 +41,12 @@ export class LicenseController {
 
 	@Post('/enterprise/community-registered')
 	async registerCommunityEdition(
-		_req: AuthlessRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Body payload: CommunityRegisteredRequestDto,
 	) {
 		return await this.licenseService.registerCommunityEdition({
+			userId: req.user.id,
 			email: payload.email,
 			instanceId: this.instanceSettings.instanceId,
 			instanceUrl: this.urlService.getInstanceBaseUrl(),

--- a/packages/cli/src/license/license.service.ts
+++ b/packages/cli/src/license/license.service.ts
@@ -61,11 +61,13 @@ export class LicenseService {
 	}
 
 	async registerCommunityEdition({
+		userId,
 		email,
 		instanceId,
 		instanceUrl,
 		licenseType,
 	}: {
+		userId: User['id'];
 		email: string;
 		instanceId: string;
 		instanceUrl: string;
@@ -83,7 +85,7 @@ export class LicenseService {
 					licenseType,
 				},
 			);
-			this.eventService.emit('license-community-plus-registered', { email, licenseKey });
+			this.eventService.emit('license-community-plus-registered', { userId, email, licenseKey });
 			return rest;
 		} catch (e: unknown) {
 			if (e instanceof AxiosError) {


### PR DESCRIPTION
## Summary

Missing `user_id` in `license-community-plus-registered` telemetry event

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2161](https://linear.app/n8n/issue/PAY-2161/fix-user-id-for-the-user-registered-for-license-community-plus-event#comment-481778bc)

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.