### PR TITLE
fix(core): Allow `index` as top-level item key for Code node

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/result-validation.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/result-validation.test.ts
@@ -28,6 +28,7 @@ describe('result validation', () => {
 			['binary', {}],
 			['pairedItem', {}],
 			['error', {}],
+			['index', {}], // temporarily allowed until refactored out
 		])(
 			'should not throw an error if the output item has %s key in addition to json',
 			(key, value) => {

--- a/packages/@n8n/task-runner/src/js-task-runner/result-validation.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/result-validation.ts
@@ -4,7 +4,19 @@ import type { INodeExecutionData } from 'n8n-workflow';
 import { ValidationError } from './errors/validation-error';
 import { isObject } from './obj-utils';
 
-export const REQUIRED_N8N_ITEM_KEYS = new Set(['json', 'binary', 'pairedItem', 'error']);
+export const REQUIRED_N8N_ITEM_KEYS = new Set([
+	'json',
+	'binary',
+	'pairedItem',
+	'error',
+
+	/**
+	 * The `index` key was added accidentally to Function, FunctionItem, Gong,
+	 * Execute Workflow, and ToolWorkflowV2, so we need to allow it temporarily.
+	 * Once we stop using it in all nodes, we can stop allowing the `index` key.
+	 */
+	'index',
+]);
 
 function validateTopLevelKeys(item: INodeExecutionData, itemIndex: number) {
 	for (const key in item) {

--- a/packages/nodes-base/nodes/Code/Sandbox.ts
+++ b/packages/nodes-base/nodes/Code/Sandbox.ts
@@ -22,7 +22,19 @@ export interface SandboxContext extends IWorkflowDataProxyData {
 	helpers: IExecuteFunctions['helpers'];
 }
 
-export const REQUIRED_N8N_ITEM_KEYS = new Set(['json', 'binary', 'pairedItem', 'error']);
+export const REQUIRED_N8N_ITEM_KEYS = new Set([
+	'json',
+	'binary',
+	'pairedItem',
+	'error',
+
+	/**
+	 * The `index` key was added accidentally to Function, FunctionItem, Gong,
+	 * Execute Workflow, and ToolWorkflowV2, so we need to allow it temporarily.
+	 * Once we stop using it in all nodes, we can stop allowing the `index` key.
+	 */
+	'index',
+]);
 
 export function getSandboxContext(
 	this: IExecuteFunctions | ISupplyDataFunctions,

--- a/packages/nodes-base/nodes/Code/test/Code.node.test.ts
+++ b/packages/nodes-base/nodes/Code/test/Code.node.test.ts
@@ -40,6 +40,13 @@ describe('Code Node unit test', () => {
 					[{ json: { count: 42 } }],
 					[{ json: { count: 42 } }],
 				],
+
+				// temporarily allowed until refactored out
+				'should handle an index key': [
+					[{ json: { count: 42 }, index: 0 }],
+					[{ json: { count: 42 }, index: 0 }],
+				],
+
 				'should handle when returned data is not an array': [
 					{ json: { count: 42 } },
 					[{ json: { count: 42 } }],


### PR DESCRIPTION
## Summary

The `index` key was [added](https://github.com/n8n-io/n8n/pull/3845/files#diff-c5213f7eecd61668679bd4344a9dbcb6a2d737745b159ae3090eea89f0f045a6R881) to the `INodeExecutionData` interface by the community, who also added it to `Function` and `FunctionItem`. It was then [added](https://github.com/n8n-io/n8n/pull/10777/files#diff-b548045ffb16b243c264d8e309ef9c2f24a0e9cf12c3c2cee25abd6313cac9a3R301) to Gong, and very recently we [added](https://github.com/n8n-io/n8n/pull/11837) it to `ExecuteWorkflowTrigger` and `ToolWorkflowV2`. 

Until we can stop using this `index` key in all nodes, the Code node will need to allowlist this key so that we do not throw during input data validation. This is especially relevant for a Code node run in a subworkflow execution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-473/task-runner-code-node-fails-when-used-in-sub-workflow

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
