### PR TITLE
fix(HTTP Request Tool Node): Prevent creation of DynamicStructuredTool with empty schema

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/ToolHttpRequest.node.ts
@@ -404,7 +404,7 @@ export class ToolHttpRequest implements INodeType {
 
 		// If the node version is 1.1 or higher, we use the N8nTool wrapper:
 		// it allows to use tool as a DynamicStructuredTool and have a fallback to DynamicTool
-		if (this.getNode().typeVersion >= 1.1) {
+		if (this.getNode().typeVersion >= 1.1 && toolParameters.length > 0) {
 			const schema = makeToolInputSchema(toolParameters);
 
 			tool = new N8nTool(this, {


### PR DESCRIPTION
## Summary
When using the HTTP Request Tool without any placeholders, an empty arguments schema was being generated. This caused compatibility issues with certain LLM providers (like Gemini) that enforce strict API validation requirements for tool schemas.

## Solution
Added a condition to check if the HTTP Request Tool has any parameters (placeholders) defined:
- If `toolParameters.length > 0`: Use `N8nTool` with the generated schema
- If `toolParameters.length === 0`: Fall back to using `DynamicTool` without a schema


## Related Linear tickets, Github issues, and Community forum posts
- https://github.com/n8n-io/n8n/issues/12109
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
