### PR TITLE
fix(createVectorStoreNode): Prevent connection leaks in PGVectorStore…

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
@@ -115,12 +115,7 @@ export class MemoryPostgresChat implements INodeType {
 			...kOptions,
 		});
 
-		async function closeFunction() {
-			void pool.end();
-		}
-
 		return {
-			closeFunction,
 			response: logWrapper(memory, this),
 		};
 	}

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -4,6 +4,7 @@ import type { Document } from '@langchain/core/documents';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { VectorStore } from '@langchain/core/vectorstores';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
+import { PGVectorStore } from '@langchain/community/vectorstores/pgvector';
 import type {
 	IExecuteFunctions,
 	INodeCredentialDescription,
@@ -395,7 +396,14 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 
 			if (mode === 'retrieve') {
 				const vectorStore = await args.getVectorStoreClient(this, filter, embeddings, itemIndex);
+
+				async function closeFunction() {
+					const pgVectorStore = vectorStore as PGVectorStore;
+					void pgVectorStore?.client?.release();
+				}
+
 				return {
+					closeFunction,
 					response: logWrapper(vectorStore, this),
 				};
 			}


### PR DESCRIPTION


## Summary
This PR fixes an issue related to connection pool management in the PostgreSQL pool of the VectorStorePGVector node. It was identified that connections were not being properly released, leading to connection leaks and eventually blocking access to PostgreSQL.
<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://community.n8n.io/t/postgres-connection-error-sorry-too-many-clients-already/63473/1
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
