### PR TITLE
fix(Postgres Node): Allow using composite key in upsert queries

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -285,7 +285,7 @@ export async function execute(
 			valuesLength = valuesLength + 1;
 			values.push(column);
 		});
-		const onConflict = ` ON CONFLICT (${conflictColumns.join(',')}) DO UPDATE `;
+		const onConflict = ` ON CONFLICT (${conflictColumns.join(',')})`;
 
 		const insertQuery = `INSERT INTO $1:name.$2:name($${valuesLength}:name) VALUES($${valuesLength}:csv)${onConflict}`;
 		valuesLength = valuesLength + 1;
@@ -300,7 +300,9 @@ export async function execute(
 			values.push(column, item[column] as string);
 		}
 
-		let query = `${insertQuery} SET ${updates.join(', ')}`;
+		const updateQuery =
+			updates?.length > 0 ? ` DO UPDATE  SET ${updates.join(', ')}` : ' DO NOTHING ';
+		let query = `${insertQuery}${updateQuery}`;
 
 		const outputColumns = this.getNodeParameter('options.outputColumns', i, ['*']) as string[];
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in Postgres Node: On Composite Key selected for "Insert or Update" DO UPDATE SET defaults to blank instead of the selected values. 
this is fixed by adding some logic to remove the update and do nothing instead if all columns are in the matching on

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2197/community-issue-postgres-node-has-error-on-composite-key-insert-or
fixes https://github.com/n8n-io/n8n/issues/12394

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
