### PR TITLE
fix(editor): Remove primary highlight color from edge being executed on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
@@ -81,18 +81,6 @@ describe('CanvasEdge', () => {
 		});
 	});
 
-	it('should correctly style a running connection', () => {
-		const { container } = renderComponent({
-			props: { ...DEFAULT_PROPS, data: { ...DEFAULT_PROPS.data, status: 'running' } },
-		});
-
-		const edge = container.querySelector('.vue-flow__edge-path');
-
-		expect(edge).toHaveStyle({
-			stroke: 'var(--color-primary)',
-		});
-	});
-
 	it('should correctly style a pinned connection', () => {
 		const { container } = renderComponent({
 			props: { ...DEFAULT_PROPS, data: { ...DEFAULT_PROPS.data, status: 'pinned' } },

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -44,8 +44,6 @@ const edgeColor = computed(() => {
 		return 'var(--color-success)';
 	} else if (status.value === 'pinned') {
 		return 'var(--color-secondary)';
-	} else if (status.value === 'running') {
-		return 'var(--color-primary)';
 	} else if (!isMainConnection.value) {
 		return 'var(--node-type-supplemental-color)';
 	} else if (props.selected) {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/026de2e0-0e3f-4cff-936e-3b824eec7640



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-442/dont-turn-output-connectors-orange-when-a-node-is-executing

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
