### PR TITLE
perf(core): Remove unneeded execution data from runner data response (no-changelog)

### DIFF
--- a/packages/cli/src/runners/task-managers/__tests__/data-request-response-stripper.test.ts
+++ b/packages/cli/src/runners/task-managers/__tests__/data-request-response-stripper.test.ts
@@ -115,24 +115,8 @@ const taskData: DataRequestResponse = {
 			contextData: {},
 			nodeExecutionStack: [],
 			metadata: {},
-			waitingExecution: {
-				[codeNode.name]: {
-					'0': {
-						main: [codeNodeInputItems],
-					},
-				},
-			},
-			waitingExecutionSource: {
-				[codeNode.name]: {
-					'0': {
-						main: [
-							{
-								previousNode: debugHelperNode.name,
-							},
-						],
-					},
-				},
-			},
+			waitingExecution: {},
+			waitingExecutionSource: {},
 		},
 	},
 	runIndex: 0,

--- a/packages/cli/src/runners/task-managers/data-request-response-builder.ts
+++ b/packages/cli/src/runners/task-managers/data-request-response-builder.ts
@@ -1,5 +1,10 @@
 import type { DataRequestResponse, PartialAdditionalData, TaskData } from '@n8n/task-runner';
-import type { IWorkflowExecuteAdditionalData, Workflow, WorkflowParameters } from 'n8n-workflow';
+import type {
+	IRunExecutionData,
+	IWorkflowExecuteAdditionalData,
+	Workflow,
+	WorkflowParameters,
+} from 'n8n-workflow';
 
 /**
  * Transforms TaskData to DataRequestResponse. The main purpose of the
@@ -20,7 +25,7 @@ export class DataRequestResponseBuilder {
 			mode: taskData.mode,
 			envProviderState: taskData.envProviderState,
 			node: taskData.node,
-			runExecutionData: taskData.runExecutionData,
+			runExecutionData: this.buildRunExecutionData(taskData.runExecutionData),
 			runIndex: taskData.runIndex,
 			selfData: taskData.selfData,
 			siblingParameters: taskData.siblingParameters,
@@ -57,6 +62,25 @@ export class DataRequestResponseBuilder {
 			pinData: workflow.pinData,
 			settings: workflow.settings,
 			staticData: workflow.staticData,
+		};
+	}
+
+	private buildRunExecutionData(runExecutionData: IRunExecutionData) {
+		return {
+			startData: runExecutionData.startData,
+			resultData: runExecutionData.resultData,
+			executionData: runExecutionData.executionData
+				? {
+						contextData: runExecutionData.executionData.contextData,
+						metadata: runExecutionData.executionData.metadata,
+
+						// These are related to workflow execution and are not something
+						// that are accessible by nodes, so we always omit them
+						nodeExecutionStack: [],
+						waitingExecution: {},
+						waitingExecutionSource: null,
+					}
+				: undefined,
 		};
 	}
 }

--- a/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
+++ b/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
@@ -52,17 +52,9 @@ export class DataRequestResponseStripper {
 				runData: this.stripRunData(runExecutionData.resultData.runData),
 				pinData: this.stripPinData(runExecutionData.resultData.pinData),
 			},
-			executionData: runExecutionData.executionData
-				? {
-						// TODO: Figure out what these two are and can they be stripped
-						contextData: runExecutionData.executionData?.contextData,
-						nodeExecutionStack: runExecutionData.executionData.nodeExecutionStack,
-
-						metadata: runExecutionData.executionData.metadata,
-						waitingExecution: runExecutionData.executionData.waitingExecution,
-						waitingExecutionSource: runExecutionData.executionData.waitingExecutionSource,
-					}
-				: undefined,
+			// TODO: We could send `runExecutionData.contextData` only if requested,
+			// since it's only needed if $input.context or $("node").context is used.
+			executionData: runExecutionData.executionData,
 		};
 	}
 


### PR DESCRIPTION

## Summary

`runExecutionData`'s `executionData` has `nodeExecutionStack`, `waitingExecution` and `waitingExecutionSource` fields that are related to workflow execution state. These are not something that nodes themselves need, so we don't need to send them to task runner.


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
