### PR TITLE
feat(Facebook Graph API Node): Update node to support API v21.0

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -81,6 +81,10 @@ export class FacebookGraphApi implements INodeType {
 						value: '',
 					},
 					{
+						name: 'v21.0',
+						value: 'v21.0',
+					},
+					{
 						name: 'v20.0',
 						value: 'v20.0',
 					},


### PR DESCRIPTION
Added new Facebook Graph API v21.0 to node.
Launched officially 10/2/2024:

https://developers.facebook.com/docs/graph-api/changelog/version21.0/


