### PR TITLE
fix(Notion Node): Extract page url

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -926,7 +926,7 @@ export function getPageId(this: IExecuteFunctions, i: number) {
 			pageId = page.value;
 		} else if (page.value.includes('p=')) {
 			// e.g https://www.notion.so/xxxxx?v=xxxxx&p=xxxxx&pm=s
-			pageId = page.value.split('p=')[1].split('&')[0];
+			pageId = new URLSearchParams(page.value).get('p')
 		} else {
 			// e.g https://www.notion.so/page_name-xxxxx
 			pageId = page.value.match(databasePageUrlValidationRegexp)?.[1] || '';

--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -926,7 +926,7 @@ export function getPageId(this: IExecuteFunctions, i: number) {
 			pageId = page.value;
 		} else if (page.value.includes('p=')) {
 			// e.g https://www.notion.so/xxxxx?v=xxxxx&p=xxxxx&pm=s
-			pageId = new URLSearchParams(page.value).get('p')
+			pageId = new URLSearchParams(page.value).get('p') || '';
 		} else {
 			// e.g https://www.notion.so/page_name-xxxxx
 			pageId = page.value.match(databasePageUrlValidationRegexp)?.[1] || '';

--- a/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
+++ b/packages/nodes-base/nodes/Notion/v2/NotionV2.node.ts
@@ -14,7 +14,7 @@ import {
 	extractBlockId,
 	extractDatabaseId,
 	extractDatabaseMentionRLC,
-	extractPageId,
+	getPageId,
 	formatBlocks,
 	formatTitle,
 	mapFilters,
@@ -401,9 +401,8 @@ export class NotionV2 implements INodeType {
 			if (operation === 'get') {
 				for (let i = 0; i < itemsLength; i++) {
 					try {
-						const pageId = extractPageId(
-							this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
-						);
+						const pageId = getPageId.call(this, i);
+
 						const simple = this.getNodeParameter('simple', i) as boolean;
 						responseData = await notionApiRequest.call(this, 'GET', `/pages/${pageId}`);
 						if (simple) {
@@ -526,9 +525,7 @@ export class NotionV2 implements INodeType {
 			if (operation === 'update') {
 				for (let i = 0; i < itemsLength; i++) {
 					try {
-						const pageId = extractPageId(
-							this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
-						);
+						const pageId = getPageId.call(this, i);
 						const simple = this.getNodeParameter('simple', i) as boolean;
 						const properties = this.getNodeParameter(
 							'propertiesUi.propertyValues',
@@ -635,9 +632,7 @@ export class NotionV2 implements INodeType {
 			if (operation === 'archive') {
 				for (let i = 0; i < itemsLength; i++) {
 					try {
-						const pageId = extractPageId(
-							this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
-						);
+						const pageId = getPageId.call(this, i);
 						const simple = this.getNodeParameter('simple', i) as boolean;
 						responseData = await notionApiRequest.call(this, 'PATCH', `/pages/${pageId}`, {
 							archived: true,
@@ -672,9 +667,7 @@ export class NotionV2 implements INodeType {
 							parent: {},
 							properties: {},
 						};
-						body.parent.page_id = extractPageId(
-							this.getNodeParameter('pageId', i, '', { extractValue: true }) as string,
-						);
+						body.parent.page_id = getPageId.call(this, i);
 						body.properties = formatTitle(this.getNodeParameter('title', i) as string);
 						const blockValues = this.getNodeParameter(
 							'blockUi.blockValues',


### PR DESCRIPTION
## Summary

Fix for extracting page url from urls of type
` https://www.notion.so/xxxxx?v=xxxxx&p=xxxxx&pm=s`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1419/notion-node-database-page-param-cant-parse-pip-links
