### PR TITLE
test(Philips Hue Node): Add test coverage (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
@@ -41,9 +41,12 @@ export async function philipsHueApiRequest(
 			delete options.qs;
 		}
 
+		console.log(options);
+
 		const response = await this.helpers.requestOAuth2.call(this, 'philipsHueOAuth2Api', options, {
 			tokenType: 'Bearer',
 		});
+		console.log(response);
 		return response;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
@@ -52,6 +55,7 @@ export async function philipsHueApiRequest(
 
 export async function getUser(this: IExecuteFunctions | ILoadOptionsFunctions): Promise<any> {
 	const { whitelist } = await philipsHueApiRequest.call(this, 'GET', '/api/0/config', {}, {});
+	console.log(whitelist);
 	//check if there is a n8n user
 	for (const user of Object.keys(whitelist as IDataObject)) {
 		if (whitelist[user].name === 'n8n') {

--- a/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
@@ -41,12 +41,16 @@ export async function philipsHueApiRequest(
 			delete options.qs;
 		}
 
+		console.log('### OPTIONS ###');
 		console.log(options);
+		console.log('### OPTIONS ###');
 
 		const response = await this.helpers.requestOAuth2.call(this, 'philipsHueOAuth2Api', options, {
 			tokenType: 'Bearer',
 		});
+		console.log('### RESPONSE ###');
 		console.log(response);
+		console.log('### RESPONSE ###');
 		return response;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
@@ -55,7 +59,6 @@ export async function philipsHueApiRequest(
 
 export async function getUser(this: IExecuteFunctions | ILoadOptionsFunctions): Promise<any> {
 	const { whitelist } = await philipsHueApiRequest.call(this, 'GET', '/api/0/config', {}, {});
-	console.log(whitelist);
 	//check if there is a n8n user
 	for (const user of Object.keys(whitelist as IDataObject)) {
 		if (whitelist[user].name === 'n8n') {

--- a/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/GenericFunctions.ts
@@ -41,16 +41,9 @@ export async function philipsHueApiRequest(
 			delete options.qs;
 		}
 
-		console.log('### OPTIONS ###');
-		console.log(options);
-		console.log('### OPTIONS ###');
-
 		const response = await this.helpers.requestOAuth2.call(this, 'philipsHueOAuth2Api', options, {
 			tokenType: 'Bearer',
 		});
-		console.log('### RESPONSE ###');
-		console.log(response);
-		console.log('### RESPONSE ###');
 		return response;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);

--- a/packages/nodes-base/nodes/PhilipsHue/test/apiResponses.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/apiResponses.ts
@@ -1,0 +1,98 @@
+export const getLightsResponse = {
+	'1': {
+		state: {
+			on: false,
+			bri: 1,
+			hue: 33761,
+			sat: 254,
+			effect: 'none',
+			xy: [0.3171, 0.3366],
+			ct: 159,
+			alert: 'none',
+			colormode: 'xy',
+			mode: 'homeautomation',
+			reachable: true,
+		},
+		swupdate: {
+			state: 'noupdates',
+			lastinstall: '2018-01-02T19:24:20',
+		},
+		type: 'Extended color light',
+		name: 'Hue color lamp 7',
+		modelid: 'LCT007',
+		manufacturername: 'Philips',
+		productname: 'Hue color lamp',
+		capabilities: {
+			certified: true,
+			control: {
+				mindimlevel: 5000,
+				maxlumen: 600,
+				colorgamuttype: 'B',
+				colorgamut: [
+					[0.675, 0.322],
+					[0.409, 0.518],
+					[0.167, 0.04],
+				],
+				ct: {
+					min: 153,
+					max: 500,
+				},
+			},
+			streaming: {
+				renderer: true,
+				proxy: false,
+			},
+		},
+		config: {
+			archetype: 'sultanbulb',
+			function: 'mixed',
+			direction: 'omnidirectional',
+		},
+		uniqueid: '00:17:88:01:00:bd:c7:b9-0b',
+		swversion: '5.105.0.21169',
+	},
+};
+
+export const getConfigResponse = {
+	name: 'Philips hue',
+	zigbeechannel: 15,
+	mac: '00:17:88:00:00:00',
+	dhcp: true,
+	ipaddress: '192.168.1.7',
+	netmask: '255.255.255.0',
+	gateway: '192.168.1.1',
+	proxyaddress: 'none',
+	proxyport: 0,
+	UTC: '2014-07-17T09:27:35',
+	localtime: '2014-07-17T11:27:35',
+	timezone: 'Europe/Madrid',
+	whitelist: {
+		ffffffffe0341b1b376a2389376a2389: {
+			'last use date': '2014-07-17T07:21:38',
+			'create date': '2014-04-08T08:55:10',
+			name: 'PhilipsHueAndroidApp#TCT ALCATEL ONE TOU',
+		},
+		pAtwdCV8NZId25Gk: {
+			'last use date': '2014-05-07T18:28:29',
+			'create date': '2014-04-09T17:29:16',
+			name: 'n8n',
+		},
+	},
+	swversion: '01012917',
+	apiversion: '1.3.0',
+	swupdate: {
+		updatestate: 0,
+		url: '',
+		text: '',
+		notify: false,
+	},
+	linkbutton: false,
+	portalservices: false,
+	portalconnection: 'connected',
+	portalstate: {
+		signedon: true,
+		incoming: false,
+		outgoing: true,
+		communication: 'disconnected',
+	},
+};

--- a/packages/nodes-base/nodes/PhilipsHue/test/apiResponses.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/apiResponses.ts
@@ -96,3 +96,13 @@ export const getConfigResponse = {
 		communication: 'disconnected',
 	},
 };
+
+export const updateLightResponse = [
+	{ success: { '/lights/1/state/bri': 200 } },
+	{ success: { '/lights/1/state/on': true } },
+	{ success: { '/lights/1/state/hue': 50000 } },
+];
+
+export const deleteLightResponse = {
+	success: '/lights/1 deleted.',
+};

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.json
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.json
@@ -1,12 +1,12 @@
 {
-	"name": "[TEST] Philips Hue",
+	"name": "[TEST] Hue",
 	"nodes": [
 		{
 			"parameters": {},
 			"type": "n8n-nodes-base.manualTrigger",
 			"typeVersion": 1,
-			"position": [-340, 0],
-			"id": "b4c1f6ce-b730-4b52-9b28-7d1cdf31e045",
+			"position": [0, 0],
+			"id": "9e687c5d-e3a5-436d-a96d-7bfde1110f40",
 			"name": "When clicking ‘Test workflow’"
 		},
 		{
@@ -16,12 +16,12 @@
 			},
 			"type": "n8n-nodes-base.philipsHue",
 			"typeVersion": 1,
-			"position": [-80, 0],
-			"id": "4c793cc6-e724-477d-9cca-8d9e7a9458e7",
+			"position": [260, 0],
+			"id": "063bcf31-3055-42f1-904f-d517f85db182",
 			"name": "Philips Hue",
 			"credentials": {
 				"philipsHueOAuth2Api": {
-					"id": "Y4sLtXQ4hjjvga7Y",
+					"id": "s6tRicNTKQoa9TDq",
 					"name": "PhilipHue account"
 				}
 			}
@@ -30,9 +30,62 @@
 			"parameters": {},
 			"type": "n8n-nodes-base.noOp",
 			"typeVersion": 1,
-			"position": [140, 0],
-			"id": "31384e0f-19e7-4ccb-8b6b-8d23a03618ec",
+			"position": [480, 0],
+			"id": "d6c4f99a-d660-4113-aa08-a7bcc9391236",
 			"name": "No Operation, do nothing"
+		},
+		{
+			"parameters": {
+				"lightId": "=1",
+				"additionalFields": {
+					"bri": 200,
+					"hue": 50000
+				}
+			},
+			"type": "n8n-nodes-base.philipsHue",
+			"typeVersion": 1,
+			"position": [260, 200],
+			"id": "c8311112-d24e-4787-80b1-cc5397aea98e",
+			"name": "Philips Hue1",
+			"credentials": {
+				"philipsHueOAuth2Api": {
+					"id": "s6tRicNTKQoa9TDq",
+					"name": "PhilipHue account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [480, 200],
+			"id": "c438bf28-0cf8-459a-bd3a-28f6c30b3f2f",
+			"name": "No Operation, do nothing1"
+		},
+		{
+			"parameters": {
+				"operation": "delete",
+				"lightId": "=1"
+			},
+			"type": "n8n-nodes-base.philipsHue",
+			"typeVersion": 1,
+			"position": [280, 400],
+			"id": "fd197627-9221-4e6d-ab51-53d262004db8",
+			"name": "Philips Hue2",
+			"credentials": {
+				"philipsHueOAuth2Api": {
+					"id": "s6tRicNTKQoa9TDq",
+					"name": "PhilipHue account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [500, 400],
+			"id": "19796164-8527-462b-b01b-71d7f60c94af",
+			"name": "No Operation, do nothing2"
 		}
 	],
 	"pinData": {
@@ -87,6 +140,22 @@
 					"swversion": "5.105.0.21169"
 				}
 			}
+		],
+		"No Operation, do nothing1": [
+			{
+				"json": {
+					"/lights/1/state/bri": 200,
+					"/lights/1/state/on": true,
+					"/lights/1/state/hue": 50000
+				}
+			}
+		],
+		"No Operation, do nothing2": [
+			{
+				"json": {
+					"success": "/lights/1 deleted."
+				}
+			}
 		]
 	},
 	"connections": {
@@ -95,6 +164,16 @@
 				[
 					{
 						"node": "Philips Hue",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Philips Hue1",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Philips Hue2",
 						"type": "main",
 						"index": 0
 					}
@@ -111,16 +190,38 @@
 					}
 				]
 			]
+		},
+		"Philips Hue1": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Philips Hue2": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing2",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
 		}
 	},
 	"active": false,
 	"settings": {
 		"executionOrder": "v1"
 	},
-	"versionId": "129107d8-2091-42a1-b211-d84558cecaf8",
+	"versionId": "2c19891b-ba8e-4026-b8c2-b5f3f508b54a",
 	"meta": {
-		"instanceId": "8c8c5237b8e37b006a7adce87f4369350c58e41f3ca9de16196d3197f69eabcd"
+		"instanceId": "0fa937d34dcabeff4bd6480d3b42cc95edf3bc20e6810819086ef1ce2623639d"
 	},
-	"id": "mp8GU0Saf16b0CAb",
+	"id": "LAngRPRzm3OGrfh0",
 	"tags": []
 }

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.json
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.json
@@ -1,0 +1,126 @@
+{
+	"name": "[TEST] Philips Hue",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-340, 0],
+			"id": "b4c1f6ce-b730-4b52-9b28-7d1cdf31e045",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "getAll",
+				"returnAll": true
+			},
+			"type": "n8n-nodes-base.philipsHue",
+			"typeVersion": 1,
+			"position": [-80, 0],
+			"id": "4c793cc6-e724-477d-9cca-8d9e7a9458e7",
+			"name": "Philips Hue",
+			"credentials": {
+				"philipsHueOAuth2Api": {
+					"id": "Y4sLtXQ4hjjvga7Y",
+					"name": "PhilipHue account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [140, 0],
+			"id": "31384e0f-19e7-4ccb-8b6b-8d23a03618ec",
+			"name": "No Operation, do nothing"
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"state": {
+						"on": false,
+						"bri": 1,
+						"hue": 33761,
+						"sat": 254,
+						"effect": "none",
+						"xy": [0.3171, 0.3366],
+						"ct": 159,
+						"alert": "none",
+						"colormode": "xy",
+						"mode": "homeautomation",
+						"reachable": true
+					},
+					"swupdate": {
+						"state": "noupdates",
+						"lastinstall": "2018-01-02T19:24:20"
+					},
+					"type": "Extended color light",
+					"name": "Hue color lamp 7",
+					"modelid": "LCT007",
+					"manufacturername": "Philips",
+					"productname": "Hue color lamp",
+					"capabilities": {
+						"certified": true,
+						"control": {
+							"mindimlevel": 5000,
+							"maxlumen": 600,
+							"colorgamuttype": "B",
+							"colorgamut": [[0.675, 0.322], [0.409, 0.518], [0.167, 0.04]],
+							"ct": {
+								"min": 153,
+								"max": 500
+							}
+						},
+						"streaming": {
+							"renderer": true,
+							"proxy": false
+						}
+					},
+					"config": {
+						"archetype": "sultanbulb",
+						"function": "mixed",
+						"direction": "omnidirectional"
+					},
+					"uniqueid": "00:17:88:01:00:bd:c7:b9-0b",
+					"swversion": "5.105.0.21169"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Philips Hue",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Philips Hue": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "129107d8-2091-42a1-b211-d84558cecaf8",
+	"meta": {
+		"instanceId": "8c8c5237b8e37b006a7adce87f4369350c58e41f3ca9de16196d3197f69eabcd"
+	},
+	"id": "mp8GU0Saf16b0CAb",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
@@ -4,15 +4,18 @@ import { setup, equalityTest, workflowToTests, getWorkflowFilenames } from '@tes
 
 import { getLightsResponse, getConfigResponse } from './apiResponses';
 
-describe('Philips Hue', () => {
+describe('PhilipsHue', () => {
 	describe('Run workflow', () => {
 		const workflows = getWorkflowFilenames(__dirname);
 		const tests = workflowToTests(workflows);
 
 		beforeAll(() => {
 			nock.disableNetConnect();
-			nock('https://api.meethue.com/route').get('/api/0/config').reply(200, getConfigResponse);
-			nock('https://api.meethue.com/route').get('/api/n8n/lights').reply(200, getLightsResponse);
+			nock('https://api.meethue.com/route')
+				.get('/api/0/config')
+				.reply(200, getConfigResponse)
+				.get('/api/n8n/lights')
+				.reply(200, getLightsResponse);
 		});
 
 		afterAll(() => {

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
@@ -1,8 +1,17 @@
 import nock from 'nock';
 
-import { setup, equalityTest, workflowToTests, getWorkflowFilenames } from '@test/nodes/Helpers';
-
-import { getLightsResponse, getConfigResponse } from './apiResponses';
+import {
+	deleteLightResponse,
+	getLightsResponse,
+	getConfigResponse,
+	updateLightResponse,
+} from './apiResponses';
+import {
+	setup,
+	equalityTest,
+	workflowToTests,
+	getWorkflowFilenames,
+} from '../../../test/nodes/Helpers';
 
 describe('PhilipsHue', () => {
 	describe('Run workflow', () => {
@@ -11,11 +20,12 @@ describe('PhilipsHue', () => {
 
 		beforeAll(() => {
 			nock.disableNetConnect();
-			nock('https://api.meethue.com/route')
-				.get('/api/0/config')
-				.reply(200, getConfigResponse)
-				.get('/api/n8n/lights')
-				.reply(200, getLightsResponse);
+
+			const mock = nock('https://api.meethue.com/route');
+			mock.persist().get('/api/0/config').reply(200, getConfigResponse);
+			mock.get('/api/pAtwdCV8NZId25Gk/lights').reply(200, getLightsResponse);
+			mock.put('/api/pAtwdCV8NZId25Gk/lights/1/state').reply(200, updateLightResponse);
+			mock.delete('/api/pAtwdCV8NZId25Gk/lights/1').reply(200, deleteLightResponse);
 		});
 
 		afterAll(() => {

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
@@ -1,0 +1,28 @@
+import nock from 'nock';
+
+import { setup, equalityTest, workflowToTests, getWorkflowFilenames } from '@test/nodes/Helpers';
+
+import { getLightsResponse, getConfigResponse } from './apiResponses';
+
+describe('Philips Hue', () => {
+	describe('Run workflow', () => {
+		const workflows = getWorkflowFilenames(__dirname);
+		const tests = workflowToTests(workflows);
+
+		beforeAll(() => {
+			nock.disableNetConnect();
+			nock('https://api.meethue.com/route').get('/api/0/config').reply(200, getConfigResponse);
+			nock('https://api.meethue.com/route').get('/api/n8n/lights').reply(200, getLightsResponse);
+		});
+
+		afterAll(() => {
+			nock.restore();
+		});
+
+		const nodeTypes = setup(tests);
+
+		for (const testData of tests) {
+			test(testData.description, async () => await equalityTest(testData, nodeTypes));
+		}
+	});
+});

--- a/packages/nodes-base/test/nodes/FakeCredentialsMap.ts
+++ b/packages/nodes-base/test/nodes/FakeCredentialsMap.ts
@@ -128,4 +128,20 @@ BQIDAQAB
 	notionApi: {
 		apiKey: 'key123',
 	},
+	philipsHueOAuth2Api: {
+		grantType: 'authorizationCode',
+		appId: 'APPID',
+		authUrl: 'https://api.meethue.com/v2/oauth2/authorize',
+		accessTokenUrl: 'https://api.meethue.com/v2/oauth2/token',
+		authQueryParameters: 'appid=APPID',
+		scope: '',
+		authentication: 'header',
+		oauthTokenData: {
+			access_token: 'ACCESSTOKEN',
+			refresh_token: 'REFRESHTOKEN',
+			scope: '',
+			token_type: 'bearer',
+			expires_in: 86400,
+		},
+	},
 } as const;


### PR DESCRIPTION
## Summary
Adds some tests for Philips Hue

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2161/test-philips-hue


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
