### PR TITLE
fix(editor): Add notice when user hits the limit for execution metadata item length

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/execution-metadata.test.ts
@@ -205,15 +205,12 @@ describe('Execution Metadata functions', () => {
 			},
 		} as IRunExecutionData;
 
-		setWorkflowExecutionMetadata(
-			executionData,
-			'test1',
-			'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab',
-		);
+		const longValue = 'a'.repeat(513);
+
+		setWorkflowExecutionMetadata(executionData, 'test1', longValue);
 
 		expect(metadata).toEqual({
-			test1:
-				'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+			test1: longValue.slice(0, 512),
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/execution-metadata.ts
@@ -38,9 +38,9 @@ export function setWorkflowExecutionMetadata(
 		Logger.error('Custom data key over 50 characters long. Truncating to 50 characters.');
 	}
 	if (val.length > 255) {
-		Logger.error('Custom data value over 255 characters long. Truncating to 255 characters.');
+		Logger.error('Custom data value over 512 characters long. Truncating to 512 characters.');
 	}
-	executionData.resultData.metadata[key.slice(0, 50)] = val.slice(0, 255);
+	executionData.resultData.metadata[key.slice(0, 50)] = val.slice(0, 512);
 }
 
 export function setAllWorkflowExecutionMetadata(

--- a/packages/nodes-base/nodes/ExecutionData/ExecutionData.node.ts
+++ b/packages/nodes-base/nodes/ExecutionData/ExecutionData.node.ts
@@ -83,6 +83,22 @@ export class ExecutionData implements INodeType {
 				],
 			},
 		],
+		hints: [
+			{
+				type: 'warning',
+				message: 'Some keys are longer than 50 characters. They will be truncated.',
+				displayCondition: '={{ $parameter.dataToSave.values.some((x) => x.key.length > 50) }}',
+				whenToDisplay: 'beforeExecution',
+				location: 'outputPane',
+			},
+			{
+				type: 'warning',
+				message: 'Some values are longer than 512 characters. They will be truncated.',
+				displayCondition: '={{ $parameter.dataToSave.values.some((x) => x.value.length > 512) }}',
+				whenToDisplay: 'beforeExecution',
+				location: 'outputPane',
+			},
+		],
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {


### PR DESCRIPTION
## Summary

This PR increases the maximum length of a value in execution metadata from 255 to 512.
Also, the hint added to the Execution Data Node's NDV with a warning when user hits the limit.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/bba2fbd2-bed8-42c3-a6f8-21f5c66dbbf0" />


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-439/highlighted-data-increase-max-length


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
