### PR TITLE
fix(editor): Render empty string instead of [empty]

### DIFF
--- a/packages/editor-ui/src/composables/useExpressionEditor.test.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.test.ts
@@ -132,6 +132,109 @@ describe('useExpressionEditor', () => {
 		});
 	});
 
+	test('render [empty] when expression evaluates to an empty string', async () => {
+		mockResolveExpression().mockReturnValueOnce('');
+
+		const {
+			expressionEditor: { segments },
+		} = await renderExpressionEditor({
+			editorValue: "{{ '' }}",
+			extensions: [n8nLang()],
+		});
+
+		await waitFor(() => {
+			expect(toValue(segments.all)).toEqual([
+				{
+					error: null,
+					from: 0,
+					kind: 'resolvable',
+					resolvable: "{{ '' }}",
+					resolved: '[empty]',
+					state: 'valid',
+					to: 8,
+				},
+			]);
+
+			expect(toValue(segments.resolvable)).toEqual([
+				{
+					error: null,
+					from: 0,
+					kind: 'resolvable',
+					resolvable: "{{ '' }}",
+					resolved: '[empty]',
+					state: 'valid',
+					to: 8,
+				},
+			]);
+
+			expect(toValue(segments.plaintext)).toEqual([]);
+		});
+	});
+
+	test('does not render [empty] when expression evaluates to an empty string within a string', async () => {
+		mockResolveExpression().mockReturnValueOnce('');
+
+		const {
+			expressionEditor: { segments },
+		} = await renderExpressionEditor({
+			editorValue: "before {{ '' }} after",
+			extensions: [n8nLang()],
+		});
+
+		await waitFor(() => {
+			expect(toValue(segments.all)).toEqual([
+				{
+					from: 0,
+					kind: 'plaintext',
+					plaintext: 'before ',
+					to: 7,
+				},
+				{
+					error: null,
+					from: 7,
+					kind: 'resolvable',
+					resolvable: "{{ '' }}",
+					resolved: '',
+					state: 'valid',
+					to: 15,
+				},
+				{
+					from: 15,
+					kind: 'plaintext',
+					plaintext: ' after',
+					to: 21,
+				},
+			]);
+
+			expect(toValue(segments.resolvable)).toEqual([
+				{
+					error: null,
+					from: 7,
+					kind: 'resolvable',
+					resolvable: "{{ '' }}",
+					resolved: '',
+					state: 'valid',
+					to: 15,
+				},
+			]);
+
+			expect(toValue(segments.plaintext)).toEqual([
+				{
+					from: 0,
+					kind: 'plaintext',
+					plaintext: 'before ',
+					to: 7,
+				},
+				{
+					from: 15,
+					kind: 'plaintext',
+					plaintext: ' after',
+					to: 21,
+				},
+			]);
+		});
+	});
+
 	describe('readEditorValue()', () => {
 		test('should return the full editor value (unresolved)', async () => {
 			mockResolveExpression().mockReturnValueOnce(15);

--- a/packages/editor-ui/src/composables/useExpressionEditor.ts
+++ b/packages/editor-ui/src/composables/useExpressionEditor.ts
@@ -22,11 +22,7 @@ import { useWorkflowHelpers } from '@/composables/useWorkflowHelpers';
 import { highlighter } from '@/plugins/codemirror/resolvableHighlighter';
 import { closeCursorInfoBox } from '@/plugins/codemirror/tooltips/InfoBoxTooltip';
 import type { Html, Plaintext, RawSegment, Resolvable, Segment } from '@/types/expressions';
-import {
-	getExpressionErrorMessage,
-	getResolvableState,
-	isEmptyExpression,
-} from '@/utils/expressions';
+import { getExpressionErrorMessage, getResolvableState } from '@/utils/expressions';
 import { closeCompletion, completionStatus } from '@codemirror/autocomplete';
 import {
 	Compartment,
@@ -129,6 +125,12 @@ export const useExpressionEditor = ({
 
 			return acc;
 		}, []);
+		if (
+			segments.value.length === 1 &&
+			segments.value[0]?.kind === 'resolvable' &&
+			segments.value[0]?.resolved === ''
+		)
+			segments.value[0].resolved = i18n.baseText('expressionModalInput.empty');
 	};
 
 	function readEditorValue(): string {
@@ -312,14 +314,6 @@ export const useExpressionEditor = ({
 			result.resolved = `[${getExpressionErrorMessage(error, hasRunData)}]`;
 			result.error = true;
 			result.fullError = error;
-		}
-
-		if (result.resolved === '') {
-			result.resolved = i18n.baseText('expressionModalInput.empty');
-		}
-
-		if (result.resolved === undefined && isEmptyExpression(resolvable)) {
-			result.resolved = i18n.baseText('expressionModalInput.empty');
 		}
 
 		if (result.resolved === undefined) {


### PR DESCRIPTION
## Summary
This PR changes the expression editor so it renders nothing for empty string '' instead of [empty] when the resolved value is part of a non empty expression

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1732/sql-editor-empty-values-rendered-in-output-as-[empty]-rather-than

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
