### PR TITLE
feat(Telegram Trigger Node): Extend Telegram triggers list with all possible options

### DIFF
--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -104,7 +104,7 @@ export class TelegramTrigger implements INodeType {
 						name: 'Chosen Inline Result',
 						value: 'chosen_inline_result',
 						description:
-							'Trigger when the result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.',
+							"Trigger when the result of an inline query that was chosen by a user and sent to their chat partner. Please see Telegram's documentation on the feedback collecting for details on how to enable these updates for your bot.",
 					},
 					{
 						name: 'Deleted Business Messages',

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -18,8 +18,8 @@ export class TelegramTrigger implements INodeType {
 		name: 'telegramTrigger',
 		icon: 'file:telegram.svg',
 		group: ['trigger'],
-		version: [1, 1.1],
-		defaultVersion: 1.1,
+		version: [1, 1.1, 1.2],
+		defaultVersion: 1.2,
 		subtitle: '=Updates: {{$parameter["updates"].join(", ")}}',
 		description: 'Starts the workflow on a Telegram update',
 		defaults: {
@@ -57,7 +57,19 @@ export class TelegramTrigger implements INodeType {
 					{
 						name: '*',
 						value: '*',
-						description: 'All updates',
+						description:
+							'All updates except chat_member, message_reaction, and message_reaction_count (default behavior of Telegram API as they produces a lot of calls of webhooks)',
+					},
+					{
+						name: 'Business Connection',
+						value: 'business_connection',
+						description:
+							'Trigger when the bot was connected to or disconnected from a business account, or a user edited an existing connection with the bot',
+					},
+					{
+						name: 'Business Message',
+						value: 'business_message',
+						description: 'Trigger on new message from a connected business account',
 					},
 					{
 						name: 'Callback Query',
@@ -69,6 +81,40 @@ export class TelegramTrigger implements INodeType {
 						value: 'channel_post',
 						description:
 							'Trigger on new incoming channel post of any kind — text, photo, sticker, etc',
+					},
+					{
+						name: 'Chat Boost',
+						value: 'chat_boost',
+						description:
+							'Trigger when a chat boost was added or changed. The bot must be an administrator in the chat to receive these updates.',
+					},
+					{
+						name: 'Chat Join Request',
+						value: 'chat_join_request',
+						description:
+							'Trigger when a request to join the chat has been sent. The bot must have the can_invite_users administrator right in the chat to receive these updates.',
+					},
+					{
+						name: 'Chat Member',
+						value: 'chat_member',
+						description:
+							"Trigger when a chat member's status was updated in a chat. The bot must be an administrator in the chat.",
+					},
+					{
+						name: 'Chosen Inline Result',
+						value: 'chosen_inline_result',
+						description:
+							'Trigger when the result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.',
+					},
+					{
+						name: 'Deleted Business Messages',
+						value: 'deleted_business_messages',
+						description: 'Trigger when messages were deleted from a connected business account',
+					},
+					{
+						name: 'Edited Business Message',
+						value: 'edited_business_message',
+						description: 'Trigger on new version of a message from a connected business account',
 					},
 					{
 						name: 'Edited Channel Post',
@@ -93,6 +139,24 @@ export class TelegramTrigger implements INodeType {
 						description: 'Trigger on new incoming message of any kind — text, photo, sticker, etc',
 					},
 					{
+						name: 'Message Reaction',
+						value: 'message_reaction',
+						description:
+							"Trigger when a reaction to a message was changed by a user. The bot must be an administrator in the chat. The update isn't received for reactions set by bots.",
+					},
+					{
+						name: 'Message Reaction Count',
+						value: 'message_reaction_count',
+						description:
+							'Trigger when reactions to a message with anonymous reactions were changed. The bot must be an administrator in the chat. The updates are grouped and can be sent with delay up to a few minutes.',
+					},
+					{
+						name: 'My Chat Member',
+						value: 'my_chat_member',
+						description:
+							"Trigger when the bot's chat member status was updated in a chat. For private chats, this update is received only when the bot is blocked or unblocked by the user.",
+					},
+					{
 						name: 'Poll',
 						value: 'poll',
 						action: 'On Poll Change',
@@ -100,10 +164,28 @@ export class TelegramTrigger implements INodeType {
 							'Trigger on new poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot.',
 					},
 					{
+						name: 'Poll Answer',
+						value: 'poll_answer',
+						description:
+							'Trigger when user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.',
+					},
+					{
 						name: 'Pre-Checkout Query',
 						value: 'pre_checkout_query',
 						description:
 							'Trigger on new incoming pre-checkout query. Contains full information about checkout.',
+					},
+					{
+						name: 'Purchased Paid Media',
+						value: 'purchased_paid_media',
+						description:
+							'Trigger when a user purchased paid media with a non-empty payload sent by the bot in a non-channel chat',
+					},
+					{
+						name: 'Removed Chat Boost',
+						value: 'removed_chat_boost',
+						description:
+							'Trigger when a boost was removed from a chat. The bot must be an administrator in the chat to receive these updates.',
 					},
 					{
 						name: 'Shipping Query',
@@ -113,6 +195,7 @@ export class TelegramTrigger implements INodeType {
 					},
 				],
 				required: true,
+				hint: 'Some triggers may require additional permissions, see <a href="https://core.telegram.org/bots/api#getting-updates">Telegram API documentation</a> for more information',
 				default: [],
 			},
 			{

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -58,7 +58,7 @@ export class TelegramTrigger implements INodeType {
 						name: '*',
 						value: '*',
 						description:
-							'All updates except chat_member, message_reaction, and message_reaction_count (default behavior of Telegram API as they produces a lot of calls of webhooks)',
+							'All updates except "Chat Member", "Message Reaction", and "Message Reaction Count" (default behavior of Telegram API as they produces a lot of calls of updates)',
 					},
 					{
 						name: 'Business Connection',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Telegram API supports more updates for bots, than can be defined in N8N Telegram Trigger.

API docs: https://core.telegram.org/bots/api#update

Most of them can be received when using `*` option. But this produces extra calls of workflows. Users who pay per execution may pay for updates they don't need.

Also there are 3 updates, that can't be received at all due to the way Telegram API works: message_reaction, message_reaction_count and chat_member. They are excluded when setting up a web hook with `allowed_updates: []` (see Description column in docs https://core.telegram.org/bots/api#setwebhook).

**So currently it looks like this:**

| Telegram Update | Support in N8N Telegram Trigger |
|-------------------------|---------|
| message                 | ✅       |
| edited_message          | ✅       |
| channel_post            | ✅       |
| edited_channel_post     | ✅       |
| business_connection     | only when using `*` option |
| business_message        | only when using `*` option |
| edited_business_message | only when using `*` option |
| deleted_business_messages | only when using `*` option |
| message_reaction        | ❌ not supported by N8N, excluded by Telegram from `*` option |
| message_reaction_count  | ❌ not supported by N8N, excluded by Telegram from `*` option |
| inline_query            | ✅       |
| chosen_inline_result    | only when using `*` option |
| callback_query          | ✅       |
| shipping_query          | ✅       |
| pre_checkout_query      | ✅       |
| purchased_paid_media    | only when using `*` option |
| poll                    | ✅       |
| poll_answer             | only when using `*` option |
| my_chat_member          | only when using `*` option |
| chat_member             | ❌ not supported by N8N, excluded by Telegram from `*` option |
| chat_join_request       | only when using `*` option |
| chat_boost              | only when using `*` option |
| removed_chat_boost      | only when using `*` option |

This MR adds support for all update options to Telegram Trigger Node for granular selection.

But preserves the backward compatibility:
- Non of currently supported Updates was deleted
- `*`option works the same, so users won't receive extra traffic to there workflows

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

There was an attempt to do something similar in May 2024, but it would cause an extra traffic to existing workflows: https://github.com/n8n-io/n8n/pull/9321

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
