### PR TITLE
fix(Zep Vector Store Node): Cloud vector store integration

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreZep/VectorStoreZep.node.test.ts
@@ -1,0 +1,73 @@
+import { ZepVectorStore } from '@langchain/community/vectorstores/zep';
+import { ZepCloudVectorStore } from '@langchain/community/vectorstores/zep_cloud';
+import { mock } from 'jest-mock-extended';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { VectorStoreZep } from './VectorStoreZep.node';
+
+describe('VectorStoreZep', () => {
+	const vectorStore = new VectorStoreZep();
+	const helpers = mock<ISupplyDataFunctions['helpers']>();
+	const executeFunctions = mock<ISupplyDataFunctions>({ helpers });
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+
+		executeFunctions.addInputData.mockReturnValue({ index: 0 });
+	});
+
+	it('should get vector store cloud client', async () => {
+		executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'mode':
+					return 'retrieve';
+				case 'collectionName':
+					return 'test-collection';
+				case 'options':
+					return {};
+				default:
+					return undefined;
+			}
+		});
+
+		executeFunctions.getCredentials.mockResolvedValue(
+			mock({
+				apiKey: 'some-key',
+				cloud: true,
+			}),
+		);
+
+		const { response } = await vectorStore.supplyData.call(executeFunctions, 0);
+
+		expect(response).toBeDefined();
+		expect(response).toBeInstanceOf(ZepCloudVectorStore);
+	});
+
+	it('should get vector store self-hosted client', async () => {
+		executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+			switch (paramName) {
+				case 'mode':
+					return 'retrieve';
+				case 'collectionName':
+					return 'test-collection';
+				case 'options':
+					return {};
+				default:
+					return undefined;
+			}
+		});
+
+		executeFunctions.getCredentials.mockResolvedValue(
+			mock({
+				apiKey: 'some-key',
+				apiUrl: 'https://example.com',
+				cloud: false,
+			}),
+		);
+
+		const { response } = await vectorStore.supplyData.call(executeFunctions, 0);
+
+		expect(response).toBeDefined();
+		expect(response).toBeInstanceOf(ZepVectorStore);
+	});
+});


### PR DESCRIPTION
## Summary

This PR addresses Zep Vector Store issue when cloud option is selected.

## Related Linear tickets, Github issues, and Community forum posts

- https://community.n8n.io/t/zep-vector-store-failed-to-parse-url-from-undefined-healthz/64343
- https://linear.app/n8n/issue/AI-537/bug-zep-vector-store-undefined-apiurl-when-cloud-option-is-selected-in


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
