### PR TITLE
feat(editor): Support newlines in node errors

### DIFF
--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -24,6 +24,7 @@ import InlineAskAssistantButton from 'n8n-design-system/components/InlineAskAssi
 import { useUIStore } from '@/stores/ui.store';
 import { isCommunityPackageName } from '@/utils/nodeTypesUtils';
 import { useAIAssistantHelpers } from '@/composables/useAIAssistantHelpers';
+import MultiLineText from '../MultiLineText/MultiLineText.vue';
 
 type Props = {
 	// TODO: .node can be undefined
@@ -423,9 +424,7 @@ async function onAskAssistantClick() {
 	<div class="node-error-view">
 		<div class="node-error-view__header">
 			<div class="node-error-view__header-message" data-test-id="node-error-message">
-				<div>
-					{{ getErrorMessage() }}
-				</div>
+				<MultiLineText :text="getErrorMessage()" />
 			</div>
 			<div
 				v-if="error.description || error.context?.descriptionKey"

--- a/packages/editor-ui/src/components/MultiLineText/MultiLineText.vue
+++ b/packages/editor-ui/src/components/MultiLineText/MultiLineText.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+/**
+ * Component that splits the given text by new lines and renders
+ * each line in a separate span element joined by a line break.
+ */
+import { computed } from 'vue';
+
+const props = defineProps<{
+	text: string;
+}>();
+
+const lines = computed(() => {
+	return props.text ? props.text.split('\n') : [];
+});
+</script>
+
+<template>
+	<div>
+		<span v-for="(line, index) in lines" :key="index">
+			{{ line }}<br v-if="index < lines.length - 1" />
+		</span>
+	</div>
+</template>

--- a/packages/editor-ui/src/components/MultiLineText/__tests__/MultiLineText.test.ts
+++ b/packages/editor-ui/src/components/MultiLineText/__tests__/MultiLineText.test.ts
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/vue';
+
+import MultiLineText from '../MultiLineText.vue';
+
+describe('MultiLineText', () => {
+	it('renders multiline text correctly', () => {
+		const { container } = render(MultiLineText, {
+			props: {
+				text: 'The quick brown fox\njumps over the lazy dog',
+			},
+		});
+
+		expect(container).toMatchSnapshot();
+	});
+});

--- a/packages/editor-ui/src/components/MultiLineText/__tests__/__snapshots__/MultiLineText.test.ts.snap
+++ b/packages/editor-ui/src/components/MultiLineText/__tests__/__snapshots__/MultiLineText.test.ts.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MultiLineText > renders multiline text correctly 1`] = `
+<div>
+  <div>
+    
+    <span>
+      The quick brown fox
+      <br />
+    </span>
+    <span>
+      jumps over the lazy dog
+      <!--v-if-->
+    </span>
+    
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary

Before:

![image](https://github.com/user-attachments/assets/45fe63b5-2eae-4c27-8fee-b1b453ab27fd)


After:

![image](https://github.com/user-attachments/assets/fadbbaa3-f535-4f1a-a9d9-ef7e14f039cf)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
