### PR TITLE
refactor(core): Add tests to `workflowPostExecute` in `TelemetryEventRelay`

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1169,7 +1169,7 @@ describe('TelemetryEventRelay', () => {
 			const runData = mock<IRun>({
 				finished: true,
 				status: 'success',
-				mode: 'trigger',
+				mode: 'manual',
 				data: { resultData: {} },
 			});
 
@@ -1189,14 +1189,14 @@ describe('TelemetryEventRelay', () => {
 					workflow_id: 'workflow123',
 					user_id: 'user123',
 					success: true,
-					is_manual: false,
-					execution_mode: 'trigger',
+					is_manual: true,
+					execution_mode: 'manual',
 				}),
 			);
 		});
 
 		it('should call telemetry.track when manual node execution finished', async () => {
-			sharedWorkflowRepository.findSharingRole.mockResolvedValue('workflow:owner');
+			sharedWorkflowRepository.findSharingRole.mockResolvedValue('workflow:editor');
 
 			const runData = {
 				status: 'error',
@@ -1270,7 +1270,7 @@ describe('TelemetryEventRelay', () => {
 					workflow_id: 'workflow123',
 					status: 'error',
 					executionStatus: 'error',
-					sharing_role: 'owner',
+					sharing_role: 'sharee',
 					error_message: 'Error message',
 					error_node_type: 'n8n-nodes-base.jira',
 					error_node_id: '1',

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1,7 +1,17 @@
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import type { IWorkflowBase } from 'n8n-workflow';
+import {
+	INode,
+	INodesGraph,
+	INodesGraphResult,
+	IRunExecutionData,
+	NodeApiError,
+	TelemetryHelpers,
+	type IRun,
+	type IWorkflowBase,
+	type WorkflowExecuteMode,
+} from 'n8n-workflow';
 
 import { N8N_VERSION } from '@/constants';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';
@@ -27,6 +37,9 @@ describe('TelemetryEventRelay', () => {
 			emails: {
 				mode: 'smtp',
 			},
+		},
+		diagnostics: {
+			enabled: true,
 		},
 		endpoints: {
 			metrics: {
@@ -1104,6 +1117,395 @@ describe('TelemetryEventRelay', () => {
 				email: 'user@example.com',
 				licenseKey: 'license123',
 			});
+		});
+	});
+
+	describe('workflow post execute events', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		const mockWorkflowBase = mock<IWorkflowBase>({
+			id: 'workflow123',
+			name: 'Test Workflow',
+			active: true,
+			nodes: [
+				{
+					id: 'node1',
+					name: 'Start',
+					type: 'n8n-nodes-base.start',
+					parameters: {},
+					typeVersion: 1,
+					position: [100, 200],
+				},
+			],
+			connections: {},
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			staticData: {},
+			settings: {},
+		});
+
+		it('should not track when workflow has no id', async () => {
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: { ...mockWorkflowBase, id: '' },
+				executionId: 'execution123',
+				userId: 'user123',
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			expect(telemetry.trackWorkflowExecution).not.toHaveBeenCalled();
+		});
+
+		it('should not track when execution status is "waiting"', async () => {
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mockWorkflowBase,
+				executionId: 'execution123',
+				userId: 'user123',
+				runData: {
+					status: 'waiting',
+					data: { resultData: {} },
+				} as IRun,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			expect(telemetry.trackWorkflowExecution).not.toHaveBeenCalled();
+		});
+
+		it('should track successful workflow execution', async () => {
+			const runData = mock<IRun>({
+				finished: true,
+				status: 'success',
+				mode: 'trigger',
+				data: { resultData: {} },
+			});
+
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mockWorkflowBase,
+				executionId: 'execution123',
+				userId: 'user123',
+				runData: runData as unknown as IRun,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			await flushPromises();
+
+			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflow_id: 'workflow123',
+					user_id: 'user123',
+					success: true,
+					is_manual: false,
+					execution_mode: 'trigger',
+				}),
+			);
+		});
+
+		it('should call telemetry.track when manual node execution finished', async () => {
+			sharedWorkflowRepository.findSharingRole.mockResolvedValue('workflow:owner');
+
+			const runData = {
+				status: 'error',
+				mode: 'manual',
+				data: {
+					startData: {
+						destinationNode: 'OpenAI',
+						runNodeFilter: ['OpenAI'],
+					},
+					resultData: {
+						runData: {},
+						lastNodeExecuted: 'OpenAI',
+						error: new NodeApiError(
+							{
+								id: '1',
+								typeVersion: 1,
+								name: 'Jira',
+								type: 'n8n-nodes-base.jira',
+								parameters: {},
+								position: [100, 200],
+							},
+							{
+								message: 'Error message',
+								description: 'Incorrect API key provided',
+								httpCode: '401',
+								stack: '',
+							},
+							{
+								message: 'Error message',
+								description: 'Error description',
+								level: 'warning',
+								functionality: 'regular',
+							},
+						),
+					},
+				},
+			} as IRun;
+
+			const nodeGraph: INodesGraphResult = {
+				nodeGraph: { node_types: [], node_connections: [], webhookNodeNames: [] },
+				nameIndices: {
+					Jira: '1',
+					OpenAI: '1',
+				},
+			} as unknown as INodesGraphResult;
+
+			jest.spyOn(TelemetryHelpers, 'generateNodesGraph').mockImplementation(() => nodeGraph);
+
+			jest
+				.spyOn(TelemetryHelpers, 'getNodeTypeForName')
+				.mockImplementation(
+					() => ({ type: 'n8n-nodes-base.jira', version: 1, name: 'Jira' }) as unknown as INode,
+				);
+
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mockWorkflowBase,
+				executionId: 'execution123',
+				userId: 'user123',
+				runData,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'Manual node exec finished',
+				expect.objectContaining({
+					webhook_domain: null,
+					user_id: 'user123',
+					workflow_id: 'workflow123',
+					status: 'error',
+					executionStatus: 'error',
+					sharing_role: 'owner',
+					error_message: 'Error message',
+					error_node_type: 'n8n-nodes-base.jira',
+					error_node_id: '1',
+					node_id: '1',
+					node_type: 'n8n-nodes-base.jira',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+				}),
+			);
+
+			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflow_id: 'workflow123',
+					success: false,
+					is_manual: true,
+					execution_mode: 'manual',
+					version_cli: N8N_VERSION,
+					error_message: 'Error message',
+					error_node_type: 'n8n-nodes-base.jira',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+					error_node_id: '1',
+				}),
+			);
+		});
+
+		it('should call telemetry.track when manual node execution finished with canceled error message', async () => {
+			sharedWorkflowRepository.findSharingRole.mockResolvedValue('workflow:owner');
+
+			const runData = {
+				status: 'error',
+				mode: 'manual',
+				data: {
+					startData: {
+						destinationNode: 'OpenAI',
+						runNodeFilter: ['OpenAI'],
+					},
+					resultData: {
+						runData: {},
+						lastNodeExecuted: 'OpenAI',
+						error: new NodeApiError(
+							{
+								id: '1',
+								typeVersion: 1,
+								name: 'Jira',
+								type: 'n8n-nodes-base.jira',
+								parameters: {},
+								position: [100, 200],
+							},
+							{
+								message: 'Error message',
+								description: 'Incorrect API key provided',
+								httpCode: '401',
+								stack: '',
+							},
+							{
+								message: 'Error message canceled',
+								description: 'Error description',
+								level: 'warning',
+								functionality: 'regular',
+							},
+						),
+					},
+				},
+			} as IRun;
+
+			const nodeGraph: INodesGraphResult = {
+				nodeGraph: { node_types: [], node_connections: [] },
+				nameIndices: {
+					Jira: '1',
+					OpenAI: '1',
+				},
+			} as unknown as INodesGraphResult;
+
+			jest.spyOn(TelemetryHelpers, 'generateNodesGraph').mockImplementation(() => nodeGraph);
+
+			jest
+				.spyOn(TelemetryHelpers, 'getNodeTypeForName')
+				.mockImplementation(
+					() => ({ type: 'n8n-nodes-base.jira', version: 1, name: 'Jira' }) as unknown as INode,
+				);
+
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mockWorkflowBase,
+				executionId: 'execution123',
+				userId: 'user123',
+				runData,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'Manual node exec finished',
+				expect.objectContaining({
+					webhook_domain: null,
+					user_id: 'user123',
+					workflow_id: 'workflow123',
+					status: 'canceled',
+					executionStatus: 'canceled',
+					sharing_role: 'owner',
+					error_message: 'Error message canceled',
+					error_node_type: 'n8n-nodes-base.jira',
+					error_node_id: '1',
+					node_id: '1',
+					node_type: 'n8n-nodes-base.jira',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+				}),
+			);
+
+			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflow_id: 'workflow123',
+					success: false,
+					is_manual: true,
+					execution_mode: 'manual',
+					version_cli: N8N_VERSION,
+					error_message: 'Error message canceled',
+					error_node_type: 'n8n-nodes-base.jira',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+					error_node_id: '1',
+				}),
+			);
+		});
+
+		it('should call telemetry.track when manual workflow execution finished', async () => {
+			sharedWorkflowRepository.findSharingRole.mockResolvedValue('workflow:owner');
+
+			const runData = {
+				status: 'error',
+				mode: 'manual',
+				data: {
+					startData: {
+						runNodeFilter: ['OpenAI'],
+					},
+					resultData: {
+						runData: {
+							Jira: [
+								{
+									data: { main: [[{ json: { headers: { origin: 'https://www.test.com' } } }]] },
+								},
+							],
+						},
+						lastNodeExecuted: 'OpenAI',
+						error: new NodeApiError(
+							{
+								id: '1',
+								typeVersion: 1,
+								name: 'Jira',
+								type: 'n8n-nodes-base.jira',
+								parameters: {},
+								position: [100, 200],
+							},
+							{
+								message: 'Error message',
+								description: 'Incorrect API key provided',
+								httpCode: '401',
+								stack: '',
+							},
+							{
+								message: 'Error message',
+								description: 'Error description',
+								level: 'warning',
+								functionality: 'regular',
+							},
+						),
+					},
+				},
+			} as unknown as IRun;
+
+			const nodeGraph: INodesGraphResult = {
+				webhookNodeNames: ['Jira'],
+				nodeGraph: { node_types: [], node_connections: [] },
+				nameIndices: {
+					Jira: '1',
+					OpenAI: '1',
+				},
+			} as unknown as INodesGraphResult;
+
+			jest.spyOn(TelemetryHelpers, 'generateNodesGraph').mockImplementation(() => nodeGraph);
+
+			jest
+				.spyOn(TelemetryHelpers, 'getNodeTypeForName')
+				.mockImplementation(
+					() => ({ type: 'n8n-nodes-base.jira', version: 1, name: 'Jira' }) as unknown as INode,
+				);
+
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mockWorkflowBase,
+				executionId: 'execution123',
+				userId: 'user123',
+				runData,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'Manual workflow exec finished',
+				expect.objectContaining({
+					webhook_domain: 'test.com',
+					user_id: 'user123',
+					workflow_id: 'workflow123',
+					status: 'error',
+					executionStatus: 'error',
+					sharing_role: 'owner',
+					error_message: 'Error message',
+					error_node_type: 'n8n-nodes-base.jira',
+					error_node_id: '1',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+				}),
+			);
+
+			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflow_id: 'workflow123',
+					success: false,
+					is_manual: true,
+					execution_mode: 'manual',
+					version_cli: N8N_VERSION,
+					error_message: 'Error message',
+					error_node_type: 'n8n-nodes-base.jira',
+					node_graph_string: JSON.stringify(nodeGraph.nodeGraph),
+					error_node_id: '1',
+				}),
+			);
 		});
 	});
 });

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1,17 +1,8 @@
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import {
-	INode,
-	INodesGraph,
-	INodesGraphResult,
-	IRunExecutionData,
-	NodeApiError,
-	TelemetryHelpers,
-	type IRun,
-	type IWorkflowBase,
-	type WorkflowExecuteMode,
-} from 'n8n-workflow';
+import type { INode, INodesGraphResult } from 'n8n-workflow';
+import { NodeApiError, TelemetryHelpers, type IRun, type IWorkflowBase } from 'n8n-workflow';
 
 import { N8N_VERSION } from '@/constants';
 import type { WorkflowEntity } from '@/databases/entities/workflow-entity';


### PR DESCRIPTION
## Summary

Prep work to be able to add new logic to the `workflowPostExecute ` method in the `TelemetryEventRelay` class. As part of the free AI credits feature, we need this to be able to add two new properties to the telemetry event once a manual node execution finish. See requirement [here](https://www.notion.so/Implementation-Handoff-1225b6e0c94f81f18b1adbcf063a9adb?d=15a5b6e0c94f80d7b281001c452fdfb1&pvs=4#15a5b6e0c94f804998cdcea17e495ab5).

See coverage here -> https://app.codecov.io/gh/n8n-io/n8n/pull/12437/blob/packages/cli/src/events/relays/telemetry.event-relay.ts#L592


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3050/add-telemetry-events

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
