### PR TITLE
chore: Add node mocking logic to the Test Runner (no-changelog)

### DIFF
--- a/packages/cli/src/evaluation/test-runner/__tests__/create-pin-data.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/create-pin-data.ee.test.ts
@@ -13,9 +13,9 @@ const executionDataJson = JSON.parse(
 
 describe('createPinData', () => {
 	test('should create pin data from past execution data', () => {
-		const pinnedNodes = ['When clicking ‘Test workflow’'].map((name) => ({ name }));
+		const mockedNodes = ['When clicking ‘Test workflow’'].map((name) => ({ name }));
 
-		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
+		const pinData = createPinData(wfUnderTestJson, mockedNodes, executionDataJson);
 
 		expect(pinData).toEqual(
 			expect.objectContaining({
@@ -24,20 +24,20 @@ describe('createPinData', () => {
 		);
 	});
 
-	test('should not create pin data for non-existing pinned nodes', () => {
-		const pinnedNodes = ['Non-existing node'].map((name) => ({ name }));
+	test('should not create pin data for non-existing mocked nodes', () => {
+		const mockedNodes = ['Non-existing node'].map((name) => ({ name }));
 
-		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
+		const pinData = createPinData(wfUnderTestJson, mockedNodes, executionDataJson);
 
 		expect(pinData).toEqual({});
 	});
 
-	test('should create pin data for all pinned nodes', () => {
-		const pinnedNodes = ['When clicking ‘Test workflow’', 'Edit Fields', 'Code'].map((name) => ({
+	test('should create pin data for all mocked nodes', () => {
+		const mockedNodes = ['When clicking ‘Test workflow’', 'Edit Fields', 'Code'].map((name) => ({
 			name,
 		}));
 
-		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
+		const pinData = createPinData(wfUnderTestJson, mockedNodes, executionDataJson);
 
 		expect(pinData).toEqual(
 			expect.objectContaining({
@@ -48,7 +48,7 @@ describe('createPinData', () => {
 		);
 	});
 
-	test('should return empty object if no pinned nodes are provided', () => {
+	test('should return empty object if no mocked nodes are provided', () => {
 		const pinData = createPinData(wfUnderTestJson, [], executionDataJson);
 
 		expect(pinData).toEqual({});

--- a/packages/cli/src/evaluation/test-runner/__tests__/create-pin-data.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/create-pin-data.ee.test.ts
@@ -13,12 +13,44 @@ const executionDataJson = JSON.parse(
 
 describe('createPinData', () => {
 	test('should create pin data from past execution data', () => {
-		const pinData = createPinData(wfUnderTestJson, executionDataJson);
+		const pinnedNodes = ['When clicking ‘Test workflow’'].map((name) => ({ name }));
+
+		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
 
 		expect(pinData).toEqual(
 			expect.objectContaining({
 				'When clicking ‘Test workflow’': expect.anything(),
 			}),
 		);
+	});
+
+	test('should not create pin data for non-existing pinned nodes', () => {
+		const pinnedNodes = ['Non-existing node'].map((name) => ({ name }));
+
+		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
+
+		expect(pinData).toEqual({});
+	});
+
+	test('should create pin data for all pinned nodes', () => {
+		const pinnedNodes = ['When clicking ‘Test workflow’', 'Edit Fields', 'Code'].map((name) => ({
+			name,
+		}));
+
+		const pinData = createPinData(wfUnderTestJson, pinnedNodes, executionDataJson);
+
+		expect(pinData).toEqual(
+			expect.objectContaining({
+				'When clicking ‘Test workflow’': expect.anything(),
+				'Edit Fields': expect.anything(),
+				Code: expect.anything(),
+			}),
+		);
+	});
+
+	test('should return empty object if no pinned nodes are provided', () => {
+		const pinData = createPinData(wfUnderTestJson, [], executionDataJson);
+
+		expect(pinData).toEqual({});
 	});
 });

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -163,6 +163,7 @@ describe('TestRunnerService', () => {
 			mock<TestDefinition>({
 				workflowId: 'workflow-under-test-id',
 				evaluationWorkflowId: 'evaluation-workflow-id',
+				pinnedNodes: [],
 			}),
 		);
 
@@ -219,6 +220,7 @@ describe('TestRunnerService', () => {
 			mock<TestDefinition>({
 				workflowId: 'workflow-under-test-id',
 				evaluationWorkflowId: 'evaluation-workflow-id',
+				pinnedNodes: [{ name: 'When clicking ‘Test workflow’' }],
 			}),
 		);
 

--- a/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -163,7 +163,7 @@ describe('TestRunnerService', () => {
 			mock<TestDefinition>({
 				workflowId: 'workflow-under-test-id',
 				evaluationWorkflowId: 'evaluation-workflow-id',
-				pinnedNodes: [],
+				mockedNodes: [],
 			}),
 		);
 
@@ -220,7 +220,7 @@ describe('TestRunnerService', () => {
 			mock<TestDefinition>({
 				workflowId: 'workflow-under-test-id',
 				evaluationWorkflowId: 'evaluation-workflow-id',
-				pinnedNodes: [{ name: 'When clicking ‘Test workflow’' }],
+				mockedNodes: [{ name: 'When clicking ‘Test workflow’' }],
 			}),
 		);
 

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -11,7 +11,7 @@ import { Service } from 'typedi';
 
 import { ActiveExecutions } from '@/active-executions';
 import type { ExecutionEntity } from '@/databases/entities/execution-entity';
-import type { TestDefinition } from '@/databases/entities/test-definition.ee';
+import type { PinnedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
@@ -52,10 +52,11 @@ export class TestRunnerService {
 	private async runTestCase(
 		workflow: WorkflowEntity,
 		pastExecutionData: IRunExecutionData,
+		pinnedNodes: PinnedNodeItem[],
 		userId: string,
 	): Promise<IRun | undefined> {
 		// Create pin data from the past execution data
-		const pinData = createPinData(workflow, pastExecutionData);
+		const pinData = createPinData(workflow, pinnedNodes, pastExecutionData);
 
 		// Determine the start node of the past execution
 		const pastExecutionStartNode = getPastExecutionTriggerNode(pastExecutionData);
@@ -196,7 +197,12 @@ export class TestRunnerService {
 			const executionData = parse(pastExecution.executionData.data) as IRunExecutionData;
 
 			// Run the test case and wait for it to finish
-			const testCaseExecution = await this.runTestCase(workflow, executionData, user.id);
+			const testCaseExecution = await this.runTestCase(
+				workflow,
+				executionData,
+				test.pinnedNodes,
+				user.id,
+			);
 
 			// In case of a permission check issue, the test case execution will be undefined.
 			// Skip them and continue with the next test case

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -11,7 +11,7 @@ import { Service } from 'typedi';
 
 import { ActiveExecutions } from '@/active-executions';
 import type { ExecutionEntity } from '@/databases/entities/execution-entity';
-import type { PinnedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
+import type { MockedNodeItem, TestDefinition } from '@/databases/entities/test-definition.ee';
 import type { User } from '@/databases/entities/user';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
@@ -31,7 +31,7 @@ import { createPinData, getPastExecutionTriggerNode } from './utils.ee';
  * and runs the workflow-under-test with the pin data.
  * After the workflow-under-test finishes, it runs the evaluation workflow
  * with the original and new run data.
- * TODO: Node pinning
+ * TODO: Node mocking
  * TODO: Collect metrics
  */
 @Service()
@@ -52,11 +52,11 @@ export class TestRunnerService {
 	private async runTestCase(
 		workflow: WorkflowEntity,
 		pastExecutionData: IRunExecutionData,
-		pinnedNodes: PinnedNodeItem[],
+		mockedNodes: MockedNodeItem[],
 		userId: string,
 	): Promise<IRun | undefined> {
 		// Create pin data from the past execution data
-		const pinData = createPinData(workflow, pinnedNodes, pastExecutionData);
+		const pinData = createPinData(workflow, mockedNodes, pastExecutionData);
 
 		// Determine the start node of the past execution
 		const pastExecutionStartNode = getPastExecutionTriggerNode(pastExecutionData);
@@ -200,7 +200,7 @@ export class TestRunnerService {
 			const testCaseExecution = await this.runTestCase(
 				workflow,
 				executionData,
-				test.pinnedNodes,
+				test.mockedNodes,
 				user.id,
 			);
 

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -30,9 +30,7 @@ import { createPinData, getPastExecutionTriggerNode } from './utils.ee';
  * past executions, creates pin data from them,
  * and runs the workflow-under-test with the pin data.
  * After the workflow-under-test finishes, it runs the evaluation workflow
- * with the original and new run data.
- * TODO: Node mocking
- * TODO: Collect metrics
+ * with the original and new run data, and collects the metrics.
  */
 @Service()
 export class TestRunnerService {

--- a/packages/cli/src/evaluation/test-runner/utils.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/utils.ee.ts
@@ -16,8 +16,10 @@ export function createPinData(
 ) {
 	const pinData = {} as IPinData;
 
+	const workflowNodeNames = new Set(workflow.nodes.map((node) => node.name));
+
 	for (const mockedNode of mockedNodes) {
-		if (workflow.nodes.find((node) => node.name === mockedNode.name)) {
+		if (workflowNodeNames.has(mockedNode.name)) {
 			const nodeData = executionData.resultData.runData[mockedNode.name];
 			if (nodeData?.[0]?.data?.main?.[0]) {
 				pinData[mockedNode.name] = nodeData[0]?.data?.main?.[0];

--- a/packages/cli/src/evaluation/test-runner/utils.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/utils.ee.ts
@@ -1,27 +1,26 @@
 import type { IRunExecutionData, IPinData } from 'n8n-workflow';
 
-import type { PinnedNodeItem } from '@/databases/entities/test-definition.ee';
+import type { MockedNodeItem } from '@/databases/entities/test-definition.ee';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 
 /**
  * Extracts the execution data from the past execution
  * and creates a pin data object from it for the given workflow.
- * For now, it only pins trigger nodes.
+ * It uses a list of mocked nodes defined in a test definition
+ * to decide which nodes to pin.
  */
 export function createPinData(
 	workflow: WorkflowEntity,
-	pinnedNodes: PinnedNodeItem[],
+	mockedNodes: MockedNodeItem[],
 	executionData: IRunExecutionData,
 ) {
-	// const triggerNodes = workflow.nodes.filter((node) => /trigger$/i.test(node.type));
-
 	const pinData = {} as IPinData;
 
-	for (const pinnedNode of pinnedNodes) {
-		if (workflow.nodes.find((node) => node.name === pinnedNode.name)) {
-			const nodeData = executionData.resultData.runData[pinnedNode.name];
+	for (const mockedNode of mockedNodes) {
+		if (workflow.nodes.find((node) => node.name === mockedNode.name)) {
+			const nodeData = executionData.resultData.runData[mockedNode.name];
 			if (nodeData?.[0]?.data?.main?.[0]) {
-				pinData[pinnedNode.name] = nodeData[0]?.data?.main?.[0];
+				pinData[mockedNode.name] = nodeData[0]?.data?.main?.[0];
 			}
 		}
 	}

--- a/packages/cli/src/evaluation/test-runner/utils.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/utils.ee.ts
@@ -1,5 +1,6 @@
 import type { IRunExecutionData, IPinData } from 'n8n-workflow';
 
+import type { PinnedNodeItem } from '@/databases/entities/test-definition.ee';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
 
 /**
@@ -7,15 +8,21 @@ import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
  * and creates a pin data object from it for the given workflow.
  * For now, it only pins trigger nodes.
  */
-export function createPinData(workflow: WorkflowEntity, executionData: IRunExecutionData) {
-	const triggerNodes = workflow.nodes.filter((node) => /trigger$/i.test(node.type));
+export function createPinData(
+	workflow: WorkflowEntity,
+	pinnedNodes: PinnedNodeItem[],
+	executionData: IRunExecutionData,
+) {
+	// const triggerNodes = workflow.nodes.filter((node) => /trigger$/i.test(node.type));
 
 	const pinData = {} as IPinData;
 
-	for (const triggerNode of triggerNodes) {
-		const triggerData = executionData.resultData.runData[triggerNode.name];
-		if (triggerData?.[0]?.data?.main?.[0]) {
-			pinData[triggerNode.name] = triggerData[0]?.data?.main?.[0];
+	for (const pinnedNode of pinnedNodes) {
+		if (workflow.nodes.find((node) => node.name === pinnedNode.name)) {
+			const nodeData = executionData.resultData.runData[pinnedNode.name];
+			if (nodeData?.[0]?.data?.main?.[0]) {
+				pinData[pinnedNode.name] = nodeData[0]?.data?.main?.[0];
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR adds actual node mocking logic to the Test Runner.
Now Test Runner uses `mockedNodes` list data of the test definition to collect a `pinData` object for a specific test case execution.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-443/[testrunner]-implement-data-pinning-logic

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
