### PR TITLE
fix(core): Fix serialization of circular json with task runner

### DIFF
--- a/packages/cli/src/runners/runner-ws-server.ts
+++ b/packages/cli/src/runners/runner-ws-server.ts
@@ -1,6 +1,6 @@
 import { TaskRunnersConfig } from '@n8n/config';
 import type { BrokerMessage, RunnerMessage } from '@n8n/task-runner';
-import { ApplicationError } from 'n8n-workflow';
+import { ApplicationError, jsonStringify } from 'n8n-workflow';
 import { Service } from 'typedi';
 import type WebSocket from 'ws';
 
@@ -83,7 +83,7 @@ export class TaskRunnerWsServer {
 	}
 
 	sendMessage(id: TaskRunner['id'], message: BrokerMessage.ToRunner.All) {
-		this.runnerConnections.get(id)?.send(JSON.stringify(message));
+		this.runnerConnections.get(id)?.send(jsonStringify(message, { replaceCircularRefs: true }));
 	}
 
 	add(id: TaskRunner['id'], connection: WebSocket) {


### PR DESCRIPTION
## Summary

Handle possible circular refs when serializing data to the task runner.

Based on a single benchmark run, this has no significant performance implication

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-433/community-issue-task-runner-timeout-when-testing-workflow-circular
https://github.com/n8n-io/n8n/issues/12235

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
