### PR TITLE
refactor(editor): Simplify the css for the color palette (no-changelog)

### DIFF
--- a/packages/design-system/src/css/_primitives.scss
+++ b/packages/design-system/src/css/_primitives.scss
@@ -4,6 +4,22 @@
 // Tokens should be used instead in components an other UI elements
 
 @mixin primitives {
+	// Primary color palette
+	--prim-color-white: hsl(0, 0, 100%);
+	--prim-color-primary: hsl(7, 100%, 68%);
+	--prim-color-secondary: hsl(247 49% 53%);
+	--prim-color-alt-a: hsl(150 60% 40%);
+	--prim-color-alt-b: hsl(36 77% 57%);
+	--prim-color-alt-c: hsl(355, 83%, 52%);
+	--prim-color-alt-d: hsl(46 100% 92%);
+	--prim-color-alt-e: hsl(210 67% 57%);
+	--prim-color-alt-f: hsl(72 100% 27%);
+	--prim-color-alt-g: hsl(276 31% 50%);
+	--prim-color-alt-h: hsl(184 44% 43%);
+	--prim-color-alt-i: hsl(147 83% 44%);
+	--prim-color-alt-j: hsl(247 10% 30%);
+	--prim-color-alt-k: hsl(355 100% 69%);
+
 	// Gray
 	--prim-gray-h: 220;
 
@@ -32,442 +48,86 @@
 	--prim-gray-0: hsl(var(--prim-gray-h), 50%, 100%);
 
 	// Color Primary
-	--prim-color-primary-h: 7;
-	--prim-color-primary-s: 100%;
-	--prim-color-primary-l: 68%;
-
-	--prim-color-primary-shade-300: hsl(
-		var(--prim-color-primary-h),
-		calc(var(--prim-color-primary-s) - 60%),
-		calc(var(--prim-color-primary-l) - 30%)
-	);
-	--prim-color-primary-shade-100: hsl(
-		var(--prim-color-primary-h),
-		calc(var(--prim-color-primary-s) - 15%),
-		calc(var(--prim-color-primary-l) - 10%)
-	);
-	--prim-color-primary: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		var(--prim-color-primary-l)
-	);
-	--prim-color-primary-alpha-010: hsla(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		var(--prim-color-primary-l),
-		0.1
-	);
-	--prim-color-primary-alpha-035: hsla(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		var(--prim-color-primary-l),
-		0.35
-	);
-	--prim-color-primary-alpha-050: hsla(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		var(--prim-color-primary-l),
-		0.5
-	);
-	--prim-color-primary-tint-100: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		calc(var(--prim-color-primary-l) + 10%)
-	);
-	--prim-color-primary-tint-200: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		calc(var(--prim-color-primary-l) + 20%)
-	);
-	--prim-color-primary-tint-250: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		calc(var(--prim-color-primary-l) + 25%)
-	);
-	--prim-color-primary-tint-270: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		calc(var(--prim-color-primary-l) + 27%)
-	);
-	--prim-color-primary-tint-300: hsl(
-		var(--prim-color-primary-h),
-		var(--prim-color-primary-s),
-		calc(var(--prim-color-primary-l) + 30%)
-	);
+	--prim-color-primary-shade-300: hsl(from var(--prim-color-primary) h calc(s - 60) calc(l - 30));
+	--prim-color-primary-shade-100: hsl(from var(--prim-color-primary) h calc(s - 15) calc(l - 10));
+	--prim-color-primary-alpha-010: hsla(from var(--prim-color-primary) h s l 0.1);
+	--prim-color-primary-alpha-035: hsla(from var(--prim-color-primary) h s l 0.35);
+	--prim-color-primary-alpha-050: hsla(from var(--prim-color-primary) h s l 0.5);
+	--prim-color-primary-tint-100: hsl(from var(--prim-color-primary) h s calc(l + 10));
+	--prim-color-primary-tint-200: hsl(from var(--prim-color-primary) h s calc(l + 20));
+	--prim-color-primary-tint-250: hsl(from var(--prim-color-primary) h s calc(l + 25));
+	--prim-color-primary-tint-270: hsl(from var(--prim-color-primary) h s calc(l + 27));
+	--prim-color-primary-tint-300: hsl(from var(--prim-color-primary) h s calc(l + 30));
 
 	// Color Secondary
