### PR TITLE
refactor(core): Extend error hierarchy

### DIFF
--- a/packages/workflow/src/errors/abstract/execution-base.error.ts
+++ b/packages/workflow/src/errors/abstract/execution-base.error.ts
@@ -1,5 +1,6 @@
 import type { Functionality, IDataObject, JsonObject } from '../../Interfaces';
-import { ApplicationError, type ReportingOptions } from '../application.error';
+import { ApplicationError } from '../application.error';
+import type { ReportingOptions } from '../error.types';
 
 interface ExecutionBaseErrorOptions extends ReportingOptions {
 	cause?: Error;

--- a/packages/workflow/src/errors/application.error.ts
+++ b/packages/workflow/src/errors/application.error.ts
@@ -1,15 +1,13 @@
 import type { Event } from '@sentry/node';
 import callsites from 'callsites';
 
-export type Level = 'warning' | 'error' | 'fatal' | 'info';
+import type { ErrorLevel, ReportingOptions } from '@/errors/error.types';
 
-export type ReportingOptions = {
-	level?: Level;
-	executionId?: string;
-} & Pick<Event, 'tags' | 'extra'>;
-
+/**
+ * @deprecated Use `UserError`, `OperationalError` or `UnexpectedError` instead.
+ */
 export class ApplicationError extends Error {
-	level: Level;
+	level: ErrorLevel;
 
 	readonly tags: NonNullable<Event['tags']>;
 

--- a/packages/workflow/src/errors/base/base.error.ts
+++ b/packages/workflow/src/errors/base/base.error.ts
@@ -34,7 +34,7 @@ export abstract class BaseError extends Error {
 		{
 			level = 'error',
 			description,
-			shouldReport = true,
+			shouldReport,
 			tags = {},
 			extra,
 			...rest
@@ -43,7 +43,7 @@ export abstract class BaseError extends Error {
 		super(message, rest);
 
 		this.level = level;
-		this.shouldReport = shouldReport;
+		this.shouldReport = shouldReport ?? (level === 'error' || level === 'fatal');
 		this.description = description;
 		this.tags = tags;
 		this.extra = extra;

--- a/packages/workflow/src/errors/base/base.error.ts
+++ b/packages/workflow/src/errors/base/base.error.ts
@@ -56,7 +56,3 @@ export abstract class BaseError extends Error {
 		} catch {}
 	}
 }
-
-export function isBaseError(error: unknown): error is BaseError {
-	return error instanceof BaseError;
-}

--- a/packages/workflow/src/errors/base/operational.error.ts
+++ b/packages/workflow/src/errors/base/operational.error.ts
@@ -1,0 +1,28 @@
+import type { BaseErrorOptions } from './base.error';
+import { BaseError } from './base.error';
+
+export type OperationalErrorOptions = Omit<BaseErrorOptions, 'level'> & {
+	level?: 'info' | 'warning' | 'error';
+};
+
+/**
+ * Error that indicates a transient issue, like a network request failing,
+ * a database query timing out, etc. These are expected to happen, are
+ * transient by nature and should be handled gracefully.
+ *
+ * Default level: warning
+ * Default shouldReport: false
+ */
+export class OperationalError extends BaseError {
+	constructor(message: string, opts: OperationalErrorOptions = {}) {
+		opts.level = opts.level ?? 'warning';
+		opts.shouldReport = opts.shouldReport ?? false;
+
+		super(message, opts);
+	}
+}
+
+/** Convenience function to check if an error is an instance of OperationalError */
+export function isOperationalError(error: Error): error is OperationalError {
+	return error instanceof OperationalError;
+}

--- a/packages/workflow/src/errors/base/operational.error.ts
+++ b/packages/workflow/src/errors/base/operational.error.ts
@@ -11,12 +11,10 @@ export type OperationalErrorOptions = Omit<BaseErrorOptions, 'level'> & {
  * transient by nature and should be handled gracefully.
  *
  * Default level: warning
- * Default shouldReport: false
  */
 export class OperationalError extends BaseError {
 	constructor(message: string, opts: OperationalErrorOptions = {}) {
 		opts.level = opts.level ?? 'warning';
-		opts.shouldReport = opts.shouldReport ?? false;
 
 		super(message, opts);
 	}

--- a/packages/workflow/src/errors/base/operational.error.ts
+++ b/packages/workflow/src/errors/base/operational.error.ts
@@ -19,8 +19,3 @@ export class OperationalError extends BaseError {
 		super(message, opts);
 	}
 }
-
-/** Convenience function to check if an error is an instance of OperationalError */
-export function isOperationalError(error: Error): error is OperationalError {
-	return error instanceof OperationalError;
-}

--- a/packages/workflow/src/errors/base/unexpected.error.ts
+++ b/packages/workflow/src/errors/base/unexpected.error.ts
@@ -19,8 +19,3 @@ export class UnexpectedError extends BaseError {
 		super(message, opts);
 	}
 }
-
-/** Convenience function to check if an error is an instance of UnexpectedError */
-export function isUnexpectedError(error: Error): error is UnexpectedError {
-	return error instanceof UnexpectedError;
-}

--- a/packages/workflow/src/errors/base/unexpected.error.ts
+++ b/packages/workflow/src/errors/base/unexpected.error.ts
@@ -1,0 +1,28 @@
+import type { BaseErrorOptions } from './base.error';
+import { BaseError } from './base.error';
+
+export type UnexpectedErrorOptions = Omit<BaseErrorOptions, 'level'> & {
+	level?: 'error' | 'fatal';
+};
+
+/**
+ * Error that indicates something is wrong in the code: logic mistakes,
+ * unhandled cases, assertions that fail. These are not recoverable and
+ * should be brought to developers' attention.
+ *
+ * Default level: error
+ * Default shouldReport: true
+ */
+export class UnexpectedError extends BaseError {
+	constructor(message: string, opts: UnexpectedErrorOptions = {}) {
+		opts.level = opts.level ?? 'error';
+		opts.shouldReport = opts.shouldReport ?? true;
+
+		super(message, opts);
+	}
+}
+
+/** Convenience function to check if an error is an instance of UnexpectedError */
+export function isUnexpectedError(error: Error): error is UnexpectedError {
+	return error instanceof UnexpectedError;
+}

--- a/packages/workflow/src/errors/base/unexpected.error.ts
+++ b/packages/workflow/src/errors/base/unexpected.error.ts
@@ -11,12 +11,10 @@ export type UnexpectedErrorOptions = Omit<BaseErrorOptions, 'level'> & {
  * should be brought to developers' attention.
  *
  * Default level: error
- * Default shouldReport: true
  */
 export class UnexpectedError extends BaseError {
 	constructor(message: string, opts: UnexpectedErrorOptions = {}) {
 		opts.level = opts.level ?? 'error';
-		opts.shouldReport = opts.shouldReport ?? true;
 
 		super(message, opts);
 	}

--- a/packages/workflow/src/errors/base/user.error.ts
+++ b/packages/workflow/src/errors/base/user.error.ts
@@ -12,14 +12,12 @@ export type UserErrorOptions = Omit<BaseErrorOptions, 'level'> & {
  * authorized to, or violates a business rule.
  *
  * Default level: info
- * Default shouldReport: false
  */
 export class UserError extends BaseError {
 	readonly description: string | null | undefined;
 
 	constructor(message: string, opts: UserErrorOptions = {}) {
 		opts.level = opts.level ?? 'info';
-		opts.shouldReport = opts.shouldReport ?? false;
 
 		super(message, opts);
 	}

--- a/packages/workflow/src/errors/base/user.error.ts
+++ b/packages/workflow/src/errors/base/user.error.ts
@@ -1,0 +1,31 @@
+import type { BaseErrorOptions } from './base.error';
+import { BaseError } from './base.error';
+
+export type UserErrorOptions = Omit<BaseErrorOptions, 'level'> & {
+	level?: 'info' | 'warning';
+	description?: string | null | undefined;
+};
+
+/**
+ * Error that indicates the user performed an action that caused an error.
+ * E.g. provided invalid input, tried to access a resource they’re not
+ * authorized to, or violates a business rule.
+ *
+ * Default level: info
+ * Default shouldReport: false
+ */
+export class UserError extends BaseError {
+	readonly description: string | null | undefined;
+
+	constructor(message: string, opts: UserErrorOptions = {}) {
+		opts.level = opts.level ?? 'info';
+		opts.shouldReport = opts.shouldReport ?? false;
+
+		super(message, opts);
+	}
+}
+
+/** Convenience function to check if an error is an instance of UserError */
+export function isUserError(error: Error): error is UserError {
+	return error instanceof UserError;
+}

--- a/packages/workflow/src/errors/base/user.error.ts
+++ b/packages/workflow/src/errors/base/user.error.ts
@@ -22,8 +22,3 @@ export class UserError extends BaseError {
 		super(message, opts);
 	}
 }
-
-/** Convenience function to check if an error is an instance of UserError */
-export function isUserError(error: Error): error is UserError {
-	return error instanceof UserError;
-}

--- a/packages/workflow/src/errors/error.types.ts
+++ b/packages/workflow/src/errors/error.types.ts
@@ -1,0 +1,14 @@
+import type { Event } from '@sentry/node';
+
+export type ErrorLevel = 'fatal' | 'error' | 'warning' | 'info';
+
+export type ErrorTags = NonNullable<Event['tags']>;
+
+export type ReportingOptions = {
+	/** Whether the error should be reported to Sentry */
+	shouldReport?: boolean;
+	level?: ErrorLevel;
+	tags?: ErrorTags;
+	extra?: Event['extra'];
+	executionId?: string;
+};

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -1,5 +1,5 @@
 export type * from './error.types';
-export { BaseError, isBaseError, type BaseErrorOptions } from './base/base.error';
+export { BaseError, type BaseErrorOptions } from './base/base.error';
 export { OperationalError, type OperationalErrorOptions } from './base/operational.error';
 export { UnexpectedError, type UnexpectedErrorOptions } from './base/unexpected.error';
 export { UserError, type UserErrorOptions } from './base/user.error';

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -1,4 +1,9 @@
-export { ApplicationError, type ReportingOptions } from './application.error';
+export type * from './error.types';
+export { BaseError, isBaseError, type BaseErrorOptions } from './base/base.error';
+export { OperationalError, type OperationalErrorOptions } from './base/operational.error';
+export { UnexpectedError, type UnexpectedErrorOptions } from './base/unexpected.error';
+export { UserError, type UserErrorOptions } from './base/user.error';
+export { ApplicationError } from './application.error';
 export { ExpressionError } from './expression.error';
 export { CredentialAccessError } from './credential-access-error';
 export { ExecutionCancelledError } from './execution-cancelled.error';

--- a/packages/workflow/src/errors/node-api.error.ts
+++ b/packages/workflow/src/errors/node-api.error.ts
@@ -5,7 +5,7 @@ import { AxiosError } from 'axios';
 import { parseString } from 'xml2js';
 
 import { NodeError } from './abstract/node.error';
-import type { ReportingOptions } from './application.error';
+import type { ErrorLevel } from './error.types';
 import {
 	NO_OP_NODE_TYPE,
 	UNKNOWN_ERROR_DESCRIPTION,
@@ -27,7 +27,7 @@ export interface NodeOperationErrorOptions {
 	description?: string;
 	runIndex?: number;
 	itemIndex?: number;
-	level?: ReportingOptions['level'];
+	level?: ErrorLevel;
 	messageMapping?: { [key: string]: string }; // allows to pass custom mapping for error messages scoped to a node
 	functionality?: Functionality;
 	type?: string;

--- a/packages/workflow/src/errors/trigger-close.error.ts
+++ b/packages/workflow/src/errors/trigger-close.error.ts
@@ -1,8 +1,9 @@
-import { ApplicationError, type Level } from './application.error';
+import { ApplicationError } from './application.error';
+import type { ErrorLevel } from './error.types';
 import type { INode } from '../Interfaces';
 
 interface TriggerCloseErrorOptions extends ErrorOptions {
-	level: Level;
+	level: ErrorLevel;
 }
 
 export class TriggerCloseError extends ApplicationError {

--- a/packages/workflow/test/errors/base/operational.error.test.ts
+++ b/packages/workflow/test/errors/base/operational.error.test.ts
@@ -1,5 +1,5 @@
 import { BaseError } from '@/errors/base/base.error';
-import { isOperationalError, OperationalError } from '@/errors/base/operational.error';
+import { OperationalError } from '@/errors/base/operational.error';
 
 describe('OperationalError', () => {
 	it('should be an instance of OperationalError', () => {
@@ -22,15 +22,5 @@ describe('OperationalError', () => {
 		const error = new OperationalError('test', { level: 'error', shouldReport: true });
 		expect(error.level).toBe('error');
 		expect(error.shouldReport).toBe(true);
-	});
-});
-
-describe('isOperationalError', () => {
-	it('should return true if the error is an instance of OperationalError', () => {
-		expect(isOperationalError(new OperationalError('test'))).toBe(true);
-	});
-
-	it('should return false if the error is not an instance of OperationalError', () => {
-		expect(isOperationalError(new Error('test'))).toBe(false);
 	});
 });

--- a/packages/workflow/test/errors/base/operational.error.test.ts
+++ b/packages/workflow/test/errors/base/operational.error.test.ts
@@ -1,0 +1,36 @@
+import { BaseError } from '@/errors/base/base.error';
+import { isOperationalError, OperationalError } from '@/errors/base/operational.error';
+
+describe('OperationalError', () => {
+	it('should be an instance of OperationalError', () => {
+		const error = new OperationalError('test');
+		expect(error).toBeInstanceOf(OperationalError);
+	});
+
+	it('should be an instance of BaseError', () => {
+		const error = new OperationalError('test');
+		expect(error).toBeInstanceOf(BaseError);
+	});
+
+	it('should have correct defaults', () => {
+		const error = new OperationalError('test');
+		expect(error.level).toBe('warning');
+		expect(error.shouldReport).toBe(false);
+	});
+
+	it('should allow overriding the default level and shouldReport', () => {
+		const error = new OperationalError('test', { level: 'error', shouldReport: true });
+		expect(error.level).toBe('error');
+		expect(error.shouldReport).toBe(true);
+	});
+});
+
+describe('isOperationalError', () => {
+	it('should return true if the error is an instance of OperationalError', () => {
+		expect(isOperationalError(new OperationalError('test'))).toBe(true);
+	});
+
+	it('should return false if the error is not an instance of OperationalError', () => {
+		expect(isOperationalError(new Error('test'))).toBe(false);
+	});
+});

--- a/packages/workflow/test/errors/base/unexpected.error.test.ts
+++ b/packages/workflow/test/errors/base/unexpected.error.test.ts
@@ -1,5 +1,5 @@
 import { BaseError } from '@/errors/base/base.error';
-import { isUnexpectedError, UnexpectedError } from '@/errors/base/unexpected.error';
+import { UnexpectedError } from '@/errors/base/unexpected.error';
 
 describe('UnexpectedError', () => {
 	it('should be an instance of UnexpectedError', () => {
@@ -22,15 +22,5 @@ describe('UnexpectedError', () => {
 		const error = new UnexpectedError('test', { level: 'fatal', shouldReport: false });
 		expect(error.level).toBe('fatal');
 		expect(error.shouldReport).toBe(false);
-	});
-});
-
-describe('isUnexpectedError', () => {
-	it('should return true if the error is an instance of UnexpectedError', () => {
-		expect(isUnexpectedError(new UnexpectedError('test'))).toBe(true);
-	});
-
-	it('should return false if the error is not an instance of UnexpectedError', () => {
-		expect(isUnexpectedError(new Error('test'))).toBe(false);
 	});
 });

--- a/packages/workflow/test/errors/base/unexpected.error.test.ts
+++ b/packages/workflow/test/errors/base/unexpected.error.test.ts
@@ -1,0 +1,36 @@
+import { BaseError } from '@/errors/base/base.error';
+import { isUnexpectedError, UnexpectedError } from '@/errors/base/unexpected.error';
+
+describe('UnexpectedError', () => {
+	it('should be an instance of UnexpectedError', () => {
+		const error = new UnexpectedError('test');
+		expect(error).toBeInstanceOf(UnexpectedError);
+	});
+
+	it('should be an instance of BaseError', () => {
+		const error = new UnexpectedError('test');
+		expect(error).toBeInstanceOf(BaseError);
+	});
+
+	it('should have correct defaults', () => {
+		const error = new UnexpectedError('test');
+		expect(error.level).toBe('error');
+		expect(error.shouldReport).toBe(true);
+	});
+
+	it('should allow overriding the default level and shouldReport', () => {
+		const error = new UnexpectedError('test', { level: 'fatal', shouldReport: false });
+		expect(error.level).toBe('fatal');
+		expect(error.shouldReport).toBe(false);
+	});
+});
+
+describe('isUnexpectedError', () => {
+	it('should return true if the error is an instance of UnexpectedError', () => {
+		expect(isUnexpectedError(new UnexpectedError('test'))).toBe(true);
+	});
+
+	it('should return false if the error is not an instance of UnexpectedError', () => {
+		expect(isUnexpectedError(new Error('test'))).toBe(false);
+	});
+});

--- a/packages/workflow/test/errors/base/user.error.test.ts
+++ b/packages/workflow/test/errors/base/user.error.test.ts
@@ -1,5 +1,4 @@
 import { BaseError } from '@/errors/base/base.error';
-import { isUserError } from '@/errors/base/user.error';
 import { UserError } from '@/errors/base/user.error';
 
 describe('UserError', () => {
@@ -23,15 +22,5 @@ describe('UserError', () => {
 		const error = new UserError('test', { level: 'warning', shouldReport: true });
 		expect(error.level).toBe('warning');
 		expect(error.shouldReport).toBe(true);
-	});
-});
-
-describe('isUserError', () => {
-	it('should return true if the error is an instance of UserError', () => {
-		expect(isUserError(new UserError('test'))).toBe(true);
-	});
-
-	it('should return false if the error is not an instance of UserError', () => {
-		expect(isUserError(new Error('test'))).toBe(false);
 	});
 });

--- a/packages/workflow/test/errors/base/user.error.test.ts
+++ b/packages/workflow/test/errors/base/user.error.test.ts
@@ -1,0 +1,37 @@
+import { BaseError } from '@/errors/base/base.error';
+import { isUserError } from '@/errors/base/user.error';
+import { UserError } from '@/errors/base/user.error';
+
+describe('UserError', () => {
+	it('should be an instance of UserError', () => {
+		const error = new UserError('test');
+		expect(error).toBeInstanceOf(UserError);
+	});
+
+	it('should be an instance of BaseError', () => {
+		const error = new UserError('test');
+		expect(error).toBeInstanceOf(BaseError);
+	});
+
+	it('should have correct defaults', () => {
+		const error = new UserError('test');
+		expect(error.level).toBe('info');
+		expect(error.shouldReport).toBe(false);
+	});
+
+	it('should allow overriding the default level and shouldReport', () => {
+		const error = new UserError('test', { level: 'warning', shouldReport: true });
+		expect(error.level).toBe('warning');
+		expect(error.shouldReport).toBe(true);
+	});
+});
+
+describe('isUserError', () => {
+	it('should return true if the error is an instance of UserError', () => {
+		expect(isUserError(new UserError('test'))).toBe(true);
+	});
+
+	it('should return false if the error is not an instance of UserError', () => {
+		expect(isUserError(new Error('test'))).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Introduce new error classes:
- `BaseError` : Base class for all other errors
- `UnexpectedError` : Error that was caused a programmer error
- `OperationalError` : A transient error like timeout
- `UserError` : Error that was caused by user's action or input

Replace all usages of `ApplicationError` in `cli/src/commands` to the new classes.

Up next:
- Convert the `ExecutionBaseError` hierarchy to use the new base class
- Replace all usages of `ApplicationError` with the new error classes


<img width="1443" alt="image" src="https://github.com/user-attachments/assets/caef8074-549d-4367-9bcd-bf8756c67a04" />




## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
