### PR TITLE
ci: Start enforcing `require-await` linting rule (no-changelog)

### DIFF
--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -444,6 +444,9 @@ const config = (module.exports = {
 		/** https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-promise-resolve-reject.md */
 		'unicorn/no-useless-promise-resolve-reject': 'error',
 
+		/** https://eslint.org/docs/latest/rules/require-await */
+		'require-await': 'error',
+
 		'lodash/path-style': ['error', 'as-needed'],
 	},
 


### PR DESCRIPTION
## Summary
Every `async` function has to yield back to the event-loop, which is not something we can negotiate on when using `await`. But when we a function as `async` without using await in it, there is a performance penalty of having to yield when it was not needed.
Combined with the fact that `async` is viral (all callers have also to be `async`, unless they use `void`), this performance penalty can end up much bigger.
This PR aims to remove `async` from any function that doesn't need it, and then start enforcing a linting rule to prevent us from adding more such code.  

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
