### PR TITLE
fix(core): Return unredacted credentials from `GET credentials/:id`

### DIFF
--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -87,7 +87,7 @@ export class EnterpriseCredentialsService {
 		if (credential) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.credentialsService.decrypt(credential);
+			decryptedData = this.credentialsService.decrypt(credential, true);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -542,7 +542,7 @@ export class CredentialsService {
 		if (sharing) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.decrypt(sharing.credentials);
+			decryptedData = this.decrypt(sharing.credentials, true);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -2,6 +2,7 @@ import { In } from '@n8n/typeorm';
 import { Container } from 'typedi';
 
 import config from '@/config';
+import { CredentialsService } from '@/credentials/credentials.service';
 import type { Project } from '@/databases/entities/project';
 import type { ProjectRole } from '@/databases/entities/project-relation';
 import type { User } from '@/databases/entities/user';
@@ -553,6 +554,22 @@ describe('GET /credentials/:id', () => {
 		const { data: secondCredential } = secondResponse.body;
 		validateMainCredentialData(secondCredential);
 		expect(secondCredential.data).toBeDefined();
+	});
+
+	test('should not redact the data when `includeData:true` is passed', async () => {
+		const credentialService = Container.get(CredentialsService);
+		const redactSpy = jest.spyOn(credentialService, 'redact');
+		const savedCredential = await saveCredential(randomCredentialPayload(), {
+			user: owner,
+		});
+
+		const response = await authOwnerAgent
+			.get(`/credentials/${savedCredential.id}`)
+			.query({ includeData: true });
+
+		validateMainCredentialData(response.body.data);
+		expect(response.body.data.data).toBeDefined();
+		expect(redactSpy).not.toHaveBeenCalled();
 	});
 
 	test('should retrieve non-owned cred for owner', async () => {

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -4,6 +4,7 @@ import { Credentials } from 'n8n-core';
 import { randomString } from 'n8n-workflow';
 import { Container } from 'typedi';
 
+import { CredentialsService } from '@/credentials/credentials.service';
 import type { Project } from '@/databases/entities/project';
 import type { User } from '@/databases/entities/user';
 import { CredentialsRepository } from '@/databases/repositories/credentials.repository';
@@ -1270,6 +1271,23 @@ describe('GET /credentials/:id', () => {
 
 		validateMainCredentialData(secondResponse.body.data);
 		expect(secondResponse.body.data.data).toBeDefined();
+	});
+
+	test('should not redact the data when `includeData:true` is passed', async () => {
+		const credentialService = Container.get(CredentialsService);
+		const redactSpy = jest.spyOn(credentialService, 'redact');
+		const savedCredential = await saveCredential(randomCredentialPayload(), {
+			user: owner,
+			role: 'credential:owner',
+		});
+
+		const response = await authOwnerAgent
+			.get(`/credentials/${savedCredential.id}`)
+			.query({ includeData: true });
+
+		validateMainCredentialData(response.body.data);
+		expect(response.body.data.data).toBeDefined();
+		expect(redactSpy).not.toHaveBeenCalled();
 	});
 
 	test('should retrieve owned cred for member', async () => {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Don't redact secrets in credentials for `GET /credentials/:id`. The FE will send back all of the data on `PATCH /credentials/:id`, so if we redact on GET we end up saving the redacted value to the DB on PATCH.

Long term fix should be to identify the redacted values and don't updated them in the db. E.g. only update passwords if the user inserted a new one. In general secrets should not be send back to the FE at all to prevent accidentally leaking them. But that's goal for another PR.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2424/not-possible-to-reconnect-google-credentials


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
