### PR TITLE
fix(core): Fix task runner sending too many offers

### DIFF
--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -262,6 +262,7 @@ export abstract class TaskRunner extends EventEmitter {
 
 	offerAccepted(offerId: string, taskId: string) {
 		if (!this.hasOpenTasks()) {
+			this.openOffers.delete(offerId);
 			this.send({
 				type: 'runner:taskrejected',
 				taskId,


### PR DESCRIPTION
## Summary

- Fix task runner not respecting the max concurrency setting and sending new task offers on every tick.
- Fix task runner sending new task offers even when its shutting down

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-459/community-issue-code-node-stopped-working

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
