### PR TITLE
fix(editor): Fix partial executions not working due to broken push message queue and race conditions

### DIFF
--- a/packages/editor-ui/src/composables/usePushConnection.test.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.test.ts
@@ -224,8 +224,6 @@ describe('usePushConnection()', () => {
 
 		describe('nodeExecuteAfter', async () => {
 			it("enqueues messages if we don't have the active execution id yet", async () => {
-				//const spy = vi.spyOn(orchestrationStore, 'updateWorkerStatus').mockImplementation(() => {});
-
 				uiStore.isActionActive.workflowRunning = true;
 				const queuePushMessageSpy = vi
 					.spyOn(pushConnection, 'queuePushMessage')

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -155,7 +155,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				// The data is not for the currently active execution or
 				// we do not have the execution id yet.
 				if (isRetry !== true) {
-					queuePushMessage(receivedData, retryAttempts);
+					instance.queuePushMessage(receivedData, retryAttempts);
 				}
 				return false;
 			}
@@ -531,7 +531,8 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 		return errorMessage;
 	}
 
-	return {
+	// This allows mocking and spying on individual functions in tests.
+	const instance = {
 		initialize,
 		terminate,
 		pushMessageReceived,
@@ -540,4 +541,6 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 		pushMessageQueue,
 		retryTimeout,
 	};
+
+	return instance;
 }

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -155,7 +155,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				// The data is not for the currently active execution or
 				// we do not have the execution id yet.
 				if (isRetry !== true) {
-					instance.queuePushMessage(receivedData, retryAttempts);
+					queuePushMessage(receivedData, retryAttempts);
 				}
 				return false;
 			}
@@ -531,8 +531,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 		return errorMessage;
 	}
 
-	// This allows mocking and spying on individual functions in tests.
-	const instance = {
+	return {
 		initialize,
 		terminate,
 		pushMessageReceived,
@@ -541,6 +540,4 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 		pushMessageQueue,
 		retryTimeout,
 	};
-
-	return instance;
 }

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -155,7 +155,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				// The data is not for the currently active execution or
 				// we do not have the execution id yet.
 				if (isRetry !== true) {
-					queuePushMessage(event as unknown as PushMessage, retryAttempts);
+					queuePushMessage(receivedData, retryAttempts);
 				}
 				return false;
 			}
@@ -200,7 +200,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				// The workflow which did finish execution did either not get started
 				// by this session or we do not have the execution id yet.
 				if (isRetry !== true) {
-					queuePushMessage(event as unknown as PushMessage, retryAttempts);
+					queuePushMessage(receivedData, retryAttempts);
 				}
 				return false;
 			}


### PR DESCRIPTION
## Summary

Partial executions are currently behaving erratic:

https://github.com/user-attachments/assets/7924f1d9-4260-4841-a571-17ee342df074

That is due to a race condition that was introduce last week somehow.

To start a manual execution the FE sends a request to `workflows/:id/run`. The result of that request contains the execution id.
The BE starts sending websocket messages for the execution before that initial REST request is returned. 
The FE receives messages for an execution is does not know about yet. It can't tell if the messages are for an older execution or the new one (for which it does not know the id yet).

To account for this messages for unknown executions are queued and retried. That part of the code had a bug in that it queued a global event object instead of the websocket message.

This PR fixes that issue which makes partial executions behave as expected again:

https://github.com/user-attachments/assets/96fce0e5-7ef2-43f7-a7ba-4fdac4c9341e

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
