### PR TITLE
chore(API): Add styling to credential callback and autoclose window

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -7,6 +7,7 @@ import { readFile } from 'fs/promises';
 import type { Server } from 'http';
 import isbot from 'isbot';
 import { Logger } from 'n8n-core';
+import path from 'path';
 
 import config from '@/config';
 import { N8N_VERSION, TEMPLATES_DIR, inDevelopment, inTest } from '@/constants';
@@ -66,6 +67,9 @@ export abstract class AbstractServer {
 		this.app.engine('handlebars', expressHandlebars({ defaultLayout: false }));
 		this.app.set('view engine', 'handlebars');
 		this.app.set('views', TEMPLATES_DIR);
+
+		const assetsPath: string = path.join(__dirname, '../../../assets');
+		this.app.use(express.static(assetsPath));
 
 		const proxyHops = config.getEnv('proxy_hops');
 		if (proxyHops > 0) this.app.set('trust proxy', proxyHops);

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -255,7 +255,7 @@ describe('OAuth2CredentialController', () => {
 					type: 'oAuth2Api',
 				}),
 			);
-			expect(res.render).toHaveBeenCalledWith('oauth-callback');
+			expect(res.render).toHaveBeenCalledWith('oauth-callback', { imagePath: 'n8n-logo.png' });
 		});
 
 		it('merges oauthTokenData if it already exists', async () => {
@@ -297,7 +297,7 @@ describe('OAuth2CredentialController', () => {
 					type: 'oAuth2Api',
 				}),
 			);
-			expect(res.render).toHaveBeenCalledWith('oauth-callback');
+			expect(res.render).toHaveBeenCalledWith('oauth-callback', { imagePath: 'n8n-logo.png' });
 		});
 
 		it('overwrites oauthTokenData if it is a string', async () => {
@@ -335,7 +335,7 @@ describe('OAuth2CredentialController', () => {
 					type: 'oAuth2Api',
 				}),
 			);
-			expect(res.render).toHaveBeenCalledWith('oauth-callback');
+			expect(res.render).toHaveBeenCalledWith('oauth-callback', { imagePath: 'n8n-logo.png' });
 		});
 	});
 });

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -149,7 +149,7 @@ export class OAuth2CredentialController extends AbstractOAuthController {
 				credentialId: credential.id,
 			});
 
