### PR TITLE
fix(editor): Hide credential’s modal menu when the credential is managed (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/editor-ui/src/components/CredentialEdit/CredentialEdit.vue
@@ -1106,7 +1106,7 @@ function resetCredentialData(): void {
 		</template>
 		<template #content>
 			<div :class="$style.container" data-test-id="credential-edit-dialog">
-				<div :class="$style.sidebar">
+				<div v-if="!isEditingManagedCredential" :class="$style.sidebar">
 					<n8n-menu
 						mode="tabs"
 						:items="sidebarItems"


### PR DESCRIPTION
## Summary

Fix [one](https://www.notion.so/n8n/Hide-tabs-when-looking-at-shared-credential-modal-16f5b6e0c94f80d4a52cd5436f6fa756?pvs=4) of the point in the feedback about the free AI credits.

## Before

![CleanShot 2025-01-06 at 09 30 46@2x](https://github.com/user-attachments/assets/4fe5ad8a-2593-4105-8b7d-d384452d18b6)


## Now

![CleanShot 2025-01-06 at 09 30 03@2x](https://github.com/user-attachments/assets/34476d9c-7ec1-4456-95a7-7fee02c4613c)



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
