### PR TITLE
fix: Chat triggers don't work with the new partial execution flow

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -126,7 +126,7 @@ describe('processError', () => {
 });
 
 describe('run', () => {
-	it('uses recreateNodeExecutionStack to create a partial execution if a preferredTrigger with data is sent', async () => {
+	it('uses recreateNodeExecutionStack to create a partial execution if a triggerToStartFrom with data is sent', async () => {
 		// ARRANGE
 		const activeExecutions = Container.get(ActiveExecutions);
 		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
@@ -151,7 +151,7 @@ describe('run', () => {
 			});
 
 		const data = mock<IWorkflowExecutionDataProcess>({
-			preferredTrigger: { name: 'trigger', data: mock<ITaskData>() },
+			triggerToStartFrom: { name: 'trigger', data: mock<ITaskData>() },
 
 			workflowData: { nodes: [] },
 			executionData: undefined,
@@ -166,7 +166,7 @@ describe('run', () => {
 		expect(recreateNodeExecutionStackSpy).toHaveBeenCalled();
 	});
 
-	it('does not use recreateNodeExecutionStack to create a partial execution if a preferredTrigger without data is sent', async () => {
+	it('does not use recreateNodeExecutionStack to create a partial execution if a triggerToStartFrom without data is sent', async () => {
 		// ARRANGE
 		const activeExecutions = Container.get(ActiveExecutions);
 		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
@@ -183,7 +183,7 @@ describe('run', () => {
 		const recreateNodeExecutionStackSpy = jest.spyOn(core, 'recreateNodeExecutionStack');
 
 		const data = mock<IWorkflowExecutionDataProcess>({
-			preferredTrigger: { name: 'trigger', data: undefined },
+			triggerToStartFrom: { name: 'trigger', data: undefined },
 
 			workflowData: { nodes: [] },
 			executionData: undefined,

--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -1,4 +1,23 @@
-import { WorkflowHooks, type ExecutionError, type IWorkflowExecuteHooks } from 'n8n-workflow';
+import { mock } from 'jest-mock-extended';
+import { DirectedGraph, WorkflowExecute } from 'n8n-core';
+import * as core from 'n8n-core';
+import type {
+	IExecuteData,
+	INode,
+	IRun,
+	ITaskData,
+	IWaitingForExecution,
+	IWaitingForExecutionSource,
+	IWorkflowExecutionDataProcess,
+	StartNodeData,
+} from 'n8n-workflow';
+import {
+	Workflow,
+	WorkflowHooks,
+	type ExecutionError,
+	type IWorkflowExecuteHooks,
+} from 'n8n-workflow';
+import PCancelable from 'p-cancelable';
 import Container from 'typedi';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -6,6 +25,7 @@ import config from '@/config';
 import type { User } from '@/databases/entities/user';
 import { ExecutionNotFoundError } from '@/errors/execution-not-found-error';
 import { Telemetry } from '@/telemetry';
+import { PermissionChecker } from '@/user-management/permission-checker';
 import { WorkflowRunner } from '@/workflow-runner';
 import { mockInstance } from '@test/mocking';
 import { createExecution } from '@test-integration/db/executions';
@@ -43,6 +63,7 @@ afterAll(() => {
 
 beforeEach(async () => {
 	await testDb.truncate(['Workflow', 'SharedWorkflow']);
+	jest.clearAllMocks();
 });
 
 describe('processError', () => {
@@ -101,5 +122,79 @@ describe('processError', () => {
 			new WorkflowHooks(hookFunctions, 'webhook', execution.id, workflow),
 		);
 		expect(watchedWorkflowExecuteAfter).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('run', () => {
+	it('uses recreateNodeExecutionStack to create a partial execution if a preferredTrigger with data is sent', async () => {
+		// ARRANGE
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
+		const permissionChecker = Container.get(PermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		jest.spyOn(WorkflowExecute.prototype, 'processRunExecutionData').mockReturnValueOnce(
+			new PCancelable(() => {
+				return mock<IRun>();
+			}),
+		);
+
+		jest.spyOn(Workflow.prototype, 'getNode').mockReturnValueOnce(mock<INode>());
+		jest.spyOn(DirectedGraph, 'fromWorkflow').mockReturnValueOnce(new DirectedGraph());
+		const recreateNodeExecutionStackSpy = jest
+			.spyOn(core, 'recreateNodeExecutionStack')
+			.mockReturnValueOnce({
+				nodeExecutionStack: mock<IExecuteData[]>(),
+				waitingExecution: mock<IWaitingForExecution>(),
+				waitingExecutionSource: mock<IWaitingForExecutionSource>(),
+			});
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			preferredTrigger: { name: 'trigger', data: mock<ITaskData>() },
+
+			workflowData: { nodes: [] },
+			executionData: undefined,
+			startNodes: [mock<StartNodeData>()],
+			destinationNode: undefined,
+		});
+
+		// ACT
+		await runner.run(data);
+
+		// ASSERT
+		expect(recreateNodeExecutionStackSpy).toHaveBeenCalled();
+	});
+
+	it('does not use recreateNodeExecutionStack to create a partial execution if a preferredTrigger without data is sent', async () => {
+		// ARRANGE
+		const activeExecutions = Container.get(ActiveExecutions);
+		jest.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+		jest.spyOn(activeExecutions, 'attachWorkflowExecution').mockReturnValueOnce();
+		const permissionChecker = Container.get(PermissionChecker);
+		jest.spyOn(permissionChecker, 'check').mockResolvedValueOnce();
+
+		jest.spyOn(WorkflowExecute.prototype, 'processRunExecutionData').mockReturnValueOnce(
+			new PCancelable(() => {
+				return mock<IRun>();
+			}),
+		);
+
+		const recreateNodeExecutionStackSpy = jest.spyOn(core, 'recreateNodeExecutionStack');
+
+		const data = mock<IWorkflowExecutionDataProcess>({
+			preferredTrigger: { name: 'trigger', data: undefined },
+
+			workflowData: { nodes: [] },
+			executionData: undefined,
+			startNodes: [mock<StartNodeData>()],
+			destinationNode: undefined,
+		});
+
+		// ACT
+		await runner.run(data);
+
+		// ASSERT
+		expect(recreateNodeExecutionStackSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -45,9 +45,11 @@ describe('TestWebhooks', () => {
 
 	describe('needsWebhook()', () => {
 		const args: Parameters<typeof testWebhooks.needsWebhook> = [
-			userId,
-			workflowEntity,
-			mock<IWorkflowExecuteAdditionalData>(),
+			{
+				userId,
+				workflowEntity,
+				additionalData: mock<IWorkflowExecuteAdditionalData>(),
+			},
 		];
 
 		test('if webhook is needed, should register then create webhook and return true', async () => {

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -95,14 +95,14 @@ describe('TestWebhooks', () => {
 			expect(result).toBe(false);
 		});
 
-		test('returns false if a preferredTrigger with triggerData is given', async () => {
+		test('returns false if a triggerToStartFrom with triggerData is given', async () => {
 			const workflow = mock<Workflow>();
 			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(workflow);
 			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook]);
 
 			const needsWebhook = await testWebhooks.needsWebhook({
 				...args,
-				preferredTrigger: {
+				triggerToStartFrom: {
 					name: 'trigger',
 					data: mock<ITaskData>(),
 				},
@@ -111,7 +111,7 @@ describe('TestWebhooks', () => {
 			expect(needsWebhook).toBe(false);
 		});
 
-		test('returns true, registers and then creates webhook if preferredTrigger is given with no triggerData', async () => {
+		test('returns true, registers and then creates webhook if triggerToStartFrom is given with no triggerData', async () => {
 			// ARRANGE
 			const workflow = mock<Workflow>();
 			const webhook2 = mock<IWebhookData>({
@@ -127,7 +127,7 @@ describe('TestWebhooks', () => {
 			// ACT
 			const needsWebhook = await testWebhooks.needsWebhook({
 				...args,
-				preferredTrigger: { name: 'trigger' },
+				triggerToStartFrom: { name: 'trigger' },
 			});
 
 			// ASSERT

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -1,6 +1,11 @@
 import type * as express from 'express';
 import { mock } from 'jest-mock-extended';
-import type { IWebhookData, IWorkflowExecuteAdditionalData, Workflow } from 'n8n-workflow';
+import type { ITaskData } from 'n8n-workflow';
+import {
+	type IWebhookData,
+	type IWorkflowExecuteAdditionalData,
+	type Workflow,
+} from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
 import { generateNanoId } from '@/databases/utils/generators';
@@ -43,14 +48,16 @@ describe('TestWebhooks', () => {
 		jest.useFakeTimers();
 	});
 
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	describe('needsWebhook()', () => {
-		const args: Parameters<typeof testWebhooks.needsWebhook> = [
-			{
-				userId,
-				workflowEntity,
-				additionalData: mock<IWorkflowExecuteAdditionalData>(),
-			},
-		];
+		const args: Parameters<typeof testWebhooks.needsWebhook>[0] = {
+			userId,
+			workflowEntity,
+			additionalData: mock<IWorkflowExecuteAdditionalData>(),
+		};
 
 		test('if webhook is needed, should register then create webhook and return true', async () => {
 			const workflow = mock<Workflow>();
@@ -58,7 +65,7 @@ describe('TestWebhooks', () => {
 			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(workflow);
 			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook]);
 
-			const needsWebhook = await testWebhooks.needsWebhook(...args);
+			const needsWebhook = await testWebhooks.needsWebhook(args);
 
 			const [registerOrder] = registrations.register.mock.invocationCallOrder;
 			const [createOrder] = workflow.createWebhookIfNotExists.mock.invocationCallOrder;
@@ -74,7 +81,7 @@ describe('TestWebhooks', () => {
 			jest.spyOn(registrations, 'register').mockRejectedValueOnce(new Error(msg));
 			registrations.getAllRegistrations.mockResolvedValue([]);
 
-			const needsWebhook = testWebhooks.needsWebhook(...args);
+			const needsWebhook = testWebhooks.needsWebhook(args);
 
 			await expect(needsWebhook).rejects.toThrowError(msg);
 		});
@@ -83,9 +90,54 @@ describe('TestWebhooks', () => {
 			webhook.webhookDescription.restartWebhook = true;
 			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook]);
 
-			const result = await testWebhooks.needsWebhook(...args);
+			const result = await testWebhooks.needsWebhook(args);
 
 			expect(result).toBe(false);
+		});
+
+		test('returns false if a preferredTrigger with triggerData is given', async () => {
+			const workflow = mock<Workflow>();
+			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(workflow);
+			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook]);
+
+			const needsWebhook = await testWebhooks.needsWebhook({
+				...args,
+				preferredTrigger: {
+					name: 'trigger',
+					data: mock<ITaskData>(),
+				},
+			});
+
+			expect(needsWebhook).toBe(false);
+		});
+
+		test('returns true, registers and then creates webhook if preferredTrigger is given with no triggerData', async () => {
+			// ARRANGE
+			const workflow = mock<Workflow>();
+			const webhook2 = mock<IWebhookData>({
+				node: 'trigger',
+				httpMethod,
+				path,
+				workflowId: workflowEntity.id,
+				userId,
+			});
+			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValueOnce(workflow);
+			jest.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([webhook, webhook2]);
+
+			// ACT
+			const needsWebhook = await testWebhooks.needsWebhook({
+				...args,
+				preferredTrigger: { name: 'trigger' },
+			});
+
+			// ASSERT
+			const [registerOrder] = registrations.register.mock.invocationCallOrder;
+			const [createOrder] = workflow.createWebhookIfNotExists.mock.invocationCallOrder;
+
+			expect(registerOrder).toBeLessThan(createOrder);
+			expect(registrations.register.mock.calls[0][0].webhook.node).toBe(webhook2.node);
+			expect(workflow.createWebhookIfNotExists.mock.calls[0][0].node).toBe(webhook2.node);
+			expect(needsWebhook).toBe(true);
 		});
 	});
 

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -218,14 +218,20 @@ export class TestWebhooks implements IWebhookManager {
 	 * Return whether activating a workflow requires listening for webhook calls.
 	 * For every webhook call to listen for, also activate the webhook.
 	 */
-	async needsWebhook(
-		userId: string,
-		workflowEntity: IWorkflowDb,
-		additionalData: IWorkflowExecuteAdditionalData,
-		runData?: IRunData,
-		pushRef?: string,
-		destinationNode?: string,
-	) {
+	async needsWebhook(options: {
+		userId: string;
+		workflowEntity: IWorkflowDb;
+		additionalData: IWorkflowExecuteAdditionalData;
+		runData?: IRunData;
+		pushRef?: string;
+		destinationNode?: string;
+	}) {
+		const userId = options.userId;
+		const workflowEntity = options.workflowEntity;
+		const additionalData = options.additionalData;
+		const runData = options.runData;
+		const pushRef = options.pushRef;
+		const destinationNode = options.destinationNode;
 		if (!workflowEntity.id) throw new WorkflowMissingIdError(workflowEntity);
 
 		const workflow = this.toWorkflow(workflowEntity);

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -261,7 +261,7 @@ export class TestWebhooks implements IWebhookManager {
 			webhooks = webhooks.filter((w) => w.node === triggerToStartFrom.name);
 		}
 
-		if (webhooks.some((w) => w.webhookDescription.restartWebhook ?? false)) {
+		if (!webhooks.some((w) => w.webhookDescription.restartWebhook !== true)) {
 			return false; // no webhooks found to start a workflow
 		}
 

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -228,13 +228,15 @@ export class TestWebhooks implements IWebhookManager {
 		destinationNode?: string;
 		preferredTrigger?: WorkflowRequest.ManualRunPayload['preferredTrigger'];
 	}) {
-		const userId = options.userId;
-		const workflowEntity = options.workflowEntity;
-		const additionalData = options.additionalData;
-		const runData = options.runData;
-		const pushRef = options.pushRef;
-		const destinationNode = options.destinationNode;
-		const preferredTrigger = options.preferredTrigger;
+		const {
+			userId,
+			workflowEntity,
+			additionalData,
+			runData,
+			pushRef,
+			destinationNode,
+			preferredTrigger,
+		} = options;
 
 		if (!workflowEntity.id) throw new WorkflowMissingIdError(workflowEntity);
 

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -226,7 +226,7 @@ export class TestWebhooks implements IWebhookManager {
 		runData?: IRunData;
 		pushRef?: string;
 		destinationNode?: string;
-		preferredTrigger?: WorkflowRequest.ManualRunPayload['preferredTrigger'];
+		triggerToStartFrom?: WorkflowRequest.ManualRunPayload['triggerToStartFrom'];
 	}) {
 		const {
 			userId,
@@ -235,7 +235,7 @@ export class TestWebhooks implements IWebhookManager {
 			runData,
 			pushRef,
 			destinationNode,
-			preferredTrigger,
+			triggerToStartFrom,
 		} = options;
 
 		if (!workflowEntity.id) throw new WorkflowMissingIdError(workflowEntity);
@@ -251,17 +251,17 @@ export class TestWebhooks implements IWebhookManager {
 
 		// If we have a preferred trigger with data, we don't have to listen for a
 		// webhook.
-		if (preferredTrigger?.data) {
+		if (triggerToStartFrom?.data) {
 			return false;
 		}
 
 		// If we have a preferred trigger without data we only want to listen for
 		// that trigger, not the other ones.
-		if (preferredTrigger) {
-			webhooks = webhooks.filter((w) => w.node === preferredTrigger.name);
+		if (triggerToStartFrom) {
+			webhooks = webhooks.filter((w) => w.node === triggerToStartFrom.name);
 		}
 
-		if (!webhooks.some((w) => w.webhookDescription.restartWebhook !== true)) {
+		if (webhooks.some((w) => w.webhookDescription.restartWebhook ?? false)) {
 			return false; // no webhooks found to start a workflow
 		}
 

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -253,6 +253,8 @@ export class TestWebhooks implements IWebhookManager {
 			return false;
 		}
 
+		// If we have a preferred trigger without data we only want to listen for
+		// that trigger, not the other ones.
 		if (preferredTrigger) {
 			webhooks = webhooks.filter((w) => w.node === preferredTrigger.name);
 		}

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -305,21 +305,17 @@ export class WorkflowRunner {
 					a.ok(node, `Could not find a node named "${data.name}" in the workflow.`);
 					return node;
 				});
+				const runData = { [data.triggerToStartFrom.name]: [data.triggerToStartFrom.data] };
 
 				const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
 					recreateNodeExecutionStack(
 						filterDisabledNodes(DirectedGraph.fromWorkflow(workflow)),
 						new Set(startNodes),
-						{ [data.triggerToStartFrom.name]: [data.triggerToStartFrom.data] },
+						runData,
 						data.pinData ?? {},
 					);
 				const executionData: IRunExecutionData = {
-					resultData: {
-						runData: data.runData ?? {
-							[data.triggerToStartFrom.name]: [data.triggerToStartFrom.data],
-						},
-						pinData,
-					},
+					resultData: { runData, pinData },
 					executionData: {
 						contextData: {},
 						metadata: {},

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -295,9 +295,9 @@ export class WorkflowRunner {
 					data.executionData,
 				);
 				workflowExecution = workflowExecute.processRunExecutionData(workflow);
-			} else if (data.preferredTrigger?.data && data.startNodes && !data.destinationNode) {
+			} else if (data.triggerToStartFrom?.data && data.startNodes && !data.destinationNode) {
 				this.logger.debug(
-					`Execution ID ${executionId} had preferredTrigger. Starting from that trigger.`,
+					`Execution ID ${executionId} had triggerToStartFrom. Starting from that trigger.`,
 					{ executionId },
 				);
 				const startNodes = data.startNodes.map((data) => {
@@ -310,13 +310,13 @@ export class WorkflowRunner {
 					recreateNodeExecutionStack(
 						filterDisabledNodes(DirectedGraph.fromWorkflow(workflow)),
 						new Set(startNodes),
-						{ [data.preferredTrigger.name]: [data.preferredTrigger.data] },
+						{ [data.triggerToStartFrom.name]: [data.triggerToStartFrom.data] },
 						data.pinData ?? {},
 					);
 				const executionData: IRunExecutionData = {
 					resultData: {
 						runData: data.runData ?? {
-							[data.preferredTrigger.name]: [data.preferredTrigger.data],
+							[data.triggerToStartFrom.name]: [data.triggerToStartFrom.data],
 						},
 						pinData,
 					},

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -341,8 +341,8 @@ export class WorkflowRunner {
 				// be removed and the previous one can be merged into
 				// `workflowExecute.runPartialWorkflow2`.
 				// Partial executions then require either a destination node from which
-				// everything else can be derived, or a preferredTrigger with
-				// triggerData. Full Execution
+				// everything else can be derived, or a triggerToStartFrom with
+				// triggerData.
 				this.logger.debug(`Execution ID ${executionId} will run executing all nodes.`, {
 					executionId,
 				});

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -2,7 +2,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { InstanceSettings, WorkflowExecute } from 'n8n-core';
+import * as a from 'assert/strict';
+import {
+	DirectedGraph,
+	InstanceSettings,
+	WorkflowExecute,
+	filterDisabledNodes,
+	recreateNodeExecutionStack,
+} from 'n8n-core';
 import type {
 	ExecutionError,
 	IDeferredPromise,
@@ -12,6 +19,7 @@ import type {
 	WorkflowExecuteMode,
 	WorkflowHooks,
 	IWorkflowExecutionDataProcess,
+	IRunExecutionData,
 } from 'n8n-workflow';
 import {
 	ErrorReporterProxy as ErrorReporter,
@@ -203,6 +211,7 @@ export class WorkflowRunner {
 	}
 
 	/** Run the workflow in current process */
+	// eslint-disable-next-line complexity
 	private async runMainProcess(
 		executionId: string,
 		data: IWorkflowExecutionDataProcess,
@@ -286,12 +295,54 @@ export class WorkflowRunner {
 					data.executionData,
 				);
 				workflowExecution = workflowExecute.processRunExecutionData(workflow);
+			} else if (data.preferredTrigger?.data && data.startNodes && !data.destinationNode) {
+				this.logger.debug(
+					`Execution ID ${executionId} had preferredTrigger. Starting from that trigger.`,
+					{ executionId },
+				);
+				const startNodes = data.startNodes.map((data) => {
+					const node = workflow.getNode(data.name);
+					a.ok(node, `Could not find a node named "${data.name}" in the workflow.`);
+					return node;
+				});
+
+				const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
+					recreateNodeExecutionStack(
+						filterDisabledNodes(DirectedGraph.fromWorkflow(workflow)),
+						new Set(startNodes),
+						{ [data.preferredTrigger.name]: [data.preferredTrigger.data] },
+						data.pinData ?? {},
+					);
+				const executionData: IRunExecutionData = {
+					resultData: {
+						runData: data.runData ?? {
+							[data.preferredTrigger.name]: [data.preferredTrigger.data],
+						},
+						pinData,
+					},
+					executionData: {
+						contextData: {},
+						metadata: {},
+						nodeExecutionStack,
+						waitingExecution,
+						waitingExecutionSource,
+					},
+				};
+
+				const workflowExecute = new WorkflowExecute(additionalData, 'manual', executionData);
+				workflowExecution = workflowExecute.processRunExecutionData(workflow);
 			} else if (
 				data.runData === undefined ||
 				data.startNodes === undefined ||
 				data.startNodes.length === 0
 			) {
 				// Full Execution
+				// TODO: When the old partial execution logic is removed this block can
+				// be removed and the previous one can be merged into
+				// `workflowExecute.runPartialWorkflow2`.
+				// Partial executions then require either a destination node from which
+				// everything else can be derived, or a preferredTrigger with
+				// triggerData. Full Execution
 				this.logger.debug(`Execution ID ${executionId} will run executing all nodes.`, {
 					executionId,
 				});

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -117,14 +117,14 @@ export class WorkflowExecutionService {
 		) {
 			const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id);
 
-			const needsWebhook = await this.testWebhooks.needsWebhook(
-				user.id,
-				workflowData,
+			const needsWebhook = await this.testWebhooks.needsWebhook({
+				userId: user.id,
+				workflowEntity: workflowData,
 				additionalData,
 				runData,
 				pushRef,
 				destinationNode,
-			);
+			});
 
 			if (needsWebhook) return { waitingForWebhook: true };
 		}

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -95,6 +95,7 @@ export class WorkflowExecutionService {
 			startNodes,
 			destinationNode,
 			dirtyNodeNames,
+			preferredTrigger,
 		}: WorkflowRequest.ManualRunPayload,
 		user: User,
 		pushRef?: string,
@@ -124,6 +125,7 @@ export class WorkflowExecutionService {
 				runData,
 				pushRef,
 				destinationNode,
+				preferredTrigger,
 			});
 
 			if (needsWebhook) return { waitingForWebhook: true };
@@ -144,6 +146,7 @@ export class WorkflowExecutionService {
 			userId: user.id,
 			partialExecutionVersion: partialExecutionVersion ?? '0',
 			dirtyNodeNames,
+			preferredTrigger,
 		};
 
 		const hasRunData = (node: INode) => runData !== undefined && !!runData[node.name];

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -95,7 +95,7 @@ export class WorkflowExecutionService {
 			startNodes,
 			destinationNode,
 			dirtyNodeNames,
-			preferredTrigger,
+			triggerToStartFrom,
 		}: WorkflowRequest.ManualRunPayload,
 		user: User,
 		pushRef?: string,
@@ -125,7 +125,7 @@ export class WorkflowExecutionService {
 				runData,
 				pushRef,
 				destinationNode,
-				preferredTrigger,
+				triggerToStartFrom,
 			});
 
 			if (needsWebhook) return { waitingForWebhook: true };
@@ -146,7 +146,7 @@ export class WorkflowExecutionService {
 			userId: user.id,
 			partialExecutionVersion: partialExecutionVersion ?? '0',
 			dirtyNodeNames,
-			preferredTrigger,
+			triggerToStartFrom,
 		};
 
 		const hasRunData = (node: INode) => runData !== undefined && !!runData[node.name];

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -30,7 +30,7 @@ export declare namespace WorkflowRequest {
 		startNodes?: StartNodeData[];
 		destinationNode?: string;
 		dirtyNodeNames?: string[];
-		preferredTrigger?: {
+		triggerToStartFrom?: {
 			name: string;
 			data?: ITaskData;
 		};

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,4 +1,11 @@
-import type { INode, IConnections, IWorkflowSettings, IRunData, StartNodeData } from 'n8n-workflow';
+import type {
+	INode,
+	IConnections,
+	IWorkflowSettings,
+	IRunData,
+	StartNodeData,
+	ITaskData,
+} from 'n8n-workflow';
 
 import type { IWorkflowDb } from '@/interfaces';
 import type { AuthenticatedRequest, ListQuery } from '@/requests';
@@ -23,6 +30,10 @@ export declare namespace WorkflowRequest {
 		startNodes?: StartNodeData[];
 		destinationNode?: string;
 		dirtyNodeNames?: string[];
+		preferredTrigger?: {
+			name: string;
+			data?: ITaskData;
+		};
 	};
 
 	type Create = AuthenticatedRequest<{}, {}, CreateUpdatePayload>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,4 @@ export { BinaryData } from './BinaryData/types';
 export { isStoredMode as isValidNonDefaultMode } from './BinaryData/utils';
 export * from './ExecutionMetadata';
 export * from './node-execution-context';
+export * from './PartialExecutionUtils';

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -46,6 +46,7 @@ import type {
 	StartNodeData,
 	IPersonalizationSurveyAnswersV4,
 	AnnotationVote,
+	ITaskData,
 } from 'n8n-workflow';
 
 import type {
@@ -201,6 +202,10 @@ export interface IStartRunData {
 	destinationNode?: string;
 	runData?: IRunData;
 	dirtyNodeNames?: string[];
+	preferredTrigger?: {
+		name: string;
+		data?: ITaskData;
+	};
 }
 
 export interface ITableData {

--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -202,7 +202,7 @@ export interface IStartRunData {
 	destinationNode?: string;
 	runData?: IRunData;
 	dirtyNodeNames?: string[];
-	preferredTrigger?: {
+	triggerToStartFrom?: {
 		name: string;
 		data?: ITaskData;
 	};

--- a/packages/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -327,7 +327,7 @@ describe('useRunWorkflow({ router })', () => {
 			);
 		});
 
-		it('should send preferredTrigger if triggerNode and nodeData are passed in', async () => {
+		it('should send triggerToStartFrom if triggerNode and nodeData are passed in', async () => {
 			// ARRANGE
 			const composable = useRunWorkflow({ router });
 			const triggerNode = 'Chat Trigger';
@@ -347,7 +347,7 @@ describe('useRunWorkflow({ router })', () => {
 			// ASSERT
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({
-					preferredTrigger: {
+					triggerToStartFrom: {
 						name: triggerNode,
 						data: nodeData,
 					},

--- a/packages/editor-ui/src/composables/useRunWorkflow.test.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.test.ts
@@ -8,6 +8,7 @@ import {
 	type IRunData,
 	type Workflow,
 	type IExecuteData,
+	type ITaskData,
 } from 'n8n-workflow';
 
 import { useRootStore } from '@/stores/root.store';
@@ -20,6 +21,7 @@ import { useToast } from './useToast';
 import { useI18n } from '@/composables/useI18n';
 import { useLocalStorage } from '@vueuse/core';
 import { ref } from 'vue';
+import { mock } from 'vitest-mock-extended';
 
 vi.mock('@/stores/workflows.store', () => ({
 	useWorkflowsStore: vi.fn().mockReturnValue({
@@ -322,6 +324,34 @@ describe('useRunWorkflow({ router })', () => {
 
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ dirtyNodeNames: [executeName] }),
+			);
+		});
+
+		it('should send preferredTrigger if triggerNode and nodeData are passed in', async () => {
+			// ARRANGE
+			const composable = useRunWorkflow({ router });
+			const triggerNode = 'Chat Trigger';
+			const nodeData = mock<ITaskData>();
+			vi.mocked(workflowHelpers).getCurrentWorkflow.mockReturnValue(
+				mock<Workflow>({ getChildNodes: vi.fn().mockReturnValue([]) }),
+			);
+			vi.mocked(workflowHelpers).getWorkflowDataToSave.mockResolvedValue(
+				mock<IWorkflowData>({ nodes: [] }),
+			);
+
+			const { runWorkflow } = composable;
+
+			// ACT
+			await runWorkflow({ triggerNode, nodeData });
+
+			// ASSERT
+			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({
+					preferredTrigger: {
+						name: triggerNode,
+						data: nodeData,
+					},
+				}),
 			);
 		});
 

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -150,6 +150,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 
 			let { runData: newRunData } = consolidatedData;
 			let executedNode: string | undefined;
+			let preferredTrigger: IStartRunData['preferredTrigger'];
 			if (
 				startNodeNames.length === 0 &&
 				'destinationNode' in options &&
@@ -157,14 +158,16 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			) {
 				executedNode = options.destinationNode;
 				startNodeNames.push(options.destinationNode);
-			} else if ('triggerNode' in options && 'nodeData' in options) {
+			} else if (options.triggerNode && options.nodeData) {
 				startNodeNames.push(
-					...workflow.getChildNodes(options.triggerNode as string, NodeConnectionType.Main, 1),
+					...workflow.getChildNodes(options.triggerNode, NodeConnectionType.Main, 1),
 				);
-				newRunData = {
-					[options.triggerNode as string]: [options.nodeData],
-				} as IRunData;
+				newRunData = { [options.triggerNode]: [options.nodeData] };
 				executedNode = options.triggerNode;
+				preferredTrigger = {
+					name: options.triggerNode,
+					data: options.nodeData,
+				};
 			}
 
 			// If the destination node is specified, check if it is a chat node or has a chat parent
@@ -258,6 +261,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				// data to use and what to ignore.
 				runData: partialExecutionVersion.value === 1 ? (runData ?? undefined) : newRunData,
 				startNodes,
+				preferredTrigger,
 			};
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -150,7 +150,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 
 			let { runData: newRunData } = consolidatedData;
 			let executedNode: string | undefined;
-			let preferredTrigger: IStartRunData['preferredTrigger'];
+			let triggerToStartFrom: IStartRunData['triggerToStartFrom'];
 			if (
 				startNodeNames.length === 0 &&
 				'destinationNode' in options &&
@@ -164,7 +164,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				);
 				newRunData = { [options.triggerNode]: [options.nodeData] };
 				executedNode = options.triggerNode;
-				preferredTrigger = {
+				triggerToStartFrom = {
 					name: options.triggerNode,
 					data: options.nodeData,
 				};
@@ -261,7 +261,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				// data to use and what to ignore.
 				runData: partialExecutionVersion.value === 1 ? (runData ?? undefined) : newRunData,
 				startNodes,
-				preferredTrigger,
+				triggerToStartFrom,
 			};
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2275,7 +2275,7 @@ export interface IWorkflowExecutionDataProcess {
 	 */
 	partialExecutionVersion?: string;
 	dirtyNodeNames?: string[];
-	preferredTrigger?: {
+	triggerToStartFrom?: {
 		name: string;
 		data?: ITaskData;
 	};

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2275,6 +2275,10 @@ export interface IWorkflowExecutionDataProcess {
 	 */
 	partialExecutionVersion?: string;
 	dirtyNodeNames?: string[];
+	preferredTrigger?: {
+		name: string;
+		data?: ITaskData;
+	};
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This fixes the chat trigger not working with the new execution flow. 

Before the chat trigger would always trigger a partial execution, but now a partial execution requires a destination node.

This PR alleviates this by re-using the parts of the new flow that does not require a destination node.

This will be simplified once we can remove the old partial execution flow logic.

**before:**

https://github.com/user-attachments/assets/bbc2f575-576c-4c4f-82b5-8838052c25e0

**after:**

https://github.com/user-attachments/assets/85c8c1f5-25af-4691-b49f-40793d9369f1


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2166/chat-triggers-dont-work-with-the-new-partial-execution-flow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
