### PR TITLE
fix(editor): Defer crypto.randomUUID call in CodeNodeEditor

### DIFF
--- a/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
+++ b/packages/editor-ui/src/components/CodeNodeEditor/CodeNodeEditor.vue
@@ -37,7 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
 	language: 'javaScript',
 	isReadOnly: false,
 	rows: 4,
-	id: crypto.randomUUID(),
+	id: () => crypto.randomUUID(),
 });
 const emit = defineEmits<{
 	'update:modelValue': [value: string];


### PR DESCRIPTION
## Summary
Vue compiler seems to hoist the calls in `withDefaults` to before the `randomUUID` polyfill is setup. This causes the frontend to break in insecure contexts.
By deferring the call, we ensure that the polyfill is setup first. 

## Related Linear tickets, Github issues, and Community forum posts

ADO-3098
Fixes #12624

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
