### PR TITLE
fix(editor): Ensure proper "AI Template" URL construction in node creator

### DIFF
--- a/packages/editor-ui/src/components/Node/NodeCreator/viewsData.ts
+++ b/packages/editor-ui/src/components/Node/NodeCreator/viewsData.ts
@@ -141,9 +141,10 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 	const chainNodes = getAiNodesBySubcategory(nodeTypesStore.allLatestNodeTypes, AI_CATEGORY_CHAINS);
 	const agentNodes = getAiNodesBySubcategory(nodeTypesStore.allLatestNodeTypes, AI_CATEGORY_AGENTS);
 
-	const websiteCategoryURL = templatesStore.websiteTemplateRepositoryParameters;
-
-	websiteCategoryURL.append('utm_user_role', 'AdvancedAI');
+	const websiteCategoryURLParams = templatesStore.websiteTemplateRepositoryParameters;
+	websiteCategoryURLParams.append('utm_user_role', 'AdvancedAI');
+	const websiteCategoryURL =
+		templatesStore.constructTemplateRepositoryURL(websiteCategoryURLParams);
 
 	return {
 		value: AI_NODE_CREATOR_VIEW,
@@ -158,7 +159,7 @@ export function AIView(_nodes: SimplifiedNodeType[]): NodeView {
 					icon: 'box-open',
 					description: i18n.baseText('nodeCreator.aiPanel.linkItem.description'),
 					name: 'ai_templates_root',
-					url: websiteCategoryURL.toString(),
+					url: websiteCategoryURL,
 					tag: {
 						type: 'info',
 						text: i18n.baseText('nodeCreator.triggerHelperPanel.manualTriggerTag'),

--- a/packages/editor-ui/src/stores/templates.store.ts
+++ b/packages/editor-ui/src/stores/templates.store.ts
@@ -167,6 +167,10 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, () => {
 			`${TEMPLATES_URLS.BASE_WEBSITE_URL}?${websiteTemplateRepositoryParameters.value.toString()}`,
 	);
 
+	const constructTemplateRepositoryURL = (params: URLSearchParams): string => {
+		return `${TEMPLATES_URLS.BASE_WEBSITE_URL}?${params.toString()}`;
+	};
+
 	const addCategories = (_categories: ITemplatesCategory[]): void => {
 		categories.value = _categories;
 	};
@@ -427,6 +431,7 @@ export const useTemplatesStore = defineStore(STORES.TEMPLATES, () => {
 		isSearchFinished,
 		hasCustomTemplatesHost,
 		websiteTemplateRepositoryURL,
+		constructTemplateRepositoryURL,
 		websiteTemplateRepositoryParameters,
 		addCategories,
 		addCollections,


### PR DESCRIPTION
## Summary

The link to the AI Templates in the NodeCreator was broken some time ago in a refactor. This fix re-introduces the proper URL to use.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/12565
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
