### PR TITLE
fix: Fix docker image path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Try n8n instantly with [npx](https://docs.n8n.io/hosting/installation/npm/) (req
 
 Or deploy with [Docker](https://docs.n8n.io/hosting/installation/docker/):
 
-`docker run -it --rm --name n8n -p 5678:5678 docker.n8n.io/n8n-io/n8n`
+`docker run -it --rm --name n8n -p 5678:5678 docker.n8n.io/n8nio/n8n`
 
 Access the editor at http://localhost:5678
 


### PR DESCRIPTION
## Summary

Fixing docker image path mentioned in QuickStart - readme.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
