### PR TITLE
fix(OpenAI Node): Add quotes to default base URL

### DIFF
--- a/packages/nodes-base/nodes/OpenAi/OpenAi.node.ts
+++ b/packages/nodes-base/nodes/OpenAi/OpenAi.node.ts
@@ -29,7 +29,7 @@ export class OpenAi implements INodeType {
 		requestDefaults: {
 			ignoreHttpStatusErrors: true,
 			baseURL:
-				'={{ $credentials.url?.split("/").slice(0,-1).join("/") || https://api.openai.com }}',
+				'={{ $credentials.url?.split("/").slice(0,-1).join("/") ?? "https://api.openai.com" }}',
 		},
 		properties: [
 			oldVersionNotice,


### PR DESCRIPTION
## Summary

The Open AI Node would break when no base URL was specified in the credentials. The expression was missing quotes around the default URL. This PR fixes that oversight.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
