### PR TITLE
test: Allow runner tests to exit cleanly

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/task-runner.test.ts
@@ -37,6 +37,8 @@ describe('TestRunner', () => {
 					maxPayload: 1024,
 				}),
 			);
+
+			runner.clearIdleTimer();
 		});
 
 		it('should handle different taskBrokerUri formats correctly', () => {
@@ -64,6 +66,8 @@ describe('TestRunner', () => {
 					maxPayload: 1024,
 				}),
 			);
+
+			runner.clearIdleTimer();
 		});
 
 		it('should throw an error if taskBrokerUri is invalid', () => {


### PR DESCRIPTION
Noticed runner tests had open handles:

```
> @n8n/task-runner@1.9.0 test /Users/ivov/Development/n8n/packages/@n8n/task-runner
> jest "--" "src/js-task-runner/__tests__/task-runner.test.ts"

 PASS  src/js-task-runner/__tests__/task-runner.test.ts
  TestRunner
    constructor
      ✓ should correctly construct WebSocket URI with provided taskBrokerUri (6 ms)
      ✓ should handle different taskBrokerUri formats correctly (1 ms)
      ✓ should throw an error if taskBrokerUri is invalid (20 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.943 s, estimated 11 s
Ran all test suites matching /src\/js-task-runner\/__tests__\/task-runner.test.ts/i.
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```