### PR TITLE
refactor(core): Lazy-load `form-data` and `ssh2` (no-changelog)

### DIFF
--- a/packages/core/src/SSHClientsManager.ts
+++ b/packages/core/src/SSHClientsManager.ts
@@ -1,7 +1,9 @@
 import type { SSHCredentials } from 'n8n-workflow';
 import { createHash } from 'node:crypto';
-import { Client, type ConnectConfig } from 'ssh2';
+import type { Client, ConnectConfig } from 'ssh2';
 import { Service } from 'typedi';
+
+let ClientClass: typeof Client;
 
 @Service()
 export class SSHClientsManager {
@@ -39,8 +41,12 @@ export class SSHClientsManager {
 			return existing.client;
 		}
 
+		if (!ClientClass) {
+			ClientClass = (await import('ssh2')).Client;
+		}
+
 		return await new Promise((resolve, reject) => {
-			const sshClient = new Client();
+			const sshClient = new ClientClass();
 			sshClient.once('error', reject);
 			sshClient.once('ready', () => {
 				sshClient.off('error', reject);

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -47,7 +47,6 @@
     "callsites": "3.1.0",
     "deep-equal": "2.2.0",
     "esprima-next": "5.8.4",
-    "form-data": "catalog:",
     "jmespath": "0.16.0",
     "js-base64": "3.7.2",
     "jssha": "3.3.1",

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -4,7 +4,7 @@ import {
 	type Node as SyntaxNode,
 	type ExpressionStatement,
 } from 'esprima-next';
-import FormData from 'form-data';
+import type FormData from 'form-data';
 import { merge } from 'lodash';
 
 import { ALPHABET } from './Constants';
@@ -22,7 +22,7 @@ BigInt.prototype.toJSON = function () {
 export const isObjectEmpty = (obj: object | null | undefined): boolean => {
 	if (obj === undefined || obj === null) return true;
 	if (typeof obj === 'object') {
-		if (obj instanceof FormData) return obj.getLengthSync() === 0;
+		if (obj.constructor.name === 'FormData') return (obj as FormData).getLengthSync() === 0;
 		if (Array.isArray(obj)) return obj.length === 0;
 		if (obj instanceof Set || obj instanceof Map) return obj.size === 0;
 		if (ArrayBuffer.isView(obj) || obj instanceof ArrayBuffer) return obj.byteLength === 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1903,9 +1903,6 @@ importers:
       esprima-next:
         specifier: 5.8.4
         version: 5.8.4
-      form-data:
-        specifier: 'catalog:'
-        version: 4.0.0
       jmespath:
         specifier: 0.16.0
         version: 0.16.0


### PR DESCRIPTION
## Summary
Loading these two packages startup increases the baseline memory usage by a bit, but it also slows the backend tests down, since these packages are loaded for every test, even if they are not used.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
