### PR TITLE
fix(core): Don't fail task runner task if logging fails

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -190,6 +190,27 @@ describe('JsTaskRunner', () => {
 				}),
 			).resolves.toBeDefined();
 		});
+
+		it('should log the context object as [[ExecutionContext]]', async () => {
+			const rpcCallSpy = jest.spyOn(defaultTaskRunner, 'makeRpcCall').mockResolvedValue(undefined);
+
+			const task = newTaskWithSettings({
+				code: `
+					console.log(this);
+					return {json: {}}
+				`,
+				nodeMode: 'runOnceForAllItems',
+			});
+
+			await execTaskWithParams({
+				task,
+				taskData: newDataRequestResponse([wrapIntoJson({})]),
+			});
+
+			expect(rpcCallSpy).toHaveBeenCalledWith(task.taskId, 'logNodeOutput', [
+				'[[ExecutionContext]]',
+			]);
+		});
 	});
 
 	describe('built-in methods and variables available in the context', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -139,7 +139,8 @@ describe('JsTaskRunner', () => {
 				});
 
 				expect(defaultTaskRunner.makeRpcCall).toHaveBeenCalledWith(task.taskId, 'logNodeOutput', [
-					'Hello world!',
+					"'Hello'",
+					"'world!'",
 				]);
 			},
 		);

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -173,6 +173,23 @@ describe('JsTaskRunner', () => {
 				}),
 			).resolves.toBeDefined();
 		});
