### PR TITLE
fix(core): Keep in-memory execution status in-sync with the DB (no-changelog)

### DIFF
--- a/packages/cli/src/execution-lifecycle-hooks/shared/__tests__/shared-hook-functions.test.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/shared/__tests__/shared-hook-functions.test.ts
@@ -23,7 +23,6 @@ describe('determineFinalExecutionStatus', () => {
 		} as IRun;
 
 		expect(determineFinalExecutionStatus(runData)).toBe('error');
-		expect(runData.status).toBe('error');
 	});
 
 	it('should return "waiting" when waitTill is defined', () => {

--- a/packages/cli/src/execution-lifecycle-hooks/shared/__tests__/shared-hook-functions.test.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/shared/__tests__/shared-hook-functions.test.ts
@@ -1,0 +1,38 @@
+import { mock } from 'jest-mock-extended';
+import type { IRun } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { determineFinalExecutionStatus } from '../shared-hook-functions';
+
+describe('determineFinalExecutionStatus', () => {
+	describe('When waitTill is not set', () => {
+		test.each(['canceled', 'crashed', 'error', 'success'])('should return "%s"', (status) => {
+			const runData = { status, data: {} } as IRun;
+			expect(determineFinalExecutionStatus(runData)).toBe(status);
+		});
+	});
+
+	it('should return "error" when resultData.error exists', () => {
+		const runData = {
+			status: 'running',
+			data: {
+				resultData: {
+					error: new NodeOperationError(mock(), 'An error occurred'),
+				},
+			},
+		} as IRun;
+
+		expect(determineFinalExecutionStatus(runData)).toBe('error');
+		expect(runData.status).toBe('error');
+	});
+
+	it('should return "waiting" when waitTill is defined', () => {
+		const runData = {
+			status: 'running',
+			data: {},
+			waitTill: new Date('2022-01-01T00:00:00'),
+		} as IRun;
+
+		expect(determineFinalExecutionStatus(runData)).toBe('waiting');
+	});
+});

--- a/packages/cli/src/execution-lifecycle-hooks/shared/shared-hook-functions.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/shared/shared-hook-functions.ts
@@ -21,6 +21,7 @@ export function determineFinalExecutionStatus(runData: IRun): ExecutionStatus {
 	if (workflowHasCrashed) workflowStatusFinal = 'crashed';
 	if (workflowWasCanceled) workflowStatusFinal = 'canceled';
 	if (runData.waitTill) workflowStatusFinal = 'waiting';
+	runData.status = workflowStatusFinal;
 	return workflowStatusFinal;
 }
 

--- a/packages/cli/src/execution-lifecycle-hooks/shared/shared-hook-functions.ts
+++ b/packages/cli/src/execution-lifecycle-hooks/shared/shared-hook-functions.ts
@@ -21,7 +21,6 @@ export function determineFinalExecutionStatus(runData: IRun): ExecutionStatus {
 	if (workflowHasCrashed) workflowStatusFinal = 'crashed';
 	if (workflowWasCanceled) workflowStatusFinal = 'canceled';
 	if (runData.waitTill) workflowStatusFinal = 'waiting';
-	runData.status = workflowStatusFinal;
 	return workflowStatusFinal;
 }
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -392,6 +392,7 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 				await restoreBinaryDataId(fullRunData, this.executionId, this.mode);
 
 				const isManualMode = this.mode === 'manual';
+				const executionStatus = determineFinalExecutionStatus(fullRunData);
 
 				try {
 					if (!isManualMode && isWorkflowIdValid(this.workflowData.id) && newStaticData) {
@@ -427,7 +428,6 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 						return;
 					}
 
-					const executionStatus = determineFinalExecutionStatus(fullRunData);
 					const shouldNotSave =
 						(executionStatus === 'success' && !saveSettings.success) ||
 						(executionStatus !== 'success' && !saveSettings.error);

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -392,7 +392,6 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 				await restoreBinaryDataId(fullRunData, this.executionId, this.mode);
 
 				const isManualMode = this.mode === 'manual';
-				const executionStatus = determineFinalExecutionStatus(fullRunData);
 
 				try {
 					if (!isManualMode && isWorkflowIdValid(this.workflowData.id) && newStaticData) {
@@ -410,6 +409,9 @@ function hookFunctionsSave(): IWorkflowExecuteHooks {
 							);
 						}
 					}
+
+					const executionStatus = determineFinalExecutionStatus(fullRunData);
+					fullRunData.status = executionStatus;
 
 					const saveSettings = toSaveSettings(this.workflowData.settings);
 
@@ -570,6 +572,7 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 					}
 
 					const workflowStatusFinal = determineFinalExecutionStatus(fullRunData);
+					fullRunData.status = workflowStatusFinal;
 
 					if (workflowStatusFinal !== 'success' && workflowStatusFinal !== 'waiting') {
 						executeErrorWorkflow(
@@ -1115,6 +1118,8 @@ export function getWorkflowHooksWorkerMain(
 			if (!fullRunData.finished) return;
 
 			const executionStatus = determineFinalExecutionStatus(fullRunData);
+			fullRunData.status = executionStatus;
+
 			const saveSettings = toSaveSettings(this.workflowData.settings);
 
 			const shouldNotSave =


### PR DESCRIPTION
## Summary
When we evaluate the final status of an execution before persisting, we were not updating the in-memory copy of that status, which was leading to the status being incorrect in certain edge-cases.

[Context](https://n8nio.slack.com/archives/C069HS026UF/p1732198534492829)
Extracted out of #11821

## Related Linear tickets, Github issues, and Community forum posts

[CAT-350](https://linear.app/n8n/issue/CAT-350)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
