### PR TITLE
feat(Linear Trigger Node): Add support for admin scope

### DIFF
--- a/packages/nodes-base/credentials/LinearOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/LinearOAuth2Api.credentials.ts
@@ -1,7 +1,5 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = ['read', 'write', 'issues:create', 'comments:create'];
-
 export class LinearOAuth2Api implements ICredentialType {
 	name = 'linearOAuth2Api';
 
@@ -51,10 +49,18 @@ export class LinearOAuth2Api implements ICredentialType {
 			default: 'user',
 		},
 		{
+			displayName: 'Include Admin Scope',
+			name: 'includeAdminScope',
+			type: 'boolean',
+			default: false,
+			description: 'Grants the "Admin" scope, Needed to create webhooks',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: scopes.join(' '),
+			default:
+				'={{$self["includeAdminScope"] ? "read write issues:create comments:create admin" : "read write issues:create comments:create"}}',
 			required: true,
 		},
 		{


### PR DESCRIPTION
## Summary
This adds a toggle option to the OAuth credential to include the "Admin" scope which is now required to create webhooks / use the trigger node.

Credential change... Not sure if we can test that so have not included tests.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2158/linear-credential-add-admin-scope

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
