### PR TITLE
fix(AI Agent Node): Add binary message before scratchpad to prevent tool calling loops

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -264,7 +264,7 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 	const hasBinaryData = this.getInputData(0, 'main')?.[0]?.binary !== undefined;
 	if (hasBinaryData && passthroughBinaryImages) {
 		const binaryMessage = await extractBinaryMessages(this);
-		messages.push(binaryMessage);
+		messages.splice(3, 0, binaryMessage);
 	}
 	const prompt = ChatPromptTemplate.fromMessages(messages);
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/execute.ts
@@ -258,14 +258,16 @@ export async function toolsAgentExecute(this: IExecuteFunctions): Promise<INodeE
 		['system', `{system_message}${outputParser ? '\n\n{formatting_instructions}' : ''}`],
 		['placeholder', '{chat_history}'],
 		['human', '{input}'],
-		['placeholder', '{agent_scratchpad}'],
 	];
 
 	const hasBinaryData = this.getInputData(0, 'main')?.[0]?.binary !== undefined;
 	if (hasBinaryData && passthroughBinaryImages) {
 		const binaryMessage = await extractBinaryMessages(this);
-		messages.splice(3, 0, binaryMessage);
+		messages.push(binaryMessage);
 	}
+	// We add the agent scratchpad last, so that the agent will not run in loops
+	// by adding binary messages between each interaction
+	messages.push(['placeholder', '{agent_scratchpad}']);
 	const prompt = ChatPromptTemplate.fromMessages(messages);
 
 	const agent = createToolCallingAgent({


### PR DESCRIPTION
## Summary

By repositioning the `binaryMessage` between the human message and the scratchpad, the agent doesn't keep adding the binary message to the back-and-forth between tool and agent.

You can test this by adding an agent that has a 4o-mini model, a telegram tool (or anything else) to send a message, and passing it a message with an image. Without the fix here, it will continue until hitting the `maxIteration` number of iterations.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-471/image-is-being-repeatedly-sent-to-llm-after-calling-tools

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
