### PR TITLE
fix(core): Execute nodes after loops correctly with the new partial execution flow

### DIFF
--- a/packages/core/src/PartialExecutionUtils/__tests__/helpers.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/helpers.ts
@@ -5,7 +5,7 @@ interface StubNode {
 	name: string;
 	parameters?: INodeParameters;
 	disabled?: boolean;
-	type?: string;
+	type?: 'n8n-nodes-base.manualTrigger' | 'n8n-nodes-base.splitInBatches' | (string & {});
 }
 
 export function createNodeData(stubData: StubNode): INode {

--- a/packages/core/src/PartialExecutionUtils/findStartNodes.ts
+++ b/packages/core/src/PartialExecutionUtils/findStartNodes.ts
@@ -1,7 +1,7 @@
-import type { INode, IPinData, IRunData } from 'n8n-workflow';
+import { NodeConnectionType, type INode, type IPinData, type IRunData } from 'n8n-workflow';
 
 import type { DirectedGraph } from './DirectedGraph';
-import { getIncomingData } from './getIncomingData';
+import { getIncomingData, getIncomingDataFromAnyRun } from './getIncomingData';
 
 /**
  * A node is dirty if either of the following is true:
@@ -73,6 +73,25 @@ function findStartNodesRecursive(
 		return startNodes;
 	}
 
+	// If the current node is a loop node, check if the `done` output has data on
+	// the last run. If it doesn't the loop wasn't fully executed and needs to be
+	// re-run from the start. Thus the loop node become the start node.
+	if (current.type === 'n8n-nodes-base.splitInBatches') {
+		const nodeRunData = getIncomingData(
+			runData,
+			current.name,
+			// last run
+			-1,
+			NodeConnectionType.Main,
+			0,
+		);
+
+		if (nodeRunData === null || nodeRunData.length === 0) {
+			startNodes.add(current);
+			return startNodes;
+		}
+	}
+
 	// If we detect a cycle stop following the branch, there is no start node on
 	// this branch.
 	if (seen.has(current)) {
@@ -82,19 +101,16 @@ function findStartNodesRecursive(
 	// Recurse with every direct child that is part of the sub graph.
 	const outGoingConnections = graph.getDirectChildConnections(current);
 	for (const outGoingConnection of outGoingConnections) {
-		const nodeRunData = getIncomingData(
+		const nodeRunData = getIncomingDataFromAnyRun(
 			runData,
 			outGoingConnection.from.name,
-			// NOTE: It's always 0 until I fix the bug that removes the run data for
-			// old runs. The FE only sends data for one run for each node.
-			0,
 			outGoingConnection.type,
 			outGoingConnection.outputIndex,
 		);
 
 		// If the node has multiple outputs, only follow the outputs that have run data.
 		const hasNoRunData =
-			nodeRunData === null || nodeRunData === undefined || nodeRunData.length === 0;
+			nodeRunData === null || nodeRunData === undefined || nodeRunData.data.length === 0;
 		if (hasNoRunData) {
 			continue;
 		}

--- a/packages/core/src/PartialExecutionUtils/getIncomingData.ts
+++ b/packages/core/src/PartialExecutionUtils/getIncomingData.ts
@@ -1,4 +1,3 @@
-import * as a from 'assert';
 import type { INodeExecutionData, IRunData, NodeConnectionType } from 'n8n-workflow';
 
 export function getIncomingData(
@@ -7,18 +6,8 @@ export function getIncomingData(
 	runIndex: number,
 	connectionType: NodeConnectionType,
 	outputIndex: number,
-): INodeExecutionData[] | null | undefined {
-	a.ok(runData[nodeName], `Can't find node with name '${nodeName}' in runData.`);
-	a.ok(
-		runData[nodeName][runIndex],
-		`Can't find a run for index '${runIndex}' for node name '${nodeName}'`,
-	);
-	a.ok(
-		runData[nodeName][runIndex].data,
-		`Can't find data for index '${runIndex}' for node name '${nodeName}'`,
-	);
-
-	return runData[nodeName][runIndex].data[connectionType][outputIndex];
+): INodeExecutionData[] | null {
+	return runData[nodeName]?.at(runIndex)?.data?.[connectionType].at(outputIndex) ?? null;
 }
 
 function getRunIndexLength(runData: IRunData, nodeName: string) {

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -360,7 +360,7 @@ export class WorkflowExecute {
 		startNodes = handleCycles(graph, startNodes, trigger);
 
 		// 6. Clean Run Data
-		const newRunData: IRunData = cleanRunData(runData, graph, startNodes);
+		runData = cleanRunData(runData, graph, startNodes);
 
 		// 7. Recreate Execution Stack
 		const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
@@ -374,7 +374,7 @@ export class WorkflowExecute {
 				runNodeFilter: Array.from(filteredNodes.values()).map((node) => node.name),
 			},
 			resultData: {
-				runData: newRunData,
+				runData,
 				pinData,
 			},
 			executionData: {

--- a/packages/core/test/helpers/constants.ts
+++ b/packages/core/test/helpers/constants.ts
@@ -11,6 +11,7 @@ import { ManualTrigger } from '../../../nodes-base/dist/nodes/ManualTrigger/Manu
 import { Merge } from '../../../nodes-base/dist/nodes/Merge/Merge.node';
 import { NoOp } from '../../../nodes-base/dist/nodes/NoOp/NoOp.node';
 import { Set } from '../../../nodes-base/dist/nodes/Set/Set.node';
+import { SplitInBatches } from '../../../nodes-base/dist/nodes/SplitInBatches/SplitInBatches.node';
 import { Start } from '../../../nodes-base/dist/nodes/Start/Start.node';
 
 export const predefinedNodesTypes: INodeTypeData = {
@@ -36,6 +37,10 @@ export const predefinedNodesTypes: INodeTypeData = {
 	},
 	'n8n-nodes-base.manualTrigger': {
 		type: new ManualTrigger(),
+		sourcePath: '',
+	},
+	'n8n-nodes-base.splitInBatches': {
+		type: new SplitInBatches(),
 		sourcePath: '',
 	},
 	'n8n-nodes-base.versionTest': {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Loops need a special treatment when finding the start node. If the loop hasn't fully completed it needs to be fully re-run. This is a simplification that saves us from figuring out how often the loop already ran and how often we still need to run it.

Additionally this fixes and issue were the wrong run data was passed into `recreateNodeExecutionStack`.

**Before:**

https://github.com/user-attachments/assets/d8ab8f18-03c2-4041-a3f2-4d31608afcc6

Contains two fixes:

- **feature(core): add custom logic to `findStartNodes` to handle loops**

**After:**

https://github.com/user-attachments/assets/5922156a-023e-4f62-935a-336ad6e70840

- **fix(core): Pass the correct runData to `recreateNodeExecutionStack`**

**After:**

https://github.com/user-attachments/assets/fc76e9e6-5388-420a-8baf-261b7871f637

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2167/executing-a-node-after-a-loop-node-does-not-work


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
