### PR TITLE
Add missing _FILE env variables for SSL DB configuration to README

### DIFF
--- a/docker/images/n8n/README.md
+++ b/docker/images/n8n/README.md
@@ -146,6 +146,9 @@ The following environment variables support file input:
 - DB_POSTGRESDB_PORT_FILE
 - DB_POSTGRESDB_USER_FILE
 - DB_POSTGRESDB_SCHEMA_FILE
+- DB_POSTGRESDB_SSL_CA_FILE
+- DB_POSTGRESDB_SSL_CERT_FILE
+- DB_POSTGRESDB_SSL_KEY_FILE
 
 ## Example Setup with Lets Encrypt
 


### PR DESCRIPTION
Important env variables for DB SSL configuration missing in README.

These environment variables allow loading SSL certificates from files instead of passing them directly as environment variables, which is particularly useful for maintaining proper PEM formatting and managing sensitive data in Docker environments.

  - DB_POSTGRESDB_SSL_CA_FILE
  - DB_POSTGRESDB_SSL_CERT_FILE
  - DB_POSTGRESDB_SSL_KEY_FILE

--- 


Otherwise, if set without _FILE, the paths will be considered as the literal cert, result in error (error | error:0480006C:PEM routines::no start line). 

Example:

      - DB_POSTGRESDB_SSL_CA=/etc/ssl/certs/docker/root-ca.pem
      - DB_POSTGRESDB_SSL_CERT=/etc/ssl/certs/docker/client-cert.pem 
      - DB_POSTGRESDB_SSL_KEY=/etc/ssl/certs/docker/client-key.pem


Log:

n8n_1          | 2024-12-01T20:42:37.088Z | info  | Initializing n8n process {"file":"start.js","function":"init"}
n8n_1          | 2024-12-01T20:42:37.636Z | debug | Lazy-loading nodes and credentials from n8n-nodes-base {"nodes":465,"credentials":367,"file":"LoggerProxy.js","function":"exports.debug"}
n8n_1          | 2024-12-01T20:42:37.646Z | debug | Lazy-loading nodes and credentials from @n8n/n8n-nodes-langchain {"nodes":78,"credentials":15,"file":"LoggerProxy.js","function":"exports.debug"}
n8n_1          | 2024-12-01T20:42:37.776Z | error | There was an error initializing DB
n8n_1          | Error: There was an error initializing DB
n8n_1          |     at Start.exitWithCrash (/usr/local/lib/node_modules/n8n/dist/commands/base-command.js:115:49)
n8n_1          |     at /usr/local/lib/node_modules/n8n/dist/commands/base-command.js:71:59
n8n_1          |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
n8n_1          |     at Start.init (/usr/local/lib/node_modules/n8n/dist/commands/base-command.js:71:9)
n8n_1          |     at Start.init (/usr/local/lib/node_modules/n8n/dist/commands/start.js:150:9)
n8n_1          |     at Start._run (/usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/command.js:301:13)
n8n_1          |     at Config.runCommand (/usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/config/config.js:424:25)
n8n_1          |     at run (/usr/local/lib/node_modules/n8n/node_modules/@oclif/core/lib/main.js:94:16)
n8n_1          |     at /usr/local/lib/node_modules/n8n/bin/n8n:71:2
n8n_1          |  {"file":"LoggerProxy.js","function":"exports.error"}
n8n_1          | 2024-12-01T20:42:37.779Z | error | error:0480006C:PEM routines::no start line
n8n_1          | Error: error:0480006C:PEM routines::no start line
n8n_1          |     at node:internal/tls/secure-context:70:13
n8n_1          |     at Array.forEach (<anonymous>)
n8n_1          |     at setCerts (node:internal/tls/secure-context:68:3)
n8n_1          |     at configSecureContext (node:internal/tls/secure-context:191:5)
n8n_1          |     at Object.createSecureContext (node:_tls_common:114:3)
n8n_1          |     at Object.connect (node:_tls_wrap:1766:48)
n8n_1          |     at getSecureStream (/usr/local/lib/node_modules/n8n/node_modules/pg/lib/stream.js:23:16)
n8n_1          |     at Socket.<anonymous> (/usr/local/lib/node_modules/n8n/node_modules/pg/lib/connection.js:100:23)
n8n_1          |     at Object.onceWrapper (node:events:634:26)
n8n_1          |     at Socket.emit (node:events:519:28)
n8n_1          |  {"file":"LoggerProxy.js","function":"exports.error"}

postgres       | 2024-12-01 20:42:39.799 UTC [245] LOG:  could not accept SSL connection: EOF detected

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
