### PR TITLE
fix(Postgres Node): Allow passing in arrays to JSON columns for insert

### DIFF
--- a/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/operations.test.ts
@@ -6,6 +6,7 @@ import type {
 	INode,
 	INodeParameters,
 } from 'n8n-workflow';
+import pgPromise from 'pg-promise';
 
 import * as deleteTable from '../../v2/actions/database/deleteTable.operation';
 import * as executeQuery from '../../v2/actions/database/executeQuery.operation';
@@ -506,6 +507,7 @@ describe('Test PostgresV2, insert operation', () => {
 			items,
 			nodeOptions,
 			createMockDb(columnsInfo),
+			pgPromise(),
 		);
 
 		expect(runQueries).toHaveBeenCalledWith(
@@ -579,6 +581,7 @@ describe('Test PostgresV2, insert operation', () => {
 			inputItems,
 			nodeOptions,
 			createMockDb(columnsInfo),
+			pgPromise(),
 		);
 
 		expect(runQueries).toHaveBeenCalledWith(
@@ -599,6 +602,96 @@ describe('Test PostgresV2, insert operation', () => {
 			inputItems,
 			nodeOptions,
 		);
+	});
+
+	it('dataMode: define, should accept an array with values if column is of type json', async () => {
+		const convertValuesToJsonWithPgpSpy = jest.spyOn(utils, 'convertValuesToJsonWithPgp');
+		const hasJsonDataTypeInSchemaSpy = jest.spyOn(utils, 'hasJsonDataTypeInSchema');
+
+		const values = [
+			{ value: { id: 1, json: [], foo: 'data 1' }, expected: { id: 1, json: '[]', foo: 'data 1' } },
+			{
+				value: {
+					id: 2,
+					json: [0, 1],
+					foo: 'data 2',
+				},
+				expected: {
+					id: 2,
+					json: '[0,1]',
+					foo: 'data 2',
+				},
+			},
+			{
+				value: {
+					id: 2,
+					json: [0],
+					foo: 'data 2',
+				},
+				expected: {
+					id: 2,
+					json: '[0]',
+					foo: 'data 2',
+				},
+			},
+		];
+
+		values.forEach(async (value) => {
+			const valuePassedIn = value.value;
+			const nodeParameters: IDataObject = {
+				schema: {
+					__rl: true,
+					mode: 'list',
+					value: 'public',
+				},
+				table: {
+					__rl: true,
+					value: 'my_table',
+					mode: 'list',
+				},
+				columns: {
+					mappingMode: 'defineBelow',
+					value: valuePassedIn,
+				},
+				options: { nodeVersion: 2.5 },
+			};
+			const columnsInfo: ColumnInfo[] = [
+				{ column_name: 'id', data_type: 'integer', is_nullable: 'NO', udt_name: '' },
+				{ column_name: 'json', data_type: 'json', is_nullable: 'NO', udt_name: '' },
+				{ column_name: 'foo', data_type: 'text', is_nullable: 'NO', udt_name: '' },
+			];
+
+			const inputItems = [
+				{
+					json: valuePassedIn,
+				},
+			];
+
+			const nodeOptions = nodeParameters.options as IDataObject;
+			const pg = pgPromise();
+
+			await insert.execute.call(
+				createMockExecuteFunction(nodeParameters),
+				runQueries,
+				inputItems,
+				nodeOptions,
+				createMockDb(columnsInfo),
+				pg,
+			);
+
+			expect(runQueries).toHaveBeenCalledWith(
+				[
+					{
+						query: 'INSERT INTO $1:name.$2:name($3:name) VALUES($3:csv) RETURNING *',
+						values: ['public', 'my_table', value.expected],
+					},
+				],
+				inputItems,
+				nodeOptions,
+			);
+			expect(convertValuesToJsonWithPgpSpy).toHaveBeenCalledWith(pg, columnsInfo, valuePassedIn);
+			expect(hasJsonDataTypeInSchemaSpy).toHaveBeenCalledWith(columnsInfo);
+		});
 	});
 });
 

--- a/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/v2/utils.test.ts
@@ -1,5 +1,6 @@
 import type { IDataObject, INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
+import pgPromise from 'pg-promise';
 
 import type { ColumnInfo } from '../../v2/helpers/interfaces';
 import {
@@ -14,6 +15,8 @@ import {
 	wrapData,
 	convertArraysToPostgresFormat,
 	isJSON,
+	convertValuesToJsonWithPgp,
+	hasJsonDataTypeInSchema,
 } from '../../v2/helpers/utils';
 
 const node: INode = {
@@ -384,6 +387,57 @@ describe('Test PostgresV2, checkItemAgainstSchema', () => {
 		} catch (error) {
 			expect(error.message).toEqual("Column 'foo' is not nullable");
 		}
+	});
+});
+
+describe('Test PostgresV2, hasJsonDataType', () => {
+	it('returns true if there are columns which are of type json', () => {
+		const schema: ColumnInfo[] = [
+			{ column_name: 'data', data_type: 'json', is_nullable: 'YES' },
+			{ column_name: 'id', data_type: 'integer', is_nullable: 'NO' },
+		];
+
+		expect(hasJsonDataTypeInSchema(schema)).toEqual(true);
+	});
+
+	it('returns false if there are columns which are of type json', () => {
+		const schema: ColumnInfo[] = [{ column_name: 'id', data_type: 'integer', is_nullable: 'NO' }];
+
+		expect(hasJsonDataTypeInSchema(schema)).toEqual(false);
+	});
+});
+
+describe('Test PostgresV2, convertValuesToJsonWithPgp', () => {
+	it('should use pgp to properly convert values to JSON', () => {
+		const pgp = pgPromise();
+		const pgpJsonSpy = jest.spyOn(pgp.as, 'json');
+
+		const schema: ColumnInfo[] = [
+			{ column_name: 'data', data_type: 'json', is_nullable: 'YES' },
+			{ column_name: 'id', data_type: 'integer', is_nullable: 'NO' },
+		];
+		const values = [
+			{
+				value: { data: [], id: 1 },
+				expected: { data: '[]', id: 1 },
+			},
+			{
+				value: { data: [0], id: 1 },
+				expected: { data: '[0]', id: 1 },
+			},
+			{
+				value: { data: { key: 2 }, id: 1 },
+				expected: { data: '{"key":2}', id: 1 },
+			},
+		];
+
+		values.forEach((value) => {
+			const data = value.value.data;
+
+			expect(convertValuesToJsonWithPgp(pgp, schema, value.value)).toEqual(value.expected);
+			expect(value.value).toEqual(value.expected);
+			expect(pgpJsonSpy).toHaveBeenCalledWith(data, true);
+		});
 	});
 });
 

--- a/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/router.ts
@@ -43,6 +43,7 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 				items,
 				options,
 				db,
+				pgp,
 			);
 			break;
 		default:

