### PR TITLE
fix(editor): Show all workflows in the error workflow dropdown in the workflow settings

### DIFF
--- a/packages/editor-ui/src/components/WorkflowSettings.test.ts
+++ b/packages/editor-ui/src/components/WorkflowSettings.test.ts
@@ -2,7 +2,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import WorkflowSettingsVue from '@/components/WorkflowSettings.vue';
 
 import { setupServer } from '@/__tests__/server';
-import { afterAll, beforeAll } from 'vitest';
+import { afterAll, beforeAll, MockInstance } from 'vitest';
 import { within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 
@@ -23,6 +23,8 @@ let pinia: ReturnType<typeof createPinia>;
 let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 let settingsStore: ReturnType<typeof useSettingsStore>;
 let uiStore: ReturnType<typeof useUIStore>;
+
+let fetchAllWorkflowsSpy: MockInstance<(typeof workflowsStore)['fetchAllWorkflows']>;
 
 const createComponent = createComponentRenderer(WorkflowSettingsVue);
 
@@ -46,6 +48,18 @@ describe('WorkflowSettingsVue', () => {
 
 		vi.spyOn(workflowsStore, 'workflowName', 'get').mockReturnValue('Test Workflow');
 		vi.spyOn(workflowsStore, 'workflowId', 'get').mockReturnValue('1');
+		fetchAllWorkflowsSpy = vi.spyOn(workflowsStore, 'fetchAllWorkflows').mockResolvedValue([
+			{
+				id: '1',
+				name: 'Test Workflow',
+				active: true,
+				nodes: [],
+				connections: {},
+				createdAt: 1,
+				updatedAt: 1,
+				versionId: '123',
+			},
+		]);
 		vi.spyOn(workflowsStore, 'getWorkflowById').mockReturnValue({
 			id: '1',
 			name: 'Test Workflow',
@@ -111,6 +125,20 @@ describe('WorkflowSettingsVue', () => {
 		await userEvent.click(dropdownItems[2]);
 
 		expect(getByTestId('workflow-caller-policy-workflow-ids')).toBeVisible();
+	});
+
+	it('should fetch all workflows and render them in the error workflows dropdown', async () => {
+		settingsStore.settings.enterprise[EnterpriseEditionFeature.Sharing] = true;
+		const { getByTestId } = createComponent({ pinia });
+
+		await nextTick();
+		const dropdownItems = await getDropdownItems(getByTestId('error-workflow'));
+
+		// first is `- No Workflow -`, second is the workflow returned by
+		// `workflowsStore.fetchAllWorkflows`
+		expect(dropdownItems).toHaveLength(2);
+		expect(fetchAllWorkflowsSpy).toHaveBeenCalledTimes(1);
+		expect(fetchAllWorkflowsSpy).toHaveBeenCalledWith();
 	});
 
 	it('should not remove valid workflow ID characters', async () => {

--- a/packages/editor-ui/src/components/WorkflowSettings.test.ts
+++ b/packages/editor-ui/src/components/WorkflowSettings.test.ts
@@ -2,7 +2,8 @@ import { createPinia, setActivePinia } from 'pinia';
 import WorkflowSettingsVue from '@/components/WorkflowSettings.vue';
 
 import { setupServer } from '@/__tests__/server';
-import { afterAll, beforeAll, MockInstance } from 'vitest';
+import type { MockInstance } from 'vitest';
+import { afterAll, beforeAll } from 'vitest';
 import { within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/editor-ui/src/components/WorkflowSettings.vue
+++ b/packages/editor-ui/src/components/WorkflowSettings.vue
@@ -266,9 +266,7 @@ const loadTimezones = async () => {
 };
 
 const loadWorkflows = async () => {
-	const workflowsData = (await workflowsStore.fetchAllWorkflows(
-		workflow.value.homeProject?.id,
-	)) as IWorkflowShortResponse[];
+	const workflowsData = (await workflowsStore.fetchAllWorkflows()) as IWorkflowShortResponse[];
 	workflowsData.sort((a, b) => {
 		if (a.name.toLowerCase() < b.name.toLowerCase()) {
 			return -1;
@@ -506,7 +504,7 @@ onMounted(async () => {
 					</el-col>
 				</el-row>
 
-				<el-row>
+				<el-row data-test-id="error-workflow">
 					<el-col :span="10" class="setting-name">
 						{{ i18n.baseText('workflowSettings.errorWorkflow') + ':' }}
 						<n8n-tooltip placement="top">


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

The error worfklow dropdown is just a special case of calling a sub workflow and should render the same list the sub workflow node is rendering:

Before:
![image](https://github.com/user-attachments/assets/4324af20-4ca0-436e-85e0-bb2b9fe95dc9)


After:
![image](https://github.com/user-attachments/assets/cfffad7c-b0cb-4943-98b6-4b5f6ed7b7e0)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2073/bug-any-workflow-sub-workflow-setting-broken-by-projects


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
