### PR TITLE
fix(editor): Fix node type properties not updating regression (no-changelog)

### DIFF
--- a/packages/editor-ui/src/__tests__/mocks.ts
+++ b/packages/editor-ui/src/__tests__/mocks.ts
@@ -54,22 +54,25 @@ export const mockNodeTypeDescription = ({
 	credentials = [],
 	inputs = [NodeConnectionType.Main],
 	outputs = [NodeConnectionType.Main],
+	properties = [],
 }: {
 	name?: INodeTypeDescription['name'];
 	version?: INodeTypeDescription['version'];
 	credentials?: INodeTypeDescription['credentials'];
 	inputs?: INodeTypeDescription['inputs'];
 	outputs?: INodeTypeDescription['outputs'];
+	properties?: INodeTypeDescription['properties'];
 } = {}) =>
 	mock<INodeTypeDescription>({
 		name,
 		displayName: name,
+		description: '',
 		version,
 		defaults: {
 			name,
 		},
 		defaultVersion: Array.isArray(version) ? version[version.length - 1] : version,
-		properties: [],
+		properties: properties as [],
 		maxNodes: Infinity,
 		group: EXECUTABLE_TRIGGER_NODE_TYPES.includes(name) ? ['trigger'] : [],
 		inputs,

--- a/packages/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -2050,6 +2050,36 @@ describe('useCanvasOperations', () => {
 			expect(workflowsStore.setConnections).toHaveBeenCalled();
 		});
 	});
+
+	it('should initialize node data from node type description', () => {
+		const nodeTypesStore = mockedStore(useNodeTypesStore);
+		const type = SET_NODE_TYPE;
+		const version = 1;
+		const expectedDescription = mockNodeTypeDescription({
+			name: type,
+			version,
+			properties: [
+				{
+					displayName: 'Value',
+					name: 'value',
+					type: 'boolean',
+					default: true,
+				},
+			],
+		});
+
+		nodeTypesStore.nodeTypes = { [type]: { [version]: expectedDescription } };
+
+		const workflow = createTestWorkflow({
+			nodes: [createTestNode()],
+			connections: {},
+		});
+
+		const { initializeWorkspace } = useCanvasOperations({ router });
+		initializeWorkspace(workflow);
+
+		expect(workflow.nodes[0].parameters).toEqual({ value: true });
+	});
 });
 
 function buildImportNodes() {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -778,8 +778,8 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			parameters,
 		};
 
-		resolveNodeParameters(nodeData);
 		resolveNodeName(nodeData);
+		resolveNodeParameters(nodeData, nodeTypeDescription);
 		resolveNodeWebhook(nodeData, nodeTypeDescription);
 
 		return nodeData;
@@ -828,10 +828,9 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		return nodeVersion;
 	}
 
-	function resolveNodeParameters(node: INodeUi) {
-		const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+	function resolveNodeParameters(node: INodeUi, nodeTypeDescription: INodeTypeDescription) {
 		const nodeParameters = NodeHelpers.getNodeParameters(
-			nodeType?.properties ?? [],
+			nodeTypeDescription?.properties ?? [],
 			node.parameters,
 			true,
 			false,
@@ -1381,7 +1380,10 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 		workflowHelpers.initState(data);
 
 		data.nodes.forEach((node) => {
+			const nodeTypeDescription = requireNodeTypeDescription(node.type, node.typeVersion);
 			nodeHelpers.matchCredentials(node);
+			resolveNodeParameters(node, nodeTypeDescription);
+			resolveNodeWebhook(node, nodeTypeDescription);
 		});
 
 		workflowsStore.setNodes(data.nodes);


### PR DESCRIPTION
## Summary

Properties are now again set correctly:

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/fa637982-4273-43be-9544-b4962a0c0f06">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7900/fix-node-type-properties-not-updating-regression

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
