### PR TITLE
ci: Fix code coverage collection

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -47,6 +47,7 @@ jobs:
       nodeVersion: ${{ matrix.node-version }}
       cacheKey: ${{ github.sha }}-base:build
       collectCoverage: ${{ matrix.node-version == '20.x' }}
+      ignoreTurboCache: ${{ matrix.node-version == '20.x' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -22,6 +22,10 @@ on:
         required: false
         default: false
         type: boolean
+      ignoreTurboCache:
+        required: false
+        default: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov upload token.'
@@ -32,6 +36,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     env:
+      TURBO_FORCE: ${{ inputs.ignoreTurboCache }}
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
     steps:
       - uses: actions/checkout@v4.1.1
@@ -73,6 +78,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: inputs.collectCoverage
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,58 @@
+codecov:
+  max_report_age: off
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        threshold: 0.5%
+
+github_checks:
+  annotations: false
+
+flags:
+  tests:
+    paths:
+      - "**"
+    carryforward: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        branches:
+          - "!master"
+  individual_components:
+    - component_id: backend_packages
+      name: Backend
+      paths:
+        - packages/@n8n/api-types/**
+        - packages/@n8n/config/**
+        - packages/@n8n/client-oauth2/**
+        - packages/@n8n/imap/**
+        - packages/@n8n/permissions/**
+        - packages/@n8n/task-runner/**
+        - packages/n8n-workflow/**
+        - packages/n8n-core/**
+        - packages/n8n-node-dev/**
+        - packages/n8n/**
+    - component_id: frontend_packages
+      name: Frontend
+      paths:
+        - packages/@n8n/chat/**
+        - packages/@n8n/codemirror-lang/**
+        - packages/n8n-design-system/**
+        - packages/n8n-editor-ui/**
+    - component_id: nodes_packages
+      name: Nodes
+      paths:
+        - packages/n8n-nodes-base/**
+        - packages/@n8n/n8n-nodes-langchain/**
+
+ignore:
+  - (?s:.*/[^\/]*\.spec\.ts.*)\Z
+  - (?s:.*/[^\/]*\.test\.ts.*)\Z
+  - (?s:.*/[^\/]*e2e[^\/]*\.ts.*)\Z

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
 		},
 		"build": {
 			"dependsOn": ["^build"],
-			"outputs": ["dist/**", "coverage/**"]
+			"outputs": ["dist/**"]
 		},
 		"typecheck": {
 			"dependsOn": ["^typecheck"]
@@ -64,7 +64,8 @@
 				"n8n-workflow#test",
 				"n8n-core#test",
 				"n8n#test"
-			]
+			],
+			"outputs": ["coverage/**"]
 		},
 		"test:frontend": {
 			"dependsOn": [
@@ -72,10 +73,12 @@
 				"@n8n/codemirror-lang#test",
 				"n8n-design-system#test",
 				"n8n-editor-ui#test"
-			]
+			],
+			"outputs": ["coverage/**"]
 		},
 		"test:nodes": {
-			"dependsOn": ["n8n-nodes-base#test", "@n8n/n8n-nodes-langchain#test"]
+			"dependsOn": ["n8n-nodes-base#test", "@n8n/n8n-nodes-langchain#test"],
+			"outputs": ["coverage/**"]
 		},
 		"test": {},
 		"watch": {


### PR DESCRIPTION
## Summary

#12434 Broke code-coverage collection on `master`.

This PR
1. Changes tests on master to run the full suite
2. Sets up `codecov.yml` so that we can maintain this file in this repo instead of in the codecov UI
3. [Enables `carryforward` flag](https://docs.codecov.com/docs/carryforward-flags) to allow uploading partial code-coverage

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
