### PR TITLE
fix(core): Correct invalid WS status code on removing connection

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -164,3 +164,13 @@ export const LOWEST_SHUTDOWN_PRIORITY = 0;
 export const DEFAULT_SHUTDOWN_PRIORITY = 100;
 /** Highest priority, meaning shut down happens before all other groups */
 export const HIGHEST_SHUTDOWN_PRIORITY = 200;
+
+export const WsStatusCodes = {
+	CloseNormal: 1000,
+	CloseGoingAway: 1001,
+	CloseProtocolError: 1002,
+	CloseUnsupportedData: 1003,
+	CloseNoStatus: 1005,
+	CloseAbnormal: 1006,
+	CloseInvalidData: 1007,
+} as const;

--- a/packages/cli/src/runners/__tests__/task-runner-ws-server.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-ws-server.test.ts
@@ -1,10 +1,23 @@
 import type { TaskRunnersConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
+import type WebSocket from 'ws';
 
 import { Time } from '@/constants';
 import { TaskRunnerWsServer } from '@/runners/runner-ws-server';
 
 describe('TaskRunnerWsServer', () => {
+	describe('removeConnection', () => {
+		it('should close with 1000 status code by default', async () => {
+			const server = new TaskRunnerWsServer(mock(), mock(), mock(), mock(), mock());
+			const ws = mock<WebSocket>();
+			server.runnerConnections.set('test-runner', ws);
+
+			await server.removeConnection('test-runner');
+
+			expect(ws.close).toHaveBeenCalledWith(1000);
+		});
+	});
+
 	describe('heartbeat timer', () => {
 		it('should set up heartbeat timer on server start', async () => {
 			const setIntervalSpy = jest.spyOn(global, 'setInterval');

--- a/packages/cli/src/runners/__tests__/task-runner-ws-server.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-ws-server.test.ts
@@ -2,7 +2,7 @@ import type { TaskRunnersConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import type WebSocket from 'ws';
 
-import { Time } from '@/constants';
+import { Time, WsStatusCodes } from '@/constants';
 import { TaskRunnerWsServer } from '@/runners/runner-ws-server';
 
 describe('TaskRunnerWsServer', () => {
@@ -14,7 +14,7 @@ describe('TaskRunnerWsServer', () => {
 
 			await server.removeConnection('test-runner');
 
-			expect(ws.close).toHaveBeenCalledWith(1000);
+			expect(ws.close).toHaveBeenCalledWith(WsStatusCodes.CloseNormal);
 		});
 	});
 

--- a/packages/cli/src/runners/runner-ws-server.ts
+++ b/packages/cli/src/runners/runner-ws-server.ts
@@ -21,15 +21,17 @@ function heartbeat(this: WebSocket) {
 	this.isAlive = true;
 }
 
-const enum WsStatusCode {
-	CloseNormal = 1000,
-	CloseGoingAway = 1001,
-	CloseProtocolError = 1002,
-	CloseUnsupportedData = 1003,
-	CloseNoStatus = 1005,
-	CloseAbnormal = 1006,
-	CloseInvalidData = 1007,
-}
+const WsStatusCodes = {
+	CloseNormal: 1000,
+	CloseGoingAway: 1001,
+	CloseProtocolError: 1002,
+	CloseUnsupportedData: 1003,
+	CloseNoStatus: 1005,
+	CloseAbnormal: 1006,
+	CloseInvalidData: 1007,
+} as const;
+
+type WsStatusCode = (typeof WsStatusCodes)[keyof typeof WsStatusCodes];
 
 @Service()
 export class TaskRunnerWsServer {
@@ -62,7 +64,7 @@ export class TaskRunnerWsServer {
 					void this.removeConnection(
 						runnerId,
 						'failed-heartbeat-check',
-						WsStatusCode.CloseNoStatus,
+						WsStatusCodes.CloseNoStatus,
 					);
 					this.runnerLifecycleEvents.emit('runner:failed-heartbeat-check');
 					return;
@@ -156,7 +158,7 @@ export class TaskRunnerWsServer {
 	async removeConnection(
 		id: TaskRunner['id'],
 		reason: DisconnectReason = 'unknown',
-		code?: WsStatusCode,
+		code: WsStatusCode = WsStatusCodes.CloseNormal,
 	) {
 		const connection = this.runnerConnections.get(id);
 		if (connection) {
@@ -181,7 +183,8 @@ export class TaskRunnerWsServer {
 		// shutting them down
 		await Promise.all(
 			Array.from(this.runnerConnections.keys()).map(
-				async (id) => await this.removeConnection(id, 'shutting-down', WsStatusCode.CloseGoingAway),
+				async (id) =>
+					await this.removeConnection(id, 'shutting-down', WsStatusCodes.CloseGoingAway),
 			),
 		);
 	}

--- a/packages/cli/src/runners/runner-ws-server.ts
+++ b/packages/cli/src/runners/runner-ws-server.ts
@@ -4,7 +4,7 @@ import { ApplicationError } from 'n8n-workflow';
 import { Service } from 'typedi';
 import type WebSocket from 'ws';
 
-import { Time } from '@/constants';
+import { Time, WsStatusCodes } from '@/constants';
 import { Logger } from '@/logging/logger.service';
 
 import { DefaultTaskRunnerDisconnectAnalyzer } from './default-task-runner-disconnect-analyzer';
@@ -20,16 +20,6 @@ import { TaskBroker, type MessageCallback, type TaskRunner } from './task-broker
 function heartbeat(this: WebSocket) {
 	this.isAlive = true;
 }
-
-const WsStatusCodes = {
-	CloseNormal: 1000,
-	CloseGoingAway: 1001,
-	CloseProtocolError: 1002,
-	CloseUnsupportedData: 1003,
-	CloseNoStatus: 1005,
-	CloseAbnormal: 1006,
-	CloseInvalidData: 1007,
-} as const;
 
 type WsStatusCode = (typeof WsStatusCodes)[keyof typeof WsStatusCodes];
 


### PR DESCRIPTION
Noticed we were occassionally calling `connection.close(undefined)` leading to:

```
Registered runner "Launcher" (8f2b63d571251e74)
Registered runner "JS Task Runner" (L2FT367NgrN5qekqlrwgQ)
First argument must be a valid error code number
TypeError: First argument must be a valid error code number
    at Sender.close (/Users/ivov/Development/n8n/node_modules/.pnpm/ws@8.17.1/node_modules/ws/lib/sender.js:181:13)
    at WebSocket.close (/Users/ivov/Development/n8n/node_modules/.pnpm/ws@8.17.1/node_modules/ws/lib/websocket.js:308:18)
    at TaskRunnerWsServer.removeConnection (/Users/ivov/Development/n8n/packages/cli/src/runners/runner-ws-server.ts:170:15)
```
