### PR TITLE
fix(core): Stop reporting ExpressionError to Sentry (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/expression.error.ts
+++ b/packages/workflow/src/errors/expression.error.ts
@@ -30,7 +30,7 @@ export interface ExpressionErrorOptions {
  */
 export class ExpressionError extends ExecutionBaseError {
 	constructor(message: string, options?: ExpressionErrorOptions) {
-		super(message, { cause: options?.cause });
+		super(message, { cause: options?.cause, level: 'warning' });
 
 		if (options?.description !== undefined) {
 			this.description = options.description;


### PR DESCRIPTION
## Summary
Looking at all existing [events](https://n8nio.sentry.io/issues/?project=4503924908883968&query=is%3Aunresolved%20ExpressionError&referrer=issue-list&statsPeriod=90d) for `ExpressionError` on Sentry, none of them seem actionable to me.
This PR changes the level for these errors, to stop reporting them.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
