### PR TITLE
fix(editor): Fix canvas ready opacity transition on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -746,6 +746,7 @@ provide(CanvasKey, {
 	width: 100%;
 	height: 100%;
 	opacity: 0;
+	transition: opacity 300ms ease;
 
 	&.ready {
 		opacity: 1;


### PR DESCRIPTION
## Summary

- Adds opacity transition to the entire canvas

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-108/bug-open-workflow-looks-like-janky-animation

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
