### PR TITLE
fix(core): Don't send a `executionFinished` event to the browser with no run data if the execution has already been cleaned up

### DIFF
--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -45,6 +45,7 @@ import {
 	NodeExecutionOutput,
 	sleep,
 	ErrorReporterProxy,
+	ExecutionCancelledError,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -155,11 +156,7 @@ export class WorkflowExecute {
 	}
 
 	static isAbortError(e?: Error) {
-		return (
-			e?.name === 'AbortError' ||
-			(e instanceof WorkflowOperationError &&
-				e.message === 'Workflow has been canceled or timed out')
-		);
+		return e?.name === 'AbortError' || e instanceof ExecutionCancelledError;
 	}
 
 	forceInputNodeExecution(workflow: Workflow): boolean {
@@ -1831,7 +1828,7 @@ export class WorkflowExecute {
 						return await this.processSuccessExecution(
 							startedAt,
 							workflow,
-							new WorkflowOperationError('Workflow has been canceled or timed out'),
+							new ExecutionCancelledError(this.additionalData.executionId ?? 'unknown'),
 							closeFunction,
 						);
 					}

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -154,8 +154,12 @@ export class WorkflowExecute {
 		return this.processRunExecutionData(workflow);
 	}
 
-	static isAbortError(e?: ExecutionBaseError) {
-		return e?.message === 'AbortError';
+	static isAbortError(e?: Error) {
+		return (
+			e?.name === 'AbortError' ||
+			(e instanceof WorkflowOperationError &&
+				e.message === 'Workflow has been canceled or timed out')
+		);
 	}
 
 	forceInputNodeExecution(workflow: Workflow): boolean {

--- a/packages/core/test/WorkflowExecute.test.ts
+++ b/packages/core/test/WorkflowExecute.test.ts
@@ -4,6 +4,7 @@ import {
 	createDeferredPromise,
 	NodeExecutionOutput,
 	Workflow,
+	WorkflowOperationError,
 } from 'n8n-workflow';
 
 import { WorkflowExecute } from '@/WorkflowExecute';
@@ -212,5 +213,24 @@ describe('WorkflowExecute', () => {
 		expect(nodeExecutionOutput).toBeInstanceOf(NodeExecutionOutput);
 		expect(nodeExecutionOutput[0][0].json.data).toEqual(123);
 		expect(nodeExecutionOutput.getHints()[0].message).toEqual('TEXT HINT');
+	});
+
+	describe('isAbortError', () => {
+		test.each([
+			['AbortError', new DOMException('', 'AbortError')],
+			[
+				'WorkflowOperationError',
+				new WorkflowOperationError('Workflow has been canceled or timed out'),
+			],
+		])('returns true when passed a %s', (_name, error) => {
+			expect(WorkflowExecute.isAbortError(error)).toBe(true);
+		});
+
+		test.each([
+			['TypeError', new TypeError()],
+			['WorkflowOperationError', new WorkflowOperationError('other message')],
+		])('returns false when passed a %s', (_name, error) => {
+			expect(WorkflowExecute.isAbortError(error)).toBe(false);
+		});
 	});
 });

--- a/packages/core/test/WorkflowExecute.test.ts
+++ b/packages/core/test/WorkflowExecute.test.ts
@@ -2,6 +2,7 @@ import type { IRun, WorkflowTestData } from 'n8n-workflow';
 import {
 	ApplicationError,
 	createDeferredPromise,
+	ExecutionCancelledError,
 	NodeExecutionOutput,
 	Workflow,
 	WorkflowOperationError,
@@ -218,17 +219,14 @@ describe('WorkflowExecute', () => {
 	describe('isAbortError', () => {
 		test.each([
 			['AbortError', new DOMException('', 'AbortError')],
-			[
-				'WorkflowOperationError',
-				new WorkflowOperationError('Workflow has been canceled or timed out'),
-			],
+			['WorkflowOperationError', new ExecutionCancelledError('1234')],
 		])('returns true when passed a %s', (_name, error) => {
 			expect(WorkflowExecute.isAbortError(error)).toBe(true);
 		});
 
 		test.each([
 			['TypeError', new TypeError()],
-			['WorkflowOperationError', new WorkflowOperationError('other message')],
+			['WorkflowOperationError', new WorkflowOperationError('test')],
 		])('returns false when passed a %s', (_name, error) => {
 			expect(WorkflowExecute.isAbortError(error)).toBe(false);
 		});

--- a/packages/core/test/WorkflowExecute.test.ts
+++ b/packages/core/test/WorkflowExecute.test.ts
@@ -2,10 +2,8 @@ import type { IRun, WorkflowTestData } from 'n8n-workflow';
 import {
 	ApplicationError,
 	createDeferredPromise,
-	ExecutionCancelledError,
 	NodeExecutionOutput,
 	Workflow,
-	WorkflowOperationError,
 } from 'n8n-workflow';
 
 import { WorkflowExecute } from '@/WorkflowExecute';
@@ -214,21 +212,5 @@ describe('WorkflowExecute', () => {
 		expect(nodeExecutionOutput).toBeInstanceOf(NodeExecutionOutput);
 		expect(nodeExecutionOutput[0][0].json.data).toEqual(123);
 		expect(nodeExecutionOutput.getHints()[0].message).toEqual('TEXT HINT');
-	});
-
-	describe('isAbortError', () => {
-		test.each([
-			['AbortError', new DOMException('', 'AbortError')],
-			['WorkflowOperationError', new ExecutionCancelledError('1234')],
-		])('returns true when passed a %s', (_name, error) => {
-			expect(WorkflowExecute.isAbortError(error)).toBe(true);
-		});
-
-		test.each([
-			['TypeError', new TypeError()],
-			['WorkflowOperationError', new WorkflowOperationError('test')],
-		])('returns false when passed a %s', (_name, error) => {
-			expect(WorkflowExecute.isAbortError(error)).toBe(false);
-		});
 	});
 });


### PR DESCRIPTION
## Summary

We've been sending multiple `executionFinished` events to the browser when an execution is stopped/cancelled.
We've been doing this for quiet a while now. I've checked at least 6 months back.

The reason for this is that we send the event as soon as the `POST executions/:id/stop` route is called.
But if there is a node currently executing that does not support cancellation it will continue to run and finish. When it finishes we send another `executionFinished` event with the run data of that node added.

Since this [PR](https://github.com/n8n-io/n8n/pull/9992/files) we're sending a third `executionFinished` event with no run data, **which causes the editor to throw away all run data it already has, thus leaving the user unable to inspect the partially run execution.**
That is because the execution is cleaned up while it's still running, which causes a `ExecutionNotFoundError` which is then handled and will send another `executionFinished` event with no data, because the run data has already been cleaned up.

A proper fix would be to not clean up the execution until it finished properly. This here is only a quick fix to alleviate the pain this causes.

Before

https://github.com/user-attachments/assets/94b0c911-aad2-47a7-9ee6-2f803d7081aa

After

https://github.com/user-attachments/assets/2bc234b3-81e0-470a-b6aa-9b513d5d540d



## Related Linear tickets, Github issues, and Community forum posts

n8n-7881

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
