### PR TITLE
fix(editor): Fix Code node bug erasing and overwriting code when switching between nodes

### DIFF
--- a/packages/editor-ui/src/__tests__/setup.ts
+++ b/packages/editor-ui/src/__tests__/setup.ts
@@ -61,3 +61,25 @@ Object.defineProperty(window, 'matchMedia', {
 		dispatchEvent: vi.fn(),
 	})),
 });
+
+class Worker {
+	onmessage: (message: string) => void;
+
+	url: string;
+
+	constructor(url: string) {
+		this.url = url;
+		this.onmessage = () => {};
+	}
+
+	postMessage(message: string) {
+		this.onmessage(message);
+	}
+
+	addEventListener() {}
+}
+
+Object.defineProperty(window, 'Worker', {
+	writable: true,
+	value: Worker,
+});

--- a/packages/editor-ui/src/composables/useCodeEditor.test.ts
+++ b/packages/editor-ui/src/composables/useCodeEditor.test.ts
@@ -96,28 +96,8 @@ describe('useCodeEditor', () => {
 
 		await user.type(input, 'test');
 
-		// Rerender will unmount and remount the component
-		// This should trigger the debounced change to be emitted
-		// Because we have `await lastChangePromise` in the unmounted hook
-		// Unmount is delayed until the last change is emitted
-		await renderResult.rerender({ key: 'old' });
-
-		const snapshotBeforeUnmount = renderResult.html();
-		expect(onChange).not.toHaveBeenCalled();
-
-		// The last change should be emitted after unmount
-		vi.advanceTimersByTime(300);
+		renderResult.unmount();
 
 		expect(onChange.mock.calls[0][0].state.doc.toString()).toEqual('test');
-
-		// This should rerender the component after unmounting
-		await renderResult.rerender({ key: 'new' });
-
-		const snapshotAfterUnmount = renderResult.html();
-
-		expect(snapshotBeforeUnmount).not.toEqual(snapshotAfterUnmount);
-		expect(snapshotBeforeUnmount.split('\n').length).toBeGreaterThan(
-			snapshotAfterUnmount.split('\n').length,
-		);
 	});
 });

--- a/packages/editor-ui/src/composables/useCodeEditor.test.ts
+++ b/packages/editor-ui/src/composables/useCodeEditor.test.ts
@@ -1,34 +1,14 @@
 import { renderComponent } from '@/__tests__/render';
 import { EditorView } from '@codemirror/view';
 import { createTestingPinia } from '@pinia/testing';
-import { cleanup, fireEvent, waitFor } from '@testing-library/vue';
+import { waitFor } from '@testing-library/vue';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, vi } from 'vitest';
 import { defineComponent, h, ref, toValue } from 'vue';
 import { useCodeEditor } from './useCodeEditor';
 import userEvent from '@testing-library/user-event';
 