--- a/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/helpers/utils.ts
@@ -394,6 +394,24 @@ export function prepareItem(values: IDataObject[]) {
 	return item;
 }
 
+export function hasJsonDataTypeInSchema(schema: ColumnInfo[]) {
+	return schema.some(({ data_type }) => data_type === 'json');
+}
+
+export function convertValuesToJsonWithPgp(
+	pgp: PgpClient,
+	schema: ColumnInfo[],
+	values: IDataObject,
+) {
+	schema
+		.filter(({ data_type }: { data_type: string }) => data_type === 'json')
+		.forEach(({ column_name }) => {
+			values[column_name] = pgp.as.json(values[column_name], true);
+		});
+
+	return values;
+}
+
 export async function columnFeatureSupport(
 	db: PgpDatabase,
 ): Promise<{ identity_generation: boolean; is_generated: boolean }> {


### PR DESCRIPTION
## Summary

An array is technically JSON. Postgres allows for this and we should
enable this for the insert node.

Workflow for testing:
```
{
  "nodes": [
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "d61ec233-ee6a-4580-9ba2-154546806f72",
              "name": "=obj",
              "value": "={{ [\n{data: [], name: 'mac',},\n{data: { age: 3 }, name: 'greg',},\n{data: [0,1], name: 'pat',},\n{data: [0], name: 'mig',}\n] }}",
              "type": "array"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        -20,
        200
      ],
      "id": "79367664-8958-463c-9b43-65858b5218d1",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "schema": {
          "__rl": true,
          "mode": "list",
          "value": "public"
        },
        "table": {
          "__rl": true,
          "value": "array_json_table",
          "mode": "list",
          "cachedResultName": "array_json_table"
        },
        "columns": {
          "mappingMode": "defineBelow",
          "value": {
            "data": "={{ $json.obj[2].data }}",
            "name": "={{ $json.obj[0].name}}"
          },
          "matchingColumns": [
            "id"
          ],
          "schema": [
            {
              "id": "id",
              "displayName": "id",
              "required": false,
              "defaultMatch": true,
              "display": true,
              "type": "number",
              "canBeUsedToMatch": true,
              "removed": true
            },
            {
              "id": "name",
              "displayName": "name",
              "required": false,
              "defaultMatch": false,
              "display": true,
              "type": "string",
              "canBeUsedToMatch": true,
              "removed": false
            },
            {
              "id": "data",
              "displayName": "data",
              "required": true,
              "defaultMatch": false,
              "display": true,
              "type": "object",
              "canBeUsedToMatch": true
            }
          ],
          "ignoreTypeMismatchErrors": false,
          "attemptToConvertTypes": false,
          "convertFieldsToString": false
        },
        "options": {}
      },
      "type": "n8n-nodes-base.postgres",
      "typeVersion": 2.5,
      "position": [
        240,
        200
      ],
      "id": "dc57fff2-cf66-495c-9270-97f2b208b11b",
      "name": "Postgres",
      "credentials": {
        "postgres": {
          "id": "UeO14x83grJWzgYI",
          "name": "dgl neon"
        }
      }
    }
  ],
  "connections": {
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Postgres",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {}
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1705/postgres-node-cant-insert-an-array-into-json-column-in-postgres

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
