### PR TITLE
fix(In-Memory Vector Store Node): Fix displaying execution data of connected embedding nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -54,6 +54,6 @@ export class VectorStoreInMemory extends createVectorStoreNode({
 		const workflowId = context.getWorkflow().id;
 		const vectorStoreInstance = MemoryVectorStoreManager.getInstance(embeddings);
 
-		void vectorStoreInstance.addDocuments(`${workflowId}__${memoryKey}`, documents, clearStore);
+		await vectorStoreInstance.addDocuments(`${workflowId}__${memoryKey}`, documents, clearStore);
 	},
 }) {}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/MemoryVectorStoreManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/MemoryVectorStoreManager.test.ts
@@ -1,0 +1,44 @@
+import type { OpenAIEmbeddings } from '@langchain/openai';
+
+import { MemoryVectorStoreManager } from './MemoryVectorStoreManager';
+import { mock } from 'jest-mock-extended';
+
+describe('MemoryVectorStoreManager', () => {
+	it('should create an instance of MemoryVectorStoreManager', () => {
+		const embeddings = mock<OpenAIEmbeddings>();
+
+		const instance = MemoryVectorStoreManager.getInstance(embeddings);
+		expect(instance).toBeInstanceOf(MemoryVectorStoreManager);
+	});
+
+	it('should return existing instance', () => {
+		const embeddings = mock<OpenAIEmbeddings>();
+
+		const instance1 = MemoryVectorStoreManager.getInstance(embeddings);
+		const instance2 = MemoryVectorStoreManager.getInstance(embeddings);
+		expect(instance1).toBe(instance2);
+	});
+
+	it('should update embeddings in existing instance', () => {
+		const embeddings1 = mock<OpenAIEmbeddings>();
+		const embeddings2 = mock<OpenAIEmbeddings>();
+
+		const instance = MemoryVectorStoreManager.getInstance(embeddings1);
+		MemoryVectorStoreManager.getInstance(embeddings2);
+
+		expect((instance as any).embeddings).toBe(embeddings2);
+	});
+
+	it('should update embeddings in existing vector store instances', async () => {
+		const embeddings1 = mock<OpenAIEmbeddings>();
+		const embeddings2 = mock<OpenAIEmbeddings>();
+
+		const instance1 = MemoryVectorStoreManager.getInstance(embeddings1);
+		await instance1.getVectorStore('test');
+
+		const instance2 = MemoryVectorStoreManager.getInstance(embeddings2);
+		const vectorStoreInstance2 = await instance2.getVectorStore('test');
+
+		expect((vectorStoreInstance2 as any).embeddings).toBe(embeddings2);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/MemoryVectorStoreManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/MemoryVectorStoreManager.ts
@@ -14,7 +14,16 @@ export class MemoryVectorStoreManager {
 	public static getInstance(embeddings: Embeddings): MemoryVectorStoreManager {
 		if (!MemoryVectorStoreManager.instance) {
 			MemoryVectorStoreManager.instance = new MemoryVectorStoreManager(embeddings);
+		} else {
+			// We need to update the embeddings in the existing instance.
+			// This is important as embeddings instance is wrapped in a logWrapper,
+			// which relies on supplyDataFunctions context which changes on each workflow run
+			MemoryVectorStoreManager.instance.embeddings = embeddings;
+			MemoryVectorStoreManager.instance.vectorStoreBuffer.forEach((vectorStoreInstance) => {
+				vectorStoreInstance.embeddings = embeddings;
+			});
 		}
+
 		return MemoryVectorStoreManager.instance;
 	}
 


### PR DESCRIPTION
## Summary

Previously, cached vector stores retained stale embedding instances, preventing proper execution status logging. This occurred because the cached `logWrapper` Proxy continued using an outdated `ISupplyDataFunctions` context from the initial workflow run.

Solution:
Modified `MemoryVectorStoreManager.getInstance()` to refresh embedding instances before returning cached vector stores.

Additionally, added `await` on vector store's `populateVectorStore` function, to properly display the status of the operation.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-417/errors-in-openai-embeddings-subnode-not-reported

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
