### PR TITLE
fix(editor): Retry button in AI assistant failing to show

### DIFF
--- a/packages/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
+++ b/packages/design-system/src/components/AskAssistantChat/AskAssistantChat.vue
@@ -237,7 +237,7 @@ async function onCopyButtonClick(content: string, e: MouseEvent) {
 								data-test-id="error-retry-button"
 								@click="() => message.retry?.()"
 							>
-								{{ t('generic.retry') }}
+								{{ t('assistantChat.retry') }}
 							</n8n-button>
 						</div>
 						<div v-else-if="message.type === 'code-diff'">

--- a/packages/design-system/src/locale/lang/en.ts
+++ b/packages/design-system/src/locale/lang/en.ts
@@ -46,5 +46,6 @@ export default {
 	'assistantChat.inputPlaceholder': 'Enter your response...',
 	'assistantChat.copy': 'Copy',
 	'assistantChat.copied': 'Copied',
+	'assistantChat.retry': 'Retry',
 	'inlineAskAssistantButton.asked': 'Asked',
 } as N8nLocale;


### PR DESCRIPTION
## Summary

 components in the `design-system` only loads keys from the `en.ts` in the same folder, and we were referencing a key from the `en.ts` in the `editor-ui` folder.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2951/bug-retry-button-failing-to-show

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
