### PR TITLE
chore: Switch to the new partial execution logic in test runner (no-changelog)

### DIFF
--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -48,6 +48,9 @@ export class TestRunnerService {
 		private readonly nodeTypes: NodeTypes,
 	) {}
 
+	/**
+	 * Prepares the start nodes and trigger node data props for the `workflowRunner.run` method input.
+	 */
 	private getStartNodesData(
 		workflow: WorkflowEntity,
 		pastExecutionData: IRunExecutionData,
@@ -64,17 +67,19 @@ export class TestRunnerService {
 		const pastExecutionTriggerNode = getPastExecutionTriggerNode(pastExecutionData);
 		assert(pastExecutionTriggerNode, 'Could not find the trigger node of the past execution');
 
-		// Prepare the data structures
+		const triggerNodeData = pastExecutionData.resultData.runData[pastExecutionTriggerNode][0];
+		assert(triggerNodeData, 'Trigger node data not found');
+
 		const triggerToStartFrom = {
 			name: pastExecutionTriggerNode,
-			data: pastExecutionData.resultData.runData[pastExecutionTriggerNode][0],
+			data: triggerNodeData,
 		};
 
 		// Start nodes are the nodes that are connected to the trigger node
 		const startNodes = workflowInstance
 			.getChildNodes(pastExecutionTriggerNode, NodeConnectionType.Main, 1)
-			.map((name) => ({
-				name,
+			.map((nodeName) => ({
+				name: nodeName,
 				sourceData: { previousNode: pastExecutionTriggerNode },
 			}));
 

--- a/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/test-runner.service.ee.ts
@@ -6,6 +6,7 @@ import type {
 	IRunExecutionData,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
+import { NodeConnectionType, Workflow } from 'n8n-workflow';
 import assert from 'node:assert';
 import { Service } from 'typedi';
 
@@ -18,6 +19,7 @@ import { ExecutionRepository } from '@/databases/repositories/execution.reposito
 import { TestMetricRepository } from '@/databases/repositories/test-metric.repository.ee';
 import { TestRunRepository } from '@/databases/repositories/test-run.repository.ee';
 import { WorkflowRepository } from '@/databases/repositories/workflow.repository';
+import { NodeTypes } from '@/node-types';
 import { getRunData } from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
 
@@ -43,7 +45,44 @@ export class TestRunnerService {
 		private readonly activeExecutions: ActiveExecutions,
 		private readonly testRunRepository: TestRunRepository,
 		private readonly testMetricRepository: TestMetricRepository,
+		private readonly nodeTypes: NodeTypes,
 	) {}
+
+	private getStartNodesData(
+		workflow: WorkflowEntity,
+		pastExecutionData: IRunExecutionData,
+	): Pick<IWorkflowExecutionDataProcess, 'startNodes' | 'triggerToStartFrom'> {
+		// Create a new workflow instance to use the helper functions (getChildNodes)
+		const workflowInstance = new Workflow({
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			active: false,
+			nodeTypes: this.nodeTypes,
+		});
+
+		// Determine the trigger node of the past execution
+		const pastExecutionTriggerNode = getPastExecutionTriggerNode(pastExecutionData);
+		assert(pastExecutionTriggerNode, 'Could not find the trigger node of the past execution');
+
+		// Prepare the data structures
+		const triggerToStartFrom = {
+			name: pastExecutionTriggerNode,
+			data: pastExecutionData.resultData.runData[pastExecutionTriggerNode][0],
+		};
+
+		// Start nodes are the nodes that are connected to the trigger node
+		const startNodes = workflowInstance
+			.getChildNodes(pastExecutionTriggerNode, NodeConnectionType.Main, 1)
+			.map((name) => ({
+				name,
+				sourceData: { previousNode: pastExecutionTriggerNode },
+			}));
+
+		return {
+			startNodes,
+			triggerToStartFrom,
+		};
+	}
 
 	/**
 	 * Runs a test case with the given pin data.
@@ -57,20 +96,13 @@ export class TestRunnerService {
 		// Create pin data from the past execution data
 		const pinData = createPinData(workflow, pastExecutionData);
 
-		// Determine the start node of the past execution
-		const pastExecutionStartNode = getPastExecutionTriggerNode(pastExecutionData);
-
 		// Prepare the data to run the workflow
 		const data: IWorkflowExecutionDataProcess = {
-			destinationNode: pastExecutionData.startData?.destinationNode,
-			startNodes: pastExecutionStartNode
-				? [{ name: pastExecutionStartNode, sourceData: null }]
-				: undefined,
+			...this.getStartNodesData(workflow, pastExecutionData),
 			executionMode: 'evaluation',
 			runData: {},
 			pinData,
 			workflowData: workflow,
-			partialExecutionVersion: '-1',
 			userId,
 		};
 

--- a/packages/cli/src/evaluation/test-runner/utils.ee.ts
+++ b/packages/cli/src/evaluation/test-runner/utils.ee.ts
@@ -23,8 +23,8 @@ export function createPinData(workflow: WorkflowEntity, executionData: IRunExecu
 }
 
 /**
- * Returns the start node of the past execution.
- * The start node is the node that has no source and has run data.
+ * Returns the trigger node of the past execution.
+ * The trigger node is the node that has no source and has run data.
  */
 export function getPastExecutionTriggerNode(executionData: IRunExecutionData) {
 	return Object.keys(executionData.resultData.runData).find((nodeName) => {

--- a/packages/cli/test/integration/deduplication/deduplication-helper.test.ts
+++ b/packages/cli/test/integration/deduplication/deduplication-helper.test.ts
@@ -1,5 +1,5 @@
 import { DataDeduplicationService } from 'n8n-core';
-import type { ICheckProcessedContextData, INodeTypeData } from 'n8n-workflow';
+import type { ICheckProcessedContextData } from 'n8n-workflow';
 import type { IDeduplicationOutput, INode, DeduplicationItemTypes } from 'n8n-workflow';
 import { Workflow } from 'n8n-workflow';
 
@@ -8,6 +8,7 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { NodeTypes } from '@/node-types';
 import { mockInstance } from '@test/mocking';
 import { createWorkflow } from '@test-integration/db/workflows';
+import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import * as testDb from '../shared/test-db';
 
@@ -22,35 +23,7 @@ mockInstance(LoadNodesAndCredentials, {
 		credentials: {},
 	},
 });
-function mockNodeTypesData(
-	nodeNames: string[],
-	options?: {
-		addTrigger?: boolean;
-	},
-) {
-	return nodeNames.reduce<INodeTypeData>((acc, nodeName) => {
-		return (
-			(acc[`n8n-nodes-base.${nodeName}`] = {
-				sourcePath: '',
-				type: {
-					description: {
-						displayName: nodeName,
-						name: nodeName,
-						group: [],
-						description: '',
-						version: 1,
-						defaults: {},
-						inputs: [],
-						outputs: [],
-						properties: [],
-					},
-					trigger: options?.addTrigger ? async () => undefined : undefined,
-				},
-			}),
-			acc
-		);
-	}, {});
-}
+
 const node: INode = {
 	id: 'uuid-1234',
 	parameters: {},

--- a/packages/cli/test/integration/permission-checker.test.ts
+++ b/packages/cli/test/integration/permission-checker.test.ts
@@ -1,4 +1,4 @@
-import type { INode, INodeTypeData } from 'n8n-workflow';
+import type { INode } from 'n8n-workflow';
 import { randomInt } from 'n8n-workflow';
 import { Container } from 'typedi';
 import { v4 as uuid } from 'uuid';
@@ -14,6 +14,7 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { NodeTypes } from '@/node-types';
 import { OwnershipService } from '@/services/ownership.service';
 import { PermissionChecker } from '@/user-management/permission-checker';
+import { mockNodeTypesData } from '@test-integration/utils/node-types-data';
 
 import { affixRoleToSaveCredential } from './shared/db/credentials';
 import { getPersonalProject } from './shared/db/projects';
@@ -24,36 +25,6 @@ import type { SaveCredentialFunction } from './shared/types';
 import { mockInstance } from '../shared/mocking';
 
 const ownershipService = mockInstance(OwnershipService);
-
-function mockNodeTypesData(
-	nodeNames: string[],
-	options?: {
-		addTrigger?: boolean;
-	},
-) {
-	return nodeNames.reduce<INodeTypeData>((acc, nodeName) => {
-		return (
-			(acc[`n8n-nodes-base.${nodeName}`] = {
-				sourcePath: '',
-				type: {
-					description: {
-						displayName: nodeName,
-						name: nodeName,
-						group: [],
-						description: '',
-						version: 1,
-						defaults: {},
-						inputs: [],
-						outputs: [],
-						properties: [],
-					},
-					trigger: options?.addTrigger ? async () => undefined : undefined,
-				},
-			}),
-			acc
-		);
-	}, {});
-}
 
 const createWorkflow = async (nodes: INode[], workflowOwner?: User): Promise<WorkflowEntity> => {
 	const workflowDetails = {

--- a/packages/cli/test/integration/shared/utils/node-types-data.ts
+++ b/packages/cli/test/integration/shared/utils/node-types-data.ts
@@ -1,0 +1,33 @@
+import type { INodeTypeData } from 'n8n-workflow';
+
+export function mockNodeTypesData(
+	nodeNames: string[],
+	options?: {
+		addTrigger?: boolean;
+	},
+) {
+	return nodeNames.reduce<INodeTypeData>((acc, nodeName) => {
+		const fullName = nodeName.indexOf('.') === -1 ? `n8n-nodes-base.${nodeName}` : nodeName;
+
+		return (
+			(acc[fullName] = {
+				sourcePath: '',
+				type: {
+					description: {
+						displayName: nodeName,
+						name: nodeName,
+						group: [],
+						description: '',
+						version: 1,
+						defaults: {},
+						inputs: [],
+						outputs: [],
+						properties: [],
+					},
+					trigger: options?.addTrigger ? async () => undefined : undefined,
+				},
+			}),
+			acc
+		);
+	}, {});
+}


### PR DESCRIPTION
## Summary

To correctly start the execution of a workflow under test from the same trigger node as in a specific past execution, we need to switch to the new partial execution logic.
This PR changes the `partialExecutionVersion` for test executions.
It also uses the `Workflow` instance to figure out start nodes (children of a trigger node).

Also, PR contains minor refactoring of the tests (`mockNodeTypesData` was extracted to a separate file to be re-used in multiple tests).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-514/switch-to-the-new-partial-execution-logic-in-test-runner
- https://linear.app/n8n/issue/AI-493/figure-out-trigger-node-for-execution-and-start-evaluation-execution
- Previous work on the same topic was done here: #11983


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
