### PR TITLE
fix(HTTP Request Tool Node): Fix HTML response optimization issue

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -1,5 +1,5 @@
 import { Readability } from '@mozilla/readability';
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 import { convert } from 'html-to-text';
 import { JSDOM } from 'jsdom';
 import get from 'lodash/get';


### PR DESCRIPTION
## Summary

This PR fixes an error that occurs in the HTTP Request node when "Optimize Response" is enabled and "Expected Response Type" is set to HTML. Previously, this combination would result in a runtime error: "Cannot read properties of undefined (reading 'load')", preventing the node from processing HTML responses correctly.

This happened because the import of `cheerio` library was not working properly.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/11385
- https://linear.app/n8n/issue/AI-416/community-issue-http-request-tool-where-enabling-optimise-response-for

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
