### PR TITLE
fix(n8n Form Node): Remove the ability to change the formatting of dates

### DIFF
--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -186,19 +186,10 @@ export const formFields: INodeProperties = {
 					},
 				},
 				{
-					displayName: 'Format Date As',
+					displayName: "The displayed date is formatted based on the locale of the user's browser",
 					name: 'formatDate',
-					type: 'string',
+					type: 'notice',
 					default: '',
-					description:
-						'How to format the date in the output data. For a table of tokens and their interpretations, see <a href="https://moment.github.io/luxon/#/formatting?ID=table-of-tokens" target="_blank">here</a>.',
-					placeholder: 'e.g. dd/mm/yyyy',
-					hint: 'Leave empty to use the default format',
-					displayOptions: {
-						show: {
-							fieldType: ['date'],
-						},
-					},
 				},
 				{
 					displayName: 'Required Field',


### PR DESCRIPTION
## Summary

Changing formatting for dates is not really possible with native inputs and handlebars. As a result, we should remove this feature.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2222/community-issue-form-date-field-returning-wrong-month-when-date-format

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
