### PR TITLE
chore(editor): Exclude codemirror range errors from Sentry

### DIFF
--- a/packages/editor-ui/src/plugins/sentry.ts
+++ b/packages/editor-ui/src/plugins/sentry.ts
@@ -8,9 +8,9 @@ const ignoredErrors = [
 	{ instanceof: ResponseError, message: /ECONNREFUSED/ },
 	{ instanceof: ResponseError, message: "Can't connect to n8n." },
 	{ instanceof: ResponseError, message: 'Unauthorized' },
-	{ instanceof: RangeError, message: /^Position \d+ is out of range for changeset of length \d+/ },
-	{ instanceof: RangeError, message: /^Invalid change range \d+ to \d+/ },
-	{ instanceof: RangeError, message: /^Selection points outside of document$/ },
+	{ instanceof: RangeError, message: /Position \d+ is out of range for changeset of length \d+/ },
+	{ instanceof: RangeError, message: /Invalid change range \d+ to \d+/ },
+	{ instanceof: RangeError, message: /Selection points outside of document$/ },
 	{ instanceof: Error, message: /ResizeObserver/ },
 ] as const;
 

--- a/packages/editor-ui/src/plugins/sentry.ts
+++ b/packages/editor-ui/src/plugins/sentry.ts
@@ -8,6 +8,9 @@ const ignoredErrors = [
 	{ instanceof: ResponseError, message: /ECONNREFUSED/ },
 	{ instanceof: ResponseError, message: "Can't connect to n8n." },
 	{ instanceof: ResponseError, message: 'Unauthorized' },
+	{ instanceof: RangeError, message: /^Position \d+ is out of range for changeset of length \d+/ },
+	{ instanceof: RangeError, message: /^Invalid change range \d+ to \d+/ },
+	{ instanceof: RangeError, message: /^Selection points outside of document$/ },
 	{ instanceof: Error, message: /ResizeObserver/ },
 ] as const;
 


### PR DESCRIPTION
## Summary

Ignore these errors from Sentry to reduce noise.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1856/multiple-instances-of-rangeerror-in-codemirror

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
