### PR TITLE
feat: Add nodeType field to $prevNode in parameter value expressions

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import type { CodeExecutionMode, IDataObject } from 'n8n-workflow';
+import { MANUAL_TRIGGER_NODE_TYPE, type CodeExecutionMode, type IDataObject } from 'n8n-workflow';
 import fs from 'node:fs';
 import { builtinModules } from 'node:module';
 
@@ -197,6 +197,7 @@ describe('JsTaskRunner', () => {
 				['$nodeVersion', 2],
 				['$prevNode.name', 'Trigger'],
 				['$prevNode.outputIndex', 0],
+				['$prevNode.nodeType', MANUAL_TRIGGER_NODE_TYPE],
 				['$runIndex', 0],
 				['{ wf: $workflow }', { wf: { active: true, id: '1', name: 'Test Workflow' } }],
 				['$vars', { var: 'value' }],

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
@@ -130,6 +130,7 @@ export class BuiltInsParser {
 		} else if (node.name === '$execution') {
 			state.markExecutionAsNeeded();
 		} else if (node.name === '$prevNode') {
+			// @Reviewer: Does us using workflow.getNodeByName() affect this?
 			state.markPrevNodeAsNeeded();
 		}
 	};

--- a/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
+++ b/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
@@ -11,6 +11,7 @@ import type {
  * Strips data from data request response based on the specified parameters
  */
 export class DataRequestResponseStripper {
+	// @Reviewer: Same question here, do we need this for node types? Maybe not since they're more "default" than node names?
 	private requestedNodeNames = new Set<string>();
 
 	constructor(

--- a/packages/editor-ui/src/components/CodeNodeEditor/completions/prevNode.completions.ts
+++ b/packages/editor-ui/src/components/CodeNodeEditor/completions/prevNode.completions.ts
@@ -10,7 +10,7 @@ export function usePrevNodeCompletions(matcher = DEFAULT_MATCHER) {
 	const i18n = useI18n();
 
 	/**
-	 * Complete `$prevNode.` to `.name .outputIndex .runIndex`.
+	 * Complete `$prevNode.` to `.name .outputIndex .runIndex .nodeType`.
 	 */
 	const prevNodeCompletions = (context: CompletionContext): CompletionResult | null => {
 		const pattern = new RegExp(`${escape(matcher)}\..*`);
@@ -31,6 +31,10 @@ export function usePrevNodeCompletions(matcher = DEFAULT_MATCHER) {
 			{
 				label: `${matcher}.runIndex`,
 				info: i18n.baseText('codeNodeEditor.completer.$prevNode.runIndex'),
+			},
+			{
+				label: `${matcher}.nodeType`,
+				info: i18n.baseText('codeNodeEditor.completer.$prevNode.nodeType'),
 			},
 		];
 

--- a/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/datatype.completions.ts
@@ -1040,6 +1040,11 @@ export const prevNodeOptions = () => {
 			returnType: 'number',
 			description: i18n.baseText('codeNodeEditor.completer.$prevNode.runIndex'),
 		},
+		{
+			name: 'nodeType',
+			returnType: 'string',
+			description: i18n.baseText('codeNodeEditor.completer.$prevNode.nodeType'),
+		},
 	].map((doc) => createCompletionOption({ name: doc.name, doc }));
 };
 

--- a/packages/editor-ui/src/plugins/codemirror/completions/prevNode.completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/prevNode.completions.test.ts
@@ -22,6 +22,7 @@ describe('prevNodeCompletions', () => {
 				expect.objectContaining({ label: '$prevNode.name' }),
 				expect.objectContaining({ label: '$prevNode.outputIndex' }),
 				expect.objectContaining({ label: '$prevNode.runIndex' }),
+				expect.objectContaining({ label: '$prevNode.nodeType' }),
 			]),
 		);
 	});
@@ -44,6 +45,7 @@ describe('prevNodeCompletions', () => {
 				expect.objectContaining({ label: '$prevNode.name' }),
 				expect.objectContaining({ label: '$prevNode.outputIndex' }),
 				expect.objectContaining({ label: '$prevNode.runIndex' }),
+				expect.objectContaining({ label: '$nodeType.runIndex' }),
 			]),
 		);
 	});

