### PR TITLE
fix(core): Use the correct docs URL for regular nodes when used as tools

### DIFF
--- a/packages/workflow/src/NodeHelpers.ts
+++ b/packages/workflow/src/NodeHelpers.ts
@@ -432,12 +432,15 @@ export function convertNodeToAiTool<
 		}
 	}
 
+	const resources = item.description.codex?.resources ?? {};
+
 	item.description.codex = {
 		categories: ['AI'],
 		subcategories: {
 			AI: ['Tools'],
 			Tools: ['Other Tools'],
 		},
+		resources,
 	};
 	return item;
 }

--- a/packages/workflow/test/NodeHelpers.test.ts
+++ b/packages/workflow/test/NodeHelpers.test.ts
@@ -3693,6 +3693,7 @@ describe('NodeHelpers', () => {
 					AI: ['Tools'],
 					Tools: ['Other Tools'],
 				},
+				resources: {},
 			});
 		});
 
@@ -3775,6 +3776,9 @@ describe('NodeHelpers', () => {
 				subcategories: {
 					Existing: ['Category'],
 				},
+				resources: {
+					primaryDocumentation: [{ url: 'https://example.com' }],
+				},
 			};
 			const result = convertNodeToAiTool(fullNodeWrapper);
 			expect(result.description.codex).toEqual({
@@ -3782,6 +3786,9 @@ describe('NodeHelpers', () => {
 				subcategories: {
 					AI: ['Tools'],
 					Tools: ['Other Tools'],
+				},
+				resources: {
+					primaryDocumentation: [{ url: 'https://example.com' }],
 				},
 			});
 		});


### PR DESCRIPTION
## Summary

When we create tool pseudo-nodes, we currently discard the original codex in the cloned description. The codex object often contains the primary documentation url, that the frontend uses to render the docs link in NDV.
This PR ensures that `NodeHelpers.convertNodeToAiTool` also copies over the original codex, to render the same docs urls for the tool version of the node and the regular version.  

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C05NR911BDH/p1730714790548369?thread_ts=1730714790.548369&cid=C05NR911BDH

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
