### PR TITLE
fix(editor): Do not show success message if there is an error saving credentials (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -749,7 +749,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 
 const createToastMessagingForNewCredentials = (
 	credentialDetails: ICredentialsDecrypted,
-	project?: Project,
+	project?: Project | null,
 ) => {
 	let toastTitle = i18n.baseText('credentials.create.personal.toast.title');
 	let toastText = '';
@@ -776,7 +776,7 @@ const createToastMessagingForNewCredentials = (
 
 async function createCredential(
 	credentialDetails: ICredentialsDecrypted,
-	project?: Project,
+	project?: Project | null,
 ): Promise<ICredentialsResponse | null> {
 	let credential;
 


### PR DESCRIPTION
## Summary

We are showing the success and error toast when there is an error creating credentials.

### Before:

![image](https://github.com/user-attachments/assets/dbc42042-f2b8-4922-8498-32773e292e12)

### Now:

![CleanShot 2024-11-04 at 16 21 19](https://github.com/user-attachments/assets/2d061296-c18d-4fc8-a04c-139089d1adef)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2758/bug-if-credential-creation-fails-shows-success-notification

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
