### PR TITLE
fix(core): Use the configured timezone in task runner

### DIFF
--- a/docker/images/n8n/n8n-task-runners.json
+++ b/docker/images/n8n/n8n-task-runners.json
@@ -7,6 +7,7 @@
 			"args": ["/usr/local/lib/node_modules/n8n/node_modules/@n8n/task-runner/dist/start.js"],
 			"allowed-env": [
 				"PATH",
+				"GENERIC_TIMEZONE",
 				"N8N_RUNNERS_GRANT_TOKEN",
 				"N8N_RUNNERS_N8N_URI",
 				"N8N_RUNNERS_MAX_PAYLOAD",

--- a/packages/@n8n/task-runner/src/config/base-runner-config.ts
+++ b/packages/@n8n/task-runner/src/config/base-runner-config.ts
@@ -34,6 +34,9 @@ export class BaseRunnerConfig {
 	@Env('N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT')
 	idleTimeout: number = 0;
 
+	@Env('GENERIC_TIMEZONE')
+	timezone: string = 'America/New_York';
+
 	@Nested
 	healthcheckServer!: HealthcheckServerConfig;
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -341,8 +341,8 @@ describe('JsTaskRunner', () => {
 					taskData,
 				});
 
-				const newYorkTimeNow = DateTime.now().setZone('Europe/Helsinki').toSeconds();
-				expect(outcome.result[0].json.val).toBeCloseTo(newYorkTimeNow, 1);
+				const helsinkiTimeNow = DateTime.now().setZone('Europe/Helsinki').toSeconds();
+				expect(outcome.result[0].json.val).toBeCloseTo(helsinkiTimeNow, 1);
 			});
 
 			it('should use the default timezone', async () => {
@@ -358,8 +358,8 @@ describe('JsTaskRunner', () => {
 					taskData: newDataRequestResponse(inputItems.map(wrapIntoJson), {}),
 				});
 
-				const newYorkTimeNow = DateTime.now().setZone('Europe/Helsinki').toSeconds();
-				expect(outcome.result[0].json.val).toBeCloseTo(newYorkTimeNow, 1);
+				const helsinkiTimeNow = DateTime.now().setZone('Europe/Helsinki').toSeconds();
+				expect(outcome.result[0].json.val).toBeCloseTo(helsinkiTimeNow, 1);
 			});
 		});
 

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -1,4 +1,4 @@
-import { ensureError } from 'n8n-workflow';
+import { ensureError, setGlobalState } from 'n8n-workflow';
 import Container from 'typedi';
 
 import { MainConfig } from './config/main-config';
@@ -43,6 +43,10 @@ function createSignalHandler(signal: string) {
 
 void (async function start() {
 	const config = Container.get(MainConfig);
+
+	setGlobalState({
+		defaultTimezone: config.baseRunnerConfig.timezone,
+	});
 
 	if (config.sentryConfig.sentryDsn) {
 		const { ErrorReporter } = await import('@/error-reporter');

--- a/packages/cli/src/runners/__tests__/task-runner-process.test.ts
+++ b/packages/cli/src/runners/__tests__/task-runner-process.test.ts
@@ -76,6 +76,7 @@ describe('TaskRunnerProcess', () => {
 			'N8N_VERSION',
 			'ENVIRONMENT',
 			'DEPLOYMENT_NAME',
+			'GENERIC_TIMEZONE',
 		])('should propagate %s from env as is', async (envVar) => {
 			jest.spyOn(authService, 'createGrantToken').mockResolvedValue('grantToken');
 			process.env[envVar] = 'custom value';

--- a/packages/cli/src/runners/task-runner-process.ts
+++ b/packages/cli/src/runners/task-runner-process.ts
@@ -54,6 +54,7 @@ export class TaskRunnerProcess extends TypedEmitter<TaskRunnerProcessEventMap> {
 
 	private readonly passthroughEnvVars = [
 		'PATH',
+		'GENERIC_TIMEZONE',
 		'NODE_FUNCTION_ALLOW_BUILTIN',
 		'NODE_FUNCTION_ALLOW_EXTERNAL',
 		'N8N_SENTRY_DSN',


### PR DESCRIPTION
## Summary

Pass the `GENERIC_TIMEZONE` env to task runner in `internal` mode and use it to define the default timezone.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-395/bug-timezones-are-incorrect-in-the-code-node


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
