### PR TITLE
fix(editor): Free AI credits experiment evaluation (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/FreeAiCreditsCallout.test.ts
+++ b/packages/editor-ui/src/components/FreeAiCreditsCallout.test.ts
@@ -86,7 +86,7 @@ describe('FreeAiCreditsCallout', () => {
 		});
 
 		(usePostHog as any).mockReturnValue({
-			isFeatureEnabled: vi.fn().mockReturnValue(true),
+			getVariant: vi.fn().mockReturnValue('variant'),
 		});
 
 		(useProjectsStore as any).mockReturnValue({
@@ -150,7 +150,7 @@ describe('FreeAiCreditsCallout', () => {
 
 	it('should not be able to claim credits if user it is not in experiment', async () => {
 		(usePostHog as any).mockReturnValue({
-			isFeatureEnabled: vi.fn().mockReturnValue(false),
+			getVariant: vi.fn().mockReturnValue('control'),
 		});
 
 		renderComponent(FreeAiCreditsCallout);

--- a/packages/editor-ui/src/components/FreeAiCreditsCallout.vue
+++ b/packages/editor-ui/src/components/FreeAiCreditsCallout.vue
@@ -27,7 +27,7 @@ const showSuccessCallout = ref(false);
 const claimingCredits = ref(false);
 
 const settingsStore = useSettingsStore();
-const postHogStore = usePostHog();
+const posthogStore = usePostHog();
 const credentialsStore = useCredentialsStore();
 const usersStore = useUsersStore();
 const ndvStore = useNDVStore();
@@ -57,7 +57,7 @@ const userCanClaimOpenAiCredits = computed(() => {
 	return (
 		settingsStore.isAiCreditsEnabled &&
 		activeNodeHasOpenAiApiCredential.value &&
-		postHogStore.isFeatureEnabled(AI_CREDITS_EXPERIMENT.name) &&
+		posthogStore.getVariant(AI_CREDITS_EXPERIMENT.name) === AI_CREDITS_EXPERIMENT.variant &&
 		!userHasOpenAiCredentialAlready.value &&
 		!userHasClaimedAiCreditsAlready.value
 	);


### PR DESCRIPTION
## Summary

Fix experiment to only show the feature when the variant is present, instead of treating it as a feature flag. Treating the experiment as a feature flag won't show the feature to users in the control or the variant. Realized this while testing the feature locally.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
