### PR TITLE
fix(editor): Partial execution of a workflow with manual chat trigger

### DIFF
--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -530,14 +530,14 @@ describe('Langchain Integration', () => {
 		workflowPage.actions.executeNode('Node 1');
 
 		getManualChatModal().should('exist');
-		sendManualChatMessage('Test')
+		sendManualChatMessage('Test');
 
 		getManualChatMessages().should('contain', 'this_my_field_1');
 		cy.getByTestId('refresh-session-button').click();
 		cy.get('button').contains('Reset').click();
 		getManualChatMessages().should('not.exist');
 
-		sendManualChatMessage('Another test')
+		sendManualChatMessage('Another test');
 		getManualChatMessages().should('contain', 'this_my_field_3');
 		getManualChatMessages().should('contain', 'this_my_field_4');
 	});
@@ -555,14 +555,14 @@ describe('Langchain Integration', () => {
 		ndv.actions.execute();
 
 		getManualChatModal().should('exist');
-		sendManualChatMessage('Test')
+		sendManualChatMessage('Test');
 
 		getManualChatMessages().should('contain', 'this_my_field_1');
 		cy.getByTestId('refresh-session-button').click();
 		cy.get('button').contains('Reset').click();
 		getManualChatMessages().should('not.exist');
 
-		sendManualChatMessage('Another test')
+		sendManualChatMessage('Another test');
 		getManualChatMessages().should('contain', 'this_my_field_3');
 		getManualChatMessages().should('contain', 'this_my_field_4');
 	});

--- a/cypress/e2e/30-langchain.cy.ts
+++ b/cypress/e2e/30-langchain.cy.ts
@@ -518,4 +518,52 @@ describe('Langchain Integration', () => {
 
 		getRunDataInfoCallout().should('not.exist');
 	});
+
+	it('should execute up to Node 1 when using partial execution', () => {
+		const workflowPage = new WorkflowPage();
+
+		cy.visit(workflowPage.url);
+		cy.createFixtureWorkflow('Test_workflow_chat_partial_execution.json');
+		workflowPage.actions.zoomToFit();
+
+		getManualChatModal().should('not.exist');
+		workflowPage.actions.executeNode('Node 1');
+
+		getManualChatModal().should('exist');
+		sendManualChatMessage('Test')
+
+		getManualChatMessages().should('contain', 'this_my_field_1');
+		cy.getByTestId('refresh-session-button').click();
+		cy.get('button').contains('Reset').click();
+		getManualChatMessages().should('not.exist');
+
+		sendManualChatMessage('Another test')
+		getManualChatMessages().should('contain', 'this_my_field_3');
+		getManualChatMessages().should('contain', 'this_my_field_4');
+	});
+
+	it('should execute up to Node 1 when using partial execution', () => {
+		const workflowPage = new WorkflowPage();
+		const ndv = new NDV();
+
+		cy.visit(workflowPage.url);
+		cy.createFixtureWorkflow('Test_workflow_chat_partial_execution.json');
+		workflowPage.actions.zoomToFit();
+
+		getManualChatModal().should('not.exist');
+		openNode('Node 1');
+		ndv.actions.execute();
+
+		getManualChatModal().should('exist');
+		sendManualChatMessage('Test')
+
+		getManualChatMessages().should('contain', 'this_my_field_1');
+		cy.getByTestId('refresh-session-button').click();
+		cy.get('button').contains('Reset').click();
+		getManualChatMessages().should('not.exist');
+
+		sendManualChatMessage('Another test')
+		getManualChatMessages().should('contain', 'this_my_field_3');
+		getManualChatMessages().should('contain', 'this_my_field_4');
+	});
 });

