### PR TITLE
fix(editor): Unify disabled parameters background color

### DIFF
--- a/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
+++ b/packages/editor-ui/src/components/InlineExpressionEditor/InlineExpressionEditorInput.vue
@@ -114,27 +114,14 @@ defineExpose({
 </script>
 
 <template>
-	<div
-		ref="root"
-		title=""
-		:class="$style.editor"
-		data-test-id="inline-expression-editor-input"
-	></div>
+	<div ref="root" title="" data-test-id="inline-expression-editor-input"></div>
 </template>
-
-<style lang="scss" module>
-.editor div[contenteditable='false'] {
-	background-color: var(--disabled-fill, var(--color-background-light));
-	cursor: not-allowed;
-}
-</style>
 
 <style lang="scss" scoped>
 :deep(.cm-editor) {
 	padding-left: 0;
 }
 :deep(.cm-content) {
-	--disabled-fill: var(--color-background-base);
 	padding-left: var(--spacing-2xs);
 
 	&[aria-readonly='true'] {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -1059,6 +1059,7 @@ onUpdated(async () => {
 				:expression-edit-dialog-visible="expressionEditDialogVisible"
 				:path="path"
 				:parameter-issues="getIssues"
+				:is-read-only="isReadOnly"
 				@update:model-value="valueChanged"
 				@modal-opener-click="openExpressionEditorModal"
 				@focus="setFocus"

--- a/packages/editor-ui/src/components/ParameterInputList.vue
+++ b/packages/editor-ui/src/components/ParameterInputList.vue
@@ -650,6 +650,7 @@ function getParameterValue<T extends NodeParameterValueType = NodeParameterValue
 
 <style lang="scss">
 .parameter-input-list-wrapper {
+	--disabled-fill: var(--color-background-base);
 	.icon-button {
 		position: absolute;
 		opacity: 0;

--- a/packages/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
+++ b/packages/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
@@ -324,6 +324,7 @@ const onAddResourceClicked = () => {
 									ref="input"
 									:model-value="expressionDisplayValue"
 									:path="path"
+									:is-read-only="isReadOnly"
 									:rows="3"
 									@update:model-value="onInputChange"
 									@modal-opener-click="emit('modalOpenerClick')"


### PR DESCRIPTION
## Summary
- Fix inconsistent disabled parameters background colors
- Fix passing of `is-read-only` prop to WorkflowSelectorParameterInput 
- Removed `--disabled-fill: var(--color-background-base);` from InlineExpressionEditorInput as we're setting it on root list level(`parameter-input-list-wrapper`).
![CleanShot 2024-12-19 at 12 58 22](https://github.com/user-attachments/assets/5206e981-56a8-437e-9c7a-528607f2ab6b)
![CleanShot 2024-12-19 at 12 58 07](https://github.com/user-attachments/assets/1d30759f-4c12-4d58-96d0-f71e8089bbfc)

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
