### PR TITLE
fix(Webflow Node): Fix issue with pagination in v2 node

### DIFF
--- a/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Webflow/GenericFunctions.ts
@@ -5,7 +5,7 @@ import type {
 	ILoadOptionsFunctions,
 	IWebhookFunctions,
 	IHttpRequestMethods,
-	IRequestOptions,
+	IHttpRequestOptions,
 	INodePropertyOptions,
 } from 'n8n-workflow';
 
@@ -20,11 +20,11 @@ export async function webflowApiRequest(
 ) {
 	let credentialsType = 'webflowOAuth2Api';
 
-	let options: IRequestOptions = {
+	let options: IHttpRequestOptions = {
 		method,
 		qs,
 		body,
-		uri: uri || `https://api.webflow.com${resource}`,
+		url: uri || `https://api.webflow.com${resource}`,
 		json: true,
 	};
 	options = Object.assign({}, options, option);
@@ -37,8 +37,8 @@ export async function webflowApiRequest(
 		}
 		options.headers = { 'accept-version': '1.0.0' };
 	} else {
-		options.resolveWithFullResponse = true;
-		options.uri = `https://api.webflow.com/v2${resource}`;
+		options.returnFullResponse = true;
+		options.url = `https://api.webflow.com/v2${resource}`;
 	}
 
 	if (Object.keys(options.qs as IDataObject).length === 0) {
@@ -48,7 +48,7 @@ export async function webflowApiRequest(
 	if (Object.keys(options.body as IDataObject).length === 0) {
 		delete options.body;
 	}
-	return await this.helpers.requestWithAuthentication.call(this, credentialsType, options);
+	return await this.helpers.httpRequestWithAuthentication.call(this, credentialsType, options);
 }
 
 export async function webflowApiRequestAllItems(

--- a/packages/nodes-base/nodes/Webflow/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Webflow/test/GenericFunctions.test.ts
@@ -1,0 +1,66 @@
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { webflowApiRequestAllItems } from '../GenericFunctions';
+
+describe('Webflow -> webflowApiRequestAllItems', () => {
+	let mockExecuteFunctions: IExecuteFunctions | ILoadOptionsFunctions;
+
+	const v1Response = {
+		items: [
+			{ id: '1', name: 'Item 1' },
+			{ id: '2', name: 'Item 2' },
+		],
+		total: 2,
+	};
+
+	const v2Response = {
+		body: {
+			items: [
+				{ id: '1', name: 'Item 1' },
+				{ id: '2', name: 'Item 2' },
+			],
+			pagination: {
+				total: 2,
+			},
+		},
+	};
+
+	const setupMockFunctions = (typeVersion: number) => {
+		mockExecuteFunctions = {
+			getNode: jest.fn().mockReturnValue({ typeVersion }),
+			getNodeParameter: jest.fn(),
+			helpers: {
+				httpRequestWithAuthentication: jest
+					.fn()
+					.mockResolvedValue(typeVersion === 1 ? v1Response : v2Response),
+			},
+		} as unknown as IExecuteFunctions | ILoadOptionsFunctions;
+		jest.clearAllMocks();
+	};
+
+	beforeEach(() => {
+		setupMockFunctions(1);
+	});
+
+	it('should return all items for type version 1', async () => {
+		const result = await webflowApiRequestAllItems.call(
+			mockExecuteFunctions,
+			'GET',
+			'/collections/collection_id/items',
+		);
+
+		expect(result).toEqual(v1Response.items);
+	});
+
+	it('should return all items for type version 2', async () => {
+		setupMockFunctions(2);
+
+		const result = await webflowApiRequestAllItems.call(
+			mockExecuteFunctions,
+			'GET',
+			'/collections/collection_id/items',
+		);
+
+		expect(result).toEqual(v2Response.body.items);
+	});
+});


### PR DESCRIPTION
## Summary
Fixed issue with Pagination in v2 node and added a quick test to make sure we don't forget the v2 api nests the data, Also updated the http request helper so this node can be canceled mid workflow.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2083/webflow-pagination-issue
https://community.n8n.io/t/problem-using-webflow-oauth2/53438/46


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