-	--prim-color-secondary-h: 247;
-	--prim-color-secondary-s: 49%;
-	--prim-color-secondary-l: 53%;
-
 	--prim-color-secondary-shade-250: hsl(
-		var(--prim-color-secondary-h),
-		calc(var(--prim-color-secondary-s) - 25%),
-		calc(var(--prim-color-secondary-l) - 25%)
+		from var(--prim-color-secondary) h calc(s - 25) calc(l - 25)
 	);
-	--prim-color-secondary-shade-100: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		calc(var(--prim-color-secondary-l) - 10%)
-	);
-	--prim-color-secondary: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		var(--prim-color-secondary-l)
-	);
-	--prim-color-secondary-alpha-025: hsla(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		var(--prim-color-secondary-l),
-		0.25
-	);
-	--prim-color-secondary-alpha-010: hsla(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		var(--prim-color-secondary-l),
-		0.1
-	);
-	--prim-color-secondary-tint-100: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		calc(var(--prim-color-secondary-l) + 10%)
-	);
-	--prim-color-secondary-tint-200: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		calc(var(--prim-color-secondary-l) + 20%)
-	);
-	--prim-color-secondary-tint-300: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		calc(var(--prim-color-secondary-l) + 30%)
-	);
-	--prim-color-secondary-tint-400: hsl(
-		var(--prim-color-secondary-h),
-		var(--prim-color-secondary-s),
-		calc(var(--prim-color-secondary-l) + 40%)
-	);
+	--prim-color-secondary-shade-100: hsl(from var(--prim-color-secondary) h s calc(l - 10));
+	--prim-color-secondary-alpha-025: hsla(from var(--prim-color-secondary) h s l 0.25);
+	--prim-color-secondary-alpha-010: hsla(from var(--prim-color-secondary) h s l 0.1);
+	--prim-color-secondary-tint-100: hsl(from var(--prim-color-secondary) h s calc(l + 10));
+	--prim-color-secondary-tint-200: hsl(from var(--prim-color-secondary) h s calc(l + 20));
+	--prim-color-secondary-tint-300: hsl(from var(--prim-color-secondary) h s calc(l + 30));
+	--prim-color-secondary-tint-400: hsl(from var(--prim-color-secondary) h s calc(l + 40));
 
 	// Color Alternate A
-	--prim-color-alt-a-h: 150;
-	--prim-color-alt-a-s: 60%;
-	--prim-color-alt-a-l: 40%;
-
-	--prim-color-alt-a-shade-200: hsl(
-		var(--prim-color-alt-a-h),
-		calc(var(--prim-color-alt-a-s) - 15%),
-		calc(var(--prim-color-alt-a-l) - 20%)
-	);
-	--prim-color-alt-a-shade-100: hsl(
-		var(--prim-color-alt-a-h),
-		calc(var(--prim-color-alt-a-s) - 15%),
-		calc(var(--prim-color-alt-a-l) - 10%)
-	);
-	--prim-color-alt-a: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		var(--prim-color-alt-a-l)
-	);
-	--prim-color-alt-a-alpha-025: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		var(--prim-color-alt-a-l),
-		0.25
-	);
-	--prim-color-alt-a-alpha-015: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		var(--prim-color-alt-a-l),
-		0.15
-	);
-	--prim-color-alt-a-tint-300: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		calc(var(--prim-color-alt-a-l) + 30%)
-	);
-	--prim-color-alt-a-tint-400: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		calc(var(--prim-color-alt-a-l) + 40%)
-	);
-	--prim-color-alt-a-tint-500: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		calc(var(--prim-color-alt-a-l) + 50%)
-	);
-	--prim-color-alt-a-tint-550: hsl(
-		var(--prim-color-alt-a-h),
-		var(--prim-color-alt-a-s),
-		calc(var(--prim-color-alt-a-l) + 55%)
-	);
+	--prim-color-alt-a-shade-200: hsl(from var(--prim-color-alt-a) h calc(s - 15) calc(l - 20));
+	--prim-color-alt-a-shade-100: hsl(from var(--prim-color-alt-a) h calc(s - 15) calc(l - 10));
+	--prim-color-alt-a-alpha-025: hsla(from var(--prim-color-alt-a) h s l 0.25);
+	--prim-color-alt-a-alpha-015: hsla(from var(--prim-color-alt-a) h s l 0.15);
+	--prim-color-alt-a-tint-300: hsl(from var(--prim-color-alt-a) h s calc(l + 30));
+	--prim-color-alt-a-tint-400: hsl(from var(--prim-color-alt-a) h s calc(l + 40));
+	--prim-color-alt-a-tint-500: hsl(from var(--prim-color-alt-a) h s calc(l + 50));
+	--prim-color-alt-a-tint-550: hsl(from var(--prim-color-alt-a) h s calc(l + 55));
 
 	// Color Alternate B