-			return res.render('oauth-callback');
+			return res.render('oauth-callback', { imagePath: 'n8n-logo.png' });
 		} catch (error) {
 			return this.renderCallbackError(
 				res,

--- a/packages/cli/templates/oauth-callback.handlebars
+++ b/packages/cli/templates/oauth-callback.handlebars
@@ -52,7 +52,7 @@
 		<div class="center-container">
 			<div class="left-container">
 				<div class="row">
-					<img src='https://github.com/n8n-io/n8n/blob/master/assets/n8n-logo.png?raw=true' class="logo" />
+					<img src="{{imagePath}}" class="logo" />
 				</div>
 				<div class="row">
 					<svg

--- a/packages/cli/templates/oauth-callback.handlebars
+++ b/packages/cli/templates/oauth-callback.handlebars
@@ -1,10 +1,53 @@
 <html>
-	<script>
-		(function messageParent() {
-			const broadcastChannel = new BroadcastChannel('oauth-callback');
-			broadcastChannel.postMessage('success');
-		})();
-	</script>
-
-	Got connected. The window can be closed now.
+	<head>
+		<style>
+			body {
+				font-family: 'Open Sans', sans-serif;
+				background-color: #2e793d;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				height: 100vh;
+				margin: 0;
+				font-weight: 400;
+			}
+			.container {
+				text-align: center;
+				background-color: #ffffff;
+				padding: 3rem 4rem;
+				border-radius: 10px;
+				box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+			}
+			h1 {
+				color: #185fb0;
+				font-size: 2.5rem;
+				margin-bottom: 0.5rem;
+			}
+			h2 {
+				color: #333333;
+				font-size: 1.5rem;
+				margin-bottom: 1rem;
+			}
+			p {
+				color: #666666;
+				font-size: 1rem;
+			}
+		</style>
+	</head>
+	<body>
+		<div class='container'>
+			<h1>Success!</h1>
+			<h2>Congrats on getting connected 🎉</h2>
+			<p>This window will close automatically in 5 seconds.</p>
+		</div>
+		<script type="text/javascript">
+			(function messageParent() {
+				const broadcastChannel = new BroadcastChannel('oauth-callback');
+				broadcastChannel.postMessage('success');
+			})();
+			(function autoclose(){
+				setTimeout(function() { window.close(); }, 5000);
+			})();
+		</script>
+	</body>
 </html>

--- a/packages/cli/templates/oauth-callback.handlebars
+++ b/packages/cli/templates/oauth-callback.handlebars
@@ -1,44 +1,76 @@
 <html>
 	<head>
 		<style>
+			html {
+				font-size: 16px;
+			}
 			body {
-				font-family: 'Open Sans', sans-serif;
-				background-color: #2e793d;
+				font-family: sans-serif;
+			}
+
+			.center-container {
 				display: flex;
-				justify-content: center;
 				align-items: center;
-				height: 100vh;
-				margin: 0;
-				font-weight: 400;
+				height: 100vh
 			}
-			.container {
-				text-align: center;
-				background-color: #ffffff;
-				padding: 3rem 4rem;
-				border-radius: 10px;
-				box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+
+			.left-container {
+				margin-left: auto;
+				margin-right: auto;
+				display: flex;
+				flex-direction: column;
 			}
+			.row {
+				display: flex;
+				flex-direction: row;
+				gap: 20px;
+			}
+
+			.icon {
+				width: 2.5rem;
+				fill: #2AA568;
+			}
+
+			.logo {
+				width: 8rem;
+			}
+
 			h1 {
-				color: #185fb0;
 				font-size: 2.5rem;
-				margin-bottom: 0.5rem;
+				color: #0F1430;
 			}
-			h2 {
-				color: #333333;
-				font-size: 1.5rem;
-				margin-bottom: 1rem;
-			}
+
 			p {
-				color: #666666;
-				font-size: 1rem;
+				font-size: 1.5rem;
+				font-weight: 500;
+				color: #707183;
+				font-size: 1.1rem;
 			}
 		</style>
 	</head>
 	<body>
-		<div class='container'>
-			<h1>Success!</h1>
-			<h2>Congrats on getting connected 🎉</h2>
-			<p>This window will close automatically in 5 seconds.</p>
+		<div class="center-container">
+			<div class="left-container">
+				<div class="row">
+					<img src='https://github.com/n8n-io/n8n/blob/master/assets/n8n-logo.png?raw=true' class="logo" />
+				</div>
+				<div class="row">
+					<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 512 512"
+							class="icon"
+					>
+							<!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+							<path
+									d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"
+							/>
+					</svg>
+					<h1>Connection successful</h1>
+				</div>
+				<div class="row">
+					<p>This window will close automatically in 5 seconds.</p>
+				</div>
+			</div>
 		</div>
 		<script type="text/javascript">
 			(function messageParent() {

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -116,7 +116,7 @@ describe('OAuth2 API', () => {
 			.query({ code: 'auth_code', state })
 			.expect(200);
 
-		expect(renderSpy).toHaveBeenCalledWith('oauth-callback');
+		expect(renderSpy).toHaveBeenCalledWith('oauth-callback', { imagePath: 'n8n-logo.png' });
 
 		const updatedCredential = await Container.get(CredentialsHelper).getCredentials(
 			credential,


### PR DESCRIPTION
## Summary

Add styling to credential callback and autoclose window. This looks more professional and also is a small reward for users setting up credentials

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-1514/google-oauth-confirmation-modal-re-add-auto-close

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
