### PR TITLE
fix(editor): Fix hiding SQL query output when trying to select

### DIFF
--- a/packages/editor-ui/src/components/SQLEditor.test.ts
+++ b/packages/editor-ui/src/components/SQLEditor.test.ts
@@ -25,6 +25,7 @@ async function focusEditor(container: Element) {
 	await waitFor(() => expect(container.querySelector('.cm-line')).toBeInTheDocument());
 	await userEvent.click(container.querySelector('.cm-line') as Element);
 }
+
 const nodes = [
 	{
 		id: '1',
@@ -171,5 +172,24 @@ describe('SqlEditor.vue', () => {
 		expect(getByTestId('sql-editor-container').getElementsByClassName('cm-line').length).toEqual(
 			getByTestId(EXPRESSION_OUTPUT_TEST_ID).getElementsByClassName('cm-line').length,
 		);
+	});
+
+	it('should keep rendered output visible when clicking', async () => {
+		const { getByTestId, queryByTestId, container, baseElement } = renderComponent(SqlEditor, {
+			...DEFAULT_SETUP,
+			props: {
+				...DEFAULT_SETUP.props,
+				modelValue: 'SELECT * FROM users',
+			},
+		});
+
+		// Does not hide output when clicking inside the output
+		await focusEditor(container);
+		await userEvent.click(getByTestId(EXPRESSION_OUTPUT_TEST_ID));
+		await waitFor(() => expect(queryByTestId(EXPRESSION_OUTPUT_TEST_ID)).toBeInTheDocument());
+
+		// Does hide output when clicking outside the container
+		await userEvent.click(baseElement);
+		await waitFor(() => expect(queryByTestId(EXPRESSION_OUTPUT_TEST_ID)).not.toBeInTheDocument());
 	});
 });


### PR DESCRIPTION
## Summary

Fix hiding SQL query output when trying to select

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1812/sql-editor-popunder-closes-when-you-click-on-it-making-selecting-text
fixes https://github.com/n8n-io/n8n/issues/11603

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
