### PR TITLE
fix(editor): Fix the `openselectivenodecreator` custom action on new canvas

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1564,7 +1564,6 @@ function registerCustomActions() {
 			node: string;
 		}) => {
 			nodeCreatorStore.openSelectiveNodeCreator({ node, connectionType, creatorView });
-			void onOpenSelectiveNodeCreator(node, connectionType);
 		},
 	});
 

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -31,6 +31,7 @@ import type {
 	IWorkflowDb,
 	IWorkflowTemplate,
 	NodeCreatorOpenSource,
+	NodeFilterType,
 	ToggleNodeCreatorOptions,
 	WorkflowDataWithTemplateId,
 	XYPosition,
@@ -1554,12 +1555,15 @@ function registerCustomActions() {
 	registerCustomAction({
 		key: 'openSelectiveNodeCreator',
 		action: ({
+			creatorview: creatorView,
 			connectiontype: connectionType,
 			node,
 		}: {
+			creatorview: NodeFilterType;
 			connectiontype: NodeConnectionType;
 			node: string;
 		}) => {
+			nodeCreatorStore.openSelectiveNodeCreator({ node, connectionType, creatorView });
 			void onOpenSelectiveNodeCreator(node, connectionType);
 		},
 	});


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/52ffbb8a-2d94-48a3-a779-62387543a881



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-512/the-openselectivenodecreator-custom-action-is-not-working


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
