### PR TITLE
feat(StripeTrigger Node): Add support for checkout.session.expired event

### DIFF
--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -186,6 +186,11 @@ export class StripeTrigger implements INodeType {
 						description: 'Occurs when a Checkout Session has been successfully completed.',
 					},
 					{
+						name: 'Checkout Session.expired',
+						value: 'checkout.session.expired',
+						description: 'Occurs when a Checkout Session is expired.',
+					},
+					{
 						name: 'Coupon Created',
 						value: 'coupon.created',
 						description: 'Occurs whenever a coupon is created.',


### PR DESCRIPTION
## Summary

Add the event `checkout.session.expired` to the list of supported Stripe events available in the StripeTrigger Node.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
