### PR TITLE
feat(Copper Node): add get person by email to Copper

### DIFF
--- a/packages/nodes-base/nodes/Copper/Copper.node.ts
+++ b/packages/nodes-base/nodes/Copper/Copper.node.ts
@@ -422,6 +422,23 @@ export class Copper implements INodeType {
 						const personId = this.getNodeParameter('personId', i);
 
 						responseData = await copperApiRequest.call(this, 'GET', `/people/${personId}`);
+					} else if (operation === 'getByEmail') {
+						// ----------------------------------------
+						//               person: getByEmail
+						// ----------------------------------------
+
+						// https://developer.copper.com/people/fetch-a-person-by-email.html
+
+						const body: IDataObject = {
+							email: this.getNodeParameter('personEmail', i),
+						};
+
+						responseData = await copperApiRequest.call(
+							this,
+							'POST',
+							'/people/fetch_by_email',
+							body,
+						);
 					} else if (operation === 'getAll') {
 						// ----------------------------------------
 						//              person: getAll

--- a/packages/nodes-base/nodes/Copper/descriptions/PersonDescription.ts
+++ b/packages/nodes-base/nodes/Copper/descriptions/PersonDescription.ts
@@ -34,6 +34,11 @@ export const personOperations: INodeProperties[] = [
 				action: 'Get a person',
 			},
 			{
+				name: 'GetByEmail',
+				value: 'getByEmail',
+				action: 'Get a person by email',
+			},
+			{
 				name: 'Get Many',
 				value: 'getAll',
 				action: 'Get many people',
@@ -130,6 +135,24 @@ export const personFields: INodeProperties[] = [
 			show: {
 				resource: ['person'],
 				operation: ['get'],
+			},
+		},
+	},
+
+	// ----------------------------------------
+	//               person: getByEmail
+	// ----------------------------------------
+	{
+		displayName: 'Person Email',
+		name: 'personEmail',
+		description: 'Email of the person to retrieve',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['person'],
+				operation: ['getByEmail'],
 			},
 		},
 	},


### PR DESCRIPTION
Copper 'Person' is more conveniently fetched by email (a unique key) in most workflows. Add a getPersonByEmail via

https://developer.copper.com/people/fetch-a-person-by-email.html

## Summary

Add means of calling Fetch a Person by Email API to Copper

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
