### PR TITLE
feat(core): Defer task on launcher handshake (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/message-types.ts
+++ b/packages/@n8n/task-runner/src/message-types.ts
@@ -184,6 +184,12 @@ export namespace RunnerMessage {
 			reason: string;
 		}
 
+		/** Message where launcher (impersonating runner) requests broker to hold task until runner is ready. */
+		export interface TaskDeferred {
+			type: 'runner:taskdeferred';
+			taskId: string;
+		}
+
 		export interface TaskDone {
 			type: 'runner:taskdone';
 			taskId: string;
@@ -243,6 +249,7 @@ export namespace RunnerMessage {
 			| TaskError
 			| TaskAccepted
 			| TaskRejected
+			| TaskDeferred
 			| TaskOffer
 			| RPC
 			| TaskDataRequest

--- a/packages/cli/src/runners/errors.ts
+++ b/packages/cli/src/runners/errors.ts
@@ -6,4 +6,10 @@ export class TaskRejectError extends ApplicationError {
 	}
 }
 
+export class TaskDeferredError extends ApplicationError {
+	constructor() {
+		super('Task deferred until runner is ready', { level: 'info' });
+	}
+}
+
 export class TaskError extends ApplicationError {}

--- a/packages/cli/src/runners/task-broker.service.ts
+++ b/packages/cli/src/runners/task-broker.service.ts
@@ -487,11 +487,7 @@ export class TaskBroker {
 			}
 			if (e instanceof TaskDeferredError) {
 				this.logger.info(`Task (${taskId}) deferred until runner is ready`);
-				this.pendingTaskRequests.push(request);
-				setTimeout(
-					() => this.settleTasks(),
-					3000 /* time for runner to go through handshake and send task offer */,
-				);
+				this.pendingTaskRequests.push(request); // will settle on receiving task offer from runner
 				return;
 			}
 			throw e;


### PR DESCRIPTION
## Summary

This PR introduces the `runner:taskdeferred` message type to allow the launcher to ask the broker to hold onto a task until the launcher can spin up a runner and this runner can connect, register itself, and send its first task offer, allowing the launcher to spawn a runner only when needed.

```mermaid
sequenceDiagram
    participant TM as Task Manager
    participant TB as Task Broker
    participant L as Launcher
    participant TR as Task Runner

    %% Initial launcher connection
    L->>+TB: WS connect
    TB-->>L: broker:info-request
    L->>TB: runner:info
    TB-->>L: broker:runner-registered

    %% Task request flow
    L->>TB: runner:task-offer
    TM->>+TB: requester:task-request
    TB-->>L: broker:task-offer-accept
    L->>TB: runner:task-deferred

    %% Launcher executes and transitions to runner
    Note over L: exec.Command()
    
    %% New runner connection
    TR->>+TB: WS connect
    TB-->>TR: broker:info-request
    TR->>TB: runner:info
    TB-->>TR: broker:runner-registered
    TR->>TB: runner:task-offer
    TB-->>L: broker:task-offer-accept
    TB-->>TM: broker:task-ready

    %% Task settings flow
    TM->>+TB: requester:task-settings
    TB-->>TR: broker:task-settings
    TR->>TB: runner:task-done
    TB-->>TM: broker:task-done
    TR->>TR: exit if idle
```

To be reviewed together with: https://github.com/n8n-io/task-runner-launcher/pull/6

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2244/implement-handshake-with-main

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
