### PR TITLE
docs: Update npm package README.md to put minimum version to v18 (no-changelog)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,7 @@ It will download everything that is needed to start n8n.
 You can then access n8n by opening:
 [http://localhost:5678](http://localhost:5678)
 
-**Note:** The minimum required version for Node.js is v14.15. Make sure to update Node.js to v14.15 or above.
+**Note:** The minimum required version for Node.js is v18. Make sure to update Node.js to v18 or above.
 
 ### Run with Docker
 


### PR DESCRIPTION
## Summary

Currently the npm package README has an outdated minimum version. This PR just bumps up the number to reflect the current requirements.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
