### PR TITLE
fix(editor): Allow zooming when panning keycode is pressed on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -661,6 +661,7 @@ provide(CanvasKey, {
 		:min-zoom="0"
 		:max-zoom="4"
 		:selection-key-code="selectionKeyCode"
+		:zoom-activation-key-code="panningKeyCode"
 		:pan-activation-key-code="panningKeyCode"
 		:disable-keyboard-a11y="true"
 		data-test-id="canvas"


### PR DESCRIPTION
## Summary

Allows zooming when panning keycode is pressed

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-448/allow-zooming-when-pan-key-is-pressed

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
