### PR TITLE
refactor(core): Enrich `relay-execution-lifecycle-event` logs

### DIFF
--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -70,7 +70,7 @@ export abstract class AbstractPush<Connection> extends TypedEmitter<AbstractPush
 	}
 
 	private sendTo<Type extends PushType>(type: Type, data: PushPayload<Type>, pushRefs: string[]) {
-		this.logger.debug(`Send data of type "${type}" to editor-UI`, {
+		this.logger.debug(`Pushed to frontend: ${type}`, {
 			dataType: type,
 			pushRefs: pushRefs.join(', '),
 		});

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -23,9 +23,13 @@ export namespace PubSub {
 	// ----------------------------------
 
 	type _ToCommand<CommandKey extends keyof PubSubCommandMap> = {
-		senderId: string;
-		targets?: string[];
 		command: CommandKey;
+
+		/** Host ID of the sender, added during publishing. */
+		senderId?: string;
+
+		/** Host IDs of the receivers. */
+		targets?: string[];
 
 		/** Whether the command should be sent to the sender as well. */
 		selfSend?: boolean;


### PR DESCRIPTION
## Summary

Once we offload manual executions to workers, the pubsub message `relay-execution-lifecycle-event` will start to be sent and received much more frequently than before, so this PR adds more details to make these logs more usable, else they become hard to distinguish from each other.

Extracted from #11284

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2366/enrich-relay-execution-lifecycle-event-messages


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
