### PR TITLE
fix(core): Do not delete waiting executions when saving of successful executions is disabled

### DIFF
--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -468,7 +468,7 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 						(executionStatus === 'success' && !saveSettings.success) ||
 						(executionStatus !== 'success' && !saveSettings.error);
 
-					if (shouldNotSave) {
+					if (shouldNotSave && !fullRunData.waitTill) {
 						if (!fullRunData.waitTill && !isManualMode) {
 							executeErrorWorkflow(
 								this.workflowData,


### PR DESCRIPTION
## Summary
When `EXECUTIONS_DATA_SAVE_ON_SUCCESS` is set to `none`, we still create the execution in the DB, but delete it when the execution finishes successfully. This happens in the `workflowExecuteAfter` hook.
When an execution goes into the `waiting` state, `workflowExecuteAfter` hook is also triggered, even though the execution isn't really finished.
This is why many parts of this hook check for `waitTill`.
The bug here was that we were not checking for `waitTill` before we deleted the execution.  

## Related Linear tickets, Github issues, and Community forum posts

NODE-1912

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
