### PR TITLE
chore: Add mockedNodes property to TestDefinition (no-changelog)

### DIFF
--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -32,6 +32,9 @@ export class TestDefinition extends WithTimestampsAndStringId {
 	@Column('text')
 	description: string;
 
+	@Column(jsonColumnType, { default: '[]' })
+	pinnedNodes: PinnedNodeItem[];
+
 	/**
 	 * Relation to the workflow under test
 	 */
@@ -62,7 +65,4 @@ export class TestDefinition extends WithTimestampsAndStringId {
 
 	@OneToMany('TestMetric', 'testDefinition')
 	metrics: TestMetric[];
-
-	@Column(jsonColumnType, { default: [] })
-	pinnedNodes: PinnedNodeItem[];
 }

--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -5,7 +5,12 @@ import { AnnotationTagEntity } from '@/databases/entities/annotation-tag-entity.
 import type { TestMetric } from '@/databases/entities/test-metric.ee';
 import { WorkflowEntity } from '@/databases/entities/workflow-entity';
 
-import { WithTimestampsAndStringId } from './abstract-entity';
+import { jsonColumnType, WithTimestampsAndStringId } from './abstract-entity';
+
+// Entity representing a node in a workflow under test which is pinned for a test definition
+export type PinnedNodeItem = {
+	name: string;
+};
 
 /**
  * Entity representing a Test Definition
@@ -57,4 +62,7 @@ export class TestDefinition extends WithTimestampsAndStringId {
 
 	@OneToMany('TestMetric', 'testDefinition')
 	metrics: TestMetric[];
+
+	@Column(jsonColumnType, { default: [] })
+	pinnedNodes: PinnedNodeItem[];
 }

--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -8,7 +8,7 @@ import { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { jsonColumnType, WithTimestampsAndStringId } from './abstract-entity';
 
 // Entity representing a node in a workflow under test which is pinned for a test definition
-export type PinnedNodeItem = {
+export type MockedNodeItem = {
 	name: string;
 };
 
@@ -33,7 +33,7 @@ export class TestDefinition extends WithTimestampsAndStringId {
 	description: string;
 
 	@Column(jsonColumnType, { default: '[]' })
-	pinnedNodes: PinnedNodeItem[];
+	mockedNodes: MockedNodeItem[];
 
 	/**
 	 * Relation to the workflow under test

--- a/packages/cli/src/databases/entities/test-definition.ee.ts
+++ b/packages/cli/src/databases/entities/test-definition.ee.ts
@@ -7,7 +7,7 @@ import { WorkflowEntity } from '@/databases/entities/workflow-entity';
 
 import { jsonColumnType, WithTimestampsAndStringId } from './abstract-entity';
 
-// Entity representing a node in a workflow under test which is pinned for a test definition
+// Entity representing a node in a workflow under test, for which data should be mocked during test execution
 export type MockedNodeItem = {
 	name: string;
 };

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
@@ -1,18 +1,18 @@
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
-export class AddPinnedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
+export class AddMockedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
 	async up({ queryRunner, tablePrefix, escape }: MigrationContext) {
 		// We have to use raw query migration instead of schemaBuilder helpers,
 		// because the typeorm schema builder implements addColumns by a table recreate for sqlite
 		// which causes weird issues with the migration
-		const pinnedNodesColumnName = escape.columnName('pinnedNodes');
+		const mockedNodesColumnName = escape.columnName('mockedNodes');
 
 		await queryRunner.query(
-			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN ${pinnedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
+			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN ${mockedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
 		);
 	}
 
 	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
-		await dropColumns('test_definition', ['pinnedNodes']);
+		await dropColumns('test_definition', ['mockedNodes']);
 	}
 }

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
@@ -1,18 +1,22 @@
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
+// We have to use raw query migration instead of schemaBuilder helpers,
+// because the typeorm schema builder implements addColumns by a table recreate for sqlite
+// which causes weird issues with the migration
 export class AddMockedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
-	async up({ queryRunner, tablePrefix, escape }: MigrationContext) {
-		// We have to use raw query migration instead of schemaBuilder helpers,
-		// because the typeorm schema builder implements addColumns by a table recreate for sqlite
-		// which causes weird issues with the migration
+	async up({ escape, runQuery }: MigrationContext) {
+		const tableName = escape.tableName('test_definition');
 		const mockedNodesColumnName = escape.columnName('mockedNodes');
 
-		await queryRunner.query(
-			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN ${mockedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
+		await runQuery(
+			`ALTER TABLE ${tableName} ADD COLUMN ${mockedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
 		);
 	}
 
-	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
-		await dropColumns('test_definition', ['mockedNodes']);
+	async down({ escape, runQuery }: MigrationContext) {
+		const tableName = escape.tableName('test_definition');
+		const columnName = escape.columnName('mockedNodes');
+
+		await runQuery(`ALTER TABLE ${tableName} DROP COLUMN ${columnName}`);
 	}
 }

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
@@ -1,12 +1,12 @@
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 export class AddPinnedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
-	async up({ runQuery, tablePrefix }: MigrationContext) {
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
 		// We have to use raw query migration instead of schemaBuilder helpers,
 		// because the typeorm schema builder implements addColumns by a table recreate for sqlite
 		// which causes weird issues with the migration
-		await runQuery(
-			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN pinnedNodes JSON DEFAULT '[]' NOT NULL`,
+		await queryRunner.query(
+			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN \`pinnedNodes\` JSON DEFAULT '[]' NOT NULL`,
 		);
 	}
 

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
@@ -1,0 +1,11 @@
+import type { MigrationContext, ReversibleMigration } from '@/databases/types';
+
+export class AddPinnedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns('test_definition', [column('pinnedNodes').json.notNull.default("'[]'")]);
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns('test_definition', ['pinnedNodes']);
+	}
+}

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
@@ -1,8 +1,13 @@
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 export class AddPinnedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
-	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
-		await addColumns('test_definition', [column('pinnedNodes').json.notNull.default("'[]'")]);
+	async up({ runQuery, tablePrefix }: MigrationContext) {
+		// We have to use raw query migration instead of schemaBuilder helpers,
+		// because the typeorm schema builder implements addColumns by a table recreate for sqlite
+		// which causes weird issues with the migration
+		await runQuery(
+			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN pinnedNodes JSON DEFAULT '[]' NOT NULL`,
+		);
 	}
 
 	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {

--- a/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddPinnedNodesColumnToTestDefinition.ts
@@ -1,12 +1,14 @@
 import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 export class AddPinnedNodesColumnToTestDefinition1733133775640 implements ReversibleMigration {
-	async up({ queryRunner, tablePrefix }: MigrationContext) {
+	async up({ queryRunner, tablePrefix, escape }: MigrationContext) {
 		// We have to use raw query migration instead of schemaBuilder helpers,
 		// because the typeorm schema builder implements addColumns by a table recreate for sqlite
 		// which causes weird issues with the migration
+		const pinnedNodesColumnName = escape.columnName('pinnedNodes');
+
 		await queryRunner.query(
-			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN \`pinnedNodes\` JSON DEFAULT '[]' NOT NULL`,
+			`ALTER TABLE ${tablePrefix}test_definition ADD COLUMN ${pinnedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
 		);
 	}
 

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -73,7 +73,7 @@ import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
-import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
+import { AddMockedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddMockedNodesColumnToTestDefinition';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -149,5 +149,5 @@ export const mysqlMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
-	AddPinnedNodesColumnToTestDefinition1733133775640,
+	AddMockedNodesColumnToTestDefinition1733133775640,
 ];

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -73,6 +73,7 @@ import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
+import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
 
 export const mysqlMigrations: Migration[] = [
 	InitialMigration1588157391238,
@@ -148,4 +149,5 @@ export const mysqlMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
+	AddPinnedNodesColumnToTestDefinition1733133775640,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -73,7 +73,7 @@ import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
-import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
+import { AddMockedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddMockedNodesColumnToTestDefinition';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -149,5 +149,5 @@ export const postgresMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
-	AddPinnedNodesColumnToTestDefinition1733133775640,
+	AddMockedNodesColumnToTestDefinition1733133775640,
 ];

--- a/packages/cli/src/databases/migrations/postgresdb/index.ts
+++ b/packages/cli/src/databases/migrations/postgresdb/index.ts
@@ -73,6 +73,7 @@ import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
+import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -148,4 +149,5 @@ export const postgresMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
+	AddPinnedNodesColumnToTestDefinition1733133775640,
 ];

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -70,6 +70,7 @@ import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/172
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
+import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -142,6 +143,7 @@ const sqliteMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
+	AddPinnedNodesColumnToTestDefinition1733133775640,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/databases/migrations/sqlite/index.ts
+++ b/packages/cli/src/databases/migrations/sqlite/index.ts
@@ -70,7 +70,7 @@ import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/172
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
 import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
-import { AddPinnedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddPinnedNodesColumnToTestDefinition';
+import { AddMockedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddMockedNodesColumnToTestDefinition';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -143,7 +143,7 @@ const sqliteMigrations: Migration[] = [
 	MigrateTestDefinitionKeyToString1731582748663,
 	CreateTestMetricTable1732271325258,
 	CreateTestRun1732549866705,
-	AddPinnedNodesColumnToTestDefinition1733133775640,
+	AddMockedNodesColumnToTestDefinition1733133775640,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/evaluation/test-definition.schema.ts
+++ b/packages/cli/src/evaluation/test-definition.schema.ts
@@ -16,5 +16,6 @@ export const testDefinitionPatchRequestBodySchema = z
 		description: z.string().optional(),
 		evaluationWorkflowId: z.string().min(1).optional(),
 		annotationTagId: z.string().min(1).optional(),
+		pinnedNodes: z.array(z.object({ name: z.string() })).optional(),
 	})
 	.strict();

--- a/packages/cli/src/evaluation/test-definition.schema.ts
+++ b/packages/cli/src/evaluation/test-definition.schema.ts
@@ -16,6 +16,6 @@ export const testDefinitionPatchRequestBodySchema = z
 		description: z.string().optional(),
 		evaluationWorkflowId: z.string().min(1).optional(),
 		annotationTagId: z.string().min(1).optional(),
-		pinnedNodes: z.array(z.object({ name: z.string() })).optional(),
+		mockedNodes: z.array(z.object({ name: z.string() })).optional(),
 	})
 	.strict();

--- a/packages/cli/src/evaluation/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation/test-definition.service.ee.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { Service } from 'typedi';
 
-import type { PinnedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
+import type { MockedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
 import { AnnotationTagRepository } from '@/databases/repositories/annotation-tag.repository.ee';
 import { TestDefinitionRepository } from '@/databases/repositories/test-definition.repository.ee';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -32,7 +32,7 @@ export class TestDefinitionService {
 		evaluationWorkflowId?: string;
 		annotationTagId?: string;
 		id?: string;
-		pinnedNodes?: PinnedNodeItem[];
+		mockedNodes?: MockedNodeItem[];
 	}) {
 		const entity: TestDefinitionLike = {};
 
@@ -66,8 +66,8 @@ export class TestDefinitionService {
 			};
 		}
 
-		if (attrs.pinnedNodes) {
-			entity.pinnedNodes = attrs.pinnedNodes;
+		if (attrs.mockedNodes) {
+			entity.mockedNodes = attrs.mockedNodes;
 		}
 
 		return entity;
@@ -114,7 +114,7 @@ export class TestDefinitionService {
 		}
 
 		// If there are pinned nodes, validate them
-		if (attrs.pinnedNodes && attrs.pinnedNodes.length > 0) {
+		if (attrs.mockedNodes && attrs.mockedNodes.length > 0) {
 			const existingTestDefinition = await this.testDefinitionRepository.findOne({
 				where: {
 					id,
@@ -126,7 +126,7 @@ export class TestDefinitionService {
 
 			const existingNodeNames = new Set(existingTestDefinition.workflow.nodes.map((n) => n.name));
 
-			attrs.pinnedNodes.forEach((node) => {
+			attrs.mockedNodes.forEach((node) => {
 				if (!existingNodeNames.has(node.name)) {
 					throw new BadRequestError(`Pinned node not found in the workflow: ${node.name}`);
 				}

--- a/packages/cli/src/evaluation/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation/test-definition.service.ee.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { Service } from 'typedi';
 
 import type { MockedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
@@ -115,14 +114,12 @@ export class TestDefinitionService {
 
 		// If there are mocked nodes, validate them
 		if (attrs.mockedNodes && attrs.mockedNodes.length > 0) {
-			const existingTestDefinition = await this.testDefinitionRepository.findOne({
+			const existingTestDefinition = await this.testDefinitionRepository.findOneOrFail({
 				where: {
 					id,
 				},
 				relations: ['workflow'],
 			});
-
-			assert(existingTestDefinition, 'Test definition not found');
 
 			const existingNodeNames = new Set(existingTestDefinition.workflow.nodes.map((n) => n.name));
 

--- a/packages/cli/src/evaluation/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation/test-definition.service.ee.ts
@@ -113,7 +113,7 @@ export class TestDefinitionService {
 			}
 		}
 
-		// If there are pinned nodes, validate them
+		// If there are mocked nodes, validate them
 		if (attrs.mockedNodes && attrs.mockedNodes.length > 0) {
 			const existingTestDefinition = await this.testDefinitionRepository.findOne({
 				where: {

--- a/packages/cli/src/evaluation/test-definitions.types.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.types.ee.ts
@@ -1,4 +1,4 @@
-import type { PinnedNodeItem } from '@/databases/entities/test-definition.ee';
+import type { MockedNodeItem } from '@/databases/entities/test-definition.ee';
 import type { AuthenticatedRequest, ListQuery } from '@/requests';
 
 // ----------------------------------
@@ -31,7 +31,7 @@ export declare namespace TestDefinitionsRequest {
 			name?: string;
 			evaluationWorkflowId?: string;
 			annotationTagId?: string;
-			pinnedNodes?: PinnedNodeItem[];
+			mockedNodes?: MockedNodeItem[];
 		}
 	>;
 

--- a/packages/cli/src/evaluation/test-definitions.types.ee.ts
+++ b/packages/cli/src/evaluation/test-definitions.types.ee.ts
@@ -1,3 +1,4 @@
+import type { PinnedNodeItem } from '@/databases/entities/test-definition.ee';
 import type { AuthenticatedRequest, ListQuery } from '@/requests';
 
 // ----------------------------------
@@ -26,7 +27,12 @@ export declare namespace TestDefinitionsRequest {
 	type Patch = AuthenticatedRequest<
 		RouteParams.TestId,
 		{},
-		{ name?: string; evaluationWorkflowId?: string; annotationTagId?: string }
+		{
+			name?: string;
+			evaluationWorkflowId?: string;
+			annotationTagId?: string;
+			pinnedNodes?: PinnedNodeItem[];
+		}
 	>;
 
 	type Delete = AuthenticatedRequest<RouteParams.TestId>;

--- a/packages/cli/src/evaluation/test-runner/__tests__/get-start-node.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/get-start-node.ee.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
-import { getPastExecutionStartNode } from '../utils.ee';
+import { getPastExecutionTriggerNode } from '../utils.ee';
 
 const executionDataJson = JSON.parse(
 	readFileSync(path.join(__dirname, './mock-data/execution-data.json'), { encoding: 'utf-8' }),
@@ -21,19 +21,19 @@ const executionDataMultipleTriggersJson2 = JSON.parse(
 
 describe('getPastExecutionStartNode', () => {
 	test('should return the start node of the past execution', () => {
-		const startNode = getPastExecutionStartNode(executionDataJson);
+		const startNode = getPastExecutionTriggerNode(executionDataJson);
 
 		expect(startNode).toEqual('When clicking ‘Test workflow’');
 	});
 
 	test('should return the start node of the past execution with multiple triggers', () => {
-		const startNode = getPastExecutionStartNode(executionDataMultipleTriggersJson);
+		const startNode = getPastExecutionTriggerNode(executionDataMultipleTriggersJson);
 
 		expect(startNode).toEqual('When clicking ‘Test workflow’');
 	});
 
 	test('should return the start node of the past execution with multiple triggers - chat trigger', () => {
-		const startNode = getPastExecutionStartNode(executionDataMultipleTriggersJson2);
+		const startNode = getPastExecutionTriggerNode(executionDataMultipleTriggersJson2);
 
 		expect(startNode).toEqual('When chat message received');
 	});

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -70,6 +70,7 @@ export class TestRunnerService {
 			runData: {},
 			pinData,
 			workflowData: workflow,
+			partialExecutionVersion: '-1',
 			userId,
 		};
 

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -22,7 +22,7 @@ import { getRunData } from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
 
 import { EvaluationMetrics } from './evaluation-metrics.ee';
-import { createPinData, getPastExecutionStartNode } from './utils.ee';
+import { createPinData, getPastExecutionTriggerNode } from './utils.ee';
 
 /**
  * This service orchestrates the running of test cases.
@@ -58,7 +58,7 @@ export class TestRunnerService {
 		const pinData = createPinData(workflow, pastExecutionData);
 
 		// Determine the start node of the past execution
-		const pastExecutionStartNode = getPastExecutionStartNode(pastExecutionData);
+		const pastExecutionStartNode = getPastExecutionTriggerNode(pastExecutionData);
 
 		// Prepare the data to run the workflow
 		const data: IWorkflowExecutionDataProcess = {
@@ -70,7 +70,6 @@ export class TestRunnerService {
 			runData: {},
 			pinData,
 			workflowData: workflow,
-			partialExecutionVersion: '-1',
 			userId,
 		};
 

--- a/packages/cli/src/evaluation/test-runner/utils.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/utils.ee.ts
@@ -26,7 +26,7 @@ export function createPinData(workflow: WorkflowEntity, executionData: IRunExecu
  * Returns the start node of the past execution.
  * The start node is the node that has no source and has run data.
  */
-export function getPastExecutionStartNode(executionData: IRunExecutionData) {
+export function getPastExecutionTriggerNode(executionData: IRunExecutionData) {
 	return Object.keys(executionData.resultData.runData).find((nodeName) => {
 		const data = executionData.resultData.runData[nodeName];
 		return !data[0].source || data[0].source.length === 0 || data[0].source[0] === null;

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -403,7 +403,7 @@ describe('PATCH /evaluation/test-definitions/:id', () => {
 		await Container.get(TestDefinitionRepository).save(newTest);
 
 		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
-			pinnedNodes: [
+			mockedNodes: [
 				{
 					name: 'Schedule Trigger',
 				},
@@ -411,7 +411,7 @@ describe('PATCH /evaluation/test-definitions/:id', () => {
 		});
 
 		expect(resp.statusCode).toBe(200);
-		expect(resp.body.data.pinnedNodes).toEqual([{ name: 'Schedule Trigger' }]);
+		expect(resp.body.data.mockedNodes).toEqual([{ name: 'Schedule Trigger' }]);
 	});
 
 	test('should return error if pinned nodes are invalid', async () => {
@@ -422,7 +422,7 @@ describe('PATCH /evaluation/test-definitions/:id', () => {
 		await Container.get(TestDefinitionRepository).save(newTest);
 
 		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
-			pinnedNodes: ['Simple string'],
+			mockedNodes: ['Simple string'],
 		});
 
 		expect(resp.statusCode).toBe(400);
@@ -436,7 +436,7 @@ describe('PATCH /evaluation/test-definitions/:id', () => {
 		await Container.get(TestDefinitionRepository).save(newTest);
 
 		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
-			pinnedNodes: [
+			mockedNodes: [
 				{
 					name: 'Invalid Node',
 				},

--- a/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
+++ b/packages/cli/test/integration/evaluation/test-definitions.api.test.ts
@@ -394,6 +394,57 @@ describe('PATCH /evaluation/test-definitions/:id', () => {
 		expect(resp.statusCode).toBe(400);
 		expect(resp.body.message).toBe('Annotation tag not found');
 	});
+
+	test('should update pinned nodes', async () => {
+		const newTest = Container.get(TestDefinitionRepository).create({
+			name: 'test',
+			workflow: { id: workflowUnderTest.id },
+		});
+		await Container.get(TestDefinitionRepository).save(newTest);
+
+		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
+			pinnedNodes: [
+				{
+					name: 'Schedule Trigger',
+				},
+			],
+		});
+
+		expect(resp.statusCode).toBe(200);
+		expect(resp.body.data.pinnedNodes).toEqual([{ name: 'Schedule Trigger' }]);
+	});
+
+	test('should return error if pinned nodes are invalid', async () => {
+		const newTest = Container.get(TestDefinitionRepository).create({
+			name: 'test',
+			workflow: { id: workflowUnderTest.id },
+		});
+		await Container.get(TestDefinitionRepository).save(newTest);
+
+		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
+			pinnedNodes: ['Simple string'],
+		});
+
+		expect(resp.statusCode).toBe(400);
+	});
+
+	test('should return error if pinned nodes are not in the workflow', async () => {
+		const newTest = Container.get(TestDefinitionRepository).create({
+			name: 'test',
+			workflow: { id: workflowUnderTest.id },
+		});
+		await Container.get(TestDefinitionRepository).save(newTest);
+
+		const resp = await authOwnerAgent.patch(`/evaluation/test-definitions/${newTest.id}`).send({
+			pinnedNodes: [
+				{
+					name: 'Invalid Node',
+				},
+			],
+		});
+
+		expect(resp.statusCode).toBe(400);
+	});
 });
 
 describe('DELETE /evaluation/test-definitions/:id', () => {


### PR DESCRIPTION
## Summary

Added a new property for a `TestDefinition` entity to store a list of mocked nodes:
- DB migration
- API endpoint for updating mockedNodes of the Test Definition

Notes:
- Had to implement DB migration using a raw query instead of schema builder, since typeorm executes `addColumns` using table recreate for legacy reasons. This leads to some weird errors in integration tests
- We are using node's names now, but possibly will shift towards ids in the near future. As the data format of the mocked nodes may change – it's stored as a JSON column, and not in a normalized form

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-423/[api]-node-pinning-feature-for-the-endpoint-evaluationtest-definitions


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
