### PR TITLE
fix(editor): Fix failing non-null assertion in useDataSchema:getNodeInputData (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/useDataSchema.test.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.test.ts
@@ -1,6 +1,16 @@
 import jp from 'jsonpath';
 import { useDataSchema } from '@/composables/useDataSchema';
-import type { Schema } from '@/Interface';
+import type { IExecutionResponse, INodeUi, Schema } from '@/Interface';
+import { setActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import {
+	NodeConnectionType,
+	type INodeExecutionData,
+	type ITaskDataConnections,
+} from 'n8n-workflow';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+
+vi.mock('@/stores/workflows.store');
 
 describe('useDataSchema', () => {
 	const getSchema = useDataSchema().getSchema;
@@ -523,5 +533,111 @@ describe('useDataSchema', () => {
 
 			expect(filterSchema(flatSchema, '')).toEqual(flatSchema);
 		});
+	});
+	describe('getNodeInputData', () => {
+		const getNodeInputData = useDataSchema().getNodeInputData;
+
+		beforeEach(() => {
+			setActivePinia(createTestingPinia());
+		});
+
+		afterEach(() => {
+			vi.clearAllMocks();
+		});
+
+		const name = 'a';
+		const makeMockData = (data: ITaskDataConnections | undefined, runDataKey?: string) => ({
+			data: {
+				resultData: {
+					runData: {
+						[runDataKey ?? name]: [{ data, startTime: 0, executionTime: 0, source: [] }],
+					},
+				},
+			},
+		});
+
+		const mockExecutionDataMarker = Symbol() as unknown as INodeExecutionData[];
+		const Main = NodeConnectionType.Main;
+
+		test.each<
+			[
+				[Partial<INodeUi> | null, number, number, Partial<IExecutionResponse> | null],
+				ReturnType<typeof getNodeInputData>,
+			]
+		>([
+			//
+			// Null / Out of Bounds Cases
+			//
+			[[null, 0, 0, null], []],
+			[[{ name }, 0, 0, null], []],
+			[[{ name }, 0, 0, { data: undefined }], []],
+			[[{ name }, 0, 0, { data: { resultData: { runData: {} } } }], []],
+			[[{ name }, 0, 0, { data: { resultData: { runData: { [name]: [] } } } }], []],
+			[[{ name }, 0, 0, makeMockData(undefined)], []],
+			[[{ name }, 1, 0, makeMockData({})], []],
+			[[{ name }, -1, 0, makeMockData({})], []],
+			[[{ name }, 0, 0, makeMockData({}, 'DIFFERENT_NAME')], []],
+			// getMainInputData cases
+			[[{ name }, 0, 0, makeMockData({ [Main]: [] })], []],
+			[[{ name }, 0, 0, makeMockData({ [Main]: [null] })], []],
+			[[{ name }, 0, 1, makeMockData({ [Main]: [null] })], []],
+			[[{ name }, 0, -1, makeMockData({ [Main]: [null] })], []],
+			[
+				[{ name }, 0, 0, makeMockData({ [Main]: [mockExecutionDataMarker] })],
+				mockExecutionDataMarker,
+			],
+			[
+				[{ name }, 0, 0, makeMockData({ [Main]: [mockExecutionDataMarker, null] })],
+				mockExecutionDataMarker,
+			],
+			[
+				[{ name }, 0, 1, makeMockData({ [Main]: [null, mockExecutionDataMarker] })],
+				mockExecutionDataMarker,
+			],
+			[
+				[
+					{ name },
+					0,
+					1,
+					makeMockData({ DIFFERENT_NAME: [], [Main]: [null, mockExecutionDataMarker] }),
+				],
+				mockExecutionDataMarker,
+			],
+			[
+				[
+					{ name },
+					2,
+					1,
+					{
+						data: {
+							resultData: {
+								runData: {
+									[name]: [
+										null,
+										null,
+										{
+											data: { [Main]: [null, mockExecutionDataMarker] },
+											startTime: 0,
+											executionTime: 0,
+											source: [],
+										},
+									],
+								},
+							},
+						},
+					},
+				],
+				mockExecutionDataMarker,
+			],
+		])(
+			'should return correct output %s',
+			([node, runIndex, outputIndex, getWorkflowExecution], output) => {
+				vi.mocked(useWorkflowsStore).mockReturnValue({
+					...useWorkflowsStore(),
+					getWorkflowExecution: getWorkflowExecution as IExecutionResponse,
+				});
+				expect(getNodeInputData(node as INodeUi, runIndex, outputIndex)).toEqual(output);
+			},
+		);
 	});
 });

--- a/packages/editor-ui/src/composables/useDataSchema.test.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.test.ts
@@ -613,8 +613,16 @@ describe('useDataSchema', () => {
 							resultData: {
 								runData: {
 									[name]: [
-										null,
-										null,
+										{
+											startTime: 0,
+											executionTime: 0,
+											source: [],
+										},
+										{
+											startTime: 0,
+											executionTime: 0,
+											source: [],
+										},
 										{
 											data: { [Main]: [null, mockExecutionDataMarker] },
 											startTime: 0,

--- a/packages/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.ts
@@ -72,12 +72,13 @@ export function useDataSchema() {
 		if (
 			!connectionsData?.hasOwnProperty(NodeConnectionType.Main) ||
 			connectionsData.main === undefined ||
-			connectionsData.main.length < outputIndex ||
+			outputIndex < 0 ||
+			outputIndex >= connectionsData.main.length ||
 			connectionsData.main[outputIndex] === null
 		) {
 			return [];
 		}
-		return connectionsData.main[outputIndex] as INodeExecutionData[];
+		return connectionsData.main[outputIndex];
 	}
 
 	function getNodeInputData(

--- a/packages/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.ts
@@ -100,11 +100,12 @@ export function useDataSchema() {
 		}
 		const runData = executionData.resultData.runData;
 
-		if (!runData?.[node.name]?.[runIndex].data || runData[node.name][runIndex].data === undefined) {
+		const taskData = runData?.[node.name]?.[runIndex];
+		if (taskData?.data === undefined) {
 			return [];
 		}
 
-		return getMainInputData(runData[node.name][runIndex].data!, outputIndex);
+		return getMainInputData(taskData.data, outputIndex);
 	}
 
 	function getInputDataWithPinned(


### PR DESCRIPTION
## Summary

This non-null assertion missed checking that `.[runIndex]` returned a valid value.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2723/typeerror-cannot-read-properties-of-null-reading-data


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
