### PR TITLE
feat: Add support for extended JSON in mongo node

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import {EJSON} from 'bson';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { MongoClient, ObjectId } from 'mongodb';
@@ -143,6 +144,10 @@ export function stringifyObjectIDs(items: INodeExecutionData[]) {
 	});
 
 	return items;
+}
+
+export function parseJsonToEjson(query: unknown) {
+		return EJSON.parse(JSON.stringify(query)) as Record<string, unknown>
 }
 
 export async function connectMongoClient(connectionString: string, credentials: IDataObject = {}) {


### PR DESCRIPTION
## Summary

This PR enhances the MongoDB node by adding support for Extended JSON (EJSON). With this update, users can now leverage EJSON features, such as converting values to specific types like `"$date"`, making it easier to handle complex MongoDB operations directly within the node.

### How to test:
1. Create or edit a MongoDB node in a workflow.
2. Input EJSON-formatted data, e.g., `{ "createdAt": { "$date": "2025-01-01T00:00:00Z" } }`.
3. Execute the node and verify the data is processed correctly in MongoDB.

Note: `EJSON.parse` will handle both normal JSON and Extended JSON gracefully.

## Related Linear tickets, GitHub issues, and Community forum posts

https://community.n8n.io/t/mongodb-date-objects-in-queries/40935/6
https://community.n8n.io/t/mongo-node-prefiltering-by-dates/4124

## Review / Merge checklist

- [x] PR title and summary are descriptive.