-	--prim-color-alt-b-h: 36;
-	--prim-color-alt-b-s: 77%;
-	--prim-color-alt-b-l: 57%;
-
-	--prim-color-alt-b-shade-350: hsl(
-		var(--prim-color-alt-b-h),
-		calc(var(--prim-color-alt-b-s) - 35%),
-		calc(var(--prim-color-alt-b-l) - 35%)
-	);
-	--prim-color-alt-b-shade-250: hsl(
-		var(--prim-color-alt-b-h),
-		calc(var(--prim-color-alt-b-s) - 35%),
-		calc(var(--prim-color-alt-b-l) - 25%)
-	);
-	--prim-color-alt-b-shade-100: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		calc(var(--prim-color-alt-b-l) - 10%)
-	);
-	--prim-color-alt-b: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		var(--prim-color-alt-b-l)
-	);
-	--prim-color-alt-b-alpha-02: hsla(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		var(--prim-color-alt-b-l),
-		0.2
-	);
-	--prim-color-alt-b-tint-150: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		calc(var(--prim-color-alt-b-l) + 15%)
-	);
-	--prim-color-alt-b-tint-250: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		calc(var(--prim-color-alt-b-l) + 25%)
-	);
-	--prim-color-alt-b-tint-300: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		calc(var(--prim-color-alt-b-l) + 30%)
-	);
-	--prim-color-alt-b-tint-400: hsl(
-		var(--prim-color-alt-b-h),
-		var(--prim-color-alt-b-s),
-		calc(var(--prim-color-alt-b-l) + 40%)
-	);
+	--prim-color-alt-b-shade-350: hsl(from var(--prim-color-alt-b) h calc(s - 35) calc(l - 35));
+	--prim-color-alt-b-shade-250: hsl(from var(--prim-color-alt-b) h calc(s - 35) calc(l - 25));
+	--prim-color-alt-b-shade-100: hsl(from var(--prim-color-alt-b) h s calc(l - 10));
+	--prim-color-alt-b-alpha-02: hsla(from var(--prim-color-alt-b) h s l 0.2);
+	--prim-color-alt-b-tint-150: hsl(from var(--prim-color-alt-b) h s calc(l + 15));
+	--prim-color-alt-b-tint-250: hsl(from var(--prim-color-alt-b) h s calc(l + 25));
+	--prim-color-alt-b-tint-300: hsl(from var(--prim-color-alt-b) h s calc(l + 30));
+	--prim-color-alt-b-tint-400: hsl(from var(--prim-color-alt-b) h s calc(l + 40));
 
 	// Color Alternate C
-	--prim-color-alt-c-h: 355;
-	--prim-color-alt-c-s: 83%;
-	--prim-color-alt-c-l: 52%;
-
-	--prim-color-alt-c-shade-250: hsl(
-		var(--prim-color-alt-c-h),
-		calc(var(--prim-color-alt-c-s) - 40%),
-		calc(var(--prim-color-alt-c-l) - 25%)
-	);
-	--prim-color-alt-c-shade-150: hsl(
-		var(--prim-color-alt-c-h),
-		calc(var(--prim-color-alt-c-s) - 40%),
-		calc(var(--prim-color-alt-c-l) - 15%)
-	);
-	--prim-color-alt-c-shade-100: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) - 10%)
-	);
-	--prim-color-alt-c: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		var(--prim-color-alt-c-l)
-	);
-	--prim-color-alt-c-alpha-02: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		var(--prim-color-alt-c-l),
-		0.2
-	);
-	--prim-color-alt-c-tint-150: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) + 15%)
-	);
-	--prim-color-alt-c-tint-250: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) + 25%)
-	);
-	--prim-color-alt-c-tint-300: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) + 30%)
-	);
-	--prim-color-alt-c-tint-400: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) + 40%)
-	);
-	--prim-color-alt-c-tint-450: hsl(
-		var(--prim-color-alt-c-h),
-		var(--prim-color-alt-c-s),
-		calc(var(--prim-color-alt-c-l) + 45%)
-	);
+	--prim-color-alt-c-shade-250: hsl(from var(--prim-color-alt-c) h calc(s - 40) calc(l - 25));
+	--prim-color-alt-c-shade-150: hsl(from var(--prim-color-alt-c) h calc(s - 40) calc(l - 15));
+	--prim-color-alt-c-shade-100: hsl(from var(--prim-color-alt-c) h s calc(l - 10));
+	--prim-color-alt-c-alpha-02: hsla(from var(--prim-color-alt-c) h s l 0.2);
+	--prim-color-alt-c-tint-150: hsl(from var(--prim-color-alt-c) h s calc(l + 15));
+	--prim-color-alt-c-tint-250: hsl(from var(--prim-color-alt-c) h s calc(l + 25));
+	--prim-color-alt-c-tint-300: hsl(from var(--prim-color-alt-c) h s calc(l + 30));
+	--prim-color-alt-c-tint-400: hsl(from var(--prim-color-alt-c) h s calc(l + 40));
+	--prim-color-alt-c-tint-450: hsl(from var(--prim-color-alt-c) h s calc(l + 45));
 
 	// Color Alternate D
