### PR TITLE
docs: Update Excel node to use external template url (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
@@ -27,7 +27,7 @@ export const versionDescription: INodeTypeDescription = {
 	properties: [
 		{
 			displayName:
-				'This node connects to the Microsoft 365 cloud platform. Use the \'Extract from File\' and \'Convert to File\' nodes to directly manipulate spreadsheet files (.xls, .csv, etc). <a href="/templates/890" target="_blank">More info</a>.',
+				'This node connects to the Microsoft 365 cloud platform. Use the \'Extract from File\' and \'Convert to File\' nodes to directly manipulate spreadsheet files (.xls, .csv, etc). <a href="https://n8n.io/workflows/890-read-in-an-excel-spreadsheet-file/" target="_blank">More info</a>.',
 			name: 'notice',
 			type: 'notice',
 			default: '',


### PR DESCRIPTION
## Summary
We prefer the external template urls, This PR changes the only node using the internal template view.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2063/update-node-workflow-links


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
