### PR TITLE
fix: Update required node js version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ If you already have VS Code and Docker installed, you can click [here](https://v
 
 #### Node.js
 
-[Node.js](https://nodejs.org/en/) version 18.10 or newer is required for development purposes.
+[Node.js](https://nodejs.org/en/) version 20.15 or newer is required for development purposes.
 
 #### pnpm
 


### PR DESCRIPTION
## Summary
in contribution guides we mention 18.10 as the minimum required Node js version, however pnpm 9.x requires 18.12 as the minimum and we require 20.15 as the minimum node js version for development
here is the error you get by running pnpm on 18.10 
```
pnpm build
ERROR: This version of pnpm requires at least Node.js v18.12
The current version of Node.js is v18.10.0
``` 
This PR updates contribution.md to avoid confusion

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1932/update-contributingmd-with-minimum-node-version
https://github.com/n8n-io/n8n/issues/10002

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
