### PR TITLE
fix(editor): Reduce cases for Auto-Add of ChatTrigger for AI Agents

### DIFF
--- a/packages/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/composables/useActions.ts
@@ -43,7 +43,6 @@ import { useExternalHooks } from '@/composables/useExternalHooks';
 import { sortNodeCreateElements, transformNodeType } from '../utils';
 import { useI18n } from '@/composables/useI18n';
 import { useCanvasStore } from '@/stores/canvas.store';
-import { useUIStore } from '@/stores/ui.store';
 
 export const useActions = () => {
 	const nodeCreatorStore = useNodeCreatorStore();
@@ -213,22 +212,10 @@ export const useActions = () => {
 		];
 
 		const isCompatibleNode = addedNodes.some((node) => COMPATIBLE_CHAT_NODES.includes(node.type));
-
 		if (!isCompatibleNode) return false;
 
-		const uiStore = useUIStore();
-		const { getNodeTypes, allNodes } = useWorkflowsStore();
-		const { getByNameAndVersion } = getNodeTypes();
-		if (allNodes.map((x) => x.type).includes(CHAT_TRIGGER_NODE_TYPE)) return false;
-
-		// Need to support Canvas V1 and V2
-		const node = uiStore.lastInteractedWithNode ?? uiStore.selectedNodes[0] ?? null;
-
-		// Add trigger if we don't have a parent node
-		if (!node) return true;
-
-		const nodeType = getByNameAndVersion(node.type, node.typeVersion);
-		return nodeType.description.group.includes('trigger');
+		const { allNodes } = useWorkflowsStore();
+		return allNodes.filter((x) => x.type !== MANUAL_TRIGGER_NODE_TYPE).length === 0;
 	}
 
 	// AI-226: Prepend LLM Chain node when adding a language model

--- a/packages/editor-ui/src/components/Node/NodeCreator/useActions.test.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/useActions.test.ts
@@ -74,7 +74,7 @@ describe('useActions', () => {
 			});
 		});
 
-		test('should insert a ChatTrigger node when an AI Agent is added without trigger', () => {
+		test('should insert a ChatTrigger node when an AI Agent is added on an empty canvas', () => {
 			const workflowsStore = useWorkflowsStore();
 
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([]);
@@ -129,43 +129,13 @@ describe('useActions', () => {
 			});
 		});
 
-		test('should not insert a ChatTrigger node when an AI Agent is added with a trigger already present', () => {
+		test('should not insert a ChatTrigger node when an AI Agent is added with a non-trigger node', () => {
 			const workflowsStore = useWorkflowsStore();
-			const uiStore = useUIStore();
-
-			vi.spyOn(uiStore, 'lastInteractedWithNode', 'get').mockReturnValue({
-				type: GITHUB_TRIGGER_NODE_TYPE,
-			} as never);
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
-				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
-			]);
-			vi.spyOn(workflowsStore, 'getNodeTypes').mockReturnValue({
-				getByNameAndVersion: () => ({ description: { group: ['trigger'] } }),
-			} as never);
-
-			const { getAddedNodesAndConnections } = useActions();
-
-			expect(getAddedNodesAndConnections([{ type: AGENT_NODE_TYPE }])).toEqual({
-				connections: [],
-				nodes: [{ type: AGENT_NODE_TYPE, openDetail: true }],
-			});
-		});
-
-		test('should not insert a ChatTrigger node when an AI Agent is added after a non-trigger node', () => {
-			const workflowsStore = useWorkflowsStore();
-			const uiStore = useUIStore();
-
-			vi.spyOn(uiStore, 'lastInteractedWithNode', 'get').mockReturnValue({
-				type: HTTP_REQUEST_NODE_TYPE,
-			} as never);
 
 			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
 				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
 				{ type: HTTP_REQUEST_NODE_TYPE } as never,
 			]);
-			vi.spyOn(workflowsStore, 'getNodeTypes').mockReturnValue({
-				getByNameAndVersion: () => ({ description: { group: ['trigger'] } }),
-			} as never);
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -177,20 +147,10 @@ describe('useActions', () => {
 
 		test('should not insert a ChatTrigger node when an AI Agent is added with a Chat Trigger already present', () => {
 			const workflowsStore = useWorkflowsStore();
-			const uiStore = useUIStore();
 
-			vi.spyOn(uiStore, 'lastInteractedWithNode', 'get').mockReturnValue({
-				type: CHAT_TRIGGER_NODE_TYPE,
-			} as never);
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
 				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
 			]);
-			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
-				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
-			]);
-			vi.spyOn(workflowsStore, 'getNodeTypes').mockReturnValue({
-				getByNameAndVersion: () => ({ description: { group: ['trigger'] } }),
-			} as never);
 
 			const { getAddedNodesAndConnections } = useActions();
 

--- a/packages/editor-ui/src/components/Node/NodeCreator/useActions.test.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/useActions.test.ts
@@ -18,7 +18,6 @@ import {
 	WEBHOOK_NODE_TYPE,
 } from '@/constants';
 import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
-import { useUIStore } from '@/stores/ui.store';
 
 describe('useActions', () => {
 	beforeAll(() => {
@@ -78,6 +77,7 @@ describe('useActions', () => {
 			const workflowsStore = useWorkflowsStore();
 
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([]);
+			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([]);
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -99,15 +99,15 @@ describe('useActions', () => {
 			});
 		});
 
-		test('should insert a ChatTrigger node when an AI Agent is added with only a Manual Trigger', () => {
+		test('should insert a ChatTrigger node when an AI Agent is added with only a Manual Trigger present', () => {
 			const workflowsStore = useWorkflowsStore();
 
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
 				{ type: MANUAL_TRIGGER_NODE_TYPE } as never,
 			]);
-			vi.spyOn(workflowsStore, 'getNodeTypes').mockReturnValue({
-				getByNameAndVersion: () => ({ description: { group: ['trigger'] } }),
-			} as never);
+			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
+				{ type: MANUAL_TRIGGER_NODE_TYPE } as never,
+			]);
 
 			const { getAddedNodesAndConnections } = useActions();
 
@@ -129,8 +129,12 @@ describe('useActions', () => {
 			});
 		});
 
-		test('should not insert a ChatTrigger node when an AI Agent is added with a non-trigger node', () => {
+		test('should not insert a ChatTrigger node when an AI Agent is added with a non-trigger node prseent', () => {
 			const workflowsStore = useWorkflowsStore();
+
+			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
+				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
+			]);
 
 			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
 				{ type: GITHUB_TRIGGER_NODE_TYPE } as never,
@@ -149,6 +153,9 @@ describe('useActions', () => {
 			const workflowsStore = useWorkflowsStore();
 
 			vi.spyOn(workflowsStore, 'workflowTriggerNodes', 'get').mockReturnValue([
+				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
+			]);
+			vi.spyOn(workflowsStore, 'allNodes', 'get').mockReturnValue([
 				{ type: CHAT_TRIGGER_NODE_TYPE } as never,
 			]);
 


### PR DESCRIPTION
## Summary

Simplify this further to only add a ChatTrigger if there is no node, or only a manual trigger.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2971/bug-auto-add-behavior-of-the-chattrigger-is-wrong


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
