### PR TITLE
fix: Don't break oauth credentials when updating them and allow fixing broken oauth credentials by repeating the authorization flow

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -6,7 +6,7 @@ import { Cipher } from 'n8n-core';
 import { Logger } from 'n8n-core';
 import nock from 'nock';
 
-import { Time } from '@/constants';
+import { CREDENTIAL_BLANKING_VALUE, Time } from '@/constants';
 import { OAuth2CredentialController } from '@/controllers/oauth/oauth2-credential.controller';
 import { CredentialsHelper } from '@/credentials-helper';
 import type { CredentialsEntity } from '@/databases/entities/credentials-entity';
@@ -226,6 +226,86 @@ describe('OAuth2CredentialController', () => {
 		it('should exchange the code for a valid token, and save it to DB', async () => {
 			credentialsRepository.findOneBy.mockResolvedValueOnce(credential);
 			credentialsHelper.getDecrypted.mockResolvedValueOnce({ csrfSecret });
+			jest.spyOn(Csrf.prototype, 'verify').mockReturnValueOnce(true);
+			nock('https://example.domain')
+				.post(
+					'/token',
+					'code=code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5678%2Frest%2Foauth2-credential%2Fcallback',
+				)
+				.reply(200, { access_token: 'access-token', refresh_token: 'refresh-token' });
+			cipher.encrypt.mockReturnValue('encrypted');
+
+			await controller.handleCallback(req, res);
+
+			expect(externalHooks.run).toHaveBeenCalledWith('oauth2.callback', [
+				expect.objectContaining({
+					clientId: 'test-client-id',
+					redirectUri: 'http://localhost:5678/rest/oauth2-credential/callback',
+				}),
+			]);
+			expect(cipher.encrypt).toHaveBeenCalledWith({
+				oauthTokenData: { access_token: 'access-token', refresh_token: 'refresh-token' },
+			});
+			expect(credentialsRepository.update).toHaveBeenCalledWith(
+				'1',
+				expect.objectContaining({
+					data: 'encrypted',
+					id: '1',
+					name: 'Test Credential',
+					type: 'oAuth2Api',
+				}),
+			);
+			expect(res.render).toHaveBeenCalledWith('oauth-callback');
+		});
+
+		it('merges oauthTokenData if it already exists', async () => {
+			credentialsRepository.findOneBy.mockResolvedValueOnce(credential);
+			credentialsHelper.getDecrypted.mockResolvedValueOnce({
+				csrfSecret,
+				oauthTokenData: { token: true },
+			});
+			jest.spyOn(Csrf.prototype, 'verify').mockReturnValueOnce(true);
+			nock('https://example.domain')
+				.post(
+					'/token',
+					'code=code&grant_type=authorization_code&redirect_uri=http%3A%2F%2Flocalhost%3A5678%2Frest%2Foauth2-credential%2Fcallback',
+				)
+				.reply(200, { access_token: 'access-token', refresh_token: 'refresh-token' });
+			cipher.encrypt.mockReturnValue('encrypted');
+
+			await controller.handleCallback(req, res);
+
+			expect(externalHooks.run).toHaveBeenCalledWith('oauth2.callback', [
+				expect.objectContaining({
+					clientId: 'test-client-id',
+					redirectUri: 'http://localhost:5678/rest/oauth2-credential/callback',
+				}),
+			]);
+			expect(cipher.encrypt).toHaveBeenCalledWith({
+				oauthTokenData: {
+					token: true,
+					access_token: 'access-token',
+					refresh_token: 'refresh-token',
+				},
+			});
+			expect(credentialsRepository.update).toHaveBeenCalledWith(
+				'1',
+				expect.objectContaining({
+					data: 'encrypted',
+					id: '1',
+					name: 'Test Credential',
+					type: 'oAuth2Api',
+				}),
+			);
+			expect(res.render).toHaveBeenCalledWith('oauth-callback');
+		});
+
+		it('overwrites oauthTokenData if it is a string', async () => {
+			credentialsRepository.findOneBy.mockResolvedValueOnce(credential);
+			credentialsHelper.getDecrypted.mockResolvedValueOnce({
+				csrfSecret,
+				oauthTokenData: CREDENTIAL_BLANKING_VALUE,
+			});
 			jest.spyOn(Csrf.prototype, 'verify').mockReturnValueOnce(true);
 			nock('https://example.domain')
 				.post(

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -133,7 +133,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 				set(oauthToken.data, 'callbackQueryString', omit(req.query, 'state', 'code'));
 			}
 
-			if (decryptedDataOriginal.oauthTokenData) {
+			if (typeof decryptedDataOriginal.oauthTokenData === 'object') {
 				// Only overwrite supplied data as some providers do for example just return the
 				// refresh_token on the very first request and not on subsequent ones.
 				Object.assign(decryptedDataOriginal.oauthTokenData, oauthToken.data);

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -33,7 +33,7 @@ describe('CredentialsController', () => {
 	});
 
 	describe('createCredentials', () => {
-		it('it should create new credentials and emit "credentials-created"', async () => {
+		it('should create new credentials and emit "credentials-created"', async () => {
 			// Arrange
 
 			const newCredentialsPayload = createNewCredentialsPayload();

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -198,7 +198,7 @@ export class CredentialsController {
 			throw new BadRequestError('Managed credentials cannot be updated');
 		}
 
-		const decryptedData = this.credentialsService.decrypt(credential);
+		const decryptedData = this.credentialsService.decrypt(credential, true);
 		const preparedCredentialData = await this.credentialsService.prepareUpdateData(
 			req.body,
 			decryptedData,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

This fixes 2 issues with oauth credentials:
1. Updating an oauth credential would save the blank value in the database for the `oauthTokenData`
2. Re-authorizing an oauth credential would not fix the `oauthTokenData` because it would object-assign the new properties on the string, which does not throw, but casts the `string` into a `String` and returns that with additional properties instead

This PR fixes both. It stops bricking oauth credentials when updating them. Additionally it allows fixing bricked credentials by re-authorizing.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2424/not-possible-to-reconnect-google-credentials#comment-41cd984f


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
