### PR TITLE
feat(core): Add health endpoint for task broker server (no-changelog)

### DIFF
--- a/packages/cli/src/runners/task-runner-server.ts
+++ b/packages/cli/src/runners/task-runner-server.ts
@@ -163,6 +163,8 @@ export class TaskRunnerServer {
 			authEndpoint,
 			send(async (req) => await this.taskRunnerAuthController.createGrantToken(req)),
 		);
+
+		this.app.get('/healthz', (_, res) => res.send({ status: 'ok' }));
 	}
 
 	private handleUpgradeRequest = (

--- a/packages/cli/test/integration/runners/task-runner-module.internal.test.ts
+++ b/packages/cli/test/integration/runners/task-runner-module.internal.test.ts
@@ -10,6 +10,7 @@ describe('TaskRunnerModule in internal mode', () => {
 	const runnerConfig = Container.get(TaskRunnersConfig);
 	runnerConfig.port = 0; // Random port
 	runnerConfig.mode = 'internal';
+	runnerConfig.enabled = true;
 	const module = Container.get(TaskRunnerModule);
 
 	afterEach(async () => {

--- a/packages/cli/test/integration/runners/task-runner-process.test.ts
+++ b/packages/cli/test/integration/runners/task-runner-process.test.ts
@@ -1,21 +1,15 @@
-import { TaskRunnersConfig } from '@n8n/config';
 import Container from 'typedi';
 
 import { TaskRunnerWsServer } from '@/runners/runner-ws-server';
 import { TaskBroker } from '@/runners/task-broker.service';
 import { TaskRunnerProcess } from '@/runners/task-runner-process';
-import { TaskRunnerServer } from '@/runners/task-runner-server';
 import { retryUntil } from '@test-integration/retry-until';
+import { setupBrokerTestServer } from '@test-integration/utils/task-broker-test-server';
 
 describe('TaskRunnerProcess', () => {
-	const authToken = 'token';
-	const runnerConfig = Container.get(TaskRunnersConfig);
-	runnerConfig.enabled = true;
-	runnerConfig.mode = 'internal';
-	runnerConfig.authToken = authToken;
-	runnerConfig.port = 0; // Use any port
-	const taskRunnerServer = Container.get(TaskRunnerServer);
-
+	const { config, server: taskRunnerServer } = setupBrokerTestServer({
+		mode: 'internal',
+	});
 	const runnerProcess = Container.get(TaskRunnerProcess);
 	const taskBroker = Container.get(TaskBroker);
 	const taskRunnerService = Container.get(TaskRunnerWsServer);
@@ -23,7 +17,7 @@ describe('TaskRunnerProcess', () => {
 	beforeAll(async () => {
 		await taskRunnerServer.start();
 		// Set the port to the actually used port
-		runnerConfig.port = taskRunnerServer.port;
+		config.port = taskRunnerServer.port;
 	});
 
 	afterAll(async () => {

--- a/packages/cli/test/integration/runners/task-runner-server.test.ts
+++ b/packages/cli/test/integration/runners/task-runner-server.test.ts
@@ -1,0 +1,22 @@
+import { setupBrokerTestServer } from '@test-integration/utils/task-broker-test-server';
+
+describe('TaskRunnerServer', () => {
+	const { agent, server } = setupBrokerTestServer({
+		authToken: 'token',
+		mode: 'external',
+	});
+
+	beforeAll(async () => {
+		await server.start();
+	});
+
+	afterAll(async () => {
+		await server.stop();
+	});
+
+	describe('/healthz', () => {
+		it('should return 200', async () => {
+			await agent.get('/healthz').expect(200);
+		});
+	});
+});

--- a/packages/cli/test/integration/shared/utils/task-broker-test-server.ts
+++ b/packages/cli/test/integration/shared/utils/task-broker-test-server.ts
@@ -1,0 +1,40 @@
+import { TaskRunnersConfig } from '@n8n/config';
+import request from 'supertest';
+import type TestAgent from 'supertest/lib/agent';
+import Container from 'typedi';
+
+import { TaskRunnerServer } from '@/runners/task-runner-server';
+
+export interface TestTaskBrokerServer {
+	server: TaskRunnerServer;
+	agent: TestAgent;
+	config: TaskRunnersConfig;
+}
+
+/**
+ * Sets up a Task Broker Server for testing purposes. The server needs
+ * to be started and stopped manually.
+ *
+ * @example
+ * const { server, agent, config } = setupBrokerTestServer();
+ *
+ * beforeAll(async () => await server.start());
+ * afterAll(async () => await server.stop());
+ */
+export const setupBrokerTestServer = (
+	config: Partial<TaskRunnersConfig> = {},
+): TestTaskBrokerServer => {
+	const runnerConfig = Container.get(TaskRunnersConfig);
+	Object.assign(runnerConfig, config);
+	runnerConfig.enabled = true;
+	runnerConfig.port = 0; // Use any port
+
+	const taskRunnerServer = Container.get(TaskRunnerServer);
+	const agent = request.agent(taskRunnerServer.app);
+
+	return {
+		server: taskRunnerServer,
+		agent,
+		config: runnerConfig,
+	};
+};


### PR DESCRIPTION
## Summary

Add healthcheck endpoint for the task broker server.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-368/add-healthcheck-endpoint-for-task-broker-and-use-that
