### PR TITLE
fix(editor): Fix selection rectangle context menu on new canvas

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -519,6 +519,13 @@ function onOpenContextMenu(event: MouseEvent) {
 	});
 }
 
+function onOpenSelectionContextMenu({ event }: { event: MouseEvent }) {
+	contextMenu.open(event, {
+		source: 'canvas',
+		nodeIds: selectedNodeIds.value,
+	});
+}
+
 function onOpenNodeContextMenu(
 	id: string,
 	event: MouseEvent,
@@ -692,6 +699,7 @@ provide(CanvasKey, {
 		@node-drag-stop="onNodeDragStop"
 		@node-click="onNodeClick"
 		@selection-drag-stop="onSelectionDragStop"
+		@selection-context-menu="onOpenSelectionContextMenu"
 		@dragover="onDragOver"
 		@drop="onDrop"
 	>


### PR DESCRIPTION
## Summary

Added missing selection context menu code.

<img width="738" alt="Screenshot 2025-01-13 at 15 17 28" src="https://github.com/user-attachments/assets/ebce2bac-6233-4069-be32-090f458ae8c7" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-464/community-issue-in-new-canvas-rmb-menu-not-showing-when-nodes-selected

Fixes #12398

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
