### PR TITLE
fix(editor): Set dangerouslyUseHTMLString in composable

### DIFF
--- a/packages/editor-ui/src/composables/useMessage.ts
+++ b/packages/editor-ui/src/composables/useMessage.ts
@@ -26,6 +26,7 @@ export function useMessage() {
 			...(config ?? (typeof configOrTitle === 'object' ? configOrTitle : {})),
 			cancelButtonClass: 'btn--cancel',
 			confirmButtonClass: 'btn--confirm',
+			dangerouslyUseHTMLString: true,
 		};
 
 		if (typeof configOrTitle === 'string') {
@@ -49,6 +50,7 @@ export function useMessage() {
 			distinguishCancelAndClose: true,
 			showClose: config?.showClose ?? false,
 			closeOnClickModal: false,
+			dangerouslyUseHTMLString: true,
 			...(config ?? (typeof configOrTitle === 'object' ? configOrTitle : {})),
 		};
 
@@ -74,6 +76,7 @@ export function useMessage() {
 			...(config ?? (typeof configOrTitle === 'object' ? configOrTitle : {})),
 			cancelButtonClass: 'btn--cancel',
 			confirmButtonClass: 'btn--confirm',
+			dangerouslyUseHTMLString: true,
 		};
 
 		if (typeof configOrTitle === 'string') {


### PR DESCRIPTION
## Summary

in this [PR](https://github.com/n8n-io/n8n/pull/12139) we missed adding this flag to the composable

there is no risk to XSS atach since that composable is already sanitising everything

## Related Linear tickets, Github issues, and Community forum posts
[PAY-2395](https://linear.app/n8n/issue/PAY-2395/html-in-workflow-was-changed-modal)

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
