### PR TITLE
fix(core): Filter out task runner errors originating from user code from sentry (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
+++ b/packages/@n8n/task-runner/src/__tests__/task-runner-sentry.test.ts
@@ -1,0 +1,178 @@
+import type { ErrorEvent } from '@sentry/types';
+import { mock } from 'jest-mock-extended';
+import type { ErrorReporter } from 'n8n-core';
+
+import { TaskRunnerSentry } from '../task-runner-sentry';
+
+describe('TaskRunnerSentry', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('filterOutUserCodeErrors', () => {
+		const sentry = new TaskRunnerSentry(
+			{
+				dsn: 'https://sentry.io/123',
+				n8nVersion: '1.0.0',
+				environment: 'local',
+				deploymentName: 'test',
+			},
+			mock(),
+		);
+
+		it('should filter out user code errors', () => {
+			const event: ErrorEvent = {
+				type: undefined,
+				exception: {
+					values: [
+						{
+							type: 'ReferenceError',
+							value: 'fetch is not defined',
+							stacktrace: {
+								frames: [
+									{
+										filename: 'app:///dist/js-task-runner/js-task-runner.js',
+										module: 'js-task-runner:js-task-runner',
+										function: 'JsTaskRunner.executeTask',
+									},
+									{
+										filename: 'app:///dist/js-task-runner/js-task-runner.js',
+										module: 'js-task-runner:js-task-runner',
+										function: 'JsTaskRunner.runForAllItems',
+									},
+									{
+										filename: '<anonymous>',
+										module: '<anonymous>',
+										function: 'new Promise',
+									},
+									{
+										filename: 'app:///dist/js-task-runner/js-task-runner.js',
+										module: 'js-task-runner:js-task-runner',
+										function: 'result',
+									},
+									{
+										filename: 'node:vm',
+										module: 'node:vm',
+										function: 'runInContext',
+									},
+									{
+										filename: 'node:vm',
+										module: 'node:vm',
+										function: 'Script.runInContext',
+									},
+									{
+										filename: 'evalmachine.<anonymous>',
+										module: 'evalmachine.<anonymous>',
+										function: '?',
+									},
+									{
+										filename: 'evalmachine.<anonymous>',
+										module: 'evalmachine.<anonymous>',
+										function: 'VmCodeWrapper',
+									},
+									{
+										filename: '<anonymous>',
+										module: '<anonymous>',
+										function: 'new Promise',
+									},
+									{
+										filename: 'evalmachine.<anonymous>',
+										module: 'evalmachine.<anonymous>',
+									},
+								],
+							},
+							mechanism: { type: 'onunhandledrejection', handled: false },
+						},
+					],
+				},
+				event_id: '18bb78bb3d9d44c4acf3d774c2cfbfd8',
+				platform: 'node',
+				contexts: {
+					trace: { trace_id: '3c3614d33a6b47f09b85ec7d2710acea', span_id: 'ad00fdf6d6173aeb' },
+					runtime: { name: 'node', version: 'v20.17.0' },
+				},
+			};
+
+			expect(sentry.filterOutUserCodeErrors(event)).toBe(true);
+		});
+	});
+
+	describe('initIfEnabled', () => {
+		const mockErrorReporter = mock<ErrorReporter>();
+
+		it('should not configure sentry if dsn is not set', async () => {
+			const sentry = new TaskRunnerSentry(
+				{
+					dsn: '',
+					n8nVersion: '1.0.0',
+					environment: 'local',
+					deploymentName: 'test',
+				},
+				mockErrorReporter,
+			);
+
+			await sentry.initIfEnabled();
+
+			expect(mockErrorReporter.init).not.toHaveBeenCalled();
+		});
+
+		it('should configure sentry if dsn is set', async () => {
+			const sentry = new TaskRunnerSentry(
+				{
+					dsn: 'https://sentry.io/123',
+					n8nVersion: '1.0.0',
+					environment: 'local',
+					deploymentName: 'test',
+				},
+				mockErrorReporter,
+			);
+
+			await sentry.initIfEnabled();
+
+			expect(mockErrorReporter.init).toHaveBeenCalledWith({
+				dsn: 'https://sentry.io/123',
+				beforeSendFilter: sentry.filterOutUserCodeErrors,
+				release: '1.0.0',
+				environment: 'local',
+				serverName: 'test',
+				serverType: 'task_runner',
+			});
+		});
+	});
+
+	describe('shutdown', () => {
+		const mockErrorReporter = mock<ErrorReporter>();
+
+		it('should not shutdown sentry if dsn is not set', async () => {
+			const sentry = new TaskRunnerSentry(
+				{
+					dsn: '',
+					n8nVersion: '1.0.0',
+					environment: 'local',
+					deploymentName: 'test',
+				},
+				mockErrorReporter,
+			);
+
+			await sentry.shutdown();
+
+			expect(mockErrorReporter.shutdown).not.toHaveBeenCalled();
+		});
+
+		it('should shutdown sentry if dsn is set', async () => {
+			const sentry = new TaskRunnerSentry(
+				{
+					dsn: 'https://sentry.io/123',
+					n8nVersion: '1.0.0',
+					environment: 'local',
+					deploymentName: 'test',
+				},
+				mockErrorReporter,
+			);
+
+			await sentry.shutdown();
+
+			expect(mockErrorReporter.shutdown).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -1,0 +1,63 @@
+import { Service } from '@n8n/di';
+import type { ErrorEvent, Exception } from '@sentry/types';
+import { ErrorReporter } from 'n8n-core';
+
+import { SentryConfig } from './config/sentry-config';
+
+/**
+ * Sentry service for the task runner.
+ */
+@Service()
+export class TaskRunnerSentry {
+	constructor(
+		private readonly config: SentryConfig,
+		private readonly errorReporter: ErrorReporter,
+	) {}
+
+	async initIfEnabled() {
+		if (!this.config.dsn) return;
+
+		await this.errorReporter.init({
+			serverType: 'task_runner',
+			dsn: this.config.dsn,
+			release: this.config.n8nVersion,
+			environment: this.config.environment,
+			serverName: this.config.deploymentName,
+			beforeSendFilter: this.filterOutUserCodeErrors,
+		});
+	}
+
+	async shutdown() {
+		if (!this.config.dsn) return;
+
+		await this.errorReporter.shutdown();
+	}
+
+	/**
+	 * Filter out errors originating from user provided code.
+	 * It is possible for users to create code that causes unhandledrejections
+	 * that end up in the sentry error reporting.
+	 */
+	filterOutUserCodeErrors = (event: ErrorEvent) => {
+		const error = event?.exception?.values?.[0];
+		if (!error) return false;
+
+		return error ? this.isUserCodeError(error) : false;
+	};
+
+	/**
+	 * Check if the error is originating from user provided code.
+	 * It is possible for users to create code that causes unhandledrejections
+	 * that end up in the sentry error reporting.
+	 */
+	private isUserCodeError(error?: Exception) {
+		if (!error) return false;
+
+		const frames = error.stacktrace?.frames;
+		if (!frames) return false;
+
+		return frames.some(
+			(frame) => frame.filename === 'node:vm' && frame.function === 'runInContext',
+		);
+	}
+}

--- a/packages/@n8n/task-runner/src/task-runner-sentry.ts
+++ b/packages/@n8n/task-runner/src/task-runner-sentry.ts
@@ -15,14 +15,16 @@ export class TaskRunnerSentry {
 	) {}
 
 	async initIfEnabled() {
-		if (!this.config.dsn) return;
+		const { dsn, n8nVersion, environment, deploymentName } = this.config;
+
+		if (!dsn) return;
 
 		await this.errorReporter.init({
 			serverType: 'task_runner',
-			dsn: this.config.dsn,
-			release: this.config.n8nVersion,
-			environment: this.config.environment,
-			serverName: this.config.deploymentName,
+			dsn,
+			release: n8nVersion,
+			environment,
+			serverName: deploymentName,
 			beforeSendFilter: this.filterOutUserCodeErrors,
 		});
 	}
@@ -40,7 +42,6 @@ export class TaskRunnerSentry {
 	 */
 	filterOutUserCodeErrors = (event: ErrorEvent) => {
 		const error = event?.exception?.values?.[0];
-		if (!error) return false;
 
 		return error ? this.isUserCodeError(error) : false;
 	};
@@ -50,9 +51,7 @@ export class TaskRunnerSentry {
 	 * It is possible for users to create code that causes unhandledrejections
 	 * that end up in the sentry error reporting.
 	 */
-	private isUserCodeError(error?: Exception) {
-		if (!error) return false;
-
+	private isUserCodeError(error: Exception) {
 		const frames = error.stacktrace?.frames;
 		if (!frames) return false;
 

--- a/packages/core/src/error-reporter.ts
+++ b/packages/core/src/error-reporter.ts
@@ -118,16 +118,21 @@ export class ErrorReporter {
 	}
 
 	async beforeSend(event: ErrorEvent, hint: EventHint) {
-		if (this.beforeSendFilter && this.beforeSendFilter(event, hint)) {
-			return null;
-		}
-
 		let { originalException } = hint;
 
 		if (!originalException) return null;
 
 		if (originalException instanceof Promise) {
 			originalException = await originalException.catch((error) => error as Error);
+		}
+
+		if (
+			this.beforeSendFilter?.(event, {
+				...hint,
+				originalException,
+			})
+		) {
+			return null;
 		}
 
 		if (originalException instanceof AxiosError) return null;

--- a/packages/core/src/error-reporter.ts
+++ b/packages/core/src/error-reporter.ts
@@ -177,15 +177,11 @@ export class ErrorReporter {
 
 	/** @returns true if the error should be filtered out */
 	private handleSqliteError(error: unknown) {
-		if (
+		return (
 			error instanceof Error &&
 			error.name === 'QueryFailedError' &&
 			['SQLITE_FULL', 'SQLITE_IOERR'].some((errMsg) => error.message.includes(errMsg))
-		) {
-			return true;
-		}
-
-		return false;
+		);
 	}
 
 	/** @returns true if the error should be filtered out */

--- a/packages/core/test/error-reporter.test.ts
+++ b/packages/core/test/error-reporter.test.ts
@@ -101,6 +101,37 @@ describe('ErrorReporter', () => {
 			const result = await errorReporter.beforeSend(event, { originalException });
 			expect(result).toBeNull();
 		});
+
+		describe('beforeSendFilter', () => {
+			const newErrorReportedWithBeforeSendFilter = (beforeSendFilter: jest.Mock) => {
+				const errorReporter = new ErrorReporter(mock());
+				// @ts-expect-error - beforeSendFilter is private
+				errorReporter.beforeSendFilter = beforeSendFilter;
+				return errorReporter;
+			};
+
+			it('should filter out based on the beforeSendFilter', async () => {
+				const beforeSendFilter = jest.fn().mockReturnValue(true);
+				const errorReporter = newErrorReportedWithBeforeSendFilter(beforeSendFilter);
+				const hint = { originalException: new Error() };
+
+				const result = await errorReporter.beforeSend(event, hint);
+
+				expect(result).toBeNull();
+				expect(beforeSendFilter).toHaveBeenCalledWith(event, hint);
+			});
+
+			it('should not filter out when beforeSendFilter returns false', async () => {
+				const beforeSendFilter = jest.fn().mockReturnValue(false);
+				const errorReporter = newErrorReportedWithBeforeSendFilter(beforeSendFilter);
+				const hint = { originalException: new Error() };
+
+				const result = await errorReporter.beforeSend(event, hint);
+
+				expect(result).toEqual(event);
+				expect(beforeSendFilter).toHaveBeenCalledWith(event, hint);
+			});
+		});
 	});
 
 	describe('error', () => {


### PR DESCRIPTION
## Summary

Filter out task runner errors originating from user code from sentry.

Adds a `beforeSendFilter` option for `ErrorReporter` that can be used to filter out certain exceptions

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-499/filter-out-exception-from-user-code

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
