### PR TITLE
docs: Update benchmark README file to fix secenario filter (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/README.md
+++ b/packages/@n8n/benchmark/README.md
@@ -27,7 +27,7 @@ docker run ghcr.io/n8n-io/n8n-benchmark:latest run \
 	--n8nUserPassword=InstanceOwnerPassword \
 	--vus=5 \
 	--duration=1m \
-	--scenarioFilter SingleWebhook
+	--scenarioFilter=single-webhook
 ```
 
 ### Using custom scenarios with the Docker image


### PR DESCRIPTION
## Summary

Updates the scenario filter in README to use the directory name instead of the `name` attribute since that doesn't currently work.