### PR TITLE
fix: Fix loading workflows with `null` connection value (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/canvasUtilsV2.test.ts
+++ b/packages/editor-ui/src/utils/canvasUtilsV2.test.ts
@@ -7,12 +7,8 @@ import {
 	parseCanvasConnectionHandleString,
 	checkOverlap,
 } from '@/utils/canvasUtilsV2';
-import {
-	IConnection,
-	type IConnections,
-	type INodeTypeDescription,
-	NodeConnectionType,
-} from 'n8n-workflow';
+import { NodeConnectionType } from 'n8n-workflow';
+import type { IConnections, INodeTypeDescription, IConnection } from 'n8n-workflow';
 import type { CanvasConnection } from '@/types';
 import { CanvasConnectionMode } from '@/types';
 import type { INodeUi } from '@/Interface';

--- a/packages/editor-ui/src/utils/canvasUtilsV2.ts
+++ b/packages/editor-ui/src/utils/canvasUtilsV2.ts
@@ -20,8 +20,8 @@ export function mapLegacyConnectionsToCanvasConnections(
 
 		fromConnectionTypes.forEach((fromConnectionType) => {
 			const fromPorts = legacyConnections[fromNodeName][fromConnectionType];
-			fromPorts.forEach((toPorts, fromIndex) => {
-				toPorts.forEach((toPort) => {
+			fromPorts?.forEach((toPorts, fromIndex) => {
+				toPorts?.forEach((toPort) => {
 					const toId = nodes.find((node) => node.name === toPort.node)?.id ?? '';
 					const toConnectionType = toPort.type as NodeConnectionType;
 					const toIndex = toPort.index;

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -177,9 +177,13 @@ export class Workflow {
 					continue;
 				}
 				for (const inputIndex in connections[sourceNode][type]) {
-					if (!connections[sourceNode][type].hasOwnProperty(inputIndex)) {
+					if (
+						!connections[sourceNode][type].hasOwnProperty(inputIndex) ||
+						!connections[sourceNode][type][inputIndex]
+					) {
 						continue;
 					}
+
 					for (connectionInfo of connections[sourceNode][type][inputIndex]) {
 						if (!returnConnection.hasOwnProperty(connectionInfo.node)) {
 							returnConnection[connectionInfo.node] = {};

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -165,6 +165,8 @@ export class Workflow {
 	__getConnectionsByDestination(connections: IConnections): IConnections {
 		const returnConnection: IConnections = {};
 
+		console.log({ connections });
+
 		let connectionInfo;
 		let maxIndex: number;
 		for (const sourceNode in connections) {
@@ -177,14 +179,11 @@ export class Workflow {
 					continue;
 				}
 				for (const inputIndex in connections[sourceNode][type]) {
-					if (
-						!connections[sourceNode][type].hasOwnProperty(inputIndex) ||
-						!connections[sourceNode][type][inputIndex]
-					) {
+					if (!connections[sourceNode][type].hasOwnProperty(inputIndex)) {
 						continue;
 					}
 
-					for (connectionInfo of connections[sourceNode][type][inputIndex]) {
+					for (connectionInfo of connections[sourceNode][type][inputIndex] ?? []) {
 						if (!returnConnection.hasOwnProperty(connectionInfo.node)) {
 							returnConnection[connectionInfo.node] = {};
 						}

--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -165,8 +165,6 @@ export class Workflow {
 	__getConnectionsByDestination(connections: IConnections): IConnections {
 		const returnConnection: IConnections = {};
 
-		console.log({ connections });
-
 		let connectionInfo;
 		let maxIndex: number;
 		for (const sourceNode in connections) {

--- a/packages/workflow/test/Workflow.test.ts
+++ b/packages/workflow/test/Workflow.test.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 
-import { NodeConnectionType } from '@/Interfaces';
+import { IConnection, NodeConnectionType } from '@/Interfaces';
 import type {
 	IBinaryKeyData,
 	IConnections,
@@ -2082,6 +2082,156 @@ describe('Workflow', () => {
 
 			abortController.abort();
 			expect(triggerResponse.closeFunction).toHaveBeenCalled();
+		});
+	});
+
+	describe('__getConnectionsByDestination', () => {
+		it('should return empty object when there are no connections', () => {
+			const workflow = new Workflow({
+				nodes: [],
+				connections: {},
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+
+			const result = workflow.__getConnectionsByDestination({});
+
+			expect(result).toEqual({});
+		});
+
+		it('should return connections by destination node', () => {
+			const connections: IConnections = {
+				Node1: {
+					[NodeConnectionType.Main]: [
+						[
+							{ node: 'Node2', type: NodeConnectionType.Main, index: 0 },
+							{ node: 'Node3', type: NodeConnectionType.Main, index: 1 },
+						],
+					],
+				},
+			};
+			const workflow = new Workflow({
+				nodes: [],
+				connections,
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+			const result = workflow.__getConnectionsByDestination(connections);
+			expect(result).toEqual({
+				Node2: {
+					[NodeConnectionType.Main]: [[{ node: 'Node1', type: NodeConnectionType.Main, index: 0 }]],
+				},
+				Node3: {
+					[NodeConnectionType.Main]: [
+						[],
+						[{ node: 'Node1', type: NodeConnectionType.Main, index: 0 }],
+					],
+				},
+			});
+		});
+
+		it('should handle multiple connection types', () => {
+			const connections: IConnections = {
+				Node1: {
+					[NodeConnectionType.Main]: [[{ node: 'Node2', type: NodeConnectionType.Main, index: 0 }]],
+					[NodeConnectionType.AiAgent]: [
+						[{ node: 'Node3', type: NodeConnectionType.AiAgent, index: 0 }],
+					],
+				},
+			};
+
+			const workflow = new Workflow({
+				nodes: [],
+				connections,
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+
+			const result = workflow.__getConnectionsByDestination(connections);
+			expect(result).toEqual({
+				Node2: {
+					[NodeConnectionType.Main]: [[{ node: 'Node1', type: NodeConnectionType.Main, index: 0 }]],
+				},
+				Node3: {
+					[NodeConnectionType.AiAgent]: [
+						[{ node: 'Node1', type: NodeConnectionType.AiAgent, index: 0 }],
+					],
+				},
+			});
+		});
+
+		it('should handle nodes with no connections', () => {
+			const connections: IConnections = {
+				Node1: {
+					[NodeConnectionType.Main]: [[]],
+				},
+			};
+
+			const workflow = new Workflow({
+				nodes: [],
+				connections,
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+
+			const result = workflow.__getConnectionsByDestination(connections);
+			expect(result).toEqual({});
+		});
+
+		// @issue https://linear.app/n8n/issue/N8N-7880/cannot-load-some-templates
+		it('should handle nodes with null connections', () => {
+			const connections: IConnections = {
+				Node1: {
+					[NodeConnectionType.Main]: [
+						null as unknown as IConnection[],
+						[{ node: 'Node2', type: NodeConnectionType.Main, index: 0 }],
+					],
+				},
+			};
+
+			const workflow = new Workflow({
+				nodes: [],
+				connections,
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+
+			const result = workflow.__getConnectionsByDestination(connections);
+			expect(result).toEqual({
+				Node2: {
+					[NodeConnectionType.Main]: [[{ node: 'Node1', type: NodeConnectionType.Main, index: 1 }]],
+				},
+			});
+		});
+
+		it('should handle nodes with multiple input connections', () => {
+			const connections: IConnections = {
+				Node1: {
+					[NodeConnectionType.Main]: [[{ node: 'Node2', type: NodeConnectionType.Main, index: 0 }]],
+				},
+				Node3: {
+					[NodeConnectionType.Main]: [[{ node: 'Node2', type: NodeConnectionType.Main, index: 0 }]],
+				},
+			};
+
+			const workflow = new Workflow({
+				nodes: [],
+				connections,
+				active: false,
+				nodeTypes: mock<INodeTypes>(),
+			});
+
+			const result = workflow.__getConnectionsByDestination(connections);
+			expect(result).toEqual({
+				Node2: {
+					[NodeConnectionType.Main]: [
+						[
+							{ node: 'Node1', type: NodeConnectionType.Main, index: 0 },
+							{ node: 'Node3', type: NodeConnectionType.Main, index: 0 },
+						],
+					],
+				},
+			});
 		});
 	});
 });

--- a/packages/workflow/test/Workflow.test.ts
+++ b/packages/workflow/test/Workflow.test.ts
@@ -1,6 +1,7 @@
 import { mock } from 'jest-mock-extended';
 
-import { IConnection, NodeConnectionType } from '@/Interfaces';
+import { NodeConnectionType } from '@/Interfaces';
+import type { IConnection } from '@/Interfaces';
 import type {
 	IBinaryKeyData,
 	IConnections,


### PR DESCRIPTION
## Summary

Some templates seem to have a `null` connection value if there's a multi-branch node (such as the IF Node) and one of the first/higher index branches is not connected.

https://github.com/user-attachments/assets/34faabb6-4d3e-457a-9552-74e9d4eee915

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7880/cannot-load-some-templates

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
