### PR TITLE
fix(spotifyNode): Handle trackID for add and delete operations consis…

### DIFF
--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -367,10 +367,10 @@ export class Spotify implements INodeType {
 
 				options: [
 					{
-						name: 'Add an Item',
+						name: 'Add Items',
 						value: 'add',
 						description: 'Add tracks to a playlist by track and playlist URI or ID',
-						action: 'Add an Item to a playlist',
+						action: 'Add one or more items to a playlist',
 					},
 					{
 						name: 'Create a Playlist',
@@ -397,10 +397,10 @@ export class Spotify implements INodeType {
 						action: "Get a playlist's tracks by URI or ID",
 					},
 					{
-						name: 'Remove an Item',
+						name: 'Remove Items',
 						value: 'delete',
 						description: 'Remove tracks from a playlist by track and playlist URI or ID',
-						action: 'Remove an item from a playlist',
+						action: 'Remove one or more items from a playlist',
 					},
 					{
 						name: 'Search',
@@ -483,9 +483,8 @@ export class Spotify implements INodeType {
 						operation: ['add', 'delete'],
 					},
 				},
-				placeholder: 'spotify:track:0xE4LEFzSNGsz1F6kvXsHU',
-				description:
-					"The track's Spotify URI or its ID. The track to add/delete from the playlist.",
+				placeholder: 'spotify:track:0xE4LEFzSNGsz1F6kvXsHU,spotify:track:0xE5LEFzSNGsz1F6kvXsHU',
+				description: 'The Spotify URI or ID of the track(s) to add or delete from the playlist',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -1083,13 +1082,15 @@ export class Spotify implements INodeType {
 
 						if (operation === 'delete') {
 							requestMethod = 'DELETE';
-							const trackId = this.getNodeParameter('trackID', i) as string;
 
-							body.tracks = [
-								{
-									uri: trackId,
-								},
-							];
+							const trackIdParameter = this.getNodeParameter('trackID', i) as string;
+
+							const trackIds =
+								typeof trackIdParameter === 'string' && trackIdParameter.includes(',')
+									? trackIdParameter.split(',').map((trackId) => trackId.trim())
+									: [trackIdParameter];
+
+							body.tracks = trackIds.map((trackId) => ({ uri: trackId }));
 
 							endpoint = `/playlists/${id}/tracks`;
 
@@ -1131,15 +1132,17 @@ export class Spotify implements INodeType {
 						} else if (operation === 'add') {
 							requestMethod = 'POST';
 
-							const trackId = this.getNodeParameter('trackID', i) as string;
+							const trackIdParameter = this.getNodeParameter('trackID', i) as string;
+							const trackIds = trackIdParameter.includes(',')
+								? trackIdParameter.split(',').map((trackId) => trackId.trim())
+								: [trackIdParameter];
+
 							const additionalFields = this.getNodeParameter('additionalFields', i);
 
-							qs = {
-								uris: trackId,
-							};
+							body.uris = trackIds;
 
 							if (additionalFields.position !== undefined) {
-								qs.position = additionalFields.position;
+								body.position = additionalFields.position;
 							}
 
 							endpoint = `/playlists/${id}/tracks`;

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -1085,10 +1085,9 @@ export class Spotify implements INodeType {
 
 							const trackIdParameter = this.getNodeParameter('trackID', i) as string;
 
-							const trackIds =
-								typeof trackIdParameter === 'string' && trackIdParameter.includes(',')
-									? trackIdParameter.split(',').map((trackId) => trackId.trim())
-									: [trackIdParameter];
+							const trackIds = trackIdParameter.includes(',')
+								? trackIdParameter.split(',').map((trackId) => trackId.trim())
+								: [trackIdParameter];
 
 							body.tracks = trackIds.map((trackId) => ({ uri: trackId }));
 


### PR DESCRIPTION

**fix(spotifyNode): Handle trackID for add and delete operations consistently**

- Update the delete method to handle multiple comma-separated trackIDs by splitting and formatting them into the required array structure.
- Optimize the add method to pass trackIDs in the request body instead of appending them to the URL.
- Ensure consistent handling of single and multiple trackIDs for both operations.

## Summary

This PR ensures that both the add and delete methods of the Spotify node handle trackIDs in a consistent manner. The delete method is updated to support multiple trackIDs, which are now properly split and formatted into the required array structure. The add method has been optimized to pass trackIDs in the request body, avoiding appending them to the URL. These changes ensure that both single and multiple trackIDs are handled correctly across both operations.

To test the changes, use a Spotify node with various trackID inputs to verify that both add and delete operations behave as expected, handling single and multiple trackIDs consistently.

## Related Linear tickets, Github issues, and Community forum posts

resolves #12527 

- [Linear issue](https://linear.app/n8n/issue/N8N-8069)


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
