### PR TITLE
chore(core): Log failed webhook requests with debug (no-changelog)

### DIFF
--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -58,6 +58,7 @@ class WebhookRequestHandler {
 			const error = ensureError(e);
 			Container.get(Logger).debug(
 				`Error in handling webhook request ${req.method} ${req.path}: ${error.message}`,
+				{ stacktrace: error.stack },
 			);
 
 			return ResponseHelper.sendErrorResponse(res, error);

--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -1,5 +1,7 @@
+import { Container } from '@n8n/di';
 import type express from 'express';
-import type { IHttpRequestMethods } from 'n8n-workflow';
+import { Logger } from 'n8n-core';
+import { ensureError, type IHttpRequestMethods } from 'n8n-workflow';
 
 import * as ResponseHelper from '@/response-helper';
 import type {
@@ -52,8 +54,13 @@ class WebhookRequestHandler {
 					response.headers,
 				);
 			}
-		} catch (error) {
-			return ResponseHelper.sendErrorResponse(res, error as Error);
+		} catch (e) {
+			const error = ensureError(e);
+			Container.get(Logger).debug(
+				`Error in handling webhook request ${req.method} ${req.path}: ${error.message}`,
+			);
+
+			return ResponseHelper.sendErrorResponse(res, error);
 		}
 	}
 


### PR DESCRIPTION
## Summary

To gain at least some visibility into why webhook calls might fail, log failed webhook requests with debug level

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
