### PR TITLE
fix(editor): Prevent connection line from showing when clicking the plus button of a node

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasConnectionLine.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasConnectionLine.test.ts
@@ -5,6 +5,7 @@ import { setActivePinia } from 'pinia';
 import type { ConnectionLineProps } from '@vue-flow/core';
 import { Position } from '@vue-flow/core';
 import { createCanvasProvide } from '@/__tests__/data';
+import { waitFor } from '@testing-library/vue';
 
 const DEFAULT_PROPS = {
 	sourceX: 0,
@@ -62,5 +63,20 @@ describe('CanvasConnectionLine', () => {
 			'd',
 			'M-50 130L-90 130L -124,130Q -140,130 -140,114L -140,-84Q -140,-100 -124,-100L-100 -100',
 		);
+	});
+
+	it('should show the connection line after a short delay', async () => {
+		vi.useFakeTimers();
+		const { container } = renderComponent({
+			props: DEFAULT_PROPS,
+		});
+
+		const edge = container.querySelector('.vue-flow__edge-path');
+
+		expect(edge).not.toHaveClass('visible');
+
+		vi.advanceTimersByTime(300);
+
+		await waitFor(() => expect(edge).toHaveClass('visible'));
 	});
 });


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/8e4dfaf7-a6de-4526-a760-44ada1946ed3



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-7604/when-clicking-on-the-plus-on-the-output-stalk-of-a-node-connector

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
