### PR TITLE
refactor(core): Minor improvements to pruning service

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -127,6 +127,9 @@ export const TIME = {
  * Eventually this will superseed `TIME` above
  */
 export const Time = {
+	milliseconds: {
+		toMinutes: 1 / (60 * 1000),
+	},
 	seconds: {
 		toMilliseconds: 1000,
 	},

--- a/packages/cli/src/services/orchestration.service.ts
+++ b/packages/cli/src/services/orchestration.service.ts
@@ -20,7 +20,7 @@ export class OrchestrationService {
 
 	private subscriber: Subscriber;
 
-	protected isInitialized = false;
+	isInitialized = false;
 
 	private isMultiMainSetupLicensed = false;
 

--- a/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
@@ -1,4 +1,4 @@
-import type { GlobalConfig } from '@n8n/config';
+import type { PruningConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 
@@ -8,9 +8,13 @@ import { mockLogger } from '@test/mocking';
 
 import { PruningService } from '../pruning.service';
 
+jest.mock('@/db', () => ({
+	connectionState: { migrated: true },
+}));
+
 describe('PruningService', () => {
 	describe('init', () => {
-		it('should start pruning if leader', () => {
+		it('should start pruning if leader main', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true }),
@@ -29,7 +33,7 @@ describe('PruningService', () => {
 			expect(startPruningSpy).toHaveBeenCalled();
 		});
 
-		it('should not start pruning if follower', () => {
+		it('should not start pruning if follower main', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false }),
@@ -48,7 +52,7 @@ describe('PruningService', () => {
 			expect(startPruningSpy).not.toHaveBeenCalled();
 		});
 
-		it('should register leadership events if multi-main setup is enabled', () => {
+		it('should register leadership events if main on multi-main setup', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true }),
@@ -88,13 +92,10 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: true } }),
+				mock<PruningConfig>({ isEnabled: true }),
 			);
 
-			// @ts-expect-error Private method
-			const isEnabled = pruningService.isEnabled();
-
-			expect(isEnabled).toBe(true);
+			expect(pruningService.isEnabled).toBe(true);
 		});
 
 		it('should return `false` based on config if leader main', () => {
@@ -107,16 +108,13 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: false } }),
+				mock<PruningConfig>({ isEnabled: false }),
 			);
 
-			// @ts-expect-error Private method
-			const isEnabled = pruningService.isEnabled();
-
-			expect(isEnabled).toBe(false);
+			expect(pruningService.isEnabled).toBe(false);
 		});
 
-		it('should return `false` if non-main even if enabled', () => {
+		it('should return `false` if non-main even if config is enabled', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false, instanceType: 'worker' }),
@@ -126,16 +124,13 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: true } }),
+				mock<PruningConfig>({ isEnabled: true }),
 			);
 
-			// @ts-expect-error Private method
-			const isEnabled = pruningService.isEnabled();
-
-			expect(isEnabled).toBe(false);
+			expect(pruningService.isEnabled).toBe(false);
 		});
 
-		it('should return `false` if follower main even if enabled', () => {
+		it('should return `false` if follower main even if config is enabled', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false, isFollower: true, instanceType: 'main' }),
@@ -145,13 +140,10 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: true }, multiMainSetup: { enabled: true } }),
+				mock<PruningConfig>({ isEnabled: true }),
 			);
 
-			// @ts-expect-error Private method
-			const isEnabled = pruningService.isEnabled();
-
-			expect(isEnabled).toBe(false);
+			expect(pruningService.isEnabled).toBe(false);
 		});
 	});
 
@@ -166,22 +158,25 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: false } }),
+				mock<PruningConfig>({ isEnabled: false }),
+			);
+
+			const scheduleRollingSoftDeletionsSpy = jest.spyOn(
+				pruningService,
+				// @ts-expect-error Private method
+				'scheduleRollingSoftDeletions',
 			);
 
 			// @ts-expect-error Private method
-			const setSoftDeletionInterval = jest.spyOn(pruningService, 'setSoftDeletionInterval');
-
-			// @ts-expect-error Private method
-			const scheduleHardDeletion = jest.spyOn(pruningService, 'scheduleHardDeletion');
+			const scheduleNextHardDeletionSpy = jest.spyOn(pruningService, 'scheduleNextHardDeletion');
 
 			pruningService.startPruning();
 
-			expect(setSoftDeletionInterval).not.toHaveBeenCalled();
-			expect(scheduleHardDeletion).not.toHaveBeenCalled();
+			expect(scheduleRollingSoftDeletionsSpy).not.toHaveBeenCalled();
+			expect(scheduleNextHardDeletionSpy).not.toHaveBeenCalled();
 		});
 
-		it('should start pruning if service is enabled', () => {
+		it('should start pruning if service is enabled and DB is migrated', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true, instanceType: 'main' }),
@@ -191,23 +186,23 @@ describe('PruningService', () => {
 					isMultiMainSetupEnabled: true,
 					multiMainSetup: mock<MultiMainSetup>(),
 				}),
-				mock<GlobalConfig>({ pruning: { isEnabled: true } }),
+				mock<PruningConfig>({ isEnabled: true }),
 			);
 
-			const setSoftDeletionInterval = jest
+			const scheduleRollingSoftDeletionsSpy = jest
 				// @ts-expect-error Private method
-				.spyOn(pruningService, 'setSoftDeletionInterval')
+				.spyOn(pruningService, 'scheduleRollingSoftDeletions')
 				.mockImplementation();
 
