### PR TITLE
fix(editor): Do not show hover tooltip when autocomplete is active

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/tooltips/InfoBoxTooltip.ts
+++ b/packages/editor-ui/src/plugins/codemirror/tooltips/InfoBoxTooltip.ts
@@ -242,6 +242,9 @@ export const hoverTooltipSource = (view: EditorView, pos: number) => {
 	const state = view.state.field(cursorInfoBoxTooltip, false);
 	const cursorTooltipOpen = !!state?.tooltip;
 
+	// Don't show hover tooltips when autocomplete is active
+	if (completionStatus(view.state) === 'active') return null;
+
 	const jsNodeResult = getJsNodeAtPosition(view.state, pos);
 
 	if (!jsNodeResult) {

--- a/packages/editor-ui/src/plugins/codemirror/tooltips/infoBoxTooltip.test.ts
+++ b/packages/editor-ui/src/plugins/codemirror/tooltips/infoBoxTooltip.test.ts
@@ -6,6 +6,16 @@ import { n8nLang } from '@/plugins/codemirror/n8nLang';
 import { hoverTooltipSource, infoBoxTooltips } from './InfoBoxTooltip';
 import * as utils from '@/plugins/codemirror/completions/utils';
 import * as workflowHelpers from '@/composables/useWorkflowHelpers';
+import { completionStatus } from '@codemirror/autocomplete';
+
+vi.mock('@codemirror/autocomplete', async (importOriginal) => {
+	const actual = await importOriginal<{}>();
+
+	return {
+		...actual,
+		completionStatus: vi.fn(() => null),
+	};
+});
 
 describe('Infobox tooltips', () => {
 	beforeEach(() => {
@@ -98,6 +108,13 @@ describe('Infobox tooltips', () => {
 			const tooltip = hoverTooltip('{{ $json.str.includ|es() }}');
 			expect(tooltip).not.toBeNull();
 			expect(infoBoxHeader(tooltip?.view)).toHaveTextContent('includes(searchString, start?)');
+		});
+
+		test('should not show a tooltip when autocomplete is open', () => {
+			vi.spyOn(workflowHelpers, 'resolveParameter').mockReturnValue('foo');
+			vi.mocked(completionStatus).mockReturnValue('active');
+			const tooltip = hoverTooltip('{{ $json.str.includ|es() }}');
+			expect(tooltip).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Do not show hover tooltip when autocomplete is active

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1889/autocomplete-infobox-showing-twice-on-first-data-mapping

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
