### PR TITLE
fix(editor): Fix collapsing nested items in expression modal schema view

### DIFF
--- a/packages/editor-ui/src/components/ExpressionEditModal.vue
+++ b/packages/editor-ui/src/components/ExpressionEditModal.vue
@@ -155,6 +155,7 @@ async function onDrop(expression: string, event: MouseEvent) {
 					:mapping-enabled="!isReadOnly"
 					:connection-type="NodeConnectionType.Main"
 					pane-type="input"
+					context="modal"
 				/>
 			</div>
 

--- a/packages/editor-ui/src/components/RunDataSchema.vue
+++ b/packages/editor-ui/src/components/RunDataSchema.vue
@@ -34,6 +34,7 @@ type Props = {
 	paneType: 'input' | 'output';
 	connectionType?: NodeConnectionType;
 	search?: string;
+	context?: 'ndv' | 'modal';
 };
 
 type SchemaNode = {
@@ -58,6 +59,7 @@ const props = withDefaults(defineProps<Props>(), {
 	connectionType: NodeConnectionType.Main,
 	search: '',
 	mappingEnabled: false,
+	context: 'ndv',
 });
 
 const draggingPath = ref<string>('');
@@ -381,7 +383,7 @@ watch(
 								:level="0"
 								:parent="null"
 								:pane-type="paneType"
-								:sub-key="snakeCase(currentNode.node.name)"
+								:sub-key="`${props.context}_${snakeCase(currentNode.node.name)}`"
 								:mapping-enabled="mappingEnabled"
 								:dragging-path="draggingPath"
 								:distance-from-active="currentNode.depth"
@@ -427,7 +429,7 @@ watch(
 				:level="0"
 				:parent="null"
 				:pane-type="paneType"
-				:sub-key="`output_${nodeSchema.type}-0-0`"
+				:sub-key="`${props.context}_output_${nodeSchema.type}-0-0`"
 				:mapping-enabled="mappingEnabled"
 				:dragging-path="draggingPath"
 				:node="node"

--- a/packages/editor-ui/src/components/RunDataSchemaItem.vue
+++ b/packages/editor-ui/src/components/RunDataSchemaItem.vue
@@ -5,6 +5,7 @@ import { checkExhaustive } from '@/utils/typeGuards';
 import { shorten } from '@/utils/typesUtils';
 import { getMappedExpression } from '@/utils/mappingUtils';
 import TextWithHighlights from './TextWithHighlights.vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 type Props = {
 	schema: Schema;
@@ -95,7 +96,7 @@ const getIconBySchemaType = (type: Schema['type']): string => {
 					:data-depth="level"
 					data-target="mappable"
 				>
-					<font-awesome-icon :icon="getIconBySchemaType(schema.type)" size="sm" />
+					<FontAwesomeIcon :icon="getIconBySchemaType(schema.type)" size="sm" />
 					<TextWithHighlights
 						v-if="isSchemaParentTypeArray"
 						:content="props.parent?.key"
@@ -120,12 +121,12 @@ const getIconBySchemaType = (type: Schema['type']): string => {
 
 		<input v-if="level > 0 && isSchemaValueArray" :id="subKey" type="checkbox" inert checked />
 		<label v-if="level > 0 && isSchemaValueArray" :class="$style.toggle" :for="subKey">
-			<font-awesome-icon icon="angle-right" />
+			<FontAwesomeIcon icon="angle-right" />
 		</label>
 
 		<div v-if="isSchemaValueArray" :class="$style.sub">
 			<div :class="$style.innerSub">
-				<run-data-schema-item
+				<RunDataSchemaItem
 					v-for="s in schemaArray"
 					:key="s.key ?? s.type"
 					:schema="s"

--- a/packages/editor-ui/src/components/__snapshots__/RunDataSchema.test.ts.snap
+++ b/packages/editor-ui/src/components/__snapshots__/RunDataSchema.test.ts.snap
@@ -702,13 +702,13 @@ exports[`RunDataSchema.vue > renders schema for data 1`] = `
             </div>
             <input
               checked=""
-              id="set_1-hobbies"
+              id="ndv_set_1-hobbies"
               inert=""
               type="checkbox"
             />
             <label
               class="toggle"
-              for="set_1-hobbies"
+              for="ndv_set_1-hobbies"
             >
               <svg
                 aria-hidden="true"
@@ -1138,13 +1138,13 @@ exports[`RunDataSchema.vue > renders schema for data 2`] = `
             </div>
             <input
               checked=""
-              id="set_2-hobbies"
+              id="ndv_set_2-hobbies"
               inert=""
               type="checkbox"
             />
             <label
               class="toggle"
-              for="set_2-hobbies"
+              for="ndv_set_2-hobbies"
             >
               <svg
                 aria-hidden="true"
@@ -1575,13 +1575,13 @@ exports[`RunDataSchema.vue > renders schema in output pane 1`] = `
               </div>
               <input
                 checked=""
-                id="output_object-0-0-hobbies"
+                id="ndv_output_object-0-0-hobbies"
                 inert=""
                 type="checkbox"
               />
               <label
                 class="toggle"
-                for="output_object-0-0-hobbies"
+                for="ndv_output_object-0-0-hobbies"
               >
                 <svg
                   aria-hidden="true"
@@ -1967,13 +1967,13 @@ exports[`RunDataSchema.vue > renders schema with spaces and dots 1`] = `
                       </div>
                       <input
                         checked=""
-                        id="set_1-hello world"
+                        id="ndv_set_1-hello world"
                         inert=""
                         type="checkbox"
                       />
                       <label
                         class="toggle"
-                        for="set_1-hello world"
+                        for="ndv_set_1-hello world"
                       >
                         <svg
                           aria-hidden="true"
@@ -2060,13 +2060,13 @@ exports[`RunDataSchema.vue > renders schema with spaces and dots 1`] = `
                             </div>
                             <input
                               checked=""
-                              id="set_1-hello world-0"
+                              id="ndv_set_1-hello world-0"
                               inert=""
                               type="checkbox"
                             />
                             <label
                               class="toggle"
-                              for="set_1-hello world-0"
+                              for="ndv_set_1-hello world-0"
                             >
                               <svg
                                 aria-hidden="true"
@@ -2144,13 +2144,13 @@ exports[`RunDataSchema.vue > renders schema with spaces and dots 1`] = `
                                   </div>
                                   <input
                                     checked=""
-                                    id="set_1-hello world-0-test"
+                                    id="ndv_set_1-hello world-0-test"
                                     inert=""
                                     type="checkbox"
                                   />
                                   <label
                                     class="toggle"
-                                    for="set_1-hello world-0-test"
+                                    for="ndv_set_1-hello world-0-test"
                                   >
                                     <svg
                                       aria-hidden="true"


### PR DESCRIPTION
## Summary

Fix collapsing nested items in expression modal schema view

Collapsing items in schema view relies on hidden checkboxes with a unique id. If the expression modal is open (over NDV) there are 2 schema views and those ids are not unique -> opening/collapsing does not work.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1941/expression-editor-modal-schema-view-nested-items-cant-be-collapsed

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