-			const scheduleHardDeletion = jest
+			const scheduleNextHardDeletionSpy = jest
 				// @ts-expect-error Private method
-				.spyOn(pruningService, 'scheduleHardDeletion')
+				.spyOn(pruningService, 'scheduleNextHardDeletion')
 				.mockImplementation();
 
 			pruningService.startPruning();
 
-			expect(setSoftDeletionInterval).toHaveBeenCalled();
-			expect(scheduleHardDeletion).toHaveBeenCalled();
+			expect(scheduleRollingSoftDeletionsSpy).toHaveBeenCalled();
+			expect(scheduleNextHardDeletionSpy).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
@@ -14,7 +14,7 @@ jest.mock('@/db', () => ({
 
 describe('PruningService', () => {
 	describe('init', () => {
-		it('should start pruning if leader main', () => {
+		it('should start pruning on main instance that is the leader', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: true }),

--- a/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
+++ b/packages/cli/src/services/pruning/__tests__/pruning.service.test.ts
@@ -33,7 +33,7 @@ describe('PruningService', () => {
 			expect(startPruningSpy).toHaveBeenCalled();
 		});
 
-		it('should not start pruning if follower main', () => {
+		it('should not start pruning on main instance that is a follower', () => {
 			const pruningService = new PruningService(
 				mockLogger(),
 				mock<InstanceSettings>({ isLeader: false }),

--- a/packages/cli/src/services/pruning/pruning.service.ts
+++ b/packages/cli/src/services/pruning/pruning.service.ts
@@ -149,7 +149,7 @@ export class PruningService {
 		}
 
 		// if high volume, speed up next hard-deletion
-		if (executionIds.length >= this.batchSize) return 1_000;
+		if (executionIds.length >= this.batchSize) return 1 * Time.seconds.toMilliseconds;
 
 		return this.rates.hardDeletion;
 	}

--- a/packages/cli/test/integration/pruning.service.test.ts
+++ b/packages/cli/test/integration/pruning.service.test.ts
@@ -1,4 +1,4 @@
-import { GlobalConfig } from '@n8n/config';
+import { PruningConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import { BinaryDataService, InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus } from 'n8n-workflow';
@@ -27,19 +27,19 @@ describe('softDeleteOnPruningCycle()', () => {
 	const now = new Date();
 	const yesterday = new Date(Date.now() - TIME.DAY);
 	let workflow: WorkflowEntity;
-	let globalConfig: GlobalConfig;
+	let pruningConfig: PruningConfig;
 
 	beforeAll(async () => {
 		await testDb.init();
 
-		globalConfig = Container.get(GlobalConfig);
+		pruningConfig = Container.get(PruningConfig);
 		pruningService = new PruningService(
 			mockLogger(),
 			instanceSettings,
 			Container.get(ExecutionRepository),
 			mockInstance(BinaryDataService),
 			mock(),
-			globalConfig,
+			pruningConfig,
 		);
 
 		workflow = await createWorkflow();
@@ -62,8 +62,8 @@ describe('softDeleteOnPruningCycle()', () => {
 
 	describe('when EXECUTIONS_DATA_PRUNE_MAX_COUNT is set', () => {
 		beforeAll(() => {
-			globalConfig.pruning.maxAge = 336;
-			globalConfig.pruning.maxCount = 1;
+			pruningConfig.maxAge = 336;
+			pruningConfig.maxCount = 1;
 		});
 
 		test('should mark as deleted based on EXECUTIONS_DATA_PRUNE_MAX_COUNT', async () => {
@@ -73,7 +73,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -92,7 +92,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -113,7 +113,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -132,7 +132,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -150,7 +150,7 @@ describe('softDeleteOnPruningCycle()', () => {
 
 			await annotateExecution(executions[0].id, { vote: 'up' }, [workflow.id]);
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -163,8 +163,8 @@ describe('softDeleteOnPruningCycle()', () => {
 
 	describe('when EXECUTIONS_DATA_MAX_AGE is set', () => {
 		beforeAll(() => {
-			globalConfig.pruning.maxAge = 1;
-			globalConfig.pruning.maxCount = 0;
+			pruningConfig.maxAge = 1;
+			pruningConfig.maxCount = 0;
 		});
 
 		test('should mark as deleted based on EXECUTIONS_DATA_MAX_AGE', async () => {
@@ -179,7 +179,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -203,7 +203,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -221,7 +221,7 @@ describe('softDeleteOnPruningCycle()', () => {
 		])('should prune %s executions', async (status, attributes) => {
 			const execution = await createExecution({ status, ...attributes }, workflow);
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -239,7 +239,7 @@ describe('softDeleteOnPruningCycle()', () => {
 				await createSuccessfulExecution(workflow),
 			];
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([
@@ -266,7 +266,7 @@ describe('softDeleteOnPruningCycle()', () => {
 
 			await annotateExecution(executions[0].id, { vote: 'up' }, [workflow.id]);
 
-			await pruningService.softDeleteOnPruningCycle();
+			await pruningService.softDelete();
 
 			const result = await findAllExecutions();
 			expect(result).toEqual([


### PR DESCRIPTION
- Simplify `isEnabled`
- Rename for clarity, add doclines
- Turn assumptions in comments into runtime checks
- Remove excess logs
- Use `PruningConfig` instead of `GlobalConfig`
- Use `ensureError` util
- Use `Time` constant