### PR TITLE
fix(editor): Add unicode code points to expression language for emoji

### DIFF
--- a/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
+++ b/packages/@n8n/codemirror-lang/src/expressions/expressions.grammar
@@ -15,7 +15,7 @@ entity { Plaintext | Resolvable }
 
   resolvableChar { unicodeChar | "}" ![}] | "\\}}" }
 
-  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u{1F300}-\u{1F64F}] | $[\u4E00-\u9FFF] }
+  unicodeChar { $[\u0000-\u007C] | $[\u007E-\u20CF] | $[\u{1F300}-\u{1FAF8}] | $[\u4E00-\u9FFF] }
 }
 
 @detectDelim

--- a/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
+++ b/packages/@n8n/codemirror-lang/src/expressions/grammar.ts
@@ -10,7 +10,7 @@ export const parser = LRParser.deserialize({
 	skippedNodes: [0],
 	repeatNodeCount: 1,
 	tokenData:
-		"&U~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TWO#O#Q#O#P#m#P#q#Q#q#r%Z#r$Ml#Q*5S41d#Q;(b;(c%x;(c;(d&O~#pWO#O#Q#O#P#m#P#q#Q#q#r$Y#r$Ml#Q*5S41d#Q;(b;(c%x;(c;(d&O~$]TO#q#Q#q#r$l#r;'S#Q;'S;=`%r<%lO#Q~$qWR~O#O#Q#O#P#m#P#q#Q#q#r%Z#r$Ml#Q*5S41d#Q;(b;(c%x;(c;(d&O~%^TO#q#Q#q#r%m#r;'S#Q;'S;=`%r<%lO#Q~%rOR~~%uP;=`<%l#Q~%{P;NQ<%l#Q~&RP;=`;JY#Q",
+		"&_~RTO#ob#o#p!h#p;'Sb;'S;=`!]<%lOb~gTQ~O#ob#o#pv#p;'Sb;'S;=`!]<%lOb~yUO#ob#p;'Sb;'S;=`!]<%l~b~Ob~~!c~!`P;=`<%lb~!hOQ~~!kVO#ob#o#p#Q#p;'Sb;'S;=`!]<%l~b~Ob~~!c~#TXO#O#Q#O#P#p#P#q#Q#q#r%d#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~#sXO#O#Q#O#P#p#P#q#Q#q#r$`#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~$cTO#q#Q#q#r$r#r;'S#Q;'S;=`%{<%lO#Q~$wXR~O#O#Q#O#P#p#P#q#Q#q#r%d#r$Ml#Q*5S41d#Q;(b;(c&R;(c;(d%{;(d;(e&X~%gTO#q#Q#q#r%v#r;'S#Q;'S;=`%{<%lO#Q~%{OR~~&OP;=`<%l#Q~&UP;NQ<%l#Q~&[P;=`;My#Q",
 	tokenizers: [0],
 	topRules: { Program: [0, 1] },
 	tokenPrec: 0,

--- a/packages/@n8n/codemirror-lang/test/expressions/cases.txt
+++ b/packages/@n8n/codemirror-lang/test/expressions/cases.txt
@@ -277,3 +277,19 @@ Program(Resolvable)
 ==>
 
 Program(Resolvable)
+
+# Resolvable with new emoji range
+
+{{ '🟢' }}
+
+==>
+
+Program(Resolvable)
+
+# Resolvable with new emoji range end of range
+
+{{ '🫸' }}
+
+==>
+
+Program(Resolvable)


### PR DESCRIPTION
## Summary

Add more emoji codepoints to the n8n syntax parser.
Co-authored with @MarcL 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2175/community-issue-bug-with-ui-and-expression-highlighting
https://github.com/n8n-io/n8n/issues/11484
closes #11484 

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
