### PR TITLE
chore: Add new table for test metrics (no-changelog)

### DIFF
--- a/packages/cli/src/databases/entities/index.ts
+++ b/packages/cli/src/databases/entities/index.ts
@@ -21,6 +21,7 @@ import { SharedCredentials } from './shared-credentials';
 import { SharedWorkflow } from './shared-workflow';
 import { TagEntity } from './tag-entity';
 import { TestDefinition } from './test-definition.ee';
+import { TestMetric } from './test-metric.ee';
 import { User } from './user';
 import { Variables } from './variables';
 import { WebhookEntity } from './webhook-entity';
@@ -60,4 +61,5 @@ export const entities = {
 	ApiKey,
 	ProcessedData,
 	TestDefinition,
+	TestMetric,
 };

--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -1,7 +1,8 @@
-import { Column, Entity, Index, ManyToOne, RelationId } from '@n8n/typeorm';
+import { Column, Entity, Index, ManyToOne, OneToMany, RelationId } from '@n8n/typeorm';
 import { Length } from 'class-validator';
 
 import { AnnotationTagEntity } from '@/databases/entities/annotation-tag-entity.ee';
+import type { TestMetric } from '@/databases/entities/test-metric.ee';
 import { WorkflowEntity } from '@/databases/entities/workflow-entity';
 
 import { WithTimestampsAndStringId } from './abstract-entity';
@@ -53,4 +54,7 @@ export class TestDefinition extends WithTimestampsAndStringId {
 
 	@RelationId((test: TestDefinition) => test.annotationTag)
 	annotationTagId: string;
+
+	@OneToMany('TestMetric', 'testDefinition')
+	metrics: TestMetric[];
 }

--- a/packages/cli/src/databases/entities/test-metric.ee.ts
+++ b/packages/cli/src/databases/entities/test-metric.ee.ts
@@ -24,6 +24,6 @@ export class TestMetric extends WithTimestampsAndStringId {
 	/**
 	 * Relation to test definition
 	 */
-	@ManyToOne('TestDefinition')
+	@ManyToOne('TestDefinition', 'metrics')
 	testDefinition: TestDefinition;
 }

--- a/packages/cli/src/databases/entities/test-metric.ee.ts
+++ b/packages/cli/src/databases/entities/test-metric.ee.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, Index, ManyToOne } from '@n8n/typeorm';
+import { Length } from 'class-validator';
+
+import { WithTimestampsAndStringId } from '@/databases/entities/abstract-entity';
+import { TestDefinition } from '@/databases/entities/test-definition.ee';
+
+/**
+ * Entity representing a Test Metric
+ * It represents a single metric that can be retrieved from evaluation workflow execution result
+ */
+@Entity()
+@Index(['testDefinition'])
+export class TestMetric extends WithTimestampsAndStringId {
+	/**
+	 * Name of the metric.
+	 * This will be used as a property name to extract metric value from the evaluation workflow execution result object
+	 */
+	@Column({ length: 255 })
+	@Length(1, 255, {
+		message: 'Metric name must be $constraint1 to $constraint2 characters long.',
+	})
+	name: string;
+
+	/**
+	 * Relation to test definition
+	 */
+	@ManyToOne('TestDefinition')
+	testDefinition: TestDefinition;
+}

