### PR TITLE
chore(core): Change NodeOperationError default level to `warning` (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/node-operation.error.ts
+++ b/packages/workflow/src/errors/node-operation.error.ts
@@ -29,7 +29,7 @@ export class NodeOperationError extends NodeError {
 		}
 
 		if (options.message) this.message = options.message;
-		if (options.level) this.level = options.level;
+		this.level = options.level ?? 'warning';
 		if (options.functionality) this.functionality = options.functionality;
 		if (options.type) this.type = options.type;
 		this.description = options.description;


### PR DESCRIPTION
## Summary
[Context](https://n8nio.slack.com/archives/C069HS026UF/p1730732804046169)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
