### PR TITLE
feat(core): Add health check endpoint to task runner server (no-changelog)

### DIFF
--- a/packages/cli/src/runners/__tests__/task-runner-server.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-server.test.ts
@@ -9,6 +9,38 @@ import { TaskRunnerServer } from '@/runners/task-runner-server';
 import type { TaskRunnerServerInitRequest } from '../runner-types';
 
 describe('TaskRunnerServer', () => {
+	describe('health endpoint', () => {
+		it('should send 200 status code', async () => {
+			const server = new TaskRunnerServer(
+				mock(),
+				mock<GlobalConfig>({ taskRunners: { path: '/runners' } }),
+				mock(),
+				mock(),
+			);
+
+			const mockResponse = { sendStatus: jest.fn() };
+
+			// @ts-expect-error Test
+			server.app = {
+				get: jest.fn().mockImplementation((path, handler) => {
+					if (path === '/runners/healthz') {
+						handler({}, mockResponse);
+					}
+				}),
+				post: jest.fn(),
+				stop: jest.fn().mockResolvedValue(undefined),
+				disable: jest.fn(),
+				use: jest.fn(),
+			};
+
+			await server.start();
+
+			expect(mockResponse.sendStatus).toHaveBeenCalledWith(200);
+
+			await server.stop(); // allow Jest to exit cleanly
+		});
+	});
+
 	describe('handleUpgradeRequest', () => {
 		it('should close WebSocket when response status code is > 200', () => {
 			const ws = mock<WebSocket>();

--- a/packages/cli/src/runners/task-runner-server.ts
+++ b/packages/cli/src/runners/task-runner-server.ts
@@ -164,8 +164,8 @@ export class TaskRunnerServer {
 			send(async (req) => await this.taskRunnerAuthController.createGrantToken(req)),
 		);
 
-		const healthEndpoint = `${this.getEndpointBasePath()}/healthz`;
-		this.app.get(healthEndpoint, (_, res) => res.sendStatus(200));
+		const healthCheckEndpoint = `${this.getEndpointBasePath()}/healthz`;
+		this.app.get(healthCheckEndpoint, (_, res) => res.sendStatus(200));
 	}
 
 	private handleUpgradeRequest = (

--- a/packages/cli/src/runners/task-runner-server.ts
+++ b/packages/cli/src/runners/task-runner-server.ts
@@ -163,6 +163,9 @@ export class TaskRunnerServer {
 			authEndpoint,
 			send(async (req) => await this.taskRunnerAuthController.createGrantToken(req)),
 		);
+
+		const healthEndpoint = `${this.getEndpointBasePath()}/healthz`;
+		this.app.get(healthEndpoint, (_, res) => res.sendStatus(200));
 	}
 
 	private handleUpgradeRequest = (


### PR DESCRIPTION
## Summary

Add `/runners/healthz` to task runner server so the launcher can wait on main instance readiness.

To be reviewed together with: https://github.com/n8n-io/task-runner-launcher/pull/16

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-349

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
