### PR TITLE
chore: Add description field to test definition (no-changelog)

### DIFF
--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -35,6 +35,9 @@ export class TestDefinition extends WithTimestamps {
 	})
 	name: string;
 
+	@Column('text')
+	description: string;
+
 	/**
 	 * Relation to the workflow under test
 	 */

--- a/packages/cli/src/databases/migrations/common/1731404028106-AddDescriptionToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1731404028106-AddDescriptionToTestDefinition.ts
@@ -1,0 +1,11 @@
+import type { MigrationContext, ReversibleMigration } from '@/databases/types';
+
+export class AddDescriptionToTestDefinition1731404028106 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns('test_definition', [column('description').text]);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns('test_definition', ['description']);
+	}
+}

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -69,6 +69,7 @@ import { SeparateExecutionCreationFromStart1727427440136 } from '../common/17274
 import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
+import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -140,4 +141,5 @@ export const mysqlMigrations: Migration[] = [
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 	UpdateProcessedDataValueColumnToText1729607673464,
 	CreateTestDefinitionTable1730386903556,
+	AddDescriptionToTestDefinition1731404028106,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -69,6 +69,7 @@ import { SeparateExecutionCreationFromStart1727427440136 } from '../common/17274
 import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../common/1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
+import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -140,4 +141,5 @@ export const postgresMigrations: Migration[] = [
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 	UpdateProcessedDataValueColumnToText1729607673464,
 	CreateTestDefinitionTable1730386903556,
+	AddDescriptionToTestDefinition1731404028106,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/1731404028106-AddDescriptionToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/sqlite/1731404028106-AddDescriptionToTestDefinition.ts
@@ -1,0 +1,5 @@
+import { AddDescriptionToTestDefinition1731404028106 as BaseMigration } from '../common/1731404028106-AddDescriptionToTestDefinition';
+
+export class AddDescriptionToTestDefinition1731404028106 extends BaseMigration {
+	transaction = false as const;
+}

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -66,6 +66,7 @@ import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-C
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
+import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -134,6 +135,7 @@ const sqliteMigrations: Migration[] = [
 	AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644,
 	UpdateProcessedDataValueColumnToText1729607673464,
 	CreateTestDefinitionTable1730386903556,
+	AddDescriptionToTestDefinition1731404028106,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -39,6 +39,7 @@ import { DropRoleMapping1705429061930 } from './1705429061930-DropRoleMapping';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { AddApiKeysTable1724951148974 } from './1724951148974-AddApiKeysTable';
 import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from './1728659839644-AddMissingPrimaryKeyOnAnnotationTagMapping';
+import { AddDescriptionToTestDefinition1731404028106 } from './1731404028106-AddDescriptionToTestDefinition';
 import { UniqueWorkflowNames1620821879465 } from '../common/1620821879465-UniqueWorkflowNames';
 import { UpdateWorkflowCredentials1630330987096 } from '../common/1630330987096-UpdateWorkflowCredentials';
 import { AddNodeIds1658930531669 } from '../common/1658930531669-AddNodeIds';
@@ -66,7 +67,6 @@ import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-C
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
-import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,

--- a/packages/cli/src/evaluation/test-definition.schema.ts
+++ b/packages/cli/src/evaluation/test-definition.schema.ts
@@ -4,13 +4,16 @@ export const testDefinitionCreateRequestBodySchema = z
 	.object({
 		name: z.string().min(1).max(255),
 		workflowId: z.string().min(1),
+		description: z.string().optional(),
 		evaluationWorkflowId: z.string().min(1).optional(),
+		annotationTagId: z.string().min(1).optional(),
 	})
 	.strict();
 
 export const testDefinitionPatchRequestBodySchema = z
 	.object({
 		name: z.string().min(1).max(255).optional(),
+		description: z.string().optional(),
 		evaluationWorkflowId: z.string().min(1).optional(),
 		annotationTagId: z.string().min(1).optional(),
 	})

--- a/packages/cli/src/evaluation/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation/test-definition.service.ee.ts
@@ -26,6 +26,7 @@ export class TestDefinitionService {
 
 	private toEntityLike(attrs: {
 		name?: string;
+		description?: string;
 		workflowId?: string;
 		evaluationWorkflowId?: string;
 		annotationTagId?: string;
@@ -39,6 +40,10 @@ export class TestDefinitionService {
 
 		if (attrs.name) {
 			entity.name = attrs.name?.trim();
+		}
+
+		if (attrs.description) {
+			entity.description = attrs.description.trim();
 		}
 
 		if (attrs.workflowId) {

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -163,9 +163,36 @@ describe('POST /evaluation/test-definitions', () => {
 		});
 
 		expect(resp.statusCode).toBe(200);
-		expect(resp.body.data.name).toBe('test');
-		expect(resp.body.data.workflowId).toBe(workflowUnderTest.id);
-		expect(resp.body.data.evaluationWorkflowId).toBe(evaluationWorkflow.id);
+		expect(resp.body.data).toEqual(
+			expect.objectContaining({
+				name: 'test',
+				workflowId: workflowUnderTest.id,
+				evaluationWorkflowId: evaluationWorkflow.id,
+			}),
+		);
+	});
+
+	test('should create test definition with all fields', async () => {
+		const resp = await authOwnerAgent.post('/evaluation/test-definitions').send({
+			name: 'test',
+			description: 'test description',
+			workflowId: workflowUnderTest.id,
+			evaluationWorkflowId: evaluationWorkflow.id,
+			annotationTagId: annotationTag.id,
+		});
+
+		expect(resp.statusCode).toBe(200);
+		expect(resp.body.data).toEqual(
+			expect.objectContaining({
+				name: 'test',
+				description: 'test description',
+				workflowId: workflowUnderTest.id,
+				evaluationWorkflowId: evaluationWorkflow.id,
+				annotationTag: expect.objectContaining({
+					id: annotationTag.id,
+				}),
+			}),
+		);
 	});
 
 	test('should return error if name is empty', async () => {


### PR DESCRIPTION
## Summary

This PR adds a text description field to the Test Definition entity and related API endpoints.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-455/add-description-field-to-test-definition


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
