### PR TITLE
feat(core): Add `is_docker` info to telemetry payload on `server-started` (no-changelog)

### DIFF
--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { snakeCase } from 'change-case';
+import { InstanceSettings } from 'n8n-core';
 import type { ExecutionStatus, INodesGraphResult, ITelemetryTrackProperties } from 'n8n-workflow';
 import { TelemetryHelpers } from 'n8n-workflow';
 import os from 'node:os';
@@ -28,6 +29,7 @@ export class TelemetryEventRelay extends EventRelay {
 		private readonly telemetry: Telemetry,
 		private readonly license: License,
 		private readonly globalConfig: GlobalConfig,
+		private readonly instanceSettings: InstanceSettings,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly nodeTypes: NodeTypes,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
@@ -760,6 +762,7 @@ export class TelemetryEventRelay extends EventRelay {
 					model: cpus[0].model,
 					speed: cpus[0].speed,
 				},
+				is_docker: this.instanceSettings.isDocker,
 			},
 			execution_variables: {
 				executions_mode: config.getEnv('executions.mode'),


### PR DESCRIPTION
## Summary
This PR updated the telemetry identification payload to introduce a `is_docker` flag to help distinguish between Docker installations from npm ones.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
