### PR TITLE
feat(editor): Show warning when user activates workflow with free AI credits credential (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/WorkflowActivator.test.ts
+++ b/packages/editor-ui/src/components/WorkflowActivator.test.ts
@@ -7,16 +7,31 @@ import { useWorkflowsStore } from '@/stores/workflows.store';
 import { createTestingPinia } from '@pinia/testing';
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
-import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE } from '@/constants';
+import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, WOOCOMMERCE_TRIGGER_NODE_TYPE } from '@/constants';
+import { useCredentialsStore } from '@/stores/credentials.store';
+import { useToast } from '@/composables/useToast';
 
 const renderComponent = createComponentRenderer(WorkflowActivator);
 let mockWorkflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+let mockCredentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
+
+vi.mock('@/composables/useToast', () => {
+	const showMessage = vi.fn();
+	return {
+		useToast: () => {
+			return {
+				showMessage,
+			};
+		},
+	};
+});
 
 describe('WorkflowActivator', () => {
 	beforeEach(() => {
 		createTestingPinia();
 
 		mockWorkflowsStore = mockedStore(useWorkflowsStore);
+		mockCredentialsStore = mockedStore(useCredentialsStore);
 	});
 
 	afterEach(() => {
@@ -78,5 +93,54 @@ describe('WorkflowActivator', () => {
 			"Execute Workflow Trigger' doesn't require activation as it is triggered by another workflow",
 		);
 		expect(getByTestId('workflow-activator-status')).toHaveTextContent('Inactive');
+	});
+
+	it('Should show warning toast if the workflow to be activated has free OpenAI credentials', async () => {
+		const toast = useToast();
+
+		mockWorkflowsStore.workflow.usedCredentials = [
+			{
+				id: '1',
+				name: '',
+				credentialType: '',
+				currentUserHasAccess: false,
+			},
+		];
+
+		mockCredentialsStore.state.credentials = {
+			'1': {
+				id: '1',
+				name: 'OpenAI',
+				type: 'openAiApi',
+				data: '',
+				isManaged: true,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		mockWorkflowsStore.workflowTriggerNodes = [
+			{ type: WOOCOMMERCE_TRIGGER_NODE_TYPE, disabled: false } as never,
+		];
+
+		const { rerender } = renderComponent({
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		});
+
+		await rerender({ workflowActive: true });
+
+		expect(toast.showMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: "You're using free OpenAI API credits",
+				message:
+					'To make sure your workflow runs smoothly in the future, replace the free OpenAI API credits with your own API key.',
+				type: 'warning',
+				duration: 0,
+			}),
+		);
 	});
 });

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -2849,5 +2849,7 @@
 	"freeAi.credits.callout.success.title.part2": "gpt-4o-mini, text-embedding-3-small, dall-e-3, tts-1, whisper-1, and text-moderation-latest",
 	"freeAi.credits.credentials.edit": "This is a managed credential and cannot be edited.",
 	"freeAi.credits.showError.claim.title": "Free AI credits",
-	"freeAi.credits.showError.claim.message": "Enable to claim credits"
+	"freeAi.credits.showError.claim.message": "Enable to claim credits",
+	"freeAi.credits.showWarning.workflow.activation.title": "You're using free OpenAI API credits",
+	"freeAi.credits.showWarning.workflow.activation.description": "To make sure your workflow runs smoothly in the future, replace the free OpenAI API credits with your own API key."
 }


### PR DESCRIPTION
## Summary

This PR address part of the feedback in the free AI credits feature. See discussion [here](https://www.notion.so/n8n/Should-we-warn-users-to-update-credential-if-activating-workflow-16f5b6e0c94f8071ba68ed3196bde940?pvs=4).

## Demo

![CleanShot 2025-01-08 at 08 08 30](https://github.com/user-attachments/assets/3b5d1a6c-cdce-45f9-8ef2-def982fde215)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
