### PR TITLE
ci: Stop publishing custom images to docker hub by default

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -20,26 +20,28 @@ jobs:
       - uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.11.0
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           file: ./docker/images/n8n-base/Dockerfile

--- a/.github/workflows/docker-images-benchmark.yml
+++ b/.github/workflows/docker-images-benchmark.yml
@@ -19,20 +19,22 @@ jobs:
       - uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.11.0
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           file: ./packages/@n8n/benchmark/Dockerfile

--- a/.github/workflows/docker-images-custom.yml
+++ b/.github/workflows/docker-images-custom.yml
@@ -1,0 +1,81 @@
+name: Docker Custom Image CI
+run-name: Build ${{ inputs.branch }} - ${{ inputs.user }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'GitHub branch to create image off.'
+        required: true
+      tag:
+        description: 'Name of the docker tag to create.'
+        required: true
+      merge-master:
+        description: 'Merge with master.'
+        type: boolean
+        required: true
+        default: false
+      user:
+        description: ''
+        required: false
+        default: 'none'
+      start-url:
+        description: 'URL to call after workflow is kicked off.'
+        required: false
+        default: ''
+      success-url:
+        description: 'URL to call after Docker Image got built successfully.'
+        required: false
+        default: ''
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call Start URL - optionally
+        if: ${{ github.event.inputs.start-url != '' }}
+        run: curl -v -X POST -d 'url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' ${{github.event.inputs.start-url}} || echo ""
+        shell: bash
+
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Merge Master - optionally
+        if: github.event.inputs.merge-master
+        run: git remote add upstream https://github.com/n8n-io/n8n.git -f; git merge upstream/master --allow-unrelated-histories || echo ""
+        shell: bash
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GHCR
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          file: ./docker/images/n8n-custom/Dockerfile
+          build-args: |
+            N8N_RELEASE_TYPE=development
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ghcr.io/${{ github.repository_owner }}/n8n:${{ inputs.tag }}
+
+      - name: Call Success URL - optionally
+        if: ${{ github.event.inputs.success-url != '' }}
+        run: curl -v ${{github.event.inputs.success-url}} || echo ""
+        shell: bash

--- a/.github/workflows/docker-images-custom.yml
+++ b/.github/workflows/docker-images-custom.yml
@@ -49,20 +49,22 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image to GHCR
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.11.0
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           file: ./docker/images/n8n-custom/Dockerfile

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -1,64 +1,18 @@
 name: Docker Nightly Image CI
-run-name: Build ${{ inputs.branch }} - ${{ inputs.user }}
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'GitHub branch to create image off.'
-        required: true
-        default: 'master'
-      tag:
-        description: 'Name of the docker tag to create.'
-        required: true
-        default: 'nightly'
-      publish-to-dockerhub:
-        description: 'Published to DockerHub'
-        type: boolean
-        required: true
-        default: false
-      merge-master:
-        description: 'Merge with master.'
-        type: boolean
-        required: true
-        default: false
-      user:
-        description: ''
-        required: false
-        default: 'schedule'
-      start-url:
-        description: 'URL to call after workflow is kicked off.'
-        required: false
-        default: ''
-      success-url:
-        description: 'URL to call after Docker Image got built successfully.'
-        required: false
-        default: ''
-
-env:
-  N8N_TAG: ${{ inputs.tag || 'nightly' }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Call Start URL - optionally
-        if: ${{ github.event.inputs.start-url != '' }}
-        run: curl -v -X POST -d 'url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' ${{github.event.inputs.start-url}} || echo ""
-        shell: bash
-
       - name: Checkout
         uses: actions/checkout@v4.1.1
         with:
-          ref: ${{ github.event.inputs.branch || 'master' }}
-
-      - name: Merge Master - optionally
-        if: github.event.inputs.merge-master
-        run: git remote add upstream https://github.com/n8n-io/n8n.git -f; git merge upstream/master --allow-unrelated-histories || echo ""
-        shell: bash
+          ref: master
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
@@ -73,7 +27,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image to GHCR
+      - name: Login to DockerHub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push image to GHCR and DockerHub
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
@@ -85,23 +45,6 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }}
-
-      - name: Login to DockerHub
-        if: env.N8N_TAG == 'nightly' || github.event.publish-to-dockerhub
-        uses: docker/login-action@v3.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push image to DockerHub
-        if: env.N8N_TAG == 'nightly' || github.event.publish-to-dockerhub
-        run: |
-          docker buildx imagetools create \
-            --tag ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }} \
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }}
             ${{ secrets.DOCKER_USERNAME }}/n8n:${{ env.N8N_TAG }}
