### PR TITLE
docs: Fix docker URL on README.md (no-changelog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Try n8n instantly with [npx](https://docs.n8n.io/hosting/installation/npm/) (req
 
 Or deploy with [Docker](https://docs.n8n.io/hosting/installation/docker/):
 
-`docker run -it --rm --name n8n -p 5678:5678 docker.n8n.io/n8n-io/n8n`
+`docker run -it --rm --name n8n -p 5678:5678 docker.n8n.io/n8nio/n8n`
 
 Access the editor at http://localhost:5678
 


### PR DESCRIPTION
## Summary
Looks like the repo was outdated.

![image](https://github.com/user-attachments/assets/784fcf0e-2156-4871-951c-cbc17605b36d)
## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
