### PR TITLE
fix(core): Fix race condition in AI tool invocation with multiple items from the parent

### DIFF
--- a/packages/core/src/CreateNodeAsTool.ts
+++ b/packages/core/src/CreateNodeAsTool.ts
@@ -391,7 +391,8 @@ class AIParametersParser {
 			description,
 			schema,
 			func: async (toolArgs: z.infer<typeof schema>) => {
-				const context = this.options.contextFactory(this.runIndex, {});
+				const currentRunIndex = this.runIndex++;
+				const context = this.options.contextFactory(currentRunIndex, {});
 				context.addInputData(NodeConnectionType.AiTool, [[{ json: toolArgs }]]);
 
 				try {
@@ -402,7 +403,7 @@ class AIParametersParser {
 					const mappedResults = result?.[0]?.flatMap((item) => item.json);
 
 					// Add output data to the context
-					context.addOutputData(NodeConnectionType.AiTool, this.runIndex, [
+					context.addOutputData(NodeConnectionType.AiTool, currentRunIndex, [
 						[{ json: { response: mappedResults } }],
 					]);
 
@@ -410,10 +411,8 @@ class AIParametersParser {
 					return JSON.stringify(mappedResults);
 				} catch (error) {
 					const nodeError = new NodeOperationError(this.options.node, error as Error);
-					context.addOutputData(NodeConnectionType.AiTool, this.runIndex, nodeError);
+					context.addOutputData(NodeConnectionType.AiTool, currentRunIndex, nodeError);
 					return 'Error during node execution: ' + nodeError.description;
-				} finally {
-					this.runIndex++;
 				}
 			},
 		});


### PR DESCRIPTION
## Summary
When an AI agent has multiple items, it can invoke a tool once for each of those items, but that can happen concurrently. 
When we increment the `runIndex` in the `finally` block, this can lead to each item executing with the same `runIndex`, since the tool handling function is `async`.
By moving `runIndex++` to where the context is created, we can now guarantee unique `runIndex` for each tool invocation.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
