### PR TITLE
fix(editor): Nodes' icon color in dark mode

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -254,6 +254,7 @@ export class ChainLlm implements INodeType {
 		displayName: 'Basic LLM Chain',
 		name: 'chainLlm',
 		icon: 'fa:link',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3, 1.4, 1.5],
 		description: 'A simple chain to prompt a large language model',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -31,6 +31,7 @@ export class ChainRetrievalQa implements INodeType {
 		displayName: 'Question and Answer Chain',
 		name: 'chainRetrievalQa',
 		icon: 'fa:link',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3, 1.4],
 		description: 'Answer questions about retrieved documents',

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/ChainSummarization.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/ChainSummarization.node.ts
@@ -10,6 +10,7 @@ export class ChainSummarization extends VersionedNodeType {
 			displayName: 'Summarization Chain',
 			name: 'chainSummarization',
 			icon: 'fa:link',
+			iconColor: 'black',
 			group: ['transform'],
 			description: 'Transforms text into a concise summary',
 			codex: {

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -78,6 +78,7 @@ export class MemoryBufferWindow implements INodeType {
 		displayName: 'Window Buffer Memory (easiest)',
 		name: 'memoryBufferWindow',
 		icon: 'fa:database',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3],
 		description: 'Stores in n8n memory, so no credentials required',

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryChatRetriever/MemoryChatRetriever.node.ts
@@ -38,6 +38,7 @@ export class MemoryChatRetriever implements INodeType {
 		displayName: 'Chat Messages Retriever',
 		name: 'memoryChatRetriever',
 		icon: 'fa:database',
+		iconColor: 'black',
 		group: ['transform'],
 		hidden: true,
 		version: 1,

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryMotorhead/MemoryMotorhead.node.ts
@@ -19,6 +19,7 @@ export class MemoryMotorhead implements INodeType {
 		displayName: 'Motorhead',
 		name: 'memoryMotorhead',
 		icon: 'fa:file-export',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3],
 		description: 'Use Motorhead Memory',

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/OutputParserAutofixing.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/OutputParserAutofixing.node.ts
@@ -21,6 +21,7 @@ export class OutputParserAutofixing implements INodeType {
 		displayName: 'Auto-fixing Output Parser',
 		name: 'outputParserAutofixing',
 		icon: 'fa:tools',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Automatically fix the output if it is not in the correct format',

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/OutputParserItemList.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/OutputParserItemList.node.ts
@@ -15,6 +15,7 @@ export class OutputParserItemList implements INodeType {
 		displayName: 'Item List Output Parser',
 		name: 'outputParserItemList',
 		icon: 'fa:bars',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Return the results as separate items',

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/OutputParserStructured.node.ts
@@ -20,6 +20,7 @@ export class OutputParserStructured implements INodeType {
 		displayName: 'Structured Output Parser',
 		name: 'outputParserStructured',
 		icon: 'fa:code',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2],
 		defaultVersion: 1.2,

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverContextualCompression/RetrieverContextualCompression.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverContextualCompression/RetrieverContextualCompression.node.ts
@@ -19,6 +19,7 @@ export class RetrieverContextualCompression implements INodeType {
 		displayName: 'Contextual Compression Retriever',
 		name: 'retrieverContextualCompression',
 		icon: 'fa:box-open',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Enhances document similarity search by contextual compression.',

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverMultiQuery/RetrieverMultiQuery.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverMultiQuery/RetrieverMultiQuery.node.ts
@@ -18,6 +18,7 @@ export class RetrieverMultiQuery implements INodeType {
 		displayName: 'MultiQuery Retriever',
 		name: 'retrieverMultiQuery',
 		icon: 'fa:box-open',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description:

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/RetrieverVectorStore.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/RetrieverVectorStore.node.ts
@@ -15,6 +15,7 @@ export class RetrieverVectorStore implements INodeType {
 		displayName: 'Vector Store Retriever',
 		name: 'retrieverVectorStore',
 		icon: 'fa:box-open',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Use a Vector Store as Retriever',

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverWorkflow/RetrieverWorkflow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverWorkflow/RetrieverWorkflow.node.ts
@@ -41,6 +41,7 @@ export class RetrieverWorkflow implements INodeType {
 		displayName: 'Workflow Retriever',
 		name: 'retrieverWorkflow',
 		icon: 'fa:box-open',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1],
 		description: 'Use an n8n Workflow as Retriever',

--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterCharacterTextSplitter/TextSplitterCharacterTextSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterCharacterTextSplitter/TextSplitterCharacterTextSplitter.node.ts
@@ -17,6 +17,7 @@ export class TextSplitterCharacterTextSplitter implements INodeType {
 		displayName: 'Character Text Splitter',
 		name: 'textSplitterCharacterTextSplitter',
 		icon: 'fa:grip-lines-vertical',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Split text into chunks by characters',

--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterRecursiveCharacterTextSplitter/TextSplitterRecursiveCharacterTextSplitter.node.ts
@@ -37,6 +37,7 @@ export class TextSplitterRecursiveCharacterTextSplitter implements INodeType {
 		displayName: 'Recursive Character Text Splitter',
 		name: 'textSplitterRecursiveCharacterTextSplitter',
 		icon: 'fa:grip-lines-vertical',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Split text into chunks by characters recursively, recommended for most use cases',

--- a/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterTokenSplitter/TextSplitterTokenSplitter.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/text_splitters/TextSplitterTokenSplitter/TextSplitterTokenSplitter.node.ts
@@ -16,6 +16,7 @@ export class TextSplitterTokenSplitter implements INodeType {
 		displayName: 'Token Splitter',
 		name: 'textSplitterTokenSplitter',
 		icon: 'fa:grip-lines-vertical',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Split text into chunks by tokens',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCalculator/ToolCalculator.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCalculator/ToolCalculator.node.ts
@@ -16,6 +16,7 @@ export class ToolCalculator implements INodeType {
 		displayName: 'Calculator',
 		name: 'toolCalculator',
 		icon: 'fa:calculator',
+		iconColor: 'black',
 		group: ['transform'],
 		version: 1,
 		description: 'Make it easier for AI agents to perform arithmetic',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -26,6 +26,7 @@ export class ToolCode implements INodeType {
 		displayName: 'Code Tool',
 		name: 'toolCode',
 		icon: 'fa:code',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1],
 		description: 'Write a tool in JS or Python',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolVectorStore/ToolVectorStore.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolVectorStore/ToolVectorStore.node.ts
@@ -18,6 +18,7 @@ export class ToolVectorStore implements INodeType {
 		displayName: 'Vector Store Tool',
 		name: 'toolVectorStore',
 		icon: 'fa:database',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1],
 		description: 'Retrieve context from vector store',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/ToolWorkflow.node.ts
@@ -32,6 +32,7 @@ export class ToolWorkflow implements INodeType {
 		displayName: 'Call n8n Workflow Tool',
 		name: 'toolWorkflow',
 		icon: 'fa:network-wired',
+		iconColor: 'black',
 		group: ['transform'],
 		version: [1, 1.1, 1.2, 1.3],
 		description: 'Uses another n8n workflow as a tool. Allows packaging any n8n node(s) as a tool.',

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -26,6 +26,7 @@ export class VectorStoreInMemory extends createVectorStoreNode({
 		name: 'vectorStoreInMemory',
 		description: 'Work with your data in In-Memory Vector Store',
 		icon: 'fa:database',
+		iconColor: 'black',
 		docsUrl:
 			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory/',
 	},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/VectorStorePinecone.node.ts
@@ -56,7 +56,7 @@ export class VectorStorePinecone extends createVectorStoreNode({
 		displayName: 'Pinecone Vector Store',
 		name: 'vectorStorePinecone',
 		description: 'Work with your data in Pinecone Vector Store',
-		icon: 'file:pinecone.svg',
+		icon: { light: 'file:pinecone.svg', dark: 'file:pinecone.dark.svg' },
 		docsUrl:
 			'https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone/',
 		credentials: [

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/pinecone.dark.svg
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/pinecone.dark.svg
@@ -1,0 +1,21 @@
+<svg width="32" height="35" viewBox="0 0 32 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.8555 34.2962C14.9325 34.2962 15.8055 33.4451 15.8055 32.3954C15.8055 31.3456 14.9325 30.4946 13.8555 30.4946C12.7786 30.4946 11.9055 31.3456 11.9055 32.3954C11.9055 33.4451 12.7786 34.2962 13.8555 34.2962Z" fill="white"/>
+<path d="M18.4138 7.19675L19.2512 2.66005" stroke="white" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M22.2656 5.5855L19.3466 2.11099L15.3748 4.37292" stroke="white" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M14.9202 26.5528L15.7337 22.0169" stroke="white" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M18.7729 24.9304L15.83 21.4671L11.8701 23.741" stroke="white" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M16.6077 17.1996L17.4212 12.6633" stroke="white" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M20.4587 15.58L17.5277 12.128L13.5679 14.3904" stroke="white" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M8.32871 26.1554L4.75171 28.5815" stroke="white" stroke-width="2.01017" stroke-linecap="square"/>
+<path d="M8.54383 30.0865L4.3208 28.8738L4.63185 24.5944" stroke="white" stroke-width="2.01017" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M21.3213 28.4299L23.8096 31.9282" stroke="white" stroke-width="2.01017" stroke-linecap="square"/>
+<path d="M19.718 32.045L24.1085 32.3365L25.3527 28.2438" stroke="white" stroke-width="2.01017" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M25.3999 21.3291L29.7784 22.0996" stroke="white" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M26.9072 25.072L30.3048 22.1919L28.1634 18.3557" stroke="white" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M24.1196 12.8615L28.0197 10.763" stroke="white" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M24.3357 8.83965L28.4869 10.5188L27.7093 14.8216" stroke="white" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M6.91639 18.1572L2.52588 17.4101" stroke="white" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M4.17731 21.1645L2 17.328L5.36167 14.436" stroke="white" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M11.0799 10.6129L8.14893 7.34769" stroke="white" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M12.2897 6.77496L7.80349 6.96156L7.01392 11.2649" stroke="white" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+</svg>

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/pinecone.svg
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePinecone/pinecone.svg
@@ -1,1 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="w-full -translate-y-0.5" viewBox="1 1 30 29"><g fill="none" fill-rule="evenodd" transform="translate(0 1)"><path stroke="currentColor" stroke-linecap="square" stroke-width="1.77" d="m14.58 5.24.7-3.89"/><path stroke="#7D7D87" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.77" d="M17.8 3.86 15.36.88l-3.32 1.94"/><path stroke="currentColor" stroke-linecap="square" stroke-width="1.77" d="m11.66 21.84.68-3.89"/><path stroke="currentColor" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.77" d="m14.88 20.45-2.46-2.97-3.31 1.95"/><path stroke="currentColor" stroke-linecap="square" stroke-width="1.77" d="m13.07 13.82.68-3.89"/><path stroke="currentColor" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.77" d="m16.29 12.43-2.45-2.96-3.31 1.94"/><circle cx="10.77" cy="26.85" r="1.63" fill="currentColor" fill-rule="nonzero"/><g stroke="currentColor" stroke-linecap="square"><path stroke-width="1.68" d="m6.15 21.5-2.99 2.08"/><path stroke-linejoin="round" stroke-width="1.68" d="M6.33 24.87 2.8 23.83l.26-3.67"/><path stroke-width="1.68" d="m17.01 23.45 2.08 3"/><path stroke-linejoin="round" stroke-width="1.68" d="m15.67 26.55 3.67.25 1.04-3.51"/><path stroke-width="1.72" d="m20.42 17.36 3.66.66"/><path stroke-linejoin="round" stroke-width="1.72" d="m21.68 20.57 2.84-2.47-1.79-3.29"/><path stroke-width="1.72" d="m19.35 10.1 3.26-1.8"/><path stroke-linejoin="round" stroke-width="1.72" d="M19.53 6.65 23 8.09l-.65 3.69"/><path stroke-width="1.72" d="M4.97 14.64 1.3 14"/><path stroke-linejoin="round" stroke-width="1.72" d="M2.68 17.22.86 13.93l2.81-2.48"/><path stroke-width="1.72" d="M8.45 8.17 6 5.37"/><path stroke-linejoin="round" stroke-width="1.72" d="m9.46 4.88-3.75.16-.66 3.69"/></g></g></svg>
+<svg width="32" height="35" viewBox="0 0 32 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.8555 34.2962C14.9325 34.2962 15.8055 33.4451 15.8055 32.3954C15.8055 31.3456 14.9325 30.4946 13.8555 30.4946C12.7786 30.4946 11.9055 31.3456 11.9055 32.3954C11.9055 33.4451 12.7786 34.2962 13.8555 34.2962Z" fill="black"/>
+<path d="M18.4138 7.19675L19.2512 2.66005" stroke="black" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M22.2656 5.5855L19.3466 2.11099L15.3748 4.37292" stroke="black" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M14.9202 26.5528L15.7337 22.0169" stroke="black" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M18.7729 24.9304L15.83 21.4671L11.8701 23.741" stroke="black" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M16.6077 17.1996L17.4212 12.6633" stroke="black" stroke-width="2.11786" stroke-linecap="square"/>
+<path d="M20.4587 15.58L17.5277 12.128L13.5679 14.3904" stroke="black" stroke-width="2.11786" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M8.32871 26.1554L4.75171 28.5815" stroke="black" stroke-width="2.01017" stroke-linecap="square"/>
+<path d="M8.54383 30.0865L4.3208 28.8738L4.63185 24.5944" stroke="black" stroke-width="2.01017" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M21.3213 28.4299L23.8096 31.9282" stroke="black" stroke-width="2.01017" stroke-linecap="square"/>
+<path d="M19.718 32.045L24.1085 32.3365L25.3527 28.2438" stroke="black" stroke-width="2.01017" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M25.3999 21.3291L29.7784 22.0996" stroke="black" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M26.9072 25.072L30.3048 22.1919L28.1634 18.3557" stroke="black" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M24.1196 12.8615L28.0197 10.763" stroke="black" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M24.3357 8.83965L28.4869 10.5188L27.7093 14.8216" stroke="black" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M6.91639 18.1572L2.52588 17.4101" stroke="black" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M4.17731 21.1645L2 17.328L5.36167 14.436" stroke="black" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+<path d="M11.0799 10.6129L8.14893 7.34769" stroke="black" stroke-width="2.05804" stroke-linecap="square"/>
+<path d="M12.2897 6.77496L7.80349 6.96156L7.01392 11.2649" stroke="black" stroke-width="2.05804" stroke-linecap="square" stroke-linejoin="round"/>
+</svg>

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -3,7 +3,7 @@
 import type { Document } from '@langchain/core/documents';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { VectorStore } from '@langchain/core/vectorstores';
-import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError, ThemeIconColor } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
 	INodeCredentialDescription,
@@ -37,6 +37,7 @@ interface NodeMeta {
 	description: string;
 	docsUrl: string;
 	icon: Icon;
+	iconColor?: ThemeIconColor;
 	credentials?: INodeCredentialDescription[];
 	operationModes?: NodeOperationMode[];
 }
@@ -125,6 +126,7 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 			name: args.meta.name,
 			description: args.meta.description,
 			icon: args.meta.icon,
+			iconColor: args.meta.iconColor,
 			group: ['transform'],
 			version: 1,
 			defaults: {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -3,7 +3,7 @@
 import type { Document } from '@langchain/core/documents';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { VectorStore } from '@langchain/core/vectorstores';
-import { NodeConnectionType, NodeOperationError, ThemeIconColor } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
 	INodeCredentialDescription,
@@ -17,6 +17,7 @@ import type {
 	INodeListSearchResult,
 	Icon,
 	INodePropertyOptions,
+	ThemeIconColor,
 } from 'n8n-workflow';
 
 import { getMetadataFiltersValues, logAiEvent } from '@utils/helpers';


### PR DESCRIPTION
## Summary

Added missing `iconColor` attribute to the LangChain nodes to improve the UI in dark mode.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-499/window-buffer-memory-icon-regression-in-dark-mode

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
