### PR TITLE
fix(editor): Handle links with relative URLs as valid router paths

### DIFF
--- a/packages/editor-ui/src/main.ts
+++ b/packages/editor-ui/src/main.ts
@@ -30,6 +30,7 @@ import { createPinia, PiniaVuePlugin } from 'pinia';
 import { JsPlumbPlugin } from '@/plugins/jsplumb';
 import { ChartJSPlugin } from '@/plugins/chartjs';
 import { SentryPlugin } from '@/plugins/sentry';
+import { ExternalRouterLinksPlugin } from '@/plugins/external-router-links';
 
 const pinia = createPinia();
 
@@ -46,6 +47,7 @@ app.use(pinia);
 app.use(router);
 app.use(i18nInstance);
 app.use(ChartJSPlugin);
+app.use(ExternalRouterLinksPlugin);
 
 app.mount('#app');
 

--- a/packages/editor-ui/src/plugins/external-router-links.test.ts
+++ b/packages/editor-ui/src/plugins/external-router-links.test.ts
@@ -4,16 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { createRouter, createWebHistory } from 'vue-router';
 import { ExternalRouterLinksPlugin } from '@/plugins/external-router-links';
 
-const routes = [
-	{
-		path: '/about',
-		component: { template: '<div />' },
-	},
-	{
-		path: '/home',
-		component: { template: '<div />' },
-	},
-];
+const routes = ['home', 'about', 'contact'].map((name) => ({
+	path: '/' + name,
+	component: { template: '<div />' },
+}));
 
 describe('Vue Router Link Plugin', () => {
 	let router: Router;
@@ -30,6 +24,7 @@ describe('Vue Router Link Plugin', () => {
 				<a id="home" href="/home">Home</a>
 				<a href="/about"><strong>About</strong></a>
 				<a id="nonExisting" href="/non-existing">Non existing</a>
+				<router-link id="routerLink" to="/contact">Contact</router-link>
 			</div>`,
 		});
 
@@ -63,5 +58,14 @@ describe('Vue Router Link Plugin', () => {
 		await userEvent.click(link);
 
 		expect(pushSpy).not.toHaveBeenCalled();
+	});
+
+	it('should not call router push twice', async () => {
+		const pushSpy = vi.spyOn(router, 'push');
+
+		const link = document.querySelector('#routerLink') as HTMLElement;
+		await userEvent.click(link);
+
+		expect(pushSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/editor-ui/src/plugins/external-router-links.test.ts
+++ b/packages/editor-ui/src/plugins/external-router-links.test.ts
@@ -4,10 +4,15 @@ import userEvent from '@testing-library/user-event';
 import { createRouter, createWebHistory } from 'vue-router';
 import { ExternalRouterLinksPlugin } from '@/plugins/external-router-links';
 
-const routes = ['home', 'about', 'contact'].map((name) => ({
-	path: '/' + name,
-	component: { template: '<div />' },
-}));
+const routes = ['home', 'about', 'contact']
+	.map((name) => ({
+		path: '/' + name,
+		component: { template: '<div />' },
+	}))
+	.concat({
+		path: '/workflow/:id',
+		component: { template: '<div />' },
+	});
 
 describe('Vue Router Link Plugin', () => {
 	let router: Router;
@@ -25,6 +30,7 @@ describe('Vue Router Link Plugin', () => {
 				<a href="/about"><strong>About</strong></a>
 				<a id="nonExisting" href="/non-existing">Non existing</a>
 				<router-link id="routerLink" to="/contact">Contact</router-link>
+				<router-link id="workflowRouterLink" to="/workflow/1">Workflow 1</router-link>
 			</div>`,
 		});
 
@@ -42,7 +48,7 @@ describe('Vue Router Link Plugin', () => {
 		expect(pushSpy).toHaveBeenCalledWith('/about');
 	});
 
-	it('should navigate to the correct route when clicking on an element inside a link', async () => {
+	it('should navigate to the correct route when clicking on the link', async () => {
 		const pushSpy = vi.spyOn(router, 'push');
 
 		const link = document.querySelector('#home') as HTMLElement;
@@ -64,6 +70,15 @@ describe('Vue Router Link Plugin', () => {
 		const pushSpy = vi.spyOn(router, 'push');
 
 		const link = document.querySelector('#routerLink') as HTMLElement;
+		await userEvent.click(link);
+
+		expect(pushSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not match routes with params', async () => {
+		const pushSpy = vi.spyOn(router, 'push');
+
+		const link = document.querySelector('#workflowRouterLink') as HTMLElement;
 		await userEvent.click(link);
 
 		expect(pushSpy).toHaveBeenCalledTimes(1);

--- a/packages/editor-ui/src/plugins/external-router-links.test.ts
+++ b/packages/editor-ui/src/plugins/external-router-links.test.ts
@@ -1,0 +1,67 @@
+import { createApp } from 'vue';
+import type { Router } from 'vue-router';
+import userEvent from '@testing-library/user-event';
+import { createRouter, createWebHistory } from 'vue-router';
+import { ExternalRouterLinksPlugin } from '@/plugins/external-router-links';
+
+const routes = [
+	{
+		path: '/about',
+		component: { template: '<div />' },
+	},
+	{
+		path: '/home',
+		component: { template: '<div />' },
+	},
+];
+
+describe('Vue Router Link Plugin', () => {
+	let router: Router;
+
+	beforeEach(() => {
+		router = createRouter({
+			history: createWebHistory(),
+			routes,
+		});
+
+		document.body.innerHTML = '<div id="app" />';
+		const app = createApp({
+			template: `<div>
+				<a id="home" href="/home">Home</a>
+				<a href="/about"><strong>About</strong></a>
+				<a id="nonExisting" href="/non-existing">Non existing</a>
+			</div>`,
+		});
+
+		app.use(router);
+		app.use(ExternalRouterLinksPlugin);
+		app.mount('#app');
+	});
+
+	it('should navigate to the correct route when clicking on an element inside a link', async () => {
+		const pushSpy = vi.spyOn(router, 'push');
+
+		const el = document.querySelector('strong') as HTMLElement;
+		await userEvent.click(el);
+
+		expect(pushSpy).toHaveBeenCalledWith('/about');
+	});
+
+	it('should navigate to the correct route when clicking on an element inside a link', async () => {
+		const pushSpy = vi.spyOn(router, 'push');
+
+		const link = document.querySelector('#home') as HTMLElement;
+		await userEvent.click(link);
+
+		expect(pushSpy).toHaveBeenCalledWith('/home');
+	});
+
+	it('should not navigate if the route does not exist', async () => {
+		const pushSpy = vi.spyOn(router, 'push');
+
+		const link = document.querySelector('#nonExisting') as HTMLElement;
+		await userEvent.click(link);
+
+		expect(pushSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/editor-ui/src/plugins/external-router-links.ts
+++ b/packages/editor-ui/src/plugins/external-router-links.ts
@@ -1,0 +1,24 @@
+import type { App } from 'vue';
+
+export const ExternalRouterLinksPlugin = {
+	install(app: App) {
+		const router = app.config.globalProperties.$router;
+		document.body.addEventListener('click', async (event: MouseEvent) => {
+			const target = event.target as HTMLElement;
+			const link = target.closest('a') as HTMLAnchorElement;
+
+			if (!link?.href) return;
+
+			const url = new URL(link.href);
+			if (url.origin === window.location.origin) {
+				const path = url.pathname;
+				const hasMatchingRoute = router.getRoutes().some((route) => route.path === path);
+
+				if (hasMatchingRoute) {
+					event.preventDefault();
+					await router.push(path);
+				}
+			}
+		});
+	},
+};

--- a/packages/editor-ui/src/plugins/external-router-links.ts
+++ b/packages/editor-ui/src/plugins/external-router-links.ts
@@ -3,22 +3,26 @@ import type { App } from 'vue';
 export const ExternalRouterLinksPlugin = {
 	install(app: App) {
 		const router = app.config.globalProperties.$router;
-		document.body.addEventListener('click', async (event: MouseEvent) => {
-			const target = event.target as HTMLElement;
-			const link = target.closest('a') as HTMLAnchorElement;
+		document.body.addEventListener(
+			'click',
+			async (event: MouseEvent) => {
+				const target = event.target as HTMLElement;
+				const link = target.closest('a') as HTMLAnchorElement;
 
-			if (!link?.href) return;
+				if (!link?.href) return;
 
-			const url = new URL(link.href);
-			if (url.origin === window.location.origin) {
-				const path = url.pathname;
-				const hasMatchingRoute = router.getRoutes().some((route) => route.path === path);
+				const url = new URL(link.href);
+				if (url.origin === window.location.origin) {
+					const path = url.pathname;
+					const hasMatchingRoute = router.getRoutes().some((route) => route.path === path);
 
-				if (hasMatchingRoute) {
-					event.preventDefault();
-					await router.push(path);
+					if (hasMatchingRoute) {
+						event.preventDefault();
+						await router.push(path);
+					}
 				}
-			}
-		});
+			},
+			true,
+		);
 	},
 };


### PR DESCRIPTION
## Summary

HTML links with relative URLs as valid router paths coming from trusted sources should not hard-load pages but use vue routing


## Related Linear tickets, Github issues, and Community forum posts

[PAY-2359](https://linear.app/n8n/issue/PAY-2359/use-vue-routing-on-links-with-relative-urls)


## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
