### PR TITLE
fix(Read/Write Files from Disk Node): Escape parenthesis when reading file

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/actions/read.operation.ts
@@ -7,7 +7,7 @@ import type {
 } from 'n8n-workflow';
 
 import glob from 'fast-glob';
-import { errorMapper } from '../helpers/utils';
+import { errorMapper, escapeSpecialCharacters } from '../helpers/utils';
 import { updateDisplayOptions } from '@utils/utilities';
 
 export const properties: INodeProperties[] = [
@@ -81,6 +81,8 @@ export async function execute(this: IExecuteFunctions, items: INodeExecutionData
 	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 		try {
 			fileSelector = String(this.getNodeParameter('fileSelector', itemIndex));
+
+			fileSelector = escapeSpecialCharacters(fileSelector);
 
 			if (/^[a-zA-Z]:/.test(fileSelector)) {
 				fileSelector = fileSelector.replace(/\\\\/g, '/');

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
@@ -30,3 +30,10 @@ export function errorMapper(
 
 	return new NodeOperationError(this.getNode(), error, { itemIndex, message, description });
 }
+
+export function escapeSpecialCharacters(str: string) {
+	// Escape parentheses
+	str = str.replace(/[()]/g, '\\$&');
+
+	return str;
+}

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
@@ -1,0 +1,15 @@
+import { escapeSpecialCharacters } from '../helpers/utils';
+
+describe('Read/Write Files from Disk, escapeSpecialCharacters', () => {
+	it('should escape parentheses in a string', () => {
+		const input = '/home/michael/Desktop/test(1).txt';
+		const expectedOutput = '/home/michael/Desktop/test\\(1\\).txt';
+		expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
+	});
+
+	it('should not modify strings that do not contain parentheses', () => {
+		const input = '/home/michael/Desktop/test.txt';
+		const expectedOutput = '/home/michael/Desktop/test.txt';
+		expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
+	});
+});


### PR DESCRIPTION
## Summary

allows to read files with filenames such as `test(1).txt`
## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2010/community-issue-readwrite-files-from-disk-node-fails-to-return-data-if
fixes #11618 