### PR TITLE
fix(core): Delete binary data parent folder when pruning executions

### DIFF
--- a/packages/core/src/BinaryData/FileSystem.manager.ts
+++ b/packages/core/src/BinaryData/FileSystem.manager.ts
@@ -93,7 +93,7 @@ export class FileSystemManager implements BinaryData.Manager {
 		// binary files stored in nested dirs - `filesystem-v2`
 
 		const binaryDataDirs = ids.map(({ workflowId, executionId }) =>
-			this.resolvePath(`workflows/${workflowId}/executions/${executionId}/binary_data/`),
+			this.resolvePath(`workflows/${workflowId}/executions/${executionId}`),
 		);
 
 		await Promise.all(

--- a/packages/core/test/FileSystem.manager.test.ts
+++ b/packages/core/test/FileSystem.manager.test.ts
@@ -167,12 +167,12 @@ describe('deleteMany()', () => {
 		expect(fsp.rm).toHaveBeenCalledTimes(2);
 		expect(fsp.rm).toHaveBeenNthCalledWith(
 			1,
-			`${storagePath}/workflows/${workflowId}/executions/${executionId}/binary_data/`,
+			`${storagePath}/workflows/${workflowId}/executions/${executionId}`,
 			rmOptions,
 		);
 		expect(fsp.rm).toHaveBeenNthCalledWith(
 			2,
-			`${storagePath}/workflows/${otherWorkflowId}/executions/${otherExecutionId}/binary_data/`,
+			`${storagePath}/workflows/${otherWorkflowId}/executions/${otherExecutionId}`,
 			rmOptions,
 		);
 	});

--- a/packages/core/test/FileSystem.manager.test.ts
+++ b/packages/core/test/FileSystem.manager.test.ts
@@ -147,6 +147,11 @@ describe('copyByFilePath()', () => {
 });
 
 describe('deleteMany()', () => {
+	const rmOptions = {
+		force: true,
+		recursive: true,
+	};
+
 	it('should delete many files by workflow ID and execution ID', async () => {
 		const ids = [
 			{ workflowId, executionId },
@@ -160,6 +165,16 @@ describe('deleteMany()', () => {
 		await expect(promise).resolves.not.toThrow();
 
 		expect(fsp.rm).toHaveBeenCalledTimes(2);
+		expect(fsp.rm).toHaveBeenNthCalledWith(
+			1,
+			`${storagePath}/workflows/${workflowId}/executions/${executionId}/binary_data/`,
+			rmOptions,
+		);
+		expect(fsp.rm).toHaveBeenNthCalledWith(
+			2,
+			`${storagePath}/workflows/${otherWorkflowId}/executions/${otherExecutionId}/binary_data/`,
+			rmOptions,
+		);
 	});
 
 	it('should suppress error on non-existing filepath', async () => {


### PR DESCRIPTION
## Summary
When deleting binary data for executions in file-system mode, we should delete the entire executions folder, because when we only delete `binary_data` folder, the empty executions folders still take up inodes on the filesystem. 
Over time these empty folders accumulate enough to exhaust available inodes on the volume.

[Context](https://n8nio.slack.com/archives/C069HS026UF/p1731685967875179)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
