### PR TITLE
feat: Enable canvas v2 only if beta feature enabled (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/frontend.config.ts
+++ b/packages/@n8n/config/src/configs/frontend.config.ts
@@ -7,5 +7,5 @@ export type FrontendBetaFeatures = 'canvas_v2';
 export class FrontendConfig {
 	/** Which UI experiments to enable. Separate multiple values with a comma `,` */
 	@Env('N8N_UI_BETA_FEATURES')
-	betaFeatures: StringArray<FrontendBetaFeatures> = [];
+	betaFeatures: StringArray<FrontendBetaFeatures> = ['canvas_v2'];
 }

--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -191,30 +191,32 @@ const workflowMenuItems = computed<ActionDropdownItem[]>(() => {
 		disabled: !onWorkflowPage.value || isNewWorkflow.value,
 	});
 
-	actions.push({
-		id: WORKFLOW_MENU_ACTIONS.SWITCH_NODE_VIEW_VERSION,
-		...(nodeViewVersion.value === '2'
-			? nodeViewSwitcherDiscovered.value || isNewUser.value
-				? {}
-				: {
-						badge: locale.baseText('menuActions.badge.new'),
-					}
-			: nodeViewSwitcherDiscovered.value
-				? {
-						badge: locale.baseText('menuActions.badge.beta'),
-						badgeProps: {
-							theme: 'tertiary',
-						},
-					}
-				: {
-						badge: locale.baseText('menuActions.badge.new'),
-					}),
-		label:
-			nodeViewVersion.value === '2'
-				? locale.baseText('menuActions.switchToOldNodeViewVersion')
-				: locale.baseText('menuActions.switchToNewNodeViewVersion'),
-		disabled: !onWorkflowPage.value,
-	});
+	if (settingsStore.isCanvasV2Enabled) {
+		actions.push({
+			id: WORKFLOW_MENU_ACTIONS.SWITCH_NODE_VIEW_VERSION,
+			...(nodeViewVersion.value === '2'
+				? nodeViewSwitcherDiscovered.value || isNewUser.value
+					? {}
+					: {
+							badge: locale.baseText('menuActions.badge.new'),
+						}
+				: nodeViewSwitcherDiscovered.value
+					? {
+							badge: locale.baseText('menuActions.badge.beta'),
+							badgeProps: {
+								theme: 'tertiary',
+							},
+						}
+					: {
+							badge: locale.baseText('menuActions.badge.new'),
+						}),
+			label:
+				nodeViewVersion.value === '2'
+					? locale.baseText('menuActions.switchToOldNodeViewVersion')
+					: locale.baseText('menuActions.switchToNewNodeViewVersion'),
+			disabled: !onWorkflowPage.value,
+		});
+	}
 
 	if ((workflowPermissions.value.delete && !props.readOnly) || isNewWorkflow.value) {
 		actions.push({

--- a/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.test.ts
+++ b/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.test.ts
@@ -16,6 +16,11 @@ describe('useNodeViewVersionSwitcher', () => {
 	const initialState = {
 		[STORES.WORKFLOWS]: {},
 		[STORES.NDV]: {},
+		[STORES.SETTINGS]: {
+			settings: {
+				betaFeatures: ['canvas_v2'],
+			},
+		},
 	};
 
 	beforeEach(() => {

--- a/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
+++ b/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
@@ -3,15 +3,18 @@ import { useLocalStorage } from '@vueuse/core';
 import { useTelemetry } from '@/composables/useTelemetry';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useNDVStore } from '@/stores/ndv.store';
+import { useSettingsStore } from '@/stores/settings.store';
 
 export function useNodeViewVersionSwitcher() {
 	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
 	const telemetry = useTelemetry();
+	const settingsStore = useSettingsStore();
 
 	const isNewUser = computed(() => workflowsStore.activeWorkflows.length === 0);
 
-	const nodeViewVersion = useLocalStorage('NodeView.version', '2');
+	const defaultVersion = settingsStore.isCanvasV2Enabled ? '2' : '1';
+	const nodeViewVersion = useLocalStorage('NodeView.version', defaultVersion);
 	const nodeViewVersionMigrated = useLocalStorage('NodeView.migrated', false);
 
 	function setNodeViewSwitcherDropdownOpened(visible: boolean) {


### PR DESCRIPTION
## Summary

- Adds `canvas_v2` to front end `betaFeatures`
- Enabled canvas switcher only if `canvas_v2` feature is present

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
