### PR TITLE
fix(Postgres Node): Allow users to wrap strings with $$ 

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/executeQuery.operation.ts
@@ -143,7 +143,7 @@ export async function execute(
 			}
 		}
 
-		queries.push({ query, values });
+		queries.push({ query, values, options: { partial: true } });
 	}
 
 	return await runQueries(queries, items, nodeOptions);

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/interfaces.ts
@@ -1,12 +1,13 @@
 import type { IDataObject, INodeExecutionData, SSHCredentials } from 'n8n-workflow';
 import type pgPromise from 'pg-promise';
+import { type IFormattingOptions } from 'pg-promise';
 import type pg from 'pg-promise/typescript/pg-subset';
 
 export type QueryMode = 'single' | 'transaction' | 'independently';
 
 export type QueryValue = string | number | IDataObject | string[];
 export type QueryValues = QueryValue[];
-export type QueryWithValues = { query: string; values?: QueryValues };
+export type QueryWithValues = { query: string; values?: QueryValues; options?: IFormattingOptions };
 
 export type WhereClause = { column: string; condition: string; value: string | number };
 export type SortRule = { column: string; direction: string };


### PR DESCRIPTION
## Summary

Allow users to wrap strings in $$ instead of quotes

Some Workflows to test:
```
{
  "nodes": [
    {
      "parameters": {
        "operation": "executeQuery",
        "query": "INSERT INTO dollar_bug (description) VALUES\n($$34loltestytest User data not saving properly$$);",
        "options": {}
      },
      "id": "b180d69a-019e-4cf4-9290-e258dad0bdf9",
      "name": "This is the problem1",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        1240,
        -160
      ],
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "Postgres account 2"
        }
      }
    },
    {
      "parameters": {
        "operation": "executeQuery",
        "query": "INSERT INTO dollar_bug (description) VALUES ($1)",
        "options": {
          "queryReplacement": "$3This is a bug related to the dollar sign $"
        }
      },
      "id": "47474b47-1009-42f3-8654-5bd23dc0a14f",
      "name": "TestCase query param",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        1220,
        20
      ],
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "Postgres account 2"
        }
      }
    },
    {
      "parameters": {
        "operation": "executeQuery",
        "query": "INSERT INTO dollar_bug (description) VALUES ($1 || $$3 hehe more text here$$)",
        "options": {
          "queryReplacement": "$3This is a bug related to the dollar sign $"
        }
      },
      "id": "676dfb87-c756-4091-8b1b-beda7018d040",
      "name": "TestCase query param and string",
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        1240,
        200
      ],
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "Postgres account 2"
        }
      }
    }
  ],
  "connections": {},
  "pinData": {}
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1673/postgres-dollar-quoted-strings-are-messed-up-on-insertion

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
