### PR TITLE
fix(editor): Fix workflow name input size on desktop (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
+++ b/packages/editor-ui/src/components/MainHeader/WorkflowDetails.vue
@@ -801,7 +801,6 @@ $--header-spacing: 20px;
 	color: $custom-font-dark;
 	font-size: 15px;
 	display: block;
-	min-width: 150px;
 }
 
 .activator {
@@ -847,6 +846,14 @@ $--header-spacing: 20px;
 	align-items: center;
 	gap: var(--spacing-m);
 	flex-wrap: nowrap;
+}
+
+@include mixins.breakpoint('xs-only') {
+	.name {
+		:deep(input) {
+			min-width: 180px;
+		}
+	}
 }
 </style>
 


### PR DESCRIPTION
## Summary

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/02201f63-e4fe-4724-8395-487f03cecd95" />

- 180px chosen to match long workflow name width on mobile

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-489/workflow-name-input-size-is-bugged


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
