### PR TITLE
fix(Google Calendar node): Correctly set dtstart for recurrence rules in addNextOccurrence function

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GenericFunctions.ts
@@ -155,11 +155,17 @@ export function addNextOccurrence(items: RecurentEvent[]) {
 	for (const item of items) {
 		if (item.recurrence) {
 			let eventRecurrence;
+			let eventStartDateTime;
 			try {
 				eventRecurrence = item.recurrence.find((r) => r.toUpperCase().startsWith('RRULE'));
+				eventStartDateTime = item.start.dateTime;
 				if (!eventRecurrence) continue;
 
-				const rrule = RRule.fromString(eventRecurrence);
+				const rruleOptions = {
+					...RRule.parseString(eventRecurrence),
+					dtstart: new Date(eventStartDateTime),
+				};
+				const rrule = new RRule(rruleOptions);
 				const until = rrule.options?.until;
 
 				const now = new Date();

--- a/packages/nodes-base/nodes/Google/Calendar/test/GeneircFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/test/GeneircFunctions.test.ts
@@ -18,3 +18,58 @@ describe('addTimezoneToDate', () => {
 		expect(result4).toBe('2021-09-01T12:00:00.000+08:00');
 	});
 });
+
+describe('Google Calendar -> addNextOccurrence', () => {
+	it('should correctly add next occurrence and split time component', () => {
+		const mockEvent = {
+			start: {
+				dateTime: '2023-09-07T09:30:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			end: {
+				dateTime: '2023-09-07T11:00:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			recurrence: ['RRULE:FREQ=WEEKLY;BYDAY=TH'],
+		};
+
+		const result = addNextOccurrence([mockEvent]);
+
+		expect(result[0].nextOccurrence).toBeDefined();
+		expect(result[0].nextOccurrence.start.dateTime.split('T')[1]).toBe('09:30:00+02:00');
+	});
+
+	it('should handle events without recurrence', () => {
+		const mockEventNoRecurrence = {
+			start: {
+				dateTime: '2023-09-07T09:30:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			end: {
+				dateTime: '2023-09-07T11:00:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			recurrence: [],
+		};
+
+		const result = addNextOccurrence([mockEventNoRecurrence]);
+		expect(result[0].nextOccurrence).toBeUndefined();
+	});
+
+	it('should handle events with invalid recurrence rules', () => {
+		const mockEventInvalidRecurrence = {
+			start: {
+				dateTime: '2023-09-07T09:30:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			end: {
+				dateTime: '2023-09-07T11:00:00+02:00',
+				timeZone: 'Europe/Berlin',
+			},
+			recurrence: ['INVALID_RRULE'],
+		};
+
+		const result = addNextOccurrence([mockEventInvalidRecurrence]);
+		expect(result[0].nextOccurrence).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #12262 issue in the Google Calendar node, where the `nextOccurrence` field was not preserving the original event's time when calculating recurring events. The changes include:

- Fixed time calculation in `addNextOccurrence` function by initializing RRule with proper `dtstart` option
- Added comprehensive test suite to verify time preservation and edge cases

It ensures the next occurrence maintains the same time as the original event

## Related Linear tickets, GitHub issues, and Community forum posts

Fixes #12262

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Tests included
- [x] No documentation update needed
- [x] Non-critical bug fix; PR doesn't need to be labelled `release/backport`