### PR TITLE
test(core): Add LDAP service unit tests (no-changelog)

### DIFF
--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1,0 +1,180 @@
+import { mock } from 'jest-mock-extended';
+import { LdapService } from '@/ldap/ldap.service.ee';
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
+import { Settings } from '@/databases/entities/settings';
+import { Logger } from '@/logging/logger.service';
+import type { LdapConfig } from '@/ldap/types';
+import { mockInstance } from '@test/mocking';
+import config from '@/config';
+import { LDAP_LOGIN_ENABLED, LDAP_LOGIN_LABEL } from '@/ldap/constants';
+import { sync } from 'fast-glob';
+
+// Need fake timers to avoid setInterval
+// problems with the scheduled sync
+jest.useFakeTimers();
+
+describe('LdapService', () => {
+	const OLD_ENV = process.env;
+
+	const fakeConfig: LdapConfig = {
+		loginEnabled: true,
+		loginLabel: 'fakeLoginLabel',
+		connectionUrl: 'https://connection.url',
+		allowUnauthorizedCerts: true,
+		connectionSecurity: 'none',
+		connectionPort: 1234,
+		baseDn: 'dc=example,dc=com',
+		bindingAdminDn: 'uid=jdoe,ou=users,dc=example,dc=com',
+		bindingAdminPassword: 'fakePassword',
+		firstNameAttribute: 'givenName',
+		lastNameAttribute: 'sn',
+		emailAttribute: 'mail',
+		loginIdAttribute: 'uid',
+		ldapIdAttribute: 'uid',
+		userFilter: '',
+		synchronizationEnabled: true,
+		synchronizationInterval: 60,
+		searchPageSize: 1,
+		searchTimeout: 6,
+	};
+
+	beforeEach(() => {
+		process.env = { ...OLD_ENV };
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+
+		process.env = OLD_ENV;
+	});
+
+	describe('init()', () => {
+		it('should load the ldap configuration', async () => {
+			const settingsRepo = mockInstance(SettingsRepository);
+
+			const ldapService = new LdapService(mock(), settingsRepo, mock(), mock());
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(fakeConfig),
+			} as Settings);
+			const loadConfigSpy = jest.spyOn(ldapService, 'loadConfig');
+
+			await ldapService.init();
+
+			expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should set expected configuration variables from LDAP config if ldap is enabled', async () => {
+			const settingsRepo = mockInstance(SettingsRepository);
+			const mockLogger = mock<Logger>();
+
+			const ldapService = new LdapService(mockLogger, settingsRepo, mock(), mock());
+
+			const configSetSpy = jest.spyOn(config, 'set');
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(fakeConfig),
+			} as Settings);
+
+			await ldapService.init();
+
+			expect(configSetSpy).toHaveBeenNthCalledWith(1, LDAP_LOGIN_ENABLED, fakeConfig.loginEnabled);
+			expect(configSetSpy).toHaveBeenNthCalledWith(
+				2,
+				'userManagement.authenticationMethod',
+				'ldap',
+			);
+			expect(configSetSpy).toHaveBeenNthCalledWith(3, LDAP_LOGIN_LABEL, fakeConfig.loginLabel);
+		});
+
+		it('should set expected configuration variables from LDAP config if ldap is not enabled', async () => {
+			const givenConfig = { ...fakeConfig, loginEnabled: false };
+
+			const settingsRepo = mockInstance(SettingsRepository);
+			const mockLogger = mock<Logger>();
+
+			const ldapService = new LdapService(mockLogger, settingsRepo, mock(), mock());
+
+			const configSetSpy = jest.spyOn(config, 'set');
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(givenConfig),
+			} as Settings);
+
+			await ldapService.init();
+
+			expect(configSetSpy).toHaveBeenNthCalledWith(1, LDAP_LOGIN_ENABLED, givenConfig.loginEnabled);
+			expect(configSetSpy).toHaveBeenNthCalledWith(
+				2,
+				'userManagement.authenticationMethod',
+				'email',
+			);
+			expect(configSetSpy).toHaveBeenNthCalledWith(3, LDAP_LOGIN_LABEL, givenConfig.loginLabel);
+		});
+
+		it('should show logger warning if authentication method is not ldap or email', async () => {
+			const settingsRepo = mockInstance(SettingsRepository);
+			const mockLogger = mock<Logger>();
+
+			const ldapService = new LdapService(mockLogger, settingsRepo, mock(), mock());
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(fakeConfig),
+			} as Settings);
+			config.set('userManagement.authenticationMethod', 'invalid');
+
+			await ldapService.init();
+
+			expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				'Cannot set LDAP login enabled state when an authentication method other than email or ldap is active (current: invalid)',
+				expect.any(Error),
+			);
+		});
+
+		it('should schedule syncing if config has enabled synchronization', async () => {
+			const givenConfig = {
+				...fakeConfig,
+				synchronizationEnabled: true,
+				synchronizationInterval: 10,
+			};
+			const settingsRepo = mockInstance(SettingsRepository);
+			const mockLogger = mock<Logger>();
+
+			const ldapService = new LdapService(mockLogger, settingsRepo, mock(), mock());
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(givenConfig),
+			} as Settings);
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+			await ldapService.init();
+
+			expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+			expect(setIntervalSpy).toHaveBeenCalledWith(
+				expect.any(Function),
+				givenConfig.synchronizationInterval * 60000,
+			);
+		});
+
+		it('should throw an error if config has enabled synchronization but no synchronizationInterval is set', async () => {
+			const givenConfig = {
+				...fakeConfig,
+				synchronizationEnabled: true,
+				synchronizationInterval: 0,
+			};
+			const settingsRepo = mockInstance(SettingsRepository);
+			const mockLogger = mock<Logger>();
+
+			const ldapService = new LdapService(mockLogger, settingsRepo, mock(), mock());
+
+			settingsRepo.findOneByOrFail.mockResolvedValue({
+				value: JSON.stringify(givenConfig),
+			} as Settings);
+			const setIntervalSpy = jest.spyOn(global, 'setInterval');
+
+			await expect(ldapService.init()).rejects.toThrowError('Interval variable has to be defined');
+			expect(setIntervalSpy).toHaveBeenCalledTimes(0);
+		});
+	});
+});

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -1389,13 +1389,11 @@ describe('LdapService', () => {
 
 	describe('stopSync()', () => {
 		it('should clear the scheduled timer', async () => {
-			const givenConfig = {
+			const ldapService = createDefaultLdapService({
 				...ldapConfig,
 				synchronizationEnabled: true,
 				synchronizationInterval: 10,
-			};
-
-			const ldapService = createDefaultLdapService(givenConfig);
+			});
 
 			const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
 

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -91,10 +91,14 @@ describe('LdapService', () => {
 		jest.restoreAllMocks();
 	});
 
-	const createDefaultLdapService = (config: LdapConfig) => {
+	const mockSettingsRespositoryFindOneByOrFail = (config: LdapConfig) => {
 		settingsRepository.findOneByOrFail.mockResolvedValueOnce({
 			value: JSON.stringify(config),
 		} as Settings);
+	};
+
+	const createDefaultLdapService = (config: LdapConfig) => {
+		mockSettingsRespositoryFindOneByOrFail(config);
 
 		return new LdapService(mockLogger(), settingsRepository, mock(), mock());
 	};
@@ -145,9 +149,7 @@ describe('LdapService', () => {
 		});
 
 		it('should show logger warning if authentication method is not ldap or email', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const logger = mockLogger();
 
@@ -218,9 +220,7 @@ describe('LdapService', () => {
 		});
 
 		it('should decipher the LDAP configuration admin password', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn(),
@@ -235,9 +235,7 @@ describe('LdapService', () => {
 		});
 
 		it('should return the expected LDAP configuration', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -273,9 +271,7 @@ describe('LdapService', () => {
 		});
 
 		it('should encrypt the binding admin password', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				encrypt: jest.fn().mockReturnValue('encryptedPassword'),
@@ -293,9 +289,7 @@ describe('LdapService', () => {
 		});
 
 		it('should delete all ldap identities if login is disabled and ldap users exist', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const authIdentityRepository = mockInstance(AuthIdentityRepository, {
 				find: jest.fn().mockResolvedValue([{ user: { id: 'userId' } }]),
@@ -318,9 +312,7 @@ describe('LdapService', () => {
 		});
 
 		it('should not delete ldap identities if login is disabled and there are no ldap identities', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const authIdentityRepository = mockInstance(AuthIdentityRepository, {
 				find: jest.fn().mockResolvedValue([]),
@@ -343,9 +335,7 @@ describe('LdapService', () => {
 		});
 
 		it('should update the LDAP configuration in the settings repository', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			mockInstance(AuthIdentityRepository, {
 				find: jest.fn().mockResolvedValue([{ user: { id: 'userId' } }]),
@@ -370,9 +360,7 @@ describe('LdapService', () => {
 		});
 
 		it('should update the LDAP login label in the config', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			mockInstance(AuthIdentityRepository, {
 				find: jest.fn().mockResolvedValue([{ user: { id: 'userId' } }]),
@@ -486,9 +474,7 @@ describe('LdapService', () => {
 
 	describe('searchWithAdminBinding()', () => {
 		it('should bind admin client', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -511,9 +497,7 @@ describe('LdapService', () => {
 		});
 
 		it('should call client search with expected parameters', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -545,9 +529,7 @@ describe('LdapService', () => {
 		});
 
 		it('should call client search with expected parameters when searchPageSize is 0', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify({ ...ldapConfig, searchPageSize: 0 }),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail({ ...ldapConfig, searchPageSize: 0 });
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -579,9 +561,7 @@ describe('LdapService', () => {
 		});
 
 		it('should unbind client after search', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -600,9 +580,7 @@ describe('LdapService', () => {
 		});
 
 		it('should return expected search entries', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const cipherMock = mock<Cipher>({
 				decrypt: jest.fn().mockReturnValue('decryptedPassword'),
@@ -719,9 +697,7 @@ describe('LdapService', () => {
 		});
 
 		it('should emit expected error if admin search fails', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const eventServiceMock = mock<EventService>({
 				emit: jest.fn(),
@@ -1283,9 +1259,7 @@ describe('LdapService', () => {
 		});
 
 		it('should emit expected event if synchronization is enabled', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const eventServiceMock = mock<EventService>({
 				emit: jest.fn(),
@@ -1315,9 +1289,7 @@ describe('LdapService', () => {
 		});
 
 		it('should emit expected event if synchronization is disabled', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const eventServiceMock = mock<EventService>({
 				emit: jest.fn(),
@@ -1348,9 +1320,7 @@ describe('LdapService', () => {
 		});
 
 		it('should emit expected event with error message if processUsers fails', async () => {
-			settingsRepository.findOneByOrFail.mockResolvedValueOnce({
-				value: JSON.stringify(ldapConfig),
-			} as Settings);
+			mockSettingsRespositoryFindOneByOrFail(ldapConfig);
 
 			const eventServiceMock = mock<EventService>({
 				emit: jest.fn(),

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -874,7 +874,19 @@ describe('LdapService', () => {
 		});
 	});
 
-	describe.skip('runSync()', () => {});
+	describe('runSync()', () => {
+		it.todo('should search for users with expected parameters');
+		it.todo('should resolve binary attributes');
+		it.todo('should throw expected error if search fails');
+		it.todo('should process users if mode is "live"');
+		it.todo('should write expected data to the database');
+		it.todo(
+			'should write expected data to the database with an error message if processing users fails',
+		);
+		it.todo('should emit expected event if synchronization is enabled');
+		it.todo('should emit expected event if synchronization is disabled');
+	});
+
 	describe('stopSync()', () => {
 		it('should clear the scheduled timer', async () => {
 			const givenConfig = {

--- a/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
+++ b/packages/cli/src/ldap.ee/__tests__/ldap.service.test.ts
@@ -9,16 +9,14 @@ import type { Settings } from '@/databases/entities/settings';
 import { AuthIdentityRepository } from '@/databases/repositories/auth-identity.repository';
 import { SettingsRepository } from '@/databases/repositories/settings.repository';
 import type { EventService } from '@/events/event.service';
+import { mockInstance, mockLogger } from '@test/mocking';
+
 import {
 	BINARY_AD_ATTRIBUTES,
 	LDAP_LOGIN_ENABLED,
 	LDAP_LOGIN_LABEL,
 	LDAP_FEATURE_NAME,
-} from '@/ldap/constants';
-import { LdapService } from '@/ldap/ldap.service.ee';
-import type { LdapConfig } from '@/ldap/types';
-import { mockInstance, mockLogger } from '@test/mocking';
-
+} from '../constants';
 import {
 	getLdapIds,
 	createFilter,
@@ -29,6 +27,8 @@ import {
 	saveLdapSynchronization,
 	resolveEntryBinaryAttributes,
 } from '../helpers.ee';
+import { LdapService } from '../ldap.service.ee';
+import type { LdapConfig } from '../types';
 
 // Mock ldapts client
 jest.mock('ldapts', () => {


### PR DESCRIPTION
## Summary

This PR introduces initial unit tests for our LDAP service. Since our LDAP implementation currently lacks good test coverage, these tests are my first step in understanding and improving it. I’m also using this as a way to deepen my knowledge of LDAP and explore the best testing approach for services.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
