### PR TITLE
perf(core): Batch items sent in runonceforeachitem mode (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -43,10 +43,6 @@ export class TaskRunnersConfig {
 	@Env('N8N_RUNNERS_MAX_CONCURRENCY')
 	maxConcurrency: number = 5;
 
-	/** Should the output of deduplication be asserted for correctness */
-	@Env('N8N_RUNNERS_ASSERT_DEDUPLICATION_OUTPUT')
-	assertDeduplicationOutput: boolean = false;
-
 	/** How long (in seconds) a task is allowed to take for completion, else the task will be aborted and the runner restarted. Must be greater than 0. */
 	@Env('N8N_RUNNERS_TASK_TIMEOUT')
 	taskTimeout: number = 60;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -231,7 +231,6 @@ describe('GlobalConfig', () => {
 			port: 5679,
 			maxOldSpaceSize: '',
 			maxConcurrency: 5,
-			assertDeduplicationOutput: false,
 			taskTimeout: 60,
 			heartbeatInterval: 30,
 		},

--- a/packages/@n8n/task-runner/src/data-request/__tests__/data-request-response-reconstruct.test.ts
+++ b/packages/@n8n/task-runner/src/data-request/__tests__/data-request-response-reconstruct.test.ts
@@ -1,0 +1,91 @@
+import { mock } from 'jest-mock-extended';
+import type {
+	IExecuteData,
+	INode,
+	INodeExecutionData,
+	ITaskDataConnectionsSource,
+} from 'n8n-workflow';
+
+import type { DataRequestResponse, InputDataChunkDefinition } from '@/runner-types';
+
+import { DataRequestResponseReconstruct } from '../data-request-response-reconstruct';
+
+describe('DataRequestResponseReconstruct', () => {
+	const reconstruct = new DataRequestResponseReconstruct();
+
+	describe('reconstructConnectionInputItems', () => {
+		it('should return all input items if no chunk is provided', () => {
+			const inputData: DataRequestResponse['inputData'] = {
+				main: [[{ json: { key: 'value' } }]],
+			};
+
+			const result = reconstruct.reconstructConnectionInputItems(inputData);
+
+			expect(result).toEqual([{ json: { key: 'value' } }]);
+		});
+
+		it('should reconstruct sparse array when chunk is provided', () => {
+			const inputData: DataRequestResponse['inputData'] = {
+				main: [[{ json: { key: 'chunked' } }]],
+			};
+			const chunk: InputDataChunkDefinition = { startIndex: 2, count: 1 };
+
+			const result = reconstruct.reconstructConnectionInputItems(inputData, chunk);
+
+			expect(result).toEqual([undefined, undefined, { json: { key: 'chunked' } }, undefined]);
+		});
+
+		it('should handle empty input data gracefully', () => {
+			const inputData: DataRequestResponse['inputData'] = { main: [[]] };
+			const chunk: InputDataChunkDefinition = { startIndex: 1, count: 1 };
+
+			const result = reconstruct.reconstructConnectionInputItems(inputData, chunk);
+
+			expect(result).toEqual([undefined]);
+		});
+	});
+
+	describe('reconstructExecuteData', () => {
+		it('should reconstruct execute data with the provided input items', () => {
+			const node = mock<INode>();
+			const connectionInputSource = mock<ITaskDataConnectionsSource>();
+			const response = mock<DataRequestResponse>({
+				inputData: { main: [[]] },
+				node,
+				connectionInputSource,
+			});
+			const inputItems: INodeExecutionData[] = [{ json: { key: 'reconstructed' } }];
+
+			const result = reconstruct.reconstructExecuteData(response, inputItems);
+
+			expect(result).toEqual<IExecuteData>({
+				data: {
+					main: [inputItems],
+				},
+				node: response.node,
+				source: response.connectionInputSource,
+			});
+		});
+
+		it('should handle empty input items gracefully', () => {
+			const node = mock<INode>();
+			const connectionInputSource = mock<ITaskDataConnectionsSource>();
+			const inputItems: INodeExecutionData[] = [];
+			const response = mock<DataRequestResponse>({
+				inputData: { main: [[{ json: { key: 'value' } }]] },
+				node,
+				connectionInputSource,
+			});
+
+			const result = reconstruct.reconstructExecuteData(response, inputItems);
+
+			expect(result).toEqual<IExecuteData>({
+				data: {
+					main: [inputItems],
+				},
+				node: response.node,
+				source: response.connectionInputSource,
+			});
+		});
+	});
+});

--- a/packages/@n8n/task-runner/src/data-request/data-request-response-reconstruct.ts
+++ b/packages/@n8n/task-runner/src/data-request/data-request-response-reconstruct.ts
@@ -13,7 +13,7 @@ export class DataRequestResponseReconstruct {
 	reconstructConnectionInputItems(
 		inputData: DataRequestResponse['inputData'],
 		chunk?: InputDataChunkDefinition,
-	): INodeExecutionData[] {
+	): Array<INodeExecutionData | undefined> {
 		const inputItems = inputData?.main?.[0] ?? [];
 		if (!chunk) {
 			return inputItems;
@@ -28,7 +28,7 @@ export class DataRequestResponseReconstruct {
 			.concat(inputItems)
 			.concat(Array.from({ length: inputItems.length - chunk.startIndex - chunk.count }));
 
-		return sparseInputItems as INodeExecutionData[];
+		return sparseInputItems;
 	}
 
 	/**

--- a/packages/@n8n/task-runner/src/data-request/data-request-response-reconstruct.ts
+++ b/packages/@n8n/task-runner/src/data-request/data-request-response-reconstruct.ts
@@ -8,7 +8,7 @@ import type { DataRequestResponse, InputDataChunkDefinition } from '@/runner-typ
  */
 export class DataRequestResponseReconstruct {
 	/**
-	 * Reconstructs `connectionInputData` from a DataRequestResponse
+	 * Reconstructs `inputData` from a DataRequestResponse
 	 */
 	reconstructConnectionInputItems(
 		inputData: DataRequestResponse['inputData'],

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/test-data.ts
@@ -16,7 +16,6 @@ export const newTaskWithSettings = (
 	settings: {
 		workflowMode: 'manual',
 		continueOnFail: false,
-		mode: 'manual',
 		...settings,
 	},
 	active: true,

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser-state.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser-state.test.ts
@@ -1,14 +1,17 @@
 import { BuiltInsParserState } from '../built-ins-parser-state';
 
 describe('BuiltInsParserState', () => {
-	describe('toDataRequestSpecification', () => {
+	describe('toDataRequestParams', () => {
 		it('should return empty array when no properties are marked as needed', () => {
 			const state = new BuiltInsParserState();
 
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: [],
 				env: false,
-				input: false,
+				input: {
+					chunk: undefined,
+					include: false,
+				},
 				prevNode: false,
 			});
 		});
@@ -20,7 +23,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: 'all',
 				env: false,
-				input: true,
+				input: {
+					chunk: undefined,
+					include: true,
+				},
 				prevNode: false,
 			});
 		});
@@ -33,7 +39,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: ['Node1', 'Node2'],
 				env: false,
-				input: false,
+				input: {
+					chunk: undefined,
+					include: false,
+				},
 				prevNode: false,
 			});
 		});
@@ -47,7 +56,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: 'all',
 				env: false,
-				input: true,
+				input: {
+					chunk: undefined,
+					include: true,
+				},
 				prevNode: false,
 			});
 		});
@@ -59,7 +71,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: [],
 				env: true,
-				input: false,
+				input: {
+					chunk: undefined,
+					include: false,
+				},
 				prevNode: false,
 			});
 		});