-	--prim-color-alt-d-h: 46;
-	--prim-color-alt-d-s: 100%;
-	--prim-color-alt-d-l: 92%;
-
-	--prim-color-alt-d-shade-700: hsl(
-		var(--prim-color-alt-d-h),
-		calc(var(--prim-color-alt-d-s) - 55%),
-		calc(var(--prim-color-alt-d-l) - 70%)
-	);
-	--prim-color-alt-d-shade-600: hsl(
-		var(--prim-color-alt-d-h),
-		calc(var(--prim-color-alt-d-s) - 55%),
-		calc(var(--prim-color-alt-d-l) - 60%)
-	);
-	--prim-color-alt-d-shade-150: hsl(
-		var(--prim-color-alt-d-h),
-		var(--prim-color-alt-d-s),
-		calc(var(--prim-color-alt-d-l) - 15%)
-	);
-	--prim-color-alt-d: hsl(
-		var(--prim-color-alt-d-h),
-		var(--prim-color-alt-d-s),
-		var(--prim-color-alt-d-l)
-	);
+	--prim-color-alt-d-shade-700: hsl(from var(--prim-color-alt-d) h calc(s - 55) calc(l - 70));
+	--prim-color-alt-d-shade-600: hsl(from var(--prim-color-alt-d) h calc(s - 55) calc(l - 60));
+	--prim-color-alt-d-shade-150: hsl(from var(--prim-color-alt-d) h s calc(l - 15));
 
 	// Color Alternate E
-	--prim-color-alt-e-h: 210;
-	--prim-color-alt-e-s: 67%;
-	--prim-color-alt-e-l: 57%;
-
-	--prim-color-alt-e-shade-350: hsl(
-		var(--prim-color-alt-e-h),
-		calc(var(--prim-color-alt-e-s) - 20%),
-		calc(var(--prim-color-alt-e-l) - 35%)
-	);
-	--prim-color-alt-e-shade-250: hsl(
-		var(--prim-color-alt-e-h),
-		calc(var(--prim-color-alt-e-s) - 20%),
-		calc(var(--prim-color-alt-e-l) - 25%)
-	);
-	--prim-color-alt-e-shade-150: hsl(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		calc(var(--prim-color-alt-e-l) - 15%)
-	);
-	--prim-color-alt-e-shade-100: hsl(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		calc(var(--prim-color-alt-e-l) - 10%)
-	);
-	--prim-color-alt-e: hsl(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		var(--prim-color-alt-e-l)
-	);
-	--prim-color-alt-e-alpha-04: hsla(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		var(--prim-color-alt-e-l),
-		0.4
-	);
-	--prim-color-alt-e-tint-250: hsl(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		calc(var(--prim-color-alt-e-l) + 25%)
-	);
-	--prim-color-alt-e-tint-350: hsl(
-		var(--prim-color-alt-e-h),
-		var(--prim-color-alt-e-s),
-		calc(var(--prim-color-alt-e-l) + 35%)
-	);
+	--prim-color-alt-e-shade-350: hsl(from var(--prim-color-alt-e) h calc(s - 20) calc(l - 35));
+	--prim-color-alt-e-shade-250: hsl(from var(--prim-color-alt-e) h calc(s - 20) calc(l - 25));
+	--prim-color-alt-e-shade-150: hsl(from var(--prim-color-alt-e) h s calc(l - 15));
+	--prim-color-alt-e-shade-100: hsl(from var(--prim-color-alt-e) h s calc(l - 10));
+	--prim-color-alt-e-alpha-04: hsla(from var(--prim-color-alt-e) h s l 0.4);
+	--prim-color-alt-e-tint-250: hsl(from var(--prim-color-alt-e) h s calc(l + 25));
+	--prim-color-alt-e-tint-350: hsl(from var(--prim-color-alt-e) h s calc(l + 35));
 
 	// Color Alternate F
