### PR TITLE
[AWAITING DEPENDENCY] Add Support for Deleting Documents from Vector Databases

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreQdrant/VectorStoreQdrant.node.ts
@@ -31,6 +31,20 @@ class ExtendedQdrantVectorStore extends QdrantVectorStore {
 	}
 }
 
+const searchFilter: INodeProperties = {
+	displayName: 'Search Filter',
+	name: 'searchFilterJson',
+	type: 'json',
+	typeOptions: {
+		rows: 5,
+	},
+	default:
+		'{\n  "should": [\n    {\n      "key": "metadata.batch",\n      "match": {\n        "value": 12345\n      }\n    }\n  ]\n}',
+	validateType: 'object',
+	description:
+		'Filter pageContent or metadata using this <a href="https://qdrant.tech/documentation/concepts/filtering/" target="_blank">filtering syntax</a>',
+}
+
 const sharedFields: INodeProperties[] = [qdrantCollectionRLC];
 
 const insertFields: INodeProperties[] = [
@@ -60,21 +74,41 @@ const retrieveFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
+		options: [searchFilter],
+	},
+];
+
+const deleteFields: INodeProperties[] = [
+	{
+		displayName: 'Delete Method',
+		name: 'deleteMethod',
+		type: 'options',
+		noDataExpression: true,
 		options: [
 			{
-				displayName: 'Search Filter',
-				name: 'searchFilterJson',
-				type: 'json',
-				typeOptions: {
-					rows: 5,
-				},
-				default:
-					'{\n  "should": [\n    {\n      "key": "metadata.batch",\n      "match": {\n        "value": 12345\n      }\n    }\n  ]\n}',
-				validateType: 'object',
-				description:
-					'Filter pageContent or metadata using this <a href="https://qdrant.tech/documentation/concepts/filtering/" target="_blank">filtering syntax</a>',
+				name: 'Delete by ID',
+				value: 'id',
+			},
+			{
+				name: 'Delete by Filter',
+				value: 'filter',
 			},
 		],
+		default: 'id',
+		description: 'Choose the method to delete entries',
+	},
+	{
+		displayName: 'ID',
+		name: 'id',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'ID of an embedding entry',
+		displayOptions: { show: { deleteMethod: ['id'] } },
+	},
+	{
+		...searchFilter,
+		displayOptions: { show: { deleteMethod: ['filter'] } },
 	},
 ];
 
@@ -92,12 +126,14 @@ export class VectorStoreQdrant extends createVectorStoreNode({
 				required: true,
 			},
 		],
+		operationModes: ['load', 'insert', 'retrieve', 'delete'],
 	},
 	methods: { listSearch: { qdrantCollectionsSearch } },
 	loadFields: retrieveFields,
 	insertFields,
 	sharedFields,
 	retrieveFields,
+	deleteFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
 		const collection = context.getNodeParameter('qdrantCollection', itemIndex, '', {
 			extractValue: true,

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -20,6 +20,7 @@ export const eventNamesAiNodes = [
 	'n8n.ai.llm.error',
 	'n8n.ai.vector.store.populated',
 	'n8n.ai.vector.store.updated',
+	'n8n.ai.vector.store.deleted',
 ] as const;
 
 export type EventNamesAiNodesType = (typeof eventNamesAiNodes)[number];

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -1199,5 +1199,23 @@ describe('LogStreamingEventRelay', () => {
 				payload,
 			});
 		});
+
+		it('should log on `ai-vector-store-deleted` event', () => {
+			const payload: RelayEventMap['ai-vector-store-deleted'] = {
+				msg: 'Test',
+				executionId: 'exec789',
+				nodeName: 'Vector Store',
+				workflowId: 'wf123',
+				workflowName: 'My Workflow',
+				nodeType: 'n8n-nodes-base.vectorStore',
+			};
+
+			eventService.emit('ai-vector-store-deleted', payload);
+
+			expect(eventBus.sendAiNodeEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.ai.vector.store.deleted',
+				payload,
+			});
+		});
 	});
 });

--- a/packages/cli/src/events/maps/ai.event-map.ts
+++ b/packages/cli/src/events/maps/ai.event-map.ts
@@ -35,4 +35,6 @@ export type AiEventMap = {
 	'ai-vector-store-populated': AiEventPayload;
 
 	'ai-vector-store-updated': AiEventPayload;
+
+	'ai-vector-store-deleted': AiEventPayload;
 };

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -61,6 +61,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'ai-llm-errored': (event) => this.aiLlmErrored(event),
 			'ai-vector-store-populated': (event) => this.aiVectorStorePopulated(event),
 			'ai-vector-store-updated': (event) => this.aiVectorStoreUpdated(event),
+			'ai-vector-store-deleted': (event) => this.aiVectorStoreDeleted(event),
 		});
 	}
 
@@ -501,6 +502,13 @@ export class LogStreamingEventRelay extends EventRelay {
 	private aiVectorStoreUpdated(payload: RelayEventMap['ai-vector-store-updated']) {
 		void this.eventBus.sendAiNodeEvent({
 			eventName: 'n8n.ai.vector.store.updated',
+			payload,
+		});
+	}
+
+	private aiVectorStoreDeleted(payload: RelayEventMap['ai-vector-store-deleted']) {
+		void this.eventBus.sendAiNodeEvent({
+			eventName: 'n8n.ai.vector.store.deleted',
 			payload,
 		});
 	}

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2275,7 +2275,8 @@ export type AiEvent =
 	| 'ai-llm-generated-output'
 	| 'ai-llm-errored'
 	| 'ai-vector-store-populated'
-	| 'ai-vector-store-updated';
+	| 'ai-vector-store-updated'
+	| 'ai-vector-store-deleted';
 
 type AiEventPayload = {
 	msg: string;


### PR DESCRIPTION
## Summary

Add support for deleting documents from vector databases, starting with Qdrant.

⚠️ Opening this PR for review only. It **cannot be merged** yet, as we are awaiting the required dependency in LangChain.

## Related Linear tickets, Github issues, and Community forum posts

Awaiting dependency: https://github.com/langchain-ai/langchainjs/pull/7176.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
