### PR TITLE
fix(editor): Fix canvas keybindings using splitter keys such as zooming using `+` key

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -205,8 +205,8 @@ const keyMap = computed(() => ({
 	ctrl_c: emitWithSelectedNodes((ids) => emit('copy:nodes', ids)),
 	enter: emitWithLastSelectedNode((id) => onSetNodeActive(id)),
 	ctrl_a: () => addSelectedNodes(graphNodes.value),
-	'+|=': async () => await onZoomIn(),
-	'-|_': async () => await onZoomOut(),
+	'shift_+|+|=': async () => await onZoomIn(),
+	'shift+_|-|_': async () => await onZoomOut(),
 	0: async () => await onResetZoom(),
 	1: async () => await onFitView(),
 	ArrowUp: emitWithLastSelectedNode(selectUpperSiblingNode),
@@ -215,7 +215,6 @@ const keyMap = computed(() => ({
 	ArrowRight: emitWithLastSelectedNode(selectRightNode),
 	shift_ArrowLeft: emitWithLastSelectedNode(selectUpstreamNodes),
 	shift_ArrowRight: emitWithLastSelectedNode(selectDownstreamNodes),
-	// @TODO implement arrow key shortcuts to modify selection
 
 	...(props.readOnly
 		? {}

--- a/packages/editor-ui/src/composables/useKeybindings.test.ts
+++ b/packages/editor-ui/src/composables/useKeybindings.test.ts
@@ -110,6 +110,18 @@ describe('useKeybindings', () => {
 		expect(handler).toHaveBeenCalled();
 	});
 
+	it('should normalize shortcut strings containing splitting key correctly', async () => {
+		const handler = vi.fn();
+		const keymap = ref({ 'ctrl_+': handler });
+
+		useKeybindings(keymap);
+
+		const event = new KeyboardEvent('keydown', { key: '+', ctrlKey: true });
+		document.dispatchEvent(event);
+
+		expect(handler).toHaveBeenCalled();
+	});
+
 	it('should normalize shortcut string alternatives correctly', async () => {
 		const handler = vi.fn();
 		const keymap = ref({ 'a|b': handler });

--- a/packages/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/editor-ui/src/composables/useKeybindings.ts
@@ -38,12 +38,28 @@ export const useKeybindings = (
 		),
 	);
 
-	function normalizeShortcutString(shortcut: string) {
-		return shortcut
-			.split(/[+_-]/)
+	function shortcutPartsToString(parts: string[]) {
+		return parts
 			.map((key) => key.toLowerCase())
 			.sort((a, b) => a.localeCompare(b))
 			.join('+');
+	}
+
+	function normalizeShortcutString(shortcut: string) {
+		if (shortcut.length === 1) {
+			return shortcut.toLowerCase();
+		}
+
+		const splitChars = ['+', '_', '-'];
+		const splitCharsRegEx = splitChars.reduce((acc, char) => {
+			if (shortcut.startsWith(char) || shortcut.endsWith(char)) {
+				return acc;
+			}
+
+			return char + acc;
+		}, '');
+
+		return shortcutPartsToString(shortcut.split(new RegExp(`[${splitCharsRegEx}]`)));
 	}
 
 	function toShortcutString(event: KeyboardEvent) {
@@ -64,7 +80,7 @@ export const useKeybindings = (
 			modifiers.push('alt');
 		}
 
-		return normalizeShortcutString([...modifiers, ...keys].join('+'));
+		return shortcutPartsToString([...modifiers, ...keys]);
 	}
 
 	function onKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary

Addresses `useKeybindings` scenarios where shortcuts use one of the splitters (`+_-`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-382/community-issue-the-key-on-the-numeric-keypad-shrinks-the-canvas
Closes #11964 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
