### PR TITLE
fix(core): Validate values which are intentionally 0

### DIFF
--- a/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
+++ b/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
@@ -247,7 +247,7 @@ describe('validateValueAgainstSchema', () => {
 		expect(typeof result).toEqual('number');
 	});
 
-	test('should validate when the value to be validated is 0, the mode is in Fixed mode, and the node is a resource mapper', () => {
+	test('should correctly validate values when the mode is in Fixed mode, and the node is a resource mapper', () => {
 		const nodeType = {
 			description: {
 				properties: [
@@ -273,6 +273,21 @@ describe('validateValueAgainstSchema', () => {
 							type: 'number',
 							required: true,
 						},
+						{
+							id: 'str',
+							type: 'string',
+							required: true,
+						},
+						{
+							id: 'obj',
+							type: 'object',
+							required: true,
+						},
+						{
+							id: 'arr',
+							type: 'array',
+							required: true,
+						},
 					],
 					attemptToConvertTypes: true,
 					mappingMode: '',
@@ -281,12 +296,63 @@ describe('validateValueAgainstSchema', () => {
 			},
 		} as unknown as INode;
 
-		const value = { num: 0 };
+		const zeroValue = { num: 0 };
+		const normalNumberValue = { num: 23 };
+		const negativeZeroValue = { num: -0 };
+		const negativeInfinityValue = { num: -Infinity };
+		const infinityValue = { num: Infinity };
+		const nanValue = { num: NaN };
+		const undefinedValue = { num: undefined };
+		const nullValue = { num: null };
+		const emptyStringValue = { str: '' };
+		const emptyStringWithSpaceValue = { str: ' ' };
+		const stringValue = { str: 'hello' };
+		const emptyArrayValue = { arr: [] };
+		const emptyObjectValue = { obj: {} };
 
 		const parameterName = 'operation.value';
 
 		expect(() =>
-			validateValueAgainstSchema(node, nodeType, value, parameterName, 0, 0),
+			validateValueAgainstSchema(node, nodeType, zeroValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, negativeZeroValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, negativeInfinityValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, infinityValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, normalNumberValue, parameterName, 0, 0),
+		).not.toThrow();
+
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, nanValue, parameterName, 0, 0),
+		).toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, undefinedValue, parameterName, 0, 0),
+		).toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, nullValue, parameterName, 0, 0),
+		).toThrow();
+
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, emptyStringValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, emptyStringWithSpaceValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, stringValue, parameterName, 0, 0),
+		).not.toThrow();
+
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, emptyArrayValue, parameterName, 0, 0),
+		).not.toThrow();
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, emptyObjectValue, parameterName, 0, 0),
 		).not.toThrow();
 	});
 });

--- a/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
+++ b/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
@@ -246,4 +246,47 @@ describe('validateValueAgainstSchema', () => {
 		// value should be type number
 		expect(typeof result).toEqual('number');
 	});
+
+	test('should validate when the value to be validated is 0, the mode is in Fixed mode, and the node is a resource mapper', () => {
+		const nodeType = {
+			description: {
+				properties: [
+					{
+						name: 'operation',
+						type: 'resourceMapper',
+						typeOptions: {
+							resourceMapper: {
+								mode: 'add',
+							},
+						},
+					},
+				],
+			},
+		} as unknown as INodeType;
+
+		const node = {
+			parameters: {
+				operation: {
+					schema: [
+						{
+							id: 'num',
+							type: 'number',
+							required: true,
+						},
+					],
+					attemptToConvertTypes: true,
+					mappingMode: '',
+					value: '',
+				},
+			},
+		} as unknown as INode;
+
+		const value = { num: 0 };
+
+		const parameterName = 'operation.value';
+
+		expect(() =>
+			validateValueAgainstSchema(node, nodeType, value, parameterName, 0, 0),
+		).not.toThrow();
+	});
 });

