### PR TITLE
chore(core): Report to Sentry successful execution with empty data

### DIFF
--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -287,7 +287,7 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		const { executionData, metadata, annotation, ...rest } = execution;
 		const serializedAnnotation = this.serializeAnnotation(annotation);
 
-		if (execution.status === 'success' && executionData.data === '[]') {
+		if (execution.status === 'success' && executionData?.data === '[]') {
 			this.errorReporter.error('Found successful execution where data is empty stringified array', {
 				extra: {
 					executionId: execution.id,

--- a/packages/cli/src/databases/repositories/execution.repository.ts
+++ b/packages/cli/src/databases/repositories/execution.repository.ts
@@ -287,6 +287,15 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 		const { executionData, metadata, annotation, ...rest } = execution;
 		const serializedAnnotation = this.serializeAnnotation(annotation);
 
+		if (execution.status === 'success' && executionData.data === '[]') {
+			this.errorReporter.error('Found successful execution where data is empty stringified array', {
+				extra: {
+					executionId: execution.id,
+					workflowId: executionData?.workflowData.id,
+				},
+			});
+		}
+
 		return {
 			...rest,
 			...(options?.includeData && {


### PR DESCRIPTION
## Summary

We have an intermittent scenario where a successful manual execution on regular mode may end up with `'[]'` in `execution_data.data` as reported in the Linear story. 

We tried:
- Reproducing it by running multiple times, and it did not reproduce. Based on execution history, this is a rare occurrence.
- We found no other differences between successful executions with data and successful executions without data.
- `flatted.stringify(undefined)` leads to `'[]'` but this call does not seem possible anywhere in the execution repository.

In this PR, we add a Sentry report to learn more about this specific issue and have more cloud instances to investigate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-480

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
