### PR TITLE
fix(core): Remove run data of utility nodes for partial executions v2

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/clean-run-data.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/clean-run-data.ts
@@ -1,4 +1,4 @@
-import type { INode, IRunData } from 'n8n-workflow';
+import { NodeConnectionType, type INode, type IRunData } from 'n8n-workflow';
 
 import type { DirectedGraph } from './directed-graph';
 
@@ -16,10 +16,22 @@ export function cleanRunData(
 
 	for (const startNode of startNodes) {
 		delete newRunData[startNode.name];
-		const children = graph.getChildren(startNode);
 
-		for (const child of children) {
-			delete newRunData[child.name];
+		const children = graph.getChildren(startNode);
+		for (const node of [startNode, ...children]) {
+			delete newRunData[node.name];
+
+			// Delete runData for subNodes
+			const subNodeConnections = graph.getParentConnections(node);
+			for (const subNodeConnection of subNodeConnections) {
+				// Sub nodes never use the Main connection type, so this filters our
+				// the connection that goes upstream of the startNode.
+				if (subNodeConnection.type === NodeConnectionType.Main) {
+					continue;
+				}
+
+				delete newRunData[subNodeConnection.from.name];
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Partial execution v2 did not clear the run data of sub nodes, which led to the wrong number of executions in the sub nodes as well as to the root node to be in the execution stack twice.

Before:

https://github.com/user-attachments/assets/fb3178b7-bebe-4efc-bee3-838fde05ec59

After:

https://github.com/user-attachments/assets/74fcce82-9b6e-4eaf-9b45-64faa3d16d0f



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2483/bug-partial-execution-of-root-node-generates-extra-run


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
