### PR TITLE
fix(editor): Fix Multi option parameter expression when the value is an array

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -365,7 +365,7 @@ const getIssues = computed<string[]>(() => {
 			if (Array.isArray(displayValue.value)) {
 				checkValues = checkValues.concat(displayValue.value);
 			} else {
-				checkValues.push(displayValue.value as string);
+				checkValues = checkValues.concat(displayValue.value?.toString().split(','));
 			}
 		}
 
@@ -857,9 +857,10 @@ async function optionSelected(command: string) {
 		) {
 			valueChanged('={{ 0 }}');
 		} else if (
-			props.parameter.type === 'number' ||
-			props.parameter.type === 'boolean' ||
-			typeof props.modelValue !== 'string'
+			props.parameter.type !== 'multiOptions' &&
+			(props.parameter.type === 'number' ||
+				props.parameter.type === 'boolean' ||
+				typeof props.modelValue !== 'string')
 		) {
 			valueChanged(`={{ ${props.modelValue} }}`);
 		} else {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -856,11 +856,12 @@ async function optionSelected(command: string) {
 			(!props.modelValue || props.modelValue === '[Object: null]')
 		) {
 			valueChanged('={{ 0 }}');
+		} else if (props.parameter.type === 'multiOptions') {
+			valueChanged(`={{ ${JSON.stringify(props.modelValue)} }}`);
 		} else if (
-			props.parameter.type !== 'multiOptions' &&
-			(props.parameter.type === 'number' ||
-				props.parameter.type === 'boolean' ||
-				typeof props.modelValue !== 'string')
+			props.parameter.type === 'number' ||
+			props.parameter.type === 'boolean' ||
+			typeof props.modelValue !== 'string'
 		) {
 			valueChanged(`={{ ${props.modelValue} }}`);
 		} else {

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -132,8 +132,11 @@ const evaluatedExpression = computed<Result<unknown, Error>>(() => {
 		}
 
 		if (props.isForCredential) opts.additionalKeys = resolvedAdditionalExpressionData.value;
-
-		return { ok: true, result: workflowHelpers.resolveExpression(value, undefined, opts, false) };
+		const stringifyExpressionResult = props.parameter.type !== 'multiOptions';
+		return {
+			ok: true,
+			result: workflowHelpers.resolveExpression(value, undefined, opts, stringifyExpressionResult),
+		};
 	} catch (error) {
 		return { ok: false, error };
 	}

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -133,7 +133,7 @@ const evaluatedExpression = computed<Result<unknown, Error>>(() => {
 
 		if (props.isForCredential) opts.additionalKeys = resolvedAdditionalExpressionData.value;
 
-		return { ok: true, result: workflowHelpers.resolveExpression(value, undefined, opts) };
+		return { ok: true, result: workflowHelpers.resolveExpression(value, undefined, opts, false) };
 	} catch (error) {
 		return { ok: false, error };
 	}


### PR DESCRIPTION
## Summary
In multi option parameters, the array is an acceptable value for expressions
This PR:
-  Fixes a regression where the expression was converted to a string causing the FE validation  to fail and reject arrays
- Fixes a bug when switching from fixed to expression, the value was surrounded by {{}} which made the expression invalid.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1535/multi-options-component-dont-show-error-when-using-array-in-expression

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
