### PR TITLE
fix(Execute Workflow Node): Pass binary data to sub-workflow

### DIFF
--- a/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/GenericFunctions.ts
@@ -97,7 +97,7 @@ export function getFieldEntries(context: IWorkflowNodeContext): FieldValueOption
 export function getWorkflowInputValues(this: ISupplyDataFunctions): INodeExecutionData[] {
 	const inputData = this.getInputData();
 
-	return inputData.map((item, itemIndex) => {
+	return inputData.map(({ json, binary }, itemIndex) => {
 		const itemFieldValues = this.getNodeParameter(
 			'workflowInputs.value',
 			itemIndex,
@@ -106,13 +106,14 @@ export function getWorkflowInputValues(this: ISupplyDataFunctions): INodeExecuti
 
 		return {
 			json: {
-				...item.json,
+				...json,
 				...itemFieldValues,
 			},
 			index: itemIndex,
 			pairedItem: {
 				item: itemIndex,
 			},
+			binary,
 		};
 	});
 }

--- a/packages/nodes-base/utils/workflowInputsResourceMapping/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/utils/workflowInputsResourceMapping/__tests__/GenericFunctions.test.ts
@@ -1,0 +1,63 @@
+import { mock } from 'jest-mock-extended';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { getWorkflowInputValues } from '../GenericFunctions';
+
+describe('getWorkflowInputValues', () => {
+	const supplyDataFunctions = mock<ISupplyDataFunctions>();
+
+	it('should correctly map the binary property', () => {
+		supplyDataFunctions.getInputData.mockReturnValue([
+			{
+				json: { key1: 'value1' },
+				binary: { file1: { data: 'binaryData1', mimeType: 'image/png' } },
+			},
+			{
+				json: { key2: 'value2' },
+				binary: { file2: { data: 'binaryData2', mimeType: 'image/jpeg' } },
+			},
+		]);
+
+		supplyDataFunctions.getNodeParameter
+			.calledWith('workflowInputs.value', 0)
+			.mockReturnValueOnce({ additionalKey1: 'additionalValue1' });
+		supplyDataFunctions.getNodeParameter
+			.calledWith('workflowInputs.value', 1)
+			.mockReturnValueOnce({ additionalKey2: 'additionalValue2' });
+
+		const result = getWorkflowInputValues.call(supplyDataFunctions);
+
+		expect(result).toEqual([
+			{
+				json: {
+					key1: 'value1',
+					additionalKey1: 'additionalValue1',
+				},
+				binary: { file1: { data: 'binaryData1', mimeType: 'image/png' } },
+				index: 0,
+				pairedItem: { item: 0 },
+			},
+			{
+				json: {
+					key2: 'value2',
+					additionalKey2: 'additionalValue2',
+				},
+				binary: { file2: { data: 'binaryData2', mimeType: 'image/jpeg' } },
+				index: 1,
+				pairedItem: { item: 1 },
+			},
+		]);
+
+		expect(supplyDataFunctions.getInputData).toHaveBeenCalled();
+		expect(supplyDataFunctions.getNodeParameter).toHaveBeenCalledWith(
+			'workflowInputs.value',
+			0,
+			{},
+		);
+		expect(supplyDataFunctions.getNodeParameter).toHaveBeenCalledWith(
+			'workflowInputs.value',
+			1,
+			{},
+		);
+	});
+});


### PR DESCRIPTION
## Summary

This fixes existing usages that pass binary data to sub-workflows. It'll be unsupported for new trigger nodes that aren't in the `Accept All Data` configuration, which we'll circle back to.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3099/community-issue-execute-workflow-node-doesnt-pass-binary-file-after
#12625 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
