### PR TITLE
fix(editor): Load node types in demo and preview modes

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -256,7 +256,7 @@ const isChatOpen = computed(() => workflowsStore.isChatPanelOpen);
 
 async function initializeData() {
 	const loadPromises = (() => {
-		if (settingsStore.isPreviewMode && isDemoRoute.value) return [nodeTypesStore.getNodeTypes()];
+		if (settingsStore.isPreviewMode && isDemoRoute.value) return [];
 
 		const promises: Array<Promise<unknown>> = [
 			workflowsStore.fetchActiveWorkflows(),
@@ -272,12 +272,12 @@ async function initializeData() {
 			promises.push(externalSecretsStore.fetchAllSecrets());
 		}
 
-		if (nodeTypesStore.allNodeTypes.length === 0) {
-			promises.push(nodeTypesStore.getNodeTypes());
-		}
-
 		return promises;
 	})();
+
+	if (nodeTypesStore.allNodeTypes.length === 0) {
+		loadPromises.push(nodeTypesStore.getNodeTypes());
+	}
 
 	try {
 		await Promise.all(loadPromises);

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -256,7 +256,7 @@ const isChatOpen = computed(() => workflowsStore.isChatPanelOpen);
 
 async function initializeData() {
 	const loadPromises = (() => {
-		if (settingsStore.isPreviewMode && isDemoRoute.value) return [];
+		if (settingsStore.isPreviewMode && isDemoRoute.value) return [nodeTypesStore.getNodeTypes()];
 
 		const promises: Array<Promise<unknown>> = [
 			workflowsStore.fetchActiveWorkflows(),


### PR DESCRIPTION
## Summary

Fixes issue causing node types not to load on new canvas preview and demo mode.

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/97d3dfd3-1d89-4204-9766-cc3ecc79ccaa">


## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
