### PR TITLE
feat(Execute Workflow Trigger Node): Add JSON-based input modes and dropdown

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -22,10 +22,9 @@ export class ExecuteWorkflowTrigger implements INodeType {
 		eventTriggerDescription: '',
 		maxNodes: 1,
 		defaults: {
-			name: 'Execute Workflow Trigger',
+			name: 'Workflow Input Trigger',
 			color: '#ff6d5a',
 		},
-
 		inputs: [],
 		outputs: [NodeConnectionType.Main],
 		properties: [
@@ -52,6 +51,26 @@ export class ExecuteWorkflowTrigger implements INodeType {
 				default: 'worklfow_call',
 			},
 			{
+				displayName: 'Input Source',
+				name: 'inputSource',
+				type: 'options',
+				options: [
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Using fields below',
+						value: 'fields',
+						description: 'Provide via UI',
+					},
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Using JSON',
+						value: 'json',
+						description: 'Provide via JSON schema',
+					},
+				],
+				default: 'fields',
+			},
+			{
 				displayName: 'Workflow Inputs',
 				name: WORKFLOW_INPUTS,
 				placeholder: 'Add Field',
@@ -63,7 +82,7 @@ export class ExecuteWorkflowTrigger implements INodeType {
 					sortable: true,
 				},
 				displayOptions: {
-					show: { '@version': [{ _cnd: { gte: 1.1 } }] },
+					show: { '@version': [{ _cnd: { gte: 1.1 } }], inputSource: ['fields'] },
 				},
 				default: {},
 				options: [
@@ -78,6 +97,7 @@ export class ExecuteWorkflowTrigger implements INodeType {
 								default: '',
 								placeholder: 'e.g. fieldName',
 								description: 'Name of the field',
+								noDataExpression: true,
 							},
 							// {
 							// 	displayName: 'Type',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -149,7 +149,7 @@ export class ExecuteWorkflowTrigger implements INodeType {
 		hints: [
 			{
 				message:
-					'We strongly recommend defining your input fields explicitly. If no inputs are provided, all data from the calling workflow will be available, and issues will be more difficult to debug later on.',
+					'We strongly recommend defining your input fields explicitly.<br>If no inputs are provided, all data from the calling workflow will be available, and issues will be more difficult to debug later on.',
 				// This condition checks if we have no input fields, which gets a bit awkward:
 				// For WORKFLOW_INPUTS: keys() only contains `VALUES` if at least one value is provided
 				// For JSON_EXAMPLE: We remove all whitespace and check if we're left with an empty object. Note that we already error if the example is not valid JSON
@@ -221,7 +221,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 			},
 			{
 				displayName:
-					'Provide an example object to infer fields and their types. To allow any type for a given field set the value to null.',
+					'Provide an example object to infer fields and their types.<br>To allow any type for a given field, set the value to null.',
 				name: `${JSON_EXAMPLE}_notice`,
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -30,7 +30,7 @@ function hasFields(context: IExecuteFunctions, index: number): boolean {
 	}
 }
 
-function parseJson(context: IExecuteFunctions, index: number): ValueOptions[] {
+function parseJson(_context: IExecuteFunctions, _index: number): ValueOptions[] {
 	return [{ name: 'Placeholder', type: 'number' }];
 }
 
@@ -107,6 +107,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 					},
 				],
 				default: FIELDS,
+				noDataExpression: true,
 			},
 			{
 				displayName: 'Workflow Inputs',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -20,8 +20,6 @@ const VALUES = 'values';
 const JSON_EXAMPLE = 'jsonExample';
 const JSON_SCHEMA = 'jsonSchema';
 const TYPE_OPTIONS: Array<{ name: string; value: FieldType | 'any' }> = [
-	// This is not a FieldType type, but will
-	// hit the default case in the type check function
 	{
 		name: 'Allow Any Type',
 		value: 'any',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -64,6 +64,16 @@ export class ExecuteWorkflowTrigger implements INodeType {
 		},
 		inputs: [],
 		outputs: [NodeConnectionType.Main],
+		hints: [
+			{
+				message:
+					'We strongly recommend defining your input fields explicitly. If no inputs are provided, all data from the calling workflow will be available, and issues will be more difficult to debug later on.',
+				// keys() on WORKFLOW_INPUTS contains `VALUES` if at least one value is provided
+				displayCondition: `={{ $parameter["${INPUT_SOURCE}"] === '${FIELDS}' && !$parameter["${WORKFLOW_INPUTS}"].keys().length  }}`, // TODO json mode condition
+				whenToDisplay: 'always',
+				location: 'ndv',
+			},
+		],
 		properties: [
 			{
 				displayName: `When an ‘Execute Workflow’ node calls this workflow, the execution starts here.<br><br>
@@ -90,7 +100,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 			},
 			{
 				displayName: 'Input Source',
-				name: 'inputSource',
+				name: INPUT_SOURCE,
 				type: 'options',
 				options: [
 					{
@@ -136,7 +146,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 								default: '',
 								placeholder: 'e.g. fieldName',
 								description: 'Name of the field',
-								noDataExpression: true,
+								// noDataExpression: true,
 							},
 							{
 								displayName: 'Type',
@@ -200,7 +210,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 						default: true,
 						description:
 							'Whether to attempt conversion on type mismatch, rather than directly returning an Error',
-						noDataExpression: true,
+						// noDataExpression: true,
 					},
 					{
 						displayName: 'Ignore Type Mismatch Errors',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -146,7 +146,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 								default: '',
 								placeholder: 'e.g. fieldName',
 								description: 'Name of the field',
-								// noDataExpression: true,
+								noDataExpression: true,
 							},
 							{
 								displayName: 'Type',
@@ -210,7 +210,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 						default: true,
 						description:
 							'Whether to attempt conversion on type mismatch, rather than directly returning an Error',
-						// noDataExpression: true,
+						noDataExpression: true,
 					},
 					{
 						displayName: 'Ignore Type Mismatch Errors',

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -96,7 +96,7 @@ function getFieldEntries(context: IExecuteFunctions): ValueOptions[] {
 	const inputSource = context.getNodeParameter(INPUT_SOURCE, 0) as string;
 	let result: ValueOptions[] | string = 'Internal Error: Invalid input source';
 	try {
-		if (inputSource === FIELDS) {
+		if (inputSource === WORKFLOW_INPUTS) {
 			result = context.getNodeParameter(`${WORKFLOW_INPUTS}.${VALUES}`, 0, []) as Array<{
 				name: string;
 				type: FieldType;

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -14,6 +14,9 @@ const FIELDS = 'fields';
 const WORKFLOW_INPUTS = 'workflowInputs';
 const INPUT_OPTIONS = 'inputOptions';
 const VALUES = 'values';
+const DEFAULT_PLACEHOLDER = null;
+
+type ValueOptions = { name: string; type: FieldType };
 
 function hasFields(context: IExecuteFunctions, index: number): boolean {
 	const inputSource = context.getNodeParameter(INPUT_SOURCE, index) as string;
@@ -27,23 +30,11 @@ function hasFields(context: IExecuteFunctions, index: number): boolean {
 	}
 }
 
-function parseJson(
-	context: IExecuteFunctions,
-	index: number,
-): Array<{
-	name: string;
-	type: FieldType;
-}> {
-	return [{ name: 'dummy', type: 'number' }];
+function parseJson(context: IExecuteFunctions, index: number): ValueOptions[] {
+	return [{ name: 'Placeholder', type: 'number' }];
 }
 
-function getSchema(
-	context: IExecuteFunctions,
-	index: number,
-): Array<{
-	name: string;
-	type: FieldType;
-}> {
+function getSchema(context: IExecuteFunctions, index: number): ValueOptions[] {
 	const inputSource = context.getNodeParameter(INPUT_SOURCE, index) as string;
 	if (inputSource === FIELDS) {
 		const fields = context.getNodeParameter(`${WORKFLOW_INPUTS}.${VALUES}`, index, []) as Array<{
@@ -55,9 +46,6 @@ function getSchema(
 		return parseJson(context, index);
 	}
 }
-type ValueOptions = { name: string; value: FieldType };
-
-const DEFAULT_PLACEHOLDER = null;
 
 export class ExecuteWorkflowTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -183,7 +171,7 @@ If you don't provide fields, all data passed into the 'Execute Workflow' node wi
 										value: 'object',
 									},
 									// Intentional omission of `dateTime`, `time`, `string-alphanumeric`, `form-fields`, `jwt` and `url`
-								] as ValueOptions[],
+								] as Array<{ name: string; value: FieldType }>,
 								default: 'string',
 								noDataExpression: true,
 							},

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -13,7 +13,6 @@ import {
 } from 'n8n-workflow';
 
 const INPUT_SOURCE = 'inputSource';
-const FIELDS = 'fields';
 const WORKFLOW_INPUTS = 'workflowInputs';
 const INPUT_OPTIONS = 'inputOptions';
 const VALUES = 'values';

--- a/packages/nodes-base/nodes/ExecuteWorkflowTrigger/test/ExecuteWorkflowTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflowTrigger/test/ExecuteWorkflowTrigger.node.test.ts
@@ -4,7 +4,7 @@ import type { IExecuteFunctions, INode, INodeExecutionData } from 'n8n-workflow'
 import { ExecuteWorkflowTrigger } from '../ExecuteWorkflowTrigger.node';
 
 describe('ExecuteWorkflowTrigger', () => {
-	it('should return its input data', async () => {
+	it('should return its input data on V1', async () => {
 		const mockInputData: INodeExecutionData[] = [
 			{ json: { item: 0, foo: 'bar' } },
 			{ json: { item: 1, foo: 'quz' } },

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -864,6 +864,7 @@
     "fast-glob": "catalog:",
     "fflate": "0.7.4",
     "get-system-fonts": "2.0.2",
+    "generate-schema": "2.6.0",
     "gm": "1.25.0",
     "html-to-text": "9.0.5",
     "iconv-lite": "0.6.3",

--- a/packages/nodes-base/tsconfig.build.json
+++ b/packages/nodes-base/tsconfig.build.json
@@ -8,7 +8,8 @@
 		"credentials/**/*.ts",
 		"nodes/**/*.ts",
 		"nodes/**/*.json",
-		"credentials/translations/**/*.json"
+		"credentials/translations/**/*.json",
+		"types/**/*.ts"
 	],
 	"exclude": ["nodes/**/*.test.ts", "credentials/**/*.test.ts", "test/**"]
 }

--- a/packages/nodes-base/tsconfig.json
+++ b/packages/nodes-base/tsconfig.json
@@ -10,7 +10,13 @@
 		"noImplicitReturns": false,
 		"useUnknownInCatchVariables": false
 	},
-	"include": ["credentials/**/*.ts", "nodes/**/*.ts", "test/**/*.ts", "utils/**/*.ts"],
+	"include": [
+		"credentials/**/*.ts",
+		"nodes/**/*.ts",
+		"test/**/*.ts",
+		"utils/**/*.ts",
+		"types/**/*.ts"
+	],
 	"references": [
 		{ "path": "../@n8n/imap/tsconfig.build.json" },
 		{ "path": "../workflow/tsconfig.build.json" },

--- a/packages/nodes-base/types/generate-schema.d.ts
+++ b/packages/nodes-base/types/generate-schema.d.ts
@@ -1,0 +1,27 @@
+declare module 'generate-schema' {
+	export interface SchemaObject {
+		$schema: string;
+		title?: string;
+		type: string;
+		properties?: {
+			[key: string]: SchemaObject | SchemaArray | SchemaProperty;
+		};
+		required?: string[];
+		items?: SchemaObject | SchemaArray;
+	}
+
+	export interface SchemaArray {
+		type: string;
+		items?: SchemaObject | SchemaArray | SchemaProperty;
+		oneOf?: Array<SchemaObject | SchemaArray | SchemaProperty>;
+		required?: string[];
+	}
+
+	export interface SchemaProperty {
+		type: string | string[];
+		format?: string;
+	}
+
+	export function json(title: string, schema: SchemaObject): SchemaObject;
+	export function json(schema: SchemaObject): SchemaObject;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,7 +1111,7 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: 'catalog:'
-        version: 0.3.15(openai@4.69.0(zod@3.23.8))
+        version: 0.3.15(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
       '@n8n/client-oauth2':
         specifier: workspace:*
         version: link:../@n8n/client-oauth2
@@ -1662,6 +1662,9 @@ importers:
       fflate:
         specifier: 0.7.4
         version: 0.7.4
+      generate-schema:
+        specifier: 2.6.0
+        version: 2.6.0
       get-system-fonts:
         specifier: 2.0.2
         version: 2.0.2
@@ -1939,7 +1942,7 @@ importers:
     devDependencies:
       '@langchain/core':
         specifier: 'catalog:'
-        version: 0.3.15(openai@4.69.0)
+        version: 0.3.15(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
       '@types/deep-equal':
         specifier: ^1.0.1
         version: 1.0.1
@@ -14657,38 +14660,6 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/core@0.3.15(openai@4.69.0(zod@3.23.8))':
-    dependencies:
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.12
-      langsmith: 0.2.3(openai@4.69.0(zod@3.23.8))
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
-    transitivePeerDependencies:
-      - openai
-
-  '@langchain/core@0.3.15(openai@4.69.0)':
-    dependencies:
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.12
-      langsmith: 0.2.3(openai@4.69.0)
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.23.8
-      zod-to-json-schema: 3.23.3(zod@3.23.8)
-    transitivePeerDependencies:
-      - openai
-
   '@langchain/google-common@0.1.1(@langchain/core@0.3.15(openai@4.69.0(encoding@0.1.13)(zod@3.23.8)))(zod@3.23.8)':
     dependencies:
       '@langchain/core': 0.3.15(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
@@ -20420,7 +20391,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.7.4(debug@4.3.7))
+      retry-axios: 2.6.0(axios@1.7.4)
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -21450,28 +21421,6 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.69.0(encoding@0.1.13)(zod@3.23.8)
-
-  langsmith@0.2.3(openai@4.69.0(zod@3.23.8)):
-    dependencies:
-      '@types/uuid': 10.0.0
-      commander: 10.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      semver: 7.6.0
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 4.69.0(zod@3.23.8)
-
-  langsmith@0.2.3(openai@4.69.0):
-    dependencies:
-      '@types/uuid': 10.0.0
-      commander: 10.0.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      semver: 7.6.0
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 4.69.0(zod@3.23.8)
 
   lazy-ass@1.6.0: {}
 
@@ -22807,22 +22756,6 @@ snapshots:
       - encoding
       - supports-color
 
-  openai@4.69.0(zod@3.23.8):
-    dependencies:
-      '@types/node': 18.16.16
-      '@types/node-fetch': 2.6.4
-      abort-controller: 3.0.0
-      agentkeepalive: 4.2.1
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-    optionalDependencies:
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
   openapi-sampler@1.5.1:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -23807,9 +23740,9 @@ snapshots:
 
   ret@0.1.15: {}
 
-  retry-axios@2.6.0(axios@1.7.4(debug@4.3.7)):
+  retry-axios@2.6.0(axios@1.7.4):
     dependencies:
-      axios: 1.7.4(debug@4.3.7)
+      axios: 1.7.4
 
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:


### PR DESCRIPTION
## Summary

Add JSON Schema and JSON Example modes for providing the interface to the workflow. Also include the dropdown itself, superseding #11900 . 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2906/execute-workflow-trigger-node-specify-using-json


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
