### PR TITLE
fix(Slack Node): Fix @version issue in param editor

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
@@ -47,7 +47,7 @@ export const fileFields: INodeProperties[] = [
 			show: {
 				operation: ['upload'],
 				resource: ['file'],
-				'@version': [2, 2.1],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		description: 'Whether the data to upload should be taken from binary field',
@@ -62,7 +62,7 @@ export const fileFields: INodeProperties[] = [
 				operation: ['upload'],
 				resource: ['file'],
 				binaryData: [false],
-				'@version': [2, 2.1],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		placeholder: '',
@@ -78,23 +78,7 @@ export const fileFields: INodeProperties[] = [
 				operation: ['upload'],
 				resource: ['file'],
 				binaryData: [true],
-				'@version': [2, 2.1],
-			},
-		},
-		placeholder: '',
-		description: 'Name of the binary property which contains the data for the file to be uploaded',
-	},
-	{
-		displayName: 'File Property',
-		name: 'binaryPropertyName',
-		type: 'string',
-		default: 'data',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['upload'],
-				resource: ['file'],
-				'@version': [{ _cnd: { gte: 2.2 } }],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		placeholder: '',
@@ -123,12 +107,28 @@ export const fileFields: INodeProperties[] = [
 				},
 				displayOptions: {
 					show: {
-						'@version': [2, 2.1],
+						'@version': [{ _cnd: { gte: 2 } }],
 					},
 				},
 				default: [],
 				description:
 					'The channels to send the file to. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Channel Name or ID',
+				name: 'channelId',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getChannels',
+				},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2.2 } }],
+					},
+				},
+				default: [],
+				description:
+					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Channel Name or ID',

--- a/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
@@ -131,22 +131,6 @@ export const fileFields: INodeProperties[] = [
 					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
-				displayName: 'Channel Name or ID',
-				name: 'channelId',
-				type: 'options',
-				typeOptions: {
-					loadOptionsMethod: 'getChannels',
-				},
-				displayOptions: {
-					show: {
-						'@version': [{ _cnd: { gte: 2.2 } }],
-					},
-				},
-				default: [],
-				description:
-					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
-			},
-			{
 				displayName: 'File Name',
 				name: 'fileName',
 				type: 'string',


### PR DESCRIPTION
Slack node version was bumped to 2.3 but this one keeps the prop field hidden in the UI

## Summary

Can't pick file prop in the UI when using **"Upload file" node for Slack**, so I'm adding the new version on prop show condition.

| Parameters | Settings |
| -- | -- |
| <img width="462" alt="image" src="https://github.com/user-attachments/assets/233e752e-c802-4955-a8ec-7175cde1e86b"> | <img width="444" alt="image" src="https://github.com/user-attachments/assets/66cfed7c-825c-493f-9d4c-8f6e24e503e5"> |

## Related PRs
- n8n-io/n8n#9323
- n8n-io/n8n#12177

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
