### PR TITLE
fix: Credentials save button is hidden unless you make changes to the

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -89,6 +89,7 @@ const isDeleting = ref(false);
 const isSaving = ref(false);
 const isTesting = ref(false);
 const hasUnsavedChanges = ref(false);
+const isSaved = ref(false);
 const loading = ref(false);
 const showValidationWarning = ref(false);
 const testedSuccessfully = ref(false);
@@ -318,8 +319,8 @@ const defaultCredentialTypeName = computed(() => {
 
 const showSaveButton = computed(() => {
 	return (
-		(hasUnsavedChanges.value || !credentialId.value) &&
-		(credentialPermissions.value.create || credentialPermissions.value.update)
+		(props.mode === 'new' || hasUnsavedChanges.value || isSaved.value) &&
+		(credentialPermissions.value.create ?? credentialPermissions.value.update)
 	);
 });
 
@@ -828,6 +829,7 @@ async function updateCredential(
 			isSharedWithChanged.value = false;
 		}
 		hasUnsavedChanges.value = false;
+		isSaved.value = true;
 
 		if (credential) {
 			await externalHooks.run('credential.saved', {
@@ -879,6 +881,7 @@ async function deleteCredential() {
 		isDeleting.value = true;
 		await credentialsStore.deleteCredential({ id: credentialId.value });
 		hasUnsavedChanges.value = false;
+		isSaved.value = true;
 	} catch (error) {
 		toast.showError(
 			error,

--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -318,7 +318,7 @@ const defaultCredentialTypeName = computed(() => {
 
 const showSaveButton = computed(() => {
 	return (
-		(hasUnsavedChanges.value || !!credentialId.value) &&
+		(hasUnsavedChanges.value || !credentialId.value) &&
 		(credentialPermissions.value.create || credentialPermissions.value.update)
 	);
 });
@@ -1064,7 +1064,7 @@ function resetCredentialData(): void {
 					/>
 					<SaveButton
 						v-if="showSaveButton"
-						:saved="!hasUnsavedChanges && !isTesting"
+						:saved="!hasUnsavedChanges && !isTesting && !!credentialId"
 						:is-saving="isSaving || isTesting"
 						:saving-label="
 							isTesting

--- a/packages/editor-ui/src/components/CredentialEdit/__tests__/CredentialEdit.test.ts
+++ b/packages/editor-ui/src/components/CredentialEdit/__tests__/CredentialEdit.test.ts
@@ -1,0 +1,70 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import CredentialEdit from '@/components/CredentialEdit/CredentialEdit.vue';
+import { createTestingPinia } from '@pinia/testing';
+import { CREDENTIAL_EDIT_MODAL_KEY, STORES } from '@/constants';
+import { cleanupAppModals, createAppModals, retry } from '@/__tests__/utils';
+
+vi.mock('@/permissions', () => ({
+	getResourcePermissions: vi.fn(() => ({
+		credential: {
+			create: true,
+			update: true,
+		},
+	})),
+}));
+
+const renderComponent = createComponentRenderer(CredentialEdit, {
+	pinia: createTestingPinia({
+		initialState: {
+			[STORES.UI]: {
+				modalsById: {
+					[CREDENTIAL_EDIT_MODAL_KEY]: { open: true },
+				},
+			},
+			[STORES.SETTINGS]: {
+				settings: {
+					templates: {
+						host: '',
+					},
+				},
+			},
+		},
+	}),
+});
+describe('CredentialEdit', () => {
+	beforeEach(() => {
+		createAppModals();
+	});
+
+	afterEach(() => {
+		cleanupAppModals();
+		vi.clearAllMocks();
+	});
+
+	test('shows the save button when credentialId is null', async () => {
+		const { queryByTestId } = renderComponent({
+			props: {
+				isTesting: false,
+				isSaving: false,
+				hasUnsavedChanges: false,
+				modalName: CREDENTIAL_EDIT_MODAL_KEY,
+				mode: 'new',
+			},
+		});
+		await retry(() => expect(queryByTestId('credential-save-button')).toBeInTheDocument());
+	});
+
+	test('hides the save button when credentialId exists and there are no unsaved changes', async () => {
+		const { queryByTestId } = renderComponent({
+			props: {
+				activeId: '123', // credentialId will be set to this value in edit mode
+				isTesting: false,
+				isSaving: false,
+				hasUnsavedChanges: false,
+				modalName: CREDENTIAL_EDIT_MODAL_KEY,
+				mode: 'edit',
+			},
+		});
+		await retry(() => expect(queryByTestId('credential-save-button')).not.toBeInTheDocument());
+	});
+});


### PR DESCRIPTION
## Summary
The save button on credentials doesn't show up unless changes made to the fields or name, this PR fixes the issue by always showing the button for new credentials

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1945/credentials-save-button-is-hidden-unless-you-make-changes-to-the

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
