### PR TITLE
fix(core): Return homeProject when filtering workflows by project id

### DIFF
--- a/packages/cli/src/databases/repositories/shared-workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/shared-workflow.repository.ts
@@ -211,4 +211,13 @@ export class SharedWorkflowRepository extends Repository<SharedWorkflow> {
 			},
 		});
 	}
+
+	async getAllRelationsForWorkflows(workflowIds: string[]) {
+		return await this.find({
+			where: {
+				workflowId: In(workflowIds),
+			},
+			relations: ['project'],
+		});
+	}
 }

--- a/packages/cli/src/databases/repositories/workflow.repository.ts
+++ b/packages/cli/src/databases/repositories/workflow.repository.ts
@@ -95,7 +95,8 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 			.execute();
 	}
 
-	async getMany(sharedWorkflowIds: string[], options?: ListQuery.Options) {
+	async getMany(sharedWorkflowIds: string[], originalOptions: ListQuery.Options = {}) {
+		const options = structuredClone(originalOptions);
 		if (sharedWorkflowIds.length === 0) return { workflows: [], count: 0 };
 
 		if (typeof options?.filter?.projectId === 'string' && options.filter.projectId !== '') {

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -66,6 +66,21 @@ export class WorkflowService {
 		let { workflows, count } = await this.workflowRepository.getMany(sharedWorkflowIds, options);
 
 		if (hasSharing(workflows)) {
+			// Since we're filtering using project ID as part of the relation,
+			// we end up filtering out all the other relations, meaning that if
+			// it's shared to a project, it won't be able to find the home project.
+			// To solve this, we have to get all the relation now, even though
+			// we're deleting them later.
+			if (typeof options?.filter?.projectId === 'string' && options.filter.projectId !== '') {
+				const relations = await this.sharedWorkflowRepository.getAllRelationsForWorkflows(
+					workflows.map((c) => c.id),
+				);
+				workflows.forEach((c) => {
+					c.shared = relations.filter((r) => r.workflowId === c.id);
+				});
+			}
+
+			console.log(workflows.length);
 			workflows = workflows.map((w) => this.ownershipService.addOwnedByAndSharedWith(w));
 		}
 
@@ -75,8 +90,8 @@ export class WorkflowService {
 		}
 
 		workflows.forEach((w) => {
-			// @ts-expect-error: This is to emulate the old behaviour of removing the shared
-			// field as part of `addOwnedByAndSharedWith`. We need this field in `addScopes`
+			// This is to emulate the old behaviour of removing the shared field as
+			// part of `addOwnedByAndSharedWith`. We need this field in `addScopes`
 			// though. So to avoid leaking the information we just delete it.
 			delete w.shared;
 		});

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -80,7 +80,6 @@ export class WorkflowService {
 				});
 			}
 
-			console.log(workflows.length);
 			workflows = workflows.map((w) => this.ownershipService.addOwnedByAndSharedWith(w));
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When filtering workflows by project Id we'd not return the home project if the user was not the owner of the workflow. Without that the FE shows incorrect ownerships of WFs:

![image](https://github.com/user-attachments/assets/d0ac7db2-3a4a-41f8-9403-0cb8104d15ab)


The reason for that is that that we're filtering the workflows based on `workflow.shared.projectId` which will also filter down the `workflow.shared` list to only contain the sharings matching that projectId:

https://github.com/n8n-io/n8n/blob/146f4893e754e44344ce48a61751a604d18d5c5c/packages/cli/src/databases/repositories/workflow.repository.ts#L102-L105

Later we iterate of `workflow.shared` assuming it contains all sharings:

https://github.com/n8n-io/n8n/blob/146f4893e754e44344ce48a61751a604d18d5c5c/packages/cli/src/services/ownership.service.ts#L82-L98

In raw SQL and with a query builder this can be fixed using sub=queries, but it's not possible to have this behavior with TypeORM's repository interface. 

For credentials this was fixed 3 months ago: https://github.com/n8n-io/n8n/pull/10144

This PR implements the same fix for workflows.

![image](https://github.com/user-attachments/assets/79674317-f278-44fe-9037-7d635cef760a)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

This does not address what's in the description, but what this comment mentions: 
https://linear.app/n8n/issue/PAY-2271/community-issue-credentials-in-project-personal-are-not-just-my#comment-9fe3bc10


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
