### PR TITLE
fix(core): Fix broken execution query when using projectId

### DIFF
--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -909,8 +909,6 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			projectId,
 		} = query;
 
-		console.log(query);
-
 		const fields = Object.keys(this.summaryFields)
 			.concat(['waitTill', 'retrySuccessId'])
 			.map((key) => `execution.${key} AS "${key}"`)

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -909,6 +909,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			projectId,
 		} = query;
 
+		console.log(query);
+
 		const fields = Object.keys(this.summaryFields)
 			.concat(['waitTill', 'retrySuccessId'])
 			.map((key) => `execution.${key} AS "${key}"`)
@@ -981,7 +983,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		if (projectId) {
 			qb.innerJoin(WorkflowEntity, 'w', 'w.id = execution.workflowId')
 				.innerJoin(SharedWorkflow, 'sw', 'sw.workflowId = w.id')
-				.where('sw.projectId = :projectId', { projectId });
+				.andWhere('sw.projectId = :projectId', { projectId });
 		}
 
 		return qb;


### PR DESCRIPTION
## Summary

We introduced execution filtering by `projectId` in #10976, but this accidentally clears any previous `where` clauses in the SQL query builder. This PR fixes that.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: PAY-2281

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
