### PR TITLE
fix(editor): Show connector label above the line when it's straight

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
@@ -1,10 +1,10 @@
-import CanvasEdge, { type CanvasEdgeProps } from './CanvasEdge.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
-import { setActivePinia } from 'pinia';
+import userEvent from '@testing-library/user-event';
 import { Position } from '@vue-flow/core';
 import { NodeConnectionType } from 'n8n-workflow';
-import userEvent from '@testing-library/user-event';
+import { setActivePinia } from 'pinia';
+import CanvasEdge, { type CanvasEdgeProps } from './CanvasEdge.vue';
 
 const DEFAULT_PROPS = {
 	sourceX: 0,
@@ -150,5 +150,39 @@ describe('CanvasEdge', () => {
 		const edge = container.querySelector('.vue-flow__edge-path');
 
 		expect(edge).toHaveAttribute('d', 'M0,0 C62.5,0 -162.5,-100 -100,-100');
+	});
+
+	it('should render a label above the connector when it is straight', () => {
+		const { container } = renderComponent({
+			props: {
+				...DEFAULT_PROPS,
+				sourceY: 50,
+				targetY: 50,
+			},
+		});
+
+		const label = container.querySelector('.vue-flow__edge-label');
+
+		expect(label).toHaveAttribute(
+			'style',
+			'transform: translate(-50%, -150%) translate(50px, 50px);',
+		);
+	});
+
+	it("should render a label in the middle of the connector when it isn't straight", () => {
+		const { container } = renderComponent({
+			props: {
+				...DEFAULT_PROPS,
+				sourceY: 0,
+				targetY: 100,
+			},
+		});
+
+		const label = container.querySelector('.vue-flow__edge-label');
+
+		expect(label).toHaveAttribute(
+			'style',
+			'transform: translate(-50%, -50%) translate(50px, 50px);',
+		);
 	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -5,7 +5,7 @@ import { isValidNodeConnectionType } from '@/utils/typeGuards';
 import type { Connection, EdgeProps } from '@vue-flow/core';
 import { BaseEdge, EdgeLabelRenderer } from '@vue-flow/core';
 import { NodeConnectionType } from 'n8n-workflow';
-import { computed, useCssModule, toRef } from 'vue';
+import { computed, toRef, useCssModule } from 'vue';
 import CanvasEdgeToolbar from './CanvasEdgeToolbar.vue';
 import { getEdgeRenderData } from './utils';
 
@@ -71,8 +71,10 @@ const edgeLabelStyle = computed(() => ({
 }));
 
 const edgeToolbarStyle = computed(() => {
+	const translateY = isConnectorStraight ? "-150%" : "-50%"
+
 	return {
-		transform: `translate(-50%, -50%) translate(${labelPosition.value[0]}px,${labelPosition.value[1]}px)`,
+		transform: `translate(-50%, ${translateY}) translate(${labelPosition.value[0]}px, calc(${labelPosition.value[1]}px)`,
 		...(props.hovered ? { zIndex: 1 } : {}),
 	};
 });
@@ -92,6 +94,8 @@ const renderData = computed(() =>
 const segments = computed(() => renderData.value.segments);
 
 const labelPosition = computed(() => renderData.value.labelPosition);
+
+const isConnectorStraight = computed(() => renderData.value.isConnectorStraight);
 
 const connection = computed<Connection>(() => ({
 	source: props.source,

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -70,6 +70,8 @@ const edgeLabelStyle = computed(() => ({
 	color: edgeColor.value,
 }));
 
+const isConnectorStraight = computed(() => renderData.value.isConnectorStraight);
+
 const edgeToolbarStyle = computed(() => {
 	const translateY = isConnectorStraight.value ? '-150%' : '-50%';
 
@@ -94,8 +96,6 @@ const renderData = computed(() =>
 const segments = computed(() => renderData.value.segments);
 
 const labelPosition = computed(() => renderData.value.labelPosition);
-
-const isConnectorStraight = computed(() => renderData.value.isConnectorStraight);
 
 const connection = computed<Connection>(() => ({
 	source: props.source,

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -71,7 +71,7 @@ const edgeLabelStyle = computed(() => ({
 }));
 
 const edgeToolbarStyle = computed(() => {
-	const translateY = isConnectorStraight.value ? "-150%" : "-50%"
+	const translateY = isConnectorStraight.value ? '-150%' : '-50%';
 
 	return {
 		transform: `translate(-50%, ${translateY}) translate(${labelPosition.value[0]}px, ${labelPosition.value[1]}px)`,

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -71,10 +71,10 @@ const edgeLabelStyle = computed(() => ({
 }));
 
 const edgeToolbarStyle = computed(() => {
-	const translateY = isConnectorStraight ? "-150%" : "-50%"
+	const translateY = isConnectorStraight.value ? "-150%" : "-50%"
 
 	return {
-		transform: `translate(-50%, ${translateY}) translate(${labelPosition.value[0]}px, calc(${labelPosition.value[1]}px)`,
+		transform: `translate(-50%, ${translateY}) translate(${labelPosition.value[0]}px, ${labelPosition.value[1]}px)`,
 		...(props.hovered ? { zIndex: 1 } : {}),
 	};
 });

--- a/packages/editor-ui/src/components/canvas/elements/edges/utils/getEdgeRenderData.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/utils/getEdgeRenderData.ts
@@ -21,12 +21,14 @@ export function getEdgeRenderData(
 	} = {},
 ) {
 	const { targetX, targetY, sourceX, sourceY, sourcePosition, targetPosition } = props;
+	const isConnectorStraight = sourceY === targetY;
 
 	if (!isRightOfSourceHandle(sourceX, targetX) || connectionType !== NodeConnectionType.Main) {
 		const segment = getBezierPath(props);
 		return {
 			segments: [segment],
 			labelPosition: [segment[1], segment[2]],
+			isConnectorStraight,
 		};
 	}
 
@@ -59,5 +61,6 @@ export function getEdgeRenderData(
 	return {
 		segments: [firstSegment, secondSegment],
 		labelPosition: [firstSegmentTargetX, firstSegmentTargetY],
+		isConnectorStraight,
 	};
 }

--- a/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
+++ b/packages/editor-ui/src/components/canvas/elements/handles/render-types/CanvasHandleMainOutput.vue
@@ -132,9 +132,9 @@ function onClickAdd() {
 
 .runDataLabel {
 	position: absolute;
-	top: 0;
+	top: 50%;
 	left: 50%;
-	transform: translate(-50%, -50%);
+	transform: translate(-50%, -150%);
 	font-size: var(--font-size-xs);
 	color: var(--color-success);
 }


### PR DESCRIPTION
## Summary

This PR fixes the position of connector label in the new editor canvas, so that the label does not overlap the connector's line when it's straight.

### Before
![Screenshot from 2025-01-15 18-09-58](https://github.com/user-attachments/assets/a64ddd86-8e48-4ae4-98ef-cee4033fcc20)
### After
![Screenshot from 2025-01-15 18-08-32](https://github.com/user-attachments/assets/c506522b-40b3-4d07-a0f7-965c2e4cf165)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SUG-4/connection-label-should-jump-above-line-if-the-line-is-straight

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
