### PR TITLE
ci: Fix turborepo cache on CI tests

### DIFF
--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -49,7 +49,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Setup build cache
-        if: inputs.collectCoverage != true
         uses: rharkor/caching-for-turbo@v1.5
 
       - name: Build

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
 		},
 		"build": {
 			"dependsOn": ["^build"],
-			"outputs": ["dist/**"]
+			"outputs": ["dist/**", "coverage/**"]
 		},
 		"typecheck": {
 			"dependsOn": ["^typecheck"]


### PR DESCRIPTION
## Summary

Since we enabled code-coverage on PRs, we broke turborepo caching on PR CI jobs.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