+
+		it('should not throw when trying to log the context object', async () => {
+			const task = newTaskWithSettings({
+				code: `
+					console.log(this);
+					return {json: {}}
+				`,
+				nodeMode: 'runOnceForAllItems',
+			});
+
+			await expect(
+				execTaskWithParams({
+					task,
+					taskData: newDataRequestResponse([wrapIntoJson({})]),
+				}),
+			).resolves.toBeDefined();
+		});
 	});
 
 	describe('built-in methods and variables available in the context', () => {

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -18,6 +18,7 @@ import type {
 	IWorkflowDataProxyData,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
+import { inspect } from 'node:util';
 import { runInNewContext, type Context } from 'node:vm';
 
 import type { MainConfig } from '@/config/main-config';
@@ -438,7 +439,7 @@ export class JsTaskRunner extends TaskRunner {
 	private buildCustomConsole(taskId: string): CustomConsole {
 		const stringifyArg = (arg: unknown) => {
 			try {
-				return typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg;
+				return typeof arg === 'object' && arg !== null ? inspect(arg) : arg;
 			} catch (e) {
 				const error = ensureError(e);
 				console.warn('Failed to stringify console.log argument:', error.message);
@@ -479,6 +480,7 @@ export class JsTaskRunner extends TaskRunner {
 		additionalProperties: Record<string, unknown> = {},
 	): Context {
 		const context: Context = {
+			[inspect.custom]: () => '[[ExecutionContext]]',
 			require: this.requireResolver,
 			module: {},
 			console: this.buildCustomConsole(taskId),

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -1,6 +1,6 @@
 import set from 'lodash/set';
 import { getAdditionalKeys } from 'n8n-core';
-import { WorkflowDataProxy, Workflow, ObservableObject } from 'n8n-workflow';
+import { WorkflowDataProxy, Workflow, ObservableObject, ensureError } from 'n8n-workflow';
 import type {
 	CodeExecutionMode,
 	IWorkflowExecuteAdditionalData,
@@ -15,6 +15,7 @@ import type {
 	EnvProviderState,
 	IExecuteData,
 	INodeTypeDescription,
+	IWorkflowDataProxyData,
 } from 'n8n-workflow';
 import * as a from 'node:assert';
 import { runInNewContext, type Context } from 'node:vm';
@@ -79,6 +80,8 @@ type CustomConsole = {
 	log: (...args: unknown[]) => void;
 };
 
+const noOp = () => {};
+
 export class JsTaskRunner extends TaskRunner {
 	private readonly requireResolver: RequireResolver;
 
@@ -129,29 +132,12 @@ export class JsTaskRunner extends TaskRunner {
 			nodeTypes: this.nodeTypes,
 		});
 
-		const noOp = () => {};
-		const customConsole = {
-			// all except `log` are dummy methods that disregard without throwing, following existing Code node behavior
-			...Object.keys(console).reduce<Record<string, () => void>>((acc, name) => {
-				acc[name] = noOp;
-				return acc;
-			}, {}),
-			// Send log output back to the main process. It will take care of forwarding
-			// it to the UI or printing to console.
-			log: (...args: unknown[]) => {
-				const logOutput = args
-					.map((arg) => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg))
-					.join(' ');
-				void this.makeRpcCall(task.taskId, 'logNodeOutput', [logOutput]);
-			},
-		};
-
 		workflow.staticData = ObservableObject.create(workflow.staticData);
 
 		const result =
 			settings.nodeMode === 'runOnceForAllItems'
-				? await this.runForAllItems(task.taskId, settings, data, workflow, customConsole, signal)
-				: await this.runForEachItem(task.taskId, settings, data, workflow, customConsole, signal);
+				? await this.runForAllItems(task.taskId, settings, data, workflow, signal)
+				: await this.runForEachItem(task.taskId, settings, data, workflow, signal);
 
 		return {
 			result,
@@ -200,22 +186,14 @@ export class JsTaskRunner extends TaskRunner {
 		settings: JSExecSettings,
 		data: JsTaskData,
 		workflow: Workflow,
-		customConsole: CustomConsole,
 		signal: AbortSignal,
 	): Promise<INodeExecutionData[]> {
 		const dataProxy = this.createDataProxy(data, workflow, data.itemIndex);
 		const inputItems = data.connectionInputData;
 
-		const context: Context = {
-			require: this.requireResolver,
-			module: {},
-			console: customConsole,
+		const context = this.buildContext(taskId, workflow, data.node, dataProxy, {
 			items: inputItems,
-			$getWorkflowStaticData: (type: 'global' | 'node') => workflow.getStaticData(type, data.node),
-			...this.getNativeVariables(),
-			...dataProxy,
-			...this.buildRpcCallObject(taskId),
-		};
+		});
 
 		try {
 			const result = await new Promise<TaskResultData['result']>((resolve, reject) => {
@@ -264,7 +242,6 @@ export class JsTaskRunner extends TaskRunner {
 		settings: JSExecSettings,
 		data: JsTaskData,
 		workflow: Workflow,
-		customConsole: CustomConsole,
 		signal: AbortSignal,
 	): Promise<INodeExecutionData[]> {
 		const inputItems = data.connectionInputData;
@@ -279,17 +256,7 @@ export class JsTaskRunner extends TaskRunner {
 		for (let index = chunkStartIdx; index < chunkEndIdx; index++) {
 			const item = inputItems[index];
 			const dataProxy = this.createDataProxy(data, workflow, index);
-			const context: Context = {
-				require: this.requireResolver,
-				module: {},
-				console: customConsole,
-				item,
-				$getWorkflowStaticData: (type: 'global' | 'node') =>
-					workflow.getStaticData(type, data.node),
-				...this.getNativeVariables(),
-				...dataProxy,
-				...this.buildRpcCallObject(taskId),
-			};
+			const context = this.buildContext(taskId, workflow, data.node, dataProxy, { item });
 
 			try {
 				let result = await new Promise<INodeExecutionData | undefined>((resolve, reject) => {
@@ -466,5 +433,62 @@ export class JsTaskRunner extends TaskRunner {
 		}
 
 		return rpcObject;
+	}
+
+	private buildCustomConsole(taskId: string): CustomConsole {
+		const stringifyArg = (arg: unknown) => {
+			try {
+				return typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg;
+			} catch (e) {
+				const error = ensureError(e);
+				console.warn('Failed to stringify console.log argument:', error.message);
+				return '[argument could not be stringified]';
+			}
+		};
+
+		return {
+			// all except `log` are dummy methods that disregard without throwing, following existing Code node behavior
+			...Object.keys(console).reduce<Record<string, () => void>>((acc, name) => {
+				acc[name] = noOp;
+				return acc;
+			}, {}),
+
+			// Send log output back to the main process. It will take care of forwarding
+			// it to the UI or printing to console.
+			log: (...args: unknown[]) => {
+				const logOutput = args.map(stringifyArg).join(' ');
+				void this.makeRpcCall(taskId, 'logNodeOutput', [logOutput]);
+			},
+		};
+	}
+
+	/**
+	 * Builds the 'global' context object that is passed to the script
+	 *
+	 * @param taskId The ID of the task. Needed for RPC calls
+	 * @param workflow The workflow that is being executed. Needed for static data
+	 * @param node The node that is being executed. Needed for static data
+	 * @param dataProxy The data proxy object that provides access to built-ins
+	 * @param additionalProperties Additional properties to add to the context
+	 */
+	private buildContext(
+		taskId: string,
+		workflow: Workflow,
+		node: INode,
+		dataProxy: IWorkflowDataProxyData,
+		additionalProperties: Record<string, unknown> = {},
+	): Context {
+		const context: Context = {
+			require: this.requireResolver,
+			module: {},
+			console: this.buildCustomConsole(taskId),
+			$getWorkflowStaticData: (type: 'global' | 'node') => workflow.getStaticData(type, node),
+			...this.getNativeVariables(),
+			...dataProxy,
+			...this.buildRpcCallObject(taskId),
+			...additionalProperties,
+		};
+
+		return context;
 	}
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -437,16 +437,6 @@ export class JsTaskRunner extends TaskRunner {
 	}
 
 	private buildCustomConsole(taskId: string): CustomConsole {
-		const stringifyArg = (arg: unknown) => {
-			try {
-				return typeof arg === 'object' && arg !== null ? inspect(arg) : arg;
-			} catch (e) {
-				const error = ensureError(e);
-				console.warn('Failed to stringify console.log argument:', error.message);
-				return '[argument could not be stringified]';
-			}
-		};
-
 		return {
 			// all except `log` are dummy methods that disregard without throwing, following existing Code node behavior
 			...Object.keys(console).reduce<Record<string, () => void>>((acc, name) => {
@@ -457,7 +447,7 @@ export class JsTaskRunner extends TaskRunner {
 			// Send log output back to the main process. It will take care of forwarding
 			// it to the UI or printing to console.
 			log: (...args: unknown[]) => {
-				const logOutput = args.map(stringifyArg).join(' ');
+				const logOutput = args.map((arg) => inspect(arg)).join(' ');
 				void this.makeRpcCall(taskId, 'logNodeOutput', [logOutput]);
 			},
 		};

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -447,8 +447,8 @@ export class JsTaskRunner extends TaskRunner {
 			// Send log output back to the main process. It will take care of forwarding
 			// it to the UI or printing to console.
 			log: (...args: unknown[]) => {
-				const logOutput = args.map((arg) => inspect(arg)).join(' ');
-				void this.makeRpcCall(taskId, 'logNodeOutput', [logOutput]);
+				const formattedLogArgs = args.map((arg) => inspect(arg));
+				void this.makeRpcCall(taskId, 'logNodeOutput', formattedLogArgs);
 			},
 		};
 	}

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -1,6 +1,6 @@
 import set from 'lodash/set';
 import { getAdditionalKeys } from 'n8n-core';
-import { WorkflowDataProxy, Workflow, ObservableObject, ensureError } from 'n8n-workflow';
+import { WorkflowDataProxy, Workflow, ObservableObject } from 'n8n-workflow';
 import type {
 	CodeExecutionMode,
 	IWorkflowExecuteAdditionalData,

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -452,15 +452,15 @@ export abstract class TaskRunner extends EventEmitter {
 			});
 		});
 
-		this.send({
-			type: 'runner:rpc',
-			callId,
-			taskId,
-			name,
-			params,
-		});
-
 		try {
+			this.send({
+				type: 'runner:rpc',
+				callId,
+				taskId,
+				name,
+				params,
+			});
+
 			const returnValue = await dataPromise;
 
 			return isSerializedBuffer(returnValue) ? toBuffer(returnValue) : returnValue;


### PR DESCRIPTION
## Summary

To conform to old Code Node behaviour, make sure JS task execution doesn't fail if logging fails. The issue mainly comes when trying to `console.log` the context object (e.g. `this`), because most of the built-ins are not serializable.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-447/console-logging-the-context-object-throws


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
