### PR TITLE
fix(Postgres Node): Account for JSON expressions

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
@@ -362,7 +362,7 @@ describe('Test PostgresV2, executeQuery operation', () => {
 		);
 	});
 
-	it('should call queries with multiple json key/value pairs', async () => {
+	it('should execute queries with multiple json key/value pairs', async () => {
 		const nodeParameters: IDataObject = {
 			operation: 'executeQuery',
 			query: 'SELECT *\nFROM users\nWHERE username IN ($1, $2, $3)',
@@ -383,7 +383,7 @@ describe('Test PostgresV2, executeQuery operation', () => {
 		}).not.toThrow();
 	});
 
-	it('should call queries with single json key/value pair', async () => {
+	it('should execute queries with single json key/value pair', async () => {
 		const nodeParameters: IDataObject = {
 			operation: 'executeQuery',
 			query: 'SELECT *\nFROM users\nWHERE username IN ($1, $2, $3)',
@@ -403,7 +403,7 @@ describe('Test PostgresV2, executeQuery operation', () => {
 		}).not.toThrow();
 	});
 
-	it('should not parse out expressions if there are valid JSON query replacements', async () => {
+	it('should not parse out expressions if there are valid JSON query parameters', async () => {
 		const query = 'SELECT *\nFROM users\nWHERE username IN ($1, $2, $3)';
 		const nodeParameters: IDataObject = {
 			operation: 'executeQuery',
@@ -429,7 +429,7 @@ describe('Test PostgresV2, executeQuery operation', () => {
 		expect(utils.stringToArray).toHaveBeenCalledTimes(0);
 	});
 
-	it('should parse out expressions if is invalid JSON in query replacements', async () => {
+	it('should parse out expressions if is invalid JSON in query parameters', async () => {
 		const query = 'SELECT *\nFROM users\nWHERE username IN ($1, $2, $3)';
 		const nodeParameters: IDataObject = {
 			operation: 'executeQuery',

--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -13,6 +13,7 @@ import {
 	replaceEmptyStringsByNulls,
 	wrapData,
 	convertArraysToPostgresFormat,
+	isJSON,
 } from '../../v2/helpers/utils';
 
 const node: INode = {
@@ -25,6 +26,15 @@ const node: INode = {
 		operation: 'executeQuery',
 	},
 };
+
+describe('Test PostgresV2, isJSON', () => {
+	it('should return true for valid JSON', () => {
+		expect(isJSON('{"key": "value"}')).toEqual(true);
+	});
+	it('should return false for invalid JSON', () => {
+		expect(isJSON('{"key": "value"')).toEqual(false);
+	});
+});
 
 describe('Test PostgresV2, wrapData', () => {
 	it('should wrap object in json', () => {

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -14,9 +14,7 @@ import type {
 	QueriesRunner,
 	QueryWithValues,
 } from '../../helpers/interfaces';
-
 import { isJSON, replaceEmptyStringsByNulls, stringToArray } from '../../helpers/utils';
-
 import { optionsCollection } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
@@ -86,7 +84,8 @@ export async function execute(
 					const resolvables = getResolvables(rawValues);
 					if (resolvables.length) {
 						for (const resolvable of resolvables) {
-							const evaluatedExpression = this.evaluateExpression(`${resolvable}`, index)?.toString()??'';
+							const evaluatedExpression =
+								this.evaluateExpression(`${resolvable}`, index)?.toString() ?? '';
 							const evaluatedValues = isJSON(evaluatedExpression)
 								? [evaluatedExpression]
 								: stringToArray(evaluatedExpression);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -93,9 +93,11 @@ export async function execute(
 					const resolvables = getResolvables(rawValues);
 					if (resolvables.length) {
 						for (const resolvable of resolvables) {
-							const evaluatedValues = stringToArray(
-								this.evaluateExpression(`${resolvable}`, index),
-							);
+							const evaluatedExpression = this.evaluateExpression(`${resolvable}`, index) as string;
+							const evaluatedValues = isJSON(evaluatedExpression)
+								? [evaluatedExpression]
+								: stringToArray(evaluatedExpression);
+
 							if (evaluatedValues.length) values.push(...evaluatedValues);
 						}
 					} else {

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -86,7 +86,7 @@ export async function execute(
 					const resolvables = getResolvables(rawValues);
 					if (resolvables.length) {
 						for (const resolvable of resolvables) {
-							const evaluatedExpression = this.evaluateExpression(`${resolvable}`, index) as string;
+							const evaluatedExpression = this.evaluateExpression(`${resolvable}`, index)?.toString()??'';
 							const evaluatedValues = isJSON(evaluatedExpression)
 								? [evaluatedExpression]
 								: stringToArray(evaluatedExpression);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -3,7 +3,6 @@ import type {
 	IExecuteFunctions,
 	INodeExecutionData,
 	INodeProperties,
-	NodeParameterValueType,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 
@@ -15,7 +14,9 @@ import type {
 	QueriesRunner,
 	QueryWithValues,
 } from '../../helpers/interfaces';
-import { replaceEmptyStringsByNulls } from '../../helpers/utils';
+
+import { isJSON, replaceEmptyStringsByNulls, stringToArray } from '../../helpers/utils';
+
 import { optionsCollection } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
@@ -76,14 +77,6 @@ export async function execute(
 			const node = this.getNode();
 
 			const rawReplacements = (node.parameters.options as IDataObject)?.queryReplacement as string;
-
-			const stringToArray = (str: NodeParameterValueType | undefined) => {
-				if (str === undefined) return [];
-				return String(str)
-					.split(',')
-					.filter((entry) => entry)
-					.map((entry) => entry.trim());
-			};
 
 			if (rawReplacements) {
 				const nodeVersion = nodeOptions.nodeVersion as number;

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -4,6 +4,7 @@ import type {
 	INode,
 	INodeExecutionData,
 	INodePropertyOptions,
+	NodeParameterValueType,
 } from 'n8n-workflow';
 import { NodeOperationError, jsonParse } from 'n8n-workflow';
 
@@ -22,11 +23,19 @@ import { generatePairedItemData } from '../../../../utils/utilities';
 
 export function isJSON(str: string) {
 	try {
-		JSON.parse(str);
+		JSON.parse(str.trim());
 		return true;
 	} catch {
 		return false;
 	}
+}
+
+export function stringToArray(str: NodeParameterValueType | undefined) {
+	if (str === undefined) return [];
+	return String(str)
+		.split(',')
+		.filter((entry) => entry)
+		.map((entry) => entry.trim());
 }
 
 export function wrapData(data: IDataObject | IDataObject[]): INodeExecutionData[] {

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -20,6 +20,15 @@ import type {
 } from './interfaces';
 import { generatePairedItemData } from '../../../../utils/utilities';
 
+export function isJSON(str: string) {
+	try {
+		JSON.parse(str);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export function wrapData(data: IDataObject | IDataObject[]): INodeExecutionData[] {
 	if (!Array.isArray(data)) {
 		return [{ json: data }];


### PR DESCRIPTION
## Summary

Fixes the bug where query params which include multiple JSON key/vals fails in Postgres Node

Workflows for testing:
```
{
  "nodes": [
    {
      "parameters": {
        "operation": "executeQuery",
        "query": "SELECT insert_ex(\n    $1::jsonb\n);",
        "options": {
          "queryReplacement": "={{ JSON.stringify(\n\n{id: \"848da11d-e72e-44c5-xxxx-c6fb9f17d366\",id2: \"848da11d-e72e-44c5-yyyy-c6fb9f17d366\"}\n\n) }}"
        }
      },
      "id": "4c1d023e-ab9c-467f-a43f-a830b214eefa",
      "name": "This is the problem1",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        1560,
        300
      ],
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "Postgres account 2"
        }
      }
    },
    {
      "parameters": {
        "operation": "executeQuery",
        "query": "SELECT insert_ex(\n        $1::jsonb\n\n);",
        "options": {
          "queryReplacement": "={{ JSON.stringify(\n\n{id: $$66$$}\n\n) }}"
        }
      },
      "id": "110341e5-7b89-4a49-a4bd-fe860a6fa7fd",
      "name": "This works1",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        1560,
        120
      ],
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "Postgres account 2"
        }
      }
    }
  ],
  "connections": {},
  "pinData": {}
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1753/postgres-node-inserting-json-with-multiple-keyvalue-via-query
https://community.n8n.io/t/issue-with-inserting-json-with-multiple-key-value-pairs-in-postgresql-jsonb/53939/

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
