### PR TITLE
fix(Invoice Ninja Node): Fix actions for bank transactions

### DIFF
--- a/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
@@ -98,7 +98,7 @@ export const bankTransactionFields: INodeProperties[] = [
 				default: '',
 			},
 			{
-				displayName: 'Currency',
+				displayName: 'Currency Name or ID',
 				name: 'currencyId',
 				type: 'options',
 				description:

--- a/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/BankTransactionDescription.ts
@@ -98,6 +98,17 @@ export const bankTransactionFields: INodeProperties[] = [
 				default: '',
 			},
 			{
+				displayName: 'Currency',
+				name: 'currencyId',
+				type: 'options',
+				description:
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+				typeOptions: {
+					loadOptionsMethod: 'getCurrencies',
+				},
+				default: '',
+			},
+			{
 				displayName: 'Date',
 				name: 'date',
 				type: 'dateTime',

--- a/packages/nodes-base/nodes/InvoiceNinja/BankTransactionInterface.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/BankTransactionInterface.ts
@@ -2,8 +2,13 @@ export interface IBankTransaction {
 	amount?: number;
 	bank_integration_id?: number;
 	base_type?: string;
+	currency_id?: number;
 	date?: string;
 	description?: string;
 	id?: string;
-	paymentId?: string;
+	payment_id?: string;
+}
+
+export interface IBankTransactions {
+	transactions: IBankTransaction[];
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When I attempted to use the changes from https://github.com/n8n-io/n8n/pull/10389 I ran into 3 minor issues which this PR attempts to fix.

- Creating a bank transaction would always use USD as currency as there was no `currency_id` field in the bank transaction body. Now all available currencies are retrieved via InvoiceNinja's API and the currency for a bank transaction can be adopted.
- The API call for matching bank transactions to a payment expects a `payment_id` param. This was mistakenly named `paymentId`.
- The API call for matching bank transactions to a payment also expects an array of transactions like this:
```js
{
  "transactions": [
    {
        "id": "{{TRANSACTION_ID}}",
        "payment_id": "{{PAYMENT_ID}}"
    }
  ]
}
```
The current implementation only provided one transaction object which didn't satisfy the InvoiceNinja API.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

Follow-up of https://github.com/n8n-io/n8n/pull/10389

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