--- a/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
+++ b/packages/core/src/node-execution-context/utils/__tests__/validateValueAgainstSchema.test.ts
@@ -247,7 +247,7 @@ describe('validateValueAgainstSchema', () => {
 		expect(typeof result).toEqual('number');
 	});
 
-	test('should correctly validate values when the mode is in Fixed mode, and the node is a resource mapper', () => {
+	describe('when the mode is in Fixed mode, and the node is a resource mapper', () => {
 		const nodeType = {
 			description: {
 				properties: [
@@ -268,26 +268,10 @@ describe('validateValueAgainstSchema', () => {
 			parameters: {
 				operation: {
 					schema: [
-						{
-							id: 'num',
-							type: 'number',
-							required: true,
-						},
-						{
-							id: 'str',
-							type: 'string',
-							required: true,
-						},
-						{
-							id: 'obj',
-							type: 'object',
-							required: true,
-						},
-						{
-							id: 'arr',
-							type: 'array',
-							required: true,
-						},
+						{ id: 'num', type: 'number', required: true },
+						{ id: 'str', type: 'string', required: true },
+						{ id: 'obj', type: 'object', required: true },
+						{ id: 'arr', type: 'array', required: true },
 					],
 					attemptToConvertTypes: true,
 					mappingMode: '',
@@ -296,63 +280,33 @@ describe('validateValueAgainstSchema', () => {
 			},
 		} as unknown as INode;
 
-		const zeroValue = { num: 0 };
-		const normalNumberValue = { num: 23 };
-		const negativeZeroValue = { num: -0 };
-		const negativeInfinityValue = { num: -Infinity };
-		const infinityValue = { num: Infinity };
-		const nanValue = { num: NaN };
-		const undefinedValue = { num: undefined };
-		const nullValue = { num: null };
-		const emptyStringValue = { str: '' };
-		const emptyStringWithSpaceValue = { str: ' ' };
-		const stringValue = { str: 'hello' };
-		const emptyArrayValue = { arr: [] };
-		const emptyObjectValue = { obj: {} };
-
 		const parameterName = 'operation.value';
 
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, zeroValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, negativeZeroValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, negativeInfinityValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, infinityValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, normalNumberValue, parameterName, 0, 0),
-		).not.toThrow();
+		describe('should correctly validate values for', () => {
+			test.each([
+				{ num: 0 },
+				{ num: 23 },
+				{ num: -0 },
+				{ num: -Infinity },
+				{ num: Infinity },
+				{ str: '' },
+				{ str: ' ' },
+				{ str: 'hello' },
+				{ arr: [] },
+				{ obj: {} },
+			])('%s', (value) => {
+				expect(() =>
+					validateValueAgainstSchema(node, nodeType, value, parameterName, 0, 0),
+				).not.toThrow();
+			});
+		});
 
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, nanValue, parameterName, 0, 0),
-		).toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, undefinedValue, parameterName, 0, 0),
-		).toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, nullValue, parameterName, 0, 0),
-		).toThrow();
-
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, emptyStringValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, emptyStringWithSpaceValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, stringValue, parameterName, 0, 0),
-		).not.toThrow();
-
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, emptyArrayValue, parameterName, 0, 0),
-		).not.toThrow();
-		expect(() =>
-			validateValueAgainstSchema(node, nodeType, emptyObjectValue, parameterName, 0, 0),
-		).not.toThrow();
+		describe('should throw an error for', () => {
+			test.each([{ num: NaN }, { num: undefined }, { num: null }])('%s', (value) => {
+				expect(() =>
+					validateValueAgainstSchema(node, nodeType, value, parameterName, 0, 0),
+				).toThrow();
+			});
+		});
 	});
 });

