### PR TITLE
fix(core): Fix orchestration flow with expired license

### DIFF
--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -287,20 +287,4 @@ describe('License', () => {
 			});
 		});
 	});
-
-	describe('reinit', () => {
-		it('should reinitialize license manager', async () => {
-			const license = new License(mockLogger(), mock(), mock(), mock(), mock());
-			await license.init();
-
-			const initSpy = jest.spyOn(license, 'init');
-
-			await license.reinit();
-
-			expect(initSpy).toHaveBeenCalledWith(true);
-
-			expect(LicenseManager.prototype.reset).toHaveBeenCalled();
-			expect(LicenseManager.prototype.initialize).toHaveBeenCalled();
-		});
-	});
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -198,7 +198,7 @@ export class Start extends BaseCommand {
 		await this.initOrchestration();
 		this.logger.debug('Orchestration init complete');
 
-		await this.license.setRenewal();
+		await this.license.enableRenewal();
 
 		if (this.globalConfig.multiMainSetup.enabled) {
 			if (this.globalConfig.license.autoRenewalEnabled) await this.license.renew();
@@ -255,11 +255,11 @@ export class Start extends BaseCommand {
 
 		orchestrationService.multiMainSetup
 			.on('leader-stepdown', async () => {
-				await this.license.setRenewal(); // to disable renewal
+				await this.license.enableRenewal(); // follower so will disable
 				await this.activeWorkflowManager.removeAllTriggerAndPollerBasedWorkflows();
 			})
 			.on('leader-takeover', async () => {
-				await this.license.setRenewal(); // to enable renewal
+				await this.license.enableRenewal(); // leader so will enable
 				await this.activeWorkflowManager.addAllTriggerAndPollerBasedWorkflows();
 			});
 	}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -200,12 +200,8 @@ export class Start extends BaseCommand {
 
 		await this.license.enableRenewal();
 
-		if (this.globalConfig.multiMainSetup.enabled) {
-			if (this.globalConfig.license.autoRenewalEnabled) await this.license.renew();
-
-			if (!this.license.isMultiMainLicensed()) {
-				throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
-			}
+		if (this.globalConfig.multiMainSetup.enabled && !this.license.isMultiMainLicensed()) {
+			throw new FeatureNotLicensedError(LICENSE_FEATURES.MULTIPLE_MAIN_INSTANCES);
 		}
 
 		Container.get(WaitTracker).init();

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -40,7 +40,10 @@ export class License {
 		this.logger = this.logger.scoped('license');
 	}
 
-	/** Set whether this instance should renew the license. */
+	/**
+	 * Set whether this instance should renew the license periodically. If true,
+	 * the manager will also renew the license immediately once.
+	 */
 	async enableRenewal() {
 		if (!this.manager || this.instanceSettings.instanceType !== 'main') return;
 

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -40,8 +40,8 @@ export class License {
 		this.logger = this.logger.scoped('license');
 	}
 
-	/** Set whether this instance should renew the license - on init and periodically. */
-	async setRenewal() {
+	/** Set whether this instance should renew the license. */
+	async enableRenewal() {
 		if (!this.manager || this.instanceSettings.instanceType !== 'main') return;
 
 		const { isLeader } = this.instanceSettings;

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -49,8 +49,7 @@ export class License {
 
 		const shouldRenew = isLeader && autoRenewalConfigEnabled;
 
-		// this.manager.setRenewOnInit(shouldRenew); // @TODO: Add method to SDK
-		// this.manager.setAutoRenewal(shouldRenew); // @TODO: Add method to SDK
+		// this.manager.enableRenewal(shouldRenew); // @TODO: Add method to SDK
 
 		this.logger.debug(shouldRenew ? 'Enabled license renewal' : 'Disabled license renewal');
 


### PR DESCRIPTION
## Summary

We have a cyclical dependency where the license needs multi-main state to decide if it should renew the license, and multi-main needs license state to determine if it should allow instance startup when multi-main is enabled.

Current flow:

1. Start instance with multi-main enabled
2. Init license with `renewalEnabled` set to `false` because `instanceRole` is `unset` because `MultiMainSetup` has not been initialized yet
3. Check that multi-main is licensed, else we block startup
4. Init multi-main via orchestration, marking `instanceRole` as `leader`
5. Add listeners to multi-main, so that we reinit the license on leader takeover and stepdown. This applies from now on, i.e. not to the leader change in step 4. Reinit re-evaluates `renewalEnabled` so only the leader renews

This flow fails if the instance starts with an expired license, as we never make it past step 3.

Proposed flow:
 
1. Init license with renewal disabled
2. Init orchestration to set instance role (both single- and multi-main)
3. If on multi-main, set listeners for leadership change
4. Enable or disable renewal on the SDK based on instance role - and if enabling, renew immediately once 
5. If on multi-main, check that multi-main is licensed

```mermaid
sequenceDiagram
    participant Instance as Start (oclif)
    participant License as License Service
    participant MultiMain as Orchestration
    participant LicenseSDK as License SDK

    Instance->>License: init license
    Note over License: init with renewal disabled
    License->>LicenseSDK: init SDK
    License-->>Instance: license ready

    Instance->>MultiMain: init orchestration
    MultiMain->>MultiMain: set instance role
    MultiMain-->>Instance: orchestration ready
    Instance->>License: enable or disable renewal based on instance role
    License->>LicenseSDK: enable or disable renewal based on instance role
    LicenseSDK->>LicenseSDK: if true, renew immediately and periodically
    LicenseSDK->>LicenseSDK: if false, stop periodic renewal
    
    alt if multi-main
        Note over MultiMain: license check for multi-main on startup
    alt on leadership change event
        MultiMain-->>License: emit leader-takeover or leader-stepdown
        License->>LicenseSDK: enable or disable renewal based on instance role
        LicenseSDK->>LicenseSDK: if true, renew immediately and periodically
        LicenseSDK->>LicenseSDK: if false, stop periodic renewal
    end
    end
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2416
https://linear.app/n8n/issue/PAY-2396

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
