### PR TITLE
fix(editor): Respect user's dark-mode preference even before the application is loaded (no-changelog)

### DIFF
--- a/packages/editor-ui/index.html
+++ b/packages/editor-ui/index.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
 		<link rel="icon" href="/favicon.ico" />
+		<style>@media (prefers-color-scheme: dark) { body { background-color: rgb(45, 46, 46) } }</style>
 		<script type="text/javascript">
 			window.BASE_PATH = '/{{BASE_PATH}}/';
 			window.REST_ENDPOINT = '{{REST_ENDPOINT}}';


### PR DESCRIPTION
## Summary

When loading the application over a slow connection, or in dev mode, the initial screen always renders with a bright background, ignoring the user's theme preference.
This PR adds an inline `<style>` block in `index.html` to use a dark color if the user prefers the dark mode. 

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03594NKD7W/p1730715631135369

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
