### PR TITLE
test: Reset numeric features as well between e2e tests

### DIFF
--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -112,6 +112,15 @@ export class E2EController {
 		[LICENSE_QUOTAS.AI_CREDITS]: 0,
 	};
 
+	private static readonly numericFeaturesDefaults: Record<NumericLicenseFeature, number> = {
+		[LICENSE_QUOTAS.TRIGGER_LIMIT]: -1,
+		[LICENSE_QUOTAS.VARIABLES_LIMIT]: -1,
+		[LICENSE_QUOTAS.USERS_LIMIT]: -1,
+		[LICENSE_QUOTAS.WORKFLOW_HISTORY_PRUNE_LIMIT]: -1,
+		[LICENSE_QUOTAS.TEAM_PROJECT_LIMIT]: 0,
+		[LICENSE_QUOTAS.AI_CREDITS]: 0,
+	};
+
 	constructor(
 		license: License,
 		private readonly settingsRepo: SettingsRepository,
@@ -180,6 +189,11 @@ export class E2EController {
 	private resetFeatures() {
 		for (const feature of Object.keys(this.enabledFeatures)) {
 			this.enabledFeatures[feature as BooleanLicenseFeature] = false;
+		}
+
+		for (const feature of Object.keys(this.numericFeatures)) {
+			this.numericFeatures[feature as NumericLicenseFeature] =
+				E2EController.numericFeaturesDefaults[feature as NumericLicenseFeature];
 		}
 	}
 

--- a/packages/cli/src/controllers/e2e.controller.ts
+++ b/packages/cli/src/controllers/e2e.controller.ts
@@ -103,7 +103,7 @@ export class E2EController {
 		[LICENSE_FEATURES.AI_CREDITS]: false,
 	};
 
-	private numericFeatures: Record<NumericLicenseFeature, number> = {
+	private static readonly numericFeaturesDefaults: Record<NumericLicenseFeature, number> = {
 		[LICENSE_QUOTAS.TRIGGER_LIMIT]: -1,
 		[LICENSE_QUOTAS.VARIABLES_LIMIT]: -1,
 		[LICENSE_QUOTAS.USERS_LIMIT]: -1,
@@ -112,13 +112,17 @@ export class E2EController {
 		[LICENSE_QUOTAS.AI_CREDITS]: 0,
 	};
 
-	private static readonly numericFeaturesDefaults: Record<NumericLicenseFeature, number> = {
-		[LICENSE_QUOTAS.TRIGGER_LIMIT]: -1,
-		[LICENSE_QUOTAS.VARIABLES_LIMIT]: -1,
-		[LICENSE_QUOTAS.USERS_LIMIT]: -1,
-		[LICENSE_QUOTAS.WORKFLOW_HISTORY_PRUNE_LIMIT]: -1,
-		[LICENSE_QUOTAS.TEAM_PROJECT_LIMIT]: 0,
-		[LICENSE_QUOTAS.AI_CREDITS]: 0,
+	private numericFeatures: Record<NumericLicenseFeature, number> = {
+		[LICENSE_QUOTAS.TRIGGER_LIMIT]:
+			E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.TRIGGER_LIMIT],
+		[LICENSE_QUOTAS.VARIABLES_LIMIT]:
+			E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.VARIABLES_LIMIT],
+		[LICENSE_QUOTAS.USERS_LIMIT]: E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.USERS_LIMIT],
+		[LICENSE_QUOTAS.WORKFLOW_HISTORY_PRUNE_LIMIT]:
+			E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.WORKFLOW_HISTORY_PRUNE_LIMIT],
+		[LICENSE_QUOTAS.TEAM_PROJECT_LIMIT]:
+			E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.TEAM_PROJECT_LIMIT],
+		[LICENSE_QUOTAS.AI_CREDITS]: E2EController.numericFeaturesDefaults[LICENSE_QUOTAS.AI_CREDITS],
 	};
 
 	constructor(


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

I had a couple of flaky tests:
https://github.com/n8n-io/n8n/actions/runs/12672759498/job/35317883350
https://github.com/n8n-io/n8n/actions/runs/12691803664/job/35376066652

These failed because before them another test was running that set a `LICENSE_QUOTAS.TEAM_PROJECT_LIMIT` of `-1` (unlimited) and the `POST e2e/reset` endpoint did not reset them to their default.
That lead the FE to assume that projects are enabled:

https://github.com/n8n-io/n8n/blob/5d409a3d0a40140ac7b3b4e515a0e0aab996e1c8/packages/editor-ui/src/stores/projects.store.ts#L63-L63

Which rendered a different string:

https://github.com/n8n-io/n8n/blob/5d409a3d0a40140ac7b3b4e515a0e0aab996e1c8/packages/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue#L92-L110

https://github.com/n8n-io/n8n/blob/5d409a3d0a40140ac7b3b4e515a0e0aab996e1c8/cypress/e2e/45-workflow-selector-parameter.cy.ts#L93-L97

This PR resets the numeric features back to their initial value as well.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
