### PR TITLE
feat: Add load options to new tool mode for vector stores

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/__snapshots__/createVectorStoreNode.test.ts.snap
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/__snapshots__/createVectorStoreNode.test.ts.snap
@@ -1,0 +1,234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createVectorStoreNode retrieve mode supplies vector store as data 1`] = `
+{
+  "codex": {
+    "categories": [
+      "AI",
+    ],
+    "resources": {
+      "primaryDocumentation": [
+        {
+          "url": undefined,
+        },
+      ],
+    },
+    "subcategories": {
+      "AI": [
+        "Vector Stores",
+        "Tools",
+        "Root Nodes",
+      ],
+      "Tools": [
+        "Other Tools",
+      ],
+    },
+  },
+  "credentials": undefined,
+  "defaults": {
+    "name": undefined,
+  },
+  "description": undefined,
+  "displayName": undefined,
+  "group": [
+    "transform",
+  ],
+  "icon": undefined,
+  "iconColor": undefined,
+  "inputs": "={{
+			((parameters) => {
+				const mode = parameters?.mode;
+				const inputs = [{ displayName: "Embedding", type: "ai_embedding", required: true, maxConnections: 1}]
+
+				if (mode === 'retrieve-as-tool') {
+					return inputs;
+				}
+
+				if (['insert', 'load', 'update'].includes(mode)) {
+					inputs.push({ displayName: "", type: "main"})
+				}
+
+				if (['insert'].includes(mode)) {
+					inputs.push({ displayName: "Document", type: "ai_document", required: true, maxConnections: 1})
+				}
+				return inputs
+			})($parameter)
+		}}",
+  "name": "mockConstructor",
+  "outputs": "={{
+			((parameters) => {
+				const mode = parameters?.mode ?? 'retrieve';
+
+				if (mode === 'retrieve-as-tool') {
+					return [{ displayName: "Tool", type: "ai_tool"}]
+				}
+
+				if (mode === 'retrieve') {
+					return [{ displayName: "Vector Store", type: "ai_vectorStore"}]
+				}
+				return [{ displayName: "", type: "main"}]
+			})($parameter)
+		}}",
+  "properties": [
+    {
+      "default": "retrieve",
+      "displayName": "Operation Mode",
+      "name": "mode",
+      "noDataExpression": true,
+      "options": [
+        {
+          "action": "Get ranked documents from vector store",
+          "description": "Get many ranked documents from vector store for query",
+          "name": "Get Many",
+          "value": "load",
+        },
+        {
+          "action": "Add documents to vector store",
+          "description": "Insert documents into vector store",
+          "name": "Insert Documents",
+          "value": "insert",
+        },
+        {
+          "action": "Retrieve documents for AI processing as Vector Store",
+          "description": "Retrieve documents from vector store to be used as vector store with AI nodes",
+          "name": "Retrieve Documents (As Vector Store for AI Agent)",
+          "outputConnectionType": "ai_vectorStore",
+          "value": "retrieve",
+        },
+        {
+          "action": "Retrieve documents for AI processing as Tool",
+          "description": "Retrieve documents from vector store to be used as tool with AI nodes",
+          "name": "Retrieve Documents (As Tool for AI Agent)",
+          "outputConnectionType": "ai_tool",
+          "value": "retrieve-as-tool",
+        },
+      ],
+      "type": "options",
+    },
+    {
+      "default": "",
+      "displayName": "This node must be connected to a vector store retriever. <a data-action='openSelectiveNodeCreator' data-action-parameter-connectiontype='ai_retriever'>Insert one</a>",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "retrieve",
+          ],
+        },
+      },
+      "name": "notice",
+      "type": "notice",
+      "typeOptions": {
+        "containerClass": "ndv-connection-hint-notice",
+      },
+    },
+    {
+      "default": "",
+      "description": "Name of the vector store",
+      "displayName": "Name",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "retrieve-as-tool",
+          ],
+        },
+      },
+      "name": "toolName",
+      "placeholder": "e.g. company_knowledge_base",
+      "required": true,
+      "type": "string",
+      "validateType": "string-alphanumeric",
+    },
+    {
+      "default": "",
+      "description": "Explain to the LLM what this tool does, a good, specific description would allow LLMs to produce expected results much more often",
+      "displayName": "Description",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "retrieve-as-tool",
+          ],
+        },
+      },
+      "name": "toolDescription",
+      "placeholder": "e.g. undefined",
+      "required": true,
+      "type": "string",
+      "typeOptions": {
+        "rows": 2,
+      },
+    },
+    {
+      "default": "",
+      "description": "Search prompt to retrieve matching documents from the vector store using similarity-based ranking",
+      "displayName": "Prompt",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "load",
+          ],
+        },
+      },
+      "name": "prompt",
+      "required": true,
+      "type": "string",
+    },
+    {
+      "default": 4,
+      "description": "Number of top results to fetch from vector store",
+      "displayName": "Limit",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "load",
+            "retrieve-as-tool",
+          ],
+        },
+      },
+      "name": "topK",
+      "type": "number",
+    },
+    {
+      "default": true,
+      "description": "Whether or not to include document metadata",
+      "displayName": "Include Metadata",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "load",
+            "retrieve-as-tool",
+          ],
+        },
+      },
+      "name": "includeDocumentMetadata",
+      "type": "boolean",
+    },
+    {
+      "default": "",
+      "description": "ID of an embedding entry",
+      "displayName": "ID",
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "update",
+          ],
+        },
+      },
+      "name": "id",
+      "required": true,
+      "type": "string",
+    },
+    {
+      "displayOptions": {
+        "show": {
+          "mode": [
+            "load",
+            "retrieve-as-tool",
+          ],
+        },
+      },
+      "name": "loadField",
+    },
+  ],
+  "version": 1,
+}
+`;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.test.ts
@@ -49,7 +49,11 @@ describe('createVectorStoreNode', () => {
 	const vectorStoreNodeArgs = mock<VectorStoreNodeConstructorArgs>({
 		sharedFields: [],
 		insertFields: [],
-		loadFields: [],
+		loadFields: [
+			{
+				name: 'loadField',
+			},
+		],
 		retrieveFields: [],
 		updateFields: [],
 		getVectorStoreClient: jest.fn().mockReturnValue(vectorStore),
@@ -82,6 +86,7 @@ describe('createVectorStoreNode', () => {
 			const wrappedVectorStore = (data.response as { logWrapped: VectorStore }).logWrapped;
 
 			// ASSERT
+			expect(nodeType.description).toMatchSnapshot();
 			expect(wrappedVectorStore).toEqual(vectorStore);
 			expect(vectorStoreNodeArgs.getVectorStoreClient).toHaveBeenCalled();
 		});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/createVectorStoreNode.ts
@@ -80,10 +80,13 @@ export interface VectorStoreNodeConstructorArgs {
 	) => Promise<VectorStore>;
 }
 
-function transformDescriptionForOperationMode(fields: INodeProperties[], mode: NodeOperationMode) {
+function transformDescriptionForOperationMode(
+	fields: INodeProperties[],
+	mode: NodeOperationMode | NodeOperationMode[],
+) {
 	return fields.map((field) => ({
 		...field,
-		displayOptions: { show: { mode: [mode] } },
+		displayOptions: { show: { mode: Array.isArray(mode) ? mode : [mode] } },
 	}));
 }
 
@@ -299,7 +302,10 @@ export const createVectorStoreNode = (args: VectorStoreNodeConstructorArgs) =>
 						},
 					},
 				},
-				...transformDescriptionForOperationMode(args.loadFields ?? [], 'load'),
+				...transformDescriptionForOperationMode(args.loadFields ?? [], [
+					'load',
+					'retrieve-as-tool',
+				]),
 				...transformDescriptionForOperationMode(args.retrieveFields ?? [], 'retrieve'),
 				...transformDescriptionForOperationMode(args.updateFields ?? [], 'update'),
 			],


### PR DESCRIPTION
## Summary

Ensure options for retrieve mode are available for vector stores as tools mode.
<img width="607" alt="Screenshot 2025-01-06 at 09 58 20" src="https://github.com/user-attachments/assets/9c23a7da-63eb-40a6-beac-903d3edb0f26" />

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
