### PR TITLE
refactor(core): Mark deprecations for v2

### DIFF
--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -96,7 +96,7 @@ export abstract class BaseCommand extends Command {
 			this.globalConfig.database.type === 'sqlite'
 		) {
 			this.logger.warn(
-				'Queue mode is not officially supported with sqlite. Please switch to PostgreSQL.',
+				'Scaling mode is not officially supported with sqlite. Please use PostgreSQL instead.',
 			);
 		}
 

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -21,6 +21,7 @@ import { LICENSE_FEATURES, inDevelopment, inTest } from '@/constants';
 import * as CrashJournal from '@/crash-journal';
 import * as Db from '@/db';
 import { getDataDeduplicationService } from '@/deduplication';
+import { DeprecationService } from '@/deprecation/deprecation.service';
 import { initErrorHandling } from '@/error-reporting';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { TelemetryEventRelay } from '@/events/relays/telemetry.event-relay';
@@ -88,33 +89,14 @@ export abstract class BaseCommand extends Command {
 				await this.exitWithCrash('There was an error running database migrations', error),
 		);
 
-		const { type: dbType } = this.globalConfig.database;
-
-		if (['mysqldb', 'mariadb'].includes(dbType)) {
-			this.logger.warn(
-				'Support for MySQL/MariaDB has been deprecated and will be removed with an upcoming version of n8n. Please migrate to PostgreSQL.',
-			);
-		}
-
-		if (process.env.N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN) {
-			this.logger.warn(
-				'The flag to skip webhook deregistration N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN has been removed. n8n no longer deregisters webhooks at startup and shutdown, in main and queue mode.',
-			);
-		}
-
-		if (config.getEnv('executions.mode') === 'queue' && dbType === 'sqlite') {
-			this.logger.warn(
-				'Queue mode is not officially supported with sqlite. Please switch to PostgreSQL.',
-			);
-		}
+		Container.get(DeprecationService).warn();
 
 		if (
-			process.env.N8N_BINARY_DATA_TTL ??
-			process.env.N8N_PERSISTED_BINARY_DATA_TTL ??
-			process.env.EXECUTIONS_DATA_PRUNE_TIMEOUT
+			config.getEnv('executions.mode') === 'queue' &&
+			this.globalConfig.database.type === 'sqlite'
 		) {
 			this.logger.warn(
-				'The env vars N8N_BINARY_DATA_TTL and N8N_PERSISTED_BINARY_DATA_TTL and EXECUTIONS_DATA_PRUNE_TIMEOUT no longer have any effect and can be safely removed. Instead of relying on a TTL system for binary data, n8n currently cleans up binary data together with executions during pruning.',
+				'Queue mode is not officially supported with sqlite. Please switch to PostgreSQL.',
 			);
 		}
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -286,6 +286,10 @@ export class Start extends BaseCommand {
 		}
 
 		if (flags.tunnel) {
+			this.logger.warn(
+				'The --tunnel flag is deprecated and will be removed in an upcoming version of n8n.',
+			);
+
 			this.log('\nWaiting for tunnel ...');
 
 			let tunnelSubdomain =

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -286,10 +286,6 @@ export class Start extends BaseCommand {
 		}
 
 		if (flags.tunnel) {
-			this.logger.warn(
-				'The --tunnel flag is deprecated and will be removed in an upcoming version of n8n.',
-			);
-
 			this.log('\nWaiting for tunnel ...');
 
 			let tunnelSubdomain =

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -17,7 +17,6 @@ describe('DeprecationService', () => {
 		['N8N_PERSISTED_BINARY_DATA_TTL', '1', true],
 		['EXECUTIONS_DATA_PRUNE_TIMEOUT', '1', true],
 		['N8N_CONFIG_FILES', '1', true],
-		['N8N_PATH', '1', true],
 		['N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', '1', true],
 	])('should detect when %s is in use', (envVar, value, inUse) => {
 		toTest(envVar, value, inUse);

--- a/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
+++ b/packages/cli/src/deprecation/__tests__/deprecation.service.test.ts
@@ -1,0 +1,42 @@
+import { mockLogger } from '@test/mocking';
+
+import { DeprecationService } from '../deprecation.service';
+
+describe('DeprecationService', () => {
+	const toTest = (envVar: string, value: string, inUse: boolean) => {
+		process.env[envVar] = value;
+		const deprecationService = new DeprecationService(mockLogger());
+
+		deprecationService.warn();
+
+		expect(deprecationService.isInUse(envVar)).toBe(inUse);
+	};
+
+	test.each([
+		['N8N_BINARY_DATA_TTL', '1', true],
+		['N8N_PERSISTED_BINARY_DATA_TTL', '1', true],
+		['EXECUTIONS_DATA_PRUNE_TIMEOUT', '1', true],
+		['N8N_CONFIG_FILES', '1', true],
+		['N8N_PATH', '1', true],
+		['N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', '1', true],
+	])('should detect when %s is in use', (envVar, value, inUse) => {
+		toTest(envVar, value, inUse);
+	});
+
+	test.each([
+		['default', true],
+		['filesystem', false],
+		['s3', false],
+	])('should handle N8N_BINARY_DATA_MODE as %s', (mode, inUse) => {
+		toTest('N8N_BINARY_DATA_MODE', mode, inUse);
+	});
+
+	test.each([
+		['sqlite', false],
+		['postgresdb', false],
+		['mysqldb', true],
+		['mariadb', true],
+	])('should handle DB_TYPE as %s', (dbType, inUse) => {
+		toTest('DB_TYPE', dbType, inUse);
+	});
+});

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -36,7 +36,10 @@ export class DeprecationService {
 			message: 'MySQL and MariaDB are deprecated. Please migrate to PostgreSQL.',
 			checkValue: (value: string) => ['mysqldb', 'mariadb'].includes(value),
 		},
-		{ envVar: 'N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', message: SAFE_TO_REMOVE },
+		{
+			envVar: 'N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN',
+			message: `n8n no longer deregisters webhooks at startup and shutdown. ${SAFE_TO_REMOVE}`,
+		},
 	];
 
 	/** Runtime state of deprecated env vars. */

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -28,7 +28,6 @@ export class DeprecationService {
 			message: 'MySQL and MariaDB are deprecated. Please migrate to PostgreSQL.',
 			checkValue: (value: string) => ['mysqldb', 'mariadb'].includes(value),
 		},
-		{ env: 'N8N_PATH', message: 'Please use N8N_BASE_URL instead.' },
 		{ env: 'N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', message: SAFE_TO_REMOVE },
 	];
 

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -1,0 +1,58 @@
+import { Service } from 'typedi';
+
+import { Logger } from '@/logging/logger.service';
+
+type Deprecation = {
+	env: string;
+	message: string;
+	inUse?: boolean;
+	checkValue?: (value: string) => boolean;
+};
+
+const SAFE_TO_REMOVE = 'This can be safely removed.';
+
+@Service()
+export class DeprecationService {
+	private readonly deprecations: Deprecation[] = [
+		{ env: 'N8N_BINARY_DATA_TTL', message: SAFE_TO_REMOVE },
+		{ env: 'N8N_PERSISTED_BINARY_DATA_TTL', message: SAFE_TO_REMOVE },
+		{ env: 'EXECUTIONS_DATA_PRUNE_TIMEOUT', message: SAFE_TO_REMOVE },
+		{
+			env: 'N8N_BINARY_DATA_MODE',
+			message: '`default` is deprecated. Please switch to `filesystem` mode.',
+			checkValue: (value: string) => value === 'default',
+		},
+		{ env: 'N8N_CONFIG_FILES', message: 'Please use .env files or *_FILE env vars instead.' },
+		{
+			env: 'DB_TYPE',
+			message: 'MySQL and MariaDB are deprecated. Please migrate to PostgreSQL.',
+			checkValue: (value: string) => ['mysqldb', 'mariadb'].includes(value),
+		},
+		{ env: 'N8N_PATH', message: 'Please use N8N_BASE_URL instead.' },
+		{ env: 'N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN', message: SAFE_TO_REMOVE },
+	];
+
+	constructor(private readonly logger: Logger) {}
+
+	warn() {
+		this.deprecations.forEach((d) => {
+			const envValue = process.env[d.env];
+			d.inUse = d.checkValue
+				? envValue !== undefined && d.checkValue(envValue)
+				: envValue !== undefined;
+		});
+
+		const inUse = this.deprecations.filter((d) => d.inUse);
+
+		if (inUse.length === 0) return;
+
+		const header = `Found deprecated feature${inUse.length === 1 ? '' : 's'} in use, to be removed in an upcoming version of n8n`;
+		const deprecations = inUse.map(({ env, message }) => ` - ${env} -> ${message}\n`).join('');
+
+		this.logger.warn(`\n${header}:\n${deprecations}`);
+	}
+
+	isInUse(env: string) {
+		return this.deprecations.find((d) => d.env === env)?.inUse ?? false;
+	}
+}

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -53,7 +53,7 @@ export class DeprecationService {
 
 		if (inUse.length === 0) return;
 
-		const header = `Found deprecated feature${inUse.length === 1 ? '' : 's'} in use, to be removed in an upcoming version of n8n`;
+		const header = `The following environment variable${inUse.length === 1 ? ' is' : 's are'} deprecated and will be removed in an upcoming version of n8n. Please take the recommended actions to update your configuration:`;
 		const deprecations = inUse.map(({ env, message }) => ` - ${env} -> ${message}\n`).join('');
 
 		this.logger.warn(`\n${header}:\n${deprecations}`);

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -16,7 +16,7 @@ type Deprecation = {
 	checkValue?: (value: string) => boolean;
 };
 
-const SAFE_TO_REMOVE = 'This can be safely removed.';
+const SAFE_TO_REMOVE = 'Remove this environment variable; it is no longer needed.';
 
 /** Responsible for warning about use of deprecated env vars. */
 @Service()

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -6,7 +6,7 @@ type Deprecation = {
 	/** Deprecated env var. */
 	env: string;
 
-	/** Message to display when the deprecated env var is in use. */
+	/** Message to display when the deprecated env var is currently in use. */
 	message: string;
 
 	/** Whether the deprecated env var is currently in use. */

--- a/packages/cli/src/deprecation/deprecation.service.ts
+++ b/packages/cli/src/deprecation/deprecation.service.ts
@@ -3,14 +3,22 @@ import { Service } from 'typedi';
 import { Logger } from '@/logging/logger.service';
 
 type Deprecation = {
+	/** Deprecated env var. */
 	env: string;
+
+	/** Message to display when the deprecated env var is in use. */
 	message: string;
+
+	/** Whether the deprecated env var is currently in use. */
 	inUse?: boolean;
+
+	/** Function to identify the specific value in the env var that is deprecated. */
 	checkValue?: (value: string) => boolean;
 };
 
 const SAFE_TO_REMOVE = 'This can be safely removed.';
 
+/** Responsible for warning about use of deprecated env vars. */
 @Service()
 export class DeprecationService {
 	private readonly deprecations: Deprecation[] = [


### PR DESCRIPTION
## Summary

Mark deprecations for `N8N_BINARY_DATA_TTL`, `N8N_PERSISTED_BINARY_DATA_TTL`, `EXECUTIONS_DATA_PRUNE_TIMEOUT`, `N8N_BINARY_DATA_MODE` as `'default'`, `N8N_CONFIG_FILES`, `DB_TYPE` as `mysqldb` or `mariadb`, and `N8N_SKIP_WEBHOOK_DEREGISTRATION_SHUTDOWN`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-60/deprecate-n8n-config-files
- https://linear.app/n8n/issue/CAT-50/deprecate-binary-data-memory-mode

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
