### PR TITLE
feat(Gmail Trigger Node): Add filter option to include drafts

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -298,6 +298,7 @@ export class GmailTrigger implements INodeType {
 				includeDrafts = (qs.includeDrafts as boolean) || true;
 			}
 			delete qs.includeDrafts;
+			const withoutDrafts = [];
 
 			for (let i = 0; i < responseData.length; i++) {
 				responseData[i] = await googleApiRequest.call(
@@ -309,8 +310,6 @@ export class GmailTrigger implements INodeType {
 				);
 				if (!includeDrafts) {
 					if (responseData[i].labelIds.includes('DRAFT')) {
-						responseData.splice(i, 1);
-						i--;
 						continue;
 					}
 				}
@@ -324,6 +323,11 @@ export class GmailTrigger implements INodeType {
 						dataPropertyNameDownload,
 					);
 				}
+				withoutDrafts.push(responseData[i]);
+			}
+
+			if (!includeDrafts) {
+				responseData = withoutDrafts;
 			}
 
 			if (simple && responseData?.length) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -24,7 +24,7 @@ export class GmailTrigger implements INodeType {
 		name: 'gmailTrigger',
 		icon: 'file:gmail.svg',
 		group: ['trigger'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description:
 			'Fetches emails from Gmail and starts the workflow on specified polling intervals.',
 		subtitle: '={{"Gmail Trigger"}}',
@@ -291,7 +291,12 @@ export class GmailTrigger implements INodeType {
 				qs.format = 'raw';
 			}
 
-			const includeDrafts = (qs.includeDrafts as boolean) || false;
+			let includeDrafts;
+			if (node.typeVersion > 1.1) {
+				includeDrafts = (qs.includeDrafts as boolean) || false;
+			} else {
+				includeDrafts = (qs.includeDrafts as boolean) || true;
+			}
 			delete qs.includeDrafts;
 
 			for (let i = 0; i < responseData.length; i++) {

--- a/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GmailTrigger.node.ts
@@ -293,9 +293,9 @@ export class GmailTrigger implements INodeType {
 
 			let includeDrafts;
 			if (node.typeVersion > 1.1) {
-				includeDrafts = (qs.includeDrafts as boolean) || false;
+				includeDrafts = (qs.includeDrafts as boolean) ?? false;
 			} else {
-				includeDrafts = (qs.includeDrafts as boolean) || true;
+				includeDrafts = (qs.includeDrafts as boolean) ?? true;
 			}
 			delete qs.includeDrafts;
 			const withoutDrafts = [];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The Gmail Trigger Node was triggering on `draft` messages as well (e.g. when a new draft was created or a draft deleted). 
This PR introduces a new filter to include these `draft` message events in the trigger poll. 

By default the `includeDrafts` filter will be false. 

<img src="https://github.com/user-attachments/assets/229fca18-c701-49da-a6aa-05abbd20ff52" width="350" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
- https://github.com/n8n-io/n8n/issues/9204
- https://linear.app/n8n/issue/NODE-1315/gmail-trigger-ignore-drafts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
