### PR TITLE
chore: Fix typo in Jenkins credential (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/JenkinsApi.credentials.ts
+++ b/packages/nodes-base/credentials/JenkinsApi.credentials.ts
@@ -9,7 +9,7 @@ export class JenkinsApi implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
-			displayName: 'Jenking Username',
+			displayName: 'Jenkins Username',
 			name: 'username',
 			type: 'string',
 			default: '',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This simply fixes a one-character typo in the Jenkins Credentials's Username. `Jenking` -> `Jenkins`

![image](https://github.com/user-attachments/assets/f38da005-2a73-4a80-960d-182ba0ea99ed)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
