### PR TITLE
fix(editor): Add optional chaining to execution socket event (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -252,7 +252,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				if (activeRunData) {
 					for (const key of Object.keys(activeRunData)) {
 						if (
-							pushData.data.data.resultData.runData[key]?.[0]?.data?.main?.[0]?.[0]?.json
+							pushData.data?.data?.resultData?.runData?.[key]?.[0]?.data?.main?.[0]?.[0]?.json
 								?.isArtificialRecoveredEventItem === true &&
 							activeRunData[key].length > 0
 						)


### PR DESCRIPTION
## Summary

Sentry reported issue

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-253/typeerror-cannot-read-properties-of-undefined-reading-data

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
