### PR TITLE
feat(cli): add optional keepDbActiveState flags to import:workflow command

### DIFF
--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -40,6 +40,7 @@ export class ImportWorkflowsCommand extends BaseCommand {
 	static examples = [
 		'$ n8n import:workflow --input=file.json',
 		'$ n8n import:workflow --separate --input=backups/latest/',
+		'$ n8n import:workflow --input=file.json --keepDbActiveState',
 		'$ n8n import:workflow --input=file.json --userId=1d64c3d2-85fe-4a83-a649-e446b07b3aae',
 		'$ n8n import:workflow --input=file.json --projectId=Ox8O54VQrmBrb4qL',
 		'$ n8n import:workflow --separate --input=backups/latest/ --userId=1d64c3d2-85fe-4a83-a649-e446b07b3aae',
@@ -59,6 +60,10 @@ export class ImportWorkflowsCommand extends BaseCommand {
 		}),
 		projectId: Flags.string({
 			description: 'The ID of the project to assign the imported workflows to',
+		}),
+		keepDbActiveState: Flags.boolean({
+			description: 'Keep the active state of the workflows as they are in the database',
+			default: false,
 		}),
 	};
 
@@ -97,7 +102,11 @@ export class ImportWorkflowsCommand extends BaseCommand {
 
 		this.logger.info(`Importing ${workflows.length} workflows...`);
 
-		await Container.get(ImportService).importWorkflows(workflows, project.id);
+		await Container.get(ImportService).importWorkflows(
+			workflows,
+			project.id,
+			flags.keepDbActiveState,
+		);
 
 		this.reportSuccess(workflows.length);
 	}


### PR DESCRIPTION
## Summary

Added new optional flag  `--keepDbActiveState` to import:workflow command.
This allow to not deactivate existing **active** workflows in the DB in subsequent imports. 

To simplify: if the workflow you try to **import** already exists in the DB and is **active**, then you import it and keep it active. In every other situation, you deactivate imported workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/disable-deactivating-workflow-during-import/28217

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
