### PR TITLE
fix(editor): Restore workers view

### DIFF
--- a/packages/editor-ui/src/components/WorkerList.ee.vue
+++ b/packages/editor-ui/src/components/WorkerList.ee.vue
@@ -9,6 +9,7 @@ import { usePushConnection } from '@/composables/usePushConnection';
 import { usePushConnectionStore } from '@/stores/pushConnection.store';
 import { useRootStore } from '@/stores/root.store';
 import { useTelemetry } from '@/composables/useTelemetry';
+import WorkerCard from './Workers/WorkerCard.ee.vue';
 
 withDefaults(
 	defineProps<{


### PR DESCRIPTION
## Summary

This PR https://github.com/n8n-io/n8n/pull/11509 accidentally removed an import for `WorkerCard`

Context: https://n8nio.slack.com/archives/C035KBDA917/p1732541195112039

## Related Linear tickets, Github issues, and Community forum posts

- https://community.n8n.io/t/updating-to-version-1-67-1-it-appears-within-settings-workers-the-worker-status-is-not-updating-displaying-properly/62241
- https://linear.app/n8n/issue/PAY-2291/workers-view-broken

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