--- a/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
+++ b/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
@@ -44,7 +44,7 @@ const validateResourceMapperValue = (
 			!skipRequiredCheck &&
 			schemaEntry?.required === true &&
 			schemaEntry.type !== 'boolean' &&
-			!resolvedValue
+			resolvedValue === undefined
 		) {
 			return {
 				valid: false,

--- a/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
+++ b/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
@@ -44,7 +44,7 @@ const validateResourceMapperValue = (
 			!skipRequiredCheck &&
 			schemaEntry?.required === true &&
 			schemaEntry.type !== 'boolean' &&
-			resolvedValue === undefined
+			(resolvedValue === undefined || resolvedValue === null)
 		) {
 			return {
 				valid: false,


### PR DESCRIPTION
## Summary

Allow for resource mapper nodes to handle intentional `0` values.

This was especially problematic in the Postgres Insert Node when a user
wants to insert `0` as a value in a table in both Fixed and Expression
mode.

In `validateValueAgainstSchema`, when a resolvedValue is `0`, the value
is considered invalid since in Javascript, `0` is considered a falsey
value which makes `!0` is equal to `true`.

Workflow for testing:

```
{
  "nodes": [
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "7e8e5d58-8178-4dd8-acfd-6a438dbcb982",
              "name": "num",
              "value": 0,
              "type": "number"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        600,
        240
      ],
      "id": "d8ffe610-f0f1-4e7f-8aa9-dd8b6cb50c70",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "schema": {
          "__rl": true,
          "mode": "list",
          "value": "public"
        },
        "table": {
          "__rl": true,
          "value": "dummy_table",
          "mode": "list",
          "cachedResultName": "dummy_table"
        },
        "columns": {
          "mappingMode": "defineBelow",
          "value": {
            "retail_price_per_unit": "={{ parseFloat($json.num) }}"
          },
          "matchingColumns": [
            "id"
          ],
          "schema": [
            {
              "id": "id",
              "displayName": "id",
              "required": false,
              "defaultMatch": true,
              "display": true,
              "type": "number",
              "canBeUsedToMatch": true,
              "removed": true
            },
            {
              "id": "retail_price_per_unit",
              "displayName": "retail_price_per_unit",
              "required": true,
              "defaultMatch": false,
              "display": true,
              "type": "number",
              "canBeUsedToMatch": true
            }
          ],
          "ignoreTypeMismatchErrors": false,
          "attemptToConvertTypes": false,
          "convertFieldsToString": false
        },
        "options": {}
      },
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        820,
        240
      ],
      "id": "9e8a2ef1-1d6b-4d62-9610-2f7faaeeaa22",
      "name": "Insert 0 with Insert w/ json (Bug)",
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "dgl neon"
        }
      }
    },
    {
      "parameters": {
        "schema": {
          "__rl": true,
          "mode": "list",
          "value": "public"
        },
        "table": {
          "__rl": true,
          "value": "dummy_table",
          "mode": "list",
          "cachedResultName": "dummy_table"
        },
        "columns": {
          "mappingMode": "defineBelow",
          "value": {
            "retail_price_per_unit": 0
          },
          "matchingColumns": [
            "id"
          ],
          "schema": [
            {
              "id": "id",
              "displayName": "id",
              "required": false,
              "defaultMatch": true,
              "display": true,
              "type": "number",
              "canBeUsedToMatch": true,
              "removed": true
            },
            {
              "id": "retail_price_per_unit",
              "displayName": "retail_price_per_unit",
              "required": true,
              "defaultMatch": false,
              "display": true,
              "type": "number",
              "canBeUsedToMatch": true
            }
          ],
          "ignoreTypeMismatchErrors": false,
          "attemptToConvertTypes": false,
          "convertFieldsToString": false
        },
        "options": {}
      },
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        820,
        440
      ],
      "id": "968b73c1-d174-47d2-8cd2-d7a181011699",
      "name": "Insert 0 with Insert (Bug)",
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "dgl neon"
        }
      }
    }
  ],
  "connections": {
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Insert 0 with Insert w/ json (Bug)",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Insert 0 with Insert w/ json (Bug)": {
      "main": [
        []
      ]
    }
  },
  "pinData": {}
}
```

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/NODE-2085/community-issue-postgres-node-validation-fails-with-0

Resolves https://github.com/n8n-io/n8n/issues/11939

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
