### PR TITLE
refactor(editor): Convert some smaller components to composition api (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/EnterpriseEdition.ee.vue
+++ b/packages/editor-ui/src/components/EnterpriseEdition.ee.vue
@@ -3,16 +3,19 @@ import { computed } from 'vue';
 import type { EnterpriseEditionFeatureValue } from '@/Interface';
 import { useSettingsStore } from '@/stores/settings.store';
 
-defineOptions({ name: 'EnterpriseEdition' });
-
-const { features = [] } = defineProps<{
-	features: EnterpriseEditionFeatureValue[];
-}>();
+const props = withDefaults(
+	defineProps<{
+		features: EnterpriseEditionFeatureValue[];
+	}>(),
+	{
+		features: () => [],
+	},
+);
 
 const settingsStore = useSettingsStore();
 
 const canAccess = computed(() =>
-	features.reduce(
+	props.features.reduce(
 		(acc: boolean, feature) => acc && !!settingsStore.isEnterpriseFeatureEnabled[feature],
 		true,
 	),

--- a/packages/editor-ui/src/components/EnterpriseEdition.ee.vue
+++ b/packages/editor-ui/src/components/EnterpriseEdition.ee.vue
@@ -1,26 +1,22 @@
-<script lang="ts">
-import { type PropType, defineComponent } from 'vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 import type { EnterpriseEditionFeatureValue } from '@/Interface';
-import { mapStores } from 'pinia';
 import { useSettingsStore } from '@/stores/settings.store';
 
-export default defineComponent({
-	name: 'EnterpriseEdition',
-	props: {
-		features: {
-			type: Array as PropType<EnterpriseEditionFeatureValue[]>,
-			default: () => [],
-		},
-	},
-	computed: {
-		...mapStores(useSettingsStore),
-		canAccess(): boolean {
-			return this.features.reduce((acc: boolean, feature) => {
-				return acc && !!this.settingsStore.isEnterpriseFeatureEnabled[feature];
-			}, true);
-		},
-	},
-});
+defineOptions({ name: 'EnterpriseEdition' });
+
+const { features = [] } = defineProps<{
+	features: EnterpriseEditionFeatureValue[];
+}>();
+
+const settingsStore = useSettingsStore();
+
+const canAccess = computed(() =>
+	features.reduce(
+		(acc: boolean, feature) => acc && !!settingsStore.isEnterpriseFeatureEnabled[feature],
+		true,
+	),
+);
 </script>
 
 <template>

--- a/packages/editor-ui/src/components/PushConnectionTracker.vue
+++ b/packages/editor-ui/src/components/PushConnectionTracker.vue
@@ -1,19 +1,16 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
-import { mapStores } from 'pinia';
+<script setup lang="ts">
+import { computed } from 'vue';
 import { useRootStore } from '@/stores/root.store';
 
-export default defineComponent({
-	name: 'PushConnectionTracker',
-	computed: {
-		...mapStores(useRootStore),
-	},
-});
+defineOptions({ name: 'PushConnectionTracker' });
+
+const rootStore = useRootStore();
+const pushConnectionActive = computed(() => rootStore.pushConnectionActive);
 </script>
 
 <template>
 	<span>
-		<div v-if="!rootStore.pushConnectionActive" class="push-connection-lost primary-color">
+		<div v-if="!pushConnectionActive" class="push-connection-lost primary-color">
 			<n8n-tooltip placement="bottom-end">
 				<template #content>
 					<div v-n8n-html="$locale.baseText('pushConnectionTracker.cannotConnectToServer')"></div>

--- a/packages/editor-ui/src/components/PushConnectionTracker.vue
+++ b/packages/editor-ui/src/components/PushConnectionTracker.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useRootStore } from '@/stores/root.store';
-
-defineOptions({ name: 'PushConnectionTracker' });
+import { useI18n } from '@/composables/useI18n';
 
 const rootStore = useRootStore();
 const pushConnectionActive = computed(() => rootStore.pushConnectionActive);
+const i18n = useI18n();
 </script>
 
 <template>
@@ -13,11 +13,11 @@ const pushConnectionActive = computed(() => rootStore.pushConnectionActive);
 		<div v-if="!pushConnectionActive" class="push-connection-lost primary-color">
 			<n8n-tooltip placement="bottom-end">
 				<template #content>
-					<div v-n8n-html="$locale.baseText('pushConnectionTracker.cannotConnectToServer')"></div>
+					<div v-n8n-html="i18n.baseText('pushConnectionTracker.cannotConnectToServer')"></div>
 				</template>
 				<span>
 					<font-awesome-icon icon="exclamation-triangle" />&nbsp;
-					{{ $locale.baseText('pushConnectionTracker.connectionLost') }}
+					{{ i18n.baseText('pushConnectionTracker.connectionLost') }}
 				</span>
 			</n8n-tooltip>
 		</div>


### PR DESCRIPTION
## Summary
This PR converts ~~7~~ 3 more component files to composition API.

1. EnterpriseEdition.ee.vue
2. PushConnectionTracker.vue
3. ResourceFiltersDropdown.vue

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
