### PR TITLE
fix(Slack Node): Fix @version issue for Slack Node

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
@@ -47,7 +47,7 @@ export const fileFields: INodeProperties[] = [
 			show: {
 				operation: ['upload'],
 				resource: ['file'],
-				'@version': [2, 2.1],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		description: 'Whether the data to upload should be taken from binary field',
@@ -62,7 +62,7 @@ export const fileFields: INodeProperties[] = [
 				operation: ['upload'],
 				resource: ['file'],
 				binaryData: [false],
-				'@version': [2, 2.1],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		placeholder: '',
@@ -78,23 +78,7 @@ export const fileFields: INodeProperties[] = [
 				operation: ['upload'],
 				resource: ['file'],
 				binaryData: [true],
-				'@version': [2, 2.1],
-			},
-		},
-		placeholder: '',
-		description: 'Name of the binary property which contains the data for the file to be uploaded',
-	},
-	{
-		displayName: 'File Property',
-		name: 'binaryPropertyName',
-		type: 'string',
-		default: 'data',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['upload'],
-				resource: ['file'],
-				'@version': [2.2],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		placeholder: '',
@@ -123,7 +107,7 @@ export const fileFields: INodeProperties[] = [
 				},
 				displayOptions: {
 					show: {
-						'@version': [2, 2.1],
+						'@version': [{ _cnd: { gte: 2 } }],
 					},
 				},
 				default: [],
@@ -139,7 +123,23 @@ export const fileFields: INodeProperties[] = [
 				},
 				displayOptions: {
 					show: {
-						'@version': [2.2],
+						'@version': [{ _cnd: { gte: 2.2 } }],
+					},
+				},
+				default: [],
+				description:
+					'The channel to send the file to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+			},
+			{
+				displayName: 'Channel Name or ID',
+				name: 'channelId',
+				type: 'options',
+				typeOptions: {
+					loadOptionsMethod: 'getChannels',
+				},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2.2 } }],
 					},
 				},
 				default: [],


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Because the Slack Node source code uses a fixed version as the condition when checking the version, the new version of the Slack Node lacks some necessary fields.

## Body

### Reproduce Env
  - n8n version: `n8n version 1.72.0 (Self Hosted)`
  - reproduce the issue at commit `614aad55f020ad61019a07fe4d95aa89d9e88330`
  - Slack Node Version: `Slack node version 2.3 (Latest)`

### Reproduce
- Create a node to output a binary file (It's a text binary file in my case)
- Create a `Slack Node` after that
- Select the `File` as Resource & `Upload` as Operation in `Slack Node`
- Click the 「Test step」button in `Slack Node`
  - See the error output ⛔️ Here is the error
    - ```js
		  {
		    "errorMessage": "Could not get parameter",
		    "errorDetails": {
		      "errorExtra": {
		        "parameterName": "binaryPropertyName"
		      }
		    },
		    "n8nDetails": {
		      "n8nVersion": "1.72.0 (Self Hosted)",
		      "binaryDataMode": "default",
		      "stackTrace": [
		        "Error: Could not get parameter",
		        "    at ExecuteContext._getNodeParameter (/***/n8n/packages/core/src/node-execution-context/node-execution-context.ts:294:10)",
		        "    at ExecuteContext.getNodeParameter (/***/n8n/packages/core/src/node-execution-context/execute-context.ts:118:9)",
		        "    at ExecuteContext.execute (/***/n8n/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts:1098:40)",
		        "    at Workflow.runNode (/***/n8n/packages/workflow/src/Workflow.ts:1394:31)",
		        "    at /***/n8n/packages/core/src/WorkflowExecute.ts:1174:42",
		        "    at /***/n8n/packages/core/src/WorkflowExecute.ts:1895:11"
		      ]
		    }
		  }
  - See the issue that **some required inputs are missing** on the `Slack Node Version > 2.1`   ⛔️ Here is the bug
    - ![CleanShot_2024-12-12_at_11 25 51@2x_1733974023046_0](https://github.com/user-attachments/assets/253ba8bd-b140-4f5e-9c5f-e17c20721087)

### Root Cause
- ```js
  displayOptions: {
    show: {
      operation: ['upload'],
        resource: ['file'],
          '@version': [2.2],  // This @version condition is fixed. Unexpected behavior occurs if the new version has been released.
    },
  },```


### Solution
  - use `_cnd: { lte: version}` instead of the specific version.
  - remove duplicate fielFields(`File Property`)

### Manually Testing

- ✅ Required fields show correctly
- ✅ Send a file correctly

![Arc 2024-12-12 14 05 03](https://github.com/user-attachments/assets/c09ff70d-3485-4246-a925-1461f2a1110d)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

### Related PRs
- https://github.com/n8n-io/n8n/pull/9323
- https://github.com/n8n-io/n8n/pull/12089


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created~~.
  - Fix the issue only; updating the documentation is unnecessary.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- ~~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~~
  -  This issue fix does not require backporting.