### PR TITLE
fix(MongoDB Node): Fix typo in variable name (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
@@ -96,7 +96,7 @@ export function prepareItems(
 		data = items.filter((item) => item.json[updateKey] !== undefined);
 	}
 
-	const preperedItems = data.map(({ json }) => {
+	const preparedItems = data.map(({ json }) => {
 		const updateItem: IDataObject = {};
 
 		for (const field of fields) {
@@ -122,7 +122,7 @@ export function prepareItems(
 		return updateItem;
 	});
 
-	return preperedItems;
+	return preparedItems;
 }
 
 export function prepareFields(fields: string) {


### PR DESCRIPTION
## Summary

No associated issue.
Renamed scoped const from "preperedItems" to "preparedItems" inside the prepareItems function.
