### PR TITLE
fix(editor): Prevent error being thrown in RLC while loading

### DIFF
--- a/packages/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/editor-ui/src/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -145,7 +145,12 @@ function onKeyDown(e: KeyboardEvent) {
 			}
 		}
 	} else if (e.key === 'Enter') {
-		emit('update:modelValue', sortedResources.value[hoverIndex.value].value);
+		const selected = sortedResources.value[hoverIndex.value]?.value;
+
+		// Selected resource can be empty when loading or empty results
+		if (selected) {
+			emit('update:modelValue', selected);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

When the user presses 'Enter' to select the current item in the RLC, it could throw when there are no items (loading or empty).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1810/typeerror-undefined-is-not-an-object-evaluating

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
