### PR TITLE
fix(core): Fix Sentry error reporting on task runners

### DIFF
--- a/packages/@n8n/config/src/configs/sentry.config.ts
+++ b/packages/@n8n/config/src/configs/sentry.config.ts
@@ -2,11 +2,35 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class SentryConfig {
-	/** Sentry DSN for the backend. */
+	/** Sentry DSN (data source name) for the backend. */
 	@Env('N8N_SENTRY_DSN')
 	backendDsn: string = '';
 
-	/** Sentry DSN for the frontend . */
+	/** Sentry DSN (data source name) for the frontend. */
 	@Env('N8N_FRONTEND_SENTRY_DSN')
 	frontendDsn: string = '';
+
+	/**
+	 * Version of the n8n instance
+	 *
+	 * @example '1.73.0'
+	 */
+	@Env('N8N_VERSION')
+	n8nVersion: string = '';
+
+	/**
+	 * Environment of the n8n instance.
+	 *
+	 * @example 'production'
+	 */
+	@Env('ENVIRONMENT')
+	environment: string = '';
+
+	/**
+	 * Name of the deployment, e.g. cloud account name.
+	 *
+	 * @example 'janober'
+	 */
+	@Env('DEPLOYMENT_NAME')
+	deploymentName: string = '';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -236,6 +236,9 @@ describe('GlobalConfig', () => {
 		sentry: {
 			backendDsn: '',
 			frontendDsn: '',
+			n8nVersion: '',
+			environment: '',
+			deploymentName: '',
 		},
 		logging: {
 			level: 'info',

--- a/packages/@n8n/task-runner/src/config/sentry-config.ts
+++ b/packages/@n8n/task-runner/src/config/sentry-config.ts
@@ -2,9 +2,9 @@ import { Config, Env } from '@n8n/config';
 
 @Config
 export class SentryConfig {
-	/** Sentry DSN */
+	/** Sentry DSN (data source name) */
 	@Env('N8N_SENTRY_DSN')
-	sentryDsn: string = '';
+	dsn: string = '';
 
 	//#region Metadata about the environment
 

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/js-task-runner.test.ts
@@ -50,7 +50,7 @@ describe('JsTaskRunner', () => {
 				...jsRunnerOpts,
 			},
 			sentryConfig: {
-				sentryDsn: '',
+				dsn: '',
 				deploymentName: '',
 				environment: '',
 				n8nVersion: '',

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -54,12 +54,12 @@ void (async function start() {
 		defaultTimezone: config.baseRunnerConfig.timezone,
 	});
 
-	const { sentryDsn, ...opts } = config.sentryConfig;
+	const { dsn } = config.sentryConfig;
 
-	if (sentryDsn) {
+	if (dsn) {
 		const { ErrorReporter } = await import('n8n-core');
 		errorReporter = Container.get(ErrorReporter);
-		await errorReporter.init('task_runner', sentryDsn, opts);
+		await errorReporter.init({ serverType: 'task_runner', ...config.sentryConfig });
 	}
 
 	runner = new JsTaskRunner(config);

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -54,10 +54,12 @@ void (async function start() {
 		defaultTimezone: config.baseRunnerConfig.timezone,
 	});
 
-	if (config.sentryConfig.sentryDsn) {
+	const { sentryDsn, ...opts } = config.sentryConfig;
+
+	if (sentryDsn) {
 		const { ErrorReporter } = await import('n8n-core');
 		errorReporter = Container.get(ErrorReporter);
-		await errorReporter.init('task_runner', config.sentryConfig.sentryDsn);
+		await errorReporter.init('task_runner', sentryDsn, opts);
 	}
 
 	runner = new JsTaskRunner(config);

--- a/packages/@n8n/task-runner/src/start.ts
+++ b/packages/@n8n/task-runner/src/start.ts
@@ -59,7 +59,14 @@ void (async function start() {
 	if (dsn) {
 		const { ErrorReporter } = await import('n8n-core');
 		errorReporter = Container.get(ErrorReporter);
-		await errorReporter.init({ serverType: 'task_runner', ...config.sentryConfig });
+		const { deploymentName, environment, n8nVersion } = config.sentryConfig;
+		await errorReporter.init({
+			serverType: 'task_runner',
+			dsn,
+			serverName: deploymentName,
+			environment,
+			release: n8nVersion,
+		});
 	}
 
 	runner = new JsTaskRunner(config);

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -61,10 +61,10 @@ export abstract class BaseCommand extends Command {
 
 	async init(): Promise<void> {
 		this.errorReporter = Container.get(ErrorReporter);
-		await this.errorReporter.init(
-			this.instanceSettings.instanceType,
-			this.globalConfig.sentry.backendDsn,
-		);
+		await this.errorReporter.init({
+			serverType: this.instanceSettings.instanceType,
+			dsn: this.globalConfig.sentry.backendDsn,
+		});
 		initExpressionEvaluator();
 
 		process.once('SIGTERM', this.onTerminationSignal('SIGTERM'));

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -64,6 +64,9 @@ export abstract class BaseCommand extends Command {
 		await this.errorReporter.init({
 			serverType: this.instanceSettings.instanceType,
 			dsn: this.globalConfig.sentry.backendDsn,
+			environment: process.env.ENVIRONMENT ?? '',
+			release: process.env.N8N_VERSION ?? '',
+			serverName: process.env.DEPLOYMENT_NAME ?? '',
 		});
 		initExpressionEvaluator();
 

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -61,12 +61,14 @@ export abstract class BaseCommand extends Command {
 
 	async init(): Promise<void> {
 		this.errorReporter = Container.get(ErrorReporter);
+
+		const { backendDsn, n8nVersion, environment, deploymentName } = this.globalConfig.sentry;
 		await this.errorReporter.init({
 			serverType: this.instanceSettings.instanceType,
-			dsn: this.globalConfig.sentry.backendDsn,
-			environment: process.env.ENVIRONMENT ?? '',
-			release: process.env.N8N_VERSION ?? '',
-			serverName: process.env.DEPLOYMENT_NAME ?? '',
+			dsn: backendDsn,
+			environment,
+			release: n8nVersion,
+			serverName: deploymentName,
 		});
 		initExpressionEvaluator();
 

--- a/packages/core/src/error-reporter.ts
+++ b/packages/core/src/error-reporter.ts
@@ -12,9 +12,9 @@ import { Logger } from './logging/logger';
 type ErrorReporterInitOptions = {
 	serverType: InstanceType | 'task_runner';
 	dsn: string;
-	release?: string;
-	environment?: string;
-	serverName?: string;
+	release: string;
+	environment: string;
+	serverName: string;
 };
 
 @Service()
@@ -52,12 +52,12 @@ export class ErrorReporter {
 		await close(timeoutInMs);
 	}
 
-	async init(opts: ErrorReporterInitOptions) {
+	async init({ dsn, serverType, release, environment, serverName }: ErrorReporterInitOptions) {
 		process.on('uncaughtException', (error) => {
 			this.error(error);
 		});
 
-		if (!opts.dsn) return;
+		if (!dsn) return;
 
 		// Collect longer stacktraces
 		Error.stackTraceLimit = 50;
@@ -74,11 +74,11 @@ export class ErrorReporter {
 		];
 
 		init({
-			dsn: opts.dsn,
-			release: opts.release ?? process.env.N8N_VERSION,
-			environment: opts.environment ?? process.env.ENVIRONMENT,
+			dsn,
+			release,
+			environment,
 			enableTracing: false,
-			serverName: opts.serverName ?? process.env.DEPLOYMENT_NAME,
+			serverName,
 			beforeBreadcrumb: () => null,
 			beforeSend: this.beforeSend.bind(this) as NodeOptions['beforeSend'],
 			integrations: (integrations) => [
@@ -97,7 +97,7 @@ export class ErrorReporter {
 			],
 		});
 
-		setTag('server_type', opts.serverType);
+		setTag('server_type', serverType);
 
 		this.report = (error, options) => captureException(error, options);
 	}

--- a/packages/core/src/error-reporter.ts
+++ b/packages/core/src/error-reporter.ts
@@ -44,7 +44,11 @@ export class ErrorReporter {
 		await close(timeoutInMs);
 	}
 
-	async init(instanceType: InstanceType | 'task_runner', dsn: string) {
+	async init(
+		instanceType: InstanceType | 'task_runner',
+		dsn: string,
+		opts: { release?: string; environment?: string; serverName?: string } = {},
+	) {
 		process.on('uncaughtException', (error) => {
 			this.error(error);
 		});
@@ -54,11 +58,9 @@ export class ErrorReporter {
 		// Collect longer stacktraces
 		Error.stackTraceLimit = 50;
 
-		const {
-			N8N_VERSION: release,
-			ENVIRONMENT: environment,
-			DEPLOYMENT_NAME: serverName,
-		} = process.env;
+		const release = opts.release ?? process.env.N8N_VERSION;
+		const environment = opts.environment ?? process.env.ENVIRONMENT;
+		const serverName = opts.serverName ?? process.env.DEPLOYMENT_NAME;
 
 		const { init, captureException, setTag } = await import('@sentry/node');
 		const { requestDataIntegration, rewriteFramesIntegration } = await import('@sentry/node');


### PR DESCRIPTION
Sentry error reporting for task runners is missing key details like release since #12168. This PR restores them.

Context: https://n8nio.slack.com/archives/C069HS026UF/p1736326002589089

Sample error with 1.73.0 release: https://n8nio.sentry.io/issues/6204460655