### PR TITLE
fix(editor): Use contrasting colors for popovers and tooltips

### DIFF
--- a/packages/design-system/src/css/common/var.scss
+++ b/packages/design-system/src/css/common/var.scss
@@ -748,14 +748,15 @@ $popover-title-font-color: var(--color-text-dark);
 /* Tooltip
 -------------------------- */
 /// color|1|Color|0
-$tooltip-fill: var(--color-background-dark);
+$tooltip-fill: var(--color-background-xlight);
 /// color|1|Color|0
-$tooltip-color: $color-white;
+$tooltip-color: var(--color-text-base);
 /// fontSize||Font|1
 $tooltip-font-size: 12px;
 /// color||Color|0
-$tooltip-border-color: var(--color-background-dark);
-$tooltip-arrow-size: 6px;
+$tooltip-border-color: var(--color-background-medium);
+$tooltip-border-width: 1px;
+$tooltip-arrow-size: 8px;
 /// padding||Spacing|3
 $tooltip-padding: 10px;
 

--- a/packages/design-system/src/css/popper.scss
+++ b/packages/design-system/src/css/popper.scss
@@ -114,6 +114,7 @@
 
 	@include mixins.when(dark) {
 		background: var.$tooltip-fill;
+		border: var.$tooltip-border-width solid var.$tooltip-border-color;
 		color: var.$tooltip-color;
 
 		&[data-popper-placement^='top'] .el-popper__arrow {

--- a/packages/editor-ui/src/components/Sticky.vue
+++ b/packages/editor-ui/src/components/Sticky.vue
@@ -358,7 +358,6 @@ const onContextMenu = (e: MouseEvent): void => {
 					<font-awesome-icon icon="trash" />
 				</div>
 				<n8n-popover
-					effect="dark"
 					trigger="click"
 					placement="top"
 					:popper-style="{ width: '208px' }"

--- a/packages/editor-ui/src/components/canvas/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
@@ -59,7 +59,6 @@ onBeforeUnmount(() => {
 
 <template>
 	<N8nPopover
-		effect="dark"
 		trigger="click"
 		placement="top"
 		:popper-class="$style.popover"


### PR DESCRIPTION
## Summary
This PR updates the popover/tooltip colors to align with the user's theme, to improve the contrast .

## Before
![dark mode](https://github.com/user-attachments/assets/8d2ae5e0-96de-4e17-8e1b-68de3ce2447d)
![light mode](https://github.com/user-attachments/assets/230dbe07-3c72-4fe1-ab0b-c04c1ebeb600)
![dark mode](https://github.com/user-attachments/assets/d3c4733d-c012-4492-85f0-6b13bff59cee)
![light mode](https://github.com/user-attachments/assets/ed45e3fe-fa52-48a1-95cf-8a2358d65d0a)


## After
![dark mode](https://github.com/user-attachments/assets/d386e59b-7dfe-415d-85e1-5134eddecd69)
![light mode](https://github.com/user-attachments/assets/7a764b05-6101-4d88-b513-1a7b5e82dbfa)
![dark mode](https://github.com/user-attachments/assets/79b07616-823f-4f57-8359-b4d11d9e3869)
![light mode](https://github.com/user-attachments/assets/333203b1-0820-41e8-8982-54571ebc047a)


## Related Linear tickets, Github issues, and Community forum posts

Fixes #11426
[CAT-273](https://linear.app/n8n/issue/CAT-273)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
