### PR TITLE
fix(n8n Form Node): Redirect if completion page to trigger

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -274,7 +274,9 @@ export class Form extends Node {
 			delete staticData[id];
 
 			if (config.redirectUrl) {
-				res.redirect(config.redirectUrl);
+				res.send(
+					`<html><head><meta http-equiv="refresh" content="0; url=${config.redirectUrl}"></head></html>`,
+				);
 				return { noWebhookResponse: true };
 			}
 


### PR DESCRIPTION
## Summary

fix for redirection not working if completion page connected to form trigger

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2001/community-issue-n8n-form-redirect-url-is-not-working
Close https://github.com/n8n-io/n8n/issues/11657
