### PR TITLE
fix(core): Fix `diagnostics.enabled` default value

### DIFF
--- a/packages/@n8n/config/src/configs/diagnostics.config.ts
+++ b/packages/@n8n/config/src/configs/diagnostics.config.ts
@@ -15,7 +15,7 @@ class PostHogConfig {
 export class DiagnosticsConfig {
 	/** Whether diagnostics are enabled. */
 	@Env('N8N_DIAGNOSTICS_ENABLED')
-	enabled: boolean = false;
+	enabled: boolean = true;
 
 	/** Diagnostics config for frontend. */
 	@Env('N8N_DIAGNOSTICS_CONFIG_FRONTEND')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -283,7 +283,7 @@ describe('GlobalConfig', () => {
 			},
 		},
 		diagnostics: {
-			enabled: false,
+			enabled: true,
 			frontendConfig: '1zPn9bgWPzlQc0p8Gj1uiK6DOTn;https://telemetry.n8n.io',
 			backendConfig: '1zPn7YoGC3ZXE9zLeTKLuQCB4F6;https://telemetry.n8n.io',
 			posthogConfig: {


### PR DESCRIPTION
Fix `diagnostics.enabled` default value, changed by accident here: https://github.com/n8n-io/n8n/pull/11761/files#diff-ff0f0df9be6611837d92c12ddedac7abf37d0ede7164509c299066a8871837e0L303