### PR TITLE
docs: Fix typo in Update action description for Google Storage

### DIFF
--- a/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
@@ -235,7 +235,7 @@ export const bucketOperations: INodeProperties[] = [
 						preSend: [parseJSONBody],
 					},
 				},
-				action: 'Create a new Bucket',
+				action: 'Update the metadata of a bucket',
 			},
 		],
 		default: 'getAll',

--- a/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/BucketDescription.ts
@@ -235,7 +235,7 @@ export const bucketOperations: INodeProperties[] = [
 						preSend: [parseJSONBody],
 					},
 				},
-				action: 'Update the metadata of a bucket',
+				action: 'Update the metadata of a Bucket',
 			},
 		],
 		default: 'getAll',


### PR DESCRIPTION
## Summary
Updates the Update action to say that it updates instead of creates.

No tests added as not needed for this.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1983/google-cloud-storage-typo-in-action-for-update

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
