### PR TITLE
fix(Postgres Chat Memory Node): Do not terminate the connection pool

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
@@ -115,12 +115,7 @@ export class MemoryPostgresChat implements INodeType {
 			...kOptions,
 		});
 
-		async function closeFunction() {
-			void pool.end();
-		}
-
 		return {
-			closeFunction,
 			response: logWrapper(memory, this),
 		};
 	}

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -186,7 +186,7 @@ export async function configurePostgres(
 		nodeVersion: options.nodeVersion as unknown as string,
 		fallBackHandler,
 		cleanUpHandler: async ({ db }) => {
-			await db.$pool.end();
+			if (!db.$pool.ended) await db.$pool.end();
 		},
 	});
 }


### PR DESCRIPTION
## Summary
Postgres connection pools aren't managed in individual nodes now, and are instead managed in the `ConnectionPoolManager`. 
When the Postgres Chat Memory node calls `pool.end()`, it terminates the pool while the `ConnectionPoolManager` still holds a reference to it. This leads to the Postgres Chat Memory node being completely broken until the `ConnectionPoolManager` cleans up the reference to this pool. And if there are a lot of postgres calls on the instance, it's possible that the pool never gets cleaned up, and all postgres nodes using that specific credential are then broken indefinitely.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #12517
https://linear.app/n8n/issue/NODE-2240
https://community.n8n.io/t/error-using-postgres-chat-memory-and-supabase-for-ai-tools-agent/70792


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
