### PR TITLE
fix(Google Drive Node): Fix file upload for streams

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -7,7 +7,6 @@ import * as transport from '../../../../v2/transport';
 import * as utils from '../../../../v2/helpers/utils';
 
 import { createMockExecuteFunction, createTestStream, driveNode } from '../helpers';
-import { Readable } from 'stream';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -6,7 +6,8 @@ import * as upload from '../../../../v2/actions/file/upload.operation';
 import * as transport from '../../../../v2/transport';
 import * as utils from '../../../../v2/helpers/utils';
 
-import { createMockExecuteFunction, driveNode } from '../helpers';
+import { createMockExecuteFunction, createTestStream, driveNode } from '../helpers';
+import { Readable } from 'stream';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');
@@ -30,7 +31,7 @@ jest.mock('../../../../v2/helpers/utils', () => {
 		getItemBinaryData: jest.fn(async function () {
 			return {
 				contentLength: '123',
-				fileContent: 'Hello Drive!',
+				fileContent: Buffer.from('Hello Drive!'),
 				originalFilename: 'original.txt',
 				mimeType: 'text/plain',
 			};
@@ -43,13 +44,17 @@ describe('test GoogleDriveV2: file upload', () => {
 		nock.disableNetConnect();
 	});
 
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	afterAll(() => {
 		nock.restore();
 		jest.unmock('../../../../v2/transport');
 		jest.unmock('../../../../v2/helpers/utils');
 	});
 
-	it('should be called with', async () => {
+	it('should upload buffers', async () => {
 		const nodeParameters = {
 			name: 'newFile.txt',
 			folderId: {
@@ -73,10 +78,10 @@ describe('test GoogleDriveV2: file upload', () => {
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'POST',
 			'/upload/drive/v3/files',
+			expect.any(Buffer),
+			{ uploadType: 'media' },
 			undefined,
-			{ uploadType: 'resumable' },
-			undefined,
-			{ returnFullResponse: true },
+			{ headers: { 'Content-Length': '123', 'Content-Type': 'text/plain' } },
 		);
 		expect(transport.googleApiRequest).toHaveBeenCalledWith(
 			'PATCH',
@@ -93,5 +98,60 @@ describe('test GoogleDriveV2: file upload', () => {
 
 		expect(utils.getItemBinaryData).toBeCalledTimes(1);
 		expect(utils.getItemBinaryData).toHaveBeenCalled();
+	});
+
+	it('should stream large files in 2MB chunks', async () => {
+		const nodeParameters = {
+			name: 'newFile.jpg',
+			folderId: {
+				__rl: true,
+				value: 'folderIDxxxxxx',
+				mode: 'list',
+				cachedResultName: 'testFolder 3',
+				cachedResultUrl: 'https://drive.google.com/drive/folders/folderIDxxxxxx',
+			},
+			options: {
+				simplifyOutput: true,
+			},
+		};
+
+		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+
+		const fileSize = 7 * 1024 * 1024; // 7MB
+		jest.mocked(utils.getItemBinaryData).mockResolvedValue({
+			mimeType: 'image/jpg',
+			originalFilename: 'test.jpg',
+			contentLength: fileSize,
+			fileContent: createTestStream(fileSize),
+		});
+
+		await upload.execute.call(fakeExecuteFunction, 0);
+
+		// 4 chunks: 7MB = 3x2MB + 1x1MB
+		expect(fakeExecuteFunction.helpers.httpRequest).toHaveBeenCalledTimes(4);
+		expect(fakeExecuteFunction.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ body: expect.any(Buffer) }),
+		);
+		expect(transport.googleApiRequest).toBeCalledTimes(2);
+		expect(transport.googleApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/upload/drive/v3/files',
+			undefined,
+			{ uploadType: 'resumable' },
+			undefined,
+			{ returnFullResponse: true },
+		);
+		expect(transport.googleApiRequest).toHaveBeenCalledWith(
+			'PATCH',
+			'/drive/v3/files/undefined',
+			{ mimeType: 'image/jpg', name: 'newFile.jpg', originalFilename: 'test.jpg' },
+			{
+				addParents: 'folderIDxxxxxx',
+				supportsAllDrives: true,
+				corpora: 'allDrives',
+				includeItemsFromAllDrives: true,
+				spaces: 'appDataFolder, drive',
+			},
+		);
 	});
 });

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -116,6 +116,7 @@ describe('test GoogleDriveV2: file upload', () => {
 		};
 
 		const fakeExecuteFunction = createMockExecuteFunction(nodeParameters, driveNode);
+		const httpRequestSpy = jest.spyOn(fakeExecuteFunction.helpers, 'httpRequest');
 
 		const fileSize = 7 * 1024 * 1024; // 7MB
 		jest.mocked(utils.getItemBinaryData).mockResolvedValue({
@@ -128,8 +129,8 @@ describe('test GoogleDriveV2: file upload', () => {
 		await upload.execute.call(fakeExecuteFunction, 0);
 
 		// 4 chunks: 7MB = 3x2MB + 1x1MB
-		expect(fakeExecuteFunction.helpers.httpRequest).toHaveBeenCalledTimes(4);
-		expect(fakeExecuteFunction.helpers.httpRequest).toHaveBeenCalledWith(
+		expect(httpRequestSpy).toHaveBeenCalledTimes(4);
+		expect(httpRequestSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ body: expect.any(Buffer) }),
 		);
 		expect(transport.googleApiRequest).toBeCalledTimes(2);

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/helpers.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/helpers.ts
@@ -34,8 +34,8 @@ export const createMockExecuteFunction = (
 		helpers: {
 			constructExecutionMetaData,
 			returnJsonArray,
-			prepareBinaryData: jest.fn(),
-			httpRequest: jest.fn(),
+			prepareBinaryData: () => {},
+			httpRequest: () => {},
 		},
 		continueOnFail: () => continueOnFail,
 	} as unknown as IExecuteFunctions;
@@ -44,7 +44,7 @@ export const createMockExecuteFunction = (
 
 export function createTestStream(byteSize: number) {
 	let bytesSent = 0;
-	const CHUNK_SIZE = 64 * 1024; // 64kB chunks (default highWaterMark)
+	const CHUNK_SIZE = 64 * 1024; // 64kB chunks (default NodeJS highWaterMark)
 
 	return new Readable({
 		read() {


### PR DESCRIPTION
## Summary

Fix file upload for streams. Google Drive API needs to receive chunks that are a multiple of 256KB. This PR implements file upload to google drive in 2MB chunks.

This bug is reproducible when using an external storage provider (S3 for example)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1640/google-drive-file-upload-does-not-work

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
