### PR TITLE
fix(core): Set the authentication methad to `email` during startup if the SAML configuration in the database has been corrupted

### DIFF
--- a/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
@@ -85,6 +85,29 @@ describe('SamlService', () => {
 			// ASSERT
 			expect(samlService.reset).toHaveBeenCalledTimes(1);
 		});
+
+		test('does not call reset and rethrows if another error is thrown', async () => {
+			// ARRANGE
+			jest
+				.spyOn(samlService, 'loadFromDbAndApplySamlPreferences')
+				.mockRejectedValue(new TypeError());
+			jest.spyOn(samlService, 'reset');
+
+			// ACT & ASSERT
+			await expect(samlService.init()).rejects.toThrowError(TypeError);
+			expect(samlService.reset).toHaveBeenCalledTimes(0);
+		});
+
+		test('does not call reset if no error is trown', async () => {
+			// ARRANGE
+			jest.spyOn(samlService, 'reset');
+
+			// ACT
+			await samlService.init();
+
+			// ASSERT
+			expect(samlService.reset).toHaveBeenCalledTimes(0);
+		});
 	});
 
 	describe('reset', () => {

--- a/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
@@ -76,7 +76,7 @@ describe('SamlService', () => {
 			// ARRANGE
 			jest
 				.spyOn(samlService, 'loadFromDbAndApplySamlPreferences')
-				.mockRejectedValue(new InvalidSamlMetadataError());
+				.mockRejectedValue(new SyntaxError());
 			jest.spyOn(samlService, 'reset');
 
 			// ACT

--- a/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/sso/saml/__tests__/saml.service.ee.test.ts
@@ -2,22 +2,29 @@ import type express from 'express';
 import { mock } from 'jest-mock-extended';
 import type { IdentityProviderInstance, ServiceProviderInstance } from 'samlify';
 
+import { SettingsRepository } from '@/databases/repositories/settings.repository';
 import { Logger } from '@/logging/logger.service';
 import { UrlService } from '@/services/url.service';
 import * as samlHelpers from '@/sso/saml/saml-helpers';
 import { SamlService } from '@/sso/saml/saml.service.ee';
 import { mockInstance } from '@test/mocking';
 
+import { SAML_PREFERENCES_DB_KEY } from '../constants';
+import { InvalidSamlMetadataError } from '../errors/invalid-saml-metadata.error';
+
 describe('SamlService', () => {
 	const logger = mockInstance(Logger);
 	const urlService = mockInstance(UrlService);
 	const samlService = new SamlService(logger, urlService);
+	const settingsRepository = mockInstance(SettingsRepository);
+
+	beforeEach(() => {
+		jest.restoreAllMocks();
+	});
 
 	describe('getAttributesFromLoginResponse', () => {
 		test('throws when any attribute is missing', async () => {
-			//
 			// ARRANGE
-			//
 			jest
 				.spyOn(samlService, 'getIdentityProviderInstance')
 				.mockReturnValue(mock<IdentityProviderInstance>());
@@ -41,14 +48,59 @@ describe('SamlService', () => {
 				],
 			});
 
-			//
 			// ACT & ASSERT
-			//
 			await expect(
 				samlService.getAttributesFromLoginResponse(mock<express.Request>(), 'post'),
 			).rejects.toThrowError(
 				'SAML Authentication failed. Invalid SAML response (missing attributes: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/firstname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/lastname, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn).',
 			);
+		});
+	});
+
+	describe('init', () => {
+		test('calls `reset` if an InvalidSamlMetadataError is thrown', async () => {
+			// ARRANGE
+			jest
+				.spyOn(samlService, 'loadFromDbAndApplySamlPreferences')
+				.mockRejectedValue(new InvalidSamlMetadataError());
+			jest.spyOn(samlService, 'reset');
+
+			// ACT
+			await samlService.init();
+
+			// ASSERT
+			expect(samlService.reset).toHaveBeenCalledTimes(1);
+		});
+
+		test('calls `reset` if a SyntaxError is thrown', async () => {
+			// ARRANGE
+			jest
+				.spyOn(samlService, 'loadFromDbAndApplySamlPreferences')
+				.mockRejectedValue(new InvalidSamlMetadataError());
+			jest.spyOn(samlService, 'reset');
+
+			// ACT
+			await samlService.init();
+
+			// ASSERT
+			expect(samlService.reset).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('reset', () => {
+		test('disables saml login and deletes the saml `features.saml` key in the db', async () => {
+			// ARRANGE
+			jest.spyOn(samlHelpers, 'setSamlLoginEnabled');
+			jest.spyOn(settingsRepository, 'delete');
+
+			// ACT
+			await samlService.reset();
+
+			// ASSERT
+			expect(samlHelpers.setSamlLoginEnabled).toHaveBeenCalledTimes(1);
+			expect(samlHelpers.setSamlLoginEnabled).toHaveBeenCalledWith(false);
+			expect(settingsRepository.delete).toHaveBeenCalledTimes(1);
+			expect(settingsRepository.delete).toHaveBeenCalledWith({ key: SAML_PREFERENCES_DB_KEY });
 		});
 	});
 });

--- a/packages/cli/src/sso/saml/errors/invalid-saml-metadata.error.ts
+++ b/packages/cli/src/sso/saml/errors/invalid-saml-metadata.error.ts
@@ -1,0 +1,7 @@
+import { ApplicationError } from 'n8n-workflow';
+
+export class InvalidSamlMetadataError extends ApplicationError {
+	constructor() {
+		super('Invalid SAML metadata', { level: 'error' });
+	}
+}

--- a/packages/cli/src/sso/saml/errors/invalid-saml-metadata.error.ts
+++ b/packages/cli/src/sso/saml/errors/invalid-saml-metadata.error.ts
@@ -2,6 +2,6 @@ import { ApplicationError } from 'n8n-workflow';
 
 export class InvalidSamlMetadataError extends ApplicationError {
 	constructor() {
-		super('Invalid SAML metadata', { level: 'error' });
+		super('Invalid SAML metadata', { level: 'warning' });
 	}
 }

--- a/packages/cli/src/sso/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso/saml/saml.service.ee.ts
@@ -16,6 +16,7 @@ import { Logger } from '@/logging/logger.service';
 import { UrlService } from '@/services/url.service';
 
 import { SAML_PREFERENCES_DB_KEY } from './constants';
+import { InvalidSamlMetadataError } from './errors/invalid-saml-metadata.error';
 import {
 	createUserFromSamlAttributes,
 	getMappedSamlAttributesFromFlowResult,
@@ -81,11 +82,24 @@ export class SamlService {
 	) {}
 
 	async init(): Promise<void> {
-		// load preferences first but do not apply so as to not load samlify unnecessarily
-		await this.loadFromDbAndApplySamlPreferences(false);
-		if (isSamlLicensedAndEnabled()) {
-			await this.loadSamlify();
-			await this.loadFromDbAndApplySamlPreferences(true);
+		try {
+			// load preferences first but do not apply so as to not load samlify unnecessarily
+			await this.loadFromDbAndApplySamlPreferences(false);
+			if (isSamlLicensedAndEnabled()) {
+				await this.loadSamlify();
+				await this.loadFromDbAndApplySamlPreferences(true);
+			}
+		} catch (error) {
+			// If the SAML configuration has been corrupted in the database we'll
+			// delete the corrupted configuration and enable email logins again.
+			if (error instanceof InvalidSamlMetadataError || error instanceof SyntaxError) {
+				this.logger.warn(
+					`SAML initialization failed: ${(error as Error).message}. Will reset SAML configuration and disable SAML.`,
+				);
+				await this.reset();
+			} else {
+				throw error;
+			}
 		}
 	}
 
@@ -98,7 +112,7 @@ export class SamlService {
 			validate: async (response: string) => {
 				const valid = await validateResponse(response);
 				if (!valid) {
-					throw new ApplicationError('Invalid SAML response');
+					throw new InvalidSamlMetadataError();
 				}
 			},
 		});
@@ -230,7 +244,7 @@ export class SamlService {
 		} else if (prefs.metadata) {
 			const validationResult = await validateMetadata(prefs.metadata);
 			if (!validationResult) {
-				throw new ApplicationError('Invalid SAML metadata');
+				throw new InvalidSamlMetadataError();
 			}
 		}
 		this.getIdentityProviderInstance(true);
@@ -370,5 +384,14 @@ export class SamlService {
 			);
 		}
 		return attributes;
+	}
+
+	/**
+	 * Disables SAML, switches to email based logins and deletes the SAML
+	 * configuration from the database.
+	 */
+	async reset() {
+		await setSamlLoginEnabled(false);
+		await Container.get(SettingsRepository).delete({ key: SAML_PREFERENCES_DB_KEY });
 	}
 }

--- a/packages/cli/src/sso/saml/saml.service.ee.ts
+++ b/packages/cli/src/sso/saml/saml.service.ee.ts
@@ -94,7 +94,7 @@ export class SamlService {
 			// delete the corrupted configuration and enable email logins again.
 			if (error instanceof InvalidSamlMetadataError || error instanceof SyntaxError) {
 				this.logger.warn(
-					`SAML initialization failed: ${(error as Error).message}. Will reset SAML configuration and disable SAML.`,
+					`SAML initialization failed because of invalid metadata in database: ${error.message}. IMPORTANT: Disabling SAML and switching to email-based login for all users. Please review your configuration and re-enable SAML.`,
 				);
 				await this.reset();
 			} else {

--- a/packages/cli/src/sso/sso-helpers.ts
+++ b/packages/cli/src/sso/sso-helpers.ts
@@ -5,10 +5,10 @@ import type { AuthProviderType } from '@/databases/entities/auth-identity';
 import { SettingsRepository } from '@/databases/repositories/settings.repository';
 
 /**
- * Only one authentication method can be active at a time. This function sets the current authentication method
- * and saves it to the database.
- * SSO methods should only switch to email and then to another method. Email can switch to any method.
- * @param authenticationMethod
+ * Only one authentication method can be active at a time. This function sets
+ * the current authentication method and saves it to the database.
+ * SSO methods should only switch to email and then to another method. Email
+ * can switch to any method.
  */
 export async function setCurrentAuthenticationMethod(
 	authenticationMethod: AuthProviderType,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

If the SAML configuration is corrupted in the database then the whole saml controller won't be loaded. Leaving the instance in a state where no changes can be done to the SAML configuration. It can't be deactivated or updated.

This PR cleans the corrupted configuration from the database and switches the authentication method back to email during startup, if either the JSON or the XML in the JSON cannot be parsed.

This allows the owner to log in and reconfigure the SAML setup.

## Related Linear tickets, Github issues, and Community forum posts


<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->

https://linear.app/n8n/issue/HELP-643/urgent-not-able-to-login-into-n8n-after-upgrading-version

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
