### PR TITLE
refactor(editor):  N8nOption type

### DIFF
--- a/packages/design-system/src/components/N8nOption/Option.vue
+++ b/packages/design-system/src/components/N8nOption/Option.vue
@@ -7,7 +7,7 @@ import { ElOption } from 'element-plus';
 type OptionProps = {
 	value: string | number | boolean | object;
 	label?: string | number;
-	disabled: boolean;
+	disabled?: boolean;
 };
 const props = defineProps<OptionProps>();
 </script>

--- a/packages/design-system/src/components/N8nOption/Option.vue
+++ b/packages/design-system/src/components/N8nOption/Option.vue
@@ -3,7 +3,7 @@ import { ElOption } from 'element-plus';
 
 const props = defineProps({
 	...ElOption.props,
-	value: { type: [String, Number], required: true },
+	value: { type: [String, Number, Boolean, Object], required: true },
 });
 </script>
 

--- a/packages/design-system/src/components/N8nOption/Option.vue
+++ b/packages/design-system/src/components/N8nOption/Option.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import { ElOption } from 'element-plus';
 
-const props = defineProps({
-	...ElOption.props,
-	value: { type: [String, Number, Boolean, Object], required: true },
-});
+/**
+ * @see https://element-plus.org/en-US/component/select.html#option-attributes
+ */
+type OptionProps = {
+	value: string | number | boolean | object;
+	label?: string | number;
+	disabled: boolean;
+};
+const props = defineProps<OptionProps>();
 </script>
 
 <template>
-	<ElOption v-bind="{ ...$props, ...$attrs }" :value="props.value"><slot /></ElOption>
+	<ElOption v-bind="props"><slot /></ElOption>
 </template>


### PR DESCRIPTION
## Summary

set the N8nOption 1 to 1 with Element Plus type
https://github.com/element-plus/element-plus/blob/dev/packages/components/select/src/option.vue#L44

this removes a bunch of console warning in dev mode

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2413](https://linear.app/n8n/issue/PAY-2413/fix-n8noption-type)



## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
