### PR TITLE
fix(editor): Add Meta key to panning activator key codes on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -145,7 +145,7 @@ const disableKeyBindings = computed(() => !props.keyBindings);
  * @see https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#whitespace_keys
  */
 
-const panningKeyCode = ' ';
+const panningKeyCode = [' ', 'Meta'];
 const isPanningEnabled = ref(false);
 const selectionKeyCode = ref<true | null>(true);
 


### PR DESCRIPTION
## Summary

Adds `Meta` key as panning activator key.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-278/support-meta-left-mouse-click-to-navigate-the-canvas

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
