### PR TITLE
fix(core): Handle `item`, `items` and `$node` correctly in JS task runner (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -62,6 +62,15 @@ describe('BuiltInsParser', () => {
 
 			expect(state).toEqual(new BuiltInsParserState({ needs$input: true }));
 		});
+
+		test.each([['items'], ['item']])(
+			'should mark input as needed when %s is used',
+			(identifier) => {
+				const state = parseAndExpectOk(`return ${identifier};`);
+
+				expect(state).toEqual(new BuiltInsParserState({ needs$input: true }));
+			},
+		);
 	});
 
 	describe('$(...)', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -144,6 +144,13 @@ describe('BuiltInsParser', () => {
 		);
 	});
 
+	describe('$node', () => {
+		it('should require all nodes when $node is used', () => {
+			const state = parseAndExpectOk('return $node["name"];');
+			expect(state).toEqual(new BuiltInsParserState({ needsAllNodes: true, needs$input: true }));
+		});
+	});
+
 	describe('ECMAScript syntax', () => {
 		describe('ES2020', () => {
 			it('should parse optional chaining', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
@@ -125,15 +125,23 @@ export class BuiltInsParser {
 	private visitIdentifier = (node: Identifier, state: BuiltInsParserState) => {
 		if (node.name === '$env') {
 			state.markEnvAsNeeded();
-		} else if (node.name === '$input' || node.name === '$json') {
+		} else if (
+			node.name === '$input' ||
+			node.name === '$json' ||
+			node.name === 'items' ||
+			// item is deprecated but we still need to support it
+			node.name === 'item'
+		) {
 			state.markInputAsNeeded();
+		} else if (node.name === '$node') {
+			// $node is legacy way of accessing any node's output. We need to
+			// support it for backward compatibility, but we're not gonna
+			// implement any optimizations
+			state.markNeedsAllNodes();
 		} else if (node.name === '$execution') {
 			state.markExecutionAsNeeded();
 		} else if (node.name === '$prevNode') {
 			state.markPrevNodeAsNeeded();
-		} else if (node.name === 'items' || node.name === 'item') {
-			// item is deprecated but we still need to support it
-			state.markInputAsNeeded();
 		}
 	};
 

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
@@ -131,6 +131,9 @@ export class BuiltInsParser {
 			state.markExecutionAsNeeded();
 		} else if (node.name === '$prevNode') {
 			state.markPrevNodeAsNeeded();
+		} else if (node.name === 'items' || node.name === 'item') {
+			// item is deprecated but we still need to support it
+			state.markInputAsNeeded();
 		}
 	};
 


### PR DESCRIPTION
## Summary

Fix input data not being available if `item` and `items` was used in JS task runner

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2218/item-var-missing

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
