### PR TITLE
fix(editor): Override selected nodes on single click without Meta/Ctrl key

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -6,7 +6,13 @@ import type {
 	CanvasEventBusEvents,
 	ConnectStartEvent,
 } from '@/types';
-import type { Connection, XYPosition, NodeDragEvent, GraphNode } from '@vue-flow/core';
+import type {
+	Connection,
+	XYPosition,
+	NodeDragEvent,
+	NodeMouseEvent,
+	GraphNode,
+} from '@vue-flow/core';
 import { useVueFlow, VueFlow, PanelPosition, MarkerType } from '@vue-flow/core';
 import { MiniMap } from '@vue-flow/minimap';
 import Node from './elements/nodes/CanvasNode.vue';
@@ -270,6 +276,14 @@ function onUpdateNodePosition(id: string, position: XYPosition) {
 
 function onNodeDragStop(event: NodeDragEvent) {
 	onUpdateNodesPosition(event.nodes.map(({ id, position }) => ({ id, position })));
+}
+
+function onNodeClick({ event, node }: NodeMouseEvent) {
+	if (event.ctrlKey || event.metaKey) {
+		return;
+	}
+
+	onSelectNodes({ ids: [node.id] });
 }
 
 function onSelectionDragStop(event: NodeDragEvent) {
@@ -676,6 +690,7 @@ provide(CanvasKey, {
 		@move-start="onPaneMoveStart"
 		@move-end="onPaneMoveEnd"
 		@node-drag-stop="onNodeDragStop"
+		@node-click="onNodeClick"
 		@selection-drag-stop="onSelectionDragStop"
 		@dragover="onDragOver"
 		@drop="onDrop"

--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -279,7 +279,7 @@ function onNodeDragStop(event: NodeDragEvent) {
 }
 
 function onNodeClick({ event, node }: NodeMouseEvent) {
-	if (event.ctrlKey || event.metaKey) {
+	if (event.ctrlKey || event.metaKey || selectedNodes.value.length < 2) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/0daadd4b-f042-40c4-8f8f-6d27f8cd6127



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-506/override-selected-nodes-on-single-click

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
