### PR TITLE
ci: Trigger workflow tests on release PRs (no-changelog)

### DIFF
--- a/.github/workflows/test-workflows.yml
+++ b/.github/workflows/test-workflows.yml
@@ -4,18 +4,70 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
+  pull_request:
+    paths:
+      - packages/core/package.json
+      - packages/nodes-base/package.json
+      - packages/@n8n/nodes-langchain/package.json
+      - .github/workflows/test-workflows.yml
+  pull_request_review:
+    types: [submitted]
 
 jobs:
-  run-test-workflows:
+  build:
+    name: Install & Build
     runs-on: ubuntu-latest
-
-    timeout-minutes: 30
-
+    if: github.event_name != 'pull_request_review' || startsWith(github.event.pull_request.base.ref, 'release/')
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.1
+      - run: corepack enable
+      - uses: actions/setup-node@v4.0.2
         with:
-          path: n8n
+          node-version: 20.x
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup build cache
+        uses: rharkor/caching-for-turbo@v1.5
+
+      - name: Build Backend
+        run: pnpm build:backend
+
+      - name: Cache build artifacts
+        uses: actions/cache/save@v4.0.0
+        with:
+          path: ./packages/**/dist
+          key: ${{ github.sha }}:workflow-tests
+
+  run-test-workflows:
+    name: Workflow Tests
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - run: corepack enable
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup build cache
+        uses: rharkor/caching-for-turbo@v1.5
+
+      - name: Restore cached build artifacts
+        uses: actions/cache/restore@v4.0.0
+        with:
+          path: ./packages/**/dist
+          key: ${{ github.sha }}:workflow-tests
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt update -y
+          echo 'tzdata tzdata/Areas select Europe' | sudo debconf-set-selections
+          echo 'tzdata tzdata/Zones/Europe select Paris' | sudo debconf-set-selections
+          DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y graphicsmagick
 
       - name: Checkout workflows repo
         uses: actions/checkout@v4.1.1
@@ -23,75 +75,30 @@ jobs:
           repository: n8n-io/test-workflows
           path: test-workflows
 
-      - run: corepack enable
-        working-directory: n8n
-
-      - uses: actions/setup-node@v4.0.2
-        with:
-          node-version: 20.x
-          cache: 'pnpm'
-          cache-dependency-path: 'n8n/pnpm-lock.yaml'
-
-      - name: Install dependencies
-        run: |
-          sudo apt update -y
-          echo 'tzdata tzdata/Areas select Europe' | sudo debconf-set-selections
-          echo 'tzdata tzdata/Zones/Europe select Paris' | sudo debconf-set-selections
-          DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y graphicsmagick
-        shell: bash
-
-      - name: pnpm install and build
-        working-directory: n8n
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build:backend
-        shell: bash
-
       - name: Import credentials
-        run: n8n/packages/cli/bin/n8n import:credentials --input=test-workflows/credentials.json
-        shell: bash
+        run: packages/cli/bin/n8n import:credentials --input=test-workflows/credentials.json
         env:
           N8N_ENCRYPTION_KEY: ${{secrets.ENCRYPTION_KEY}}
 
       - name: Import workflows
-        run: n8n/packages/cli/bin/n8n import:workflow --separate --input=test-workflows/workflows
-        shell: bash
+        run: packages/cli/bin/n8n import:workflow --separate --input=test-workflows/workflows
         env:
           N8N_ENCRYPTION_KEY: ${{secrets.ENCRYPTION_KEY}}
 
       - name: Copy static assets
         run: |
-          cp n8n/assets/n8n-logo.png /tmp/n8n-logo.png
-          cp n8n/assets/n8n-screenshot.png /tmp/n8n-screenshot.png
+          cp assets/n8n-logo.png /tmp/n8n-logo.png
+          cp assets/n8n-screenshot.png /tmp/n8n-screenshot.png
           cp test-workflows/testData/pdfs/*.pdf /tmp/
-        shell: bash
 
       - name: Run tests
-        run: n8n/packages/cli/bin/n8n executeBatch --shallow --skipList=test-workflows/skipList.txt --githubWorkflow --shortOutput --concurrency=16 --compare=test-workflows/snapshots
-        shell: bash
+        run: packages/cli/bin/n8n executeBatch --shallow --skipList=test-workflows/skipList.txt --githubWorkflow --shortOutput --concurrency=16 --compare=test-workflows/snapshots
         id: tests
         env:
           N8N_ENCRYPTION_KEY: ${{secrets.ENCRYPTION_KEY}}
           SKIP_STATISTICS_EVENTS: true
           DB_SQLITE_POOL_SIZE: 4
           N8N_SENTRY_DSN: ${{secrets.CI_SENTRY_DSN}}
-
-      # -
-      #   name: Export credentials
-      #   if: always()
-      #   run: n8n/packages/cli/bin/n8n export:credentials --output=test-workflows/credentials.json --all --pretty
-      #   shell: bash
-      #   env:
-      #     N8N_ENCRYPTION_KEY: ${{secrets.ENCRYPTION_KEY}}
-      # -
-      #   name: Commit and push credential changes
-      #   if: always()
-      #   run: |
-      #     cd test-workflows
-      #     git config --global user.name 'n8n test bot'
-      #     git config --global user.email 'n8n-test-bot@users.noreply.github.com'
-      #     git commit -am "Automated credential update"
-      #     git push --force --quiet "https://janober:${{ secrets.TOKEN }}@github.com/n8n-io/test-workflows.git" main:main
 
       - name: Notify Slack on failure
         uses: act10ns/slack@v2.0.0


### PR DESCRIPTION
## Summary
This PR updates the workflow tests CI job to
1. trigger automatically when any nodes dependencies get updated, or when the workflow yaml is updated
2. trigger on release PRs, when the PR is approved
3. split the workflow into multiple jobs, and use build cache, to be consistent with other CI workflows

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
