### PR TITLE
feat(Intercom Node): Update credential to new style

### DIFF
--- a/packages/nodes-base/credentials/IntercomApi.credentials.ts
+++ b/packages/nodes-base/credentials/IntercomApi.credentials.ts
@@ -1,4 +1,9 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
 
 export class IntercomApi implements ICredentialType {
 	name = 'intercomApi';
@@ -16,4 +21,22 @@ export class IntercomApi implements ICredentialType {
 			default: '',
 		},
 	];
+
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+				Accept: 'application/json',
+			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: 'https://api.intercom.io',
+			url: '/me',
+			method: 'GET',
+		},
+	};
 }

--- a/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Intercom/GenericFunctions.ts
@@ -4,7 +4,7 @@ import type {
 	IHookFunctions,
 	ILoadOptionsFunctions,
 	JsonObject,
-	IRequestOptions,
+	IHttpRequestOptions,
 	IHttpRequestMethods,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
@@ -18,24 +18,16 @@ export async function intercomApiRequest(
 	query?: IDataObject,
 	uri?: string,
 ): Promise<any> {
-	const credentials = await this.getCredentials('intercomApi');
-
-	const headerWithAuthentication = Object.assign(
-		{},
-		{ Authorization: `Bearer ${credentials.apiKey}`, Accept: 'application/json' },
-	);
-
-	const options: IRequestOptions = {
-		headers: headerWithAuthentication,
+	const options: IHttpRequestOptions = {
 		method,
 		qs: query,
-		uri: uri || `https://api.intercom.io${endpoint}`,
+		url: uri ?? `https://api.intercom.io${endpoint}`,
 		body,
 		json: true,
 	};
 
 	try {
-		return await this.helpers.request(options);
+		return await this.helpers.httpRequestWithAuthentication.call(this, 'intercomApi', options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}


### PR DESCRIPTION
## Summary
Updates the Intercom credential and node so it can be used in the HTTP Request node, Also added the credential test.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1943/allow-intercom-credential-to-be-used-with-http-request-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
