### PR TITLE
fix(core): Remove run data of nodes unrelated to the current partial execution

### DIFF
--- a/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
+++ b/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
@@ -42,8 +42,8 @@ export class DirectedGraph {
 
 	private connections: Map<DirectedGraphKey, GraphConnection> = new Map();
 
-	getNode(nodeName: string) {
-		return this.nodes.get(nodeName);
+	hasNode(nodeName: string) {
+		return this.nodes.has(nodeName);
 	}
 
 	getNodes() {

--- a/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
+++ b/packages/core/src/PartialExecutionUtils/DirectedGraph.ts
@@ -42,6 +42,10 @@ export class DirectedGraph {
 
 	private connections: Map<DirectedGraphKey, GraphConnection> = new Map();
 
+	getNode(nodeName: string) {
+		return this.nodes.get(nodeName);
+	}
+
 	getNodes() {
 		return new Map(this.nodes.entries());
 	}

--- a/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
@@ -472,4 +472,30 @@ describe('DirectedGraph', () => {
 			expect(graph).toEqual(expectedGraph);
 		});
 	});
+
+	describe('getNode', () => {
+		test("returns node if it's part of the graph", () => {
+			// ARRANGE
+			const node = createNodeData({ name: 'node' });
+			const graph = new DirectedGraph().addNodes(node);
+
+			// ACT
+			const gotNode = graph.getNode(node.name);
+
+			// ASSERT
+			expect(gotNode).toBe(node);
+		});
+
+		test('returns undefined if there is no node with that name in the graph', () => {
+			// ARRANGE
+			const node = createNodeData({ name: 'node' });
+			const graph = new DirectedGraph().addNodes(node);
+
+			// ACT
+			const gotNode = graph.getNode(node.name + 'foo');
+
+			// ASSERT
+			expect(gotNode).toBeUndefined();
+		});
+	});
 });

--- a/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
@@ -43,8 +43,8 @@ describe('DirectedGraph', () => {
 	});
 
 	//    ┌─────┐    ┌─────┐──► null
-	//    │node1├───►│node2|   ┌─────┐
-	//    └─────┘    └─────┘──►│node3|
+	//    │node1├───►│node2│   ┌─────┐
+	//    └─────┘    └─────┘──►│node3│
 	//                         └─────┘
 	//
 	test('linear workflow with null connections', () => {

--- a/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/DirectedGraph.test.ts
@@ -473,17 +473,14 @@ describe('DirectedGraph', () => {
 		});
 	});
 
-	describe('getNode', () => {
+	describe('hasNode', () => {
 		test("returns node if it's part of the graph", () => {
 			// ARRANGE
 			const node = createNodeData({ name: 'node' });
 			const graph = new DirectedGraph().addNodes(node);
 
-			// ACT
-			const gotNode = graph.getNode(node.name);
-
-			// ASSERT
-			expect(gotNode).toBe(node);
+			// ACT & ASSERT
+			expect(graph.hasNode(node.name)).toBe(true);
 		});
 
 		test('returns undefined if there is no node with that name in the graph', () => {
@@ -491,11 +488,8 @@ describe('DirectedGraph', () => {
 			const node = createNodeData({ name: 'node' });
 			const graph = new DirectedGraph().addNodes(node);
 
-			// ACT
-			const gotNode = graph.getNode(node.name + 'foo');
-
-			// ASSERT
-			expect(gotNode).toBeUndefined();
+			// ACT & ASSERT
+			expect(graph.hasNode(node.name + 'foo')).toBe(false);
 		});
 	});
 });

--- a/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
+++ b/packages/core/src/PartialExecutionUtils/__tests__/cleanRunData.test.ts
@@ -84,4 +84,31 @@ describe('cleanRunData', () => {
 		// TODO: Find out if this is a desirable result in milestone 2
 		expect(newRunData).toEqual({});
 	});
+
+	// ┌─────┐    ┌─────┐
+	// │node1├───►│node2│
+	// └─────┘    └─────┘
+	test('removes run data of nodes that are not in the subgraph', () => {
+		// ARRANGE
+		const node1 = createNodeData({ name: 'Node1' });
+		const node2 = createNodeData({ name: 'Node2' });
+		const graph = new DirectedGraph()
+			.addNodes(node1, node2)
+			.addConnections({ from: node1, to: node2 });
+		// not part of the graph
+		const node3 = createNodeData({ name: 'Node3' });
+		const runData: IRunData = {
+			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
+			[node2.name]: [toITaskData([{ data: { value: 2 } }])],
+			[node3.name]: [toITaskData([{ data: { value: 3 } }])],
+		};
+
+		// ACT
+		const newRunData = cleanRunData(runData, graph, new Set([node2]));
+
+		// ASSERT
+		expect(newRunData).toEqual({
+			[node1.name]: [toITaskData([{ data: { value: 1 } }])],
+		});
+	});
 });