--- a/cypress/fixtures/Test_workflow_chat_partial_execution.json
+++ b/cypress/fixtures/Test_workflow_chat_partial_execution.json
@@ -1,0 +1,77 @@
+{
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "535fd3dd-e78f-4ffa-a085-79723fc81b38",
+      "name": "When chat message received",
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [
+        320,
+        -380
+      ],
+      "webhookId": "4fb58136-3481-494a-a30f-d9e064dac186"
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"this_my_field_1\": \"value\",\n  \"this_my_field_2\": 1\n}\n",
+        "options": {}
+      },
+      "id": "78201ec2-6def-40b7-85e5-97b580d7f642",
+      "name": "Node 1",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        580,
+        -380
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"this_my_field_3\": \"value\",\n  \"this_my_field_4\": 1\n}\n",
+        "options": {}
+      },
+      "id": "1cfca06d-3ec3-427f-89f7-1ef321e025ff",
+      "name": "Node 2",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        780,
+        -380
+      ]
+    }
+  ],
+  "connections": {
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "Node 1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Node 1": {
+      "main": [
+        [
+          {
+            "node": "Node 2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "178ef8a5109fc76c716d40bcadb720c455319f7b7a3fd5a39e4f336a091f524a"
+  }
+}

--- a/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
+++ b/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
@@ -201,7 +201,7 @@ async function createExecutionPromise() {
 
 async function onRunChatWorkflow(payload: RunWorkflowChatPayload) {
 	try {
-		const runWorkflowOptions = {
+		const runWorkflowOptions: Parameters<typeof runWorkflow>[0] = {
 			triggerNode: payload.triggerNode,
 			nodeData: payload.nodeData,
 			source: payload.source,

--- a/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
+++ b/packages/editor-ui/src/components/CanvasChat/CanvasChat.vue
@@ -201,11 +201,18 @@ async function createExecutionPromise() {
 
 async function onRunChatWorkflow(payload: RunWorkflowChatPayload) {
 	try {
-		const response = await runWorkflow({
+		const runWorkflowOptions = {
 			triggerNode: payload.triggerNode,
 			nodeData: payload.nodeData,
 			source: payload.source,
-		});
+		};
+
+		if (workflowsStore.chatPartialExecutionDestinationNode) {
+			runWorkflowOptions.destinationNode = workflowsStore.chatPartialExecutionDestinationNode;
+			workflowsStore.chatPartialExecutionDestinationNode = null;
+		}
+
+		const response = await runWorkflow(runWorkflowOptions);
 
 		if (response) {
 			await createExecutionPromise();

--- a/packages/editor-ui/src/components/NodeExecuteButton.vue
+++ b/packages/editor-ui/src/components/NodeExecuteButton.vue
@@ -319,6 +319,7 @@ async function onClick() {
 
 	if (isChatNode.value || (isChatChild.value && ndvStore.isInputPanelEmpty)) {
 		ndvStore.setActiveNodeName(null);
+		workflowsStore.chatPartialExecutionDestinationNode = props.nodeName;
 		nodeViewEventBus.emit('openChat');
 	} else if (isListeningForEvents.value) {
 		await stopWaitingForWebhook();

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -109,8 +109,6 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 		nodeData?: ITaskData;
 		source?: string;
 	}): Promise<IExecutionPushResponse | undefined> {
-		debugger;
-
 		const workflow = workflowHelpers.getCurrentWorkflow();
 
 		if (uiStore.isActionActive['workflowRunning']) {

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -109,6 +109,8 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 		nodeData?: ITaskData;
 		source?: string;
 	}): Promise<IExecutionPushResponse | undefined> {
+		debugger;
+
 		const workflow = workflowHelpers.getCurrentWorkflow();
 
 		if (uiStore.isActionActive['workflowRunning']) {
@@ -164,6 +166,9 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 				);
 				newRunData = { [options.triggerNode]: [options.nodeData] };
 				executedNode = options.triggerNode;
+			}
+
+			if (options.triggerNode && options.nodeData) {
 				triggerToStartFrom = {
 					name: options.triggerNode,
 					data: options.nodeData,
@@ -174,7 +179,8 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			if (
 				options.destinationNode &&
 				(workflowsStore.checkIfNodeHasChatParent(options.destinationNode) ||
-					destinationNodeType === CHAT_TRIGGER_NODE_TYPE)
+					destinationNodeType === CHAT_TRIGGER_NODE_TYPE) &&
+				options.source !== 'RunData.ManualChatMessage'
 			) {
 				const startNode = workflow.getStartNode(options.destinationNode);
 				if (startNode && startNode.type === CHAT_TRIGGER_NODE_TYPE) {
@@ -186,6 +192,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					// If the chat node has no input data or pin data, open the chat modal
 					// and halt the execution
 					if (!chatHasInputData && !chatHasPinData) {
+						workflowsStore.chatPartialExecutionDestinationNode = options.destinationNode;
 						workflowsStore.setPanelOpen('chat', true);
 						return;
 					}

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -145,6 +145,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const nodeMetadata = ref<NodeMetadataMap>({});
 	const isInDebugMode = ref(false);
 	const chatMessages = ref<string[]>([]);
+	const chatPartialExecutionDestinationNode = ref<string | null>(null);
 	const isChatPanelOpen = ref(false);
 	const isLogsPanelOpen = ref(false);
 
@@ -1634,6 +1635,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		nodeMetadata,
 		isInDebugMode,
 		chatMessages,
+		chatPartialExecutionDestinationNode,
 		workflowName,
 		workflowId,
 		workflowVersionId,


### PR DESCRIPTION
## Summary

When the workflow starts with a manual chat trigger and user tries to partially execute the workflow – chat panel opens. After typing a message full workflow execution happens instead of partial.
This PR adds `destinationNode` parameter when running a workflow starting with a manual chat trigger.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-349/chat-trigger-does-not-honour-manual-partial-execution


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
