### PR TITLE
fix(HubSpot Node): HubSpot Trigger add the propertyName param for ticket.propertyChange event

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -189,7 +189,7 @@ export class HubspotTrigger implements INodeType {
 								required: true,
 							},
 							{
-								displayName: 'Property Name',
+								displayName: 'Property Name or ID',
 								name: 'property',
 								type: 'options',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -189,6 +189,24 @@ export class HubspotTrigger implements INodeType {
 								required: true,
 							},
 							{
+								displayName: 'Property Name',
+								name: 'property',
+								type: 'options',
+								description:
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								typeOptions: {
+									loadOptionsDependsOn: ['ticket.propertyChange'],
+									loadOptionsMethod: 'getTicketProperties',
+								},
+								displayOptions: {
+									show: {
+										name: ['ticket.propertyChange'],
+									},
+								},
+								default: '',
+								required: true,
+							},
+							{
 								displayName: 'Property Name or ID',
 								name: 'property',
 								type: 'options',
@@ -288,6 +306,22 @@ export class HubspotTrigger implements INodeType {
 			async getDealProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
 				const endpoint = '/properties/v2/deals/properties';
+				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				for (const property of properties) {
+					const propertyName = property.label;
+					const propertyId = property.name;
+					returnData.push({
+						name: propertyName,
+						value: propertyId,
+					});
+				}
+				return returnData;
+			},
+			// Get all the available ticket properties to display them to user so that they can
+			// select them easily
+			async getTicketProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const returnData: INodePropertyOptions[] = [];
+				const endpoint = '/properties/v2/tickets/properties';
 				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
 				for (const property of properties) {
 					const propertyName = property.label;

--- a/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
@@ -135,6 +135,7 @@ export const propertyEvents = [
 	'contact.propertyChange',
 	'company.propertyChange',
 	'deal.propertyChange',
+	'ticket.propertyChange',
 ];
 
 export const contactFields = [


### PR DESCRIPTION
## Summary

Allows the Property to be set on the Hubspot trigger node when selecting `ticket.propertyChange` (similar to the way company, contact and deal property change triggers work)

## Related Linear tickets, Github issues, and Community forum posts

Forum post on this issue: https://community.n8n.io/t/hubspot-trigger-node-failed-to-create-subscription-propertyname-must-be-set-for-this-event-type/54666

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


I haven't been able to get n8n running locally from the code yet to property run and test this but will try again, opening this in case anyone else wanted to check it out.