### PR TITLE
fix(editor): Fix parameter input validation

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -365,7 +365,7 @@ const getIssues = computed<string[]>(() => {
 			if (Array.isArray(displayValue.value)) {
 				checkValues = checkValues.concat(displayValue.value);
 			} else {
-				checkValues = checkValues.concat(displayValue.value?.toString().split(','));
+				checkValues.push(displayValue.value);
 			}
 		}
 

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -132,10 +132,10 @@ const evaluatedExpression = computed<Result<unknown, Error>>(() => {
 		}
 
 		if (props.isForCredential) opts.additionalKeys = resolvedAdditionalExpressionData.value;
-		const stringifyExpressionResult = props.parameter.type !== 'multiOptions';
+		const stringifyObject = props.parameter.type !== 'multiOptions';
 		return {
 			ok: true,
-			result: workflowHelpers.resolveExpression(value, undefined, opts, stringifyExpressionResult),
+			result: workflowHelpers.resolveExpression(value, undefined, opts, stringifyObject),
 		};
 	} catch (error) {
 		return { ok: false, error };


### PR DESCRIPTION
## Summary
This PR fixes a regression introduced by https://github.com/n8n-io/n8n/pull/12430 which broke parameter input validation
it also renames the variable stringifyExpressionResult as it is already declared in the same file
## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2217/schedule-trigger-node-not-accepting-times

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
