### PR TITLE
fix(core): AugmentObject should check for own propeties correctly

### DIFF
--- a/packages/workflow/test/AugmentObject.test.ts
+++ b/packages/workflow/test/AugmentObject.test.ts
@@ -572,5 +572,22 @@ describe('AugmentObject', () => {
 			expect('z' in augmentedObject.x).toBe(true);
 			expect('y' in augmentedObject.x).toBe(true);
 		});
+
+		test('should ignore non-enumerable keys', () => {
+			const originalObject: { toString?: string } = { toString: '123' };
+			const augmentedObject = augmentObject(originalObject);
+			expect('toString' in augmentedObject).toBe(true);
+			expect(Object.keys(augmentedObject)).toEqual(['toString']);
+			expect(Object.getOwnPropertyDescriptor(augmentedObject, 'toString')?.value).toEqual(
+				originalObject.toString,
+			);
+			expect(augmentedObject.toString).toEqual(originalObject.toString);
+
+			augmentedObject.toString = '456';
+			expect(augmentedObject.toString).toBe('456');
+
+			delete augmentedObject.toString;
+			expect(augmentedObject.toString).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## Summary
This updates `AugmentObject` to check for own properties using `hasOwnProperty` instead of the `in` operator.

## Related Linear tickets, Github issues, and Community forum posts
CAT-498
closes #12521


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
