### PR TITLE
fix(core): Only show personal credentials in the personal space

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -106,9 +106,7 @@ export class CredentialsService {
 
 			if (includeScopes) {
 				const projectRelations = await this.projectService.getProjectRelationsForUser(user);
-				credentials = credentials.map((c) =>
-					this.roleService.addScopes(c, user, projectRelations!),
-				);
+				credentials = credentials.map((c) => this.roleService.addScopes(c, user, projectRelations));
 			}
 
 			if (includeData) {
@@ -163,7 +161,7 @@ export class CredentialsService {
 
 		if (includeScopes) {
 			const projectRelations = await this.projectService.getProjectRelationsForUser(user);
-			credentials = credentials.map((c) => this.roleService.addScopes(c, user, projectRelations!));
+			credentials = credentials.map((c) => this.roleService.addScopes(c, user, projectRelations));
 		}
 
 		if (includeData) {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -20,7 +20,6 @@ import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
 import { CredentialTypes } from '@/credential-types';
 import { createCredentialsFromCredentialsEntity } from '@/credentials-helper';
 import { CredentialsEntity } from '@/databases/entities/credentials-entity';
-import type { ProjectRelation } from '@/databases/entities/project-relation';
 import { SharedCredentials } from '@/databases/entities/shared-credentials';
 import type { User } from '@/databases/entities/user';
 import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
@@ -85,23 +84,6 @@ export class CredentialsService {
 			listQueryOptions.includeData = true;
 		}
 
-		let projectRelations: ProjectRelation[] | undefined = undefined;
-		if (includeScopes) {
-			projectRelations = await this.projectService.getProjectRelationsForUser(user);
-			if (listQueryOptions.filter?.projectId && user.hasGlobalScope('credential:list')) {
-				// Only instance owners and admins have the credential:list scope
-				// Those users should be able to use _all_ credentials within their workflows.
-				// TODO: Change this so we filter by `workflowId` in this case. Require a slight FE change
-				const projectRelation = projectRelations.find(
-					(relation) => relation.projectId === listQueryOptions.filter?.projectId,
-				);
-				if (projectRelation?.role === 'project:personalOwner') {
-					// Will not affect team projects as these have admins, not owners.
-					delete listQueryOptions.filter?.projectId;
-				}
-			}
-		}
-
 		if (returnAll) {
 			let credentials = await this.credentialsRepository.findMany(listQueryOptions);
 
@@ -123,6 +105,7 @@ export class CredentialsService {
 			}
 
 			if (includeScopes) {
+				const projectRelations = await this.projectService.getProjectRelationsForUser(user);
 				credentials = credentials.map((c) =>
 					this.roleService.addScopes(c, user, projectRelations!),
 				);
@@ -179,6 +162,7 @@ export class CredentialsService {
 		}
 
 		if (includeScopes) {
+			const projectRelations = await this.projectService.getProjectRelationsForUser(user);
 			credentials = credentials.map((c) => this.roleService.addScopes(c, user, projectRelations!));
 		}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Currently if an owner or admin look at the personal space they see all credentials they have access to, not just the personal ones:

![image](https://github.com/user-attachments/assets/cfcace07-94ff-4729-8fb0-9749ea2a8bad)


The reason for that is a previous fix: https://github.com/n8n-io/n8n/pull/9396

If a user with the global `credential:list` makes the request and passes the query `includeScopes:true` the project filter would be ignored. That was done because the endpoint was also used to get the credentials that can be used in a node and the differentiating factor was the `includeScopes` parameter.

![image](https://github.com/user-attachments/assets/d9df8b8c-783e-4925-a183-7360ff540e17)

Since then we created a new API endpoint for fetching credentials that can be used in a node/worfklow and thus don't need this hack anymore: https://github.com/n8n-io/n8n/pull/9718

Now when we remove this hack we get the anticipated result:

![image](https://github.com/user-attachments/assets/a1a87e41-0797-4de4-b6e6-4b2a43930f46)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2422/credentials-in-personal-list-showing-all-credentials-i-have-access-to


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
