### PR TITLE
chore: Fix `naming-convention` lint config

### DIFF
--- a/packages/@n8n/client-oauth2/src/constants.ts
+++ b/packages/@n8n/client-oauth2/src/constants.ts
@@ -6,7 +6,9 @@ export const DEFAULT_URL_BASE = 'https://example.org/';
  * Default headers for executing OAuth 2.0 flows.
  */
 export const DEFAULT_HEADERS: Headers = {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	Accept: 'application/json, application/x-www-form-urlencoded',
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	'Content-Type': 'application/x-www-form-urlencoded',
 };
 

--- a/packages/@n8n_io/eslint-config/base.js
+++ b/packages/@n8n_io/eslint-config/base.js
@@ -233,6 +233,10 @@ const config = (module.exports = {
 				format: ['camelCase'],
 				leadingUnderscore: 'allowSingleOrDouble',
 			},
+			{
+				selector: 'import',
+				format: ['camelCase', 'PascalCase'],
+			},
 		],
 
 		/**
@@ -299,17 +303,6 @@ const config = (module.exports = {
 		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/triple-slash-reference.md
 		 */
 		'@typescript-eslint/triple-slash-reference': 'off', // @TECH_DEBT: Enable, disallowing in all cases - N8N-5820
-
-		/**
-		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md
-		 */
-		'@typescript-eslint/naming-convention': [
-			'error',
-			{
-				selector: 'import',
-				format: ['camelCase', 'PascalCase'],
-			},
-		],
 
 		/**
 		 * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md


### PR DESCRIPTION
Noticed an unintended override while working on #12325