-
-      - name: Call Success URL - optionally
-        if: ${{ github.event.inputs.success-url != '' }}
-        run: curl -v ${{github.event.inputs.success-url}} || echo ""
-        shell: bash

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -48,5 +48,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }}
-            ${{ secrets.DOCKER_USERNAME }}/n8n:${{ env.N8N_TAG }}
+            ghcr.io/${{ github.repository_owner }}/n8n:nightly
+            ${{ secrets.DOCKER_USERNAME }}/n8n:nightly

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -15,26 +15,28 @@ jobs:
           ref: master
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push image to GHCR and DockerHub
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.11.0
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           file: ./docker/images/n8n-custom/Dockerfile

--- a/.github/workflows/docker-images-nightly.yml
+++ b/.github/workflows/docker-images-nightly.yml
@@ -14,6 +14,11 @@ on:
         description: 'Name of the docker tag to create.'
         required: true
         default: 'nightly'
+      publish-to-dockerhub:
+        description: 'Published to DockerHub'
+        type: boolean
+        required: true
+        default: false
       merge-master:
         description: 'Merge with master.'
         type: boolean
@@ -41,8 +46,8 @@ jobs:
 
     steps:
       - name: Call Start URL - optionally
-        run: |
-          [[ "${{github.event.inputs.start-url}}" != "" ]] && curl -v -X POST -d 'url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' ${{github.event.inputs.start-url}} || echo ""
+        if: ${{ github.event.inputs.start-url != '' }}
+        run: curl -v -X POST -d 'url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' ${{github.event.inputs.start-url}} || echo ""
         shell: bash
 
       - name: Checkout
@@ -50,24 +55,25 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'master' }}
 
+      - name: Merge Master - optionally
+        if: github.event.inputs.merge-master
+        run: git remote add upstream https://github.com/n8n-io/n8n.git -f; git merge upstream/master --allow-unrelated-histories || echo ""
+        shell: bash
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
 
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v3.0.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge Master - optionally
-        run: |
-          [[ "${{github.event.inputs.merge-master}}" == "true" ]] && git remote add upstream https://github.com/n8n-io/n8n.git -f; git merge upstream/master --allow-unrelated-histories || echo ""
-        shell: bash
-
-      - name: Build and push to DockerHub
+      - name: Build and push image to GHCR
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
@@ -79,24 +85,23 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ${{ secrets.DOCKER_USERNAME }}/n8n:${{ env.N8N_TAG }}
+          tags: ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }}
 
-      - name: Login to GitHub Container Registry
-        if: env.N8N_TAG == 'nightly'
+      - name: Login to DockerHub
+        if: env.N8N_TAG == 'nightly' || github.event.publish-to-dockerhub
         uses: docker/login-action@v3.0.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push image to GHCR
-        if: env.N8N_TAG == 'nightly'
+      - name: Push image to DockerHub
+        if: env.N8N_TAG == 'nightly' || github.event.publish-to-dockerhub
         run: |
           docker buildx imagetools create \
-            --tag ghcr.io/${{ github.repository_owner }}/n8n:nightly \
-            ${{ secrets.DOCKER_USERNAME }}/n8n:nightly
+            --tag ghcr.io/${{ github.repository_owner }}/n8n:${{ env.N8N_TAG }} \
+            ${{ secrets.DOCKER_USERNAME }}/n8n:${{ env.N8N_TAG }}
 
       - name: Call Success URL - optionally
-        run: |
-          [[ "${{github.event.inputs.success-url}}" != "" ]] && curl -v ${{github.event.inputs.success-url}} || echo ""
+        if: ${{ github.event.inputs.success-url != '' }}
+        run: curl -v ${{github.event.inputs.success-url}} || echo ""
         shell: bash

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -73,26 +73,28 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.3.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6.11.0
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: ./docker/images/n8n
           build-args: |

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@v3.0.0
+      - uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: docker/login-action@v3.0.0
+      - uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
This PR:
1. Splits workflows for custom and nightly images
2. Upgrades docker related actions
3. Stops publishing custom images to DockerHub

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
