### PR TITLE
ci: When saving credentials in e2e tests, wait for the save operation to finish (no-changelog)

### DIFF
--- a/cypress/composables/modals/credential-modal.ts
+++ b/cypress/composables/modals/credential-modal.ts
@@ -35,10 +35,11 @@ export function setCredentialConnectionParameterInputByName(name: string, value:
 }
 
 export function saveCredential() {
-	cy.intercept('POST', '/rest/credentials').as('credentialSave');
-	getCredentialSaveButton().click({ force: true });
-	cy.wait('@credentialSave');
-	getCredentialSaveButton().should('contain.text', 'Saved');
+	getCredentialSaveButton()
+		.click({ force: true })
+		.within(() => {
+			cy.get('button').should('not.exist');
+		});
 }
 
 export function closeCredentialModal() {

--- a/cypress/composables/modals/credential-modal.ts
+++ b/cypress/composables/modals/credential-modal.ts
@@ -35,7 +35,9 @@ export function setCredentialConnectionParameterInputByName(name: string, value:
 }
 
 export function saveCredential() {
+	cy.intercept('POST', '/rest/credentials').as('credentialSave');
 	getCredentialSaveButton().click({ force: true });
+	cy.wait('@credentialSave');
 }
 
 export function closeCredentialModal() {

--- a/cypress/composables/modals/credential-modal.ts
+++ b/cypress/composables/modals/credential-modal.ts
@@ -38,6 +38,7 @@ export function saveCredential() {
 	cy.intercept('POST', '/rest/credentials').as('credentialSave');
 	getCredentialSaveButton().click({ force: true });
 	cy.wait('@credentialSave');
+	getCredentialSaveButton().should('contain.text', 'Saved');
 }
 
 export function closeCredentialModal() {


### PR DESCRIPTION
## Summary
In e2e tests when we click on the credentials saving button, if we don't wait for the operation to finish before clicking the modal close button, the UI shows the "Close before saving" prompt, which makes these tests flaky.
This PR updated the credentials saving operation to wait until the saving request finishes.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
