### PR TITLE
fix(core): Always save executions when they go into waiting state

### DIFF
--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -12,6 +12,13 @@ type ExecutionStarted = {
 	};
 };
 
+type ExecutionWaiting = {
+	type: 'executionWaiting';
+	data: {
+		executionId: string;
+	};
+};
+
 type ExecutionFinished = {
 	type: 'executionFinished';
 	data: {
@@ -45,6 +52,7 @@ type NodeExecuteAfter = {
 
 export type ExecutionPushMessage =
 	| ExecutionStarted
+	| ExecutionWaiting
 	| ExecutionFinished
 	| ExecutionRecovered
 	| NodeExecuteBefore

--- a/packages/cli/src/execution-lifecycle-hooks/__tests__/save-execution-progress.test.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/__tests__/save-execution-progress.test.ts
@@ -1,5 +1,4 @@
 import {
-	deepCopy,
 	ErrorReporterProxy,
 	type IRunExecutionData,
 	type ITaskData,
@@ -69,37 +68,6 @@ test('should update execution when saving progress is enabled', async () => {
 	executionRepository.findSingleExecution.mockResolvedValue({} as IExecutionResponse);
 
 	await saveExecutionProgress(...commonArgs);
-
-	expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith('some-execution-id', {
-		data: {
-			executionData: undefined,
-			resultData: {
-				lastNodeExecuted: 'My Node',
-				runData: {
-					'My Node': [{}],
-				},
-			},
-			startData: {},
-		},
-		status: 'running',
-	});
-
-	expect(reporterSpy).not.toHaveBeenCalled();
-});
-
-test('should update execution when saving progress is disabled, but waitTill is defined', async () => {
-	jest.spyOn(fnModule, 'toSaveSettings').mockReturnValue({
-		...commonSettings,
-		progress: false,
-	});
-
-	const reporterSpy = jest.spyOn(ErrorReporterProxy, 'error');
-
-	executionRepository.findSingleExecution.mockResolvedValue({} as IExecutionResponse);
-
-	const args = deepCopy(commonArgs);
-	args[4].waitTill = new Date();
-	await saveExecutionProgress(...args);
 
 	expect(executionRepository.updateExistingExecution).toHaveBeenCalledWith('some-execution-id', {
 		data: {

--- a/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/save-execution-progress.ts
@@ -16,7 +16,7 @@ export async function saveExecutionProgress(
 ) {
 	const saveSettings = toSaveSettings(workflowData.settings);
 
-	if (!saveSettings.progress && !executionData.waitTill) return;
+	if (!saveSettings.progress) return;
 
 	const logger = Container.get(Logger);
 

--- a/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/to-save-settings.ts
@@ -18,20 +18,20 @@ export function toSaveSettings(workflowSettings: IWorkflowSettings = {}) {
 		PROGRESS: config.getEnv('executions.saveExecutionProgress'),
 	};
 
+	const {
+		saveDataErrorExecution = DEFAULTS.ERROR,
+		saveDataSuccessExecution = DEFAULTS.SUCCESS,
+		saveManualExecutions = DEFAULTS.MANUAL,
+		saveExecutionProgress = DEFAULTS.PROGRESS,
+	} = workflowSettings;
+
 	return {
-		error: workflowSettings.saveDataErrorExecution
-			? workflowSettings.saveDataErrorExecution !== 'none'
-			: DEFAULTS.ERROR !== 'none',
-		success: workflowSettings.saveDataSuccessExecution
-			? workflowSettings.saveDataSuccessExecution !== 'none'
-			: DEFAULTS.SUCCESS !== 'none',
-		manual:
-			workflowSettings === undefined || workflowSettings.saveManualExecutions === 'DEFAULT'
-				? DEFAULTS.MANUAL
-				: (workflowSettings.saveManualExecutions ?? DEFAULTS.MANUAL),
-		progress:
-			workflowSettings === undefined || workflowSettings.saveExecutionProgress === 'DEFAULT'
-				? DEFAULTS.PROGRESS
-				: (workflowSettings.saveExecutionProgress ?? DEFAULTS.PROGRESS),
+		error: saveDataErrorExecution === 'DEFAULT' ? DEFAULTS.ERROR : saveDataErrorExecution === 'all',
+		success:
+			saveDataSuccessExecution === 'DEFAULT'
+				? DEFAULTS.SUCCESS
+				: saveDataSuccessExecution === 'all',
+		manual: saveManualExecutions === 'DEFAULT' ? DEFAULTS.MANUAL : saveManualExecutions,
+		progress: saveExecutionProgress === 'DEFAULT' ? DEFAULTS.PROGRESS : saveExecutionProgress,
 	};
 }

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -464,6 +464,11 @@ export async function executeWebhook(
 			projectId: project?.id,
 		};
 
+		// When resuming from a wait node, copy over the pushRef from the execution-data
+		if (!runData.pushRef) {
+			runData.pushRef = runExecutionData.pushRef;
+		}
+
 		let responsePromise: IDeferredPromise<IN8nHttpFullResponse> | undefined;
 		if (responseMode === 'responseNode') {
 			responsePromise = createDeferredPromise<IN8nHttpFullResponse>();

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -309,7 +309,7 @@ function hookFunctionsPush(): IWorkflowExecuteHooks {
 			},
 		],
 		workflowExecuteAfter: [
-			async function (this: WorkflowHooks): Promise<void> {
+			async function (this: WorkflowHooks, fullRunData: IRun): Promise<void> {
 				const { pushRef, executionId } = this;
 				if (pushRef === undefined) return;
 
@@ -320,7 +320,9 @@ function hookFunctionsPush(): IWorkflowExecuteHooks {
 					workflowId,
 				});
 
-				pushInstance.send('executionFinished', { executionId }, pushRef);
+			const pushType =
+					fullRunData.status === 'waiting' ? 'executionWaiting' : 'executionFinished';
+				pushInstance.send(pushType, { executionId }, pushRef);
 			},
 		],
 	};

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -913,7 +913,6 @@ export class WorkflowExecute {
 		let nodeSuccessData: INodeExecutionData[][] | null | undefined;
 		let runIndex: number;
 		let startTime: number;
-		let taskData: ITaskData;
 
 		if (this.runExecutionData.startData === undefined) {
 			this.runExecutionData.startData = {};
@@ -1443,12 +1442,12 @@ export class WorkflowExecute {
 						this.runExecutionData.resultData.runData[executionNode.name] = [];
 					}
 
-					taskData = {
+					const taskData: ITaskData = {
 						hints: executionHints,
 						startTime,
 						executionTime: new Date().getTime() - startTime,
 						source: !executionData.source ? [] : executionData.source.main,
-						executionStatus: 'success',
+						executionStatus: this.runExecutionData.waitTill ? 'waiting' : 'success',
 					};
 
 					if (executionError !== undefined) {

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -446,13 +446,17 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				runDataExecutedStartData: iRunExecutionData.startData,
 				resultDataError: iRunExecutionData.resultData.error,
 			});
+		} else if (receivedData.type === 'executionWaiting') {
+			// Nothing to do
 		} else if (receivedData.type === 'executionStarted') {
 			// Nothing to do
 		} else if (receivedData.type === 'nodeExecuteAfter') {
 			// A node finished to execute. Add its data
 			const pushData = receivedData.data;
 			workflowsStore.addNodeExecutionData(pushData);
-			workflowsStore.removeExecutingNode(pushData.nodeName);
+			if (pushData.data.executionStatus !== 'waiting') {
+				workflowsStore.removeExecutingNode(pushData.nodeName);
+			}
 			void assistantStore.onNodeExecution(pushData);
 		} else if (receivedData.type === 'nodeExecuteBefore') {
 			// A node started to be executed. Set it as executing.


### PR DESCRIPTION
## Summary
When an execution reaches a wait node, and the wait node yields, we need to save the state of that execution irrespective of the execution saving settings.

## Related Linear tickets, Github issues, and Community forum posts

NODE-1912

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
