### PR TITLE
feat(Slack Node): Update wait for approval to use markdown

### DIFF
--- a/packages/nodes-base/nodes/Slack/Slack.node.ts
+++ b/packages/nodes-base/nodes/Slack/Slack.node.ts
@@ -14,7 +14,7 @@ export class Slack extends VersionedNodeType {
 			group: ['output'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume Slack API',
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -22,6 +22,7 @@ export class Slack extends VersionedNodeType {
 			2: new SlackV2(baseDescription),
 			2.1: new SlackV2(baseDescription),
 			2.2: new SlackV2(baseDescription),
+			2.3: new SlackV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import get from 'lodash/get';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -7,10 +8,9 @@ import type {
 	IRequestOptions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
-
 import { NodeOperationError } from 'n8n-workflow';
 
-import get from 'lodash/get';
+import type { SendAndWaitMessageBody } from './MessageInterface';
 import { getSendAndWaitConfig } from '../../../utils/sendAndWait/utils';
 
 export async function slackApiRequest(
@@ -265,7 +265,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 
 	const config = getSendAndWaitConfig(context);
 
-	const body: IDataObject = {
+	const body: SendAndWaitMessageBody = {
 		channel: target,
 		blocks: [
 			{
@@ -274,7 +274,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 			{
 				type: 'section',
 				text: {
-					type: 'plain_text',
+					type: context.getNode().typeVersion > 2.2 ? 'mrkdwn' : 'plain_text',
 					text: config.message,
 					emoji: true,
 				},
@@ -306,6 +306,10 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 			},
 		],
 	};
+
+	if (context.getNode().typeVersion > 2.2 && body.blocks?.[1]?.type === 'section') {
+		delete body.blocks[1].text.emoji;
+	}
 
 	return body;
 }

--- a/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
@@ -3,3 +3,36 @@ export interface IAttachment {
 		item?: object[];
 	};
 }
+
+// Used for SendAndWaitMessage
+export interface TextBlock {
+	type: string;
+	text: string;
+	emoji?: boolean;
+}
+
+export interface SectionBlock {
+	type: 'section';
+	text: TextBlock;
+}
+
+export interface DividerBlock {
+	type: 'divider';
+}
+
+export interface ButtonElement {
+	type: 'button';
+	style?: 'primary';
+	text: TextBlock;
+	url: string;
+}
+
+export interface ActionsBlock {
+	type: 'actions';
+	elements: ButtonElement[];
+}
+
+export interface SendAndWaitMessageBody {
+	channel: string;
+	blocks: Array<DividerBlock | SectionBlock | ActionsBlock>;
+}

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -52,7 +52,7 @@ export class SlackV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: [2, 2.1, 2.2],
+			version: [2, 2.1, 2.2, 2.3],
 			defaults: {
 				name: 'Slack',
 			},

--- a/packages/nodes-base/nodes/Slack/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/utils.test.ts
@@ -1,5 +1,6 @@
 import { type MockProxy, mock } from 'jest-mock-extended';
 import type { IExecuteFunctions } from 'n8n-workflow';
+
 import { getTarget, createSendAndWaitMessageBody } from '../../V2/GenericFunctions';
 
 describe('Slack Utility Functions', () => {
@@ -12,7 +13,7 @@ describe('Slack Utility Functions', () => {
 	});
 
 	describe('getTarget', () => {
-		it('should return corect target id', () => {
+		it('should return correct target id', () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
 				if (parameterName === 'user') {
 					return 'testUser';
@@ -26,7 +27,7 @@ describe('Slack Utility Functions', () => {
 	});
 
 	describe('createSendAndWaitMessageBody', () => {
-		it('should create message with single button', () => {
+		it('should create message with single button - pre 2.3 plain_text', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channel');
 			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channelID');
 
@@ -79,7 +80,7 @@ describe('Slack Utility Functions', () => {
 			});
 		});
 
-		it('should create message with double buttona', () => {
+		it('should create message with double buttons - pre 2.3 plain_text', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channel');
 			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channelID');
 
@@ -99,6 +100,124 @@ describe('Slack Utility Functions', () => {
 							emoji: true,
 							text: 'message',
 							type: 'plain_text',
+						},
+						type: 'section',
+					},
+					{
+						text: {
+							text: ' ',
+							type: 'plain_text',
+						},
+						type: 'section',
+					},
+					{
+						type: 'divider',
+					},
+					{
+						elements: [
+							{
+								style: undefined,
+								text: {
+									emoji: true,
+									text: 'Disapprove',
+									type: 'plain_text',
+								},
+								type: 'button',
+								url: 'localhost/node123?approved=false',
+							},
+
+							{
+								style: 'primary',
+								text: {
+									emoji: true,
+									text: 'Approve',
+									type: 'plain_text',
+								},
+								type: 'button',
+								url: 'localhost/node123?approved=true',
+							},
+						],
+						type: 'actions',
+					},
+				],
+				channel: 'channelID',
+			});
+		});
+
+		it('should create message with single button - 2.3+ mrkdwn', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channel');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channelID');
+
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('subject');
+			mockExecuteFunctions.evaluateExpression.mockReturnValueOnce('localhost');
+			mockExecuteFunctions.evaluateExpression.mockReturnValueOnce('node123');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({});
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Slack', typeVersion: 2.3 } as any);
+
+			expect(createSendAndWaitMessageBody(mockExecuteFunctions)).toEqual({
+				blocks: [
+					{
+						type: 'divider',
+					},
+					{
+						text: {
+							text: 'message',
+							type: 'mrkdwn',
+						},
+						type: 'section',
+					},
+					{
+						text: {
+							text: ' ',
+							type: 'plain_text',
+						},
+						type: 'section',
+					},
+					{
+						type: 'divider',
+					},
+					{
+						elements: [
+							{
+								style: 'primary',
+								text: {
+									emoji: true,
+									text: 'Approve',
+									type: 'plain_text',
+								},
+								type: 'button',
+								url: 'localhost/node123?approved=true',
+							},
+						],
+						type: 'actions',
+					},
+				],
+				channel: 'channelID',
+			});
+		});
+
+		it('should create message with double buttons - 2.3+ mrkdwn', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channel');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('channelID');
+
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('message');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce('subject');
+			mockExecuteFunctions.evaluateExpression.mockReturnValueOnce('localhost');
+			mockExecuteFunctions.evaluateExpression.mockReturnValueOnce('node123');
+			mockExecuteFunctions.getNodeParameter.mockReturnValueOnce({ approvalType: 'double' });
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Slack', typeVersion: 2.3 } as any);
+
+			expect(createSendAndWaitMessageBody(mockExecuteFunctions)).toEqual({
+				blocks: [
+					{
+						type: 'divider',
+					},
+					{
+						text: {
+							text: 'message',
+							type: 'mrkdwn',
 						},
 						type: 'section',
 					},


### PR DESCRIPTION
## Summary
This adds a new version for the Slack node that uses Markdown only for the approval message, This also supports plain text and emojis so there shouldn't be any need to support plain text at all.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2036/slack-human-in-the-loop-support-markdown

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
