### PR TITLE
fix(core): Unload any existing version of a community nodes package before upgrading it

### DIFF
--- a/packages/cli/src/services/__tests__/community-packages.service.test.ts
+++ b/packages/cli/src/services/__tests__/community-packages.service.test.ts
@@ -410,6 +410,12 @@ describe('CommunityPackagesService', () => {
 				expect.any(Object),
 				expect.any(Function),
 			);
+			expect(loadNodesAndCredentials.unloadPackage).toHaveBeenCalledWith(
+				installedPackage.packageName,
+			);
+			expect(loadNodesAndCredentials.loadPackage).toHaveBeenCalledWith(
+				installedPackage.packageName,
+			);
 		});
 
 		test('should throw when not licensed', async () => {

--- a/packages/cli/src/services/community-packages.service.ts
+++ b/packages/cli/src/services/community-packages.service.ts
@@ -354,6 +354,7 @@ export class CommunityPackagesService {
 
 		let loader: PackageDirectoryLoader;
 		try {
+			await this.loadNodesAndCredentials.unloadPackage(packageName);
 			loader = await this.loadNodesAndCredentials.loadPackage(packageName);
 		} catch (error) {
 			// Remove this package since loading it failed


### PR DESCRIPTION
## Summary
This broke because in #10979 we added a check to prevent loading a second copy of a nodes package.
This PR updates the community package install/upgrade code to first unload the current copy of the package

## Related Linear tickets, Github issues, and Community forum posts
Fixes #11723


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
