### PR TITLE
fix: Rapid7 InsightVM copy tweaks and docs url (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/Rapid7InsightVmApi.credentials.ts
+++ b/packages/nodes-base/credentials/Rapid7InsightVmApi.credentials.ts
@@ -8,9 +8,9 @@ import type {
 export class Rapid7InsightVmApi implements ICredentialType {
 	name = 'rapid7InsightVmApi';
 
-	displayName = 'Rapid7 InsightVm API';
+	displayName = 'Rapid7 InsightVM API';
 
-	documentationUrl = 'Rapid7 InsightVm';
+	documentationUrl = 'rapid7insightvm';
 
 	icon = {
 		light: 'file:icons/Rapid7InsightVm.svg',
@@ -18,7 +18,7 @@ export class Rapid7InsightVmApi implements ICredentialType {
 	} as const;
 
 	httpRequestNode = {
-		name: 'Rapid7 Insight Vm',
+		name: 'Rapid7 InsightVM',
 		docsUrl: 'https://docs.rapid7.com/',
 		apiBaseUrlPlaceholder: 'https://insight.rapid7.com/',
 	};


### PR DESCRIPTION
## Summary
Changes the Node name to match company branding and fixes docs url

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1948/community-pr-add-rapid7-insightvm-credentials

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
