### PR TITLE
fix(Chat Trigger Node): Return empty messages if loadPreviousSession and memory not connected

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -473,7 +473,6 @@ export class ChatTrigger implements INodeType {
 		try {
 			await validateAuth(this);
 		} catch (error) {
-			console.log('🚀 ~ ChatTrigger ~ webhook ~ error:', error);
 			if (error) {
 				res.writeHead((error as IDataObject).responseCode as number, {
 					'www-authenticate': 'Basic realm="Webhook"',
@@ -540,8 +539,6 @@ export class ChatTrigger implements INodeType {
 				} catch (error) {
 					webhookResponse.error = error.message;
 					this.logger.error(`Could not retrieve memory for loadPreviousSession: ${error.message}`);
-				} finally {
-					return { webhookResponse };
 				}
 			}
 

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/test/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/test/ChatTrigger.node.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { testWebhookTriggerNode } from 'n8n-nodes-base/test/nodes/TriggerHelpers';
+import { ApplicationError, NodeConnectionType } from 'n8n-workflow';
+
+import { ChatTrigger } from '../ChatTrigger.node';
+
+describe('ChatTrigger', () => {
+	// Helper function to create mocked message JSON
+	const mockedMessageJson = (content: string, type: string) => ({
+		toJSON: () => ({ content, type }),
+	});
+
+	describe('webhook setup (GET request)', () => {
+		it('should return 404 when not public', async () => {
+			const { response } = await testWebhookTriggerNode(ChatTrigger, {
+				webhookName: 'setup',
+				node: {
+					parameters: {
+						public: false,
+					},
+				},
+			});
+
+			expect(response.status).toHaveBeenCalledWith(404);
+		});
+
+		it('should return chat page for public hosted mode', async () => {
+			const { response } = await testWebhookTriggerNode(ChatTrigger, {
+				webhookName: 'setup',
+				node: {
+					parameters: {
+						public: true,
+						mode: 'hostedChat',
+						initialMessages: 'Hello\nHow can I help?',
+						options: {
+							title: 'Test Chat',
+							subtitle: 'Test Subtitle',
+							inputPlaceholder: 'Type here...',
+						},
+					},
+				},
+			});
+
+			expect(response.status).toHaveBeenCalledWith(200);
+			expect(response.send).toHaveBeenCalledWith(expect.stringContaining('Test Chat'));
+			expect(response.send).toHaveBeenCalledWith(expect.stringContaining('Test Subtitle'));
+			expect(response.send).toHaveBeenCalledWith(expect.stringContaining('Type here...'));
+		});
+
+		it('should not return chat page for webhook mode', async () => {
+			const { response } = await testWebhookTriggerNode(ChatTrigger, {
+				webhookName: 'setup',
+				node: {
+					parameters: {
+						public: true,
+						mode: 'webhook',
+					},
+				},
+			});
+
+			expect(response.send).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('webhook execution (POST request)', () => {
+		it('should handle regular message', async () => {
+			const { responseData } = await testWebhookTriggerNode(ChatTrigger, {
+				node: {
+					parameters: {
+						public: true,
+						mode: 'hostedChat',
+					},
+				},
+				bodyData: {
+					message: 'Test message',
+				},
+			});
+
+			expect(responseData?.workflowData?.[0]).toEqual([{ json: { message: 'Test message' } }]);
+		});
+
+		it('should handle file uploads', async () => {
+			const mockFile = {
+				filepath: '/tmp/test.txt',
+				originalFilename: 'test.txt',
+				newFilename: 'test.txt',
+				mimetype: 'text/plain',
+			};
+
+			const { responseData } = await testWebhookTriggerNode(ChatTrigger, {
+				node: {
+					parameters: {
+						public: true,
+						mode: 'hostedChat',
+						options: {
+							allowFileUploads: true,
+						},
+					},
+				},
+				request: {
+					method: 'POST',
+					contentType: 'multipart/form-data',
+					body: {
+						data: { message: 'Test with file' },
+						files: {
+							upload: mockFile,
+						},
+					},
+				},
+			});
+
+			const returnData = responseData?.workflowData?.[0]?.[0];
+
+			expect(returnData?.json?.files).toBeDefined();
+			const returnDataFiles = returnData?.json?.files;
+			expect(Array.isArray(returnDataFiles)).toBe(true);
+			if (Array.isArray(returnDataFiles)) {
+				expect(returnDataFiles.length).toBeGreaterThan(0);
+			}
+			expect(returnData?.binary).toBeDefined();
+		});
+
+		it('should load previous session from memory when requested', async () => {
+			// Mock memory with chat history
+			const mockMemory = {
+				chatHistory: {
+					getMessages: jest
+						.fn()
+						.mockResolvedValue([
+							mockedMessageJson('My name is Nathan.', 'human'),
+							mockedMessageJson('K.', 'ai'),
+							mockedMessageJson('What is my name?', 'human'),
+							mockedMessageJson('Nathan.', 'ai'),
+						]),
+				},
+			};
+
+			const node = {
+				parameters: {
+					public: true,
+					mode: 'hostedChat',
+					options: {
+						loadPreviousSession: 'memory',
+					},
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(ChatTrigger, {
+				node,
+				bodyData: {
+					action: 'loadPreviousSession',
+				},
+				childNodes: [
+					{
+						name: 'Memory',
+						type: NodeConnectionType.AiMemory,
+						typeVersion: 1,
+					},
+				],
+				async getInputConnectionData(type) {
+					if (type === NodeConnectionType.AiMemory) {
+						return mockMemory;
+					}
+					return {};
+				},
+			});
+
+			// Check if the previous session is loaded correctly
+			expect(responseData?.webhookResponse?.data).toHaveLength(4);
+			expect(responseData?.webhookResponse?.data[2]).toEqual({
+				content: 'What is my name?',
+				type: 'human',
+			});
+		});
+
+		it('should return empty array when loadPreviousSession is notSupported', async () => {
+			const { responseData } = await testWebhookTriggerNode(ChatTrigger, {
+				node: {
+					parameters: {
+						public: true,
+						mode: 'hostedChat',
+						options: {
+							loadPreviousSession: 'notSupported',
+						},
+					},
+				},
+				bodyData: {
+					action: 'loadPreviousSession',
+				},
+			});
+
+			expect(responseData?.webhookResponse?.data).toEqual([]);
+		});
+
+		it('should return empty array when loadPreviousSession throws but configured in params', async () => {
+			// Mock memory with an error when getting messages
+			const mockMemory = {
+				chatHistory: {
+					getMessages: jest.fn().mockResolvedValue([
+						{
+							toJSON: () => {
+								throw new ApplicationError('Error when getting message');
+							},
+						},
+					]),
+				},
+			};
+
+			const node = {
+				parameters: {
+					public: true,
+					mode: 'hostedChat',
+					options: {
+						loadPreviousSession: 'memory',
+					},
+				},
+			};
+
+			const errorLogger = jest.fn();
+			const { responseData } = await testWebhookTriggerNode(ChatTrigger, {
+				node,
+				bodyData: {
+					action: 'loadPreviousSession',
+				},
+				childNodes: [
+					{
+						name: 'Memory',
+						type: NodeConnectionType.AiMemory,
+						typeVersion: 1,
+					},
+				],
+				async getInputConnectionData(type) {
+					if (type === NodeConnectionType.AiMemory) {
+						return mockMemory;
+					}
+					return {};
+				},
+				logger: {
+					error: errorLogger,
+				},
+			});
+
+			// Check if the response is empty and contains an error message
+			expect(responseData?.webhookResponse?.data).toHaveLength(0);
+			expect(errorLogger).toHaveBeenCalledWith(
+				expect.stringContaining('Could not retrieve memory for loadPreviousSession'),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -6,6 +6,7 @@ import set from 'lodash/set';
 import { PollContext, returnJsonArray, type InstanceSettings } from 'n8n-core';
 import { ScheduledTaskManager } from 'n8n-core/dist/ScheduledTaskManager';
 import type {
+	FunctionsBase,
 	IBinaryData,
 	ICredentialDataDecryptedObject,
 	IDataObject,
@@ -16,6 +17,7 @@ import type {
 	ITriggerFunctions,
 	IWebhookFunctions,
 	IWorkflowExecuteAdditionalData,
+	NodeConnectionType,
 	NodeTypeAndVersion,
 	VersionedNodeType,
 	Workflow,
@@ -37,6 +39,8 @@ type TestWebhookTriggerNodeOptions = TestTriggerNodeOptions & {
 	request?: MockDeepPartial<express.Request>;
 	bodyData?: IDataObject;
 	childNodes?: NodeTypeAndVersion[];
+	getInputConnectionData?: (type: NodeConnectionType) => Promise<unknown>;
+	logger?: Partial<FunctionsBase['logger']>;
 };
 
 type TestPollingTriggerNodeOptions = TestTriggerNodeOptions & {};
@@ -154,7 +158,13 @@ export async function testWebhookTriggerNode(
 		getInstanceId: () => 'instanceId',
 		getBodyData: () => options.bodyData ?? {},
 		getHeaderData: () => ({}),
-		getInputConnectionData: async () => ({}),
+		getInputConnectionData: options.getInputConnectionData ?? jest.fn(),
+		logger: options.logger ?? {
+			error: jest.fn(),
+			warn: jest.fn(),
+			info: jest.fn(),
+			debug: jest.fn(),
+		},
 		getNodeWebhookUrl: (name) => `/test-webhook-url/${name}`,
 		getParamsData: () => ({}),
 		getQueryData: () => ({}),


### PR DESCRIPTION
## Summary

This PR refactors the ChatTrigger node to improve error handling and adds some test coverage.

## Changes

- Refactored `ChatTrigger` class to implement `INodeType` instead of extending `Node` to be better testable
- Moved `handleFormData` to a standalone function for better modularity and due to "this" naming req. of INodeType context argument
- Added error handling for memory loading failures in chat sessions


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
