### PR TITLE
fix(core): Opt-out from optimizations if `$item` is used

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -17,7 +17,7 @@ describe('BuiltInsParser', () => {
 	const parseAndExpectOk = (code: string) => {
 		const result = parser.parseUsedBuiltIns(code);
 		if (!result.ok) {
-			fail(result.error);
+			throw result.error;
 		}
 
 		return result.result;
@@ -147,6 +147,13 @@ describe('BuiltInsParser', () => {
 	describe('$node', () => {
 		it('should require all nodes when $node is used', () => {
 			const state = parseAndExpectOk('return $node["name"];');
+			expect(state).toEqual(new BuiltInsParserState({ needsAllNodes: true, needs$input: true }));
+		});
+	});
+
+	describe('$item', () => {
+		it('should require all nodes and input when $item is used', () => {
+			const state = parseAndExpectOk('$item("0").$node["my node"].json["title"]');
 			expect(state).toEqual(new BuiltInsParserState({ needsAllNodes: true, needs$input: true }));
 		});
 	});

--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/built-ins-parser.ts
@@ -125,6 +125,11 @@ export class BuiltInsParser {
 	private visitIdentifier = (node: Identifier, state: BuiltInsParserState) => {
 		if (node.name === '$env') {
 			state.markEnvAsNeeded();
+		} else if (node.name === '$item') {
+			// $item is legacy syntax that is basically an alias for WorkflowDataProxy
+			// and allows accessing any data. We need to support it for backwards
+			// compatibility, but we're not gonna implement any optimizations
+			state.markNeedsAllNodes();
 		} else if (
 			node.name === '$input' ||
 			node.name === '$json' ||


### PR DESCRIPTION
## Summary

`$item` is legacy syntax in the Code Node and should not be used. We still need to support it. Opt-out from any optimizations in this case so we have correct data available.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-396/referenced-node-is-unexecuted-[item-0]-error

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
