### PR TITLE
feat(core): Run evaluation workflow per each test case (no-changelog)

### DIFF
--- a/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.evaluation.json
+++ b/packages/cli/src/evaluation/test-runner/__tests__/mock-data/workflow.evaluation.json
@@ -21,7 +21,7 @@
 					"conditions": [
 						{
 							"id": "9d3abc8d-3270-4bec-9a59-82622d5dbb5a",
-							"leftValue": "={{ $json.actual.Code[0].data.main[0].length }}",
+							"leftValue": "={{ $json.newExecution.Code[0].data.main[0].length }}",
 							"rightValue": 3,
 							"operator": {
 								"type": "number",
@@ -30,7 +30,7 @@
 						},
 						{
 							"id": "894ce84b-13a4-4415-99c0-0c25182903bb",
-							"leftValue": "={{ $json.actual.Code[0].data.main[0][0].json.random }}",
+							"leftValue": "={{ $json.newExecution.Code[0].data.main[0][0].json.random }}",
 							"rightValue": 0.7,
 							"operator": {
 								"type": "number",

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -18,6 +18,10 @@ const wfUnderTestJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/workflow.under-test.json'), { encoding: 'utf-8' }),
 );
 
+const wfEvaluationJson = JSON.parse(
+	readFileSync(path.join(__dirname, './mock-data/workflow.evaluation.json'), { encoding: 'utf-8' }),
+);
+
 const executionDataJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/execution-data.json'), { encoding: 'utf-8' }),
 );
@@ -84,6 +88,11 @@ describe('TestRunnerService', () => {
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',
 			...wfUnderTestJson,
+		});
+
+		workflowRepository.findById.calledWith('evaluation-workflow-id').mockResolvedValueOnce({
+			id: 'evaluation-workflow-id',
+			...wfEvaluationJson,
 		});
 
 		workflowRunner.run.mockResolvedValue('test-execution-id');

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -2,6 +2,7 @@ import type { SelectQueryBuilder } from '@n8n/typeorm';
 import { stringify } from 'flatted';
 import { readFileSync } from 'fs';
 import { mock, mockDeep } from 'jest-mock-extended';
+import type { IRun } from 'n8n-workflow';
 import path from 'path';
 
 import type { ActiveExecutions } from '@/active-executions';
@@ -45,6 +46,16 @@ const executionMocks = [
 	}),
 ];
 
+function mockExecutionData() {
+	return mock<IRun>({
+		data: {
+			resultData: {
+				runData: {},
+			},
+		},
+	});
+}
+
 describe('TestRunnerService', () => {
 	const executionRepository = mock<ExecutionRepository>();
 	const workflowRepository = mock<WorkflowRepository>();
@@ -64,6 +75,11 @@ describe('TestRunnerService', () => {
 		executionRepository.findOne
 			.calledWith(expect.objectContaining({ where: { id: 'some-execution-id-2' } }))
 			.mockResolvedValueOnce(executionMocks[1]);
+	});
+
+	afterEach(() => {
+		activeExecutions.getPostExecutePromise.mockClear();
+		workflowRunner.run.mockClear();
 	});
 
 	test('should create an instance of TestRunnerService', async () => {
@@ -101,11 +117,64 @@ describe('TestRunnerService', () => {
 			mock<User>(),
 			mock<TestDefinition>({
 				workflowId: 'workflow-under-test-id',
+				evaluationWorkflowId: 'evaluation-workflow-id',
 			}),
 		);
 
 		expect(executionRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
 		expect(executionRepository.findOne).toHaveBeenCalledTimes(2);
 		expect(workflowRunner.run).toHaveBeenCalledTimes(2);
+	});
+
+	test('should run both workflow under test and evaluation workflow', async () => {
+		const testRunnerService = new TestRunnerService(
+			workflowRepository,
+			workflowRunner,
+			executionRepository,
+			activeExecutions,
+		);
+
+		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
+			id: 'workflow-under-test-id',
+			...wfUnderTestJson,
+		});
+
+		workflowRepository.findById.calledWith('evaluation-workflow-id').mockResolvedValueOnce({
+			id: 'evaluation-workflow-id',
+			...wfEvaluationJson,
+		});
+
+		workflowRunner.run.mockResolvedValueOnce('some-execution-id');
+		workflowRunner.run.mockResolvedValueOnce('some-execution-id-2');
+		workflowRunner.run.mockResolvedValueOnce('some-execution-id-3');
+		workflowRunner.run.mockResolvedValueOnce('some-execution-id-4');
+
+		// Mock executions of workflow under test
+		activeExecutions.getPostExecutePromise
+			.calledWith('some-execution-id')
+			.mockResolvedValue(mockExecutionData());
+
+		activeExecutions.getPostExecutePromise
+			.calledWith('some-execution-id-2')
+			.mockResolvedValue(mockExecutionData());
+
+		// Mock executions of evaluation workflow
+		activeExecutions.getPostExecutePromise
+			.calledWith('some-execution-id-3')
+			.mockResolvedValue(mockExecutionData());
+
+		activeExecutions.getPostExecutePromise
+			.calledWith('some-execution-id-4')
+			.mockResolvedValue(mockExecutionData());
+
+		await testRunnerService.runTest(
+			mock<User>(),
+			mock<TestDefinition>({
+				workflowId: 'workflow-under-test-id',
+				evaluationWorkflowId: 'evaluation-workflow-id',
+			}),
+		);
+
+		expect(workflowRunner.run).toHaveBeenCalledTimes(4);
 	});
 });

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -176,5 +176,36 @@ describe('TestRunnerService', () => {
 		);
 
 		expect(workflowRunner.run).toHaveBeenCalledTimes(4);
+
+		// Check workflow under test was executed
+		expect(workflowRunner.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				executionMode: 'evaluation',
+				pinData: {
+					'When clicking ‘Test workflow’':
+						executionDataJson.resultData.runData['When clicking ‘Test workflow’'][0].data.main[0],
+				},
+				workflowData: expect.objectContaining({
+					id: 'workflow-under-test-id',
+				}),
+			}),
+		);
+
+		// Check evaluation workflow was executed
+		expect(workflowRunner.run).toHaveBeenCalledWith(
+			expect.objectContaining({
+				executionMode: 'evaluation',
+				executionData: expect.objectContaining({
+					executionData: expect.objectContaining({
+						nodeExecutionStack: expect.arrayContaining([
+							expect.objectContaining({ data: expect.anything() }),
+						]),
+					}),
+				}),
+				workflowData: expect.objectContaining({
+					id: 'evaluation-workflow-id',
+				}),
+			}),
+		);
 	});
 });

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -2,6 +2,7 @@ import type { SelectQueryBuilder } from '@n8n/typeorm';
 import { stringify } from 'flatted';
 import { readFileSync } from 'fs';
 import { mock, mockDeep } from 'jest-mock-extended';