@@ -71,7 +86,33 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: [],
 				env: false,
-				input: true,
+				input: {
+					chunk: undefined,
+					include: true,
+				},
+				prevNode: false,
+			});
+		});
+
+		it('should use the given chunk', () => {
+			const state = new BuiltInsParserState();
+			state.markInputAsNeeded();
+
+			expect(
+				state.toDataRequestParams({
+					count: 10,
+					startIndex: 5,
+				}),
+			).toEqual({
+				dataOfNodes: [],
+				env: false,
+				input: {
+					chunk: {
+						count: 10,
+						startIndex: 5,
+					},
+					include: true,
+				},
 				prevNode: false,
 			});
 		});
@@ -83,7 +124,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: [],
 				env: false,
-				input: false,
+				input: {
+					chunk: undefined,
+					include: false,
+				},
 				prevNode: true,
 			});
 		});
@@ -98,7 +142,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: 'all',
 				env: true,
-				input: true,
+				input: {
+					chunk: undefined,
+					include: true,
+				},
 				prevNode: true,
 			});
 		});
@@ -109,7 +156,10 @@ describe('BuiltInsParserState', () => {
 			expect(state.toDataRequestParams()).toEqual({
 				dataOfNodes: 'all',
 				env: true,
-				input: true,
+				input: {
+					chunk: undefined,
+					include: true,
+				},
 				prevNode: true,
 			});
 		});

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser-state.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser-state.ts
@@ -1,4 +1,5 @@
 import type { BrokerMessage } from '@/message-types';
