### PR TITLE
fix(editor): Keep workflow pristine after load on new canvas

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -7,7 +7,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeHelpers } from 'n8n-workflow';
 import { useCanvasOperations } from '@/composables/useCanvasOperations';
-import type { CanvasNode } from '@/types';
+import type { CanvasConnection, CanvasNode } from '@/types';
 import { CanvasConnectionMode } from '@/types';
 import type { ICredentialsResponse, INodeUi, IWorkflowDb } from '@/Interface';
 import { RemoveNodeCommand } from '@/models/history';
@@ -648,6 +648,48 @@ describe('useCanvasOperations', () => {
 			const added = await addNodes(nodes, {});
 			expect(added.length).toBe(2);
 		});
+
+		it('should mark UI state as dirty', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const uiStore = mockedStore(useUIStore);
+			const nodeTypesStore = useNodeTypesStore();
+			const nodeTypeName = 'type';
+			const nodes = [mockNode({ name: 'Node 1', type: nodeTypeName, position: [30, 40] })];
+
+			workflowsStore.getCurrentWorkflow.mockReturnValue(
+				createTestWorkflowObject(workflowsStore.workflow),
+			);
+
+			nodeTypesStore.nodeTypes = {
+				[nodeTypeName]: { 1: mockNodeTypeDescription({ name: nodeTypeName }) },
+			};
+
+			const { addNodes } = useCanvasOperations({ router });
+			await addNodes(nodes, { keepPristine: false });
+
+			expect(uiStore.stateIsDirty).toEqual(true);
+		});
+
+		it('should not mark UI state as dirty if keepPristine is true', async () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const uiStore = mockedStore(useUIStore);
+			const nodeTypesStore = useNodeTypesStore();
+			const nodeTypeName = 'type';
+			const nodes = [mockNode({ name: 'Node 1', type: nodeTypeName, position: [30, 40] })];
+
+			workflowsStore.getCurrentWorkflow.mockReturnValue(
+				createTestWorkflowObject(workflowsStore.workflow),
+			);
+
+			nodeTypesStore.nodeTypes = {
+				[nodeTypeName]: { 1: mockNodeTypeDescription({ name: nodeTypeName }) },
+			};
+
+			const { addNodes } = useCanvasOperations({ router });
+			await addNodes(nodes, { keepPristine: true });
+
+			expect(uiStore.stateIsDirty).toEqual(false);
+		});
 	});
 
 	describe('revertAddNode', () => {
@@ -1043,6 +1085,26 @@ describe('useCanvasOperations', () => {
 				],
 			});
 		});
+
+		it('should set UI state as dirty', async () => {
+			const uiStore = mockedStore(useUIStore);
+			const connections: CanvasConnection[] = [];
+
+			const { addConnections } = useCanvasOperations({ router });
+			await addConnections(connections, { keepPristine: false });
+
+			expect(uiStore.stateIsDirty).toBe(true);
+		});
+
+		it('should not set UI state as dirty if keepPristine is true', async () => {
+			const uiStore = mockedStore(useUIStore);
+			const connections: CanvasConnection[] = [];
+
+			const { addConnections } = useCanvasOperations({ router });
+			await addConnections(connections, { keepPristine: true });
+
+			expect(uiStore.stateIsDirty).toBe(false);
+		});
 	});
 
 	describe('createConnection', () => {
@@ -1131,6 +1193,57 @@ describe('useCanvasOperations', () => {
 				],
 			});
 			expect(uiStore.stateIsDirty).toBe(true);
+		});
+
+		it('should not set UI state as dirty if keepPristine is true', () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const uiStore = mockedStore(useUIStore);
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+
+			const nodeTypeDescription = mockNodeTypeDescription({
+				name: SET_NODE_TYPE,
+				inputs: [NodeConnectionType.Main],
+				outputs: [NodeConnectionType.Main],
+			});
+
+			const nodeA = createTestNode({
+				id: 'a',
+				type: nodeTypeDescription.name,
+				name: 'Node A',
+			});
+
+			const nodeB = createTestNode({
+				id: 'b',
+				type: nodeTypeDescription.name,
+				name: 'Node B',
+			});
+
+			const connection: Connection = {
+				source: nodeA.id,
+				sourceHandle: `outputs/${NodeConnectionType.Main}/0`,
+				target: nodeB.id,
+				targetHandle: `inputs/${NodeConnectionType.Main}/0`,
+			};
+
+			nodeTypesStore.nodeTypes = {
+				node: { 1: nodeTypeDescription },
+			};
+
+			workflowsStore.workflow.nodes = [nodeA, nodeB];
+			workflowsStore.getNodeById.mockReturnValueOnce(nodeA).mockReturnValueOnce(nodeB);
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
+
+			const workflowObject = createTestWorkflowObject(workflowsStore.workflow);
+			workflowsStore.getCurrentWorkflow.mockReturnValue(workflowObject);
+
+			const { createConnection, editableWorkflowObject } = useCanvasOperations({ router });
+
+			editableWorkflowObject.value.nodes[nodeA.name] = nodeA;
+			editableWorkflowObject.value.nodes[nodeB.name] = nodeB;
+
+			createConnection(connection, { keepPristine: true });
+
+			expect(uiStore.stateIsDirty).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/77605991-2673-4156-8941-e8fd2c0a9c05



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7885/bug-opening-workflow-marks-it-as-unsaved

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
