### PR TITLE
fix(editor): Show only error title and 'Open errored node' button; hide 'Ask Assistant' in root for sub-node errors

### DIFF
--- a/packages/editor-ui/src/components/Error/NodeErrorView.test.ts
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.test.ts
@@ -1,24 +1,27 @@
 import { createComponentRenderer } from '@/__tests__/render';
-import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
+
 import NodeErrorView from '@/components/Error/NodeErrorView.vue';
-import { STORES } from '@/constants';
+
 import { createTestingPinia } from '@pinia/testing';
 import { type INode } from 'n8n-workflow';
 import { useAssistantStore } from '@/stores/assistant.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
+import { mockedStore } from '@/__tests__/utils';
 
-const DEFAULT_SETUP = {
-	pinia: createTestingPinia({
-		initialState: {
-			[STORES.SETTINGS]: SETTINGS_STORE_DEFAULT_STATE,
-		},
-	}),
-};
+const renderComponent = createComponentRenderer(NodeErrorView);
 
-const renderComponent = createComponentRenderer(NodeErrorView, DEFAULT_SETUP);
+let aiAssistantStore: ReturnType<typeof mockedStore<typeof useAssistantStore>>;
+let nodeTypeStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 describe('NodeErrorView.vue', () => {
 	let mockNode: INode;
+
+	beforeEach(() => {
+		createTestingPinia();
+
+		aiAssistantStore = mockedStore(useAssistantStore);
+		nodeTypeStore = mockedStore(useNodeTypesStore);
+	});
 	afterEach(() => {
 		mockNode = {
 			parameters: {
@@ -67,9 +70,6 @@ describe('NodeErrorView.vue', () => {
 	});
 
 	it('should not render AI assistant button when error happens in deprecated function node', async () => {
-		const aiAssistantStore = useAssistantStore(DEFAULT_SETUP.pinia);
-		const nodeTypeStore = useNodeTypesStore(DEFAULT_SETUP.pinia);
-
 		//@ts-expect-error
 		nodeTypeStore.getNodeType = vi.fn(() => ({
 			type: 'n8n-nodes-base.function',
@@ -77,7 +77,6 @@ describe('NodeErrorView.vue', () => {
 			hidden: true,
 		}));
 
-		//@ts-expect-error
 		aiAssistantStore.canShowAssistantButtonsOnCanvas = true;
 
 		const { queryByTestId } = renderComponent({

--- a/packages/editor-ui/src/components/Error/NodeErrorView.test.ts
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.test.ts
@@ -3,7 +3,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import NodeErrorView from '@/components/Error/NodeErrorView.vue';
 
 import { createTestingPinia } from '@pinia/testing';
-import { type INode } from 'n8n-workflow';
+import type { NodeError } from 'n8n-workflow';
 import { useAssistantStore } from '@/stores/assistant.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { mockedStore } from '@/__tests__/utils';
@@ -14,28 +14,53 @@ let aiAssistantStore: ReturnType<typeof mockedStore<typeof useAssistantStore>>;
 let nodeTypeStore: ReturnType<typeof mockedStore<typeof useNodeTypesStore>>;
 
 describe('NodeErrorView.vue', () => {
-	let mockNode: INode;
+	let error: NodeError;
 
 	beforeEach(() => {
 		createTestingPinia();
 
 		aiAssistantStore = mockedStore(useAssistantStore);
 		nodeTypeStore = mockedStore(useNodeTypesStore);
+		//@ts-expect-error
+		error = {
+			name: 'NodeOperationError',
+			message: 'Test error message',
+			description: 'Test error description',
+			context: {
+				descriptionKey: 'noInputConnection',
+				nodeCause: 'Test node cause',
+				runIndex: '1',
+				itemIndex: '2',
+				parameter: 'testParameter',
+				data: { key: 'value' },
+				causeDetailed: 'Detailed cause',
+			},
+			node: {
+				parameters: {
+					mode: 'runOnceForAllItems',
+					language: 'javaScript',
+					jsCode: 'cons error = 9;',
+					notice: '',
+				},
+				id: 'd1ce5dc9-f9ae-4ac6-84e5-0696ba175dd9',
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				typeVersion: 2,
+				position: [940, 240],
+			},
+			messages: ['Test message 1', 'Test message 2'],
+			timestamp: Date.now(),
+			stack: 'Test stack trace',
+			findProperty: () => 'Test error data',
+			addToMessages: () => {},
+			setDescriptiveErrorMessage: () => [
+				'Test error data',
+				['Test raw message 1', 'Test raw message 2'],
+			],
+			lineNumber: 1,
+		};
 	});
 	afterEach(() => {
-		mockNode = {
-			parameters: {
-				mode: 'runOnceForAllItems',
-				language: 'javaScript',
-				jsCode: 'cons error = 9;',
-				notice: '',
-			},
-			id: 'd1ce5dc9-f9ae-4ac6-84e5-0696ba175dd9',
-			name: 'Code',
-			type: 'n8n-nodes-base.code',
-			typeVersion: 2,
-			position: [940, 240],
-		};
 		vi.clearAllMocks();
 	});
 
@@ -43,7 +68,7 @@ describe('NodeErrorView.vue', () => {
 		const { getByTestId } = renderComponent({
 			props: {
 				error: {
-					node: mockNode,
+					node: error.node,
 					messages: ['Unexpected identifier [line 1]'],
 				},
 			},
@@ -58,7 +83,7 @@ describe('NodeErrorView.vue', () => {
 		const { getByTestId } = renderComponent({
 			props: {
 				error: {
-					node: mockNode,
+					node: error.node,
 					message: 'Unexpected identifier [line 1]',
 				},
 			},
@@ -83,7 +108,7 @@ describe('NodeErrorView.vue', () => {
 			props: {
 				error: {
 					node: {
-						...mockNode,
+						...error.node,
 						type: 'n8n-nodes-base.function',
 						typeVersion: 1,
 					},
@@ -94,5 +119,28 @@ describe('NodeErrorView.vue', () => {
 		const aiAssistantButton = queryByTestId('ask-assistant-button');
 
 		expect(aiAssistantButton).toBeNull();
+	});
+
+	it('renders error message', () => {
+		const { getByTestId } = renderComponent({
+			props: { error },
+		});
+		expect(getByTestId('node-error-message').textContent).toContain('Test error message');
+	});
+
+	it('renders error description', () => {
+		const { getByTestId } = renderComponent({
+			props: { error },
+		});
+		expect(getByTestId('node-error-description').innerHTML).toContain(
+			'This node has no input data. Please make sure this node is connected to another node.',
+		);
+	});
+
+	it('renders stack trace', () => {
+		const { getByText } = renderComponent({
+			props: { error },
+		});
+		expect(getByText('Test stack trace')).toBeTruthy();
 	});
 });

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -381,7 +381,7 @@ function nodeIsHidden() {
 	return nodeType?.hidden ?? false;
 }
 
-const openErrorNodeDetail = () => {
+const onOpenErrorNodeDetailClick = () => {
 	ndvStore.activeNodeName = props.error.node.name;
 };
 
@@ -434,13 +434,13 @@ async function onAskAssistantClick() {
 					icon="arrow-right"
 					type="secondary"
 					:label="i18n.baseText('pushConnection.executionError.openNode')"
-					class="node-error-view__assistant-button"
-					@click="openErrorNodeDetail"
+					class="node-error-view__button"
+					@click="onOpenErrorNodeDetailClick"
 				/>
 			</div>
 			<div
 				v-if="isAskAssistantAvailable"
-				class="node-error-view__assistant-button"
+				class="node-error-view__button"
 				data-test-id="node-error-view-ask-assistant-button"
 			>
 				<InlineAskAssistantButton :asked="assistantAlreadyAsked" @click="onAskAssistantClick" />
@@ -701,9 +701,14 @@ async function onAskAssistantClick() {
 		}
 	}
 
-	&__assistant-button {
+	&__button {
 		margin-left: var(--spacing-s);
 		margin-bottom: var(--spacing-xs);
+		flex-direction: row-reverse;
+		span {
+			margin-right: var(--spacing-5xs);
+			margin-left: var(--spacing-5xs);
+		}
 	}
 
 	&__debugging {
@@ -836,7 +841,7 @@ async function onAskAssistantClick() {
 	}
 }
 
-.node-error-view__assistant-button {
+.node-error-view__button {
 	margin-top: var(--spacing-xs);
 }
 </style>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -435,6 +435,7 @@ async function onAskAssistantClick() {
 					type="secondary"
 					:label="i18n.baseText('pushConnection.executionError.openNode')"
 					class="node-error-view__button"
+					data-test-id="node-error-view-open-node-button"
 					@click="onOpenErrorNodeDetailClick"
 				/>
 			</div>

--- a/packages/editor-ui/src/components/Error/NodeErrorView.vue
+++ b/packages/editor-ui/src/components/Error/NodeErrorView.vue
@@ -117,7 +117,7 @@ const prepareRawMessages = computed(() => {
 });
 
 const isAskAssistantAvailable = computed(() => {
-	if (!node.value) {
+	if (!node.value || isSubNodeError.value) {
 		return false;
 	}
 	const isCustomNode = node.value.type === undefined || isCommunityPackageName(node.value.type);
@@ -130,6 +130,13 @@ const assistantAlreadyAsked = computed(() => {
 		error: assistantHelpers.simplifyErrorForAssistant(props.error),
 		node: props.error.node || ndvStore.activeNode,
 	});
+});
+
+const isSubNodeError = computed(() => {
+	return (
+		props.error.name === 'NodeOperationError' &&
+		(props.error as NodeOperationError).functionality === 'configuration-node'
+	);
 });
 
 function nodeVersionTag(nodeType: NodeError['node']): string {
@@ -153,19 +160,6 @@ function prepareDescription(description: string): string {
 }
 
 function getErrorDescription(): string {
-	const isSubNodeError =
-		props.error.name === 'NodeOperationError' &&
-		(props.error as NodeOperationError).functionality === 'configuration-node';
-
-	if (isSubNodeError) {
-		return prepareDescription(
-			props.error.description +
-				i18n.baseText('pushConnection.executionError.openNode', {
-					interpolate: { node: props.error.node.name },
-				}),
-		);
-	}
-
 	if (props.error.context?.descriptionKey) {
 		const interpolate = {
 			nodeCause: props.error.context.nodeCause as string,
@@ -205,13 +199,10 @@ function addItemIndexSuffix(message: string): string {
 function getErrorMessage(): string {
 	let message = '';
 
-	const isSubNodeError =
-		props.error.name === 'NodeOperationError' &&
-		(props.error as NodeOperationError).functionality === 'configuration-node';
 	const isNonEmptyString = (value?: unknown): value is string =>
 		!!value && typeof value === 'string';
 
-	if (isSubNodeError) {
+	if (isSubNodeError.value) {
 		message = i18n.baseText('nodeErrorView.errorSubNode', {
 			interpolate: { node: props.error.node.name },
 		});
@@ -390,6 +381,10 @@ function nodeIsHidden() {
 	return nodeType?.hidden ?? false;
 }
 
+const openErrorNodeDetail = () => {
+	ndvStore.activeNodeName = props.error.node.name;
+};
+
 async function onAskAssistantClick() {
 	const { message, lineNumber, description } = props.error;
 	const sessionInProgress = !assistantStore.isSessionEnded;
@@ -428,11 +423,21 @@ async function onAskAssistantClick() {
 				</div>
 			</div>
 			<div
-				v-if="error.description || error.context?.descriptionKey"
+				v-if="(error.description || error.context?.descriptionKey) && !isSubNodeError"
 				data-test-id="node-error-description"
 				class="node-error-view__header-description"
 				v-n8n-html="getErrorDescription()"
 			></div>
+
+			<div v-if="isSubNodeError">
+				<n8n-button
+					icon="arrow-right"
+					type="secondary"
+					:label="i18n.baseText('pushConnection.executionError.openNode')"
+					class="node-error-view__assistant-button"
+					@click="openErrorNodeDetail"
+				/>
+			</div>
 			<div
 				v-if="isAskAssistantAvailable"
 				class="node-error-view__assistant-button"

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1498,7 +1498,7 @@
 	"pushConnection.executionFailed": "Execution failed",
 	"pushConnection.executionFailed.message": "There might not be enough memory to finish the execution. Tips for avoiding this <a target=\"_blank\" href=\"https://docs.n8n.io/flow-logic/error-handling/memory-errors/\">here</a>",
 	"pushConnection.executionError": "There was a problem executing the workflow{error}",
-	"pushConnection.executionError.openNode": " <a data-action='openNodeDetail' data-action-parameter-node='{node}'>Open node</a>",
+	"pushConnection.executionError.openNode": "Open errored node",
 	"pushConnection.executionError.details": "<br /><strong>{details}</strong>",
 	"prompts.productTeamMessage": "Our product team will get in touch personally",
 	"prompts.npsSurvey.recommendationQuestion": "How likely are you to recommend n8n to a friend or colleague?",


### PR DESCRIPTION
## Summary

Show only error title and 'Open errored node' button; hide 'Ask Assistant' in root for sub-node errors
## Related Linear tickets, Github issues, and Community forum posts

[<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
](https://linear.app/n8n/issue/ADO-2730/feature-change-error-display-of-sub-node)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
