### PR TITLE
ci: Upgrade task runner launcher to 0.5.0-rc

### DIFF
--- a/docker/images/n8n-custom/Dockerfile
+++ b/docker/images/n8n-custom/Dockerfile
@@ -33,7 +33,7 @@ COPY docker/images/n8n/docker-entrypoint.sh /
 
 # Setup the Task Runner Launcher
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=0.4.0-rc
+ARG LAUNCHER_VERSION=0.5.0-rc
 COPY docker/images/n8n/n8n-task-runners.json /etc/n8n-task-runners.json
 # Download, verify, then extract the launcher binary
 RUN \

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
 
 # Setup the Task Runner Launcher
 ARG TARGETPLATFORM
-ARG LAUNCHER_VERSION=0.4.0-rc
+ARG LAUNCHER_VERSION=0.5.0-rc
 COPY n8n-task-runners.json /etc/n8n-task-runners.json
 # Download, verify, then extract the launcher binary
 RUN \


### PR DESCRIPTION
Upgrade to https://github.com/n8n-io/task-runner-launcher/releases/tag/0.5.0-rc
