### PR TITLE
fix(editor): Fix rendering of AI logs

### DIFF
--- a/cypress/e2e/233-AI-switch-to-logs-on-error.cy.ts
+++ b/cypress/e2e/233-AI-switch-to-logs-on-error.cy.ts
@@ -90,6 +90,14 @@ function createRunDataWithError(inputMessage: string) {
 					routine: 'InitPostgres',
 				} as unknown as Error,
 			} as ExecutionError,
+			metadata: {
+				subRun: [
+					{
+						node: 'Postgres Chat Memory',
+						runIndex: 0,
+					},
+				],
+			},
 		}),
 		createMockNodeExecutionData(AGENT_NODE_NAME, {
 			executionStatus: 'error',
@@ -124,14 +132,6 @@ function createRunDataWithError(inputMessage: string) {
 				description: 'Internal error',
 				message: 'Internal error',
 			} as unknown as ExecutionError,
-			metadata: {
-				subRun: [
-					{
-						node: 'Postgres Chat Memory',
-						runIndex: 0,
-					},
-				],
-			},
 		}),
 	];
 }

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -278,6 +278,9 @@ describe('Langchain Integration', () => {
 							},
 						},
 					},
+					metadata: {
+						subRun: [{ node: AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME, runIndex: 0 }],
+					},
 					inputOverride: {
 						ai_languageModel: [
 							[
@@ -315,9 +318,6 @@ describe('Langchain Integration', () => {
 				createMockNodeExecutionData(AGENT_NODE_NAME, {
 					jsonData: {
 						main: { output: 'Hi there! How can I assist you today?' },
-					},
-					metadata: {
-						subRun: [{ node: AI_LANGUAGE_MODEL_OPENAI_CHAT_MODEL_NODE_NAME, runIndex: 0 }],
 					},
 				}),
 			],

--- a/packages/editor-ui/src/components/OutputPanel.vue
+++ b/packages/editor-ui/src/components/OutputPanel.vue
@@ -100,14 +100,15 @@ const isTriggerNode = computed(() => {
 });
 
 const hasAiMetadata = computed(() => {
+	if (isNodeRunning.value || !workflowRunData.value) {
+		return false;
+	}
+
 	if (node.value) {
-		const resultData = workflowsStore.getWorkflowResultDataByNodeName(node.value.name);
+		const connectedSubNodes = props.workflow.getParentNodes(node.value.name, 'ALL_NON_MAIN');
+		const resultData = connectedSubNodes.map(workflowsStore.getWorkflowResultDataByNodeName);
 
-		if (!resultData || !Array.isArray(resultData) || resultData.length === 0) {
-			return false;
-		}
-
-		return !!resultData[resultData.length - 1].metadata;
+		return resultData && Array.isArray(resultData) && resultData.length > 0;
 	}
 	return false;
 });
@@ -295,6 +296,7 @@ const activatePane = () => {
 		:block-u-i="blockUI"
 		:is-production-execution-preview="isProductionExecutionPreview"
 		:is-pane-active="isPaneActive"
+		:hide-pagination="outputMode === 'logs'"
 		pane-type="output"
 		:data-output-type="outputMode"
 		@activate-pane="activatePane"
@@ -368,7 +370,7 @@ const activatePane = () => {
 		</template>
 
 		<template v-if="outputMode === 'logs' && node" #content>
-			<RunDataAi :node="node" :run-index="runIndex" />
+			<RunDataAi :node="node" :run-index="runIndex" :workflow="workflow" />
 		</template>
 
 		<template #recovered-artificial-output-data>

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineAsyncComponent, defineComponent, toRef } from 'vue';
+import { defineAsyncComponent, defineComponent, h, toRef } from 'vue';
 import type { PropType } from 'vue';
 import { mapStores } from 'pinia';
 import { useStorage } from '@/composables/useStorage';
@@ -159,6 +159,10 @@ export default defineComponent({
 			default: false,
 		},
 		isPaneActive: {
+			type: Boolean,
+			default: false,
+		},
+		hidePagination: {
 			type: Boolean,
 			default: false,
 		},
@@ -1743,6 +1747,7 @@ export default defineComponent({
 		</div>
 		<div
 			v-if="
+				hidePagination === false &&
 				hasNodeRun &&
 				!hasRunError &&
 				displayMode !== 'binary' &&

--- a/packages/editor-ui/src/components/RunData.vue
+++ b/packages/editor-ui/src/components/RunData.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineAsyncComponent, defineComponent, h, toRef } from 'vue';
+import { defineAsyncComponent, defineComponent, toRef } from 'vue';
 import type { PropType } from 'vue';
 import { mapStores } from 'pinia';
 import { useStorage } from '@/composables/useStorage';

--- a/packages/editor-ui/src/components/RunDataAi/RunDataAi.vue
+++ b/packages/editor-ui/src/components/RunDataAi/RunDataAi.vue
@@ -142,9 +142,14 @@ function getTreeNodeData(nodeName: string, currentDepth: number): TreeNode[] {
 	if (!connections) {
 		return resultData.map((d) => createNode(nodeName, currentDepth, d));
 	}
+
 	// Get the first level of children
 	const connectedSubNodes = props.workflow.getParentNodes(nodeName, 'ALL_NON_MAIN', 1);
-	const children = connectedSubNodes.flatMap((name) => getTreeNodeData(name, currentDepth + 1));
+
+	const children = connectedSubNodes
+		// Only include sub-nodes which have data
+		.filter((name) => aiData.value?.find((data) => data.node === name))
+		.flatMap((name) => getTreeNodeData(name, currentDepth + 1));
 
 	children.sort((a, b) => a.startTime - b.startTime);
 

--- a/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
@@ -145,9 +145,9 @@ const messageVars = {
 	'--chat--color-typing': 'var(--color-text-dark)',
 };
 
+const workflow = computed(() => workflowsStore.getCurrentWorkflow());
 function getTriggerNode() {
-	const workflow = workflowHelpers.getCurrentWorkflow();
-	const triggerNode = workflow.queryNodes((nodeType: INodeType) =>
+	const triggerNode = workflow.value.queryNodes((nodeType: INodeType) =>
 		[CHAT_TRIGGER_NODE_TYPE, MANUAL_CHAT_TRIGGER_NODE_TYPE].includes(nodeType.description.name),
 	);
 
@@ -164,19 +164,19 @@ function setNode() {
 		return;
 	}
 
-	const workflow = workflowHelpers.getCurrentWorkflow();
-	const childNodes = workflow.getChildNodes(triggerNode.name);
+	const childNodes = workflow.value.getChildNodes(triggerNode.name);
 
 	for (const childNode of childNodes) {
 		// Look for the first connected node with metadata
 		// TODO: Allow later users to change that in the UI
-		const resultData = workflowsStore.getWorkflowResultDataByNodeName(childNode);
+		const connectedSubNodes = workflow.value.getParentNodes(childNode, 'ALL_NON_MAIN');
+		const resultData = connectedSubNodes.map(workflowsStore.getWorkflowResultDataByNodeName);
 
 		if (!resultData && !Array.isArray(resultData)) {
 			continue;
 		}
 
-		if (resultData[resultData.length - 1].metadata) {
+		if (resultData.some((data) => data?.[0].metadata)) {
 			node.value = workflowsStore.getNodeByName(childNode);
 			break;
 		}
@@ -190,7 +190,6 @@ function setConnectedNode() {
 		showError(new Error('Chat Trigger Node could not be found!'), 'Trigger Node not found');
 		return;
 	}
-	const workflow = workflowHelpers.getCurrentWorkflow();
 
 	const chatNode = workflowsStore.getNodes().find((storeNode: INodeUi): boolean => {
 		if (storeNode.type === CHAIN_SUMMARIZATION_LANGCHAIN_NODE_TYPE) return false;
@@ -202,10 +201,10 @@ function setConnectedNode() {
 
 		let isCustomChainOrAgent = false;
 		if (nodeType.name === AI_CODE_NODE_TYPE) {
-			const inputs = NodeHelpers.getNodeInputs(workflow, storeNode, nodeType);
+			const inputs = NodeHelpers.getNodeInputs(workflow.value, storeNode, nodeType);
 			const inputTypes = NodeHelpers.getConnectionTypes(inputs);
 
-			const outputs = NodeHelpers.getNodeOutputs(workflow, storeNode, nodeType);
+			const outputs = NodeHelpers.getNodeOutputs(workflow.value, storeNode, nodeType);
 			const outputTypes = NodeHelpers.getConnectionTypes(outputs);
 
 			if (
@@ -219,7 +218,7 @@ function setConnectedNode() {
 
 		if (!isAgent && !isChain && !isCustomChainOrAgent) return false;
 
-		const parentNodes = workflow.getParentNodes(storeNode.name);
+		const parentNodes = workflow.value.getParentNodes(storeNode.name);
 		const isChatChild = parentNodes.some((parentNodeName) => parentNodeName === triggerNode.name);
 
 		return Boolean(isChatChild && (isAgent || isChain || isCustomChainOrAgent));
@@ -431,10 +430,9 @@ async function sendMessage(message: string, files?: File[]) {
 }
 
 function displayExecution(executionId: string) {
-	const workflow = workflowHelpers.getCurrentWorkflow();
 	const route = router.resolve({
 		name: VIEWS.EXECUTION_PREVIEW,
-		params: { name: workflow.id, executionId },
+		params: { name: workflow.value.id, executionId },
 	});
 	window.open(route.href, '_blank');
 }
@@ -452,9 +450,10 @@ function reuseMessage(message: ChatMessageText) {
 function getChatMessages(): ChatMessageText[] {
 	if (!connectedNode.value) return [];
 
-	const workflow = workflowHelpers.getCurrentWorkflow();
 	const connectedMemoryInputs =
-		workflow.connectionsByDestinationNode[connectedNode.value.name][NodeConnectionType.AiMemory];
+		workflow.value.connectionsByDestinationNode[connectedNode.value.name][
+			NodeConnectionType.AiMemory
+		];
 	if (!connectedMemoryInputs) return [];
 
 	const memoryConnection = (connectedMemoryInputs ?? []).find((i) => i.length > 0)?.[0];
@@ -573,7 +572,13 @@ onMounted(() => {
 						locale.baseText('chat.window.logs')
 					}}</n8n-text>
 					<div :class="$style.logs">
-						<LazyRunDataAi :key="messages.length" :node="node" hide-title slim />
+						<LazyRunDataAi
+							:key="messages.length"
+							:node="node"
+							hide-title
+							slim
+							:workflow="workflow"
+						/>
 					</div>
 				</div>
 			</div>

--- a/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
+++ b/packages/editor-ui/src/components/WorkflowLMChat/WorkflowLMChat.vue
@@ -22,7 +22,6 @@ import { useUsersStore } from '@/stores/users.store';
 import MessagesList from '@n8n/chat/components/MessagesList.vue';
 import type { ArrowKeyDownPayload } from '@n8n/chat/components/Input.vue';
 import ChatInput from '@n8n/chat/components/Input.vue';
-import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { useRouter } from 'vue-router';
 import { useRunWorkflow } from '@/composables/useRunWorkflow';
 import type { Chat, ChatMessage, ChatMessageText, ChatOptions } from '@n8n/chat/types';
@@ -78,7 +77,6 @@ interface MemoryOutput {
 }
 
 const router = useRouter();
-const workflowHelpers = useWorkflowHelpers({ router });
 const { runWorkflow } = useRunWorkflow({ router });
 const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();


### PR DESCRIPTION
## Summary

This PR updates how we handle and display AI execution logs in the OutputPanel to align with the recent supply node refactoring (#11421). Previously, AI metadata was stored in the root node's execution data, but with the new execution context changes, this data is now distributed across individual supply nodes.

### Changes

- Modified how we retrieve AI execution metadata by scanning connected supply nodes instead of relying on root node data
- Updated tree node data collection to use workflow graph traversal instead of direct connection lookup
- Fixed tree visualization to properly represent the execution hierarchy of AI nodes
- Removed pagination from log view since it's not relevant for AI execution data


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
