### PR TITLE
refactor(core): Extract hook context out of NodeExecutionFunctions (no-changelog)

### DIFF
--- a/packages/core/src/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/node-execution-context/__tests__/hook-context.test.ts
@@ -1,0 +1,147 @@
+import { mock } from 'jest-mock-extended';
+import type {
+	Expression,
+	ICredentialDataDecryptedObject,
+	ICredentialsHelper,
+	INode,
+	INodeType,
+	INodeTypes,
+	IWebhookDescription,
+	IWebhookData,
+	IWorkflowExecuteAdditionalData,
+	Workflow,
+	WorkflowActivateMode,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+import { HookContext } from '../hook-context';
+
+describe('HookContext', () => {
+	const testCredentialType = 'testCredential';
+	const webhookDescription: IWebhookDescription = {
+		name: 'default',
+		httpMethod: 'GET',
+		responseMode: 'onReceived',
+		path: 'testPath',
+	};
+	const nodeType = mock<INodeType>({
+		description: {
+			credentials: [
+				{
+					name: testCredentialType,
+					required: true,
+				},
+			],
+			properties: [
+				{
+					name: 'testParameter',
+					required: true,
+				},
+			],
+		},
+	});
+	nodeType.description.webhooks = [webhookDescription];
+	const nodeTypes = mock<INodeTypes>();
+	const expression = mock<Expression>();
+	const workflow = mock<Workflow>({ expression, nodeTypes });
+	const node = mock<INode>({
+		credentials: {
+			[testCredentialType]: {
+				id: 'testCredentialId',
+			},
+		},
+	});
+	node.parameters = {
+		testParameter: 'testValue',
+	};
+	const credentialsHelper = mock<ICredentialsHelper>();
+	const additionalData = mock<IWorkflowExecuteAdditionalData>({ credentialsHelper });
+	const mode: WorkflowExecuteMode = 'manual';
+	const activation: WorkflowActivateMode = 'init';
+	const webhookData = mock<IWebhookData>({
+		webhookDescription: {
+			name: 'default',
+			isFullPath: true,
+		},
+	});
+
+	const hookContext = new HookContext(
+		workflow,
+		node,
+		additionalData,
+		mode,
+		activation,
+		webhookData,
+	);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+		expression.getParameterValue.mockImplementation((value) => value);
+		expression.getSimpleParameterValue.mockImplementation((_, value) => value);
+	});
+
+	describe('getActivationMode', () => {
+		it('should return the activation property', () => {
+			const result = hookContext.getActivationMode();
+			expect(result).toBe(activation);
+		});
+	});
+
+	describe('getCredentials', () => {
+		it('should get decrypted credentials', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue(nodeType);
+			credentialsHelper.getDecrypted.mockResolvedValue({ secret: 'token' });
+
+			const credentials =
+				await hookContext.getCredentials<ICredentialDataDecryptedObject>(testCredentialType);
+
+			expect(credentials).toEqual({ secret: 'token' });
+		});
+	});
+
+	describe('getNodeParameter', () => {
+		it('should return parameter value when it exists', () => {
+			const parameter = hookContext.getNodeParameter('testParameter');
+
+			expect(parameter).toBe('testValue');
+		});
+	});
+
+	describe('getNodeWebhookUrl', () => {
+		it('should return node webhook url', () => {
+			const url = hookContext.getNodeWebhookUrl('default');
+
+			expect(url).toContain('testPath');
+		});
+	});
+
+	describe('getWebhookName', () => {
+		it('should return webhook name', () => {
+			const name = hookContext.getWebhookName();
+
+			expect(name).toBe('default');
+		});
+
+		it('should throw an error if webhookData is undefined', () => {
+			const hookContextWithoutWebhookData = new HookContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				activation,
+			);
+
+			expect(() => hookContextWithoutWebhookData.getWebhookName()).toThrow(ApplicationError);
+		});
+	});
+
+	describe('getWebhookDescription', () => {
+		it('should return webhook description', () => {
+			const description = hookContext.getWebhookDescription('default');
+
+			expect(description).toEqual<IWebhookDescription>(webhookDescription);
+		});
+	});
+});

