### PR TITLE
test(editor): Update `28-debug` e2e tests for new canvas (no-changelog)

### DIFF
--- a/cypress/e2e/28-debug.cy.ts
+++ b/cypress/e2e/28-debug.cy.ts
@@ -87,11 +87,28 @@ describe('Debug', () => {
 		confirmDialog.get('.btn--confirm').click();
 		cy.url().should('include', '/debug');
 
-		workflowPage.getters.canvasNodes().first().should('have.descendants', '.node-pin-data-icon');
-		workflowPage.getters
-			.canvasNodes()
-			.not(':first')
-			.should('not.have.descendants', '.node-pin-data-icon');
+		cy.ifCanvasVersion(
+			() => {
+				workflowPage.getters
+					.canvasNodes()
+					.first()
+					.should('have.descendants', '.node-pin-data-icon');
+				workflowPage.getters
+					.canvasNodes()
+					.not(':first')
+					.should('not.have.descendants', '.node-pin-data-icon');
+			},
+			() => {
+				workflowPage.getters
+					.canvasNodes()
+					.first()
+					.should('have.descendants', '[data-test-id="canvas-node-status-pinned"]');
+				workflowPage.getters
+					.canvasNodes()
+					.not(':first')
+					.should('not.have.descendants', '[data-test-id="canvas-node-status-pinned"]');
+			},
+		);
 
 		cy.reload(true);
 		cy.wait(['@getExecution']);
@@ -114,7 +131,18 @@ describe('Debug', () => {
 		confirmDialog.get('.btn--confirm').click();
 		cy.url().should('include', '/debug');
 
-		workflowPage.getters.canvasNodes().last().find('.node-info-icon').should('be.empty');
+		cy.ifCanvasVersion(
+			() => {
+				workflowPage.getters.canvasNodes().last().find('.node-info-icon').should('be.empty');
+			},
+			() => {
+				workflowPage.getters
+					.canvasNodes()
+					.last()
+					.find('[class*="statusIcons"]')
+					.should('not.exist');
+			},
+		);
 
 		workflowPage.getters.canvasNodes().first().dblclick();
 		ndv.actions.unPinData();


### PR DESCRIPTION
## Summary

<img width="1647" alt="Screenshot 2024-12-11 at 12 20 09" src="https://github.com/user-attachments/assets/d22817c8-424b-4ccb-b3c1-e8085c7aaa90">


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-421/28-debug

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
