### PR TITLE
fix(core): Bring back execution data on the `executionFinished` push message

### DIFF
--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -1,4 +1,4 @@
-import type { ITaskData, WorkflowExecuteMode } from 'n8n-workflow';
+import type { ExecutionStatus, ITaskData, WorkflowExecuteMode } from 'n8n-workflow';
 
 type ExecutionStarted = {
 	type: 'executionStarted';
@@ -23,6 +23,10 @@ type ExecutionFinished = {
 	type: 'executionFinished';
 	data: {
 		executionId: string;
+		workflowId: string;
+		status: ExecutionStatus;
+		/** @deprecated: Please construct execution data in the frontend from the data pushed in previous messages, instead of depending on this additional payload serialization */
+		rawData?: string;
 	};
 };
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -5,6 +5,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { PushType } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
+import { stringify } from 'flatted';
 import { WorkflowExecute } from 'n8n-core';
 import {
 	ApplicationError,
@@ -318,9 +319,17 @@ function hookFunctionsPush(): IWorkflowExecuteHooks {
 					workflowId,
 				});
 
-				const pushType =
-					fullRunData.status === 'waiting' ? 'executionWaiting' : 'executionFinished';
-				pushInstance.send(pushType, { executionId }, pushRef);
+				const { status } = fullRunData;
+				if (status === 'waiting') {
+					pushInstance.send('executionWaiting', { executionId }, pushRef);
+				} else {
+					const rawData = stringify(fullRunData.data);
+					pushInstance.send(
+						'executionFinished',
+						{ executionId, workflowId, status, rawData },
+						pushRef,
+					);
+				}
 			},
 		],
 	};

--- a/packages/editor-ui/src/composables/usePushConnection.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.ts
@@ -35,6 +35,7 @@ import { useTelemetry } from '@/composables/useTelemetry';
 import type { PushMessageQueueItem } from '@/types';
 import { useAssistantStore } from '@/stores/assistant.store';
 import NodeExecutionErrorMessage from '@/components/NodeExecutionErrorMessage.vue';
+import type { IExecutionResponse } from '@/Interface';
 
 export function usePushConnection({ router }: { router: ReturnType<typeof useRouter> }) {
 	const workflowHelpers = useWorkflowHelpers({ router });
@@ -205,11 +206,19 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 				return false;
 			}
 
-			// pull execution data for the execution from the server
-			const executionData = await workflowsStore.fetchExecutionDataById(executionId);
-			if (!executionData?.data) return false;
-			// data comes in as 'flatten' object, so we need to parse it
-			executionData.data = parse(executionData.data as unknown as string) as IRunExecutionData;
+			let executionData: Pick<IExecutionResponse, 'workflowId' | 'data' | 'status'>;
+			if (receivedData.type === 'executionFinished' && receivedData.data.rawData) {
+				const { workflowId, status, rawData } = receivedData.data;
+				executionData = { workflowId, data: parse(rawData), status };
+			} else {
+				const execution = await workflowsStore.fetchExecutionDataById(executionId);
+				if (!execution?.data) return false;
+				executionData = {
+					workflowId: execution.workflowId,
+					data: parse(execution.data as unknown as string),
+					status: execution.status,
+				};
+			}
 
 			const iRunExecutionData: IRunExecutionData = {
 				startData: executionData.data?.startData,
@@ -265,7 +274,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 
 				// Workflow did start but had been put to wait
 				workflowHelpers.setDocumentTitle(workflow.name as string, 'IDLE');
-			} else if (executionData.finished !== true) {
+			} else if (executionData.status === 'error' || executionData.status === 'canceled') {
 				workflowHelpers.setDocumentTitle(workflow.name as string, 'ERROR');
 
 				if (
@@ -347,17 +356,14 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 						duration: 0,
 					});
 				} else {
-					let title: string;
-					const isManualExecutionCancelled =
-						executionData.mode === 'manual' && executionData.status === 'canceled';
-
-					// Do not show the error message if the workflow got canceled manually
-					if (isManualExecutionCancelled) {
+					// Do not show the error message if the workflow got canceled
+					if (executionData.status === 'canceled') {
 						toast.showMessage({
 							title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
 							type: 'success',
 						});
 					} else {
+						let title: string;
 						if (iRunExecutionData.resultData.lastNodeExecuted) {
 							title = `Problem in node ‘${iRunExecutionData.resultData.lastNodeExecuted}‘`;
 						} else {
@@ -421,7 +427,7 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 			}
 
 			workflowsStore.executingNode.length = 0;
-			workflowsStore.setWorkflowExecutionData(executionData);
+			workflowsStore.setWorkflowExecutionData(executionData as IExecutionResponse);
 			uiStore.removeActiveAction('workflowRunning');
 
 			// Set the node execution issues on all the nodes which produced an error so that


### PR DESCRIPTION
## Summary
We removed the full execution data from the payload for `executionFinished` push message in #11703, because that serialization sometimes required quite a lot of memory.
This PR "temporarily" brings that data back, but now we instead serialize the data using `flatted.stringify` instead of `JSON.stringify`, which is a lot less expensive.

This change is still temporary, as we should instead improve the state management in the frontend to construct the final execution data based on all the partial data already delivered in the `nodeExecuteAfter` push messages.

## Related Linear tickets, Github issues, and Community forum posts
PAY-2270


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
