### PR TITLE
Add returnSourceDocuments option to Retrieval QA Chain node

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -8,6 +8,7 @@ import {
 import type { BaseRetriever } from '@langchain/core/retrievers';
 import { RetrievalQAChain } from 'langchain/chains';
 import {
+	IDataObject,
 	NodeConnectionType,
 	type IExecuteFunctions,
 	type INodeExecutionData,
@@ -136,6 +137,13 @@ export class ChainRetrievalQa implements INodeType {
 				},
 			},
 			{
+				displayName: 'Return Source Documents',
+				name: 'returnSourceDocuments',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include source documents in the output',
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				type: 'collection',
@@ -159,8 +167,7 @@ export class ChainRetrievalQa implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		this.logger.debug('Executing Retrieval QA Chain');
-
+		// Log input connections
 		const model = (await this.getInputConnectionData(
 			NodeConnectionType.AiLanguageModel,
 			0,
@@ -199,6 +206,12 @@ export class ChainRetrievalQa implements INodeType {
 					systemPromptTemplate?: string;
 				};
 
+				const returnSourceDocuments = this.getNodeParameter(
+					'returnSourceDocuments',
+					itemIndex,
+					false,
+				) as boolean;
+
 				const chainParameters = {} as {
 					prompt?: PromptTemplate | ChatPromptTemplate;
 				};
@@ -222,13 +235,25 @@ export class ChainRetrievalQa implements INodeType {
 					}
 				}
 
-				const chain = RetrievalQAChain.fromLLM(model, retriever, chainParameters);
+				const chain = RetrievalQAChain.fromLLM(model, retriever, {
+					...chainParameters,
+					returnSourceDocuments,
+				});
 
 				const response = await chain.withConfig(getTracingConfig(this)).invoke({ query });
-				returnData.push({ json: { response } });
-			} catch (error) {
+
+				const result: Record<string, unknown> = { response };
+				if (returnSourceDocuments) {
+					result.documents = response.sourceDocuments || [];
+				}
+
+				returnData.push({ json: result as IDataObject });
+			} catch (error: unknown) {
 				if (this.continueOnFail()) {
-					returnData.push({ json: { error: error.message }, pairedItem: { item: itemIndex } });
+					returnData.push({
+						json: { error: (error as Error).message } as IDataObject,
+						pairedItem: { item: itemIndex },
+					});
 					continue;
 				}
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -167,7 +167,8 @@ export class ChainRetrievalQa implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		// Log input connections
+		this.logger.debug('Executing Retrieval QA Chain');
+
 		const model = (await this.getInputConnectionData(
 			NodeConnectionType.AiLanguageModel,
 			0,
@@ -182,7 +183,6 @@ export class ChainRetrievalQa implements INodeType {
 
 		const returnData: INodeExecutionData[] = [];
 
-		// Run for each item
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			try {
 				let query;


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `returnSourceDocuments` option to the Retrieval QA Chain node. When enabled, it includes the source documents in the output for enhanced context and traceability.

### Why is this feature needed?

Many users require access to the source documents that contribute to the answer generated by the Retrieval QA Chain. This feature provides greater transparency and usability.

### Changes made:
- Added `returnSourceDocuments` as a boolean property.
- Updated `RetrievalQAChain` call to include `returnSourceDocuments` in parameters.
- Included `documents` in the output when the option is enabled.

## Summary

Toggled False (same as current QA chain is)

![image](https://github.com/user-attachments/assets/ebc977c4-0aa9-445c-9a67-2b2a87929c4e)

Toggled True 

![image](https://github.com/user-attachments/assets/73595bf5-7030-43c2-b3dc-076b8b92b508)

Output structure toggled False (default) is as before:

```
[
  {
    "response": {
      "text": "Yes, there is a stunning one-bedroom apartment available. It is located in Hampton apartments, Royal Arsenal riverside, and features river views, real wood flooring, a spacious double bedroom, and a high-quality open-plan kitchen with integrated appliances. It will be available from 1st December."
    }
  }
]
```

Output structure toggled True:


```
[
{
"response": 
{
"text": 
"Yes, there is a stunning one-bedroom apartment available in Hampton apartments, Royal Arsenal riverside. It features river views and will be available from 1st December.",
"sourceDocuments": 
[
{
  "pageContent": "Available 1st December\n\nStunning One-Bedroom Apartment with River Views",
  "metadata": {
    "id": "153206408",
    "loc": {
      "lines": {
        "to": 3,
        "from": 1
      }
    },
    "source": "blob",
    "blobType": "text/plain"
  }
}
{...
```
