### PR TITLE
docs: Fixes link to luxon docs in datetime node

### DIFF
--- a/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
+++ b/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
@@ -61,7 +61,7 @@ const versionDescription: INodeTypeDescription = {
 	properties: [
 		{
 			displayName:
-				"More powerful date functionality is available in <a href='https://docs.n8n.io/code/expressions/luxon/' target='_blank'>expressions</a>,</br> e.g. <code>{{ $now.plus(1, 'week') }}</code>",
+				"More powerful date functionality is available in <a href='https://docs.n8n.io/code/cookbook/luxon/' target='_blank'>expressions</a>,</br> e.g. <code>{{ $now.plus(1, 'week') }}</code>",
 			name: 'noticeDateTime',
 			type: 'notice',
 			default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/AddToDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/AddToDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const AddToDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			"You can also do this using an expression, e.g. <code>{{your_date.plus(5, 'minutes')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/expressions/luxon/'>More info</a>",
+			"You can also do this using an expression, e.g. <code>{{your_date.plus(5, 'minutes')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/cookbook/luxon/'>More info</a>",
 		name: 'notice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/CurrentDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/CurrentDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const CurrentDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			'You can also refer to the current date in n8n expressions by using <code>{{$now}}</code> or <code>{{$today}}</code>. <a target="_blank" href="https://docs.n8n.io/code/expressions/luxon/">More info</a>',
+			'You can also refer to the current date in n8n expressions by using <code>{{$now}}</code> or <code>{{$today}}</code>. <a target="_blank" href="https://docs.n8n.io/code/cookbook/luxon/">More info</a>',
 		name: 'notice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/ExtractDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/ExtractDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const ExtractDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			'You can also do this using an expression, e.g. <code>{{ your_date.extract("month") }}}</code>. <a target="_blank" href="https://docs.n8n.io/code/expressions/luxon/">More info</a>',
+			'You can also do this using an expression, e.g. <code>{{ your_date.extract("month") }}}</code>. <a target="_blank" href="https://docs.n8n.io/code/cookbook/luxon/">More info</a>',
 		name: 'notice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/FormatDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/FormatDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const FormatDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			"You can also do this using an expression, e.g. <code>{{your_date.format('yyyy-MM-dd')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/expressions/luxon/'>More info</a>",
+			"You can also do this using an expression, e.g. <code>{{your_date.format('yyyy-MM-dd')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/cookbook/luxon/'>More info</a>",
 		name: 'notice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/RoundDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/RoundDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const RoundDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			"You can also do this using an expression, e.g. <code>{{ your_date.beginningOf('month') }}</code> or <code>{{ your_date.endOfMonth() }}</code>. <a target='_blank' href='https://docs.n8n.io/code/expressions/luxon/'>More info</a>",
+			"You can also do this using an expression, e.g. <code>{{ your_date.beginningOf('month') }}</code> or <code>{{ your_date.endOfMonth() }}</code>. <a target='_blank' href='https://docs.n8n.io/code/cookbook/luxon/'>More info</a>",
 		name: 'notice',
 		type: 'notice',
 		default: '',

--- a/packages/nodes-base/nodes/DateTime/V2/SubtractFromDateDescription.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/SubtractFromDateDescription.ts
@@ -5,7 +5,7 @@ import { includeInputFields } from './common.descriptions';
 export const SubtractFromDateDescription: INodeProperties[] = [
 	{
 		displayName:
-			"You can also do this using an expression, e.g. <code>{{your_date.minus(5, 'minutes')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/expressions/luxon/'>More info</a>",
+			"You can also do this using an expression, e.g. <code>{{your_date.minus(5, 'minutes')}}</code>. <a target='_blank' href='https://docs.n8n.io/code/cookbook/luxon/'>More info</a>",
 		name: 'notice',
 		type: 'notice',
 		default: '',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
Just a quick fix to update the correct link to our luxon documentation.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
