### PR TITLE
fix: Remove item key from subworkflow mapping

### DIFF
--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.test.ts
@@ -12,8 +12,8 @@ jest.mock('../../../utils/workflowInputsResourceMapping/GenericFunctions', () =>
 
 describe('ExecuteWorkflowTrigger', () => {
 	const mockInputData: INodeExecutionData[] = [
-		{ json: { item: 0, foo: 'bar' }, index: 0 },
-		{ json: { item: 1, foo: 'quz' }, index: 1 },
+		{ json: { item: 0, foo: 'bar' }, pairedItem: { item: 0 } },
+		{ json: { item: 1, foo: 'quz' }, pairedItem: { item: 1 } },
 	];
 	const mockNode = mock<INode>({ typeVersion: 1 });
 	const executeFns = mock<IExecuteFunctions>({
@@ -42,8 +42,14 @@ describe('ExecuteWorkflowTrigger', () => {
 		const result = await new ExecuteWorkflowTrigger().execute.call(executeFns);
 		const expected = [
 			[
-				{ index: 0, json: { value1: null, value2: null, foo: mockInputData[0].json.foo } },
-				{ index: 1, json: { value1: null, value2: null, foo: mockInputData[1].json.foo } },
+				{
+					pairedItem: { item: 0 },
+					json: { value1: null, value2: null, foo: mockInputData[0].json.foo },
+				},
+				{
+					pairedItem: { item: 1 },
+					json: { value1: null, value2: null, foo: mockInputData[1].json.foo },
+				},
 			],
 		];
 

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -216,6 +216,7 @@ export class ExecuteWorkflowTrigger implements INodeType {
 					// which we do not want to expose past this node.
 					..._.pickBy(row.json, (_value, key) => newKeys.has(key)),
 				},
+				...(row.pairedItem ? { pairedItem: row.pairedItem } : {}),
 			}));
 
 			return [itemsInSchema];

--- a/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/ExecuteWorkflow/ExecuteWorkflowTrigger/ExecuteWorkflowTrigger.node.ts
@@ -209,14 +209,13 @@ export class ExecuteWorkflowTrigger implements INodeType {
 		} else {
 			const newParams = getFieldEntries(this);
 			const newKeys = new Set(newParams.map((x) => x.name));
-			const itemsInSchema: INodeExecutionData[] = inputData.map((row, index) => ({
+			const itemsInSchema: INodeExecutionData[] = inputData.map((row) => ({
 				json: {
 					...Object.fromEntries(newParams.map((x) => [x.name, FALLBACK_DEFAULT_VALUE])),
 					// Need to trim to the expected schema to support legacy Execute Workflow callers passing through all their data
 					// which we do not want to expose past this node.
 					..._.pickBy(row.json, (_value, key) => newKeys.has(key)),
 				},
-				index,
 			}));
 
 			return [itemsInSchema];

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -127,7 +127,6 @@ export function getCurrentWorkflowInputData(this: ISupplyDataFunctions) {
 		const removedKeys = new Set(schema.filter((x) => x.removed).map((x) => x.displayName));
 
 		const filteredInputData: INodeExecutionData[] = inputData.map((item, index) => ({
-			index,
 			pairedItem: { item: index },
 			json: _.pickBy(item.json, (_v, key) => !removedKeys.has(key)),
 		}));

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -109,7 +109,6 @@ export function getWorkflowInputValues(this: ISupplyDataFunctions): INodeExecuti
 				...item.json,
 				...itemFieldValues,
 			},
-			index: itemIndex,
 			pairedItem: {
 				item: itemIndex,
 			},


### PR DESCRIPTION
## Summary

The inclusion of this key causes issues in some nodes like `Code`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-473/task-runner-code-node-fails-when-used-in-sub-workflow


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
