### PR TITLE
refactor(core): Extract SupplyDataContext out of NodeExecutionFunctions (no-changelog)

### DIFF
--- a/packages/core/src/CreateNodeAsTool.ts
+++ b/packages/core/src/CreateNodeAsTool.ts
@@ -1,5 +1,10 @@
 import { DynamicStructuredTool } from '@langchain/core/tools';
-import type { IExecuteFunctions, INodeParameters, INodeType } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	INodeParameters,
+	INodeType,
+	ISupplyDataFunctions,
+} from 'n8n-workflow';
 import { jsonParse, NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import { z } from 'zod';
 
@@ -18,13 +23,13 @@ interface FromAIArgument {
  * generating Zod schemas, and creating LangChain tools.
  */
 class AIParametersParser {
-	private ctx: IExecuteFunctions;
+	private ctx: ISupplyDataFunctions;
 
 	/**
 	 * Constructs an instance of AIParametersParser.
 	 * @param ctx The execution context.
 	 */
-	constructor(ctx: IExecuteFunctions) {
+	constructor(ctx: ISupplyDataFunctions) {
 		this.ctx = ctx;
 	}
 
@@ -388,7 +393,7 @@ class AIParametersParser {
 
 				try {
 					// Execute the node with the proxied context
-					const result = await node.execute?.bind(this.ctx)();
+					const result = await node.execute?.bind(this.ctx as IExecuteFunctions)();
 
 					// Process and map the results
 					const mappedResults = result?.[0]?.flatMap((item) => item.json);
@@ -423,7 +428,7 @@ class AIParametersParser {
  * @returns An object containing the DynamicStructuredTool instance.
  */
 export function createNodeAsTool(
-	ctx: IExecuteFunctions,
+	ctx: ISupplyDataFunctions,
 	node: INodeType,
 	nodeParameters: INodeParameters,
 ) {

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2899,7 +2899,7 @@ export async function getInputConnectionData(
 
 			if (!nodeType.supplyData) {
 				if (nodeType.description.outputs.includes(NodeConnectionType.AiTool)) {
-					nodeType.supplyData = async function (this: IExecuteFunctions) {
+					nodeType.supplyData = async function (this: ISupplyDataFunctions) {
 						return createNodeAsTool(this, nodeType, this.getNode().parameters);
 					};
 				} else {

--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -2881,18 +2881,16 @@ export async function getInputConnectionData(
 				connectedNode.type,
 				connectedNode.typeVersion,
 			);
-
-			// eslint-disable-next-line @typescript-eslint/no-use-before-define
-			const context = getSupplyDataFunctions(
+			const context = new SupplyDataContext(
 				workflow,
+				connectedNode,
+				additionalData,
+				mode,
 				runExecutionData,
 				runIndex,
 				connectionInputData,
 				inputData,
-				connectedNode,
-				additionalData,
 				executeData,
-				mode,
 				closeFunctions,
 				abortSignal,
 			);
@@ -3941,34 +3939,6 @@ export function getExecuteFunctions(
 			),
 		};
 	})(workflow, runExecutionData, connectionInputData, inputData, node) as IExecuteFunctions;
-}
-
-export function getSupplyDataFunctions(
-	workflow: Workflow,
-	runExecutionData: IRunExecutionData,
-	runIndex: number,
-	connectionInputData: INodeExecutionData[],
-	inputData: ITaskDataConnections,
-	node: INode,
-	additionalData: IWorkflowExecuteAdditionalData,
-	executeData: IExecuteData,
-	mode: WorkflowExecuteMode,
-	closeFunctions: CloseFunction[],
-	abortSignal?: AbortSignal,
-): ISupplyDataFunctions {
-	return new SupplyDataContext(
-		workflow,
-		node,
-		additionalData,
-		mode,
-		runExecutionData,
-		runIndex,
-		connectionInputData,
-		inputData,
-		executeData,
-		closeFunctions,
-		abortSignal,
-	);
 }
 
 /**

--- a/packages/core/src/node-execution-context/index.ts
+++ b/packages/core/src/node-execution-context/index.ts
@@ -3,5 +3,6 @@ export { ExecuteSingleContext } from './execute-single-context';
 export { HookContext } from './hook-context';
 export { LoadOptionsContext } from './load-options-context';
 export { PollContext } from './poll-context';
+export { SupplyDataContext } from './supply-data-context';
 export { TriggerContext } from './trigger-context';
 export { WebhookContext } from './webhook-context';

--- a/packages/core/src/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/node-execution-context/supply-data-context.ts
@@ -1,0 +1,371 @@
+import type {
+	AiEvent,
+	CallbackManager,
+	CloseFunction,
+	ExecuteWorkflowData,
+	ICredentialDataDecryptedObject,
+	IExecuteData,
+	IExecuteWorkflowInfo,
+	IGetNodeParameterOptions,
+	INode,
+	INodeExecutionData,
+	IRunExecutionData,
+	ISupplyDataFunctions,
+	ITaskDataConnections,
+	ITaskMetadata,
+	IWorkflowExecuteAdditionalData,
+	NodeConnectionType,
+	RelatedExecution,
+	Workflow,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import {
+	ApplicationError,
+	createDeferredPromise,
+	NodeHelpers,
+	WorkflowDataProxy,
+} from 'n8n-workflow';
+import Container from 'typedi';
+
+import { BinaryDataService } from '@/BinaryData/BinaryData.service';
+// eslint-disable-next-line import/no-cycle
+import {
+	assertBinaryData,
+	continueOnFail,
+	constructExecutionMetaData,
+	copyInputItems,
+	getAdditionalKeys,
+	getBinaryDataBuffer,
+	getBinaryHelperFunctions,
+	getCheckProcessedHelperFunctions,
+	getCredentials,
+	getFileSystemHelperFunctions,
+	getNodeParameter,
+	getRequestHelperFunctions,
+	getSSHTunnelFunctions,
+	normalizeItems,
+	returnJsonArray,
+	getInputConnectionData,
+	addExecutionDataFunctions,
+} from '@/NodeExecuteFunctions';
+
+import { NodeExecutionContext } from './node-execution-context';
+
+export class SupplyDataContext extends NodeExecutionContext implements ISupplyDataFunctions {
+	readonly helpers: ISupplyDataFunctions['helpers'];
+
+	readonly getNodeParameter: ISupplyDataFunctions['getNodeParameter'];
+
+	constructor(
+		workflow: Workflow,
+		node: INode,
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		private readonly runExecutionData: IRunExecutionData,
+		private readonly runIndex: number,
+		private readonly connectionInputData: INodeExecutionData[],
+		private readonly inputData: ITaskDataConnections,
+		private readonly executeData: IExecuteData,
+		private readonly closeFunctions: CloseFunction[],
+		private readonly abortSignal?: AbortSignal,
+	) {
+		super(workflow, node, additionalData, mode);
+
+		this.helpers = {
+			createDeferredPromise,
+			copyInputItems,
+			...getRequestHelperFunctions(
+				workflow,
+				node,
+				additionalData,
+				runExecutionData,
+				connectionInputData,
+			),
+			...getSSHTunnelFunctions(),
+			...getFileSystemHelperFunctions(node),
+			...getBinaryHelperFunctions(additionalData, workflow.id),
+			...getCheckProcessedHelperFunctions(workflow, node),
+			assertBinaryData: (itemIndex, propertyName) =>
+				assertBinaryData(inputData, node, itemIndex, propertyName, 0),
+			getBinaryDataBuffer: async (itemIndex, propertyName) =>
+				await getBinaryDataBuffer(inputData, itemIndex, propertyName, 0),
+
+			returnJsonArray,
+			normalizeItems,
+			constructExecutionMetaData,
+		};
+
+		this.getNodeParameter = ((
+			parameterName: string,
+			itemIndex: number,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			fallbackValue?: any,
+			options?: IGetNodeParameterOptions,
+		) =>
+			getNodeParameter(
+				this.workflow,
+				this.runExecutionData,
+				this.runIndex,
+				this.connectionInputData,
+				this.node,
+				parameterName,
+				itemIndex,
+				this.mode,
+				getAdditionalKeys(this.additionalData, this.mode, this.runExecutionData),
+				this.executeData,
+				fallbackValue,
+				options,
+			)) as ISupplyDataFunctions['getNodeParameter'];
+	}
+
+	getExecutionCancelSignal() {
+		return this.abortSignal;
+	}
+
+	onExecutionCancellation(handler: () => unknown) {
+		const fn = () => {
+			this.abortSignal?.removeEventListener('abort', fn);
+			handler();
+		};
+		this.abortSignal?.addEventListener('abort', fn);
+	}
+
+	async getCredentials<T extends object = ICredentialDataDecryptedObject>(
+		type: string,
+		itemIndex: number,
+	) {
+		return await getCredentials<T>(
+			this.workflow,
+			this.node,
+			type,
+			this.additionalData,
+			this.mode,
+			this.executeData,
+			this.runExecutionData,
+			this.runIndex,
+			this.connectionInputData,
+			itemIndex,
+		);
+	}
+
+	continueOnFail() {
+		return continueOnFail(this.node);
+	}
+
+	evaluateExpression(expression: string, itemIndex: number) {
+		return this.workflow.expression.resolveSimpleParameterValue(
+			`=${expression}`,
+			{},
+			this.runExecutionData,
+			this.runIndex,
+			itemIndex,
+			this.node.name,
+			this.connectionInputData,
+			this.mode,
+			getAdditionalKeys(this.additionalData, this.mode, this.runExecutionData),
+			this.executeData,
+		);
+	}
+
+	async executeWorkflow(
+		workflowInfo: IExecuteWorkflowInfo,
+		inputData?: INodeExecutionData[],
+		parentCallbackManager?: CallbackManager,
+		options?: {
+			doNotWaitToFinish?: boolean;
+			parentExecution?: RelatedExecution;
+		},
+	): Promise<ExecuteWorkflowData> {
+		return await this.additionalData
+			.executeWorkflow(workflowInfo, this.additionalData, {
+				parentWorkflowId: this.workflow.id?.toString(),
+				inputData,
+				parentWorkflowSettings: this.workflow.settings,
+				node: this.node,
+				parentCallbackManager,
+				...options,
+			})
+			.then(async (result) => {
+				const data = await Container.get(BinaryDataService).duplicateBinaryData(
+					this.workflow.id,
+					this.additionalData.executionId!,
+					result.data,
+				);
+				return { ...result, data };
+			});
+	}
+
+	getNodeOutputs() {
+		const nodeType = this.workflow.nodeTypes.getByNameAndVersion(
+			this.node.type,
+			this.node.typeVersion,
+		);
+		return NodeHelpers.getNodeOutputs(this.workflow, this.node, nodeType.description).map(
+			(output) => {
+				if (typeof output === 'string') {
+					return {
+						type: output,
+					};
+				}
+				return output;
+			},
+		);
+	}
+
+	async getInputConnectionData(inputName: NodeConnectionType, itemIndex: number): Promise<unknown> {
+		return await getInputConnectionData.call(
+			this,
+			this.workflow,
+			this.runExecutionData,
+			this.runIndex,
+			this.connectionInputData,
+			this.inputData,
+			this.additionalData,
+			this.executeData,
+			this.mode,
+			this.closeFunctions,
+			inputName,
+			itemIndex,
+			this.abortSignal,
+		);
+	}
+
+	getInputData(inputIndex = 0, inputName = 'main') {
+		if (!this.inputData.hasOwnProperty(inputName)) {
+			// Return empty array because else it would throw error when nothing is connected to input
+			return [];
+		}
+
+		// TODO: Check if nodeType has input with that index defined
+		if (this.inputData[inputName].length < inputIndex) {
+			throw new ApplicationError('Could not get input with given index', {
+				extra: { inputIndex, inputName },
+			});
+		}
+
+		if (this.inputData[inputName][inputIndex] === null) {
+			throw new ApplicationError('Value of input was not set', {
+				extra: { inputIndex, inputName },
+			});
+		}
+
+		return this.inputData[inputName][inputIndex];
+	}
+
+	getWorkflowDataProxy(itemIndex: number) {
+		return new WorkflowDataProxy(
+			this.workflow,
+			this.runExecutionData,
+			this.runIndex,
+			itemIndex,
+			this.node.name,
+			this.connectionInputData,
+			{},
+			this.mode,
+			getAdditionalKeys(this.additionalData, this.mode, this.runExecutionData),
+			this.executeData,
+		).getDataProxy();
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	sendMessageToUI(...args: any[]): void {
+		if (this.mode !== 'manual') {
+			return;
+		}
+		try {
+			if (this.additionalData.sendDataToUI) {
+				args = args.map((arg) => {
+					// prevent invalid dates from being logged as null
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+					if (arg.isLuxonDateTime && arg.invalidReason) return { ...arg };
+
+					// log valid dates in human readable format, as in browser
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
+					if (arg.isLuxonDateTime) return new Date(arg.ts).toString();
+					if (arg instanceof Date) return arg.toString();
+
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+					return arg;
+				});
+
+				this.additionalData.sendDataToUI('sendConsoleMessage', {
+					source: `[Node: "${this.node.name}"]`,
+					messages: args,
+				});
+			}
+		} catch (error) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			this.logger.warn(`There was a problem sending message to UI: ${error.message}`);
+		}
+	}
+
+	logAiEvent(eventName: AiEvent, msg: string) {
+		return this.additionalData.logAiEvent(eventName, {
+			executionId: this.additionalData.executionId ?? 'unsaved-execution',
+			nodeName: this.node.name,
+			workflowName: this.workflow.name ?? 'Unnamed workflow',
+			nodeType: this.node.type,
+			workflowId: this.workflow.id ?? 'unsaved-workflow',
+			msg,
+		});
+	}
+
+	addInputData(
+		connectionType: NodeConnectionType,
+		data: INodeExecutionData[][],
+	): { index: number } {
+		const nodeName = this.getNode().name;
+		let currentNodeRunIndex = 0;
+		if (this.runExecutionData.resultData.runData.hasOwnProperty(nodeName)) {
+			currentNodeRunIndex = this.runExecutionData.resultData.runData[nodeName].length;
+		}
+
+		addExecutionDataFunctions(
+			'input',
+			this.node.name,
+			data,
+			this.runExecutionData,
+			connectionType,
+			this.additionalData,
+			this.node.name,
+			this.runIndex,
+			currentNodeRunIndex,
+		).catch((error) => {
+			this.logger.warn(
+				`There was a problem logging input data of node "${this.node.name}": ${
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					error.message
+				}`,
+			);
+		});
+
+		return { index: currentNodeRunIndex };
+	}
+
+	addOutputData(
+		connectionType: NodeConnectionType,
+		currentNodeRunIndex: number,
+		data: INodeExecutionData[][],
+		metadata?: ITaskMetadata,
+	): void {
+		addExecutionDataFunctions(
+			'output',
+			this.node.name,
+			data,
+			this.runExecutionData,
+			connectionType,
+			this.additionalData,
+			this.node.name,
+			this.runIndex,
+			currentNodeRunIndex,
+			metadata,
+		).catch((error) => {
+			this.logger.warn(
+				`There was a problem logging output data of node "${this.node.name}": ${
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					error.message
+				}`,
+			);
+		});
+	}
+}


### PR DESCRIPTION
## Summary
This PR extracts SupplyDataContext object out of NodeExecutionFunctions, and adds unit tests for most of this code.

## Related Linear tickets, Github issues, and Community forum posts
[CAT-311](https://linear.app/n8n/issue/CAT-311/)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
