### PR TITLE
feat(core): Add option to filter for empty variables

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -3,3 +3,4 @@ export { RoleChangeRequestDto } from './user/role-change-request.dto';
 export { SettingsUpdateRequestDto } from './user/settings-update-request.dto';
 export { UserUpdateRequestDto } from './user/user-update-request.dto';
 export { CommunityRegisteredRequestDto } from './license/community-registered-request.dto';
+export { VariableListRequestDto } from './variables/variables-list-request.dto';

--- a/packages/@n8n/api-types/src/dto/variables/variables-list-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/variables/variables-list-request.dto.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+import { Z } from 'zod-class';
+
+export class VariableListRequestDto extends Z.class({
+	state: z.literal('empty').optional(),
+}) {}

--- a/packages/cli/src/environments/variables/variables.controller.ee.ts
+++ b/packages/cli/src/environments/variables/variables.controller.ee.ts
@@ -1,4 +1,7 @@
+import { VariableListRequestDto } from '@n8n/api-types';
+
 import { Delete, Get, GlobalScope, Licensed, Patch, Post, RestController } from '@/decorators';
+import { Query } from '@/decorators/args';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { VariableCountLimitReachedError } from '@/errors/variable-count-limit-reached.error';
@@ -13,8 +16,8 @@ export class VariablesController {
 
 	@Get('/')
 	@GlobalScope('variable:list')
-	async getVariables() {
-		return await this.variablesService.getAllCached();
+	async getVariables(_req: unknown, _res: unknown, @Query query: VariableListRequestDto) {
+		return await this.variablesService.getAllCached(query.state);
 	}
 
 	@Post('/')

--- a/packages/cli/src/environments/variables/variables.service.ee.ts
+++ b/packages/cli/src/environments/variables/variables.service.ee.ts
@@ -18,13 +18,22 @@ export class VariablesService {
 		private readonly eventService: EventService,
 	) {}
 
-	async getAllCached(): Promise<Variables[]> {
-		const variables = await this.cacheService.get('variables', {
+	async getAllCached(state?: 'empty'): Promise<Variables[]> {
+		let variables = await this.cacheService.get('variables', {
 			async refreshFn() {
 				return await Container.get(VariablesService).findAll();
 			},
 		});
-		return (variables as Array<Partial<Variables>>).map((v) => this.variablesRepository.create(v));
+
+		if (variables === undefined) {
+			return [];
+		}
+
+		if (state === 'empty') {
+			variables = variables.filter((v) => v.value === '');
+		}
+
+		return variables.map((v) => this.variablesRepository.create(v));
 	}
 
 	async getCount(): Promise<number> {

--- a/packages/cli/test/integration/variables.test.ts
+++ b/packages/cli/test/integration/variables.test.ts
@@ -65,19 +65,32 @@ beforeEach(async () => {
 // ----------------------------------------
 describe('GET /variables', () => {
 	beforeEach(async () => {
-		await Promise.all([createVariable('test1', 'value1'), createVariable('test2', 'value2')]);
+		await Promise.all([
+			createVariable('test1', 'value1'),
+			createVariable('test2', 'value2'),
+			createVariable('empty', ''),
+		]);
 	});
 
 	test('should return all variables for an owner', async () => {
 		const response = await authOwnerAgent.get('/variables');
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(2);
+		expect(response.body.data.length).toBe(3);
 	});
 
 	test('should return all variables for a member', async () => {
 		const response = await authMemberAgent.get('/variables');
 		expect(response.statusCode).toBe(200);
-		expect(response.body.data.length).toBe(2);
+		expect(response.body.data.length).toBe(3);
+	});
+
+	describe('state:empty', () => {
+		test('only return empty variables', async () => {
+			const response = await authOwnerAgent.get('/variables').query({ state: 'empty' });
+			expect(response.statusCode).toBe(200);
+			expect(response.body.data.length).toBe(1);
+			expect(response.body.data[0]).toMatchObject({ key: 'empty', value: '', type: 'string' });
+		});
 	});
 });
 

--- a/packages/cli/test/integration/variables.test.ts
+++ b/packages/cli/test/integration/variables.test.ts
@@ -4,6 +4,7 @@ import type { Variables } from '@/databases/entities/variables';
 import { VariablesRepository } from '@/databases/repositories/variables.repository';
 import { generateNanoId } from '@/databases/utils/generators';
 import { VariablesService } from '@/environments/variables/variables.service.ee';
+import { CacheService } from '@/services/cache/cache.service';
 
 import { createOwner, createUser } from './shared/db/users';
 import * as testDb from './shared/test-db';
@@ -70,6 +71,15 @@ describe('GET /variables', () => {
 			createVariable('test2', 'value2'),
 			createVariable('empty', ''),
 		]);
+	});
+
+	test('should return an empty array if there is nothing in the cache', async () => {
+		const cacheService = Container.get(CacheService);
+		const spy = jest.spyOn(cacheService, 'get').mockResolvedValueOnce(undefined);
+		const response = await authOwnerAgent.get('/variables');
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data.length).toBe(0);
 	});
 
 	test('should return all variables for an owner', async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When using environments and pulling down changes we create stubs for variables and credentials.

We want to give users an easy overview over all credentials and variables that still need to be filled in.

For this we're adding a filter to show "empty" variables and credentials.

This PR adds the filter for variables.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2306/check-for-empty-credentials-or-variables


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
