### PR TITLE
fix(Notion Node): Add null safety check for Get Many Database pages to avoid errors with Simplify option 

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -643,7 +643,7 @@ function simplifyProperty(property: any) {
 			(file: { type: string; [key: string]: any }) => file[file.type].url,
 		);
 	} else if (['status'].includes(property.type as string)) {
-		result = property[type].name;
+		result = property[type]?.name;
 	}
 	return result;
 }


### PR DESCRIPTION
## Summary
This PR adds a null safety check for Get Many Database pages to avoid errors with Simplify option

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1629/notion-node-get-many-database-pages-errors-with-simplify-option-not

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
