### PR TITLE
fix(editor): Change Home label to Overview

### DIFF
--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -176,7 +176,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 		let menuItems = cy.getByTestId('menu-item');
 
 		menuItems.filter('[class*=active_]').should('have.length', 1);
-		menuItems.filter(':contains("Home")[class*=active_]').should('exist');
+		menuItems.filter(':contains("Overview")[class*=active_]').should('exist');
 
 		projects.getMenuItems().first().click();
 
@@ -222,7 +222,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 		menuItems = cy.getByTestId('menu-item');
 
 		menuItems.filter('[class*=active_]').should('have.length', 1);
-		menuItems.filter(':contains("Home")[class*=active_]').should('exist');
+		menuItems.filter(':contains("Overview")[class*=active_]').should('exist');
 
 		workflowsPage.getters.workflowCards().should('have.length', 2).first().click();
 
@@ -230,7 +230,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 		cy.getByTestId('execute-workflow-button').should('be.visible');
 
 		menuItems = cy.getByTestId('menu-item');
-		menuItems.filter(':contains("Home")[class*=active_]').should('not.exist');
+		menuItems.filter(':contains("Overview")[class*=active_]').should('not.exist');
 
 		menuItems = cy.getByTestId('menu-item');
 		menuItems.filter('[class*=active_]').should('have.length', 1);

--- a/packages/editor-ui/src/components/Projects/ProjectHeader.test.ts
+++ b/packages/editor-ui/src/components/Projects/ProjectHeader.test.ts
@@ -65,7 +65,7 @@ describe('ProjectHeader', () => {
 	it('should render the correct title', async () => {
 		const { getByText, rerender } = renderComponent();
 
-		expect(getByText('Home')).toBeVisible();
+		expect(getByText('Overview')).toBeVisible();
 
 		projectsStore.currentProject = { type: ProjectTypes.Personal } as Project;
 		await rerender({});

--- a/packages/editor-ui/src/components/Projects/ProjectHeader.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectHeader.vue
@@ -23,7 +23,7 @@ const headerIcon = computed(() => {
 
 const projectName = computed(() => {
 	if (!projectsStore.currentProject) {
-		return i18n.baseText('projects.menu.home');
+		return i18n.baseText('projects.menu.overview');
 	} else if (projectsStore.currentProject.type === ProjectTypes.Personal) {
 		return i18n.baseText('projects.menu.personal');
 	} else {

--- a/packages/editor-ui/src/components/Projects/ProjectNavigation.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectNavigation.vue
@@ -27,7 +27,7 @@ const isCreatingProject = ref(false);
 const isComponentMounted = ref(false);
 const home = computed<IMenuItem>(() => ({
 	id: 'home',
-	label: locale.baseText('projects.menu.home'),
+	label: locale.baseText('projects.menu.overview'),
 	icon: 'home',
 	route: {
 		to: { name: VIEWS.HOMEPAGE },

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2499,7 +2499,7 @@
 	"settings.mfa.title": "Multi-factor Authentication",
 	"settings.mfa.updateConfiguration": "MFA configuration updated",
 	"settings.mfa.invalidAuthenticatorCode": "Invalid authenticator code",
-	"projects.menu.home": "Home",
+	"projects.menu.overview": "Overview",
 	"projects.menu.title": "Projects",
 	"projects.menu.personal": "Personal",
 	"projects.menu.addProject": "Add project",


### PR DESCRIPTION
## Summary

According to some users, Overview is more appropriate for the section that shows all workflows, credentials and executions they have access to

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2223](https://linear.app/n8n/issue/PAY-2223/change-name-of-home-menu-item-to-overview)

## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