--- a/packages/core/src/node-execution-context/hook-context.ts
+++ b/packages/core/src/node-execution-context/hook-context.ts
@@ -1,0 +1,103 @@
+import type {
+	ICredentialDataDecryptedObject,
+	IGetNodeParameterOptions,
+	INode,
+	INodeExecutionData,
+	IHookFunctions,
+	IRunExecutionData,
+	IWorkflowExecuteAdditionalData,
+	NodeParameterValueType,
+	Workflow,
+	WorkflowActivateMode,
+	WorkflowExecuteMode,
+	IWebhookData,
+	WebhookType,
+} from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+// eslint-disable-next-line import/no-cycle
+import {
+	getAdditionalKeys,
+	getCredentials,
+	getNodeParameter,
+	getNodeWebhookUrl,
+	getWebhookDescription,
+} from '@/NodeExecuteFunctions';
+
+import { RequestHelpers } from './helpers/request-helpers';
+import { NodeExecutionContext } from './node-execution-context';
+
+export class HookContext extends NodeExecutionContext implements IHookFunctions {
+	readonly helpers: IHookFunctions['helpers'];
+
+	constructor(
+		workflow: Workflow,
+		node: INode,
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		private readonly activation: WorkflowActivateMode,
+		private readonly webhookData?: IWebhookData,
+	) {
+		super(workflow, node, additionalData, mode);
+
+		this.helpers = new RequestHelpers(this, workflow, node, additionalData);
+	}
+
+	getActivationMode() {
+		return this.activation;
+	}
+
+	async getCredentials<T extends object = ICredentialDataDecryptedObject>(type: string) {
+		return await getCredentials<T>(this.workflow, this.node, type, this.additionalData, this.mode);
+	}
+
+	getNodeParameter(
+		parameterName: string,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		fallbackValue?: any,
+		options?: IGetNodeParameterOptions,
+	): NodeParameterValueType | object {
+		const runExecutionData: IRunExecutionData | null = null;
+		const itemIndex = 0;
+		const runIndex = 0;
+		const connectionInputData: INodeExecutionData[] = [];
+
+		return getNodeParameter(
+			this.workflow,
+			runExecutionData,
+			runIndex,
+			connectionInputData,
+			this.node,
+			parameterName,
+			itemIndex,
+			this.mode,
+			getAdditionalKeys(this.additionalData, this.mode, runExecutionData),
+			undefined,
+			fallbackValue,
+			options,
+		);
+	}
+
+	getNodeWebhookUrl(name: WebhookType): string | undefined {
+		return getNodeWebhookUrl(
+			name,
+			this.workflow,
+			this.node,
+			this.additionalData,
+			this.mode,
+			getAdditionalKeys(this.additionalData, this.mode, null),
+			this.webhookData?.isTest,
+		);
+	}
+
+	getWebhookName(): string {
+		if (this.webhookData === undefined) {
+			throw new ApplicationError('Only supported in webhook functions');
+		}
+		return this.webhookData.webhookDescription.name;
+	}
+
+	getWebhookDescription(name: WebhookType) {
+		return getWebhookDescription(name, this.workflow, this.node);
+	}
+}

--- a/packages/core/src/node-execution-context/index.ts
+++ b/packages/core/src/node-execution-context/index.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-cycle
+export { HookContext } from './hook-context';
 export { LoadOptionsContext } from './load-options-context';
 export { PollContext } from './poll-context';
 export { TriggerContext } from './trigger-context';

--- a/packages/core/src/node-execution-context/webhook-context.ts
+++ b/packages/core/src/node-execution-context/webhook-context.ts
@@ -14,6 +14,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	NodeConnectionType,
 	NodeParameterValueType,
+	WebhookType,
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
@@ -108,7 +109,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return httpRequest;
 	}
 
-	getNodeWebhookUrl(name: string): string | undefined {
+	getNodeWebhookUrl(name: WebhookType): string | undefined {
 		return getNodeWebhookUrl(
 			name,
 			this.workflow,

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1104,8 +1104,8 @@ export interface ITriggerFunctions
 export interface IHookFunctions
 	extends FunctionsBaseWithRequiredKeys<'getMode' | 'getActivationMode'> {
 	getWebhookName(): string;
-	getWebhookDescription(name: string): IWebhookDescription | undefined;
-	getNodeWebhookUrl: (name: string) => string | undefined;
+	getWebhookDescription(name: WebhookType): IWebhookDescription | undefined;
+	getNodeWebhookUrl: (name: WebhookType) => string | undefined;
 	getNodeParameter(
 		parameterName: string,
 		fallbackValue?: any,
@@ -1127,7 +1127,7 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 		fallbackValue?: any,
 		options?: IGetNodeParameterOptions,
 	): NodeParameterValueType | object;
-	getNodeWebhookUrl: (name: string) => string | undefined;
+	getNodeWebhookUrl: (name: WebhookType) => string | undefined;
 	evaluateExpression(expression: string, itemIndex?: number): NodeParameterValueType;
 	getParamsData(): object;
 	getQueryData(): object;
@@ -1619,7 +1619,7 @@ export interface INodeType {
 		};
 	};
 	webhookMethods?: {
-		[name in IWebhookDescription['name']]?: {
+		[name in WebhookType]?: {
 			[method in WebhookSetupMethodNames]: (this: IHookFunctions) => Promise<boolean>;
 		};
 	};
@@ -1972,11 +1972,13 @@ export interface IWebhookData {
 	staticData?: Workflow['staticData'];
 }
 
+export type WebhookType = 'default' | 'setup';
+
 export interface IWebhookDescription {
 	[key: string]: IHttpRequestMethods | WebhookResponseMode | boolean | string | undefined;
 	httpMethod: IHttpRequestMethods | string;
 	isFullPath?: boolean;
-	name: 'default' | 'setup';
+	name: WebhookType;
 	path: string;
 	responseBinaryPropertyName?: string;
 	responseContentType?: string;


### PR DESCRIPTION
## Summary

This PR extracts Hook context object out of NodeExecutionFunctions, and adds unit tests for most of this code.

## Related Linear tickets, Github issues, and Community forum posts

CAT-283

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
