### PR TITLE
fix(editor): Fix execution list hover & selection colour in dark mode

### DIFF
--- a/packages/design-system/src/css/_tokens.dark.scss
+++ b/packages/design-system/src/css/_tokens.dark.scss
@@ -227,6 +227,7 @@
 	--color-notification-background: var(--prim-gray-740);
 
 	// Execution
+	--execution-card-background: var(--color-foreground-light);
 	--execution-card-background-hover: var(--color-foreground-base);
 	--execution-selector-background: var(--prim-gray-740);
 	--execution-selector-text: var(--color-text-base);

--- a/packages/design-system/src/css/_tokens.scss
+++ b/packages/design-system/src/css/_tokens.scss
@@ -289,6 +289,7 @@
 	--execution-card-border-waiting: var(--prim-color-secondary-tint-300);
 	--execution-card-border-running: var(--prim-color-alt-b-tint-250);
 	--execution-card-border-unknown: var(--prim-gray-120);
+	--execution-card-background: var(--color-foreground-xlight);
 	--execution-card-background-hover: var(--color-foreground-light);
 	--execution-card-text-waiting: var(--color-secondary);
 	--execution-selector-background: var(--color-background-dark);

--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionsCard.vue
@@ -182,7 +182,7 @@ function onRetryMenuItemSelect(action: string): void {
 @import '@/styles/variables';
 
 .WorkflowExecutionsCard {
-	--execution-list-item-background: var(--color-foreground-xlight);
+	--execution-list-item-background: var(--execution-card-background);
 	--execution-list-item-highlight-background: var(--color-warning-tint-1);
 
 	display: flex;
@@ -200,7 +200,7 @@ function onRetryMenuItemSelect(action: string): void {
 	&:hover,
 	&.active {
 		.executionLink {
-			--execution-list-item-background: var(--color-foreground-light);
+			--execution-list-item-background: var(--execution-card-background-hover);
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

### Dark Mode

Selected and hover

| Before | After |
|--|--|
|  ![image](https://github.com/user-attachments/assets/c2c01092-2cea-4a27-8e4c-c8922c82ec0a)  |  ![image](https://github.com/user-attachments/assets/04f2ecbc-60fd-4975-adfe-17d48a6c8824) |

### Light mode (no changes here)

| Before | After |
|--|--|
|   ![image](https://github.com/user-attachments/assets/a26ea009-4d8e-4b7e-a081-37a9b2ff8949)  |   ![image](https://github.com/user-attachments/assets/17b193f9-10b6-4ff0-a79d-e00c14a74811) |


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2472/bug-selected-execution-is-unclear-in-workflow-executions-view-in-dark

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
