### PR TITLE
fix(core): Fix hot-reload that broke after chokidar upgrade (no-changelog)

### DIFF
--- a/packages/cli/src/load-nodes-and-credentials.ts
+++ b/packages/cli/src/load-nodes-and-credentials.ts
@@ -390,7 +390,15 @@ export class LoadNodesAndCredentials {
 			const toWatch = loader.isLazyLoaded
 				? ['**/nodes.json', '**/credentials.json']
 				: ['**/*.js', '**/*.json'];
-			watch(toWatch, { cwd: realModulePath }).on('change', reloader);
+			const files = await glob(toWatch, {
+				cwd: realModulePath,
+				ignore: ['node_modules/**'],
+			});
+			const watcher = watch(files, {
+				cwd: realModulePath,
+				ignoreInitial: true,
+			});
+			watcher.on('add', reloader).on('change', reloader).on('unlink', reloader);
 		});
 	}
 }


### PR DESCRIPTION
## Summary
When we upgraded chokidar, I missed the bit in [their changelog](https://github.com/paulmillr/chokidar?tab=readme-ov-file#changelog) that clearly states that chokidar 4 dropped support for glob. 
This PR updates the hot-reload code to use fast-glob to get a list of files to watch, and then passes that list down to chokidar.

## Related Linear tickets, Github issues, and Community forum posts
Fixes #11577
NODE-1977


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
