### PR TITLE
feat: Add get release by tag operation to Github node

### DIFF
--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -341,6 +341,12 @@ export class Github implements INodeType {
 						action: 'Get a release',
 					},
 					{
+						name: 'Get by Tag',
+						value: 'getByTag',
+						description: 'Get a release by Tag',
+						action: 'Get a release by Tag',
+					},
+					{
 						name: 'Get Many',
 						value: 'getAll',
 						description: 'Get many repository releases',
@@ -1274,6 +1280,13 @@ export class Github implements INodeType {
 						description: 'Whether to point out that the release is non-production ready',
 					},
 					{
+						displayName: 'Latest',
+						name: 'make_latest',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to mark the release as latest or not',
+					},
+					{
 						displayName: 'Target Commitish',
 						name: 'target_commitish',
 						type: 'string',
@@ -1352,6 +1365,13 @@ export class Github implements INodeType {
 						description: 'Whether to point out that the release is non-production ready',
 					},
 					{
+						displayName: 'Latest',
+						name: 'make_latest',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to mark the release as latest or not',
+					},
+					{
 						displayName: 'Tag Name',
 						name: 'tag_name',
 						type: 'string',
@@ -1401,6 +1421,23 @@ export class Github implements INodeType {
 				},
 				default: 50,
 				description: 'Max number of results to return',
+			},
+			// ----------------------------------
+			//         release:getByTag
+			// ----------------------------------
+			{
+				displayName: 'Tag Name',
+				name: 'tag_name',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['release'],
+						operation: ['getByTag'],
+					},
+				},
+				default: '',
+				description: 'Release Tag Name',
 			},
 
 			// ----------------------------------
@@ -2031,6 +2068,7 @@ export class Github implements INodeType {
 			'repository:listReferrers',
 			'user:getRepositories',
 			'release:getAll',
+			'release:getByTag',
 			'review:getAll',
 			'organization:getRepositories',
 		];
@@ -2306,6 +2344,16 @@ export class Github implements INodeType {
 						if (!returnAll) {
 							qs.per_page = this.getNodeParameter('limit', 0);
 						}
+					}
+					if (operation === 'getByTag') {
+						// ----------------------------------
+						//         getbyTag
+						// ----------------------------------
+
+						requestMethod = 'GET';
+						const tagName = this.getNodeParameter('tag_name', i) as string;
+
+						endpoint = `/repos/${owner}/${repository}/releases/tags/${tagName}`;
 					}
 					if (operation === 'update') {
 						// ----------------------------------


### PR DESCRIPTION
## Summary

feat: Add get release by tag operation to Github node

- This PR adds the method `getByTag` operation to the Github Node when resource is `release`. 
- Also adds the additional Field `Latest` (make_latest) to the resource `release` when operation `update or create`

![Screenshot 2024-11-24 at 9 58 34 PM](https://github.com/user-attachments/assets/2db7de19-9310-4687-8a3b-4b31714a44ad)
![Screenshot 2024-11-24 at 10 17 43 PM](https://github.com/user-attachments/assets/8ffffc8a-3b57-41b3-8afb-02e4376a8b29)


### Reference to Github API docs 

- [release#getByTag](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name)  
- [update-a-release#make_latest](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release) 

### Validation

I did local validation using a GH Token and a real repository to validate both changes. 
The `make_latest` worked fine as boolean. 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
