### PR TITLE
fix(Google Sheets Trigger Node): Fix issue with regex showing correct sheet as invalid

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
@@ -7,7 +7,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
-import { GOOGLE_DRIVE_FILE_URL_REGEX } from '../constants';
+import { GOOGLE_DRIVE_FILE_URL_REGEX, GOOGLE_SHEETS_SHEET_URL_REGEX } from '../constants';
 import { apiRequest } from './v2/transport';
 import { sheetsSearch, spreadSheetsSearch } from './v2/methods/listSearch';
 import { GoogleSheet } from './v2/helpers/GoogleSheet';
@@ -137,15 +137,13 @@ export class GoogleSheetsTrigger implements INodeType {
 						type: 'string',
 						extractValue: {
 							type: 'regex',
-							regex:
-								'https:\\/\\/docs\\.google\\.com/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+\\/edit\\#gid=([0-9]+)',
+							regex: GOOGLE_SHEETS_SHEET_URL_REGEX,
 						},
 						validation: [
 							{
 								type: 'regex',
 								properties: {
-									regex:
-										'https:\\/\\/docs\\.google\\.com/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+\\/edit\\#gid=([0-9]+)',
+									regex: GOOGLE_SHEETS_SHEET_URL_REGEX,
 									errorMessage: 'Not a valid Sheet URL',
 								},
 							},

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/Sheet.resource.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/Sheet.resource.ts
@@ -1,5 +1,5 @@
 import type { INodeProperties } from 'n8n-workflow';
-import { GOOGLE_DRIVE_FILE_URL_REGEX } from '../../../../constants';
+import { GOOGLE_DRIVE_FILE_URL_REGEX, GOOGLE_SHEETS_SHEET_URL_REGEX } from '../../../../constants';
 import * as append from './append.operation';
 import * as appendOrUpdate from './appendOrUpdate.operation';
 import * as clear from './clear.operation';
@@ -156,15 +156,13 @@ export const descriptions: INodeProperties[] = [
 				type: 'string',
 				extractValue: {
 					type: 'regex',
-					regex:
-						'https:\\/\\/docs\\.google.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)',
+					regex: GOOGLE_SHEETS_SHEET_URL_REGEX,
 				},
 				validation: [
 					{
 						type: 'regex',
 						properties: {
-							regex:
-								'https:\\/\\/docs\\.google.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)',
+							regex: GOOGLE_SHEETS_SHEET_URL_REGEX,
 							errorMessage: 'Not a valid Sheet URL',
 						},
 					},

--- a/packages/nodes-base/nodes/Google/constants.ts
+++ b/packages/nodes-base/nodes/Google/constants.ts
@@ -3,3 +3,6 @@ export const GOOGLE_DRIVE_FILE_URL_REGEX =
 
 export const GOOGLE_DRIVE_FOLDER_URL_REGEX =
 	'https:\\/\\/drive\\.google\\.com(?:\\/.*|)\\/folders\\/([0-9a-zA-Z\\-_]+)(?:\\/.*|)';
+
+export const GOOGLE_SHEETS_SHEET_URL_REGEX =
+	'https:\\/\\/docs\\.google\\.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)';


### PR DESCRIPTION
## Summary
The regex used for the normal node was different to the trigger node, Moved it to a const and added a few tests.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2028/google-sheets-trigger-by-url-fe-validation-is-too-sensitive

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