-// vi.mock('@/composables/useAutocompleteTelemetry', () => ({
-// 	useAutocompleteTelemetry: vi.fn(),
-// }));
-//
-// vi.mock('@/stores/ndv.store', () => ({
-// 	useNDVStore: vi.fn(() => ({
-// 		activeNode: { type: 'n8n-nodes-base.test' },
-// 	})),
-// }));
-
 describe('useCodeEditor', () => {
-	// const mockResolveExpression = () => {
-	// 	const mock = vi.fn();
-	// 	vi.spyOn(workflowHelpers, 'useWorkflowHelpers').mockReturnValueOnce({
-	// 		...workflowHelpers.useWorkflowHelpers({ router: useRouter() }),
-	// 		resolveExpression: mock,
-	// 	});
-	//
-	// 	return mock;
-	// };
-
 	const defaultOptions: Omit<Parameters<typeof useCodeEditor>[0], 'editorRef'> = {
 		language: 'javaScript',
 	};

--- a/packages/editor-ui/src/composables/useCodeEditor.test.ts
+++ b/packages/editor-ui/src/composables/useCodeEditor.test.ts
@@ -1,0 +1,143 @@
+import { renderComponent } from '@/__tests__/render';
+import { EditorView } from '@codemirror/view';
+import { createTestingPinia } from '@pinia/testing';
+import { cleanup, fireEvent, waitFor } from '@testing-library/vue';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, vi } from 'vitest';
+import { defineComponent, h, ref, toValue } from 'vue';
+import { useCodeEditor } from './useCodeEditor';
+import userEvent from '@testing-library/user-event';
+
+// vi.mock('@/composables/useAutocompleteTelemetry', () => ({
+// 	useAutocompleteTelemetry: vi.fn(),
+// }));
+//
+// vi.mock('@/stores/ndv.store', () => ({
+// 	useNDVStore: vi.fn(() => ({
+// 		activeNode: { type: 'n8n-nodes-base.test' },
+// 	})),
+// }));
+
+describe('useCodeEditor', () => {
+	// const mockResolveExpression = () => {
+	// 	const mock = vi.fn();
+	// 	vi.spyOn(workflowHelpers, 'useWorkflowHelpers').mockReturnValueOnce({
+	// 		...workflowHelpers.useWorkflowHelpers({ router: useRouter() }),
+	// 		resolveExpression: mock,
+	// 	});
+	//
+	// 	return mock;
+	// };
+
+	const defaultOptions: Omit<Parameters<typeof useCodeEditor>[0], 'editorRef'> = {
+		language: 'javaScript',
+	};
+
+	const renderCodeEditor = async (options: Partial<typeof defaultOptions> = defaultOptions) => {
+		let codeEditor!: ReturnType<typeof useCodeEditor>;
+		const renderResult = renderComponent(
+			defineComponent({
+				setup() {
+					const root = ref<HTMLElement>();
+					codeEditor = useCodeEditor({ ...defaultOptions, ...options, editorRef: root });
+
+					return () => h('div', { ref: root, 'data-test-id': 'editor-root' });
+				},
+			}),
+			{ props: { options } },
+		);
+		expect(renderResult.getByTestId('editor-root')).toBeInTheDocument();
+		await waitFor(() => toValue(codeEditor.editor));
+		return { renderResult, codeEditor };
+	};
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia());
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('should create an editor', async () => {
+		const { codeEditor } = await renderCodeEditor();
+
+		await waitFor(() => expect(toValue(codeEditor.editor)).toBeInstanceOf(EditorView));
+	});
+
+	it('should focus editor', async () => {
+		const { renderResult, codeEditor } = await renderCodeEditor({});
+
+		const root = renderResult.getByTestId('editor-root');
+		const input = root.querySelector('.cm-line') as HTMLDivElement;
+
+		await userEvent.click(input);
+
+		expect(codeEditor.editor.value?.hasFocus).toBe(true);
+	});
+
+	it('should emit changes', async () => {
+		vi.useFakeTimers();
+
+		const user = userEvent.setup({
+			advanceTimers: vi.advanceTimersByTime,
+		});
+
+		const onChange = vi.fn();
+		const { renderResult } = await renderCodeEditor({
+			onChange,
+		});
+
+		const root = renderResult.getByTestId('editor-root');
+		const input = root.querySelector('.cm-line') as HTMLDivElement;
+
+		await user.type(input, 'test');
+
+		vi.advanceTimersByTime(300);
+
+		expect(onChange.mock.calls[0][0].state.doc.toString()).toEqual('test');
+	});
+
+	it('should emit debounced changes before unmount', async () => {
+		vi.useFakeTimers();
+
+		const user = userEvent.setup({
+			advanceTimers: vi.advanceTimersByTime,
+		});
+
+		const onChange = vi.fn();
+		const { renderResult } = await renderCodeEditor({
+			onChange,
+		});
+
+		const root = renderResult.getByTestId('editor-root');
+		const input = root.querySelector('.cm-line') as HTMLDivElement;
+
+		await user.type(input, 'test');
+
+		// Rerender will unmount and remount the component
+		// This should trigger the debounced change to be emitted
+		// Because we have `await lastChangePromise` in the unmounted hook
+		// Unmount is delayed until the last change is emitted
+		await renderResult.rerender({ key: 'old' });
+
+		const snapshotBeforeUnmount = renderResult.html();
+		expect(onChange).not.toHaveBeenCalled();
+
+		// The last change should be emitted after unmount
+		vi.advanceTimersByTime(300);
+
+		expect(onChange.mock.calls[0][0].state.doc.toString()).toEqual('test');
+
+		// This should rerender the component after unmounting
+		await renderResult.rerender({ key: 'new' });
+
+		const snapshotAfterUnmount = renderResult.html();
+
+		expect(snapshotBeforeUnmount).not.toEqual(snapshotAfterUnmount);
+		expect(snapshotBeforeUnmount.split('\n').length).toBeGreaterThan(
+			snapshotAfterUnmount.split('\n').length,
+		);
+	});
+});

--- a/packages/editor-ui/src/utils/forceParse.ts
+++ b/packages/editor-ui/src/utils/forceParse.ts
@@ -1,4 +1,7 @@
+import { Annotation } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
+
+export const ignoreUpdateAnnotation = Annotation.define<boolean>();
 
 /**
  * Simulate user action to force parser to catch up during scroll.
@@ -6,9 +9,11 @@ import type { EditorView } from '@codemirror/view';
 export function forceParse(view: EditorView) {
 	view.dispatch({
 		changes: { from: view.viewport.to, insert: '_' },
+		annotations: [ignoreUpdateAnnotation.of(true)],
 	});
 
 	view.dispatch({
 		changes: { from: view.viewport.to - 1, to: view.viewport.to, insert: '' },
+		annotations: [ignoreUpdateAnnotation.of(true)],
 	});
 }


### PR DESCRIPTION
## Summary

- Replaced `lastChange` with `lastChangePromise`, ensuring last change fulfills before unmount
- Added tests for `useCodeEditor`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2246/community-issue-[code-node-bug]-erases-and-overwites-your-code

Closes #12627


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
