### PR TITLE
fix(editor): Fix adding connections when initializing workspace in templates view on new canvas

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1431,7 +1431,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 		// Add nodes and connections
 		await addNodes(data.nodes, { keepPristine: true });
-		workflowsStore.setConnections(data.connections);
+		await addConnections(mapLegacyConnectionsToCanvasConnections(data.connections, data.nodes));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

1. Enable templates view by running `export N8N_TEMPLATES_ENABLED=true`
2. Go to `/templates/2454`
3. Check that connections are added

https://github.com/user-attachments/assets/adf57c7e-0e80-48a3-83ad-4ca2c01037c1

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7874/template-pages-not-loading-connections

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
