### PR TITLE
fix(editor): Don't re-render input panel after node finishes executing

### DIFF
--- a/packages/editor-ui/src/components/InputPanel.vue
+++ b/packages/editor-ui/src/components/InputPanel.vue
@@ -145,7 +145,7 @@ const isExecutingPrevious = computed(() => {
 	if (
 		activeNode.value &&
 		triggeredNode === activeNode.value.name &&
-		!workflowsStore.isNodeExecuting(activeNode.value.name)
+		workflowsStore.isNodeExecuting(props.currentNodeName)
 	) {
 		return true;
 	}


### PR DESCRIPTION
## Summary

## Before

https://share.cleanshot.com/VXhQ7rb9

## Now

![CleanShot 2024-11-20 at 10 41 23](https://github.com/user-attachments/assets/1235c702-e116-497d-b2ee-e327db5ad874)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2607/bug-previous-node-re-execution-when-it-should-not


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
