### PR TITLE
fix(core): Include `projectId` in range query middleware

### DIFF
--- a/packages/cli/src/executions/__tests__/parse-range-query.middleware.test.ts
+++ b/packages/cli/src/executions/__tests__/parse-range-query.middleware.test.ts
@@ -108,6 +108,22 @@ describe('`parseRangeQuery` middleware', () => {
 			expect(nextFn).toBeCalledTimes(1);
 		});
 
+		test('should parse `projectId` field', () => {
+			const req = mock<ExecutionRequest.GetMany>({
+				query: {
+					filter: '{ "projectId": "123" }',
+					limit: undefined,
+					firstId: undefined,
+					lastId: undefined,
+				},
+			});
+
+			parseRangeQuery(req, res, nextFn);
+
+			expect(req.rangeQuery.projectId).toBe('123');
+			expect(nextFn).toBeCalledTimes(1);
+		});
+
 		test('should delete invalid fields', () => {
 			const req = mock<ExecutionRequest.GetMany>({
 				query: {

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -66,6 +66,7 @@ export const schemaGetExecutionsQueryFilter = {
 		startedBefore: { type: 'date-time' },
 		annotationTags: { type: 'array', items: { type: 'string' } },
 		vote: { type: 'string' },
+		projectId: { type: 'string' },
 	},
 	$defs: {
 		metadata: {


### PR DESCRIPTION
Follow-up to #10976

This was not caught in that PR as those tests were for logic after middleware.

Context: https://n8nio.slack.com/archives/C04B1GZ4T0U/p1730894474755699