+import { mockInstance } from 'n8n-core/test/utils';
 import path from 'path';
 
 import type { ActiveExecutions } from '@/active-executions';
@@ -10,6 +11,7 @@ import type { TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
 import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import type { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
 import type { WorkflowRunner } from '@/workflow-runner';
 
 import { TestRunnerService } from '../test-runner.service.ee';
@@ -64,6 +66,7 @@ describe('TestRunnerService', () => {
 
 	test('should create an instance of TestRunnerService', async () => {
 		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
 			workflowRepository,
 			workflowRunner,
 			executionRepository,
@@ -75,11 +78,19 @@ describe('TestRunnerService', () => {
 
 	test('should create and run test cases from past executions', async () => {
 		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
 			workflowRepository,
 			workflowRunner,
 			executionRepository,
 			activeExecutions,
 		);
+
+		testDefinitionService.findOne.calledWith('some-test-id').mockResolvedValueOnce({
+			id: 'some-test-id',
+			workflowId: 'workflow-under-test-id',
+			evaluationWorkflowId: 'evaluation-workflow-id',
+			annotationTagId: 'some-annotation-tag-id',
+		});
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -11,6 +11,7 @@ import type { TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
 import type { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import type { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { TestDefinitionService } from '@/evaluation/test-definition.service.ee';
 import type { WorkflowRunner } from '@/workflow-runner';
 
@@ -74,6 +75,21 @@ describe('TestRunnerService', () => {
 		);
 
 		expect(testRunnerService).toBeInstanceOf(TestRunnerService);
+	});
+
+	test('should return an error if test definition is not found', async () => {
+		const testRunnerService = new TestRunnerService(
+			testDefinitionService,
+			workflowRepository,
+			workflowRunner,
+			executionRepository,
+		);
+
+		testDefinitionService.findOne.mockResolvedValueOnce(null);
+
+		await expect(testRunnerService.runTest(mock<User>(), 'some-test-id', [])).rejects.toThrowError(
+			NotFoundError,
+		);
 	});
 
 	test('should create and run test cases from past executions', async () => {

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -2,7 +2,6 @@ import type { SelectQueryBuilder } from '@n8n/typeorm';
 import { stringify } from 'flatted';
 import { readFileSync } from 'fs';
 import { mock, mockDeep } from 'jest-mock-extended';
-import { mockInstance } from 'n8n-core/test/utils';
 import path from 'path';
 
 import type { ActiveExecutions } from '@/active-executions';
@@ -22,25 +21,6 @@ const wfUnderTestJson = JSON.parse(
 const executionDataJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/execution-data.json'), { encoding: 'utf-8' }),
 );
-
-const executionMocks = [
-	mock<ExecutionEntity>({
-		id: 'some-execution-id',
-		workflowId: 'workflow-under-test-id',
-		status: 'success',
-		executionData: {
-			data: stringify(executionDataJson),
-		},
-	}),
-	mock<ExecutionEntity>({
-		id: 'some-execution-id-2',
-		workflowId: 'workflow-under-test-id',
-		status: 'success',
-		executionData: {
-			data: stringify(executionDataJson),
-		},
-	}),
-];
 
 const executionMocks = [
 	mock<ExecutionEntity>({

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -85,12 +85,14 @@ describe('TestRunnerService', () => {
 			activeExecutions,
 		);
 
-		testDefinitionService.findOne.calledWith('some-test-id').mockResolvedValueOnce({
-			id: 'some-test-id',
-			workflowId: 'workflow-under-test-id',
-			evaluationWorkflowId: 'evaluation-workflow-id',
-			annotationTagId: 'some-annotation-tag-id',
-		});
+		testDefinitionService.findOne.calledWith('some-test-id', []).mockResolvedValueOnce(
+			mock<TestDefinition>({
+				id: 'some-test-id',
+				workflowId: 'workflow-under-test-id',
+				evaluationWorkflowId: 'evaluation-workflow-id',
+				annotationTagId: 'some-annotation-tag-id',
+			}),
+		);
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -85,14 +85,16 @@ describe('TestRunnerService', () => {
 			activeExecutions,
 		);
 
-		testDefinitionService.findOne.calledWith('some-test-id', []).mockResolvedValueOnce(
-			mock<TestDefinition>({
-				id: 'some-test-id',
-				workflowId: 'workflow-under-test-id',
-				evaluationWorkflowId: 'evaluation-workflow-id',
-				annotationTagId: 'some-annotation-tag-id',
-			}),
-		);
+		testDefinitionService.findOne
+			.calledWith('some-test-id', expect.anything())
+			.mockResolvedValueOnce(
+				mock<TestDefinition>({
+					id: 'some-test-id',
+					workflowId: 'workflow-under-test-id',
+					evaluationWorkflowId: 'evaluation-workflow-id',
+					annotationTagId: 'some-annotation-tag-id',
+				}),
+			);
 
 		workflowRepository.findById.calledWith('workflow-under-test-id').mockResolvedValueOnce({
 			id: 'workflow-under-test-id',

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -1,5 +1,11 @@
 import { parse } from 'flatted';
-import type { IDataObject, IPinData, IRun, IRunData, IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import type {
+	IDataObject,
+	IPinData,
+	IRun,
+	IRunData,
+	IWorkflowExecutionDataProcess,
+} from 'n8n-workflow';
 import assert from 'node:assert';
 import { Service } from 'typedi';
 
@@ -33,11 +39,12 @@ export class TestRunnerService {
 	) {}
 
 	/**
+	 * Extracts the execution data from the past execution.
 	 * Creates a pin data object from the past execution data
 	 * for the given workflow.
 	 * For now, it only pins trigger nodes.
 	 */
-	private createPinDataFromExecution(workflow: WorkflowEntity, execution: ExecutionEntity) {
+	private createTestDataFromExecution(workflow: WorkflowEntity, execution: ExecutionEntity) {
 		const executionData = parse(execution.executionData.data) as IExecutionResponse['data'];
 
 		const triggerNodes = workflow.nodes.filter((node) => /trigger$/i.test(node.type));
@@ -78,9 +85,7 @@ export class TestRunnerService {
 		assert(executionId);
 
 		// Wait for the execution to finish
-		const executePromise = this.activeExecutions.getPostExecutePromise(
-			executionId,
-		);
+		const executePromise = this.activeExecutions.getPostExecutePromise(executionId);
 
 		return await executePromise;
 	}
@@ -161,8 +166,8 @@ export class TestRunnerService {
 			});
 			assert(pastExecution, 'Execution not found');
 
-			const testCase = this.createPinDataFromExecution(workflow, pastExecution);
-			const { pinData, executionData } = testCase;
+			const testData = this.createTestDataFromExecution(workflow, pastExecution);
+			const { pinData, executionData } = testData;
 
 			// Run the test case and wait for it to finish
 			const execution = await this.runTestCase(workflow, pinData, user.id);

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -151,6 +151,7 @@ export class TestRunnerService {
 			const executionId = await this.workflowRunner.run(data);
 			assert(executionId);
 
+			// Wait for the execution to finish
 			const executePromise = this.activeExecutions.getPostExecutePromise(
 				executionId,
 			);

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -87,7 +87,9 @@ export class TestRunnerService {
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted;
 		assert(lastNodeExecuted, 'Could not find the last node executed in evaluation workflow');
 
-		return execution.data.resultData.runData[lastNodeExecuted]?.[0].data?.main[0]?.[0]?.json ?? {};
+		// Extract the output of the last node executed in the evaluation workflow
+		// We use only the first main output
+		return execution.data.resultData.runData[lastNodeExecuted]?.[0]?.data?.main[0]?.[0]?.json ?? {};
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR adds execution of evaluation workflow per each test case during the workflow test execution.

The evaluation workflow is being executed with the input data containing:
- Past execution data
- New execution data (collected after running workflow under test with mocked/pinned data from a specific test case)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-428/[testrunner]-kick-off-evaluation-workflow
- https://github.com/n8n-io/n8n/pull/11735


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
