### PR TITLE
ci: Do not cancel e2e and chromatic jobs on regular PR comments

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,13 +8,14 @@ on:
     types: [submitted]
 
 concurrency:
-  group: chromatic-${{ github.event.pull_request.number || github.ref }}
+  group: chromatic-${{ github.event.pull_request.number || github.ref }}-${{github.event.review.state}}
   cancel-in-progress: true
 
 jobs:
   get-metadata:
     name: Get Metadata
     runs-on: ubuntu-latest
+    if: github.event.review.state == 'approved'
     steps:
       - name: Check out current commit
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests-pr.yml
+++ b/.github/workflows/e2e-tests-pr.yml
@@ -5,13 +5,14 @@ on:
     types: [submitted]
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-${{ github.event.pull_request.number || github.ref }}-${{github.event.review.state}}
   cancel-in-progress: true
 
 jobs:
   get-metadata:
     name: Get Metadata
     runs-on: ubuntu-latest
+    if: github.event.review.state == 'approved'
     steps:
       - name: Check out current commit
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
PR comments should not cancel any ongoing e2e runs for that PR.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
