### PR TITLE
chore(core): Mark `item.index` as deprecated

### DIFF
--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1184,6 +1184,11 @@ export interface INodeExecutionData {
 	metadata?: {
 		subExecution: RelatedExecution;
 	};
+
+	/**
+	 * @deprecated This key was added by accident and will be removed in the
+	 *  future. For more information see PR #12469.
+	 */
 	index?: number;
 }
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -1186,8 +1186,8 @@ export interface INodeExecutionData {
 	};
 
 	/**
-	 * @deprecated This key was added by accident and will be removed in the
-	 *  future. For more information see PR #12469.
+	 * @deprecated This key was added by accident and should not be used as it
+	 * will be removed in future. For more information see PR #12469.
 	 */
 	index?: number;
 }


### PR DESCRIPTION
Follow-up to https://github.com/n8n-io/n8n/pull/12469