### PR TITLE
fix(core): Don't use unbound context methods in code sandboxes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -81,31 +81,20 @@ function getSandbox(
 	const workflowMode = this.getMode();
 
 	const context = getSandboxContext.call(this, itemIndex);
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.addInputData = this.addInputData;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.addOutputData = this.addOutputData;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getInputConnectionData = this.getInputConnectionData;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getInputData = this.getInputData;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getNode = this.getNode;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getExecutionCancelSignal = this.getExecutionCancelSignal;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getNodeOutputs = this.getNodeOutputs;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.executeWorkflow = this.executeWorkflow;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
-	context.getWorkflowDataProxy = this.getWorkflowDataProxy;
-	// eslint-disable-next-line @typescript-eslint/unbound-method
+	context.addInputData = this.addInputData.bind(this);
+	context.addOutputData = this.addOutputData.bind(this);
+	context.getInputConnectionData = this.getInputConnectionData.bind(this);
+	context.getInputData = this.getInputData.bind(this);
+	context.getNode = this.getNode.bind(this);
+	context.getExecutionCancelSignal = this.getExecutionCancelSignal.bind(this);
+	context.getNodeOutputs = this.getNodeOutputs.bind(this);
+	context.executeWorkflow = this.executeWorkflow.bind(this);
+	context.getWorkflowDataProxy = this.getWorkflowDataProxy.bind(this);
 	context.logger = this.logger;
 
 	if (options?.addItems) {
 		context.items = context.$input.all();
 	}
-	// eslint-disable-next-line @typescript-eslint/unbound-method
 
 	const sandbox = new JavaScriptSandbox(context, code, this.helpers, {
 		resolver: vmResolver,

--- a/packages/nodes-base/nodes/AiTransform/AiTransform.node.ts
+++ b/packages/nodes-base/nodes/AiTransform/AiTransform.node.ts
@@ -121,7 +121,7 @@ export class AiTransform implements INodeType {
 			sandbox.on(
 				'output',
 				workflowMode === 'manual'
-					? this.sendMessageToUI
+					? this.sendMessageToUI.bind(this)
 					: CODE_ENABLE_STDOUT === 'true'
 						? (...args) =>
 								console.log(`[Workflow "${this.getWorkflow().id}"][Node "${node.name}"]`, ...args)

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -133,7 +133,7 @@ export class Code implements INodeType {
 			sandbox.on(
 				'output',
 				workflowMode === 'manual'
-					? this.sendMessageToUI
+					? this.sendMessageToUI.bind(this)
 					: CODE_ENABLE_STDOUT === 'true'
 						? (...args) =>
 								console.log(`[Workflow "${this.getWorkflow().id}"][Node "${node.name}"]`, ...args)

--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -35,8 +35,8 @@ export function getSandboxContext(
 	};
 	return {
 		// from NodeExecuteFunctions
-		$getNodeParameter: this.getNodeParameter,
-		$getWorkflowStaticData: this.getWorkflowStaticData,
+		$getNodeParameter: this.getNodeParameter.bind(this),
+		$getWorkflowStaticData: this.getWorkflowStaticData.bind(this),
 		helpers,
 
 		// to bring in all $-prefixed vars and methods from WorkflowDataProxy

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -92,8 +92,8 @@ return items;`,
 
 		// Define the global objects for the custom function
 		const sandbox = {
-			getNodeParameter: this.getNodeParameter,
-			getWorkflowStaticData: this.getWorkflowStaticData,
+			getNodeParameter: this.getNodeParameter.bind(this),
+			getWorkflowStaticData: this.getWorkflowStaticData.bind(this),
 			helpers: this.helpers,
 			items,
 			// To be able to access data of other items
@@ -157,7 +157,7 @@ return items;`,
 		const vm = new NodeVM(options);
 
 		if (mode === 'manual') {
-			vm.on('console.log', this.sendMessageToUI);
+			vm.on('console.log', this.sendMessageToUI.bind(this));
 		}
 
 		// Get the code to execute

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -113,8 +113,8 @@ return item;`,
 						}
 						item.binary = data;
 					},
-					getNodeParameter: this.getNodeParameter,
-					getWorkflowStaticData: this.getWorkflowStaticData,
+					getNodeParameter: this.getNodeParameter.bind(this),
+					getWorkflowStaticData: this.getWorkflowStaticData.bind(this),
 					helpers: this.helpers,
 					item: item.json,
 					getBinaryDataAsync: async (): Promise<IBinaryKeyData | undefined> => {
@@ -165,7 +165,7 @@ return item;`,
 				const vm = new NodeVM(options as unknown as NodeVMOptions);
 
 				if (mode === 'manual') {
-					vm.on('console.log', this.sendMessageToUI);
+					vm.on('console.log', this.sendMessageToUI.bind(this));
 				}
 
 				// Get the code to execute


### PR DESCRIPTION
## Summary

Since #11853, almost all methods on context objects now live on the prototype chain, and hence can't be used unbound.
This is a temporary fix, until we replace these sandbox objects with proxies built on top of the context objects. That will be addressed in CAT-367.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
