### PR TITLE
docs(Google Drive Node): Replace the description of the 'Can Share' capability in Google Drive (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Google/Drive/v2/actions/drive/create.operation.ts
+++ b/packages/nodes-base/nodes/Google/Drive/v2/actions/drive/create.operation.ts
@@ -159,7 +159,7 @@ const properties: INodeProperties[] = [
 						name: 'canShare',
 						type: 'boolean',
 						default: false,
-						description: 'Whether the current user can rename this shared drive',
+						description: 'Whether the current user can share files or folders in this shared drive',
 					},
 					{
 						displayName: 'Can Trash Children',


### PR DESCRIPTION
## Summary

The current description of the `canShare` capability when creating a new Google Drive is reusing the string from `canRenameDrive`. This commit updates it to refer to sharing capabilities.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
