### PR TITLE
fix(editor): Fix node position not getting set when dragging selection on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.test.ts
+++ b/packages/editor-ui/src/components/canvas/Canvas.test.ts
@@ -87,8 +87,6 @@ describe('Canvas', () => {
 	});
 
 	it('should handle `update:nodes:position` event', async () => {
-		vi.useFakeTimers();
-
 		const nodes = [createCanvasNodeElement()];
 		const { container, emitted } = renderComponent({
 			props: {
@@ -111,8 +109,6 @@ describe('Canvas', () => {
 			clientY: 40,
 		});
 		await fireEvent.mouseUp(node, { view: window });
-
-		vi.advanceTimersByTime(250); // Event debounce time
 
 		expect(emitted()['update:nodes:position']).toEqual([
 			[

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -271,6 +271,10 @@ function onNodeDragStop(event: NodeDragEvent) {
 	onUpdateNodesPosition(event.nodes.map(({ id, position }) => ({ id, position })));
 }
 
+function onSelectionDragStop(event: NodeDragEvent) {
+	onUpdateNodesPosition(event.nodes.map(({ id, position }) => ({ id, position })));
+}
+
 function onSetNodeActive(id: string) {
 	props.eventBus.emit('nodes:action', { ids: [id], action: 'update:node:active' });
 	emit('update:node:active', id);
@@ -644,6 +648,7 @@ provide(CanvasKey, {
 		@move-start="onPaneMoveStart"
 		@move-end="onPaneMoveEnd"
 		@node-drag-stop="onNodeDragStop"
+		@selection-drag-stop="onSelectionDragStop"
 	>
 		<template #node-canvas-node="nodeProps">
 			<Node


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/17880b47-2124-43b7-91b8-dc42d86a7d38

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-356/executing-a-workflow-manually-rearranges-nodes

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
