### PR TITLE
feat(core): Detect restart loop in a task runner process (no-changelog)

### DIFF
--- a/packages/cli/src/runners/__tests__/task-runner-process-restart-loop-detector.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-process-restart-loop-detector.test.ts
@@ -1,0 +1,57 @@
+import { TaskRunnersConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+
+import type { Logger } from '@/logging/logger.service';
+import type { TaskRunnerAuthService } from '@/runners/auth/task-runner-auth.service';
+import { TaskRunnerRestartLoopError } from '@/runners/errors/task-runner-restart-loop-error';
+import { RunnerLifecycleEvents } from '@/runners/runner-lifecycle-events';
+import { TaskRunnerProcess } from '@/runners/task-runner-process';
+import { TaskRunnerProcessRestartLoopDetector } from '@/runners/task-runner-process-restart-loop-detector';
+
+describe('TaskRunnerProcessRestartLoopDetector', () => {
+	const mockLogger = mock<Logger>();
+	const mockAuthService = mock<TaskRunnerAuthService>();
+	const runnerConfig = new TaskRunnersConfig();
+	const taskRunnerProcess = new TaskRunnerProcess(
+		mockLogger,
+		runnerConfig,
+		mockAuthService,
+		new RunnerLifecycleEvents(),
+	);
+
+	it('should detect a restart loop if process exits 5 times within 5s', () => {
+		const restartLoopDetector = new TaskRunnerProcessRestartLoopDetector(taskRunnerProcess);
+		let emittedError: TaskRunnerRestartLoopError | undefined = undefined;
+		restartLoopDetector.on('restart-loop-detected', (error) => {
+			emittedError = error;
+		});
+
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+
+		expect(emittedError).toBeInstanceOf(TaskRunnerRestartLoopError);
+	});
+
+	it('should not detect a restart loop if process exits less than 5 times within 5s', () => {
+		jest.useFakeTimers();
+		const restartLoopDetector = new TaskRunnerProcessRestartLoopDetector(taskRunnerProcess);
+		let emittedError: TaskRunnerRestartLoopError | undefined = undefined;
+		restartLoopDetector.on('restart-loop-detected', (error) => {
+			emittedError = error;
+		});
+
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+		taskRunnerProcess.emit('exit');
+
+		jest.advanceTimersByTime(5010);
+
+		taskRunnerProcess.emit('exit');
+
+		expect(emittedError).toBeUndefined();
+	});
+});

--- a/packages/cli/src/runners/errors/task-runner-restart-loop-error.ts
+++ b/packages/cli/src/runners/errors/task-runner-restart-loop-error.ts
@@ -5,7 +5,7 @@ export class TaskRunnerRestartLoopError extends ApplicationError {
 		public readonly howManyTimes: number,
 		public readonly timePeriodMs: number,
 	) {
-		const message = `Task runner has restarted ${howManyTimes} times within ${timePeriodMs / 1000} seconds`;
+		const message = `Task runner has restarted ${howManyTimes} times within ${timePeriodMs / 1000} seconds. This is an abnormally high restart rate that suggests a bug or other issue is preventing your runner process from starting up. If this issues persists, please file a report at: https://github.com/n8n-io/n8n/issues`;
 
 		super(message, {
 			level: 'fatal',

--- a/packages/cli/src/runners/errors/task-runner-restart-loop-error.ts
+++ b/packages/cli/src/runners/errors/task-runner-restart-loop-error.ts
@@ -1,0 +1,14 @@
+import { ApplicationError } from 'n8n-workflow';
+
+export class TaskRunnerRestartLoopError extends ApplicationError {
+	constructor(
+		public readonly howManyTimes: number,
+		public readonly timePeriodMs: number,
+	) {
+		const message = `Task runner has restarted ${howManyTimes} times within ${timePeriodMs / 1000} seconds`;
+
+		super(message, {
+			level: 'fatal',
+		});
+	}
+}

--- a/packages/cli/src/runners/task-runner-module.ts
+++ b/packages/cli/src/runners/task-runner-module.ts
@@ -30,13 +30,11 @@ export class TaskRunnerModule {
 
 	private taskRunnerProcessRestartLoopDetector: TaskRunnerProcessRestartLoopDetector | undefined;
 
-	private readonly logger: Logger;
-
 	constructor(
-		logger: Logger,
+		private readonly logger: Logger,
 		private readonly runnerConfig: TaskRunnersConfig,
 	) {
-		this.logger = logger.scoped('task-runner');
+		this.logger = this.logger.scoped('task-runner');
 	}
 
 	async start() {

--- a/packages/cli/src/runners/task-runner-module.ts
+++ b/packages/cli/src/runners/task-runner-module.ts
@@ -113,7 +113,7 @@ export class TaskRunnerModule {
 		);
 	}
 
-	private onRunnerRestartLoopDetected = async (error: Error) => {
+	private onRunnerRestartLoopDetected = async (error: TaskRunnerRestartLoopError) => {
 		this.logger.error(error.message);
 		ErrorReporterProxy.error(error);
 

--- a/packages/cli/src/runners/task-runner-module.ts
+++ b/packages/cli/src/runners/task-runner-module.ts
@@ -5,6 +5,7 @@ import Container, { Service } from 'typedi';
 
 import { OnShutdown } from '@/decorators/on-shutdown';
 import { Logger } from '@/logging/logger.service';
+import type { TaskRunnerRestartLoopError } from '@/runners/errors/task-runner-restart-loop-error';
 import type { TaskRunnerProcess } from '@/runners/task-runner-process';
 import { TaskRunnerProcessRestartLoopDetector } from '@/runners/task-runner-process-restart-loop-detector';
 

--- a/packages/cli/src/runners/task-runner-module.ts
+++ b/packages/cli/src/runners/task-runner-module.ts
@@ -1,9 +1,12 @@
 import { TaskRunnersConfig } from '@n8n/config';
+import { ErrorReporterProxy, sleep } from 'n8n-workflow';
 import * as a from 'node:assert/strict';
 import Container, { Service } from 'typedi';
 
 import { OnShutdown } from '@/decorators/on-shutdown';
+import { Logger } from '@/logging/logger.service';
 import type { TaskRunnerProcess } from '@/runners/task-runner-process';
+import { TaskRunnerProcessRestartLoopDetector } from '@/runners/task-runner-process-restart-loop-detector';
 
 import { MissingAuthTokenError } from './errors/missing-auth-token.error';
 import { TaskRunnerWsServer } from './runner-ws-server';
@@ -25,7 +28,16 @@ export class TaskRunnerModule {
 
 	private taskRunnerProcess: TaskRunnerProcess | undefined;
 
-	constructor(private readonly runnerConfig: TaskRunnersConfig) {}
+	private taskRunnerProcessRestartLoopDetector: TaskRunnerProcessRestartLoopDetector | undefined;
+
+	private readonly logger: Logger;
+
+	constructor(
+		logger: Logger,
+		private readonly runnerConfig: TaskRunnersConfig,
+	) {
+		this.logger = logger.scoped('task-runner');
+	}
 
 	async start() {
 		a.ok(this.runnerConfig.enabled, 'Task runner is disabled');
@@ -83,6 +95,14 @@ export class TaskRunnerModule {
 
 		const { TaskRunnerProcess } = await import('@/runners/task-runner-process');
 		this.taskRunnerProcess = Container.get(TaskRunnerProcess);
+		this.taskRunnerProcessRestartLoopDetector = new TaskRunnerProcessRestartLoopDetector(
+			this.taskRunnerProcess,
+		);
+		this.taskRunnerProcessRestartLoopDetector.on(
+			'restart-loop-detected',
+			this.onRunnerRestartLoopDetected,
+		);
+
 		await this.taskRunnerProcess.start();
 
 		const { InternalTaskRunnerDisconnectAnalyzer } = await import(
@@ -92,4 +112,13 @@ export class TaskRunnerModule {
 			Container.get(InternalTaskRunnerDisconnectAnalyzer),
 		);
 	}
+
+	private onRunnerRestartLoopDetected = async (error: Error) => {
+		this.logger.error(error.message);
+		ErrorReporterProxy.error(error);
+
+		// Allow some time for the error to be flushed
+		await sleep(1000);
+		process.exit(1);
+	};
 }

--- a/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
+++ b/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
@@ -4,7 +4,7 @@ import type { TaskRunnerProcess } from '@/runners/task-runner-process';
 import { TypedEmitter } from '@/typed-emitter';
 
 const MAX_RESTARTS = 5;
-const RESTARTS_WINDOW = 5 * Time.seconds.toMilliseconds;
+const RESTARTS_WINDOW = 2 * Time.seconds.toMilliseconds;
 
 export type TaskRunnerProcessRestartLoopDetectorEventMap = {
 	'restart-loop-detected': TaskRunnerRestartLoopError;

--- a/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
+++ b/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
@@ -1,0 +1,73 @@
+import { Time } from '@/constants';
+import { TaskRunnerRestartLoopError } from '@/runners/errors/task-runner-restart-loop-error';
+import type { TaskRunnerProcess } from '@/runners/task-runner-process';
+import { TypedEmitter } from '@/typed-emitter';
+
+const RESTART_LOOP_COUNT_LIMIT = 5;
+const RESTART_LOOP_TIME_LIMIT = 5 * Time.seconds.toMilliseconds;
+
+export type TaskRunnerProcessRestartLoopDetectorEventMap = {
+	'restart-loop-detected': TaskRunnerRestartLoopError;
+};
+
+/**
+ * A class to monitor the task runner process for restart loops
+ */
+export class TaskRunnerProcessRestartLoopDetector extends TypedEmitter<TaskRunnerProcessRestartLoopDetectorEventMap> {
+	/**
+	 * How many times the process needs to restart for it to be detected
+	 * being in a loop.
+	 */
+	private readonly maxCount = RESTART_LOOP_COUNT_LIMIT;
+
+	/**
+	 * The time interval in which the process needs to restart `maxCount` times
+	 * to be detected as being in a loop.
+	 */
+	private readonly resetTimeInMs = RESTART_LOOP_TIME_LIMIT;
+
+	private counter = 0;
+
+	/** Time when the first restart of a loop happened */
+	private firstIncrementTime = Date.now();
+
+	constructor(private readonly taskRunnerProcess: TaskRunnerProcess) {
+		super();
+
+		this.taskRunnerProcess.on('exit', () => {
+			this.increment();
+
+			if (this.isMaxCountExceeded()) {
+				this.emit(
+					'restart-loop-detected',
+					new TaskRunnerRestartLoopError(this.counter, this.msSinceFirstIncrement()),
+				);
+			}
+		});
+	}
+
+	/**
+	 * Increments the counter
+	 */
+	private increment() {
+		const now = Date.now();
+		if (now > this.firstIncrementTime + this.resetTimeInMs) {
+			this.reset();
+		}
+
+		this.counter++;
+	}
+
+	private reset() {
+		this.counter = 0;
+		this.firstIncrementTime = Date.now();
+	}
+
+	private isMaxCountExceeded() {
+		return this.counter >= this.maxCount;
+	}
+
+	private msSinceFirstIncrement() {
+		return Date.now() - this.firstIncrementTime;
+	}
+}

--- a/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
+++ b/packages/cli/src/runners/task-runner-process-restart-loop-detector.ts
@@ -6,7 +6,7 @@ import { TypedEmitter } from '@/typed-emitter';
 const MAX_RESTARTS = 5;
 const RESTARTS_WINDOW = 2 * Time.seconds.toMilliseconds;
 
-export type TaskRunnerProcessRestartLoopDetectorEventMap = {
+type TaskRunnerProcessRestartLoopDetectorEventMap = {
 	'restart-loop-detected': TaskRunnerRestartLoopError;
 };
 

--- a/packages/cli/test/integration/runners/task-runner-module.external.test.ts
+++ b/packages/cli/test/integration/runners/task-runner-module.external.test.ts
@@ -1,4 +1,5 @@
 import { TaskRunnersConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
 import Container from 'typedi';
 
 import { MissingAuthTokenError } from '@/runners/errors/missing-auth-token.error';
@@ -32,7 +33,7 @@ describe('TaskRunnerModule in external mode', () => {
 			runnerConfig.enabled = true;
 			runnerConfig.authToken = '';
 
-			const module = new TaskRunnerModule(runnerConfig);
+			const module = new TaskRunnerModule(mock(), runnerConfig);
 
 			await expect(module.start()).rejects.toThrowError(MissingAuthTokenError);
 		});


### PR DESCRIPTION
## Summary

Detect restart loop in a task runner process 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-309/detect-task-runner-restart-loop


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
