### PR TITLE
fix(editor): Unify executions card label color

### DIFF
--- a/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
+++ b/packages/editor-ui/src/components/executions/global/GlobalExecutionsListItem.vue
@@ -351,7 +351,7 @@ async function handleActionItemClick(commandData: Command) {
 	}
 
 	&.new td:first-child::before {
-		background: var(--execution-card-border-new);
+		background: var(--execution-card-border-waiting);
 	}
 
 	&.running td:first-child::before {
@@ -401,8 +401,8 @@ async function handleActionItemClick(commandData: Command) {
 		font-weight: var(--font-weight-normal);
 	}
 
-	.new {
-		color: var(--color-text-dark);
+	.new & {
+		color: var(--execution-card-text-waiting);
 	}
 
 	.running & {


### PR DESCRIPTION
## Summary

Use the same color for queued execution in the project executions tab as in the workflow executions tab

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2308](https://linear.app/n8n/issue/PAY-2308/fix-queued-execution-card-color-in-project-executions-view)

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] PR Labeled with `release/backport`