+import type { InputDataChunkDefinition } from '@/runner-types';
 
 /**
  * Class to keep track of which built-in variables are accessed in the code
@@ -53,11 +54,16 @@ export class BuiltInsParserState {
 		this.needs$prevNode = true;
 	}
 
-	toDataRequestParams(): BrokerMessage.ToRequester.TaskDataRequest['requestParams'] {
+	toDataRequestParams(
+		chunk?: InputDataChunkDefinition,
+	): BrokerMessage.ToRequester.TaskDataRequest['requestParams'] {
 		return {
 			dataOfNodes: this.needsAllNodes ? 'all' : Array.from(this.neededNodeNames),
 			env: this.needs$env,
-			input: this.needs$input,
+			input: {
+				include: this.needs$input,
+				chunk,
+			},
 			prevNode: this.needs$prevNode,
 		};
 	}

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -142,7 +142,6 @@ export class JsTaskRunner extends TaskRunner {
 		};
 	}
 
-	/** Validates that task settings are valid */
 	private validateTaskSettings(settings: JSExecSettings) {
 		a.ok(settings.code, 'No code to execute');
 

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -352,7 +352,12 @@ export class JsTaskRunner extends TaskRunner {
 		const inputData = this.taskDataReconstruct.reconstructConnectionInputItems(
 			response.inputData,
 			chunk,
-		);
+			// This type assertion is intentional. Chunking is only supported in
+			// runOnceForEachItem mode and if a chunk was requested, we intentionally
+			// fill the array with undefined values for the items outside the chunk.
+			// We only iterate over the chunk items but WorkflowDataProxy expects
+			// the full array of items.
+		) as INodeExecutionData[];
 
 		return {
 			...response,

--- a/packages/@n8n/task-runner/src/runner-types.ts
+++ b/packages/@n8n/task-runner/src/runner-types.ts
@@ -15,6 +15,18 @@ import type {
 	WorkflowParameters,
 } from 'n8n-workflow';
 
+export interface InputDataChunkDefinition {
+	startIndex: number;
+	count: number;
+}
+
+export interface InputDataRequestParams {
+	/** Whether to include the input data in the response */
+	include: boolean;
+	/** Optionally request only a specific chunk of data instead of all input data */
+	chunk?: InputDataChunkDefinition;
+}
+
 /**
  * Specifies what data should be included for a task data request.
  */
@@ -22,7 +34,7 @@ export interface TaskDataRequestParams {
 	dataOfNodes: string[] | 'all';
 	prevNode: boolean;
 	/** Whether input data for the node should be included */
-	input: boolean;
+	input: InputDataRequestParams;
 	/** Whether env provider's state should be included */
 	env: boolean;
 }

--- a/packages/cli/src/runners/__tests__/task-broker.test.ts
+++ b/packages/cli/src/runners/__tests__/task-broker.test.ts
@@ -524,7 +524,9 @@ describe('TaskBroker', () => {
 			const requestParams: RunnerMessage.ToBroker.TaskDataRequest['requestParams'] = {
 				dataOfNodes: 'all',
 				env: true,
-				input: true,
+				input: {
+					include: true,
+				},
 				prevNode: true,
 			};
 

--- a/packages/cli/src/runners/task-managers/__tests__/data-request-response-stripper.test.ts
+++ b/packages/cli/src/runners/task-managers/__tests__/data-request-response-stripper.test.ts
@@ -18,6 +18,7 @@ const workflow: DataRequestResponse['workflow'] = mock<DataRequestResponse['work
 const debugHelperNodeOutItems: INodeExecutionData[] = [
 	{
 		json: {
+			idx: 0,
 			uid: 'abb74fd4-bef2-4fae-9d53-ea24e9eb3032',
 			email: 'Dan.Schmidt31@yahoo.com',
 			firstname: 'Toni',
@@ -26,6 +27,31 @@ const debugHelperNodeOutItems: INodeExecutionData[] = [
 		},
 		pairedItem: {
 			item: 0,
+		},
+	},
+	{
+		json: {
+			idx: 1,
+			uid: '4620e4-c1b4-dd8b-9a45-d0f9a29a3b7f',
+			email: 'bob.johnson@domain.com',
+			firstName: 'Bob',
+			lastName: 'Johnson',
+			password: '6e41b5ecf',
+		},
+		pairedItem: {
+			item: 1,
+		},
+	},
+	{
+		json: {
+			idx: 2,
+			email: '4358d3-418b-a8b3-49cb-076b1180f402',
+			firstName: 'Eve',
+			lastName: 'Johnson',
+			password: 'e2414620e',
+		},
+		pairedItem: {
+			item: 2,
 		},
 	},
 ];
@@ -137,7 +163,9 @@ describe('DataRequestResponseStripper', () => {
 	const allDataParam: TaskDataRequestParams = {
 		dataOfNodes: 'all',
 		env: true,
-		input: true,
+		input: {
+			include: true,
+		},
 		prevNode: true,
 	};
 
@@ -177,7 +205,9 @@ describe('DataRequestResponseStripper', () => {
 
 	describe('input data', () => {
 		const allExceptInputParam = newRequestParam({
-			input: false,
+			input: {
+				include: false,
+			},
 		});
 
 		it('drops input data from result', () => {
@@ -186,10 +216,23 @@ describe('DataRequestResponseStripper', () => {
 			expect(result.inputData).toStrictEqual({});
 		});
 
-		it('drops input data from result', () => {
-			const result = new DataRequestResponseStripper(taskData, allExceptInputParam).strip();
+		it('returns only chunked data', () => {
+			const result = new DataRequestResponseStripper(
+				taskData,
+				newRequestParam({
+					input: {
+						include: true,
+						chunk: {
+							startIndex: 1,
+							count: 1,
+						},
+					},
+				}),
+			).strip();
 
-			expect(result.inputData).toStrictEqual({});
+			expect(result.inputData).toStrictEqual({
+				main: [debugHelperNodeOutItems.slice(1, 2)],
+			});
 		});
 	});
 

--- a/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
+++ b/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
@@ -99,7 +99,7 @@ export class DataRequestResponseStripper {
 		}
 
 		// If a chunk of the input data is requested, we only return that chunk
-		// It is the responsibility of the requested to rebuild the input data
+		// It is the responsibility of the requester to rebuild the input data
 		const chunkInputItems = inputItems.slice(chunk.startIndex, chunk.startIndex + chunk.count);
 		const chunkedInputData: ITaskDataConnections = {
 			...inputData,

--- a/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
+++ b/packages/cli/src/runners/task-managers/data-request-response-stripper.ts
@@ -6,6 +6,7 @@ import type {
 	IRunExecutionData,
 	ITaskDataConnections,
 } from 'n8n-workflow';
+import * as a from 'node:assert/strict';
 
 /**
  * Strips data from data request response based on the specified parameters
@@ -81,11 +82,31 @@ export class DataRequestResponseStripper {
 	}
 
 	private stripInputData(inputData: ITaskDataConnections): ITaskDataConnections {
-		if (this.stripParams.input) {
+		if (!this.stripParams.input.include) {
+			return {};
+		}
+
+		return this.stripParams.input.chunk ? this.stripChunkedInputData(inputData) : inputData;
+	}
+
+	private stripChunkedInputData(inputData: ITaskDataConnections): ITaskDataConnections {
+		const { chunk } = this.stripParams.input;
+		a.ok(chunk);
+
+		const inputItems = inputData.main?.[0];
+		if (!inputItems) {
 			return inputData;
 		}
 
-		return {};
+		// If a chunk of the input data is requested, we only return that chunk
+		// It is the responsibility of the requested to rebuild the input data
+		const chunkInputItems = inputItems.slice(chunk.startIndex, chunk.startIndex + chunk.count);
+		const chunkedInputData: ITaskDataConnections = {
+			...inputData,
+			main: [chunkInputItems],
+		};
+
+		return chunkedInputData;
 	}
 
 	/**

--- a/packages/cli/src/runners/task-managers/task-manager.ts
+++ b/packages/cli/src/runners/task-managers/task-manager.ts
@@ -1,6 +1,5 @@
-import { TaskRunnersConfig } from '@n8n/config';
 import type { TaskResultData, RequesterMessage, BrokerMessage, TaskData } from '@n8n/task-runner';
-import { DataRequestResponseReconstruct, RPC_ALLOW_LIST } from '@n8n/task-runner';
+import { RPC_ALLOW_LIST } from '@n8n/task-runner';
 import type {
 	EnvProviderState,
 	IExecuteFunctions,
@@ -18,8 +17,7 @@ import type {
 } from 'n8n-workflow';
 import { createResultOk, createResultError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
-import * as a from 'node:assert/strict';
-import Container, { Service } from 'typedi';
+import { Service } from 'typedi';
 
 import { NodeTypes } from '@/node-types';
 
@@ -58,8 +56,6 @@ export abstract class TaskManager {
 	pendingRequests: Map<string, TaskRequest> = new Map();
 
 	tasks: Map<string, Task> = new Map();
-
-	private readonly runnerConfig = Container.get(TaskRunnersConfig);
 
 	private readonly dataResponseBuilder = new DataRequestResponseBuilder();
 
@@ -245,18 +241,6 @@ export abstract class TaskManager {
 		}
 
 		const dataRequestResponse = this.dataResponseBuilder.buildFromTaskData(job.data);
-
-		if (this.runnerConfig.assertDeduplicationOutput) {
-			const reconstruct = new DataRequestResponseReconstruct();
-			a.deepStrictEqual(
-				reconstruct.reconstructConnectionInputData(dataRequestResponse.inputData),
-				job.data.connectionInputData,
-			);
-			a.deepStrictEqual(
-				reconstruct.reconstructExecuteData(dataRequestResponse),
-				job.data.executeData,
-			);
-		}
 
 		const strippedData = new DataRequestResponseStripper(
 			dataRequestResponse,

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -111,10 +111,11 @@ export class Code implements INodeType {
 		if (runnersConfig.enabled && language === 'javaScript') {
 			const code = this.getNodeParameter(codeParameterName, 0) as string;
 			const sandbox = new JsTaskRunnerSandbox(code, nodeMode, workflowMode, this);
+			const numInputItems = this.getInputData().length;
 
 			return nodeMode === 'runOnceForAllItems'
 				? [await sandbox.runCodeAllItems()]
-				: [await sandbox.runCodeForEachItem()];
+				: [await sandbox.runCodeForEachItem(numInputItems)];
 		}
 
 		const getSandbox = (index = 0) => {

--- a/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
+++ b/packages/nodes-base/nodes/Code/JsTaskRunnerSandbox.ts
@@ -18,6 +18,7 @@ export class JsTaskRunnerSandbox {
 		private readonly nodeMode: CodeExecutionMode,
 		private readonly workflowMode: WorkflowExecuteMode,
 		private readonly executeFunctions: IExecuteFunctions,
+		private readonly chunkSize = 1000,
 	) {}
 
 	async runCodeAllItems(): Promise<INodeExecutionData[]> {
@@ -39,24 +40,37 @@ export class JsTaskRunnerSandbox {
 			: this.throwExecutionError(executionResult.error);
 	}
 
-	async runCodeForEachItem(): Promise<INodeExecutionData[]> {
+	async runCodeForEachItem(numInputItems: number): Promise<INodeExecutionData[]> {
 		validateNoDisallowedMethodsInRunForEach(this.jsCode, 0);
+
 		const itemIndex = 0;
+		const chunks = this.chunkInputItems(numInputItems);
+		let executionResults: INodeExecutionData[] = [];
 
-		const executionResult = await this.executeFunctions.startJob<INodeExecutionData[]>(
-			'javascript',
-			{
-				code: this.jsCode,
-				nodeMode: this.nodeMode,
-				workflowMode: this.workflowMode,
-				continueOnFail: this.executeFunctions.continueOnFail(),
-			},
-			itemIndex,
-		);
+		for (const chunk of chunks) {
+			const executionResult = await this.executeFunctions.startJob<INodeExecutionData[]>(
+				'javascript',
+				{
+					code: this.jsCode,
+					nodeMode: this.nodeMode,
+					workflowMode: this.workflowMode,
+					continueOnFail: this.executeFunctions.continueOnFail(),
+					chunk: {
+						startIndex: chunk.startIdx,
+						count: chunk.count,
+					},
+				},
+				itemIndex,
+			);
 
-		return executionResult.ok
-			? executionResult.result
-			: this.throwExecutionError(executionResult.error);
+			if (!executionResult.ok) {
+				return this.throwExecutionError(executionResult.error);
+			}
+
+			executionResults = executionResults.concat(executionResult.result);
+		}
+
+		return executionResults;
 	}
 
 	private throwExecutionError(error: unknown): never {
@@ -69,5 +83,23 @@ export class JsTaskRunnerSandbox {
 		}
 
 		throw new ApplicationError(`Unknown error: ${JSON.stringify(error)}`);
+	}
+
+	/** Chunks the input items into chunks of 1000 items each */
+	private chunkInputItems(numInputItems: number) {
+		const numChunks = Math.ceil(numInputItems / this.chunkSize);
+		const chunks = [];
+
+		for (let i = 0; i < numChunks; i++) {
+			const startIdx = i * this.chunkSize;
+			const isLastChunk = i === numChunks - 1;
+			const count = isLastChunk ? numInputItems - startIdx : this.chunkSize;
+			chunks.push({
+				startIdx,
+				count,
+			});
+		}
+
+		return chunks;
 	}
 }

--- a/packages/nodes-base/nodes/Code/test/JsTaskRunnerSandbox.test.ts
+++ b/packages/nodes-base/nodes/Code/test/JsTaskRunnerSandbox.test.ts
@@ -1,0 +1,61 @@
+import { mock } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { createResultOk } from 'n8n-workflow';
+
+import { JsTaskRunnerSandbox } from '../JsTaskRunnerSandbox';
+
+describe('JsTaskRunnerSandbox', () => {
+	describe('runCodeForEachItem', () => {
+		it('should chunk the input items and execute the code for each chunk', async () => {
+			const jsCode = 'console.log($item);';
+			const nodeMode = 'runOnceForEachItem';
+			const workflowMode = 'manual';
+			const executeFunctions = mock<IExecuteFunctions>();
+			const sandbox = new JsTaskRunnerSandbox(jsCode, nodeMode, workflowMode, executeFunctions, 2);
+			let i = 1;
+			executeFunctions.startJob.mockResolvedValue(createResultOk([{ json: { item: i++ } }]));
+
+			const numInputItems = 5;
+			await sandbox.runCodeForEachItem(numInputItems);
+
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			expect(executeFunctions.startJob).toHaveBeenCalledTimes(3);
+			const calls = executeFunctions.startJob.mock.calls;
+			expect(calls).toEqual([
+				[
+					'javascript',
+					{
+						code: jsCode,
+						nodeMode,
+						workflowMode,
+						continueOnFail: executeFunctions.continueOnFail(),
+						chunk: { startIndex: 0, count: 2 },
+					},
+					0,
+				],
+				[
+					'javascript',
+					{
+						code: jsCode,
+						nodeMode,
+						workflowMode,
+						continueOnFail: executeFunctions.continueOnFail(),
+						chunk: { startIndex: 2, count: 2 },
+					},
+					0,
+				],
+				[
+					'javascript',
+					{
+						code: jsCode,
+						nodeMode,
+						workflowMode,
+						continueOnFail: executeFunctions.continueOnFail(),
+						chunk: { startIndex: 4, count: 1 },
+					},
+					0,
+				],
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

To reduce memory footprint, execute runOnceForEachItem in chunks of 1000
items at a time. This makes the execution a bit slower but reduces the max
memory usage. In the future we could consider e.g. sampling the input data
and determine the chunk size based on that.

Also remove `N8N_RUNNERS_ASSERT_DEDUPLICATION_OUTPUT` as it can't be checked in all cases anymore and we haven't had any assertion issues with it.

<details>
<summary>Tested using this WF:</summary>

```
{
  "meta": {
    "instanceId": "5b46fac5e9673392b3401e98bcc7f9ea17bef74f40d13b962cd1ae3eda2b46e0"
  },
  "nodes": [
    {
      "parameters": {},
      "id": "d4ef24a2-e448-479d-ae04-2ffa58988c8b",
      "name": "When clicking ‘Test workflow’",
      "type": "n8n-nodes-base.manualTrigger",
      "position": [
        460,
        460
      ],
      "typeVersion": 1
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "be9f61bf-17d0-448a-b5c9-dc9a0823a9f5",
              "name": "fullName",
              "value": "={{ $json.firstName }} {{ $json.lastName }}",
              "type": "string"
            },
            {
              "id": "506ecd03-53be-4a7e-b1ce-dd892260931b",
              "name": "updatedAt",
              "value": "={{ $now.toISO() }}",
              "type": "string"
            }
          ]
        },
        "includeOtherFields": true,
        "options": {}
      },
      "id": "49124629-9c05-44c4-8952-1335ddd10427",
      "name": "Edit Fields",
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        920,
        460
      ]
    },
    {
      "parameters": {
        "jsCode": "function getRandomUser(idx) {\n  const firstNames = [\"Alice\", \"Bob\", \"Charlie\", \"David\", \"Eve\"];\n  const lastNames = [\"Smith\", \"Johnson\", \"Brown\", \"Williams\", \"Jones\"];\n  const domains = [\"example.com\", \"test.com\", \"domain.com\"];\n\n  const getRandomElement = (arr) => arr[Math.floor(Math.random() * arr.length)];\n  const getRandomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;\n\n  const firstName = getRandomElement(firstNames);\n  const lastName = getRandomElement(lastNames);\n  const age = getRandomInt(18, 70);\n  const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@${getRandomElement(domains)}`;\n  const userId = getRandomInt(1000, 9999);\n\n  return {\n    idx,\n    userId,\n    firstName,\n    lastName,\n    age,\n    email,\n    isActive: Math.random() > 0.5,\n    createdAt: new Date(Date.now() - getRandomInt(0, 1000 * 60 * 60 * 24 * 365)).toISOString(),\n  };\n}\n\nreturn Array.from({ length: 10_000 }).map((_, idx) => getRandomUser(idx))"
      },
      "id": "baaa6158-553b-41df-bd4a-8b4b5458c07b",
      "name": "CreateData",
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        680,
        460
      ]
    },
    {
      "parameters": {
        "mode": "runOnceForEachItem",
        "jsCode": "\nreturn {\n  ...$json,\n  domain: $json.email.split(\"@\")[1]\n}"
      },
      "id": "502761a1-d54f-40ef-a0c7-3d00e8378ac3",
      "name": "AddField",
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        1140,
        460
      ]
    },
    {
      "parameters": {
        "jsCode": "let maxId = 0\nlet sumAge = 0\n\nfor (let it of $input.all()) {\n  maxId = Math.max(maxId, it.json.userId)\n  sumAge += it.json.age\n}\n\nreturn {\n  json: {\n    maxId,\n    avgAge: sumAge / $input.all().length\n  }\n}"
      },
      "id": "e4a21d7d-6ac6-4d40-b9aa-63076a4823c4",
      "name": "Aggregate",
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        1400,
        460
      ]
    },
    {
      "parameters": {
        "jsCode": "const items = $('CreateData').all()\nconst stats = $input.first().json\n\nreturn items.map(i => ({\n  ...i,\n  stats\n}))"
      },
      "id": "9f1f3762-5870-4905-a67e-4a8a92746a2f",
      "name": "AccessPastNode",
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        1620,
        460
      ]
    }
  ],
  "connections": {
    "When clicking ‘Test workflow’": {
      "main": [
        [
          {
            "node": "CreateData",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "AddField",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "CreateData": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "AddField": {
      "main": [
        [
          {
            "node": "Aggregate",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Aggregate": {
      "main": [
        [
          {
            "node": "AccessPastNode",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

</details>

<img width="949" alt="image" src="https://github.com/user-attachments/assets/7d00616a-e73a-4542-bea2-fbd3975728e1">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-300/[memory]-batch-items-sent-in-runonceforeachitem-mode


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
