### PR TITLE
test: Fix sub-workflow selection in e2e tests (no-changelog)

### DIFF
--- a/cypress/e2e/45-workflow-selector-parameter.cy.ts
+++ b/cypress/e2e/45-workflow-selector-parameter.cy.ts
@@ -94,7 +94,7 @@ describe('Workflow Selector Parameter', () => {
 			.findChildByTestId('rlc-item')
 			.eq(0)
 			.find('span')
-			.should('have.text', 'Create a new sub-workflow');
+			.should('contain.text', 'Create a '); // Due to some inconsistency we're sometimes in a project, this covers both cases
 
 		getVisiblePopper().findChildByTestId('rlc-item').eq(0).click();
 

--- a/cypress/e2e/48-subworkflow-inputs.cy.ts
+++ b/cypress/e2e/48-subworkflow-inputs.cy.ts
@@ -89,7 +89,7 @@ function navigateWorkflowSelectionDropdown(index: number, expectedText: string) 
 		.findChildByTestId('rlc-item')
 		.eq(index)
 		.find('span')
-		.should('have.text', expectedText)
+		.should('contain.text', expectedText)
 		.click();
 }
 
@@ -167,7 +167,7 @@ describe('Sub-workflow creation and typed usage', () => {
 				cy.visit(url);
 			});
 		});
-		navigateWorkflowSelectionDropdown(0, 'Create a new sub-workflow');
+		navigateWorkflowSelectionDropdown(0, 'Create a ');
 		// **************************
 		// NAVIGATE TO CHILD WORKFLOW
 		// **************************
@@ -227,7 +227,7 @@ describe('Sub-workflow creation and typed usage', () => {
 				cy.visit(url);
 			});
 		});
-		navigateWorkflowSelectionDropdown(0, 'Create a new sub-workflow');
+		navigateWorkflowSelectionDropdown(0, 'Create a ');
 
 		openNode('Workflow Input Trigger');
 


### PR DESCRIPTION
## Summary

For some reason we are sometimes in a project when executing this test. Fortunately we can support either with this change.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
