### PR TITLE
fix(editor): Don't reset all Parameter Inputs when switched to read-only 

### DIFF
--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -194,7 +194,8 @@ function onDrop(newParamValue: string) {
 watch(
 	() => props.isReadOnly,
 	(isReadOnly) => {
-		if (isReadOnly) {
+		// Patch fix, see https://linear.app/n8n/issue/ADO-2974/resource-mapper-values-are-emptied-when-refreshing-the-columns
+		if (isReadOnly && props.parameter.disabledOptions !== undefined) {
 			valueChanged({ name: props.path, value: props.parameter.default });
 		}
 	},


### PR DESCRIPTION
## Summary

The original code is a bit too wide and ends up resetting previously set values on the resource mapper. We narrow it here to suit the specific use case and behavior today, and will determine the proper way to differentiate properties in a follow up.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2974/resource-mapper-values-are-emptied-when-refreshing-the-columns

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
