### PR TITLE
fix(Redis Chat Memory Node): Respect the SSL flag from the credential

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
@@ -120,6 +120,7 @@ export class MemoryRedisChat implements INodeType {
 			socket: {
 				host: credentials.host as string,
 				port: credentials.port as number,
+				tls: credentials.ssl === true,
 			},
 			database: credentials.database as number,
 		};


### PR DESCRIPTION
## Summary
Redis credentials have a SSL flag, that's used in the regular Redis node, but not in the  
Redis Chat Memory node. This prevents the Redis Chat Memory node from working with any redis instance that only supports a secure connection.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
