### PR TITLE
fix(editor): Fix the issue with RMC Values to Send collection disappears 

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -190,7 +190,7 @@ const matchingColumns = computed<string[]>(() => {
 });
 
 const hasAvailableMatchingColumns = computed<boolean>(() => {
-	if (resourceMapperMode.value !== 'add') {
+	if (resourceMapperMode.value !== 'add' && resourceMapperMode.value !== 'upsert') {
 		return (
 			state.paramValue.schema.filter(
 				(field) =>


### PR DESCRIPTION

## Summary
This PR fixes the issue with Values to Send collection disappears if you delete all the fields

Using the operation "Append or Update Row", if "Column to Match On" is empty and I delete all the fields in  "Values to Send", the whole "Values to Send" collection disappears

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1530/rmc-values-to-send-collection-disappears-if-you-delete-all-the-fields

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
