### PR TITLE
refactor(core): Extract load-options context out of NodeExecutionFunctions (no-changelog)

### DIFF
--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -1,4 +1,4 @@
-import { NodeExecuteFunctions } from 'n8n-core';
+import { LoadOptionsContext, NodeExecuteFunctions } from 'n8n-core';
 import type {
 	ILoadOptions,
 	ILoadOptionsFunctions,
@@ -253,6 +253,6 @@ export class DynamicNodeParametersService {
 		workflow: Workflow,
 	) {
 		const node = workflow.nodes['Temp-Node'];
-		return NodeExecuteFunctions.getLoadOptionsFunctions(workflow, node, path, additionalData);
+		return new LoadOptionsContext(workflow, node, additionalData, path);
 	}
 }

--- a/packages/core/src/node-execution-context/__tests__/load-options-context.test.ts
+++ b/packages/core/src/node-execution-context/__tests__/load-options-context.test.ts
@@ -1,0 +1,102 @@
+import { mock } from 'jest-mock-extended';
+import type {
+	Expression,
+	ICredentialDataDecryptedObject,
+	ICredentialsHelper,
+	INode,
+	INodeType,
+	INodeTypes,
+	IWorkflowExecuteAdditionalData,
+	Workflow,
+} from 'n8n-workflow';
+
+import { LoadOptionsContext } from '../load-options-context';
+
+describe('LoadOptionsContext', () => {
+	const testCredentialType = 'testCredential';
+	const nodeType = mock<INodeType>({
+		description: {
+			credentials: [
+				{
+					name: testCredentialType,
+					required: true,
+				},
+			],
+			properties: [
+				{
+					name: 'testParameter',
+					required: true,
+				},
+			],
+		},
+	});
+	const nodeTypes = mock<INodeTypes>();
+	const expression = mock<Expression>();
+	const workflow = mock<Workflow>({ expression, nodeTypes });
+	const node = mock<INode>({
+		credentials: {
+			[testCredentialType]: {
+				id: 'testCredentialId',
+			},
+		},
+	});
+	node.parameters = {
+		testParameter: 'testValue',
+	};
+	const credentialsHelper = mock<ICredentialsHelper>();
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const path = 'testPath';
+
+	const loadOptionsContext = new LoadOptionsContext(workflow, node, additionalData, path);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getCredentials', () => {
+		it('should get decrypted credentials', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+
+			const credentials =
+				await loadOptionsContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentials).toEqual({ secret: 'token' });
+		});
+	});
+
+	describe('getCurrentNodeParameter', () => {
+		beforeEach(() => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+		});
+
+		it('should return parameter value when it exists', () => {
+			additionalData.currentNodeParameters = {
+				testParameter: 'testValue',
+			};
+
+			const parameter = loadOptionsContext.getCurrentNodeParameter('testParameter');
+
+			expect(parameter).toBe('testValue');
+		});
+	});
+
+	describe('getNodeParameter', () => {
+		beforeEach(() => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			expression.getParameterValue.mockImplementation((value) => value);
+		});
+
+		it('should return parameter value when it exists', () => {
+			const parameter = loadOptionsContext.getNodeParameter('testParameter');
+
+			expect(parameter).toBe('testValue');
+		});
+
+		it('should return the fallback value when the parameter does not exist', () => {
+			const parameter = loadOptionsContext.getNodeParameter('otherParameter', 'fallback');
+
+			expect(parameter).toBe('fallback');
+		});
+	});
+});

--- a/packages/core/src/node-execution-context/index.ts
+++ b/packages/core/src/node-execution-context/index.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-cycle
+export { LoadOptionsContext } from './load-options-context';
 export { PollContext } from './poll-context';
 export { TriggerContext } from './trigger-context';
 export { WebhookContext } from './webhook-context';

