### PR TITLE
feat: Improve Markdown Support in Default Data Loader

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.test.ts
@@ -1,0 +1,165 @@
+import { N8nBinaryLoader } from './N8nBinaryLoader';
+import type { TextSplitter } from '@langchain/textsplitters';
+import { NodeOperationError } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+// Mock the helpers module
+jest.mock('./helpers', () => ({
+	getMetadataFiltersValues: jest.fn().mockReturnValue({}),
+}));
+jest.mock('langchain/document_loaders/fs/text');
+jest.mock('n8n-workflow');
+
+describe('N8nBinaryLoader', () => {
+	let mockContext: IExecuteFunctions;
+	let testLoader: N8nBinaryLoader;
+
+	beforeEach(() => {
+		mockContext = {
+			getNode: jest.fn().mockReturnValue({ name: 'Test Node' }),
+			getNodeParameter: jest.fn((parameterName: string, _: number, defaultValue?: any) => {
+				switch (parameterName) {
+					case 'loader':
+						return 'auto';
+					case 'binaryMode':
+						return 'allInputData';
+					case 'options':
+						return { metadata: [] };
+					default:
+						return defaultValue;
+				}
+			}),
+			helpers: {
+				assertBinaryData: jest.fn(),
+				binaryToBuffer: jest.fn(),
+				getBinaryStream: jest.fn(),
+			},
+			getInputData: jest.fn().mockReturnValue([]),
+		} as unknown as IExecuteFunctions;
+
+		testLoader = new N8nBinaryLoader(mockContext);
+	});
+
+	describe('processItem with Markdown file', () => {
+		it('should process markdown files using TextLoader', async () => {
+			const mockMarkdownContent = '# Test Markdown\nThis is a test';
+			const mockBinaryData = {
+				mimeType: 'text/markdown',
+				data: Buffer.from(mockMarkdownContent).toString('base64'),
+				fileName: 'test.md',
+			};
+
+			mockContext.helpers.assertBinaryData = jest.fn().mockReturnValue(mockBinaryData);
+
+			const mockInputItem: INodeExecutionData = {
+				binary: {
+					data: mockBinaryData,
+				},
+				json: {},
+			};
+
+			mockContext.getInputData = jest.fn().mockReturnValue([mockInputItem]);
+
+			const expectedDoc = {
+				pageContent: mockMarkdownContent,
+				metadata: {
+					source: 'test.md',
+				},
+			};
+
+			const TextLoader = require('langchain/document_loaders/fs/text').TextLoader;
+			TextLoader.prototype.load = jest.fn().mockResolvedValue([expectedDoc]);
+
+			const result = await testLoader.processItem(mockInputItem, 0);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual(expectedDoc);
+			expect(TextLoader).toHaveBeenCalled();
+			expect(mockContext.helpers.assertBinaryData).toHaveBeenCalledWith(0, 'data');
+		});
+
+		it('should handle markdown files with text splitter if provided', async () => {
+			const mockTextSplitter: TextSplitter = {
+				splitDocuments: jest.fn().mockImplementation((docs) => Promise.resolve(docs)),
+			} as unknown as TextSplitter;
+
+			testLoader = new N8nBinaryLoader(mockContext, '', '', mockTextSplitter);
+
+			const mockMarkdownContent = '# Test Markdown\nThis is a test';
+			const mockBinaryData = {
+				mimeType: 'text/markdown',
+				data: Buffer.from(mockMarkdownContent).toString('base64'),
+				fileName: 'test.md',
+			};
+
+			mockContext.helpers.assertBinaryData = jest.fn().mockReturnValue(mockBinaryData);
+
+			const mockInputItem: INodeExecutionData = {
+				binary: {
+					data: mockBinaryData,
+				},
+				json: {},
+			};
+
+			mockContext.getInputData = jest.fn().mockReturnValue([mockInputItem]);
+
+			const expectedDoc = {
+				pageContent: mockMarkdownContent,
+				metadata: {
+					source: 'test.md',
+				},
+			};
+
+			const TextLoader = require('langchain/document_loaders/fs/text').TextLoader;
+			TextLoader.prototype.load = jest.fn().mockResolvedValue([expectedDoc]);
+
+			const result = await testLoader.processItem(mockInputItem, 0);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual(expectedDoc);
+			expect(mockTextSplitter.splitDocuments).toHaveBeenCalledWith([expectedDoc]);
+		});
+
+		it('should throw error for unsupported mime type with text loader', async () => {
+			const mockBinaryData = {
+				mimeType: 'application/pdf',
+				data: Buffer.from('test content').toString('base64'),
+				fileName: 'test.pdf',
+			};
+
+			// Set up context for text loader with PDF file
+			mockContext.getNodeParameter = jest.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'loader') return 'textLoader';
+				if (paramName === 'binaryMode') return 'allInputData';
+				if (paramName === 'options') return { metadata: [] };
+				return undefined;
+			});
+
+			mockContext.helpers.assertBinaryData = jest.fn().mockReturnValue(mockBinaryData);
+			mockContext.getInputData = jest.fn().mockReturnValue([
+				{
+					binary: {
+						data: mockBinaryData,
+					},
+					json: {},
+				},
+			]);
+
+			const mockInputItem: INodeExecutionData = {
+				binary: {
+					data: mockBinaryData,
+				},
+				json: {},
+			};
+
+			return testLoader
+				.processItem(mockInputItem, 0)
+				.then(() => {
+					throw new Error('Expected method to reject.');
+				})
+				.catch((error) => {
+					expect(error).toBeInstanceOf(NodeOperationError);
+				});
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
+++ b/packages/@n8n/nodes-langchain/utils/N8nBinaryLoader.ts
@@ -26,7 +26,7 @@ const SUPPORTED_MIME_TYPES = {
 	csvLoader: ['text/csv'],
 	epubLoader: ['application/epub+zip'],
 	docxLoader: ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-	textLoader: ['text/plain', 'text/mdx', 'text/md'],
+	textLoader: ['text/plain', 'text/mdx', 'text/md', 'text/markdown'],
 	jsonLoader: ['application/json'],
 };
 


### PR DESCRIPTION
## Summary

This PR improves support for markdown documents by allowing the Default Data Loader to handle files with a mine type of `text/markdown`. This enables the Default Data Loader to consume data directly from the "GitHub - Get a File" Action.

![image](https://github.com/user-attachments/assets/07a32fd2-9105-42c2-8d5f-68b6ff32d702)

A simple way to test this change by connecting a "GitHub - Get a File" Action to an "In-Memory Vector Store" and selecting the "Default Data Loader" with automatic mime type detection enabled. See screen shots.

<img width="448" alt="Screenshot 2024-11-06 at 3 40 56 PM" src="https://github.com/user-attachments/assets/3316c303-f31b-4601-a40c-b72c3190768a">

<img width="405" alt="image" src="https://github.com/user-attachments/assets/1d775acf-fd81-4a3e-8d2f-2b4cb755e7db">


## Related Linear tickets, Github issues, and Community forum posts

GHC-407

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
