### PR TITLE
fix(n8n Form Trigger Node): Checkboxes different sizes

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -226,6 +226,7 @@
 
 			.multiselect-checkbox {
 				vertical-align: middle;
+				min-width: 18px;
 			}
 
 			input[type='checkbox'] {


### PR DESCRIPTION
## Summary

fix check boxes have different size depending text length

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1568/n8n-form-trigger-node-checkboxes-had-different-sizes
