### PR TITLE
feat(core): Add workflowId filter to the test-definitions endpoint (no-changelog)

### DIFF
--- a/packages/cli/src/databases/repositories/test-definition.repository.ee.ts
+++ b/packages/cli/src/databases/repositories/test-definition.repository.ee.ts
@@ -3,6 +3,7 @@ import { DataSource, In, Repository } from '@n8n/typeorm';
 import { Service } from 'typedi';
 
 import { TestDefinition } from '@/databases/entities/test-definition.ee';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ListQuery } from '@/requests';
 
 @Service()
@@ -14,12 +15,21 @@ export class TestDefinitionRepository extends Repository<TestDefinition> {
 	async getMany(accessibleWorkflowIds: string[], options?: ListQuery.Options) {
 		if (accessibleWorkflowIds.length === 0) return { tests: [], count: 0 };
 
-		const where: FindOptionsWhere<TestDefinition> = {
-			...options?.filter,
-			workflow: {
+		const where: FindOptionsWhere<TestDefinition> = {};
+
+		if (options?.filter?.workflowId) {
+			if (!accessibleWorkflowIds.includes(options.filter.workflowId as string)) {
+				throw new ForbiddenError('User does not have access to the workflow');
+			}
+
+			where.workflow = {
+				id: options.filter.workflowId as string,
+			};
+		} else {
+			where.workflow = {
 				id: In(accessibleWorkflowIds),
-			},
-		};
+			};
+		}
 
 		const findManyOptions: FindManyOptions<TestDefinition> = {
 			where,

--- a/packages/cli/src/middlewares/list-query/dtos/test-definitions.filter.dto.ts
+++ b/packages/cli/src/middlewares/list-query/dtos/test-definitions.filter.dto.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+
+import { BaseFilter } from './base.filter.dto';
+
+export class TestDefinitionsFilter extends BaseFilter {
+	@IsString()
+	@IsOptional()
+	@Expose()
+	workflowId?: string;
+
+	static async fromString(rawFilter: string) {
+		return await this.toFilter(rawFilter, TestDefinitionsFilter);
+	}
+}

--- a/packages/cli/src/middlewares/list-query/filter.ts
+++ b/packages/cli/src/middlewares/list-query/filter.ts
@@ -5,6 +5,7 @@ import * as ResponseHelper from '@/response-helper';
 import { toError } from '@/utils';
 
 import { CredentialsFilter } from './dtos/credentials.filter.dto';
+import { TestDefinitionsFilter } from './dtos/test-definitions.filter.dto';
 import { UserFilter } from './dtos/user.filter.dto';
 import { WorkflowFilter } from './dtos/workflow.filter.dto';
 
@@ -25,6 +26,8 @@ export const filterListQueryMiddleware = async (
 		Filter = CredentialsFilter;
 	} else if (req.baseUrl.endsWith('users')) {
 		Filter = UserFilter;
+	} else if (req.baseUrl.endsWith('test-definitions')) {
+		Filter = TestDefinitionsFilter;
 	} else {
 		return next();
 	}


### PR DESCRIPTION
## Summary

This PR adds filter by `workflowId` to the `/test-definitions` list endpoint.

## Related Linear tickets, Github issues, and Community forum posts
- #11591
- https://linear.app/n8n/issue/AI-456/[api]-add-option-to-filter-test-definitions-by-a-specific-workflow


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
