### PR TITLE
feat(core): Shut down runner on idle timeout (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/config/base-runner-config.ts
+++ b/packages/@n8n/task-runner/src/config/base-runner-config.ts
@@ -26,6 +26,14 @@ export class BaseRunnerConfig {
 	@Env('N8N_RUNNERS_MAX_CONCURRENCY')
 	maxConcurrency: number = 5;
 
+	/**
+	 * How long (in seconds) a runner may be idle for before exit. Intended
+	 * for use in `external` mode - launcher must pass the env var when launching
+	 * the runner. Disabled with `0` on `internal` mode.
+	 */
+	@Env('N8N_RUNNERS_IDLE_TIMEOUT')
+	idleTimeout: number = 0;
+
 	@Nested
 	healthcheckServer!: HealthcheckServerConfig;
 }

--- a/packages/@n8n/task-runner/src/config/base-runner-config.ts
+++ b/packages/@n8n/task-runner/src/config/base-runner-config.ts
@@ -31,7 +31,7 @@ export class BaseRunnerConfig {
 	 * for use in `external` mode - launcher must pass the env var when launching
 	 * the runner. Disabled with `0` on `internal` mode.
 	 */
-	@Env('N8N_RUNNERS_IDLE_TIMEOUT')
+	@Env('N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT')
 	idleTimeout: number = 0;
 
 	@Nested

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -51,6 +51,9 @@ void (async function start() {
 	}
 
 	runner = new JsTaskRunner(config);
+	runner.on('runner:reached-idle-timeout', () => {
+		void createSignalHandler('IDLE_TIMEOUT')();
+	});
 
 	const { enabled, host, port } = config.baseRunnerConfig.healthcheckServer;
 

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -294,7 +294,6 @@ export abstract class TaskRunner {
 			taskId,
 			error,
 		});
-		console.error(`Runner failed to complete task ${taskId}`);
 		this.runningTasks.delete(taskId);
 		this.sendOffers();
 	}
@@ -306,7 +305,6 @@ export abstract class TaskRunner {
 			data,
 		});
 		this.runningTasks.delete(taskId);
-		console.log(`Runner completed task ${taskId}`);
 		this.resetIdleTimer();
 		this.sendOffers();
 	}

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -305,7 +305,6 @@ export abstract class TaskRunner {
 			data,
 		});
 		this.runningTasks.delete(taskId);
-		this.resetIdleTimer();
 		this.sendOffers();
 	}
 
@@ -326,6 +325,7 @@ export abstract class TaskRunner {
 		} catch (error) {
 			this.taskErrored(taskId, error);
 		}
+		this.resetIdleTimer();
 	}
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -326,8 +326,9 @@ export abstract class TaskRunner extends EventEmitter {
 			this.taskDone(taskId, data);
 		} catch (error) {
 			this.taskErrored(taskId, error);
+		} finally {
+			this.resetIdleTimer();
 		}
-		this.resetIdleTimer();
 	}
 
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -462,6 +462,7 @@ export abstract class TaskRunner {
 
 	clearIdleTimer() {
 		if (this.idleTimer) clearTimeout(this.idleTimer);
+		this.idleTimer = undefined;
 	}
 
 	private async closeConnection() {

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -78,6 +78,7 @@ export abstract class TaskRunner {
 
 	private idleTimer: NodeJS.Timeout | undefined;
 
+	/** How long (in seconds) a runner may be idle for before exit. */
 	private readonly idleTimeout: number;
 
 	constructor(opts: TaskRunnerOpts) {

--- a/packages/cli/src/runners/runner-ws-server.ts
+++ b/packages/cli/src/runners/runner-ws-server.ts
@@ -126,7 +126,7 @@ export class TaskRunnerWsServer {
 						this.sendMessage.bind(this, id) as MessageCallback,
 					);
 
-					this.logger.info(`Runner "${message.name}" (${id}) has been registered`);
+					this.logger.info(`Registered runner "${message.name}" (${id}) `);
 					return;
 				}
 
@@ -166,6 +166,7 @@ export class TaskRunnerWsServer {
 				heartbeatInterval: this.taskTunnersConfig.heartbeatInterval,
 			});
 			this.taskBroker.deregisterRunner(id, disconnectError);
+			this.logger.debug(`Deregistered runner "${id}"`);
 			connection.close(code);
 			this.runnerConnections.delete(id);
 		}

--- a/packages/cli/src/runners/task-broker.service.ts
+++ b/packages/cli/src/runners/task-broker.service.ts
@@ -525,7 +525,7 @@ export class TaskBroker {
 				return;
 			}
 			if (e instanceof TaskDeferredError) {
-				this.logger.info(`Task (${taskId}) deferred until runner is ready`);
+				this.logger.debug(`Task (${taskId}) deferred until runner is ready`);
 				this.pendingTaskRequests.push(request); // will settle on receiving task offer from runner
 				return;
 			}


### PR DESCRIPTION
## Summary

Exit the runner if idle for longer than `N8N_RUNNERS_IDLE_TIMEOUT` seconds in `external` mode. Launcher will later re-launch runner on demand.

To be reviewed together with: https://github.com/n8n-io/task-runner-launcher/pull/13

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2246

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
