### PR TITLE
fix(core): Ensure runners do not throw on unsupported console methods

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -136,6 +136,36 @@ describe('JsTaskRunner', () => {
 				]);
 			},
 		);
+
+		it('should not throw when using unsupported console methods', async () => {
+			const task = newTaskWithSettings({
+				code: `
+					console.warn('test');
+					console.error('test');
+					console.info('test');
+					console.debug('test');
+					console.trace('test');
+					console.dir({});
+					console.time('test');
+					console.timeEnd('test');
+					console.timeLog('test');
+					console.assert(true);
+					console.clear();
+					console.group('test');
+					console.groupEnd();
+					console.table([]);
+					return {json: {}}
+				`,
+				nodeMode: 'runOnceForAllItems',
+			});
+
+			await expect(
+				execTaskWithParams({
+					task,
+					taskData: newDataRequestResponse([wrapIntoJson({})]),
+				}),
+			).resolves.toBeDefined();
+		});
 	});
 
 	describe('built-in methods and variables available in the context', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -121,7 +121,13 @@ export class JsTaskRunner extends TaskRunner {
 			nodeTypes: this.nodeTypes,
 		});
 
+		const noOp = () => {};
 		const customConsole = {
+			// all except `log` are dummy methods that disregard without throwing, following existing Code node behavior
+			...Object.keys(console).reduce<Record<string, () => void>>((acc, name) => {
+				acc[name] = noOp;
+				return acc;
+			}, {}),
 			// Send log output back to the main process. It will take care of forwarding
 			// it to the UI or printing to console.
 			log: (...args: unknown[]) => {
@@ -130,21 +136,6 @@ export class JsTaskRunner extends TaskRunner {
 					.join(' ');
 				void this.makeRpcCall(task.taskId, 'logNodeOutput', [logOutput]);
 			},
-			// dummy methods to disregard without throwing, following existing Code node behavior
-			warn: () => {},
-			error: () => {},
-			info: () => {},
-			debug: () => {},
-			trace: () => {},
-			dir: () => {},
-			time: () => {},
-			timeEnd: () => {},
-			timeLog: () => {},
-			assert: () => {},
-			clear: () => {},
-			group: () => {},
-			groupEnd: () => {},
-			table: () => {},
 		};
 
 		const result =

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -130,6 +130,21 @@ export class JsTaskRunner extends TaskRunner {
 					.join(' ');
 				void this.makeRpcCall(task.taskId, 'logNodeOutput', [logOutput]);
 			},
+			// dummy methods to disregard without throwing, following existing Code node behavior
+			warn: () => {},
+			error: () => {},
+			info: () => {},
+			debug: () => {},
+			trace: () => {},
+			dir: () => {},
+			time: () => {},
+			timeEnd: () => {},
+			timeLog: () => {},
+			assert: () => {},
+			clear: () => {},
+			group: () => {},
+			groupEnd: () => {},
+			table: () => {},
 		};
 
 		const result =


### PR DESCRIPTION
https://linear.app/n8n/issue/PAY-2353/typeerror-consoleerror-is-not-a-function