### PR TITLE
fix(editor): Fix switching from v2 to v1

### DIFF
--- a/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
+++ b/packages/editor-ui/src/composables/useNodeViewVersionSwitcher.ts
@@ -36,6 +36,10 @@ export function useNodeViewVersionSwitcher() {
 	function switchNodeViewVersion() {
 		const toVersion = nodeViewVersion.value === '2' ? '1' : '2';
 
+		if (!nodeViewVersionMigrated.value) {
+			nodeViewVersionMigrated.value = true;
+		}
+
 		telemetry.track('User switched canvas version', {
 			to_version: toVersion,
 		});
@@ -49,7 +53,6 @@ export function useNodeViewVersionSwitcher() {
 		}
 
 		switchNodeViewVersion();
-		nodeViewVersionMigrated.value = true;
 	}
 
 	return {


### PR DESCRIPTION
## Summary

When switching from v2 to v1 as a new user, you would instantly get migrated to v2 first time you load v1

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7924/fix-switching-canvas-version-from-v2-to-v1-for-new-users


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
