### PR TITLE
fix(AI Agent Node): Escape curly brackets in tools description for non Tool agents

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ConversationalAgent/execute.ts
@@ -31,7 +31,7 @@ export async function conversationalAgentExecute(
 		| BaseChatMemory
 		| undefined;
 
-	const tools = await getConnectedTools(this, nodeVersion >= 1.5);
+	const tools = await getConnectedTools(this, nodeVersion >= 1.5, true, true);
 	const outputParsers = await getOptionalOutputParsers(this);
 
 	await checkForStructuredTools(tools, this.getNode(), 'Conversational Agent');

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/PlanAndExecuteAgent/execute.ts
@@ -26,7 +26,7 @@ export async function planAndExecuteAgentExecute(
 		0,
 	)) as BaseChatModel;
 
-	const tools = await getConnectedTools(this, nodeVersion >= 1.5);
+	const tools = await getConnectedTools(this, nodeVersion >= 1.5, true, true);
 
 	await checkForStructuredTools(tools, this.getNode(), 'Plan & Execute Agent');
 	const outputParsers = await getOptionalOutputParsers(this);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ReActAgent/execute.ts
@@ -31,7 +31,7 @@ export async function reActAgentAgentExecute(
 		| BaseLanguageModel
 		| BaseChatModel;
 
-	const tools = await getConnectedTools(this, nodeVersion >= 1.5);
+	const tools = await getConnectedTools(this, nodeVersion >= 1.5, true, true);
 
 	await checkForStructuredTools(tools, this.getNode(), 'ReAct Agent');
 

--- a/packages/@n8n/nodes-langchain/utils/helpers.ts
+++ b/packages/@n8n/nodes-langchain/utils/helpers.ts
@@ -167,16 +167,20 @@ export function serializeChatHistory(chatHistory: BaseMessage[]): string {
 
 export function escapeSingleCurlyBrackets(text?: string): string | undefined {
 	if (text === undefined) return undefined;
-	return (
-		text
-			// Replace single curly brackets with double curly brackets
-			// The negative lookbehind and lookahead ensure we don't match if there's already a matching bracket
-			// For opening brackets {
-			.replace(/(?<!{){(?!{)/g, '{{')
-			// For closing brackets }
-			.replace(/(?<!})}(?!})/g, '}}')
-			.replace(/(?<!})}(?!})/g, '}}')
-	);
+
+	let result = text;
+
+	result = result
+		// First handle triple brackets to avoid interference with double brackets
+		.replace(/(?<!{){{{(?!{)/g, '{{{{')
+		.replace(/(?<!})}}}(?!})/g, '}}}}')
+		// Then handle single brackets, but only if they're not part of double brackets
+		// Convert single { to {{ if it's not already part of {{ or {{{
+		.replace(/(?<!{){(?!{)/g, '{{')
+		// Convert single } to }} if it's not already part of }} or }}}
+		.replace(/(?<!})}(?!})/g, '}}');
+
+	return result;
 }
 
 export const getConnectedTools = async (

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -68,6 +68,61 @@ describe('escapeSingleCurlyBrackets', () => {
 	it('should handle string with whitespace in curly brackets', () => {
 		expect(escapeSingleCurlyBrackets('Whitespace {  } here')).toBe('Whitespace {{  }} here');
 	});
+	it('should handle multi-line input with single curly brackets', () => {
+		const input = `
+      Line 1 {test}
+      Line 2 {another test}
+      Line 3
+    `;
+		const expected = `
+      Line 1 {{test}}
+      Line 2 {{another test}}
+      Line 3
+    `;
+		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
+	});
+
+	it('should handle multi-line input with mixed single and double curly brackets', () => {
+		const input = `
+      {Line 1}
+      {{Line 2}}
+      Line {3} {{4}}
+    `;
+		const expected = `
+      {{Line 1}}
+      {{Line 2}}
+      Line {{3}} {{4}}
+    `;
+		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
+	});
+
+	it('should handle multi-line input with curly brackets at line starts and ends', () => {
+		const input = `
+      {Start of line 1
+      End of line 2}
+      {3} Line 3 {3}
+    `;
+		const expected = `
+      {{Start of line 1
+      End of line 2}}
+      {{3}} Line 3 {{3}}
+    `;
+		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
+	});
+
+	it('should handle multi-line input with nested curly brackets', () => {
+		const input = `
+      Outer {
+        Inner {nested}
+      }
+    `;
+		const expected = `
+      Outer {{
+        Inner {{nested}}
+      }}
+    `;
+		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
+	});
 });
 
 describe('getConnectedTools', () => {

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -1,0 +1,161 @@
+import { DynamicTool, type Tool } from '@langchain/core/tools';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import { NodeOperationError } from 'n8n-workflow';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { escapeSingleCurlyBrackets, getConnectedTools } from '../helpers';
+import { N8nTool } from '../N8nTool';
+
+describe('escapeSingleCurlyBrackets', () => {
+	it('should return undefined when input is undefined', () => {
+		expect(escapeSingleCurlyBrackets(undefined)).toBeUndefined();
+	});
+
+	it('should escape single curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Hello {world}')).toBe('Hello {{world}}');
+		expect(escapeSingleCurlyBrackets('Test {value} here')).toBe('Test {{value}} here');
+	});
+
+	it('should not escape already double curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Hello {{world}}')).toBe('Hello {{world}}');
+		expect(escapeSingleCurlyBrackets('Test {{value}} here')).toBe('Test {{value}} here');
+	});
+
+	it('should handle mixed single and double curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Hello {{world}} and {earth}')).toBe(
+			'Hello {{world}} and {{earth}}',
+		);
+	});
+
+	it('should handle empty string', () => {
+		expect(escapeSingleCurlyBrackets('')).toBe('');
+	});
+	it('should handle string with no curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Hello world')).toBe('Hello world');
+	});
+
+	it('should handle string with only opening curly bracket', () => {
+		expect(escapeSingleCurlyBrackets('Hello { world')).toBe('Hello {{ world');
+	});
+
+	it('should handle string with only closing curly bracket', () => {
+		expect(escapeSingleCurlyBrackets('Hello world }')).toBe('Hello world }}');
+	});
+
+	it('should handle string with multiple single curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('{Hello} {world}')).toBe('{{Hello}} {{world}}');
+	});
+
+	it('should handle string with alternating single and double curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('{a} {{b}} {c} {{d}}')).toBe('{{a}} {{b}} {{c}} {{d}}');
+	});
+
+	it('should handle string with curly brackets at the start and end', () => {
+		expect(escapeSingleCurlyBrackets('{start} middle {end}')).toBe('{{start}} middle {{end}}');
+	});
+
+	it('should handle string with special characters', () => {
+		expect(escapeSingleCurlyBrackets('Special {!@#$%^&*} chars')).toBe(
+			'Special {{!@#$%^&*}} chars',
+		);
+	});
+
+	it('should handle string with numbers in curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Numbers {123} here')).toBe('Numbers {{123}} here');
+	});
+
+	it('should handle string with whitespace in curly brackets', () => {
+		expect(escapeSingleCurlyBrackets('Whitespace {  } here')).toBe('Whitespace {{  }} here');
+	});
+});
+
+describe('getConnectedTools', () => {
+	let mockExecuteFunctions: IExecuteFunctions;
+	let mockNode: INode;
+	let mockN8nTool: N8nTool;
+
+	beforeEach(() => {
+		mockNode = {
+			id: 'test-node',
+			name: 'Test Node',
+			type: 'test',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		mockExecuteFunctions = createMockExecuteFunction({}, mockNode);
+
+		mockN8nTool = new N8nTool(mockExecuteFunctions, {
+			name: 'Dummy Tool',
+			description: 'A dummy tool for testing',
+			func: jest.fn(),
+			schema: z.object({
+				foo: z.string(),
+			}),
+		});
+	});
+
+	it('should return empty array when no tools are connected', async () => {
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue([]);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, true);
+		expect(tools).toEqual([]);
+	});
+
+	it('should return tools without modification when enforceUniqueNames is false', async () => {
+		const mockTools = [
+			{ name: 'tool1', description: 'desc1' },
+			{ name: 'tool1', description: 'desc2' }, // Duplicate name
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, false);
+		expect(tools).toEqual(mockTools);
+	});
+
+	it('should throw error when duplicate tool names exist and enforceUniqueNames is true', async () => {
+		const mockTools = [
+			{ name: 'tool1', description: 'desc1' },
+			{ name: 'tool1', description: 'desc2' },
+		];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+
+		await expect(getConnectedTools(mockExecuteFunctions, true)).rejects.toThrow(NodeOperationError);
+	});
+
+	it('should escape curly brackets in tool descriptions when escapeCurlyBrackets is true', async () => {
+		const mockTools = [{ name: 'tool1', description: 'Test {value}' }] as Tool[];
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, true, false, true);
+		expect(tools[0].description).toBe('Test {{value}}');
+	});
+
+	it('should convert N8nTool to dynamic tool when convertStructuredTool is true', async () => {
+		const mockDynamicTool = new DynamicTool({
+			name: 'dynamicTool',
+			description: 'desc',
+			func: jest.fn(),
+		});
+		const asDynamicToolSpy = jest.fn().mockReturnValue(mockDynamicTool);
+		mockN8nTool.asDynamicTool = asDynamicToolSpy;
+
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue([mockN8nTool]);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, true, true);
+		expect(asDynamicToolSpy).toHaveBeenCalled();
+		expect(tools[0]).toEqual(mockDynamicTool);
+	});
+
+	it('should not convert N8nTool when convertStructuredTool is false', async () => {
+		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue([mockN8nTool]);
+
+		const tools = await getConnectedTools(mockExecuteFunctions, true, false);
+		expect(tools[0]).toBe(mockN8nTool);
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -123,6 +123,35 @@ describe('escapeSingleCurlyBrackets', () => {
     `;
 		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
 	});
+	it('should handle string with triple uneven curly brackets - opening', () => {
+		expect(escapeSingleCurlyBrackets('Hello {{{world}')).toBe('Hello {{{{world}}');
+	});
+
+	it('should handle string with triple uneven curly brackets - closing', () => {
+		expect(escapeSingleCurlyBrackets('Hello world}}}')).toBe('Hello world}}}}');
+	});
+
+	it('should handle string with triple uneven curly brackets - mixed opening and closing', () => {
+		expect(escapeSingleCurlyBrackets('{{{Hello}}} {world}}}')).toBe('{{{{Hello}}}} {{world}}}}');
+	});
+
+	it('should handle string with triple uneven curly brackets - multiple occurrences', () => {
+		expect(escapeSingleCurlyBrackets('{{{a}}} {{b}}} {{{c}')).toBe('{{{{a}}}} {{b}}}} {{{{c}}');
+	});
+
+	it('should handle multi-line input with triple uneven curly brackets', () => {
+		const input = `
+					{{{Line 1}
+					Line 2}}}
+					{{{3}}} Line 3 {{{4
+			`;
+		const expected = `
+					{{{{Line 1}}
+					Line 2}}}}
+					{{{{3}}}} Line 3 {{{{4
+			`;
+		expect(escapeSingleCurlyBrackets(input)).toBe(expected);
+	});
 });
 
 describe('getConnectedTools', () => {


### PR DESCRIPTION
## Summary
This PR fixes an issue where the ReAct agent (and other non Tool agents) would fail when tool descriptions contain single curly brackets, throwing a "Single '}' in template" error. This commonly occurs when trying to specify JSON schemas in tool descriptions.

## Changes
- Added curly bracket escaping for tool descriptions
- Updated all non Tool agents to use this escaping by default
- Added tests to verify the fix

## Related Linear tickets, Github issues, and Community forum posts
fixes #11721

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
