### PR TITLE
fix(editor): Show NDV errors when opening existing nodes with errors

### DIFF
--- a/packages/editor-ui/src/composables/useCanvasOperations.test.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.test.ts
@@ -995,6 +995,18 @@ describe('useCanvasOperations', () => {
 
 			expect(ndvStore.activeNodeName).toBe('Existing Node');
 		});
+
+		it('should set node as dirty when node is set active', () => {
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			const node = createTestNode();
+
+			workflowsStore.getNodeById.mockImplementation(() => node);
+
+			const { setNodeActive } = useCanvasOperations({ router });
+			setNodeActive(node.id);
+
+			expect(workflowsStore.setNodePristine).toHaveBeenCalledWith(node.name, false);
+		});
 	});
 
 	describe('setNodeActiveByName', () => {

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -381,6 +381,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 			return;
 		}
 
+		workflowsStore.setNodePristine(node.name, false);
 		setNodeActiveByName(node.name);
 	}
 


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/36b104f0-d439-4796-be8b-09eacd720e0a



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-510/show-node-issues-when-opening-ndv-for-existing-nodes


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
