### PR TITLE
fix(editor): Condition to show the warning after workflow activation for free AI credits (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/WorkflowActivator.test.ts
+++ b/packages/editor-ui/src/components/WorkflowActivator.test.ts
@@ -95,7 +95,7 @@ describe('WorkflowActivator', () => {
 		expect(getByTestId('workflow-activator-status')).toHaveTextContent('Inactive');
 	});
 
-	it('Should show warning toast if the workflow to be activated has free OpenAI credentials', async () => {
+	it('Should show warning toast if the workflow to be activated has non-disabled node using free OpenAI credentials', async () => {
 		const toast = useToast();
 
 		mockWorkflowsStore.usedCredentials = {
@@ -123,6 +123,24 @@ describe('WorkflowActivator', () => {
 			{ type: WOOCOMMERCE_TRIGGER_NODE_TYPE, disabled: false } as never,
 		];
 
+		mockWorkflowsStore.allNodes = [
+			{
+				credentials: {
+					openAiApi: {
+						name: 'OpenAI',
+						id: '1',
+					},
+				},
+				disabled: false,
+				position: [1, 1],
+				name: '',
+				id: '',
+				typeVersion: 0,
+				type: '',
+				parameters: {},
+			},
+		];
+
 		const { rerender } = renderComponent({
 			props: {
 				workflowActive: false,
@@ -142,5 +160,105 @@ describe('WorkflowActivator', () => {
 				duration: 0,
 			}),
 		);
+	});
+
+	it('Should not show warning toast if the workflow to be activated has disabled node using free OpenAI credentials', async () => {
+		const toast = useToast();
+
+		mockWorkflowsStore.usedCredentials = {
+			'1': {
+				id: '1',
+				name: '',
+				credentialType: '',
+				currentUserHasAccess: false,
+			},
+		};
+
+		mockCredentialsStore.state.credentials = {
+			'1': {
+				id: '1',
+				name: 'OpenAI',
+				type: 'openAiApi',
+				data: '',
+				isManaged: true,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		mockWorkflowsStore.workflowTriggerNodes = [
+			{ type: WOOCOMMERCE_TRIGGER_NODE_TYPE, disabled: false } as never,
+		];
+
+		mockWorkflowsStore.allNodes = [
+			{
+				credentials: {
+					openAiApi: {
+						name: 'OpenAI',
+						id: '1',
+					},
+				},
+				disabled: true,
+				position: [1, 1],
+				name: '',
+				id: '',
+				typeVersion: 0,
+				type: '',
+				parameters: {},
+			},
+		];
+
+		const { rerender } = renderComponent({
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		});
+
+		await rerender({ workflowActive: true });
+
+		expect(toast.showMessage).not.toHaveBeenCalled();
+	});
+
+	it('Should not show warning toast if the workflow to be activated has no node with free OpenAI credential', async () => {
+		const toast = useToast();
+
+		mockWorkflowsStore.usedCredentials = {
+			'1': {
+				id: '1',
+				name: '',
+				credentialType: '',
+				currentUserHasAccess: false,
+			},
+		};
+
+		mockCredentialsStore.state.credentials = {
+			'1': {
+				id: '1',
+				name: 'Jira',
+				type: 'jiraApi',
+				data: '',
+				isManaged: true,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		};
+
+		mockWorkflowsStore.workflowTriggerNodes = [
+			{ type: WOOCOMMERCE_TRIGGER_NODE_TYPE, disabled: false } as never,
+		];
+
+		const { rerender } = renderComponent({
+			props: {
+				workflowActive: false,
+				workflowId: '1',
+				workflowPermissions: { update: true },
+			},
+		});
+
+		await rerender({ workflowActive: true });
+
+		expect(toast.showMessage).not.toHaveBeenCalled();
 	});
 });

--- a/packages/editor-ui/src/components/WorkflowActivator.test.ts
+++ b/packages/editor-ui/src/components/WorkflowActivator.test.ts
@@ -98,14 +98,14 @@ describe('WorkflowActivator', () => {
 	it('Should show warning toast if the workflow to be activated has free OpenAI credentials', async () => {
 		const toast = useToast();
 
-		mockWorkflowsStore.workflow.usedCredentials = [
-			{
+		mockWorkflowsStore.usedCredentials = {
+			'1': {
 				id: '1',
 				name: '',
 				credentialType: '',
 				currentUserHasAccess: false,
 			},
-		];
+		};
 
 		mockCredentialsStore.state.credentials = {
 			'1': {

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -102,11 +102,9 @@ const shouldShowFreeAiCreditsWarning = computed((): boolean => {
 	const usedCredentials = workflowsStore?.usedCredentials;
 	if (!usedCredentials) return false;
 
-	// Find any managed OpenAI credentials being used
 	const managedOpenAiCredentialId = findManagedOpenAiCredentialId(usedCredentials);
 	if (!managedOpenAiCredentialId) return false;
 
-	// Check if any non-disabled node uses these credentials
 	return hasActiveNodeUsingCredential(workflowsStore.allNodes, managedOpenAiCredentialId);
 });
 

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -74,9 +74,8 @@ const disabled = computed((): boolean => {
 
 const currentWorkflowHasFreeAiCredits = computed((): boolean => {
 	if (!workflowsStore?.workflow?.usedCredentials) return false;
-	return workflowsStore.workflow.usedCredentials.some(
-		(usedCredential: IUsedCredential) =>
-			credentialsStore.state.credentials[usedCredential.id].isManaged,
+	return Object.keys(workflowsStore.usedCredentials).some(
+		(id: string) => credentialsStore.state.credentials[id].isManaged,
 	);
 });
 

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -10,7 +10,8 @@ import type { PermissionsRecord } from '@/permissions';
 import { EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, PLACEHOLDER_EMPTY_WORKFLOW_ID } from '@/constants';
 import WorkflowActivationErrorMessage from './WorkflowActivationErrorMessage.vue';
 import { useCredentialsStore } from '@/stores/credentials.store';
-import type { IUsedCredential } from '@/Interface';
+import type { INodeUi, IUsedCredential } from '@/Interface';
+import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
 
 const props = defineProps<{
 	workflowActive: boolean;
@@ -72,11 +73,39 @@ const disabled = computed((): boolean => {
 	return false;
 });
 
-const currentWorkflowHasFreeAiCredits = computed((): boolean => {
-	if (!workflowsStore?.workflow?.usedCredentials) return false;
-	return Object.keys(workflowsStore.usedCredentials).some(
-		(id: string) => credentialsStore.state.credentials[id].isManaged,
+function findManagedOpenAiCredentialId(
+	usedCredentials: Record<string, IUsedCredential>,
+): string | undefined {
+	return Object.keys(usedCredentials).find((credentialId) => {
+		const credential = credentialsStore.state.credentials[credentialId];
+		return credential.isManaged && credential.type === OPEN_AI_API_CREDENTIAL_TYPE;
+	});
+}
+
+function hasActiveNodeUsingCredential(nodes: INodeUi[], credentialId: string): boolean {
+	return nodes.some(
+		(node) =>
+			node?.credentials?.[OPEN_AI_API_CREDENTIAL_TYPE]?.id === credentialId && !node.disabled,
 	);
+}
+
+/**
+ * Computed property to determine if the warning for free AI credits should be shown.
+ *
+ * This function checks if the current workflow uses any managed credentials of type `OPEN_AI_API_CREDENTIAL_TYPE`.
+ * If such credentials are found and are associated with any non-disabled node in the workflow, the warning will be shown.
+ *
+ */
+const shouldShowFreeAiCreditsWarning = computed((): boolean => {
+	const usedCredentials = workflowsStore?.usedCredentials;
+	if (!usedCredentials) return false;
+
+	// Find any managed OpenAI credentials being used
+	const managedOpenAiCredentialId = findManagedOpenAiCredentialId(usedCredentials);
+	if (!managedOpenAiCredentialId) return false;
+
+	// Check if any non-disabled node uses these credentials
+	return hasActiveNodeUsingCredential(workflowsStore.allNodes, managedOpenAiCredentialId);
 });
 
 async function activeChanged(newActiveState: boolean) {
@@ -114,7 +143,7 @@ async function displayActivationError() {
 watch(
 	() => props.workflowActive,
 	(workflowActive) => {
-		if (workflowActive && currentWorkflowHasFreeAiCredits.value) {
+		if (workflowActive && shouldShowFreeAiCreditsWarning.value) {
 			showMessage({
 				title: i18n.baseText('freeAi.credits.showWarning.workflow.activation.title'),
 				message: i18n.baseText('freeAi.credits.showWarning.workflow.activation.description'),

--- a/packages/editor-ui/src/components/WorkflowActivator.vue
+++ b/packages/editor-ui/src/components/WorkflowActivator.vue
@@ -90,10 +90,12 @@ function hasActiveNodeUsingCredential(nodes: INodeUi[], credentialId: string): b
 }
 
 /**
- * Computed property to determine if the warning for free AI credits should be shown.
+ * Determines if the warning for free AI credits should be shown in the workflow.
  *
- * This function checks if the current workflow uses any managed credentials of type `OPEN_AI_API_CREDENTIAL_TYPE`.
- * If such credentials are found and are associated with any non-disabled node in the workflow, the warning will be shown.
+ * This computed property evaluates whether to display a warning about free AI credits
+ * in the workflow. The warning is shown when both conditions are met:
+ * 1. The workflow uses managed OpenAI API credentials
+ * 2. Those credentials are associated with at least one enabled node
  *
  */
 const shouldShowFreeAiCreditsWarning = computed((): boolean => {


### PR DESCRIPTION
## Summary

1. Addresses bug found during review due to the `workflowsStore.workflow.usedCredentials` not set all the time.  This PR instead relies  on the `workflowsStore.usedCredentials`.
2. Addresses use case when the node with the free AI credentials is disabled. If that case, do not show the warning.
3. Add more tests]]

## Demo:

![CleanShot 2025-01-08 at 16 41 31](https://github.com/user-attachments/assets/b12d89a0-ba11-4e2c-a97a-fc75df28071f)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
