### PR TITLE
fix(Item List Output Parser Node): Fix number of items parameter issue

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
@@ -35,6 +35,7 @@ describe('OutputParserItemList', () => {
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
 			expect(response).toBeInstanceOf(N8nItemListOutputParser);
+			expect((response as any).numberOfItems).toBe(3);
 		});
 
 		it('should create a parser with custom number of items', async () => {
@@ -48,6 +49,20 @@ describe('OutputParserItemList', () => {
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
 			expect(response).toBeInstanceOf(N8nItemListOutputParser);
 			expect((response as any).numberOfItems).toBe(5);
+		});
+
+		it('should create a parser with unlimited number of items', async () => {
+			thisArg.getNodeParameter.mockImplementation((parameterName) => {
+				if (parameterName === 'options') {
+					return { numberOfItems: -1 };
+				}
+
+				throw new ApplicationError('Not implemented');
+			});
+
+			const { response } = await outputParser.supplyData.call(thisArg, 0);
+			expect(response).toBeInstanceOf(N8nItemListOutputParser);
+			expect((response as any).numberOfItems).toBeUndefined();
 		});
 
 		it('should create a parser with custom separator', async () => {

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nItemListOutputParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nItemListOutputParser.ts
@@ -3,16 +3,21 @@ import { BaseOutputParser, OutputParserException } from '@langchain/core/output_
 export class N8nItemListOutputParser extends BaseOutputParser<string[]> {
 	lc_namespace = ['n8n-nodes-langchain', 'output_parsers', 'list_items'];
 
-	private numberOfItems: number = 3;
+	private numberOfItems: number | undefined;
 
 	private separator: string;
 
 	constructor(options: { numberOfItems?: number; separator?: string }) {
 		super();
-		if (options.numberOfItems && options.numberOfItems > 0) {
-			this.numberOfItems = options.numberOfItems;
+
+		const { numberOfItems = 3, separator = '\n' } = options;
+
+		if (numberOfItems && numberOfItems > 0) {
+			this.numberOfItems = numberOfItems;
 		}
-		this.separator = options.separator ?? '\\n';
+
+		this.separator = separator;
+
 		if (this.separator === '\\n') {
 			this.separator = '\n';
 		}
@@ -39,7 +44,7 @@ export class N8nItemListOutputParser extends BaseOutputParser<string[]> {
 			this.numberOfItems ? this.numberOfItems + ' ' : ''
 		}items separated by`;
 
-		const numberOfExamples = this.numberOfItems;
+		const numberOfExamples = this.numberOfItems ?? 3; // Default number of examples in case numberOfItems is not set
 
 		const examples: string[] = [];
 		for (let i = 1; i <= numberOfExamples; i++) {


### PR DESCRIPTION
## Summary

This PR fixes an issue with parameter "Number Of Items" of the Item List Output Parser Node. Previously, the number of items was incorrectly capped at 3 items even when parameter set to -1 (unlimited). Now the node correctly processes all items when -1 is specified.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-454/community-issue-basic-llm-chain-node-with-item-list-output-parser-is
- Resolves #11686 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
