### PR TITLE
fix(editor): Correct missing whitespace in JSON output

### DIFF
--- a/packages/editor-ui/src/components/RunDataJson.vue
+++ b/packages/editor-ui/src/components/RunDataJson.vue
@@ -258,6 +258,7 @@ const getListItemName = (path: string) => {
 	> span {
 		padding: 0 var(--spacing-5xs) 0 var(--spacing-5xs);
 		margin-left: var(--spacing-5xs);
+		white-space: pre-wrap;
 	}
 }
 


### PR DESCRIPTION
## Summary

By default, browsers will collapse sequences of whitespace which causes the input to look different to the output in the NDV JSON view. This fixes it.

## Related Linear tickets, Github issues, and Community forum posts

Fixes: https://linear.app/n8n/issue/PAY-1866/community-issue-additional-spaces-are-missed-in-the-json-output

closes #10418 

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
