### PR TITLE
fix(editor): Fix rendering of code-blocks in sticky notes

### DIFF
--- a/packages/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -251,17 +251,9 @@ const onCheckboxChange = (index: number) => {
 		}
 	}
 
-	pre {
-		margin-bottom: var(--spacing-s);
-		display: grid;
-	}
-
 	pre > code {
-		display: block;
-		padding: var(--spacing-s);
-		color: var(--color-text-dark);
 		background-color: var(--color-background-base);
-		overflow-x: auto;
+		color: var(--color-text-dark);
 	}
 
 	li > code,
@@ -356,9 +348,8 @@ input[type='checkbox'] + label {
 		}
 	}
 
-	code {
+	pre > code {
 		background-color: var(--color-sticky-code-background);
-		padding: 0 var(--spacing-4xs);
 		color: var(--color-sticky-code-font);
 	}
 
@@ -382,6 +373,20 @@ input[type='checkbox'] + label {
 		&[src*='#full-width'] {
 			width: 100%;
 		}
+	}
+}
+
+.sticky,
+.markdown {
+	pre {
+		margin-bottom: var(--spacing-s);
+		display: grid;
+	}
+
+	pre > code {
+		display: block;
+		padding: var(--spacing-s);
+		overflow-x: auto;
 	}
 }
 


### PR DESCRIPTION
## Summary

## Before
![dark](https://github.com/user-attachments/assets/2a0c34fb-b38a-44a6-b2e0-63f3195b3930)
![light](https://github.com/user-attachments/assets/112ea135-0371-4025-a705-f30683bfd27e)


## After
![dark](https://github.com/user-attachments/assets/f37a6466-591d-4131-a021-e101f1e7ae4f)
![light](https://github.com/user-attachments/assets/000095dd-518b-4da4-a663-0fc0d70db746)



## Related Linear tickets, Github issues, and Community forum posts
[CAT-245](https://linear.app/n8n/issue/CAT-245)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