--- a/packages/core/src/PartialExecutionUtils/cleanRunData.ts
+++ b/packages/core/src/PartialExecutionUtils/cleanRunData.ts
@@ -23,5 +23,14 @@ export function cleanRunData(
 		}
 	}
 
+	// Remove run data for all nodes that are not part of the subgraph
+	for (const nodeName of Object.keys(newRunData)) {
+		const node = graph.getNode(nodeName);
+		if (!node) {
+			// remove run data for node that is not part of the graph
+			delete newRunData[nodeName];
+		}
+	}
+
 	return newRunData;
 }

--- a/packages/core/src/PartialExecutionUtils/cleanRunData.ts
+++ b/packages/core/src/PartialExecutionUtils/cleanRunData.ts
@@ -25,8 +25,7 @@ export function cleanRunData(
 
 	// Remove run data for all nodes that are not part of the subgraph
 	for (const nodeName of Object.keys(newRunData)) {
-		const node = graph.getNode(nodeName);
-		if (!node) {
+		if (!graph.hasNode(nodeName)) {
 			// remove run data for node that is not part of the graph
 			delete newRunData[nodeName];
 		}

--- a/packages/core/src/WorkflowExecute.ts
+++ b/packages/core/src/WorkflowExecute.ts
@@ -354,13 +354,13 @@ export class WorkflowExecute {
 		}
 
 		// 2. Find the Subgraph
-		const graph = DirectedGraph.fromWorkflow(workflow);
-		const subgraph = findSubgraph({ graph: filterDisabledNodes(graph), destination, trigger });
-		const filteredNodes = subgraph.getNodes();
+		let graph = DirectedGraph.fromWorkflow(workflow);
+		graph = findSubgraph({ graph: filterDisabledNodes(graph), destination, trigger });
+		const filteredNodes = graph.getNodes();
 
 		// 3. Find the Start Nodes
 		runData = omit(runData, dirtyNodeNames);
-		let startNodes = findStartNodes({ graph: subgraph, trigger, destination, runData, pinData });
+		let startNodes = findStartNodes({ graph, trigger, destination, runData, pinData });
 
 		// 4. Detect Cycles
 		// 5. Handle Cycles
@@ -371,7 +371,7 @@ export class WorkflowExecute {
 
 		// 7. Recreate Execution Stack
 		const { nodeExecutionStack, waitingExecution, waitingExecutionSource } =
-			recreateNodeExecutionStack(subgraph, new Set(startNodes), runData, pinData ?? {});
+			recreateNodeExecutionStack(graph, new Set(startNodes), runData, pinData ?? {});
 
 		// 8. Execute
 		this.status = 'running';
@@ -393,7 +393,7 @@ export class WorkflowExecute {
 			},
 		};
 
-		return this.processRunExecutionData(subgraph.toWorkflow({ ...workflow }));
+		return this.processRunExecutionData(graph.toWorkflow({ ...workflow }));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The new partial execution flow does not remove run data of unrelated nodes:

https://github.com/user-attachments/assets/59cfdca6-5b8e-4691-ac81-7427611215d1

That's may be confusing, but also poses problems to the execution evaluation project, as it makes it harder to figure out which trigger triggered the execution. Currently this is done by looking for the first run in the run data that has no source data. If we retain the old trigger's run data though this may not be correct. 

Now all run data from all nodes unrelated to the current partial execution is removed:


https://github.com/user-attachments/assets/df5e0ef5-f052-4090-9843-d06cad9d5f9c

You can review this commit by commit:
- **fix ascii diagram**
- **add `DirectedGraph.getNode`**
- **use a let binding to make it less likely to pass the wrong graph to subsequent functions**
- **remove run data of nodes that are not part of the current partial execution**

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2346/delete-run-data-of-nodes-not-that-are-not-part-of-the-sub-graph


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
