### PR TITLE
fix(Anthropic Chat Model Node): Update credentials test endpoint

### DIFF
--- a/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
+++ b/packages/@n8n/nodes-langchain/credentials/AnthropicApi.credentials.ts
@@ -35,15 +35,15 @@ export class AnthropicApi implements ICredentialType {
 	test: ICredentialTestRequest = {
 		request: {
 			baseURL: 'https://api.anthropic.com',
-			url: '/v1/complete',
+			url: '/v1/messages',
 			method: 'POST',
 			headers: {
 				'anthropic-version': '2023-06-01',
 			},
 			body: {
-				model: 'claude-2',
-				prompt: '\n\nHuman: Hello, world!\n\nAssistant:',
-				max_tokens_to_sample: 256,
+				model: 'claude-3-haiku-20240307',
+				messages: [{ role: 'user', content: 'Hey' }],
+				max_tokens: 1,
 			},
 		},
 	};


### PR DESCRIPTION
## Summary

This PR updates an endpoint used to check Anthropic credentials. Previous one was deprecated by Anthropic and started to respond with 500 Internal Server Error error recently.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-466/community-issue-internal-server-error-with-antropic-nodes
- fixes #11734 


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
