### PR TITLE
refactor: Move OpenAI Base URL option to credentials

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -173,7 +173,7 @@ export class EmbeddingsOpenAi implements INodeType {
 						type: 'string',
 						displayOptions: {
 							hide: {
-								'/@version': [{ _cnd: { gte: 1.2 } }],
+								'@version': [{ _cnd: { gte: 1.2 } }],
 							},
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -224,10 +224,7 @@ export class EmbeddingsOpenAi implements INodeType {
 		const configuration: ClientOptions = {};
 		if (options.baseURL) {
 			configuration.baseURL = options.baseURL;
-		}
-
-		// in version 1.2 we moved the Base URL parameter to the credentials
-		if (credentials.url) {
+		} else if (credentials.url) {
 			configuration.baseURL = credentials.url as string;
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -79,7 +79,7 @@ export class EmbeddingsOpenAi implements INodeType {
 			},
 		],
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description: 'Use Embeddings OpenAI',
 		defaults: {
 			name: 'Embeddings OpenAI',
@@ -106,7 +106,7 @@ export class EmbeddingsOpenAi implements INodeType {
 		requestDefaults: {
 			ignoreHttpStatusErrors: true,
 			baseURL:
-				'={{ $parameter.options?.baseURL?.split("/").slice(0,-1).join("/") || "https://api.openai.com" }}',
+				'={{ $parameter.options?.baseURL?.split("/").slice(0,-1).join("/") || $credentials.url?.split("/").slice(0,-1).join("/") || "https://api.openai.com" }}',
 		},
 		properties: [
 			getConnectionHintNoticeField([NodeConnectionType.AiVectorStore]),
@@ -171,6 +171,11 @@ export class EmbeddingsOpenAi implements INodeType {
 						default: 'https://api.openai.com/v1',
 						description: 'Override the default base URL for the API',
 						type: 'string',
+						displayOptions: {
+							hide: {
+								'/@version': [1.2],
+							},
+						},
 					},
 					{
 						displayName: 'Batch Size',
@@ -219,6 +224,11 @@ export class EmbeddingsOpenAi implements INodeType {
 		const configuration: ClientOptions = {};
 		if (options.baseURL) {
 			configuration.baseURL = options.baseURL;
+		}
+
+		// in version 1.2 we moved the Base URL parameter to the credentials
+		if (credentials.url) {
+			configuration.baseURL = credentials.url as string;
 		}
 
 		const embeddings = new OpenAIEmbeddings(

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOpenAI/EmbeddingsOpenAi.node.ts
@@ -173,7 +173,7 @@ export class EmbeddingsOpenAi implements INodeType {
 						type: 'string',
 						displayOptions: {
 							hide: {
-								'/@version': [1.2],
+								'/@version': [{ _cnd: { gte: 1.2 } }],
 							},
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -158,7 +158,7 @@ export class LmChatOpenAi implements INodeType {
 						type: 'string',
 						displayOptions: {
 							hide: {
-								'/@version': [{ _cnd: { gte: 1.1 } }],
+								'@version': [{ _cnd: { gte: 1.1 } }],
 							},
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -158,7 +158,7 @@ export class LmChatOpenAi implements INodeType {
 						type: 'string',
 						displayOptions: {
 							hide: {
-								'/@version': [1.1],
+								'/@version': [{ _cnd: { gte: 1.1 } }],
 							},
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -266,9 +266,7 @@ export class LmChatOpenAi implements INodeType {
 		const configuration: ClientOptions = {};
 		if (options.baseURL) {
 			configuration.baseURL = options.baseURL;
-		}
-
-		if (credentials.url) {
+		} else if (credentials.url) {
 			configuration.baseURL = credentials.url as string;
 		}
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -107,7 +107,7 @@ const properties: INodeProperties[] = [
 				type: 'string',
 				displayOptions: {
 					hide: {
-						'/@version': [1.8],
+						'/@version': [{ _cnd: { gte: 1.8 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -107,7 +107,7 @@ const properties: INodeProperties[] = [
 				type: 'string',
 				displayOptions: {
 					hide: {
-						'/@version': [{ _cnd: { gte: 1.8 } }],
+						'@version': [{ _cnd: { gte: 1.8 } }],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -105,6 +105,11 @@ const properties: INodeProperties[] = [
 				default: 'https://api.openai.com/v1',
 				description: 'Override the default base URL for the API',
 				type: 'string',
+				displayOptions: {
+					hide: {
+						'/@version': [1.8],
+					},
+				},
 			},
 			{
 				displayName: 'Max Retries',
@@ -181,11 +186,13 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		preserveOriginalTools?: boolean;
 	};
 
+	const baseURL = (options.baseURL ?? credentials.url) as string;
+
 	const client = new OpenAIClient({
 		apiKey: credentials.apiKey as string,
 		maxRetries: options.maxRetries ?? 2,
 		timeout: options.timeout ?? 10000,
-		baseURL: options.baseURL,
+		baseURL,
 	});
 
 	const agent = new OpenAIAssistantRunnable({ assistantId, client, asAgent: true });

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/versionDescription.ts
@@ -77,7 +77,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'openAi',
 	icon: { light: 'file:openAi.svg', dark: 'file:openAi.dark.svg' },
 	group: ['transform'],
-	version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7],
+	version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8],
 	subtitle: `={{(${prettifyOperation})($parameter.resource, $parameter.operation)}}`,
 	description: 'Message an assistant or GPT, analyze images, generate audio, etc.',
 	defaults: {

--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -51,8 +51,8 @@ export class OpenAiApi implements ICredentialType {
 
 	test: ICredentialTestRequest = {
 		request: {
-			baseURL: 'https://api.openai.com',
-			url: '/v1/models',
+			baseURL: '={{$credentials?.url}}',
+			url: '/models',
 		},
 	};
 }

--- a/packages/nodes-base/credentials/OpenAiApi.credentials.ts
+++ b/packages/nodes-base/credentials/OpenAiApi.credentials.ts
@@ -30,6 +30,13 @@ export class OpenAiApi implements ICredentialType {
 			description:
 				"For users who belong to multiple organizations, you can set which organization is used for an API request. Usage from these API requests will count against the specified organization's subscription quota.",
 		},
+		{
+			displayName: 'Base URL',
+			name: 'url',
+			type: 'string',
+			default: 'https://api.openai.com/v1',
+			description: 'Override the default base URL for the API',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {

--- a/packages/nodes-base/nodes/OpenAi/OpenAi.node.ts
+++ b/packages/nodes-base/nodes/OpenAi/OpenAi.node.ts
@@ -28,7 +28,8 @@ export class OpenAi implements INodeType {
 		],
 		requestDefaults: {
 			ignoreHttpStatusErrors: true,
-			baseURL: 'https://api.openai.com',
+			baseURL:
+				'={{ $credentials.url?.split("/").slice(0,-1).join("/") || https://api.openai.com }}',
 		},
 		properties: [
 			oldVersionNotice,


### PR DESCRIPTION
## Summary

Prep work to be able to offer free AI credits and also harmonization as we usually have Base URLs in the credentials and not in the node itself.  

Removes the Base URL parameters from the OpenAI nodes and uses the new Base URL parameters in the  OpenAI credentials. I added versioning so this change should only affect the new version and keep "old" nodes using the Base URL from the node parameters working.

Only downside it's that we won't be able to show the `notice` [here](https://github.com/n8n-io/n8n/blob/95f8ed601da82e3db5da5ba3de7d60db4ae5a866/packages/%40n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts#L134), since there is no way to reference a value from credentials in the displayOptions. Right?

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-2887/[n8n-nodes]-move-openai-base-url-option-to-credentials

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
