### PR TITLE
chore: Fix DB migration for older versions of MySQL

### DIFF
--- a/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
+++ b/packages/cli/src/databases/migrations/common/1733133775640-AddMockedNodesColumnToTestDefinition.ts
@@ -9,7 +9,7 @@ export class AddMockedNodesColumnToTestDefinition1733133775640 implements Revers
 		const mockedNodesColumnName = escape.columnName('mockedNodes');
 
 		await runQuery(
-			`ALTER TABLE ${tableName} ADD COLUMN ${mockedNodesColumnName} JSON DEFAULT '[]' NOT NULL`,
+			`ALTER TABLE ${tableName} ADD COLUMN ${mockedNodesColumnName} JSON DEFAULT ('[]') NOT NULL`,
 		);
 	}
 


### PR DESCRIPTION
## Summary

MySQL does not support using literal constants as default values for JSON columns, but do support expressions (expression value can be literal).
Wrapping the default value for a column in parentheses improves compatibility (MySQL 8.0.13+) and does not affect other DBs.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/12304
- https://linear.app/n8n/issue/PAY-2399/community-issue-migration-script-crash#comment-841f320d


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
