### PR TITLE
fix(core): Prevent prototype pollution of internal classes in task runner

### DIFF
--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -40,13 +40,13 @@
     "acorn": "8.14.0",
     "acorn-walk": "8.3.4",
     "lodash": "catalog:",
+    "luxon": "catalog:",
     "n8n-core": "workspace:*",
     "n8n-workflow": "workspace:*",
     "nanoid": "catalog:",
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/lodash": "catalog:",
-    "luxon": "catalog:"
+    "@types/lodash": "catalog:"
   }
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -109,7 +109,7 @@ export class JsTaskRunner extends TaskRunner {
 	}
 
 	private preventPrototypePollution() {
-		// Freeze globals. Needed for Jest
+		// Freeze globals, except for Jest
 		if (process.env.NODE_ENV !== 'test') {
 			Object.getOwnPropertyNames(globalThis)
 				// @ts-expect-error globalThis does not have string in index signature

--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -1,6 +1,7 @@
 import set from 'lodash/set';
+import { DateTime, Duration, Interval } from 'luxon';
 import { getAdditionalKeys } from 'n8n-core';
-import { WorkflowDataProxy, Workflow, ObservableObject } from 'n8n-workflow';
+import { WorkflowDataProxy, Workflow, ObservableObject, Expression } from 'n8n-workflow';
 import type {
 	CodeExecutionMode,
 	IWorkflowExecuteAdditionalData,
@@ -108,15 +109,21 @@ export class JsTaskRunner extends TaskRunner {
 	}
 
 	private preventPrototypePollution() {
-		if (process.env.NODE_ENV === 'test') return; // needed for Jest
+		// Freeze globals. Needed for Jest
+		if (process.env.NODE_ENV !== 'test') {
+			Object.getOwnPropertyNames(globalThis)
+				// @ts-expect-error globalThis does not have string in index signature
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+				.map((name) => globalThis[name])
+				.filter((value) => typeof value === 'function')
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+				.forEach((fn) => Object.freeze(fn.prototype));
+		}
 
-		Object.getOwnPropertyNames(globalThis)
-			// @ts-expect-error globalThis does not have string in index signature
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-			.map((name) => globalThis[name])
-			.filter((value) => typeof value === 'function')
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-			.forEach((fn) => Object.freeze(fn.prototype));
+		// Freeze internal classes
+		[Workflow, Expression, WorkflowDataProxy, DateTime, Interval, Duration]
+			.map((constructor) => constructor.prototype)
+			.forEach(Object.freeze);
 	}
 
 	async executeTask(
@@ -478,7 +485,7 @@ export class JsTaskRunner extends TaskRunner {
 	 * @param dataProxy The data proxy object that provides access to built-ins
 	 * @param additionalProperties Additional properties to add to the context
 	 */
-	private buildContext(
+	buildContext(
 		taskId: string,
 		workflow: Workflow,
 		node: INode,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,9 @@ importers:
       lodash:
         specifier: 'catalog:'
         version: 4.17.21
+      luxon:
+        specifier: 'catalog:'
+        version: 3.4.4
       n8n-core:
         specifier: workspace:*
         version: link:../../core
@@ -709,9 +712,6 @@ importers:
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.14.195
-      luxon:
-        specifier: 'catalog:'
-        version: 3.4.4
 
   packages/@n8n_io/eslint-config:
     devDependencies:


### PR DESCRIPTION
## Summary

Ensure prototypes of certain internal classes cannot be modified

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-503/ensure-context-object-cant-be-mutated


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
