### PR TITLE
fix(Google BigQuery Node): Add item index to insert error

### DIFF
--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/insert.operation.ts
@@ -275,6 +275,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				: '';
 			throw new NodeOperationError(this.getNode(), `${failedMessage}${stoppedMessage}`, {
 				description: errors.join('\n, '),
+				itemIndex: i,
 			});
 		}
 


### PR DESCRIPTION
## Summary
Adds missing item index to error output.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1904/bigquery-doesnt-return-the-item-index-on-error-confusing-error-on

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
