### PR TITLE
fix(core): Make push work for waiting webhooks

### DIFF
--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -215,7 +215,7 @@ export class WaitingWebhooks implements IWebhookManager {
 				workflowData as IWorkflowDb,
 				workflowStartNode,
 				executionMode,
-				undefined,
+				runExecutionData.pushRef,
 				runExecutionData,
 				execution.id,
 				req,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -495,6 +495,11 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 						retryOf: this.retryOf,
 					});
 
+					// When going into the waiting state, store the pushRef in the execution-data
+					if (fullRunData.waitTill && isManualMode) {
+						fullExecutionData.data.pushRef = this.pushRef;
+					}
+
 					await updateExistingExecution({
 						executionId: this.executionId,
 						workflowId: this.workflowData.id,

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2114,6 +2114,7 @@ export interface IRunExecutionData {
 		waitingExecutionSource: IWaitingForExecutionSource | null;
 	};
 	waitTill?: Date;
+	pushRef?: string;
 }
 
 export interface IRunData {


### PR DESCRIPTION
## Summary
When an execution goes into the waiting state, the execution context is destroyed, since it could be a while before the execution gets resumed. This and the fact that `pushRef` has so far been kept on the execution context, and not persisted anywhere, has led to push not working in the UI once the execution goes into the waiting state.
[This has led to us adding a polling mechanism ](https://github.com/n8n-io/n8n/pull/10815), which is now creating race condition when `EXECUTIONS_DATA_SAVE_ON_SUCCESS` is set to `none`.
Instead of trying to fix the race condition, we should remove the polling instead, and ensure that push works for all manual executions.

## Related Linear tickets, Github issues, and Community forum posts
CAT-328


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
