### PR TITLE
fix(editor): Fix callout component border issue (no-changelog)

### DIFF
--- a/packages/design-system/src/components/N8nCallout/Callout.vue
+++ b/packages/design-system/src/components/N8nCallout/Callout.vue
@@ -23,6 +23,7 @@ interface CalloutProps {
 	iconless?: boolean;
 	slim?: boolean;
 	roundCorners?: boolean;
+	onlyBottomBorder?: boolean;
 }
 
 defineOptions({ name: 'N8nCallout' });
@@ -38,6 +39,7 @@ const classes = computed(() => [
 	$style[props.theme],
 	props.slim ? $style.slim : '',
 	props.roundCorners ? $style.round : '',
+	props.onlyBottomBorder ? $style.onlyBottomBorder : '',
 ]);
 
 const getIcon = computed(
@@ -93,6 +95,12 @@ const getIconSize = computed<IconSize>(() => {
 
 .round {
 	border-radius: var(--border-radius-base);
+}
+
+.onlyBottomBorder {
+	border-top: 0;
+	border-left: 0;
+	border-right: 0;
 }
 
 .messageSection {

--- a/packages/editor-ui/src/components/banners/BaseBanner.vue
+++ b/packages/editor-ui/src/components/banners/BaseBanner.vue
@@ -39,6 +39,7 @@ async function onCloseClick() {
 		icon-size="medium"
 		:round-corners="false"
 		:data-test-id="`banners-${props.name}`"
+		:only-bottom-border="true"
 	>
 		<div :class="[$style.mainContent, !hasTrailingContent ? $style.keepSpace : '']">
 			<slot name="mainContent" />
@@ -62,7 +63,7 @@ async function onCloseClick() {
 
 <style lang="scss" module>
 .callout {
-	height: calc(var(--header-height) * 1px);
+	// height: calc(var(--header-height) * 1px);
 }
 
 .mainContent {
@@ -77,11 +78,5 @@ async function onCloseClick() {
 	display: flex;
 	align-items: center;
 	gap: var(--spacing-l);
-}
-
-:global(.n8n-callout) {
-	border-top: 0;
-	border-left: 0;
-	border-right: 0;
 }
 </style>

--- a/packages/editor-ui/src/components/banners/BaseBanner.vue
+++ b/packages/editor-ui/src/components/banners/BaseBanner.vue
@@ -63,7 +63,7 @@ async function onCloseClick() {
 
 <style lang="scss" module>
 .callout {
-	// height: calc(var(--header-height) * 1px);
+	height: calc(var(--header-height) * 1px);
 }
 
 .mainContent {

--- a/packages/editor-ui/src/components/banners/__snapshots__/V1Banner.test.ts.snap
+++ b/packages/editor-ui/src/components/banners/__snapshots__/V1Banner.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`V1 Banner > should render banner 1`] = `
 <div>
   <div
-    class="n8n-callout callout warning callout v1container"
+    class="n8n-callout callout warning onlyBottomBorder callout v1container"
     data-test-id="banners-V1"
     role="alert"
   >
@@ -104,7 +104,7 @@ exports[`V1 Banner > should render banner 1`] = `
 exports[`V1 Banner > should render banner with dismiss call if user is owner 1`] = `
 <div>
   <div
-    class="n8n-callout callout warning callout v1container"
+    class="n8n-callout callout warning onlyBottomBorder callout v1container"
     data-test-id="banners-V1"
     role="alert"
   >


### PR DESCRIPTION
## Summary

Fixes this issue with the (missing) callout borders:
<img width="513" alt="image" src="https://github.com/user-attachments/assets/7066b130-7477-4884-87cb-8746c7893eb9">

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DX-171/callout-component-height-and-border-fixes
closes #DX-171

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
