### PR TITLE
feat(Mautic Node): add get contact by email

### DIFF
--- a/packages/nodes-base/nodes/Mautic/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/ContactDescription.ts
@@ -43,6 +43,12 @@ export const contactOperations: INodeProperties[] = [
 				action: 'Get a contact',
 			},
 			{
+				name: 'Get By Email',
+				value: 'getByEmail',
+				description: 'Get data of a contact via email key',
+				action: 'Get a contact via email key',
+			},
+			{
 				name: 'Get Many',
 				value: 'getAll',
 				description: 'Get data of many contacts',
@@ -473,6 +479,7 @@ export const contactFields: INodeProperties[] = [
 		},
 		default: '',
 	},
+
 	{
 		displayName: 'JSON Parameters',
 		name: 'jsonParameters',
@@ -1111,7 +1118,21 @@ export const contactFields: INodeProperties[] = [
 		},
 		default: '',
 	},
-
+	/* -------------------------------------------------------------------------- */
+	/*                                 contact:getByEmail                         */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Contact Email',
+		name: 'contactEmail',
+		type: 'string',
+		displayOptions: {
+			show: {
+				operation: ['getByEmail'],
+				resource: ['contact'],
+			},
+		},
+		default: '',
+	},
 	/* -------------------------------------------------------------------------- */
 	/*                                contact:getAll                              */
 	/* -------------------------------------------------------------------------- */

--- a/packages/nodes-base/nodes/Mautic/Mautic.node.ts
+++ b/packages/nodes-base/nodes/Mautic/Mautic.node.ts
@@ -828,6 +828,28 @@ export class Mautic implements INodeType {
 							responseData = responseData.map((item) => item.fields.all);
 						}
 					}
+					//https://developer.mautic.org/?php#get-contact
+					if (operation === 'getByEmail') {
+						const options = this.getNodeParameter('options', i);
+						const email = this.getNodeParameter('contactEmail', i) as string;
+						const qs = {
+							'where[0][col]': 'email',
+							'where[0][expr]': 'eq',
+							'where[0][val]': email,
+						};
+						//            const query = `where[0][col]=email&where[0][expr]=eq&where[0][val]=${email}&minimal=0`;
+						responseData = await mauticApiRequest.call(this, 'GET', '/contacts', {}, qs);
+						let result;
+						for (const key in responseData.contacts) {
+							result = responseData.contacts[key];
+							break;
+						}
+						responseData = [result];
+						if (options.rawData === false) {
+							responseData = responseData.map((item) => item.fields.all);
+						}
+					}
+
 					//https://developer.mautic.org/?php#list-contacts
 					if (operation === 'getAll') {
 						const returnAll = this.getNodeParameter('returnAll', i);


### PR DESCRIPTION
Many workflows have the user email but not the unique mautic ID, allow looking up the user by email.

## Summary

Many workflows have the user email, but not their unique mautic ID. Lookup and return the mautic contact via email.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
