### PR TITLE
fix(editor): Show run workflow button when chat trigger has pinned data

### DIFF
--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1073,7 +1073,9 @@ const isExecutionDisabled = computed(() => {
 	return !containsTriggerNodes.value || allTriggerNodesDisabled.value;
 });
 
-const isRunWorkflowButtonVisible = computed(() => !isOnlyChatTriggerNodeActive.value);
+const isRunWorkflowButtonVisible = computed(
+	() => !isOnlyChatTriggerNodeActive.value || chatTriggerNodePinnedData.value,
+);
 const isStopExecutionButtonVisible = computed(
 	() => isWorkflowRunning.value && !isExecutionWaitingForWebhook.value,
 );


### PR DESCRIPTION
## Summary

This change modifies the visibility condition for the Run Workflow button in the NodeView component. Previously, the button was hidden when the Chat Trigger node was the only active trigger. The change now allows the button to be visible in two scenarios:

1. When there are active nodes other than the Chat Trigger node.
2. When the Chat Trigger node has pinned data.

This adjustment improves the user experience by providing the option to run the workflow even when a Chat Trigger node with pinned data is the only active node in the workflow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-590/bug-execute-workflow-button-missing-when-chat-is-pinned

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
