### PR TITLE
fix(core): Ensure task runner server closes websocket connection correctly

### DIFF
--- a/packages/cli/src/runners/__tests__/task-runner-server.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-server.test.ts
@@ -1,0 +1,45 @@
+import type { GlobalConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import { ServerResponse } from 'node:http';
+import type WebSocket from 'ws';
+
+import type { TaskRunnerAuthController } from '@/runners/auth/task-runner-auth.controller';
+import { TaskRunnerServer } from '@/runners/task-runner-server';
+
+import type { TaskRunnerServerInitRequest } from '../runner-types';
+
+describe('TaskRunnerServer', () => {
+	describe('handleUpgradeRequest', () => {
+		it('should close WebSocket when response status code is > 200', () => {
+			const ws = mock<WebSocket>();
+			const request = mock<TaskRunnerServerInitRequest>({
+				url: '/runners/_ws',
+				ws,
+			});
+
+			const server = new TaskRunnerServer(
+				mock(),
+				mock<GlobalConfig>({ taskRunners: { path: '/runners' } }),
+				mock<TaskRunnerAuthController>(),
+				mock(),
+			);
+
+			// @ts-expect-error Private property
+			server.handleUpgradeRequest(request, mock(), Buffer.from(''));
+
+			const response = new ServerResponse(request);
+			response.writeHead = (statusCode) => {
+				if (statusCode > 200) ws.close();
+				return response;
+			};
+
+			response.writeHead(401);
+			expect(ws.close).toHaveBeenCalledWith(); // no args
+
+			jest.clearAllMocks();
+
+			response.writeHead(200);
+			expect(ws.close).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/runners/__tests__/task-runner-server.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-server.test.ts
@@ -35,8 +35,30 @@ describe('TaskRunnerServer', () => {
 
 			response.writeHead(401);
 			expect(ws.close).toHaveBeenCalledWith(); // no args
+		});
 
-			jest.clearAllMocks();
+		it('should not close WebSocket when response status code is 200', () => {
+			const ws = mock<WebSocket>();
+			const request = mock<TaskRunnerServerInitRequest>({
+				url: '/runners/_ws',
+				ws,
+			});
+
+			const server = new TaskRunnerServer(
+				mock(),
+				mock<GlobalConfig>({ taskRunners: { path: '/runners' } }),
+				mock<TaskRunnerAuthController>(),
+				mock(),
+			);
+
+			// @ts-expect-error Private property
+			server.handleUpgradeRequest(request, mock(), Buffer.from(''));
+
+			const response = new ServerResponse(request);
+			response.writeHead = (statusCode) => {
+				if (statusCode > 200) ws.close();
+				return response;
+			};
 
 			response.writeHead(200);
 			expect(ws.close).not.toHaveBeenCalled();

--- a/packages/cli/src/runners/task-runner-server.ts
+++ b/packages/cli/src/runners/task-runner-server.ts
@@ -181,7 +181,7 @@ export class TaskRunnerServer {
 
 			const response = new ServerResponse(request);
 			response.writeHead = (statusCode) => {
-				if (statusCode > 200) ws.close(100);
+				if (statusCode > 200) ws.close();
 				return response;
 			};
 


### PR DESCRIPTION
The task runner server was erroring out when attempting to close the websocket connection with `100` which is not a [valid error code](https://github.com/Luka967/websocket-close-codes).

https://linear.app/n8n/issue/PAY-2189