### PR TITLE
fix(core): Fix manually running a pinned trigger with offloading enabled

### DIFF
--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -147,6 +147,12 @@ export class WorkflowExecutionService {
 			triggerToStartFrom,
 		};
 
+		const hasRunData = (node: INode) => runData !== undefined && !!runData[node.name];
+
+		if (pinnedTrigger && !hasRunData(pinnedTrigger)) {
+			data.startNodes = [{ name: pinnedTrigger.name, sourceData: null }];
+		}
+
 		/**
 		 * Historically, manual executions in scaling mode ran in the main process,
 		 * so some execution details were never persisted in the database.
@@ -160,7 +166,7 @@ export class WorkflowExecutionService {
 		) {
 			data.executionData = {
 				startData: {
-					startNodes,
+					startNodes: data.startNodes,
 					destinationNode,
 				},
 				resultData: {
@@ -174,12 +180,6 @@ export class WorkflowExecutionService {
 					triggerToStartFrom,
 				},
 			};
-		}
-
-		const hasRunData = (node: INode) => runData !== undefined && !!runData[node.name];
-
-		if (pinnedTrigger && !hasRunData(pinnedTrigger)) {
-			data.startNodes = [{ name: pinnedTrigger.name, sourceData: null }];
 		}
 
 		const executionId = await this.workflowRunner.run(data);


### PR DESCRIPTION
## Summary

Until recently, manual executions in scaling mode ran in the main process, so some execution details were never persisted in the database - those details remained in memory and were used in the same process. But as #11284, we offload manual executions from mains to workers if a flag is enabled. Offloading persists manual execution details to the DB, so that the worker can retrieve them to know how to run the manual execution.

There is an edge case where, if the manual execution has one or more pinned triggers, we set the first pinned trigger in the execution details. In this case we collect execution details too early, failing to account for the pinned trigger that was set. This PR fixes this edge case.

## Test

The execution flow is not yet easily testable.

To test manually:

- Start a main with `export OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`
- Start a worker
- Create a workflow with a webhook node, pin its output, run the workflow
- Unpin the webhook node, run the workflow

Expected: The webhook should use its pinned data the first time, and wait for a webhook the second time.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2442/fix-manually-running-a-pinned-webhook-with-offloading-enabled


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
