### PR TITLE
test: Skip flaky 39-projects e2e tests (no-changelog)

### DIFF
--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -441,6 +441,8 @@ describe('Projects', { disableAutoLogin: true }, () => {
 				.should('contain.text', 'Notion account personal project');
 		});
 
+		// Skip flaky test
+		// eslint-disable-next-line n8n-local-rules/no-skipped-tests
 		it.skip('should move resources between projects', () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);
@@ -684,6 +686,8 @@ describe('Projects', { disableAutoLogin: true }, () => {
 				.should('have.length', 1);
 		});
 
+		// Skip flaky test
+		// eslint-disable-next-line n8n-local-rules/no-skipped-tests
 		it.skip('should allow to change inaccessible credential when the workflow was moved to a team project', () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);

--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -441,7 +441,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 				.should('contain.text', 'Notion account personal project');
 		});
 
-		it('should move resources between projects', () => {
+		it.skip('should move resources between projects', () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);
 
@@ -684,7 +684,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 				.should('have.length', 1);
 		});
 
-		it('should allow to change inaccessible credential when the workflow was moved to a team project', () => {
+		it.skip('should allow to change inaccessible credential when the workflow was moved to a team project', () => {
 			cy.signinAsOwner();
 			cy.visit(workflowsPage.url);
 


### PR DESCRIPTION
## Summary

This PR adds `.skip` to the following flaky `39-projects` e2e tests:
- should move resources between projects
- should allow to change inaccessible credential when the workflow was moved to a team project
