### PR TITLE
fix: Toast not aligned to the bottom when AI assistant disable

### DIFF
--- a/packages/editor-ui/src/composables/useToast.ts
+++ b/packages/editor-ui/src/composables/useToast.ts
@@ -10,6 +10,7 @@ import { useExternalHooks } from './useExternalHooks';
 import { VIEWS } from '@/constants';
 import type { ApplicationError } from 'n8n-workflow';
 import { useStyles } from './useStyles';
+import { useSettingsStore } from '@/stores/settings.store';
 
 export interface NotificationErrorWithNodeAndDescription extends ApplicationError {
 	node: {
@@ -26,13 +27,14 @@ export function useToast() {
 	const uiStore = useUIStore();
 	const externalHooks = useExternalHooks();
 	const i18n = useI18n();
+	const settingsStore = useSettingsStore();
 	const { APP_Z_INDEXES } = useStyles();
 
 	const messageDefaults: Partial<Omit<NotificationOptions, 'message'>> = {
 		dangerouslyUseHTMLString: false,
 		position: 'bottom-right',
 		zIndex: APP_Z_INDEXES.TOASTS, // above NDV and modal overlays
-		offset: 64,
+		offset: settingsStore.isAiAssistantEnabled ? 64 : 0,
 		appendTo: '#app-grid',
 		customClass: 'content-toast',
 	};


### PR DESCRIPTION
## Summary

### When AI assistant disable

![CleanShot 2024-11-04 at 16 53 05](https://github.com/user-attachments/assets/34b1902d-8497-4e78-83ef-75234702842e)

### When AI assistant enabled

![CleanShot 2024-11-04 at 16 54 42](https://github.com/user-attachments/assets/df2a250a-42be-4407-b828-8789ba04613e)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2719/toast-not-aligned-to-the-bottom

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