--- a/packages/editor-ui/src/plugins/codemirror/completions/prevNode.completions.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/prevNode.completions.test.ts
@@ -16,7 +16,7 @@ describe('prevNodeCompletions', () => {
 		const result = prevNodeCompletions(context);
 
 		expect(result).not.toBeNull();
-		expect(result?.options).toHaveLength(3);
+		expect(result?.options).toHaveLength(4);
 		expect(result?.options).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ label: '$prevNode.name' }),
@@ -39,13 +39,13 @@ describe('prevNodeCompletions', () => {
 		const result = prevNodeCompletions(context);
 
 		expect(result).not.toBeNull();
-		expect(result?.options).toHaveLength(3);
+		expect(result?.options).toHaveLength(4);
 		expect(result?.options).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ label: '$prevNode.name' }),
 				expect.objectContaining({ label: '$prevNode.outputIndex' }),
 				expect.objectContaining({ label: '$prevNode.runIndex' }),
-				expect.objectContaining({ label: '$nodeType.runIndex' }),
+				expect.objectContaining({ label: '$prevNode.nodeType' }),
 			]),
 		);
 	});

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -253,6 +253,7 @@
 	"codeNodeEditor.completer.$prevNode.name": "The name of the node that the current input came from. \n\nAlways uses the current node's first input connector if there is more than one (e.g. in the 'Merge' node).",
 	"codeNodeEditor.completer.$prevNode.outputIndex": "The index of the output connector that the current input came from. Use this when the previous node had multiple outputs (such as an 'If' or 'Switch' node). \n\nAlways uses the current node's first input connector if there is more than one (e.g. in the 'Merge' node).",
 	"codeNodeEditor.completer.$prevNode.runIndex": "The run of the previous node that generated the current input. \n\nAlways uses the current node's first input connector if there is more than one (e.g. in the 'Merge' node). ",
+	"codeNodeEditor.completer.$prevNode.nodeType": "The node type of the previous node that generated the current input. \n\nAlways uses the current node's first input connector if there is more than one (e.g. in the 'Merge' node). ",
 	"codeNodeEditor.completer.$runIndex": "The index of the current run of the current node execution. Starts at 0.",
 	"codeNodeEditor.completer.$nodeVersion": "The version of the current node (as displayed at the bottom of the nodes's settings pane)",
 	"codeNodeEditor.completer.$today": "A DateTime representing midnight at the start of the current day. \n\nUses the instance's time zone (unless overridden in the workflow's settings).",

--- a/packages/workflow/src/WorkflowDataProxy.ts
+++ b/packages/workflow/src/WorkflowDataProxy.ts
@@ -500,7 +500,7 @@ export class WorkflowDataProxy {
 	}
 
 	private prevNodeGetter() {
-		const allowedValues = ['name', 'outputIndex', 'runIndex'];
+		const allowedValues = ['name', 'outputIndex', 'runIndex', 'nodeType'];
 		const that = this;
 
 		return new Proxy(
@@ -528,12 +528,12 @@ export class WorkflowDataProxy {
 
 					if (name === 'name') {
 						return sourceData.previousNode;
-					}
-					if (name === 'outputIndex') {
+					} else if (name === 'outputIndex') {
 						return sourceData.previousNodeOutput || 0;
-					}
-					if (name === 'runIndex') {
+					} else if (name === 'runIndex') {
 						return sourceData.previousNodeRun || 0;
+					} else if (name === 'nodeType') {
+						return that.workflow.getNode(sourceData.previousNode)?.type || '';
 					}
 
 					return Reflect.get(target, name, receiver);

--- a/packages/workflow/test/WorkflowDataProxy.test.ts
+++ b/packages/workflow/test/WorkflowDataProxy.test.ts
@@ -196,7 +196,12 @@ describe('WorkflowDataProxy', () => {
 		});
 
 		test('$prevNode', () => {
-			expect(proxy.$prevNode).toEqual({ name: 'Rename', outputIndex: 0, runIndex: 0 });
+			expect(proxy.$prevNode).toEqual({
+				name: 'Rename',
+				outputIndex: 0,
+				runIndex: 0,
+				nodeType: 'test.set',
+			});
 		});
 
 		test('$runIndex', () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2858/expose-nodetype-in-expression

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
