### PR TITLE
feat(API): Exclude pinned data from workflows

### DIFF
--- a/packages/cli/src/databases/entities/workflow-entity.ts
+++ b/packages/cli/src/databases/entities/workflow-entity.ts
@@ -80,7 +80,7 @@ export class WorkflowEntity extends WithTimestampsAndStringId implements IWorkfl
 		nullable: true,
 		transformer: sqlite.jsonColumn,
 	})
-	pinData: ISimplifiedPinData;
+	pinData?: ISimplifiedPinData;
 
 	@Column({ length: 36 })
 	versionId: string;

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -74,11 +74,12 @@ export declare namespace WorkflowRequest {
 			active: boolean;
 			name?: string;
 			projectId?: string;
+			excludePinnedData?: boolean;
 		}
 	>;
 
 	type Create = AuthenticatedRequest<{}, {}, WorkflowEntity, {}>;
-	type Get = AuthenticatedRequest<{ id: string }, {}, {}, {}>;
+	type Get = AuthenticatedRequest<{ id: string }, {}, {}, { excludePinnedData?: boolean }>;
 	type Delete = Get;
 	type Update = AuthenticatedRequest<{ id: string }, {}, WorkflowEntity, {}>;
 	type Activate = Get;

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
@@ -9,6 +9,7 @@ get:
     - name: excludePinnedData
       in: query
       required: false
+      description: Set this to avoid retrieving pinned data
       schema:
         type: boolean
         example: true

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
@@ -6,6 +6,12 @@ get:
   summary: Retrieves a workflow
   description: Retrieves a workflow.
   parameters:
+    - name: excludePinnedData
+      in: query
+      required: false
+      schema:
+        type: boolean
+        example: true
     - $ref: '../schemas/parameters/workflowId.yml'
   responses:
     '200':

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
@@ -63,6 +63,7 @@ get:
     - name: excludePinnedData
       in: query
       required: false
+      description: Set this to avoid retrieving pinned data
       schema:
         type: boolean
         example: true

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
@@ -60,6 +60,12 @@ get:
       schema:
         type: string
         example: VmwOO9HeTEj20kxM
+    - name: excludePinnedData
+      in: query
+      required: false
+      schema:
+        type: boolean
+        example: true
     - $ref: '../../../../shared/spec/parameters/limit.yml'
     - $ref: '../../../../shared/spec/parameters/cursor.yml'
   responses:

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -105,6 +105,7 @@ export = {
 		projectScope('workflow:read', 'workflow'),
 		async (req: WorkflowRequest.Get, res: express.Response): Promise<express.Response> => {
 			const { id } = req.params;
+			const { excludePinnedData = false } = req.query;
 
 			const workflow = await Container.get(SharedWorkflowRepository).findWorkflowForUser(
 				id,
@@ -120,6 +121,10 @@ export = {
 				return res.status(404).json({ message: 'Not Found' });
 			}
 
+			if (excludePinnedData) {
+				delete workflow.pinData;
+			}
+
 			Container.get(EventService).emit('user-retrieved-workflow', {
 				userId: req.user.id,
 				publicApi: true,
@@ -131,7 +136,15 @@ export = {
 	getWorkflows: [
 		validCursor,
 		async (req: WorkflowRequest.GetAll, res: express.Response): Promise<express.Response> => {
-			const { offset = 0, limit = 100, active, tags, name, projectId } = req.query;
+			const {
+				offset = 0,
+				limit = 100,
+				excludePinnedData = false,
+				active,
+				tags,
+				name,
+				projectId,
+			} = req.query;
 
 			const where: FindOptionsWhere<WorkflowEntity> = {
 				...(active !== undefined && { active }),
@@ -198,6 +211,12 @@ export = {
 				where,
 				...(!config.getEnv('workflowTagsDisabled') && { relations: ['tags'] }),
 			});
+
+			if (excludePinnedData) {
+				workflows.forEach((workflow) => {
+					delete workflow.pinData;
+				});
+			}
 
 			Container.get(EventService).emit('user-retrieved-all-workflows', {
 				userId: req.user.id,


### PR DESCRIPTION
## Summary

Adds the ability to exclude pinned data when retrieving workflows via the public API. This can be applied to both the retrieval of all workflows and to the retrieval of a single workflow.

To avoid breaking the existing API contract, a query parameter `?excludePinnedData=true` should be added to explicitly exclude the data. By default, it continues to be included.

There was no great approach to excluding the data when making a database query without explicitly creating a `select` option which includes all data. This would introduce a brittle query that always has to match any changes to the workflow and corresponding joined data. Instead, I've opted to delete the data after retrieval from the DB. Shout if you think there's a better approach.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: PAY-2238

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
