### PR TITLE
fix(Telegram Trigger Node): Fix header secret check

### DIFF
--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -238,7 +238,10 @@ export class TelegramTrigger implements INodeType {
 			const headerSecretBuffer = Buffer.from(
 				String(headerData['x-telegram-bot-api-secret-token'] ?? ''),
 			);
-			if (!crypto.timingSafeEqual(secretBuffer, headerSecretBuffer)) {
+			if (
+				secretBuffer.byteLength !== headerSecretBuffer.byteLength ||
+				!crypto.timingSafeEqual(secretBuffer, headerSecretBuffer)
+			) {
 				const res = this.getResponseObject();
 				res.status(403).json({ message: 'Provided secret is not valid' });
 				return {


### PR DESCRIPTION
## Summary

`crypto.timingSafeEqual` throws if the given buffers are not of equal byte length. We don't want to throw but instead reject the webhook request.

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/n8n-1-68-1-69-docker-telegram-webhook-input-buffers-issue/62491/3

https://linear.app/n8n/issue/NODE-2114/telegram-trigger-node-checking-x-telegram-bot-api-secret-token

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
