### PR TITLE
feat(editor): Remove edge execution animation on new canvas

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasMapping.spec.ts
+++ b/packages/editor-ui/src/composables/useCanvasMapping.spec.ts
@@ -743,7 +743,6 @@ describe('useCanvasMapping', () => {
 					target,
 					targetHandle,
 					type: 'canvas-edge',
-					animated: false,
 				},
 			]);
 		});
@@ -832,7 +831,6 @@ describe('useCanvasMapping', () => {
 					target: targetA,
 					targetHandle: targetHandleA,
 					type: 'canvas-edge',
-					animated: false,
 				},
 				{
 					data: {
@@ -855,7 +853,6 @@ describe('useCanvasMapping', () => {
 					targetHandle: targetHandleB,
 					type: 'canvas-edge',
 					markerEnd: MarkerType.ArrowClosed,
-					animated: false,
 				},
 			]);
 		});

--- a/packages/editor-ui/src/composables/useCanvasMapping.ts
+++ b/packages/editor-ui/src/composables/useCanvasMapping.ts
@@ -507,7 +507,6 @@ export function useCanvasMapping({
 					data,
 					type,
 					label,
-					animated: data.status === 'running',
 					markerEnd: MarkerType.ArrowClosed,
 				};
 			},


### PR DESCRIPTION
## Summary

<img width="707" alt="image" src="https://github.com/user-attachments/assets/e406a8c1-f5af-4a07-a7bb-5957d9a1c0e6">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7704/remove-output-connector-highlightinganimation-when-node-is-executing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