-	--prim-color-alt-f-h: 72;
-	--prim-color-alt-f-s: 100%;
-	--prim-color-alt-f-l: 27%;
-
-	--prim-color-alt-f: hsl(
-		var(--prim-color-alt-f-h),
-		var(--prim-color-alt-f-s),
-		var(--prim-color-alt-f-l)
-	);
-
-	--prim-color-alt-f-tint-150: hsl(
-		var(--prim-color-alt-f-h),
-		var(--prim-color-alt-f-s),
-		calc(var(--prim-color-alt-f-l) + 15%)
-	);
+	--prim-color-alt-f-tint-150: hsl(from var(--prim-color-alt-f) h s calc(l + 15));
 
 	// Color Alternate G
-	--prim-color-alt-g-h: 276;
-	--prim-color-alt-g-s: 31%;
-	--prim-color-alt-g-l: 50%;
-
-	--prim-color-alt-g: hsl(
-		var(--prim-color-alt-g-h),
-		var(--prim-color-alt-g-s),
-		var(--prim-color-alt-g-l)
-	);
-
-	--prim-color-alt-g-tint-150: hsl(
-		var(--prim-color-alt-g-h),
-		var(--prim-color-alt-g-s),
-		calc(var(--prim-color-alt-g-l) + 15%)
-	);
-
-	// Color Alternate H
-	--prim-color-alt-h-h: 184;
-	--prim-color-alt-h-s: 44%;
-	--prim-color-alt-h-l: 43%;
-
-	--prim-color-alt-h: hsl(
-		var(--prim-color-alt-h-h),
-		var(--prim-color-alt-h-s),
-		var(--prim-color-alt-h-l)
-	);
-
-	// Color Alternate I
-	--prim-color-alt-i-h: 147;
-	--prim-color-alt-i-s: 83%;
-	--prim-color-alt-i-l: 44%;
-
-	--prim-color-alt-i: hsl(
-		var(--prim-color-alt-i-h),
-		var(--prim-color-alt-i-s),
-		var(--prim-color-alt-i-l)
-	);
+	--prim-color-alt-g-tint-150: hsl(from var(--prim-color-alt-g) h s calc(l + 15));
 
 	// Color Alternate J
-	--prim-color-alt-j-h: 247;
-	--prim-color-alt-j-s: 10%;
-	--prim-color-alt-j-l: 30%;
+	--prim-color-alt-j-alpha-075: hsla(var(--prim-color-alt-j) h s l 0.75);
 
-	--prim-color-alt-j: hsl(
-		var(--prim-color-alt-j-h),
-		var(--prim-color-alt-j-s),
-		var(--prim-color-alt-j-l)
-	);
-	--prim-color-alt-j-alpha-075: hsla(
-		var(--prim-color-alt-j-h),
-		var(--prim-color-alt-j-s),
-		var(--prim-color-alt-j-l),
-		0.75
-	);
-
-	// Color Alternate K - Used for errors in dark mode
-	--prim-color-alt-k-h: 355;
-	--prim-color-alt-k-s: 100%;
-	--prim-color-alt-k-l: 69%;
-
-	--prim-color-alt-k: hsl(
-		var(--prim-color-alt-k-h),
-		var(--prim-color-alt-k-s),
-		var(--prim-color-alt-k-l)
-	);
-
-	--prim-color-white: hsl(0, 0%, 100%);
+	// TODO: remove all usage of these, and derive colors from the color palette
+	--prim-color-primary-h: 7;
+	--prim-color-primary-s: 100%;
 }
 
 :root {


### PR DESCRIPTION
## Summary
The way we currently have colors setup seems too verbose, and relatively harder to maintain.
This PR moves our entire color palette into a single code block that is easier to read and maintain, and updates rest of the colors to derive from these, instead of all of the individual H, S, and L variables.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
