### PR TITLE
fix(OpenAI Node): Remove preview chatInput parameter for `Assistant:Messsage` operation

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -18,7 +18,7 @@ import {
 } from 'n8n-workflow';
 import { OpenAI as OpenAIClient } from 'openai';
 
-import { promptTypeOptions, textFromPreviousNode } from '../../../../../utils/descriptions';
+import { promptTypeOptions } from '../../../../../utils/descriptions';
 import { getConnectedTools } from '../../../../../utils/helpers';
 import { getTracingConfig } from '../../../../../utils/tracing';
 import { formatToOpenAIAssistantTool } from '../../helpers/utils';
@@ -29,16 +29,6 @@ const properties: INodeProperties[] = [
 	{
 		...promptTypeOptions,
 		name: 'prompt',
-	},
-	{
-		...textFromPreviousNode,
-		disabledOptions: { show: { prompt: ['auto'] } },
-		displayOptions: {
-			show: {
-				prompt: ['auto'],
-				'@version': [{ _cnd: { gte: 1.7 } }],
-			},
-		},
 	},
 	{
 		displayName: 'Text',


### PR DESCRIPTION
This PR fixes an issue when using expressions for OpenAI Image:Generate action, the prompt field from Assistant:Message operation conflicts with Image:Generate operation's prompt. This conflict emerged after PR #11491 introduced "preview inputs" in disabled mode with promptType set to "auto".  As a quick fix, we remove this preview field from `Assistant:Message` operation as it's visual only.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
