### PR TITLE
fix(editor): Add optional chaining to `pruning.isEnabled` (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -163,7 +163,7 @@ export interface FrontendSettings {
 		pruneTime: number;
 		licensePruneTime: number;
 	};
-	pruning: {
+	pruning?: {
 		isEnabled: boolean;
 		maxAge: number;
 		maxCount: number;

--- a/packages/editor-ui/src/composables/useDebugInfo.ts
+++ b/packages/editor-ui/src/composables/useDebugInfo.ts
@@ -96,7 +96,7 @@ export function useDebugInfo() {
 	};
 
 	const pruningInfo = () => {
-		if (!settingsStore.pruning.isEnabled) return { enabled: false } as const;
+		if (!settingsStore.pruning?.isEnabled) return { enabled: false } as const;
 
 		return {
 			enabled: true,

--- a/packages/editor-ui/src/composables/useDebugInfo.ts
+++ b/packages/editor-ui/src/composables/useDebugInfo.ts
@@ -100,8 +100,8 @@ export function useDebugInfo() {
 
 		return {
 			enabled: true,
-			maxAge: `${settingsStore.pruning.maxAge} hours`,
-			maxCount: `${settingsStore.pruning.maxCount} executions`,
+			maxAge: `${settingsStore.pruning?.maxAge} hours`,
+			maxCount: `${settingsStore.pruning?.maxCount} executions`,
 		} as const;
 	};
 

--- a/packages/editor-ui/tsconfig.json
+++ b/packages/editor-ui/tsconfig.json
@@ -20,7 +20,8 @@
 			"@/*": ["./src/*"],
 			"n8n-design-system": ["../design-system/src/main.ts"],
 			"n8n-design-system/*": ["../design-system/src/*"],
-			"@n8n/chat/*": ["../@n8n/chat/src/*"]
+			"@n8n/chat/*": ["../@n8n/chat/src/*"],
+			"@n8n/api-types*": ["../@n8n/api-types/src*"]
 		},
 		"lib": ["esnext", "dom", "dom.iterable", "scripthost"],
 		// TODO: remove all options below this line


### PR DESCRIPTION
## Summary

Sentry issue

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-394/typeerror-cannot-read-properties-of-undefined-reading-isenabled


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
