### PR TITLE
feat: Send and wait operation - freeText and customForm response types

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -450,7 +450,11 @@
 
 				<div class='card' id='submitted-form' style='display: none;'>
 					<div class='form-header'>
-						<h1 id='submitted-header'>Form Submitted</h1>
+						{{#if formSubmittedHeader}}
+							<h1 id='submitted-header'>{{formSubmittedHeader}}</h1>
+						{{else}}
+							<h1 id='submitted-header'>Form Submitted</h1>
+						{{/if}}
 						{{#if formSubmittedText}}
 							<p id='submitted-content'>
 								{{formSubmittedText}}

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -2,6 +2,7 @@ import type {
 	FormFieldsParameter,
 	IExecuteFunctions,
 	INodeExecutionData,
+	INodeProperties,
 	INodeTypeDescription,
 	IWebhookFunctions,
 	NodeTypeAndVersion,
@@ -22,6 +23,45 @@ import { formDescription, formFields, formTitle } from '../Form/common.descripti
 import { prepareFormReturnItem, renderForm, resolveRawData } from '../Form/utils';
 import { type CompletionPageConfig } from './interfaces';
 
+export const formFieldsProperties: INodeProperties[] = [
+	{
+		displayName: 'Define Form',
+		name: 'defineForm',
+		type: 'options',
+		noDataExpression: true,
+		options: [
+			{
+				name: 'Using Fields Below',
+				value: 'fields',
+			},
+			{
+				name: 'Using JSON',
+				value: 'json',
+			},
+		],
+		default: 'fields',
+	},
+	{
+		displayName: 'Form Fields',
+		name: 'jsonOutput',
+		type: 'json',
+		typeOptions: {
+			rows: 5,
+		},
+		default:
+			'[\n   {\n      "fieldLabel":"Name",\n      "placeholder":"enter you name",\n      "requiredField":true\n   },\n   {\n      "fieldLabel":"Age",\n      "fieldType":"number",\n      "placeholder":"enter your age"\n   },\n   {\n      "fieldLabel":"Email",\n      "fieldType":"email",\n      "requiredField":true\n   }\n]',
+		validateType: 'form-fields',
+		ignoreValidationDuringExecution: true,
+		hint: '<a href="hhttps://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.form/" target="_blank">See docs</a> for field syntax',
+		displayOptions: {
+			show: {
+				defineForm: ['json'],
+			},
+		},
+	},
+	{ ...formFields, displayOptions: { show: { defineForm: ['fields'] } } },
+];
+
 const pageProperties = updateDisplayOptions(
 	{
 		show: {
@@ -29,42 +69,7 @@ const pageProperties = updateDisplayOptions(
 		},
 	},
 	[
-		{
-			displayName: 'Define Form',
-			name: 'defineForm',
-			type: 'options',
-			noDataExpression: true,
-			options: [
-				{
-					name: 'Using Fields Below',
-					value: 'fields',
-				},
-				{
-					name: 'Using JSON',
-					value: 'json',
-				},
-			],
-			default: 'fields',
-		},
-		{
-			displayName: 'Form Fields',
-			name: 'jsonOutput',
-			type: 'json',
-			typeOptions: {
-				rows: 5,
-			},
-			default:
-				'[\n   {\n      "fieldLabel":"Name",\n      "placeholder":"enter you name",\n      "requiredField":true\n   },\n   {\n      "fieldLabel":"Age",\n      "fieldType":"number",\n      "placeholder":"enter your age"\n   },\n   {\n      "fieldLabel":"Email",\n      "fieldType":"email",\n      "requiredField":true\n   }\n]',
-			validateType: 'form-fields',
-			ignoreValidationDuringExecution: true,
-			hint: '<a href="hhttps://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.form/" target="_blank">See docs</a> for field syntax',
-			displayOptions: {
-				show: {
-					defineForm: ['json'],
-				},
-			},
-		},
-		{ ...formFields, displayOptions: { show: { defineForm: ['fields'] } } },
+		...formFieldsProperties,
 		{
 			displayName: 'Options',
 			name: 'options',

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -22,6 +22,7 @@ export type FormTriggerData = {
 	validForm: boolean;
 	formTitle: string;
 	formDescription?: string;
+	formSubmittedHeader?: string;
 	formSubmittedText?: string;
 	redirectUrl?: string;
 	n8nWebsiteLink: string;

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -28,6 +28,7 @@ import { getResolvables } from '../../utils/utilities';
 export function prepareFormData({
 	formTitle,
 	formDescription,
+	formSubmittedHeader,
 	formSubmittedText,
 	redirectUrl,
 	formFields,
@@ -49,6 +50,7 @@ export function prepareFormData({
 	useResponseData?: boolean;
 	appendAttribution?: boolean;
 	buttonLabel?: string;
+	formSubmittedHeader?: string;
 }) {
 	const validForm = formFields.length > 0;
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
@@ -63,6 +65,7 @@ export function prepareFormData({
 		validForm,
 		formTitle,
 		formDescription,
+		formSubmittedHeader,
 		formSubmittedText,
 		n8nWebsiteLink,
 		formFields: [],

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.json
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.json
@@ -52,5 +52,5 @@
 			}
 		]
 	},
-	"alias": ["email"]
+	"alias": ["email", "human in the loop", "form", "wait"]
 }

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.json
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.json
@@ -52,5 +52,5 @@
 			}
 		]
 	},
-	"alias": ["email", "human in the loop", "form", "wait"]
+	"alias": ["email", "human", "form", "wait"]
 }

--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -88,6 +88,15 @@ const versionDescription: INodeTypeDescription = {
 			restartWebhook: true,
 			isFullPath: true,
 		},
+		{
+			name: 'default',
+			httpMethod: 'POST',
+			responseMode: 'onReceived',
+			responseData: '',
+			path: '={{ $nodeId }}',
+			restartWebhook: true,
+			isFullPath: true,
+		},
 	],
 	properties: [
 		{

--- a/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
@@ -59,7 +59,7 @@ export const messageOperations: INodeProperties[] = [
 				action: 'Send a message',
 			},
 			{
-				name: 'Send Message and Wait for Response',
+				name: 'Send and Wait for Response',
 				value: SEND_AND_WAIT_OPERATION,
 				action: 'Send message and wait for response',
 			},

--- a/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
@@ -59,9 +59,9 @@ export const messageOperations: INodeProperties[] = [
 				action: 'Send a message',
 			},
 			{
-				name: 'Send and Wait for Approval',
+				name: 'Send Message and Wait for Response',
 				value: SEND_AND_WAIT_OPERATION,
-				action: 'Send a message and wait for approval',
+				action: 'Send message and wait for response',
 			},
 		],
 		default: 'send',

--- a/packages/nodes-base/nodes/Slack/Slack.node.json
+++ b/packages/nodes-base/nodes/Slack/Slack.node.json
@@ -3,6 +3,7 @@
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Communication"],
+	"alias": ["human in the loop", "form", "wait"],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Slack/Slack.node.json
+++ b/packages/nodes-base/nodes/Slack/Slack.node.json
@@ -3,7 +3,7 @@
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Communication"],
-	"alias": ["human in the loop", "form", "wait"],
+	"alias": ["human", "form", "wait"],
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -294,7 +294,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 				elements: config.options.map((option) => {
 					return {
 						type: 'button',
-						style: option.style === 'primary' || option.style === 'info' ? 'primary' : undefined,
+						style: option.style === 'primary' ? 'primary' : undefined,
 						text: {
 							type: 'plain_text',
 							text: option.label,

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -294,7 +294,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 				elements: config.options.map((option) => {
 					return {
 						type: 'button',
-						style: option.style === 'primary' ? 'primary' : undefined,
+						style: option.style === 'primary' || 'info' ? 'primary' : undefined,
 						text: {
 							type: 'plain_text',
 							text: option.label,

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -294,7 +294,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 				elements: config.options.map((option) => {
 					return {
 						type: 'button',
-						style: option.style === 'primary' || 'info' ? 'primary' : undefined,
+						style: option.style === 'primary' || option.style === 'info' ? 'primary' : undefined,
 						text: {
 							type: 'plain_text',
 							text: option.label,

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -33,9 +33,9 @@ export const messageOperations: INodeProperties[] = [
 				action: 'Send a message',
 			},
 			{
-				name: 'Send and Wait for Approval',
+				name: 'Send Message and Wait for Response',
 				value: SEND_AND_WAIT_OPERATION,
-				action: 'Send a message and wait for approval',
+				action: 'Send message and wait for response',
 			},
 			{
 				name: 'Update',

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -33,7 +33,7 @@ export const messageOperations: INodeProperties[] = [
 				action: 'Send a message',
 			},
 			{
-				name: 'Send Message and Wait for Response',
+				name: 'Send and Wait for Response',
 				value: SEND_AND_WAIT_OPERATION,
 				action: 'Send message and wait for response',
 			},

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -89,6 +89,15 @@ export class SlackV2 implements INodeType {
 					restartWebhook: true,
 					isFullPath: true,
 				},
+				{
+					name: 'default',
+					httpMethod: 'POST',
+					responseMode: 'onReceived',
+					responseData: '',
+					path: '={{ $nodeId }}',
+					restartWebhook: true,
+					isFullPath: true,
+				},
 			],
 			properties: [
 				{

--- a/packages/nodes-base/utils/sendAndWait/email-templates.ts
+++ b/packages/nodes-base/utils/sendAndWait/email-templates.ts
@@ -103,7 +103,7 @@ export function createEmailBody(message: string, buttons: string, instanceId?: s
 					<tr>
 						<td
 							style="text-align: center; padding-top: 8px; font-family: Arial, sans-serif; font-size: 14px; color: #7e8186;">
-							<p>${message}</p>
+							<p style="white-space: pre-line;">${message}</p>
 						</td>
 					</tr>
 					<tr>

--- a/packages/nodes-base/utils/sendAndWait/email-templates.ts
+++ b/packages/nodes-base/utils/sendAndWait/email-templates.ts
@@ -2,8 +2,6 @@ export const BUTTON_STYLE_SECONDARY =
 	'display:inline-block; text-decoration:none; background-color:#fff; color:#4a4a4a; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border:1px solid #d1d1d1; border-radius:6px; min-width:120px; margin: 12px 6px 0 6px;';
 export const BUTTON_STYLE_PRIMARY =
 	'display:inline-block; text-decoration:none; background-color:#ff6d5a; color: #fff; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border-radius:6px; min-width:120px; margin: 12px 2px 0 2px;';
-export const BUTTON_STYLE_INFO =
-	'display:inline-block; text-decoration:none; background-color:#4438a3; color: #fff; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border-radius:6px; min-width:120px; margin: 12px 2px 0 2px;';
 
 export const ACTION_RECORDED_PAGE = `
 	<html lang='en'>

--- a/packages/nodes-base/utils/sendAndWait/email-templates.ts
+++ b/packages/nodes-base/utils/sendAndWait/email-templates.ts
@@ -2,6 +2,8 @@ export const BUTTON_STYLE_SECONDARY =
 	'display:inline-block; text-decoration:none; background-color:#fff; color:#4a4a4a; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border:1px solid #d1d1d1; border-radius:6px; min-width:120px; margin: 12px 6px 0 6px;';
 export const BUTTON_STYLE_PRIMARY =
 	'display:inline-block; text-decoration:none; background-color:#ff6d5a; color: #fff; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border-radius:6px; min-width:120px; margin: 12px 2px 0 2px;';
+export const BUTTON_STYLE_INFO =
+	'display:inline-block; text-decoration:none; background-color:#4438a3; color: #fff; padding:12px 24px; font-family: Arial,sans-serif; font-size:14px;font-weight:600; border-radius:6px; min-width:120px; margin: 12px 2px 0 2px;';
 
 export const ACTION_RECORDED_PAGE = `
 	<html lang='en'>

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -207,5 +207,162 @@ describe('Send and Wait utils tests', () => {
 				workflowData: [[{ json: { data: { approved: false } } }]],
 			});
 		});
+
+		it('should handle freeText GET webhook', async () => {
+			const mockRender = jest.fn();
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'GET',
+			} as any);
+
+			mockWebhookFunctions.getResponseObject.mockReturnValue({
+				render: mockRender,
+			} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'freeText',
+					message: 'Test message',
+					options: {},
+				};
+				return params[parameterName];
+			});
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({
+				noWebhookResponse: true,
+			});
+
+			expect(mockRender).toHaveBeenCalledWith('form-trigger', {
+				testRun: false,
+				validForm: true,
+				formTitle: '',
+				formDescription: 'Test message',
+				formSubmittedHeader: 'Got it, thanks',
+				formSubmittedText: 'This page can be closed now',
+				n8nWebsiteLink: 'https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger',
+				formFields: [
+					{
+						id: 'field-0',
+						errorId: 'error-field-0',
+						label: 'Response',
+						inputRequired: 'form-required',
+						defaultValue: '',
+						isTextarea: true,
+					},
+				],
+				appendAttribution: true,
+				buttonLabel: 'Submit',
+			});
+		});
+
+		it('should handle freeText POST webhook', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'POST',
+			} as any);
+
+			mockWebhookFunctions.getBodyData.mockReturnValue({
+				data: {
+					'field-0': 'test value',
+				},
+			} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'freeText',
+				};
+				return params[parameterName];
+			});
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toEqual([[{ json: { data: { text: 'test value' } } }]]);
+		});
+
+		it('should handle customForm GET webhook', async () => {
+			const mockRender = jest.fn();
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'GET',
+			} as any);
+
+			mockWebhookFunctions.getResponseObject.mockReturnValue({
+				render: mockRender,
+			} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'customForm',
+					message: 'Test message',
+					defineForm: 'fields',
+					'formFields.values': [{ label: 'Field 1', fieldType: 'text', requiredField: true }],
+					options: {
+						responseFormTitle: 'Test title',
+						responseFormDescription: 'Test description',
+						responseFormButtonLabel: 'Test button',
+					},
+				};
+				return params[parameterName];
+			});
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(result).toEqual({
+				noWebhookResponse: true,
+			});
+
+			expect(mockRender).toHaveBeenCalledWith('form-trigger', {
+				testRun: false,
+				validForm: true,
+				formTitle: 'Test title',
+				formDescription: 'Test description',
+				formSubmittedHeader: 'Got it, thanks',
+				formSubmittedText: 'This page can be closed now',
+				n8nWebsiteLink: 'https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger',
+				formFields: [
+					{
+						id: 'field-0',
+						errorId: 'error-field-0',
+						inputRequired: 'form-required',
+						defaultValue: '',
+						isInput: true,
+						type: 'text',
+					},
+				],
+				appendAttribution: true,
+				buttonLabel: 'Test button',
+			});
+		});
+
+		it('should handle customForm POST webhook', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'POST',
+			} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'customForm',
+					defineForm: 'fields',
+					'formFields.values': [
+						{
+							fieldLabel: 'test 1',
+							fieldType: 'text',
+						},
+					],
+				};
+				return params[parameterName];
+			});
+
+			mockWebhookFunctions.getBodyData.mockReturnValue({
+				data: {
+					'field-0': 'test value',
+				},
+			} as any);
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toEqual([[{ json: { data: { 'test 1': 'test value' } } }]]);
+		});
 	});
 });

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -6,7 +6,6 @@ import {
 	getSendAndWaitConfig,
 	createEmail,
 	sendAndWaitWebhook,
-	MESSAGE_PREFIX,
 } from '../utils';
 
 describe('Send and Wait utils tests', () => {
@@ -159,7 +158,7 @@ describe('Send and Wait utils tests', () => {
 
 			expect(email).toEqual({
 				to: 'test@example.com',
-				subject: `${MESSAGE_PREFIX}Test subject`,
+				subject: 'Test subject',
 				body: '',
 				htmlBody: expect.stringContaining('Test message'),
 			});

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -31,6 +31,7 @@ type SendAndWaitConfig = {
 
 type FormResponseTypeOptions = {
 	messageButtonLabel?: string;
+	responseFormTitle?: string;
 	responseFormDescription?: string;
 	responseFormButtonLabel?: string;
 };
@@ -182,18 +183,6 @@ export function getSendAndWaitProperties(
 				},
 			},
 		},
-		{
-			displayName: 'Response Form Title',
-			name: 'responseFormTitle',
-			description: 'Title of the form that the user can access to provide their response',
-			type: 'string',
-			default: '',
-			displayOptions: {
-				show: {
-					responseType: ['freeText', 'customForm'],
-				},
-			},
-		},
 		...updateDisplayOptions(
 			{
 				show: {
@@ -214,6 +203,13 @@ export function getSendAndWaitProperties(
 					name: 'messageButtonLabel',
 					type: 'string',
 					default: 'Respond',
+				},
+				{
+					displayName: 'Response Form Title',
+					name: 'responseFormTitle',
+					description: 'Title of the form that the user can access to provide their response',
+					type: 'string',
+					default: '',
 				},
 				{
 					displayName: 'Response Form Description',
@@ -254,12 +250,16 @@ const getFormResponseCustomizations = (context: IWebhookFunctions) => {
 	const message = context.getNodeParameter('message', '') as string;
 	const options = context.getNodeParameter('options', {}) as FormResponseTypeOptions;
 
-	const formTitle = context.getNodeParameter('responseFormTitle', '') as string;
+	let formTitle = '';
+	if (options.responseFormTitle) {
+		formTitle = options.responseFormTitle;
+	}
 
 	let formDescription = message;
 	if (options.responseFormDescription) {
 		formDescription = options.responseFormDescription;
 	}
+	formDescription = formDescription.replace(/\\n/g, '\n').replace(/<br>/g, '\n');
 
 	let buttonLabel = 'Submit';
 	if (options.responseFormButtonLabel) {
@@ -268,7 +268,7 @@ const getFormResponseCustomizations = (context: IWebhookFunctions) => {
 
 	return {
 		formTitle,
-		formDescription: formDescription.replace(/\\n/g, '\n').replace(/<br>/g, '\n'),
+		formDescription,
 		buttonLabel,
 	};
 };

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -214,9 +214,10 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 	if (responseType === 'freeText') {
 		if (this.getRequestObject().method === 'GET') {
 			const res = this.getResponseObject();
+			const message = this.getNodeParameter('message', '') as string;
 
 			const data = prepareFormData({
-				formTitle: 'Provide Input',
+				formTitle: 'You need to input ' + message,
 				formDescription: '',
 				formSubmittedHeader: 'Got it, thanks',
 				formSubmittedText: 'This page can be closed now',


### PR DESCRIPTION
## Summary

For `sendAndWait` operation added two new response mods - `freeText` and `customForm`
- `freeText` simplified version of `customForm` that allows user to send custom text response
- `customForm` allows to define form that could be filled by user allowing to receive more structured data
![image](https://github.com/user-attachments/assets/c54e88be-9779-4975-824f-2153ffba6ab2)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2092/send-message-and-wait-for-response
