### PR TITLE
fix(core): Ensure job processor does not reprocess amended executions

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -1,0 +1,21 @@
+import { mock } from 'jest-mock-extended';
+
+import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import type { IExecutionResponse } from '@/interfaces';
+
+import { JobProcessor } from '../job-processor';
+import type { Job } from '../scaling.types';
+
+describe('JobProcessor', () => {
+	it('should refrain from processing a crashed execution', async () => {
+		const executionRepository = mock<ExecutionRepository>();
+		executionRepository.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({ status: 'crashed' }),
+		);
+		const jobProcessor = new JobProcessor(mock(), executionRepository, mock(), mock(), mock());
+
+		const result = await jobProcessor.processJob(mock<Job>());
+
+		expect(result).toEqual({ success: false });
+	});
+});

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -58,6 +58,13 @@ export class JobProcessor {
 			);
 		}
 
+		/**
+		 * Bull's implicit retry mechanism and n8n's execution recovery mechanism may
+		 * cause a crashed execution to be enqueued. We refrain from processing it,
+		 * until we have reworked both mechanisms to prevent this scenario.
+		 */
+		if (execution.status === 'crashed') return { success: false };
+
 		const workflowId = execution.workflowData.id;
 
 		this.logger.info(`Worker started execution ${executionId} (job ${job.id})`, {

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -14,7 +14,6 @@ import type {
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
 	ErrorReporterProxy as ErrorReporter,
 	ExecutionCancelledError,
 	Workflow,
@@ -381,17 +380,6 @@ export class WorkflowRunner {
 		let job: Job;
 		let hooks: WorkflowHooks;
 		try {
-			// check to help diagnose PAY-2100
-			if (
-				data.executionData?.executionData?.nodeExecutionStack?.length === 0 &&
-				config.getEnv('deployment.type') === 'internal'
-			) {
-				await this.executionRepository.setRunning(executionId); // set `startedAt` so we display it correctly in UI
-				throw new ApplicationError('Execution to enqueue has empty node execution stack', {
-					extra: { executionData: data.executionData },
-				});
-			}
-
 			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
 
 			hooks = WorkflowExecuteAdditionalData.getWorkflowHooksWorkerMain(


### PR DESCRIPTION
## Summary

This PR fixes an edge case caused by an unwanted interaction between Bull's implicit retry mechanism and n8n's execution recovery mechanism.

When a worker crashes mid-execution, it fails to send a heartbeat back to Redis, prompting Bull to re-enqueue the job. When the worker restarts, its event bus looks at the filesystem logs and marks the execution as `crashed` and amends its data. But, the job is still in the queue. When this worker (or another worker, makes no difference) receives the job, the processor tries to run the execution but finds its amended data is lacking some of the data needed for execution, hence `Cannot read properties of undefined (reading 'node')` where `undefined` should have been the zeroth item in the `nodeExecutionStack`.

This unwanted interaction comes from two legacy systems that we are planning to rework in future, so this PR ensures that amended executions cannot be reprocessed by workers.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/PAY-2100/cannot-read-properties-of-undefined-reading-node
- https://linear.app/n8n/issue/PAY-2011/errored-execution-has-no-errored-node-queue-mode
- https://community.n8n.io/t/error-cannot-read-property-node-of-undefined/11820
- https://community.n8n.io/t/cannot-read-properties-of-undefined-reading-node-error/49555

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
