### PR TITLE
fix(Supabase Node): Allow for filtering on the same field multiple times

### DIFF
--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -293,8 +293,8 @@ export class Supabase implements INodeType {
 
 						if (keys.length !== 0) {
 							if (matchType === 'allFilters') {
-								const data = keys.reduce((obj, value) => buildQuery(obj, value), {});
-								Object.assign(qs, data);
+								const data = keys.map((key) => buildOrQuery(key));
+								Object.assign(qs, { and: `(${data.join(',')})` });
 							}
 							if (matchType === 'anyFilter') {
 								const data = keys.map((key) => buildOrQuery(key));

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -1,0 +1,99 @@
+import { mock } from 'jest-mock-extended';
+import { get } from 'lodash';
+import {
+	type IDataObject,
+	type IExecuteFunctions,
+	type IGetNodeParameterOptions,
+	type INodeExecutionData,
+	type IPairedItemData,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+import * as utils from '../GenericFunctions';
+import { Supabase } from '../Supabase.node';
+
+describe('Test Supabase Node', () => {
+	const node = new Supabase();
+
+	const input = [{ json: {} }];
+
+	const createMockExecuteFunction = (
+		nodeParameters: IDataObject,
+		continueOnFail: boolean = false,
+	) => {
+		const fakeExecuteFunction = {
+			getNodeParameter(
+				parameterName: string,
+				itemIndex: number,
+				fallbackValue?: IDataObject | undefined,
+				options?: IGetNodeParameterOptions | undefined,
+			) {
+				const parameter = options?.extractValue ? `${parameterName}.value` : parameterName;
+
+				const parameterValue = get(nodeParameters, parameter, fallbackValue);
+
+				if ((parameterValue as IDataObject)?.nodeOperationError) {
+					throw new NodeOperationError(mock(), 'Get Options Error', { itemIndex });
+				}
+
+				return parameterValue;
+			},
+			getNode() {
+				return node;
+			},
+			continueOnFail: () => continueOnFail,
+			getInputData: () => input,
+			helpers: {
+				constructExecutionMetaData: (
+					_inputData: INodeExecutionData[],
+					_options: { itemData: IPairedItemData | IPairedItemData[] },
+				) => [],
+				returnJsonArray: (_jsonData: IDataObject | IDataObject[]) => [],
+			},
+		} as unknown as IExecuteFunctions;
+		return fakeExecuteFunction;
+	};
+
+	it('should allow filtering on the same field multiple times', async () => {
+		const supabaseApiRequest = jest
+			.spyOn(utils, 'supabaseApiRequest')
+			.mockImplementation(async () => {
+				return [];
+			});
+
+		const fakeExecuteFunction = createMockExecuteFunction({
+			resource: 'row',
+			operation: 'getAll',
+			returnAll: true,
+			filterType: 'manual',
+			matchType: 'allFilters',
+			tableId: 'my_table',
+			filters: {
+				conditions: [
+					{
+						condition: 'gt',
+						keyName: 'created_at',
+						keyValue: '2025-01-02 08:03:43.952051+00',
+					},
+					{
+						condition: 'lt',
+						keyName: 'created_at',
+						keyValue: '2025-01-02 08:07:36.102231+00',
+					},
+				],
+			},
+		});
+
+		await node.execute.call(fakeExecuteFunction);
+
+		expect(supabaseApiRequest).toHaveBeenCalledWith(
+			'GET',
+			'/my_table',
+			{},
+			{
+				and: '(created_at.gt.2025-01-02 08:03:43.952051+00,created_at.lt.2025-01-02 08:07:36.102231+00)',
+				offset: 0,
+			},
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This PR allows filtering on the same field multiple times

Workflow for testing:
```
{
  "nodes": [
    {
      "parameters": {
        "operation": "getAll",
        "tableId": "my_table",
        "returnAll": true,
        "matchType": "allFilters",
        "filters": {
          "conditions": [
            {
              "keyName": "created_at",
              "condition": "gt",
              "keyValue": "={{ $json.greaterThan }}"
            },
            {
              "keyName": "created_at",
              "condition": "lt",
              "keyValue": "={{ $json.lessThan }}"
            }
          ]
        }
      },
      "type": "n8n-nodes-base.supabase",
      "typeVersion": 1,
      "position": [
        280,
        200
      ],
      "id": "59b409d0-4046-4612-b091-dca68d5bdefd",
      "name": "Supabase1",
      "credentials": {
        "supabaseApi": {
          "id": "f7FuHuk2EpV4d9bH",
          "name": "Supabase account"
        }
      }
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "df329893-69c7-49e4-bdba-5f44a2007e35",
              "name": "lessThan",
              "value": "2025-01-02 08:07:36.102231+00",
              "type": "string"
            },
            {
              "id": "f7080c12-08cd-41e4-9a2e-473d7bbdc775",
              "name": "greaterThan",
              "value": "2025-01-02 08:03:43.952051+00",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        40,
        200
      ],
      "id": "7acaee5c-393a-481f-8531-ab78039bbebd",
      "name": "Edit Fields"
    }
  ],
  "connections": {
    "Supabase1": {
      "main": [
        []
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Supabase1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {
    "Supabase1": [
      {
        "id": 4,
        "created_at": "2025-01-02T08:03:49.790638+00:00",
        "name": "jaja"
      },
      {
        "id": 5,
        "created_at": "2025-01-02T08:03:53.075208+00:00",
        "name": "lol"
      },
      {
        "id": 6,
        "created_at": "2025-01-02T08:07:33.870578+00:00",
        "name": "lol"
      }
    ]
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2107/community-issue-manual-filtering-bug-with-supabase

Closes https://github.com/n8n-io/n8n/issues/11998

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
