### PR TITLE
fix(editor): Open chat when executing agent node in canvas v2 

### DIFF
--- a/cypress/composables/modals/credential-modal.ts
+++ b/cypress/composables/modals/credential-modal.ts
@@ -2,6 +2,8 @@
  * Getters
  */
 
+import { clearNotifications } from '../../pages/notifications';
+
 export function getCredentialConnectionParameterInputs() {
 	return cy.getByTestId('credential-connection-parameter');
 }
@@ -55,5 +57,6 @@ export function setCredentialValues(values: Record<string, string>, save = true)
 	if (save) {
 		saveCredential();
 		closeCredentialModal();
+		clearNotifications();
 	}
 }

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -924,11 +924,13 @@ async function onImportWorkflowUrlEvent(data: IDataObject) {
 function addImportEventBindings() {
 	nodeViewEventBus.on('importWorkflowData', onImportWorkflowDataEvent);
 	nodeViewEventBus.on('importWorkflowUrl', onImportWorkflowUrlEvent);
+	nodeViewEventBus.on('openChat', onOpenChat);
 }
 
 function removeImportEventBindings() {
 	nodeViewEventBus.off('importWorkflowData', onImportWorkflowDataEvent);
 	nodeViewEventBus.off('importWorkflowUrl', onImportWorkflowUrlEvent);
+	nodeViewEventBus.off('openChat', onOpenChat);
 }
 
 /**


### PR DESCRIPTION
## Summary

- fix(editor): Open chat when executing agent node in canvas v2 

To make it behave the same as in v1. And fix `233-AI-switch-to-logs-on-error.cy.ts` tests

- test: Clear notifications after saving credentials in e2e tests 

Often the "Credential saved" notification is left floating over other elements
that prevent the test from continuing until the notification goes away. This
should speed up the e2e tests a tiny wee bit.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-518/manually-executing-ai-agent-node-doesnt-open-the-chat-panel


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
