### PR TITLE
fix(editor): Fit view consistently after nodes are initialized on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -41,7 +41,6 @@ import { GRID_SIZE } from '@/utils/nodeViewUtils';
 import { CanvasKey } from '@/constants';
 import { onKeyDown, onKeyUp, useDebounceFn } from '@vueuse/core';
 import CanvasArrowHeadMarker from './elements/edges/CanvasArrowHeadMarker.vue';
-import { CanvasNodeRenderType } from '@/types';
 import CanvasBackgroundStripedPattern from './elements/CanvasBackgroundStripedPattern.vue';
 import { isMiddleMouseButton } from '@/utils/eventUtils';
 
@@ -123,7 +122,6 @@ const {
 	nodes: graphNodes,
 	onPaneReady,
 	findNode,
-	onNodesInitialized,
 	viewport,
 } = useVueFlow({ id: props.id, deleteKeyCode: null });
 

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -538,11 +538,6 @@ onPaneReady(async () => {
 	isPaneReady.value = true;
 });
 
-onNodesInitialized((nodes) => {
-	if (nodes.length !== 1 || nodes[0].data?.render.type !== CanvasNodeRenderType.AddNodes) return;
-	void onFitView();
-});
-
 watch(() => props.readOnly, setReadonly, {
 	immediate: true,
 });

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -6,7 +6,7 @@ import type { IWorkflowDb } from '@/Interface';
 import { useCanvasMapping } from '@/composables/useCanvasMapping';
 import type { EventBus } from 'n8n-design-system';
 import { createEventBus } from 'n8n-design-system';
-import { CanvasEventBusEvents, CanvasNodeRenderType } from '@/types';
+import type { CanvasEventBusEvents } from '@/types';
 import { useVueFlow } from '@vue-flow/core';
 
 defineOptions({

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -53,11 +53,11 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 	workflowObject,
 });
 
-const initialFitView = ref(false); // Workaround for https://github.com/bcakmakoglu/vue-flow/issues/1636
+const initialFitViewDone = ref(false); // Workaround for https://github.com/bcakmakoglu/vue-flow/issues/1636
 onNodesInitialized(() => {
-	if (!initialFitView.value || props.showFallbackNodes) {
+	if (!initialFitViewDone.value || props.showFallbackNodes) {
 		props.eventBus.emit('fitView');
-		initialFitView.value = true;
+		initialFitViewDone.value = true;
 	}
 });
 </script>

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import Canvas from '@/components/canvas/Canvas.vue';
-import { computed, toRef, useCssModule } from 'vue';
+import { computed, ref, toRef, useCssModule } from 'vue';
 import type { Workflow } from 'n8n-workflow';
 import type { IWorkflowDb } from '@/Interface';
 import { useCanvasMapping } from '@/composables/useCanvasMapping';
 import type { EventBus } from 'n8n-design-system';
 import { createEventBus } from 'n8n-design-system';
-import type { CanvasEventBusEvents } from '@/types';
+import { CanvasEventBusEvents, CanvasNodeRenderType } from '@/types';
+import { useVueFlow } from '@vue-flow/core';
 
 defineOptions({
 	inheritAttrs: false,
@@ -34,6 +35,8 @@ const props = withDefaults(
 
 const $style = useCssModule();
 
+const { onNodesInitialized } = useVueFlow({ id: props.id });
+
 const workflow = toRef(props, 'workflow');
 const workflowObject = toRef(props, 'workflowObject');
 
@@ -48,6 +51,14 @@ const { nodes: mappedNodes, connections: mappedConnections } = useCanvasMapping(
 	nodes,
 	connections,
 	workflowObject,
+});
+
+const initialFitView = ref(false); // Workaround for https://github.com/bcakmakoglu/vue-flow/issues/1636
+onNodesInitialized(() => {
+	if (!initialFitView.value || props.showFallbackNodes) {
+		props.eventBus.emit('fitView');
+		initialFitView.value = true;
+	}
 });
 </script>
 


### PR DESCRIPTION
## Summary

Used to happen randomly when reloading and navigating to another tab.


https://github.com/user-attachments/assets/f607809f-66e9-429a-9fbf-b0a305012e2f



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7717/zoom-to-fit-not-working-when-reloading-sometimes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
