### PR TITLE
chore: Fix flaky cypress tests (no-changelog)

### DIFF
--- a/cypress/e2e/17-sharing.cy.ts
+++ b/cypress/e2e/17-sharing.cy.ts
@@ -88,7 +88,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 
 		cy.visit(workflowsPage.url);
 		workflowsPage.getters.workflowCards().should('have.length', 1);
-		workflowsPage.getters.workflowCard('Workflow W1').click();
+		workflowsPage.getters.workflowCardContent('Workflow W1').click();
 		workflowPage.actions.addNodeToCanvas('Airtable', true, true);
 		ndv.getters.credentialInput().find('input').should('have.value', 'Credential C2');
 		ndv.actions.close();
@@ -104,7 +104,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 
 		cy.visit(workflowsPage.url);
 		workflowsPage.getters.workflowCards().should('have.length', 2);
-		workflowsPage.getters.workflowCard('Workflow W1').click();
+		workflowsPage.getters.workflowCardContent('Workflow W1').click();
 		workflowPage.actions.addNodeToCanvas('Airtable', true, true);
 		ndv.getters.credentialInput().find('input').should('have.value', 'Credential C2');
 		ndv.actions.close();
@@ -133,7 +133,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 
 		cy.visit(workflowsPage.url);
 		workflowsPage.getters.workflowCards().should('have.length', 2);
-		workflowsPage.getters.workflowCard('Workflow W1').click();
+		workflowsPage.getters.workflowCardContent('Workflow W1').click();
 		workflowPage.actions.openNode('Notion');
 		ndv.getters
 			.credentialInput()
@@ -144,7 +144,7 @@ describe('Sharing', { disableAutoLogin: true }, () => {
 
 		cy.waitForLoad();
 		cy.visit(workflowsPage.url);
-		workflowsPage.getters.workflowCard('Workflow W2').click('top');
+		workflowsPage.getters.workflowCardContent('Workflow W2').click('top');
 		workflowPage.actions.executeWorkflow();
 	});
 
@@ -353,7 +353,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 		credentialsPage.getters.emptyListCreateCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 		cy.visit(workflowsPage.url);
-		workflowsPage.getters.workflowCard(workflowName).click();
+		workflowsPage.getters.workflowCardContent(workflowName).click();
 		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 
 		// Only the own credential the shared one (+ the 'Create new' option)
@@ -398,7 +398,7 @@ describe('Credential Usage in Cross Shared Workflows', () => {
 		credentialsPage.getters.createCredentialButton().click();
 		credentialsModal.actions.createNewCredential('Notion API');
 		cy.visit(workflowsPage.url);
-		workflowsPage.getters.workflowCard(workflowName).click();
+		workflowsPage.getters.workflowCardContent(workflowName).click();
 		workflowPage.actions.addNodeToCanvas(NOTION_NODE_NAME, true, true);
 
 		// Only the personal credentials of the workflow owner and the global owner

--- a/cypress/e2e/39-projects.cy.ts
+++ b/cypress/e2e/39-projects.cy.ts
@@ -186,7 +186,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 		menuItems.filter(':contains("Development")[class*=active_]').should('exist');
 
 		cy.intercept('GET', '/rest/workflows/*').as('loadWorkflow');
-		workflowsPage.getters.workflowCards().first().click();
+		workflowsPage.getters.workflowCards().first().findChildByTestId('card-content').click();
 
 		cy.wait('@loadWorkflow');
 		menuItems = cy.getByTestId('menu-item');
@@ -747,7 +747,7 @@ describe('Projects', { disableAutoLogin: true }, () => {
 
 			// Open the moved workflow
 			workflowsPage.getters.workflowCards().should('have.length', 1);
-			workflowsPage.getters.workflowCards().first().click();
+			workflowsPage.getters.workflowCards().first().findChildByTestId('card-content').click();
 
 			// Check if the credential can be changed
 			workflowPage.getters.canvasNodeByName(NOTION_NODE_NAME).should('be.visible').dblclick();

--- a/cypress/pages/workflows.ts
+++ b/cypress/pages/workflows.ts
@@ -56,6 +56,8 @@ export class WorkflowsPage extends BasePage {
 				.parents('[data-test-id="resources-list-item"]'),
 		workflowTags: (workflowName: string) =>
 			this.getters.workflowCard(workflowName).findChildByTestId('workflow-card-tags'),
+		workflowCardContent: (workflowName: string) =>
+			this.getters.workflowCard(workflowName).findChildByTestId('card-content'),
 		workflowActivator: (workflowName: string) =>
 			this.getters.workflowCard(workflowName).findChildByTestId('workflow-card-activator'),
 		workflowActivatorStatus: (workflowName: string) =>

--- a/packages/design-system/src/components/N8nCard/Card.vue
+++ b/packages/design-system/src/components/N8nCard/Card.vue
@@ -20,10 +20,10 @@ const classes = computed(() => ({
 
 <template>
 	<div :class="classes" v-bind="$attrs">
-		<div v-if="$slots.prepend" :class="$style.icon">
+		<div v-if="$slots.prepend" data-test-id="card-prepend" :class="$style.icon">
 			<slot name="prepend" />
 		</div>
-		<div :class="$style.content">
+		<div :class="$style.content" data-test-id="card-content">
 			<div v-if="$slots.header" :class="$style.header">
 				<slot name="header" />
 			</div>
@@ -34,7 +34,7 @@ const classes = computed(() => ({
 				<slot name="footer" />
 			</div>
 		</div>
-		<div v-if="$slots.append" :class="$style.append">
+		<div v-if="$slots.append" data-test-id="card-append" :class="$style.append">
 			<slot name="append" />
 		</div>
 	</div>

--- a/packages/design-system/src/components/N8nCard/__snapshots__/Card.test.ts.snap
+++ b/packages/design-system/src/components/N8nCard/__snapshots__/Card.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`components > N8nCard > should render correctly 1`] = `
 "<div class="card">
   <!--v-if-->
-  <div class="content">
+  <div class="content" data-test-id="card-content">
     <!--v-if-->
     <div class="body">This is a card.</div>
     <!--v-if-->
@@ -15,7 +15,7 @@ exports[`components > N8nCard > should render correctly 1`] = `
 exports[`components > N8nCard > should render correctly with header and footer 1`] = `
 "<div class="card">
   <!--v-if-->
-  <div class="content">
+  <div class="content" data-test-id="card-content">
     <div class="header">Header</div>
     <div class="body">This is a card.</div>
     <div class="footer">Footer</div>


### PR DESCRIPTION
## Summary

Sometimes there were issues while running cypress test, when it tried to click on a workflow card. Depending on a owner name (generated randomly while running tests), the center of a workflow card might be clickable or not.
This changes the click target to a card content part, which should always be clickable.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
