### PR TITLE
fix(Postgres PGVector Store Node): Do not initialize client to avoid idle connections

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -194,7 +194,8 @@ class ExtendedPGVectorStore extends PGVectorStore {
 		const { dimensions, ...rest } = args;
 		const postgresqlVectorStore = new this(embeddings, rest);
 
-		await postgresqlVectorStore._initializeClient();
+		// Workaround to fix https://github.com/langchain-ai/langchainjs/issues/5029#issuecomment-2468147921
+		// await postgresqlVectorStore._initializeClient();
 		await postgresqlVectorStore.ensureTableInDatabase(dimensions);
 		if (postgresqlVectorStore.collectionTableName) {
 			await postgresqlVectorStore.ensureCollectionTableInDatabase();
@@ -307,6 +308,7 @@ export class VectorStorePGVector extends createVectorStoreNode({
 			metadataColumnName: 'metadata',
 		}) as ColumnOptions;
 
-		await PGVectorStore.fromDocuments(documents, embeddings, config);
+		const vectorStore = await PGVectorStore.fromDocuments(documents, embeddings, config);
+		await vectorStore.end();
 	},
 }) {}


### PR DESCRIPTION
## Summary

When using `Postgres PGVector Store` to import a lot of documents, the Postgres server will deny connection after some items due to the number of clients : 
```js
remaining connection slots are reserved for roles with the SUPERUSER attribute
error: remaining connection slots are reserved for roles with the SUPERUSER attribute
    at /usr/local/lib/node_modules/n8n/node_modules/pg-pool/index.js:45:11
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at PGVectorStore._initializeClient (/usr/local/lib/node_modules/n8n/node_modules/@langchain/community/dist/vectorstores/pgvector.cjs:344:23)
    at Function.initialize (/usr/local/lib/node_modules/n8n/node_modules/@langchain/community/dist/vectorstores/pgvector.cjs:336:9)
    at Function.fromDocuments (/usr/local/lib/node_modules/n8n/node_modules/@langchain/community/dist/vectorstores/pgvector.cjs:735:26)
    at Object.populateVectorStore (/usr/local/lib/node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/dist/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.js:239:9)
    at ExecuteContext.execute (/usr/local/lib/node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/dist/nodes/vector_store/shared/createVectorStoreNode.js:206:21)
    at Workflow.runNode (/usr/local/lib/node_modules/n8n/node_modules/n8n-workflow/dist/Workflow.js:741:19)
    at /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/WorkflowExecute.js:724:51
    at /usr/local/lib/node_modules/n8n/node_modules/n8n-core/dist/WorkflowExecute.js:1155:20
```

All of the Postgres clients are in `idle` state, waiting for the event `ClientRead`.

### Test

Example workflow : [Test_Postgres_PGVector_Store.json](https://github.com/user-attachments/files/18200205/Test_Postgres_PGVector_Store.json)

1. List Postgres connected clients at reset with : `SELECT count(1) FROM pg_stat_activity;`
2. Run multiples time this workflow without the patch, and list again Postgres connected clients.
3. Apply the patch, rebuild, run multiples time the workflow and list again Postgres connected clients.

You should see more connection after the test without the patch, there here until the n8n server is terminated.
With the patch, you should get the same number of connections as the number at reset.

## Related Linear tickets, Github issues, and Community forum posts

The fix is based of [this comment](https://github.com/langchain-ai/langchainjs/issues/5029#issuecomment-2468147921) of langchain-ai/langchainjs#5029.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
