### PR TITLE
fix(editor): Don't show toolsUnused notice if run had errors

### DIFF
--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -47,7 +47,6 @@ import {
 } from '../composables/workflow';
 import { NDV, WorkflowPage } from '../pages';
 import { createMockNodeExecutionData, runMockWorkflowExecution } from '../utils';
-import { ExecutionError } from 'n8n-workflow';
 
 describe('Langchain Integration', () => {
 	beforeEach(() => {

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -47,6 +47,7 @@ import {
 } from '../composables/workflow';
 import { NDV, WorkflowPage } from '../pages';
 import { createMockNodeExecutionData, runMockWorkflowExecution } from '../utils';
+import { ExecutionError } from 'n8n-workflow';
 
 describe('Langchain Integration', () => {
 	beforeEach(() => {

--- a/packages/editor-ui/src/components/OutputPanel.vue
+++ b/packages/editor-ui/src/components/OutputPanel.vue
@@ -120,16 +120,17 @@ const hasAiMetadata = computed(() => {
 	return false;
 });
 
-const hasError = computed(
-	() =>
+const hasError = computed(() =>
+	Boolean(
 		workflowRunData.value &&
-		node.value &&
-		(workflowRunData.value[node.value.name]?.[props.runIndex]?.error as NodeError),
+			node.value &&
+			workflowRunData.value[node.value.name]?.[props.runIndex]?.error,
+	),
 );
 
 // Determine the initial output mode to logs if the node has an error and the logs are available
 const defaultOutputMode = computed<OutputType>(() => {
-	return Boolean(hasError) && hasAiMetadata.value ? OUTPUT_TYPE.LOGS : OUTPUT_TYPE.REGULAR;
+	return hasError.value && hasAiMetadata.value ? OUTPUT_TYPE.LOGS : OUTPUT_TYPE.REGULAR;
 });
 
 const isNodeRunning = computed(() => {
@@ -218,7 +219,7 @@ const canPinData = computed(() => {
 });
 
 const allToolsWereUnusedNotice = computed(() => {
-	if (!node.value || runsCount.value === 0 || hasError) return undefined;
+	if (!node.value || runsCount.value === 0 || hasError.value) return undefined;
 
 	// With pinned data there's no clear correct answer for whether
 	// we should use historic or current parents, so we don't show the notice,

--- a/packages/editor-ui/src/components/OutputPanel.vue
+++ b/packages/editor-ui/src/components/OutputPanel.vue
@@ -120,13 +120,15 @@ const hasAiMetadata = computed(() => {
 	return false;
 });
 
-// Determine the initial output mode to logs if the node has an error and the logs are available
-const defaultOutputMode = computed<OutputType>(() => {
-	const hasError =
+const hasError = computed(
+	() =>
 		workflowRunData.value &&
 		node.value &&
-		(workflowRunData.value[node.value.name]?.[props.runIndex]?.error as NodeError);
+		(workflowRunData.value[node.value.name]?.[props.runIndex]?.error as NodeError),
+);
 
+// Determine the initial output mode to logs if the node has an error and the logs are available
+const defaultOutputMode = computed<OutputType>(() => {
 	return Boolean(hasError) && hasAiMetadata.value ? OUTPUT_TYPE.LOGS : OUTPUT_TYPE.REGULAR;
 });
 
@@ -216,7 +218,7 @@ const canPinData = computed(() => {
 });
 
 const allToolsWereUnusedNotice = computed(() => {
-	if (!node.value || runsCount.value === 0) return undefined;
+	if (!node.value || runsCount.value === 0 || hasError) return undefined;
 
 	// With pinned data there's no clear correct answer for whether
 	// we should use historic or current parents, so we don't show the notice,

--- a/packages/editor-ui/src/components/OutputPanel.vue
+++ b/packages/editor-ui/src/components/OutputPanel.vue
@@ -4,7 +4,6 @@ import {
 	NodeConnectionType,
 	type IRunData,
 	type IRunExecutionData,
-	type NodeError,
 	type Workflow,
 } from 'n8n-workflow';
 import RunData from './RunData.vue';


### PR DESCRIPTION
## Summary

Before: 
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/f25657e9-011b-4ac3-a55c-d10d1b8deca1" />

After:
<img width="970" alt="image" src="https://github.com/user-attachments/assets/04bfc36d-258c-48c6-ae9a-f52781fdc214" />

Considered adding another test case, but we did e2e testing (`30-langchain`) here and the mocking proves non-trivial. Added a tech debt ticket to move these to unit tests in `OutputPanel.vue` instead: https://linear.app/n8n/issue/ADO-3077/tech-debt-move-toolsunused-callout-e2e-tests-to-unit-tests


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3076/the-none-of-your-tools-were-used-warning-is-also-showing-when-the


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
