### PR TITLE
fix(editor): Fix canvasNodes reactivity in canvas chat (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
+++ b/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
@@ -52,6 +52,7 @@ const isChatOpen = computed(() => {
 	const result = workflowsStore.isChatPanelOpen;
 	return result;
 });
+const canvasNodes = computed(() => workflowsStore.allNodes);
 const isLogsOpen = computed(() => workflowsStore.isLogsPanelOpen);
 const previousChatMessages = computed(() => workflowsStore.getPastChatMessages);
 
@@ -70,7 +71,7 @@ const { runWorkflow } = useRunWorkflow({ router });
 const { chatTriggerNode, connectedNode, allowFileUploads, setChatTriggerNode, setConnectedNode } =
 	useChatTrigger({
 		workflow,
-		canvasNodes: workflowsStore.allNodes,
+		canvasNodes,
 		getNodeByName: workflowsStore.getNodeByName,
 		getNodeType: nodeTypesStore.getNodeType,
 	});

--- a/packages/editor-ui/src/components/CanvasChat/composables/useChatTrigger.ts
+++ b/packages/editor-ui/src/components/CanvasChat/composables/useChatTrigger.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
 import { ref, computed, unref } from 'vue';
 import {
 	CHAIN_SUMMARIZATION_LANGCHAIN_NODE_TYPE,

--- a/packages/editor-ui/src/components/CanvasChat/composables/useChatTrigger.ts
+++ b/packages/editor-ui/src/components/CanvasChat/composables/useChatTrigger.ts
@@ -1,5 +1,5 @@
-import type { ComputedRef } from 'vue';
-import { ref, computed } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
+import { ref, computed, unref } from 'vue';
 import {
 	CHAIN_SUMMARIZATION_LANGCHAIN_NODE_TYPE,
 	NodeConnectionType,
@@ -19,7 +19,7 @@ import type { INodeUi } from '@/Interface';
 export interface ChatTriggerDependencies {
 	getNodeByName: (name: string) => INodeUi | null;
 	getNodeType: (type: string, version: number) => INodeTypeDescription | null;
-	canvasNodes: INodeUi[];
+	canvasNodes: MaybeRef<INodeUi[]>;
 	workflow: ComputedRef<Workflow>;
 }
 
@@ -52,7 +52,7 @@ export function useChatTrigger({
 
 	/** Gets the chat trigger node from the workflow */
 	function setChatTriggerNode() {
-		const triggerNode = canvasNodes.find((node) =>
+		const triggerNode = unref(canvasNodes).find((node) =>
 			[CHAT_TRIGGER_NODE_TYPE, MANUAL_CHAT_TRIGGER_NODE_TYPE].includes(node.type),
 		);
 


### PR DESCRIPTION
## Summary

This PR addresses a bug that cropped up after the changes in #11634. The bug prevented the canvas chat panel from loading correctly in the updated canvas version. The root cause was that we were passing a static canvasNodes array to useChatTrigger, and it wasn't updating when the actual nodes loaded.

To resolve this, we need to convert canvasNodes to a computed ref and unref it in composable.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
