### PR TITLE
fix(editor): Prevent deleting a sticky note while editing (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/Sticky.vue
+++ b/packages/editor-ui/src/components/Sticky.vue
@@ -62,6 +62,7 @@ const isTouchActive = ref<boolean>(false);
 const forceActions = ref(false);
 const isColorPopoverVisible = ref(false);
 const stickOptions = ref<HTMLElement>();
+const isEditing = ref(false);
 
 const setForceActions = (value: boolean) => {
 	forceActions.value = value;
@@ -166,6 +167,8 @@ onMounted(() => {
 const onShowPopover = () => setForceActions(true);
 const onHidePopover = () => setForceActions(false);
 const deleteNode = async () => {
+	if (isEditing.value) return;
+
 	assert(data.value);
 	// Wait a tick else vue causes problems because the data is gone
 	await nextTick();
@@ -187,6 +190,7 @@ const changeColor = (index: number) => {
 };
 
 const onEdit = (edit: boolean) => {
+	isEditing.value = true;
 	if (edit && !props.isActive && node.value) {
 		ndvStore.activeNodeName = node.value.name;
 	} else if (props.isActive && !edit) {

--- a/packages/editor-ui/src/components/Sticky.vue
+++ b/packages/editor-ui/src/components/Sticky.vue
@@ -148,8 +148,13 @@ const workflowRunning = computed(() => uiStore.isActionActive.workflowRunning);
 
 const showActions = computed(
 	() =>
-		!(props.hideActions || props.isReadOnly || workflowRunning.value || isResizing.value) ||
-		forceActions.value,
+		!(
+			props.hideActions ||
+			isEditing.value ||
+			props.isReadOnly ||
+			workflowRunning.value ||
+			isResizing.value
+		) || forceActions.value,
 );
 
 onMounted(() => {
@@ -167,8 +172,6 @@ onMounted(() => {
 const onShowPopover = () => setForceActions(true);
 const onHidePopover = () => setForceActions(false);
 const deleteNode = async () => {
-	if (isEditing.value) return;
-
 	assert(data.value);
 	// Wait a tick else vue causes problems because the data is gone
 	await nextTick();
@@ -190,7 +193,7 @@ const changeColor = (index: number) => {
 };
 
 const onEdit = (edit: boolean) => {
-	isEditing.value = true;
+	isEditing.value = edit;
 	if (edit && !props.isActive && node.value) {
 		ndvStore.activeNodeName = node.value.name;
 	} else if (props.isActive && !edit) {

--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
@@ -3,6 +3,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { createCanvasNodeProvide } from '@/__tests__/data';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
+import { fireEvent } from '@testing-library/vue';
 
 const renderComponent = createComponentRenderer(CanvasNodeStickyNote);
 
@@ -41,5 +42,30 @@ describe('CanvasNodeStickyNote', () => {
 		const resizeControls = container.querySelectorAll('.vue-flow__resize-control');
 
 		expect(resizeControls).toHaveLength(0);
+	});
+
+	it('should disable sticky options when in edit mode', async () => {
+		const { container } = renderComponent({
+			global: {
+				provide: {
+					...createCanvasNodeProvide({
+						id: 'sticky',
+						readOnly: false,
+					}),
+				},
+			},
+		});
+
+		const stickyTextarea = container.querySelector('.sticky-textarea');
+
+		if (!stickyTextarea) return;
+
+		await fireEvent.dblClick(stickyTextarea);
+
+		const stickyOptions = container.querySelector('.sticky-options');
+
+		if (!stickyOptions) return;
+
+		expect(getComputedStyle(stickyOptions).display).toBe('none');
 	});
 });


### PR DESCRIPTION
## Summary

### Before

See video in ticket description -> https://linear.app/n8n/issue/ADO-2766/sticky-notes-deleted-when-dragging-highlighting-text

### After

![CleanShot 2024-11-05 at 19 51 07](https://github.com/user-attachments/assets/417c12f6-51e7-4d03-913e-abae5defd180)

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2766/sticky-notes-deleted-when-dragging-highlighting-text

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