--- a/packages/cli/src/databases/migrations/common/1732271325258-CreateTestMetricTable.ts
+++ b/packages/cli/src/databases/migrations/common/1732271325258-CreateTestMetricTable.ts
@@ -6,7 +6,7 @@ export class CreateTestMetricTable1732271325258 implements ReversibleMigration {
 	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
 		await createTable(testMetricEntityTableName)
 			.withColumns(
-				column('id').int.notNull.primary.autoGenerate,
+				column('id').varchar(36).primary.notNull,
 				column('name').varchar(255).notNull,
 				column('testDefinitionId').varchar(36).notNull,
 			)

--- a/packages/cli/src/databases/migrations/common/1732271325258-CreateTestMetricTable.ts
+++ b/packages/cli/src/databases/migrations/common/1732271325258-CreateTestMetricTable.ts
@@ -1,0 +1,24 @@
+import type { MigrationContext, ReversibleMigration } from '@/databases/types';
+
+const testMetricEntityTableName = 'test_metric';
+
+export class CreateTestMetricTable1732271325258 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(testMetricEntityTableName)
+			.withColumns(
+				column('id').int.notNull.primary.autoGenerate,
+				column('name').varchar(255).notNull,
+				column('testDefinitionId').varchar(36).notNull,
+			)
+			.withIndexOn('testDefinitionId')
+			.withForeignKey('testDefinitionId', {
+				tableName: 'test_definition',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(testMetricEntityTableName);
+	}
+}

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -71,6 +71,7 @@ import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../comm
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
+import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -144,4 +145,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateTestDefinitionTable1730386903556,
 	AddDescriptionToTestDefinition1731404028106,
 	MigrateTestDefinitionKeyToString1731582748663,
+	CreateTestMetricTable1732271325258,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -71,6 +71,7 @@ import { AddMissingPrimaryKeyOnAnnotationTagMapping1728659839644 } from '../comm
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
+import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -144,4 +145,5 @@ export const postgresMigrations: Migration[] = [
 	CreateTestDefinitionTable1730386903556,
 	AddDescriptionToTestDefinition1731404028106,
 	MigrateTestDefinitionKeyToString1731582748663,
+	CreateTestMetricTable1732271325258,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -68,6 +68,7 @@ import { CreateProcessedDataTable1726606152711 } from '../common/1726606152711-C
 import { SeparateExecutionCreationFromStart1727427440136 } from '../common/1727427440136-SeparateExecutionCreationFromStart';
 import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/1729607673464-UpdateProcessedDataValueColumnToText';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
+import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -138,6 +139,7 @@ const sqliteMigrations: Migration[] = [
 	CreateTestDefinitionTable1730386903556,
 	AddDescriptionToTestDefinition1731404028106,
 	MigrateTestDefinitionKeyToString1731582748663,
+	CreateTestMetricTable1732271325258,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/databases/repositories/test-definition.repository.ee.ts
+++ b/packages/cli/src/databases/repositories/test-definition.repository.ee.ts
@@ -45,7 +45,7 @@ export class TestDefinitionRepository extends Repository<TestDefinition> {
 					id: In(accessibleWorkflowIds),
 				},
 			},
-			relations: ['annotationTag'],
+			relations: ['annotationTag', 'metrics'],
 		});
 	}
 

--- a/packages/cli/src/databases/repositories/test-metric.repository.ee.ts
+++ b/packages/cli/src/databases/repositories/test-metric.repository.ee.ts
@@ -1,0 +1,11 @@
+import { DataSource, Repository } from '@n8n/typeorm';
+import { Service } from 'typedi';
+
+import { TestMetric } from '@/databases/entities/test-metric.ee';
+
+@Service()
+export class TestMetricRepository extends Repository<TestMetric> {
+	constructor(dataSource: DataSource) {
+		super(TestMetric, dataSource.manager);
+	}
+}

--- a/packages/cli/src/evaluation/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation/test-definition.service.ee.ts
@@ -10,7 +10,7 @@ import type { ListQuery } from '@/requests';
 
 type TestDefinitionLike = Omit<
 	Partial<TestDefinition>,
-	'workflow' | 'evaluationWorkflow' | 'annotationTag'
+	'workflow' | 'evaluationWorkflow' | 'annotationTag' | 'metrics'
 > & {
 	workflow?: { id: string };
 	evaluationWorkflow?: { id: string };


### PR DESCRIPTION
## Summary

This is a part of a TestRunner framework for workflow evaluation.
Metric is just a property name to look for in the output of evaluation workflow.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-432/[db]-metric
- #11832 
- #11757


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
