### PR TITLE
fix(editor): Use optional chaining for all members in execution data when using the debug feature

### DIFF
--- a/packages/editor-ui/src/composables/useExecutionDebugging.test.ts
+++ b/packages/editor-ui/src/composables/useExecutionDebugging.test.ts
@@ -1,14 +1,84 @@
 import { createTestingPinia } from '@pinia/testing';
-import { setActivePinia } from 'pinia';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useExecutionDebugging } from './useExecutionDebugging';
 import type { INodeUi, IExecutionResponse } from '@/Interface';
 import type { Workflow } from 'n8n-workflow';
+import { useToast } from '@/composables/useToast';
+
+vi.mock('@/composables/useToast', () => {
+	const showToast = vi.fn();
+	return {
+		useToast: () => ({
+			showToast,
+		}),
+	};
+});
+
+let executionDebugging: ReturnType<typeof useExecutionDebugging>;
+let toast: ReturnType<typeof useToast>;
 
 describe('useExecutionDebugging()', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		createTestingPinia();
+		executionDebugging = useExecutionDebugging();
+		toast = useToast();
+	});
+
+	it('should not throw when runData node is an empty array', async () => {
+		const mockExecution = {
+			data: {
+				resultData: {
+					runData: {
+						testNode: [],
+					},
+				},
+			},
+		} as unknown as IExecutionResponse;
+
+		const workflowStore = mockedStore(useWorkflowsStore);
+		workflowStore.getNodes.mockReturnValue([{ name: 'testNode' }] as INodeUi[]);
+		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
+		workflowStore.getCurrentWorkflow.mockReturnValue({
+			pinData: {},
+			getParentNodes: vi.fn().mockReturnValue([]),
+		} as unknown as Workflow);
+
+		await expect(executionDebugging.applyExecutionData('1')).resolves.not.toThrowError();
+	});
+
+	it('should show missing nodes warning toast', async () => {
+		const mockExecution = {
+			data: {
+				resultData: {
+					runData: {
+						testNode: [
+							{
+								data: {},
+							},
+						],
+					},
+				},
+			},
+		} as unknown as IExecutionResponse;
+
+		const workflowStore = mockedStore(useWorkflowsStore);
+		workflowStore.getNodes.mockReturnValue([{ name: 'testNode2' }] as INodeUi[]);
+		workflowStore.getExecution.mockResolvedValueOnce(mockExecution);
+		workflowStore.getCurrentWorkflow.mockReturnValue({
+			pinData: {},
+			getParentNodes: vi.fn().mockReturnValue([]),
+		} as unknown as Workflow);
+
+		await executionDebugging.applyExecutionData('1');
+
+		expect(workflowStore.setWorkflowExecutionData).toHaveBeenCalledWith(mockExecution);
+		expect(toast.showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
+		expect(toast.showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+	});
+
 	it('should applyExecutionData', async () => {
-		setActivePinia(createTestingPinia());
 		const mockExecution = {
 			data: {
 				resultData: {
@@ -31,10 +101,9 @@ describe('useExecutionDebugging()', () => {
 			getParentNodes: vi.fn().mockReturnValue([]),
 		} as unknown as Workflow);
 
-		const { applyExecutionData } = useExecutionDebugging();
-
-		await applyExecutionData('1');
+		await executionDebugging.applyExecutionData('1');
 
 		expect(workflowStore.setWorkflowExecutionData).toHaveBeenCalledWith(mockExecution);
+		expect(toast.showToast).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/editor-ui/src/composables/useExecutionDebugging.ts
+++ b/packages/editor-ui/src/composables/useExecutionDebugging.ts
@@ -108,7 +108,7 @@ export const useExecutionDebugging = () => {
 		let pinnings = 0;
 
 		pinnableNodes.forEach((node: INodeUi) => {
-			const nodeData = runData[node.name]?.[0].data?.main?.[0];
+			const nodeData = runData[node.name]?.[0]?.data?.main?.[0];
 			if (nodeData) {
 				pinnings++;
 				workflowsStore.pinData({


### PR DESCRIPTION
## Summary

Execution run data by nodes can be an empty array.

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2074](https://linear.app/n8n/issue/PAY-2074/typeerror-bmain-is-undefined)


## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] PR Labeled with `release/backport`
