### PR TITLE
feat(Execute Workflow Node): Remove ignoreTypeMismatch option (no-changelog)

### DIFF
--- a/cypress/fixtures/Test_Subworkflow-Inputs.json
+++ b/cypress/fixtures/Test_Subworkflow-Inputs.json
@@ -19,7 +19,6 @@
 					"value": {},
 					"matchingColumns": [],
 					"schema": [],
-					"ignoreTypeMismatchErrors": false,
 					"attemptToConvertTypes": false,
 					"convertFieldsToString": true
 				},

--- a/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
+++ b/packages/core/src/node-execution-context/utils/validateValueAgainstSchema.ts
@@ -61,11 +61,7 @@ const validateResourceMapperValue = (
 			});
 
 			if (!validationResult.valid) {
-				if (!resourceMapperField.ignoreTypeMismatchErrors) {
-					return { ...validationResult, fieldName: key };
-				} else {
-					paramValues[key] = resolvedValue;
-				}
+				return { ...validationResult, fieldName: key };
 			} else {
 				// If it's valid, set the casted value
 				paramValues[key] = validationResult.newValue;

--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -63,7 +63,6 @@ const state = reactive({
 		value: {},
 		matchingColumns: [] as string[],
 		schema: [] as ResourceMapperField[],
-		ignoreTypeMismatchErrors: false,
 		attemptToConvertTypes: false,
 		// This should always be true if `showTypeConversionOptions` is provided
 		// It's used to avoid accepting any value as string without casting it
@@ -660,23 +659,6 @@ defineExpose({
 				@update="
 					(x: IUpdateInformation<NodeParameterValueType>) => {
 						state.paramValue.attemptToConvertTypes = x.value as boolean;
-						emitValueChanged();
-					}
-				"
-			/>
-			<ParameterInputFull
-				:parameter="{
-					name: 'ignoreTypeMismatchErrors',
-					type: 'boolean',
-					displayName: locale.baseText('resourceMapper.ignoreTypeMismatchErrors.displayName'),
-					default: false,
-					description: locale.baseText('resourceMapper.ignoreTypeMismatchErrors.description'),
-				}"
-				:path="props.path + '.ignoreTypeMismatchErrors'"
-				:value="state.paramValue.ignoreTypeMismatchErrors"
-				@update="
-					(x: IUpdateInformation<NodeParameterValueType>) => {
-						state.paramValue.ignoreTypeMismatchErrors = x.value as boolean;
 						emitValueChanged();
 					}
 				"

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1600,8 +1600,6 @@
 	"resourceMapper.staleDataWarning.notice": "Refresh to see the updated fields",
 	"resourceMapper.attemptToConvertTypes.displayName": "Attempt to convert types",
 	"resourceMapper.attemptToConvertTypes.description": "Attempt to convert types when mapping fields",
-	"resourceMapper.ignoreTypeMismatchErrors.displayName": "Ignore type mismatch errors",
-	"resourceMapper.ignoreTypeMismatchErrors.description": "Whether type mismatches should be ignored, rather than returning an Error",
 	"runData.openSubExecution": "Inspect Sub-Execution {id}",
 	"runData.openParentExecution": "Inspect Parent Execution {id}",
 	"runData.emptyItemHint": "This is an item, but it's empty.",

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2710,7 +2710,6 @@ export type ResourceMapperValue = {
 	value: { [key: string]: string | number | boolean | null } | null;
 	matchingColumns: string[];
 	schema: ResourceMapperField[];
-	ignoreTypeMismatchErrors: boolean;
 	attemptToConvertTypes: boolean;
 	convertFieldsToString: boolean;
 };


### PR DESCRIPTION
## Summary

Remove this option as we deem it harmful.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3068/hide-option-for-ignoretypeerrors-in-execute-workflow-node


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
