### PR TITLE
feat(core): Initial TestRunner service with basic test execution (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -163,7 +163,13 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			if (!queryParams.relations) {
 				queryParams.relations = [];
 			}
-			(queryParams.relations as string[]).push('executionData', 'metadata');
+
+			if (Array.isArray(queryParams.relations)) {
+				queryParams.relations.push('executionData', 'metadata');
+			} else {
+				queryParams.relations.executionData = true;
+				queryParams.relations.metadata = true;
+			}
 		}
 
 		const executions = await this.find(queryParams);

--- a/packages/cli/src/evaluation/test-definitions.controller.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.controller.ee.ts
@@ -131,14 +131,18 @@ export class TestDefinitionsController {
 	}
 
 	@Post('/:id/run')
-	async runTest(req: TestDefinitionsRequest.Run) {
+	async runTest(req: TestDefinitionsRequest.Run, res: express.Response) {
 		const { id: testDefinitionId } = req.params;
 
 		const workflowIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
+		// Check test definition exists
+		const testDefinition = await this.testDefinitionService.findOne(testDefinitionId, workflowIds);
+		if (!testDefinition) throw new NotFoundError('Test definition not found');
+
 		// We do not await for the test run to complete
 		void this.testRunnerService.runTest(req.user, testDefinitionId, workflowIds);
 
-		return { success: true };
+		res.status(202).json({ success: true });
 	}
 }

--- a/packages/cli/src/evaluation/test-definitions.controller.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.controller.ee.ts
@@ -141,7 +141,7 @@ export class TestDefinitionsController {
 		if (!testDefinition) throw new NotFoundError('Test definition not found');
 
 		// We do not await for the test run to complete
-		void this.testRunnerService.runTest(req.user, testDefinitionId, workflowIds);
+		void this.testRunnerService.runTest(req.user, testDefinition);
 
 		res.status(202).json({ success: true });
 	}

--- a/packages/cli/src/evaluation/test-definitions.controller.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.controller.ee.ts
@@ -138,7 +138,9 @@ export class TestDefinitionsController {
 
 		const workflowIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return await this.testRunnerService.runTest(req.user, Number(req.params.id), workflowIds);
+		// We do not await for the test run to complete
+		void this.testRunnerService.runTest(req.user, Number(req.params.id), workflowIds);
+
+		return { success: true };
 	}
 }

