### PR TITLE
feat(editor): Add map option to preserve field order

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper.test.ts
+++ b/packages/editor-ui/src/components/ResourceMapper.test.ts
@@ -74,6 +74,27 @@ describe('ResourceMapper.vue', () => {
 		expect(queryByTestId('matching-column-select')).not.toBeInTheDocument();
 	});
 
+	it('renders map mode properly', async () => {
+		const { getByTestId, queryByTestId } = renderComponent(
+			{
+				props: {
+					parameter: {
+						typeOptions: {
+							resourceMapper: {
+								mode: 'map',
+							},
+						},
+					},
+				},
+			},
+			{ merge: true },
+		);
+		await waitAllPromises();
+		expect(getByTestId('resource-mapper-container')).toBeInTheDocument();
+		// This mode doesn't render matching column selector
+		expect(queryByTestId('matching-column-select')).not.toBeInTheDocument();
+	});
+
 	it('renders multi-key match selector properly', async () => {
 		const { container, getByTestId } = renderComponent(
 			{

--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -164,7 +164,7 @@ const showMappingModeSelect = computed<boolean>(() => {
 const showMatchingColumnsSelector = computed<boolean>(() => {
 	return (
 		!state.loading &&
-		props.parameter.typeOptions?.resourceMapper?.mode !== 'add' &&
+		['upsert', 'update'].includes(props.parameter.typeOptions?.resourceMapper?.mode ?? '') &&
 		state.paramValue.schema.length > 0
 	);
 });

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/ExecuteWorkflow.node.ts
@@ -222,7 +222,7 @@ export class ExecuteWorkflow implements INodeType {
 					resourceMapper: {
 						localResourceMapperMethod: 'loadWorkflowInputMappings',
 						valuesLabel: 'Workflow Inputs',
-						mode: 'add',
+						mode: 'map',
 						fieldWords: {
 							singular: 'workflow input',
 							plural: 'workflow inputs',

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflow/methods/resourceMapping.ts
@@ -21,7 +21,7 @@ export async function loadWorkflowInputMappings(
 				id: currentWorkflowInput.name,
 				displayName: currentWorkflowInput.name,
 				required: false,
-				defaultMatch: true,
+				defaultMatch: false,
 				display: true,
 				canBeUsedToMatch: true,
 			};

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1366,7 +1366,7 @@ export interface INodePropertyTypeOptions {
 }
 
 export interface ResourceMapperTypeOptionsBase {
-	mode: 'add' | 'update' | 'upsert';
+	mode: 'add' | 'update' | 'upsert' | 'map';
 	valuesLabel?: string;
 	fieldWords?: {
 		singular: string;


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Add map option to preserve field order, fetched from sub-workflow input fields

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/ADO-2898/execute-workflow-node-add-workflow-inputs-parameter


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
