### PR TITLE
fix(editor): Update free AI credits success claim callout (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/FreeAiCreditsCallout.test.ts
+++ b/packages/editor-ui/src/components/FreeAiCreditsCallout.test.ts
@@ -55,7 +55,17 @@ const assertUserCanClaimCredits = () => {
 };
 
 const assertUserClaimedCredits = () => {
-	expect(screen.getByText('Claimed 100 free OpenAI API credits')).toBeInTheDocument();
+	expect(
+		screen.getByText(
+			'Claimed 100 free OpenAI API credits! Please note these free credits are only for the following models:',
+		),
+	).toBeInTheDocument();
+
+	expect(
+		screen.getByText(
+			'gpt-4o-mini, text-embedding-3-small, dall-e-3, tts-1, whisper-1, and text-moderation-latest',
+		),
+	).toBeInTheDocument();
 };
 
 describe('FreeAiCreditsCallout', () => {

--- a/packages/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -108,11 +108,16 @@ const onClaimCreditsClicked = async () => {
 			</template>
 		</n8n-callout>
 		<n8n-callout v-else-if="showSuccessCallout" theme="success" icon="check-circle">
-			{{
-				i18n.baseText('freeAi.credits.callout.success.title', {
-					interpolate: { credits: settingsStore.aiCreditsQuota },
-				})
-			}}
+			<n8n-text>
+				{{
+					i18n.baseText('freeAi.credits.callout.success.title.part1', {
+						interpolate: { credits: settingsStore.aiCreditsQuota },
+					})
+				}}</n8n-text
+			>&nbsp;
+			<n8n-text :bold="true">
+				{{ i18n.baseText('freeAi.credits.callout.success.title.part2') }}</n8n-text
+			>
 		</n8n-callout>
 	</div>
 </template>

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2812,7 +2812,8 @@
 	"testDefinition.deleteTest": "Delete Test",
 	"freeAi.credits.callout.claim.title": "Get {credits} free OpenAI API credits",
 	"freeAi.credits.callout.claim.button.label": "Claim credits",
-	"freeAi.credits.callout.success.title": "Claimed {credits} free OpenAI API credits",
+	"freeAi.credits.callout.success.title.part1": "Claimed {credits} free OpenAI API credits! Please note these free credits are only for the following models:",
+	"freeAi.credits.callout.success.title.part2": "gpt-4o-mini, text-embedding-3-small, dall-e-3, tts-1, whisper-1, and text-moderation-latest",
 	"freeAi.credits.credentials.edit": "This is a managed credential and cannot be edited.",
 	"freeAi.credits.showError.claim.title": "Free AI credits",
 	"freeAi.credits.showError.claim.message": "Enable to claim credits"


### PR DESCRIPTION
## Summary

Make explicit to the user which models will be available with the n8n free AI credits credential. This is part of the feedback of the free AI credits feature. See discussion [here](https://n8nio.slack.com/archives/C04CPHD7VDW/p1736176147171519).

## Before

![CleanShot 2025-01-06 at 21 07 47@2x](https://github.com/user-attachments/assets/7c2986a5-8334-459c-a3fe-25e238dde948)


## Now

![image](https://github.com/user-attachments/assets/94f3442d-8845-4948-a206-9776ac63284d)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
