### PR TITLE
fix(Facebook Lead Ads Trigger Node): Fix issue with optional fields

### DIFF
--- a/packages/nodes-base/nodes/FacebookLeadAds/FacebookLeadAdsTrigger.node.ts
+++ b/packages/nodes-base/nodes/FacebookLeadAds/FacebookLeadAdsTrigger.node.ts
@@ -273,7 +273,10 @@ export class FacebookLeadAdsTrigger implements INodeType {
 						return {
 							id: lead.id,
 							data: lead.field_data.reduce(
-								(acc, field) => ({ ...acc, [field.name]: field.values[0] }),
+								(acc, field) => ({
+									...acc,
+									[field.name]: field.values && field.values.length > 0 ? field.values[0] : null,
+								}),
 								{},
 							),
 							form: {

--- a/packages/nodes-base/nodes/FacebookLeadAds/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FacebookLeadAds/GenericFunctions.ts
@@ -33,7 +33,7 @@ export async function facebookApiRequest(
 		qs,
 		body,
 		gzip: true,
-		uri: `https://graph.facebook.com/v17.0${resource}`,
+		uri: `https://graph.facebook.com/v21.0${resource}`,
 		json: true,
 	};
 
@@ -89,7 +89,7 @@ export async function facebookAppApiRequest(
 		method,
 		qs,
 		gzip: true,
-		uri: `https://graph.facebook.com/v17.0${resource}`,
+		uri: `https://graph.facebook.com/v21.0${resource}`,
 		json: true,
 	};
 
@@ -181,7 +181,7 @@ export async function facebookPageApiRequest(
 		qs,
 		body,
 		gzip: true,
-		uri: `https://graph.facebook.com/v17.0${resource}`,
+		uri: `https://graph.facebook.com/v21.0${resource}`,
 		json: true,
 	};
 


### PR DESCRIPTION
## Summary
If a lead form is using an optional field which is empty it will result in the array being empty that we get the data from, This PR makes sure it is set and > 0 otherwise just use null.

Also used this chance to update the API version from 17 to 21 which is non breaking. Tests to follow when we start on trigger node testing

## Related Linear tickets, Github issues, and Community forum posts
resolves #11400
https://linear.app/n8n/issue/NODE-1917/community-issue-facebook-leads-webook-error

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
