### PR TITLE
fix(core): Save execution progress for waiting executions, even when progress saving is disabled

### DIFF
--- a/packages/cli/src/execution-lifecycle-hooks/__tests__/save-execution-progress.test.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/__tests__/save-execution-progress.test.ts
@@ -1,4 +1,5 @@
 import {
+	deepCopy,
 	ErrorReporterProxy,
 	type IRunExecutionData,
 	type ITaskData,
@@ -57,7 +58,7 @@ test('should ignore on leftover async call', async () => {
 	expect(executionRepository.updateExistingExecution).not.toHaveBeenCalled();
 });
 
-test('should update execution', async () => {
+test('should update execution when saving progress is enabled', async () => {
 	jest.spyOn(fnModule, 'toSaveSettings').mockReturnValue({
 		...commonSettings,
 		progress: true,
@@ -68,6 +69,37 @@ test('should update execution', async () => {
 	executionRepository.findSingleExecution.mockResolvedValue({} as IExecutionResponse);
 
 	await saveExecutionProgress(...commonArgs);
+
+	expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith('some-execution-id', {
+		data: {
+			executionData: undefined,
+			resultData: {
+				lastNodeExecuted: 'My Node',
+				runData: {
+					'My Node': [{}],
+				},
+			},
+			startData: {},
+		},
+		status: 'running',
+	});
+
+	expect(reporterSpy).not.toHaveBeenCalled();
+});
+
+test('should update execution when saving progress is disabled, but waitTill is defined', async () => {
+	jest.spyOn(fnModule, 'toSaveSettings').mockReturnValue({
+		...commonSettings,
+		progress: false,
+	});
+
+	const reporterSpy = jest.spyOn(ErrorReporterProxy, 'error');
+
+	executionRepository.findSingleExecution.mockResolvedValue({} as IExecutionResponse);
+
+	const args = deepCopy(commonArgs);
+	args[4].waitTill = new Date();
+	await saveExecutionProgress(...args);
 
 	expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith('some-execution-id', {
 		data: {

--- a/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
@@ -14,9 +14,9 @@ export async function saveExecutionProgress(
 	executionData: IRunExecutionData,
 	pushRef?: string,
 ) {
-	const saveSettings = toSaveSettings(workflowData.settings, executionData.waitTill);
+	const saveSettings = toSaveSettings(workflowData.settings);
 
-	if (!saveSettings.progress) return;
+	if (!saveSettings.progress && !executionData.waitTill) return;
 
 	const logger = Container.get(Logger);
 

--- a/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
@@ -14,7 +14,7 @@ export async function saveExecutionProgress(
 	executionData: IRunExecutionData,
 	pushRef?: string,
 ) {
-	const saveSettings = toSaveSettings(workflowData.settings);
+	const saveSettings = toSaveSettings(workflowData.settings, executionData.waitTill);
 
 	if (!saveSettings.progress) return;
 

--- a/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
@@ -10,7 +10,7 @@ import config from '@/config';
  * - `manual`: Whether to save successful or failed manual executions.
  * - `progress`: Whether to save execution progress, i.e. after each node's execution.
  */
-export function toSaveSettings(workflowSettings: IWorkflowSettings = {}, waitTill?: Date) {
+export function toSaveSettings(workflowSettings: IWorkflowSettings = {}) {
 	const DEFAULTS = {
 		ERROR: config.getEnv('executions.saveDataOnError'),
 		SUCCESS: config.getEnv('executions.saveDataOnSuccess'),
@@ -22,10 +22,9 @@ export function toSaveSettings(workflowSettings: IWorkflowSettings = {}, waitTil
 		error: workflowSettings.saveDataErrorExecution
 			? workflowSettings.saveDataErrorExecution !== 'none'
 			: DEFAULTS.ERROR !== 'none',
-		success:
-			!waitTill || workflowSettings.saveDataSuccessExecution
-				? workflowSettings.saveDataSuccessExecution !== 'none'
-				: DEFAULTS.SUCCESS !== 'none',
+		success: workflowSettings.saveDataSuccessExecution
+			? workflowSettings.saveDataSuccessExecution !== 'none'
+			: DEFAULTS.SUCCESS !== 'none',
 		manual:
 			workflowSettings === undefined || workflowSettings.saveManualExecutions === 'DEFAULT'
 				? DEFAULTS.MANUAL

--- a/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
@@ -10,7 +10,7 @@ import config from '@/config';
  * - `manual`: Whether to save successful or failed manual executions.
  * - `progress`: Whether to save execution progress, i.e. after each node's execution.
  */
-export function toSaveSettings(workflowSettings: IWorkflowSettings = {}) {
+export function toSaveSettings(workflowSettings: IWorkflowSettings = {}, waitTill?: Date) {
 	const DEFAULTS = {
 		ERROR: config.getEnv('executions.saveDataOnError'),
 		SUCCESS: config.getEnv('executions.saveDataOnSuccess'),
@@ -22,9 +22,10 @@ export function toSaveSettings(workflowSettings: IWorkflowSettings = {}) {
 		error: workflowSettings.saveDataErrorExecution
 			? workflowSettings.saveDataErrorExecution !== 'none'
 			: DEFAULTS.ERROR !== 'none',
-		success: workflowSettings.saveDataSuccessExecution
-			? workflowSettings.saveDataSuccessExecution !== 'none'
-			: DEFAULTS.SUCCESS !== 'none',
+		success:
+			!waitTill || workflowSettings.saveDataSuccessExecution
+				? workflowSettings.saveDataSuccessExecution !== 'none'
+				: DEFAULTS.SUCCESS !== 'none',
 		manual:
 			workflowSettings === undefined || workflowSettings.saveManualExecutions === 'DEFAULT'
 				? DEFAULTS.MANUAL


### PR DESCRIPTION
## Summary

When saving of execution progress is disabled, we still need to save the progress when the execution goes into the waiting state. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
