### PR TITLE
fix(editor): Do not overwrite the webhookId in the new canvas

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -8,7 +8,7 @@ import type {
 	IVersionNotificationSettings,
 } from '@n8n/api-types';
 import type { Scope } from '@n8n/permissions';
-import type { IMenuItem, NodeCreatorTag } from 'n8n-design-system';
+import type { NodeCreatorTag } from 'n8n-design-system';
 import type {
 	GenericValue,
 	IConnections,
@@ -887,51 +887,6 @@ export interface RootState {
 
 export interface NodeMetadataMap {
 	[nodeName: string]: INodeMetadata;
-}
-export interface IRootState {
-	activeExecutions: IExecutionsCurrentSummaryExtended[];
-	activeWorkflows: string[];
-	activeActions: string[];
-	activeCredentialType: string | null;
-	baseUrl: string;
-	defaultLocale: string;
-	endpointForm: string;
-	endpointFormTest: string;
-	endpointFormWaiting: string;
-	endpointWebhook: string;
-	endpointWebhookTest: string;
-	endpointWebhookWaiting: string;
-	executionId: string | null;
-	executingNode: string[];
-	executionWaitingForWebhook: boolean;
-	pushConnectionActive: boolean;
-	saveDataErrorExecution: string;
-	saveDataSuccessExecution: string;
-	saveManualExecutions: boolean;
-	timezone: string;
-	stateIsDirty: boolean;
-	executionTimeout: number;
-	maxExecutionTimeout: number;
-	versionCli: string;
-	oauthCallbackUrls: object;
-	n8nMetadata: object;
-	workflowExecutionData: IExecutionResponse | null;
-	workflowExecutionPairedItemMappings: { [itemId: string]: Set<string> };
-	lastSelectedNode: string | null;
-	lastSelectedNodeOutputIndex: number | null;
-	nodeViewOffsetPosition: XYPosition;
-	nodeViewMoveInProgress: boolean;
-	selectedNodes: INodeUi[];
-	pushRef: string;
-	urlBaseEditor: string;
-	urlBaseWebhook: string;
-	workflow: IWorkflowDb;
-	workflowsById: IWorkflowsMap;
-	sidebarMenuItems: IMenuItem[];
-	instanceId: string;
-	nodeMetadata: NodeMetadataMap;
-	subworkflowExecutionError: Error | null;
-	binaryDataMode: string;
 }
 
 export interface CommunityPackageMap {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1080,7 +1080,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 	}
 
 	function resolveNodeWebhook(node: INodeUi, nodeTypeDescription: INodeTypeDescription) {
-		if (nodeTypeDescription.webhooks?.length) {
+		if (nodeTypeDescription.webhooks?.length && !node.webhookId) {
 			node.webhookId = uuid();
 		}
 

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -1932,5 +1932,6 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		fetchWorkflowDataFromUrl,
 		resetWorkspace,
 		initializeWorkspace,
+		resolveNodeWebhook,
 	};
 }


### PR DESCRIPTION
## Summary
`webhookId` should only be overwritten when a webhook node is duplicated, or when it's missing a `webhookId`.

## Related Linear tickets, Github issues, and Community forum posts

NODE-1968
Fixes #11547

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
