### PR TITLE
feat(editor): Enable sourcemaps for production builds (no-changelog)

### DIFF
--- a/packages/editor-ui/vite.config.mts
+++ b/packages/editor-ui/vite.config.mts
@@ -79,7 +79,7 @@ export default mergeConfig(
 		},
 		build: {
 			minify: !!release,
-			sourcemap: !!release,
+			sourcemap: true,
 		},
 	}),
 	vitestConfig,


### PR DESCRIPTION
## Summary

Enables sourcemaps for production builds to make debugging easier. 
- n8n is source-available so it poses virtually no risk
- sourcemaps are only loaded when devtools are opened

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7922/enable-sourcemaps-for-production-build

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
