### PR TITLE
chore(editor): Stop reporting `ResponseError: Unauthorized` error to Sentry (no-changelog)

### DIFF
--- a/packages/editor-ui/src/plugins/sentry.ts
+++ b/packages/editor-ui/src/plugins/sentry.ts
@@ -7,6 +7,7 @@ const ignoredErrors = [
 	{ instanceof: AxiosError },
 	{ instanceof: ResponseError, message: /ECONNREFUSED/ },
 	{ instanceof: ResponseError, message: "Can't connect to n8n." },
+	{ instanceof: ResponseError, message: 'Unauthorized' },
 	{ instanceof: Error, message: /ResizeObserver/ },
 ] as const;
 


### PR DESCRIPTION
## Summary
This should stop any more events of https://n8nio.sentry.io/issues/6016580895

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