--- a/packages/core/src/node-execution-context/load-options-context.ts
+++ b/packages/core/src/node-execution-context/load-options-context.ts
@@ -1,0 +1,102 @@
+import { get } from 'lodash';
+import type {
+	ICredentialDataDecryptedObject,
+	IGetNodeParameterOptions,
+	INode,
+	INodeExecutionData,
+	ILoadOptionsFunctions,
+	IRunExecutionData,
+	IWorkflowExecuteAdditionalData,
+	NodeParameterValueType,
+	Workflow,
+} from 'n8n-workflow';
+
+import { extractValue } from '@/ExtractValue';
+// eslint-disable-next-line import/no-cycle
+import { getAdditionalKeys, getCredentials, getNodeParameter } from '@/NodeExecuteFunctions';
+
+import { RequestHelpers } from './helpers/request-helpers';
+import { SSHTunnelHelpers } from './helpers/ssh-tunnel-helpers';
+import { NodeExecutionContext } from './node-execution-context';
+
+export class LoadOptionsContext extends NodeExecutionContext implements ILoadOptionsFunctions {
+	readonly helpers: ILoadOptionsFunctions['helpers'];
+
+	constructor(
+		workflow: Workflow,
+		node: INode,
+		additionalData: IWorkflowExecuteAdditionalData,
+		private readonly path: string,
+	) {
+		super(workflow, node, additionalData, 'internal');
+
+		this.helpers = {
+			...new RequestHelpers(this, workflow, node, additionalData).exported,
+			...new SSHTunnelHelpers().exported,
+		};
+	}
+
+	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
+		return await getCredentials<T>(this.workflow, this.node, type, this.additionalData, this.mode);
+	}
+
+	getCurrentNodeParameter(
+		parameterPath: string,
+		options?: IGetNodeParameterOptions,
+	): NodeParameterValueType | object | undefined {
+		const nodeParameters = this.additionalData.currentNodeParameters;
+
+		if (parameterPath.charAt(0) === '&') {
+			parameterPath = `${this.path.split('.').slice(1, -1).join('.')}.${parameterPath.slice(1)}`;
+		}
+
+		let returnData = get(nodeParameters, parameterPath);
+
+		// This is outside the try/catch because it throws errors with proper messages
+		if (options?.extractValue) {
+			const nodeType = this.workflow.nodeTypes.getByNameAndVersion(
+				this.node.type,
+				this.node.typeVersion,
+			);
+			returnData = extractValue(
+				returnData,
+				parameterPath,
+				this.node,
+				nodeType,
+			) as NodeParameterValueType;
+		}
+
+		return returnData;
+	}
+
+	getCurrentNodeParameters() {
+		return this.additionalData.currentNodeParameters;
+	}
+
+	getNodeParameter(
+		parameterName: string,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		fallbackValue?: any,
+		options?: IGetNodeParameterOptions,
+	): NodeParameterValueType | object {
+		const runExecutionData: IRunExecutionData | null = null;
+		const itemIndex = 0;
+		const runIndex = 0;
+		const connectionInputData: INodeExecutionData[] = [];
+
+		return getNodeParameter(
+			this.workflow,
+			runExecutionData,
+			runIndex,
+			connectionInputData,
+			this.node,
+			parameterName,
+			itemIndex,
+			this.mode,
+			getAdditionalKeys(this.additionalData, this.mode, runExecutionData),
+			undefined,
+			fallbackValue,
+			options,
+		);
+	}
+}

--- a/packages/core/src/node-execution-context/webhook-context.ts
+++ b/packages/core/src/node-execution-context/webhook-context.ts
@@ -74,38 +74,23 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 	}
 
 	getBodyData() {
-		if (this.additionalData.httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
-		}
-		return this.additionalData.httpRequest.body as IDataObject;
+		return this.assertHttpRequest().body as IDataObject;
 	}
 
 	getHeaderData() {
-		if (this.additionalData.httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
-		}
-		return this.additionalData.httpRequest.headers;
+		return this.assertHttpRequest().headers;
 	}
 
 	getParamsData(): object {
-		if (this.additionalData.httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
-		}
-		return this.additionalData.httpRequest.params;
+		return this.assertHttpRequest().params;
 	}
 
 	getQueryData(): object {
-		if (this.additionalData.httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
-		}
-		return this.additionalData.httpRequest.query;
+		return this.assertHttpRequest().query;
 	}
 
 	getRequestObject(): Request {
-		if (this.additionalData.httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
-		}
-		return this.additionalData.httpRequest;
+		return this.assertHttpRequest();
 	}
 
 	getResponseObject(): Response {
@@ -113,6 +98,14 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 			throw new ApplicationError('Response is missing');
 		}
 		return this.additionalData.httpResponse;
+	}
+
+	private assertHttpRequest() {
+		const { httpRequest } = this.additionalData;
+		if (httpRequest === undefined) {
+			throw new ApplicationError('Request is missing');
+		}
+		return httpRequest;
 	}
 
 	getNodeWebhookUrl(name: string): string | undefined {


### PR DESCRIPTION
## Summary

This PR extracts LoadOptions context object out of NodeExecutionFunctions, and adds unit tests for most of this code.

## Related Linear tickets, Github issues, and Community forum posts

CAT-282

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
