### PR TITLE
fix(editor): Redirect Settings to the proper sub page depending on the instance type (cloud or not)

### DIFF
--- a/packages/editor-ui/src/router.test.ts
+++ b/packages/editor-ui/src/router.test.ts
@@ -14,6 +14,8 @@ const App = {
 };
 const renderComponent = createComponentRenderer(App);
 
+let settingsStore: ReturnType<typeof useSettingsStore>;
+
 describe('router', () => {
 	let server: ReturnType<typeof setupServer>;
 	const initializeAuthenticatedFeaturesSpy = vi.spyOn(init, 'initializeAuthenticatedFeatures');
@@ -28,6 +30,7 @@ describe('router', () => {
 	});
 
 	beforeEach(() => {
+		settingsStore = useSettingsStore();
 		initializeAuthenticatedFeaturesSpy.mockImplementation(async () => await Promise.resolve());
 	});
 
@@ -114,7 +117,6 @@ describe('router', () => {
 	])(
 		'should resolve %s to %s with %s user permissions',
 		async (path, name, scopes) => {
-			const settingsStore = useSettingsStore();
 			const rbacStore = useRBACStore();
 
 			settingsStore.settings.communityNodesEnabled = true;
@@ -127,8 +129,12 @@ describe('router', () => {
 		10000,
 	);
 
-	it('Settings should redirect to Personal settings', async () => {
+	test.each([
+		[VIEWS.PERSONAL_SETTINGS, true],
+		[VIEWS.USAGE, false],
+	])('should redirect Settings to %s', async (name, hideUsagePage) => {
+		settingsStore.settings.hideUsagePage = hideUsagePage;
 		await router.push('/settings');
-		expect(router.currentRoute.value.name).toBe(VIEWS.PERSONAL_SETTINGS);
+		expect(router.currentRoute.value.name).toBe(name);
 	});
 });

--- a/packages/editor-ui/src/router.test.ts
+++ b/packages/editor-ui/src/router.test.ts
@@ -126,4 +126,9 @@ describe('router', () => {
 		},
 		10000,
 	);
+
+	it('Settings should redirect to Personal settings', async () => {
+		await router.push('/settings');
+		expect(router.currentRoute.value.name).toBe(VIEWS.PERSONAL_SETTINGS);
+	});
 });

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -482,8 +482,13 @@ export const routes: RouteRecordRaw[] = [
 		name: VIEWS.SETTINGS,
 		component: SettingsView,
 		props: true,
-		// Redirect to Personal settings and not to Usage and plan because Usage and plan is not available on cloud
-		redirect: { name: VIEWS.PERSONAL_SETTINGS },
+		redirect: () => {
+			const settingsStore = useSettingsStore();
+			if (settingsStore.settings.hideUsagePage) {
+				return { name: VIEWS.PERSONAL_SETTINGS };
+			}
+			return { name: VIEWS.USAGE };
+		},
 		children: [
 			{
 				path: 'usage',

--- a/packages/editor-ui/src/router.ts
+++ b/packages/editor-ui/src/router.ts
@@ -482,7 +482,8 @@ export const routes: RouteRecordRaw[] = [
 		name: VIEWS.SETTINGS,
 		component: SettingsView,
 		props: true,
-		redirect: { name: VIEWS.USAGE },
+		// Redirect to Personal settings and not to Usage and plan because Usage and plan is not available on cloud
+		redirect: { name: VIEWS.PERSONAL_SETTINGS },
 		children: [
 			{
 				path: 'usage',

--- a/packages/editor-ui/src/views/SettingsView.test.ts
+++ b/packages/editor-ui/src/views/SettingsView.test.ts
@@ -50,7 +50,7 @@ const router = createRouter({
 			name: VIEWS.SETTINGS,
 			component: SettingsView,
 			props: true,
-			redirect: { name: VIEWS.USAGE },
+			redirect: { name: VIEWS.PERSONAL_SETTINGS },
 			children: settingsRouteChildren,
 		},
 	],


### PR DESCRIPTION
## Summary

Settings redirection needs to take instance type into account (cloud or not)

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2334](https://linear.app/n8n/issue/PAY-2334/cannot-access-settings-anymore)


## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] PR Labeled with `release/backport`
