### PR TITLE
fix(n8n Form Node): Open form page if form trigger has pin data

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -359,7 +359,10 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 
 		let isFormShown =
 			!options.destinationNode &&
-			workflowsStore.allNodes.some((node) => node.type === FORM_TRIGGER_NODE_TYPE);
+			workflowsStore.allNodes.some(
+				(node) =>
+					node.type === FORM_TRIGGER_NODE_TYPE && !workflowsStore?.pinnedWorkflowData?.[node.name],
+			);
 
 		const resolveWaitingNodesData = async (): Promise<void> => {
 			return await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

open form pop-up if form trigger has pined data

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1989/form-node-not-compatible-with-pinned-form-trigger
