### PR TITLE
test: Get rid of a warning log in tests

### DIFF
--- a/packages/cli/test/setup-test-folder.ts
+++ b/packages/cli/test/setup-test-folder.ts
@@ -10,6 +10,7 @@ mkdirSync(baseDir, { recursive: true });
 const testDir = mkdtempSync(baseDir);
 mkdirSync(join(testDir, '.n8n'));
 process.env.N8N_USER_FOLDER = testDir;
+process.env.N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS = 'false';
 
 writeFileSync(
 	join(testDir, '.n8n/config'),


### PR DESCRIPTION

## Summary

Removes the

```
  console.warn
    Could not ensure settings file permissions: Cannot read properties of undefined (reading 'mode'). To skip this check, set N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false.
```

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
