### PR TITLE
fix(core): Update isDocker check to return true on kubernetes/containerd

### DIFF
--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -158,7 +158,12 @@ export class InstanceSettings {
 		} catch {}
 		try {
 			const cgroupV2 = readFileSync('/proc/self/mountinfo', 'utf8');
-			if (cgroupV2.includes('kubelet') || cgroupV2.includes('containerd')) return true;
+			if (
+				cgroupV2.includes('docker') ||
+				cgroupV2.includes('kubelet') ||
+				cgroupV2.includes('containerd')
+			)
+				return true;
 		} catch {}
 		return false;
 	}

--- a/packages/core/src/InstanceSettings.ts
+++ b/packages/core/src/InstanceSettings.ts
@@ -142,19 +142,25 @@ export class InstanceSettings {
 	}
 
 	/**
-	 * Whether this instance is running inside a Docker container.
-	 *
-	 * Based on: https://github.com/sindresorhus/is-docker
+	 * Whether this instance is running inside a Docker/Podman/Kubernetes container.
 	 */
 	@Memoized
 	get isDocker() {
+		if (existsSync('/.dockerenv') || existsSync('/run/.containerenv')) return true;
 		try {
-			return (
-				existsSync('/.dockerenv') || readFileSync('/proc/self/cgroup', 'utf8').includes('docker')
-			);
-		} catch {
-			return false;
-		}
+			const cgroupV1 = readFileSync('/proc/self/cgroup', 'utf8');
+			if (
+				cgroupV1.includes('docker') ||
+				cgroupV1.includes('kubepods') ||
+				cgroupV1.includes('containerd')
+			)
+				return true;
+		} catch {}
+		try {
+			const cgroupV2 = readFileSync('/proc/self/mountinfo', 'utf8');
+			if (cgroupV2.includes('kubelet') || cgroupV2.includes('containerd')) return true;
+		} catch {}
+		return false;
 	}
 
 	update(newSettings: WritableSettings) {

--- a/packages/core/test/InstanceSettings.test.ts
+++ b/packages/core/test/InstanceSettings.test.ts
@@ -214,33 +214,58 @@ describe('InstanceSettings', () => {
 		});
 
 		it('should return true if /.dockerenv exists', () => {
-			mockFs.existsSync.calledWith('/.dockerenv').mockReturnValueOnce(true);
+			mockFs.existsSync.mockImplementation((path) => path === '/.dockerenv');
 			expect(settings.isDocker).toBe(true);
 			expect(mockFs.existsSync).toHaveBeenCalledWith('/.dockerenv');
 			expect(mockFs.readFileSync).not.toHaveBeenCalledWith('/proc/self/cgroup', 'utf8');
 		});
 
-		it('should return true if /proc/self/cgroup contains docker', () => {
-			mockFs.existsSync.calledWith('/.dockerenv').mockReturnValueOnce(false);
-			mockFs.readFileSync
-				.calledWith('/proc/self/cgroup', 'utf8')
-				.mockReturnValueOnce('docker cgroup');
-
+		it('should return true if /run/.containerenv exists', () => {
+			mockFs.existsSync.mockImplementation((path) => path === '/run/.containerenv');
 			expect(settings.isDocker).toBe(true);
-			expect(mockFs.existsSync).toHaveBeenCalledWith('/.dockerenv');
-			expect(mockFs.readFileSync).toHaveBeenCalledWith('/proc/self/cgroup', 'utf8');
+			expect(mockFs.existsSync).toHaveBeenCalledWith('/run/.containerenv');
+			expect(mockFs.readFileSync).not.toHaveBeenCalledWith('/proc/self/cgroup', 'utf8');
 		});
+
+		test.each(['docker', 'kubepods', 'containerd'])(
+			'should return true if /proc/self/cgroup contains %s',
+			(str) => {
+				mockFs.existsSync.mockReturnValueOnce(false);
+				mockFs.readFileSync.calledWith('/proc/self/cgroup', 'utf8').mockReturnValueOnce(str);
+
+				expect(settings.isDocker).toBe(true);
+				expect(mockFs.existsSync).toHaveBeenCalledWith('/.dockerenv');
+				expect(mockFs.readFileSync).toHaveBeenCalledWith('/proc/self/cgroup', 'utf8');
+			},
+		);
+
+		test.each(['kubelet', 'containerd'])(
+			'should return true if /proc/self/mountinfo contains %s',
+			(str) => {
+				mockFs.existsSync.mockReturnValueOnce(false);
+				mockFs.readFileSync.calledWith('/proc/self/cgroup', 'utf8').mockReturnValueOnce('');
+				mockFs.readFileSync.calledWith('/proc/self/mountinfo', 'utf8').mockReturnValueOnce(str);
+
+				expect(settings.isDocker).toBe(true);
+				expect(mockFs.existsSync).toHaveBeenCalledWith('/.dockerenv');
+				expect(mockFs.readFileSync).toHaveBeenCalledWith('/proc/self/cgroup', 'utf8');
+				expect(mockFs.readFileSync).toHaveBeenCalledWith('/proc/self/mountinfo', 'utf8');
+			},
+		);
 
 		it('should return false if no docker indicators are found', () => {
 			mockFs.existsSync.calledWith('/.dockerenv').mockReturnValueOnce(false);
 			mockFs.readFileSync.calledWith('/proc/self/cgroup', 'utf8').mockReturnValueOnce('');
+			mockFs.readFileSync.calledWith('/proc/self/mountinfo', 'utf8').mockReturnValueOnce('');
 			expect(settings.isDocker).toBe(false);
 		});
 
-		it('should return false if checking for docker throws an error', () => {
-			mockFs.existsSync.calledWith('/.dockerenv').mockImplementationOnce(() => {
-				throw new Error('Access denied');
+		it('should return false if reading any of these files throws an error', () => {
+			mockFs.existsSync.mockReturnValue(false);
+			mockFs.readFileSync.mockImplementation(() => {
+				throw new Error('File not found');
 			});
+
 			expect(settings.isDocker).toBe(false);
 		});
 

--- a/packages/core/test/InstanceSettings.test.ts
+++ b/packages/core/test/InstanceSettings.test.ts
@@ -239,7 +239,7 @@ describe('InstanceSettings', () => {
 			},
 		);
 
-		test.each(['kubelet', 'containerd'])(
+		test.each(['docker', 'kubelet', 'containerd'])(
 			'should return true if /proc/self/mountinfo contains %s',
 			(str) => {
 				mockFs.existsSync.mockReturnValueOnce(false);


### PR DESCRIPTION
## Summary
When running in a non-docker container runtime, `/proc/self/cgroup` does not contain the string `docker`. This PR updates the check to also check for containerd using cgroups v2.

[CAT-521](https://linear.app/n8n/issue/CAT-521/platform-is-not-detected-correctly-in-debug-information)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
