### PR TITLE
ci(core): Use tempfs for mariadb and postgres in tests

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - MARIADB_MYSQL_LOCALHOST_USER=true
     ports:
       - 3306:3306
+    tmpfs:
+      - /var/lib/mysql
 
   postgres:
     image: postgres:16
@@ -17,3 +19,5 @@ services:
       - POSTGRES_PASSWORD=password
     ports:
       - 5432:5432
+    tmpfs:
+      - /var/lib/postgresql/data


### PR DESCRIPTION
## Summary

Speed up DB test execution by using a [tmpfs mount](https://docs.docker.com/engine/storage/tmpfs/) in the containers. Seems to speed up the execution by ~30s (sample size 1). Test run [here](https://github.com/n8n-io/n8n/actions/runs/11953398983?pr=11824).

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