--- a/packages/cli/src/evaluation/test-definitions.controller.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.controller.ee.ts
@@ -132,14 +132,12 @@ export class TestDefinitionsController {
 
 	@Post('/:id/run')
 	async runTest(req: TestDefinitionsRequest.Run) {
-		if (!isPositiveInteger(req.params.id)) {
-			throw new BadRequestError('Test ID is not a number');
-		}
+		const { id: testDefinitionId } = req.params;
 
 		const workflowIds = await getSharedWorkflowIds(req.user, ['workflow:read']);
 
 		// We do not await for the test run to complete
-		void this.testRunnerService.runTest(req.user, Number(req.params.id), workflowIds);
+		void this.testRunnerService.runTest(req.user, testDefinitionId, workflowIds);
 
 		return { success: true };
 	}

--- a/packages/cli/src/evaluation/test-definitions.types.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.types.ee.ts
@@ -30,4 +30,6 @@ export declare namespace TestDefinitionsRequest {
 	>;
 
 	type Delete = AuthenticatedRequest<RouteParams.TestId>;
+
+	type Run = AuthenticatedRequest<RouteParams.TestId>;
 }

--- a/packages/cli/src/evaluation/test-runner/__tests__/mock-data/execution-data.json
+++ b/packages/cli/src/evaluation/test-runner/__tests__/mock-data/execution-data.json
@@ -1,0 +1,171 @@
+{
+	"startData": {},
+	"resultData": {
+		"runData": {
+			"When clicking ‘Test workflow’": [
+				{
+					"hints": [],
+					"startTime": 1731079118048,
+					"executionTime": 0,
+					"source": [],
+					"executionStatus": "success",
+					"data": {
+						"main": [
+							[
+								{
+									"json": {
+										"query": "First item"
+									},
+									"pairedItem": {
+										"item": 0
+									}
+								},
+								{
+									"json": {
+										"query": "Second item"
+									},
+									"pairedItem": {
+										"item": 0
+									}
+								},
+								{
+									"json": {
+										"query": "Third item"
+									},
+									"pairedItem": {
+										"item": 0
+									}
+								}
+							]
+						]
+					}
+				}
+			],
+			"Edit Fields": [
+				{
+					"hints": [],
+					"startTime": 1731079118049,
+					"executionTime": 0,
+					"source": [
+						{
+							"previousNode": "When clicking ‘Test workflow’"
+						}
+					],
+					"executionStatus": "success",
+					"data": {
+						"main": [
+							[
+								{
+									"json": {
+										"foo": "bar"
+									},
+									"pairedItem": {
+										"item": 0
+									}
+								},
+								{
+									"json": {
+										"foo": "bar"
+									},
+									"pairedItem": {
+										"item": 1
+									}
+								},
+								{
+									"json": {
+										"foo": "bar"
+									},
+									"pairedItem": {
+										"item": 2
+									}
+								}
+							]
+						]
+					}
+				}
+			],
+			"Code": [
+				{
+					"hints": [],
+					"startTime": 1731079118049,
+					"executionTime": 3,
+					"source": [
+						{
+							"previousNode": "Edit Fields"
+						}
+					],
+					"executionStatus": "success",
+					"data": {
+						"main": [
+							[
+								{
+									"json": {
+										"foo": "bar",
+										"random": 0.6315509336851373
+									},
+									"pairedItem": {
+										"item": 0
+									}
+								},
+								{
+									"json": {
+										"foo": "bar",
+										"random": 0.3336315687359024
+									},
+									"pairedItem": {
+										"item": 1
+									}
+								},
+								{
+									"json": {
+										"foo": "bar",
+										"random": 0.4241870158917733
+									},
+									"pairedItem": {
+										"item": 2
+									}
+								}
+							]
+						]
+					}
+				}
+			]
+		},
+		"pinData": {
+			"When clicking ‘Test workflow’": [
+				{
+					"json": {
+						"query": "First item"
+					},
+					"pairedItem": {
+						"item": 0
+					}
+				},
+				{
+					"json": {
+						"query": "Second item"
+					},
+					"pairedItem": {
+						"item": 0
+					}
+				},
+				{
+					"json": {
+						"query": "Third item"
+					},
+					"pairedItem": {
+						"item": 0
+					}
+				}
+			]
+		},
+		"lastNodeExecuted": "Code"
+	},
+	"executionData": {
+		"contextData": {},
+		"nodeExecutionStack": [],
+		"metadata": {},
+		"waitingExecution": {},
+		"waitingExecutionSource": {}
+	}
+}

--- a/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.evaluation.json
+++ b/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.evaluation.json
@@ -1,0 +1,124 @@
+{
+	"name": "Evaluation Workflow",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "285ac92b-256f-4bb2-a450-6486b01593cb",
+			"name": "Execute Workflow Trigger",
+			"type": "n8n-nodes-base.executeWorkflowTrigger",
+			"typeVersion": 1,
+			"position": [520, 340]
+		},
+		{
+			"parameters": {
+				"conditions": {
+					"options": {
+						"caseSensitive": true,
+						"leftValue": "",
+						"typeValidation": "strict",
+						"version": 2
+					},
+					"conditions": [
+						{
+							"id": "9d3abc8d-3270-4bec-9a59-82622d5dbb5a",
+							"leftValue": "={{ $json.actual.Code[0].data.main[0].length }}",
+							"rightValue": 3,
+							"operator": {
+								"type": "number",
+								"operation": "gte"
+							}
+						},
+						{
+							"id": "894ce84b-13a4-4415-99c0-0c25182903bb",
+							"leftValue": "={{ $json.actual.Code[0].data.main[0][0].json.random }}",
+							"rightValue": 0.7,
+							"operator": {
+								"type": "number",
+								"operation": "lt"
+							}
+						}
+					],
+					"combinator": "and"
+				},
+				"options": {}
+			},
+			"id": "320b0355-3886-41df-b039-4666bf28e47b",
+			"name": "If",
+			"type": "n8n-nodes-base.if",
+			"typeVersion": 2.2,
+			"position": [740, 340]
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "3b65d55a-158f-40c6-9853-a1c44b7ba1e5",
+							"name": "success",
+							"value": true,
+							"type": "boolean"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "0c7a1ee8-0cf0-4d7f-99a3-186bbcd8815a",
+			"name": "Success",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [980, 220]
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "6cc8b402-4a30-4873-b825-963a1f1b8b82",
+							"name": "success",
+							"value": false,
+							"type": "boolean"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "50d3f84a-d99f-4e04-bdbd-3e8c2668e708",
+			"name": "Fail",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [980, 420]
+		}
+	],
+	"connections": {
+		"Execute Workflow Trigger": {
+			"main": [
+				[
+					{
+						"node": "If",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"If": {
+			"main": [
+				[
+					{
+						"node": "Success",
+						"type": "main",
+						"index": 0
+					}
+				],
+				[
+					{
+						"node": "Fail",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}

--- a/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.under-test.json
+++ b/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.under-test.json
@@ -1,0 +1,78 @@
+{
+	"name": "Workflow Under Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-80, 0],
+			"id": "72256d90-3a67-4e29-b032-47df4e5768af",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "acfeecbe-443c-4220-b63b-d44d69216902",
+							"name": "foo",
+							"value": "bar",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [140, 0],
+			"id": "319f29bc-1dd4-4122-b223-c584752151a4",
+			"name": "Edit Fields"
+		},
+		{
+			"parameters": {
+				"jsCode": "for (const item of $input.all()) {\n  item.json.random = Math.random();\n}\n\nreturn $input.all();"
+			},
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [380, 0],
+			"id": "d2474215-63af-40a4-a51e-0ea30d762621",
+			"name": "Code"
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Edit Fields",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Edit Fields": {
+			"main": [
+				[
+					{
+						"node": "Wait",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Wait": {
+			"main": [
+				[
+					{
+						"node": "Code",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	}
+}

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -2,10 +2,9 @@ import type { SelectQueryBuilder } from '@n8n/typeorm';
 import { stringify } from 'flatted';
 import { readFileSync } from 'fs';
 import { mock, mockDeep } from 'jest-mock-extended';
-import { mockInstance } from 'n8n-core/test/utils';
 import path from 'path';
 
-import { ActiveExecutions } from '@/active-executions';
+import type { ActiveExecutions } from '@/active-executions';
 import type { ExecutionEntity } from '@/databases/entities/execution-entity';
 import type { TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
@@ -22,8 +21,6 @@ const wfUnderTestJson = JSON.parse(
 const executionDataJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/execution-data.json'), { encoding: 'utf-8' }),
 );
-
-mockInstance(ActiveExecutions);
 
 const executionMocks = [
 	mock<ExecutionEntity>({
@@ -48,6 +45,7 @@ describe('TestRunnerService', () => {
 	const executionRepository = mock<ExecutionRepository>();
 	const workflowRepository = mock<WorkflowRepository>();
 	const workflowRunner = mock<WorkflowRunner>();
+	const activeExecutions = mock<ActiveExecutions>();
 
 	beforeEach(() => {
 		const executionsQbMock = mockDeep<SelectQueryBuilder<ExecutionEntity>>({
@@ -69,6 +67,7 @@ describe('TestRunnerService', () => {
 			workflowRepository,
 			workflowRunner,
 			executionRepository,
+			activeExecutions,
 		);
 
 		expect(testRunnerService).toBeInstanceOf(TestRunnerService);
@@ -79,6 +78,7 @@ describe('TestRunnerService', () => {
 			workflowRepository,
 			workflowRunner,
 			executionRepository,
+			activeExecutions,
 		);
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -78,14 +78,16 @@ describe('TestRunnerService', () => {
 			executionRepository,
 		);
 
-		testDefinitionService.findOne.calledWith('some-test-id', []).mockResolvedValueOnce(
-			mock<TestDefinition>({
-				id: 'some-test-id',
-				workflowId: 'workflow-under-test-id',
-				evaluationWorkflowId: 'evaluation-workflow-id',
-				annotationTagId: 'some-annotation-tag-id',
-			}),
-		);
+		testDefinitionService.findOne
+			.calledWith('some-test-id', expect.anything())
+			.mockResolvedValueOnce(
+				mock<TestDefinition>({
+					id: 'some-test-id',
+					workflowId: 'workflow-under-test-id',
+					evaluationWorkflowId: 'evaluation-workflow-id',
+					annotationTagId: 'some-annotation-tag-id',
+				}),
+			);
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -1,0 +1,97 @@
+import { stringify } from 'flatted';
+import { readFileSync } from 'fs';
+import { mock, mockDeep } from 'jest-mock-extended';
+import { mockInstance } from 'n8n-core/test/utils';
+import path from 'path';
+
+import { ActiveExecutions } from '@/active-executions';
+import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import type { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
+import type { WorkflowRunner } from '@/workflow-runner';
+
+import { TestRunnerService } from '../test-runner.service.ee';
+
+const wfUnderTestJson = JSON.parse(
+	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json')),
+);
+
+const executionDataJson = JSON.parse(
+	readFileSync(path.join(__dirname, './mock-data/execution-data.json')),
+);
+
+const activeExecutions = mockInstance(ActiveExecutions);
+
+describe('TestRunnerService', () => {
+	const executionRepository = mock<ExecutionRepository>();
+	const testDefinitionService = mock<TestDefinitionService>();
+	const workflowRepository = mock<WorkflowRepository>();
+	const workflowRunner = mock<WorkflowRunner>();
+
+	beforeEach(() => {
+		const executionsQbMock = mockDeep<SelectQueryBuilder<ExecutionEntity>>({
+			fallbackMockImplementation: jest.fn().mockReturnThis(),
+		});
+
+		executionsQbMock.getMany.mockResolvedValueOnce([
+			{
+				id: 'some-execution-id',
+				workflowId: 'workflow-under-test-id',
+				status: 'success',
+				finishedAt: new Date(),
+				executionData: {
+					data: stringify(executionDataJson),
+				},
+			},
+			{
+				id: 'some-execution-id-2',
+				workflowId: 'workflow-under-test-id',
+				status: 'success',
+				finishedAt: new Date(),
+				executionData: {
+					data: stringify(executionDataJson),
+				},
+			},
+		]);
+
+		executionRepository.createQueryBuilder.mockReturnValueOnce(executionsQbMock);
+	});
+
+	test('should create an instance of TestRunnerService', async () => {
+		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
+			workflowRepository,
+			executionRepository,
+		);
+
+		expect(testRunnerService).toBeInstanceOf(TestRunnerService);
+	});
+
+	test('should create and run test cases from past executions', async () => {
+		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
+			workflowRepository,
+			workflowRunner,
+			executionRepository,
+		);
+
+		testDefinitionService.findOne.calledWith('some-test-id').mockResolvedValueOnce({
+			id: 'some-test-id',
+			workflowId: 'workflow-under-test-id',
+			evaluationWorkflowId: 'evaluation-workflow-id',
+			annotationTagId: 'some-annotation-tag-id',
+		});
+
+		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
+			id: 'workflow-under-test-id',
+			...wfUnderTestJson,
+		});
+
+		workflowRunner.run.mockResolvedValue('test-execution-id');
+
+		await testRunnerService.runTest(mock<User>(), 'some-test-id');
+
+		expect(executionRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+		expect(workflowRunner.run).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -1,3 +1,4 @@
+import type { SelectQueryBuilder } from '@n8n/typeorm';
 import { stringify } from 'flatted';
 import { readFileSync } from 'fs';
 import { mock, mockDeep } from 'jest-mock-extended';
@@ -5,6 +6,9 @@ import { mockInstance } from 'n8n-core/test/utils';
 import path from 'path';
 
 import { ActiveExecutions } from '@/active-executions';
+import type { ExecutionEntity } from '@/databases/entities/execution-entity';
+import type { TestDefinition } from '@/databases/entities/test-definition.ee';
+import type { User } from '@/databases/entities/user';
 import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
 import type { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
@@ -13,14 +17,14 @@ import type { WorkflowRunner } from '@/workflow-runner';
 import { TestRunnerService } from '../test-runner.service.ee';
 
 const wfUnderTestJson = JSON.parse(
-	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json')),
+	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json'), { encoding: 'utf-8' }),
 );
 
 const executionDataJson = JSON.parse(
-	readFileSync(path.join(__dirname, './mock-data/execution-data.json')),
+	readFileSync(path.join(__dirname, './mock-data/execution-data.json'), { encoding: 'utf-8' }),
 );
 
-const activeExecutions = mockInstance(ActiveExecutions);
+mockInstance(ActiveExecutions);
 
 describe('TestRunnerService', () => {
 	const executionRepository = mock<ExecutionRepository>();
@@ -34,24 +38,22 @@ describe('TestRunnerService', () => {
 		});
 
 		executionsQbMock.getMany.mockResolvedValueOnce([
-			{
+			mock<ExecutionEntity>({
 				id: 'some-execution-id',
 				workflowId: 'workflow-under-test-id',
 				status: 'success',
-				finishedAt: new Date(),
 				executionData: {
 					data: stringify(executionDataJson),
 				},
-			},
-			{
+			}),
+			mock<ExecutionEntity>({
 				id: 'some-execution-id-2',
 				workflowId: 'workflow-under-test-id',
 				status: 'success',
-				finishedAt: new Date(),
 				executionData: {
 					data: stringify(executionDataJson),
 				},
-			},
+			}),
 		]);
 
 		executionRepository.createQueryBuilder.mockReturnValueOnce(executionsQbMock);
@@ -61,6 +63,7 @@ describe('TestRunnerService', () => {
 		const testRunnerService = new TestRunnerService(
 			testDefinitionService,
 			workflowRepository,
+			workflowRunner,
 			executionRepository,
 		);
 
@@ -75,12 +78,14 @@ describe('TestRunnerService', () => {
 			executionRepository,
 		);
 
-		testDefinitionService.findOne.calledWith('some-test-id').mockResolvedValueOnce({
-			id: 'some-test-id',
-			workflowId: 'workflow-under-test-id',
-			evaluationWorkflowId: 'evaluation-workflow-id',
-			annotationTagId: 'some-annotation-tag-id',
-		});
+		testDefinitionService.findOne.calledWith('some-test-id', []).mockResolvedValueOnce(
+			mock<TestDefinition>({
+				id: 'some-test-id',
+				workflowId: 'workflow-under-test-id',
+				evaluationWorkflowId: 'evaluation-workflow-id',
+				annotationTagId: 'some-annotation-tag-id',
+			}),
+		);
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',
@@ -89,7 +94,7 @@ describe('TestRunnerService', () => {
 
 		workflowRunner.run.mockResolvedValue('test-execution-id');
 
-		await testRunnerService.runTest(mock<User>(), 'some-test-id');
+		await testRunnerService.runTest(mock<User>(), 'some-test-id', []);
 
 		expect(executionRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
 		expect(workflowRunner.run).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -11,6 +11,7 @@ import type { TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
 import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
 import type { WorkflowRunner } from '@/workflow-runner';
 
@@ -68,6 +69,21 @@ describe('TestRunnerService', () => {
 		);
 
 		expect(testRunnerService).toBeInstanceOf(TestRunnerService);
+	});
+
+	test('should return an error if test definition is not found', async () => {
+		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
+			workflowRepository,
+			workflowRunner,
+			executionRepository,
+		);
+
+		testDefinitionService.findOne.mockResolvedValueOnce(null);
+
+		await expect(testRunnerService.runTest(mock<User>(), 'some-test-id', [])).rejects.toThrowError(
+			NotFoundError,
+		);
 	});
 
 	test('should create and run test cases from past executions', async () => {

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -1,7 +1,7 @@
 import { parse } from 'flatted';
-import type { IPinData, IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import type { IPinData, IRun, IWorkflowExecutionDataProcess } from 'n8n-workflow';
 import assert from 'node:assert';
-import { Container, Service } from 'typedi';
+import { Service } from 'typedi';
 
 import { ActiveExecutions } from '@/active-executions';
 import type { ExecutionEntity } from '@/databases/entities/execution-entity';
@@ -10,7 +10,7 @@ import type { User } from '@/databases/entities/user';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
-import type { IExecutionDb, IExecutionResponse } from '@/interfaces';
+import type { IExecutionResponse } from '@/interfaces';
 import { WorkflowRunner } from '@/workflow-runner';
 
 /**
@@ -28,6 +28,7 @@ export class TestRunnerService {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowRunner: WorkflowRunner,
 		private readonly executionRepository: ExecutionRepository,
+		private readonly activeExecutions: ActiveExecutions,
 	) {}
 
 	/**
@@ -63,7 +64,7 @@ export class TestRunnerService {
 		workflow: WorkflowEntity,
 		testCase: IPinData,
 		userId: string,
-	): Promise<IExecutionDb | undefined> {
+	): Promise<IRun | undefined> {
 		const data: IWorkflowExecutionDataProcess = {
 			executionMode: 'evaluation',
 			runData: {},
@@ -78,9 +79,7 @@ export class TestRunnerService {
 		assert(executionId);
 
 		// Wait for the workflow to finish execution
-		const executePromise = Container.get(ActiveExecutions).getPostExecutePromise(
-			executionId,
-		) as Promise<IExecutionDb | undefined>;
+		const executePromise = this.activeExecutions.getPostExecutePromise(executionId);
 
 		return await executePromise;
 	}

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -36,9 +36,6 @@ export class TestRunnerService {
 	 * Creates a pin data object from the past execution data
 	 * for the given workflow.
 	 * For now, it only pins trigger nodes.
-	 * @param workflow
-	 * @param execution
-	 * @private
 	 */
 	private createPinDataFromExecution(
 		workflow: WorkflowEntity,
@@ -63,10 +60,6 @@ export class TestRunnerService {
 	/**
 	 * Runs a test case with the given pin data.
 	 * Waits for the workflow under test to finish execution.
-	 * @param workflow
-	 * @param testCase
-	 * @param userId
-	 * @private
 	 */
 	private async runTestCase(
 		workflow: WorkflowEntity,
@@ -96,11 +89,8 @@ export class TestRunnerService {
 
 	/**
 	 * Creates a new test run for the given test definition.
-	 * @param user
-	 * @param testId
-	 * @param accessibleWorkflowIds
 	 */
-	public async runTest(user: User, testId: string, accessibleWorkflowIds: string[]): Promise<any> {
+	public async runTest(user: User, testId: string, accessibleWorkflowIds: string[]): Promise<void> {
 		const test = await this.testDefinitionsService.findOne(testId, accessibleWorkflowIds);
 
 		if (!test) {
@@ -140,7 +130,5 @@ export class TestRunnerService {
 
 			// TODO: 2.3 Collect the run data
 		}
-
-		return { success: true };
 	}
 }

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -62,13 +62,13 @@ export class TestRunnerService {
 	 */
 	private async runTestCase(
 		workflow: WorkflowEntity,
-		testCase: IPinData,
+		testCasePinData: IPinData,
 		userId: string,
 	): Promise<IRun | undefined> {
 		const data: IWorkflowExecutionDataProcess = {
 			executionMode: 'evaluation',
 			runData: {},
-			pinData: testCase,
+			pinData: testCasePinData,
 			workflowData: workflow,
 			partialExecutionVersion: '-1',
 			userId,

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -69,7 +69,7 @@ export class TestRunnerService {
 		return await executePromise;
 	}
 
-	public async runTest(user: User, testId: number, accessibleWorkflowIds: string[]): Promise<any> {
+	public async runTest(user: User, testId: string, accessibleWorkflowIds: string[]): Promise<any> {
 		const test = await this.testDefinitionsService.findOne(testId, accessibleWorkflowIds);
 
 		if (!test) {

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -35,7 +35,7 @@ export class TestRunnerService {
 
 		for (const triggerNode of triggerNodes) {
 			const triggerData = executionData.resultData.runData[triggerNode.name];
-			if (triggerData[0]?.data?.main?.[0]) {
+			if (triggerData?.[0]?.data?.main?.[0]) {
 				pinData[triggerNode.name] = triggerData[0]?.data?.main?.[0];
 			}
 		}

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -63,13 +63,11 @@ export class TestRunnerService {
 			.andWhere('execution.workflowId = :workflowId', { workflowId: test.workflowId })
 			.getMany();
 
-		const testCases = executions.map((execution) => {
-			return this.createPinDataFromExecution(workflow, execution);
-		});
+		const testCases = executions.map((execution) =>
+			this.createPinDataFromExecution(workflow, execution),
+		);
 
 		for (const testCase of testCases) {
-			console.log({ testCase });
-
 			// Start the workflow
 			const data: IWorkflowExecutionDataProcess = {
 				executionMode: 'evaluation',
@@ -89,7 +87,6 @@ export class TestRunnerService {
 			) as Promise<IExecutionDb | undefined>;
 
 			const execution = await executePromise;
-			console.log(execution?.data.resultData.runData);
 		}
 
 		return { success: true };

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -1,0 +1,100 @@
+import { parse } from 'flatted';
+import type { IPinData, IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import assert from 'node:assert';
+import { Container, Service } from 'typedi';
+
+import { ActiveExecutions } from '@/active-executions';
+import type { User } from '@/databases/entities/user';
+import { ExecutionRepository } from '@/databases/repositories/execution.repository';
+import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
+import type { IExecutionDb, IExecutionResponse } from '@/interfaces';
+import { WorkflowRunner } from '@/workflow-runner';
+// import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+@Service()
+export class TestRunnerService {
+	constructor(
+		private readonly testDefinitionsService: TestDefinitionService,
+		private readonly workflowRepository: WorkflowRepository,
+		// private readonly workflowExecutionService: WorkflowExecutionService,
+		private readonly workflowRunner: WorkflowRunner,
+		private readonly executionRepository: ExecutionRepository,
+	) {}
+
+	public async runTest(user: User, testId: number, accessibleWorkflowIds: string[]): Promise<any> {
+		const test = await this.testDefinitionsService.findOne(testId, accessibleWorkflowIds);
+
+		console.log({ test });
+
+		if (!test) {
+			throw new NotFoundError('Test definition not found');
+		}
+
+		const workflow = await this.workflowRepository.findById(test.workflowId);
+		assert(workflow, 'Workflow not found');
+
+		// Make a list of test cases
+		// const executions = await this.executionRepository.findManyByRangeQuery({
+		// 	kind: 'range',
+		// 	range: {
+		// 		limit: 99,
+		// 	},
+		// 	annotationTags: [test.annotationTagId],
+		// 	accessibleWorkflowIds,
+		// });
+		const executions = await this.executionRepository
+			.createQueryBuilder('execution')
+			.leftJoin('execution.annotation', 'annotation')
+			.leftJoin('annotation.tags', 'annotationTag')
+			.leftJoinAndSelect('execution.executionData', 'executionData')
+			.leftJoinAndSelect('execution.metadata', 'metadata')
+			.where('annotationTag.id = :tagId', { tagId: test.annotationTagId })
+			.andWhere('execution.workflowId = :workflowId', { workflowId: test.workflowId })
+			.getMany();
+
+		const testCases = executions.map((execution) => {
+			const executionData = parse(execution.executionData.data) as IExecutionResponse['data'];
+
+			return {
+				pinData: {
+					'When clicking ‘Test workflow’':
+						executionData.resultData.runData['When clicking ‘Test workflow’'][0]?.data?.main?.[0],
+				} as IPinData,
+			};
+		});
+
+		console.log({ testCases });
+
+		for (const testCase of testCases) {
+			// Start the workflow
+			const data: IWorkflowExecutionDataProcess = {
+				executionMode: 'evaluation',
+				runData: {},
+				pinData: testCase.pinData,
+				workflowData: workflow,
+				userId: user.id,
+				partialExecutionVersion: '-1',
+			};
+
+			// if (pinnedTrigger && !hasRunData(pinnedTrigger)) {
+			// 	data.startNodes = [{ name: pinnedTrigger.name, sourceData: null }];
+			// }
+
+			const executionId = await this.workflowRunner.run(data);
+
+			assert(executionId);
+
+			const executePromise = Container.get(ActiveExecutions).getPostExecutePromise(
+				executionId,
+			) as Promise<IExecutionDb | undefined>;
+
+			const execution = await executePromise;
+			console.log({ execution });
+			console.log(execution?.data.resultData.runData.Code?.[0].data?.main[0]);
+		}
+
+		return { success: true };
+	}
+}

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -401,8 +401,8 @@ describe('POST /evaluation/test-definitions/:id/run', () => {
 
 		const resp = await authOwnerAgent.post(`/evaluation/test-definitions/${newTest.id}/run`);
 
-		expect(resp.statusCode).toBe(200);
-		expect(resp.body.data).toEqual(
+		expect(resp.statusCode).toBe(202);
+		expect(resp.body).toEqual(
 			expect.objectContaining({
 				success: true,
 			}),

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -1,9 +1,13 @@
+import { readFileSync } from 'fs';
+import { mockInstance } from 'n8n-core/test/utils';
+import path from 'path';
 import { Container } from 'typedi';
 
 import type { AnnotationTagEntity } from '@/databases/entities/annotation-tag-entity.ee';
 import type { User } from '@/databases/entities/user';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { TestDefinitionRepository } from '@/databases/repositories/test-definition.repository.ee';
+import { TestRunnerService } from '@/evaluation/test-runner/test-runner.service.ee';
 import { createAnnotationTags } from '@test-integration/db/executions';
 
 import { createUserShell } from './../shared/db/users';
@@ -11,6 +15,8 @@ import { createWorkflow } from './../shared/db/workflows';
 import * as testDb from './../shared/test-db';
 import type { SuperAgentTest } from './../shared/types';
 import * as utils from './../shared/utils/';
+
+const testRunner = mockInstance(TestRunnerService);
 
 let authOwnerAgent: SuperAgentTest;
 let workflowUnderTest: WorkflowEntity;
@@ -384,5 +390,26 @@ describe('DELETE /evaluation/test-definitions/:id', () => {
 
 		expect(resp.statusCode).toBe(404);
 		expect(resp.body.message).toBe('Test definition not found');
+	});
+});
+
+describe('POST /evaluation/test-definitions/:id/run', () => {
+	test('should trigger the test run', async () => {
+		const newTest = Container.get(TestDefinitionRepository).create({
+			name: 'test',
+			workflow: { id: workflowUnderTest.id },
+		});
+		await Container.get(TestDefinitionRepository).save(newTest);
+
+		const resp = await authOwnerAgent.post(`/evaluation/test-definitions/${newTest.id}/run`);
+
+		expect(resp.statusCode).toBe(200);
+		expect(resp.body.data).toEqual(
+			expect.objectContaining({
+				success: true,
+			}),
+		);
+
+		expect(testRunner.runTest).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from 'fs';
 import { mockInstance } from 'n8n-core/test/utils';
-import path from 'path';
 import { Container } from 'typedi';
 
 import type { AnnotationTagEntity } from '@/databases/entities/annotation-tag-entity.ee';

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2371,7 +2371,8 @@ export type WorkflowExecuteMode =
 	| 'manual'
 	| 'retry'
 	| 'trigger'
-	| 'webhook';
+	| 'webhook'
+	| 'evaluation';
 
 export type WorkflowActivateMode =
 	| 'init'


### PR DESCRIPTION
## Summary

This PR introduces a new test runner service that enables execution of test workflows.

Key features:
- Creates a test case set from existing executions according to the criteria set in test definition (aka specific annotation tag applied)
- Triggers the execution of workflow under test with all trigger nodes data mocked with the values from each specific test case
- Awaits for the test execution to finish before continuing with the next test case

Additionally, the new endpoint was added to trigger running tests for a specific test definition.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-427/[testrunner]-kick-off-workflow-under-test


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
