### PR TITLE
fix(editor): Don't send run data for full manual executions

### DIFF
--- a/packages/editor-ui/src/components/CanvasChat/CanvasChat.test.ts
+++ b/packages/editor-ui/src/components/CanvasChat/CanvasChat.test.ts
@@ -230,28 +230,28 @@ describe('CanvasChat', () => {
 			// Verify workflow execution
 			expect(workflowsStore.runWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({
-					runData: {
-						'When chat message received': [
-							{
-								data: {
-									main: [
-										[
-											{
-												json: {
-													action: 'sendMessage',
-													chatInput: 'Hello AI!',
-													sessionId: expect.any(String),
-												},
+					runData: undefined,
+					triggerToStartFrom: {
+						name: 'When chat message received',
+						data: {
+							data: {
+								main: [
+									[
+										{
+											json: {
+												action: 'sendMessage',
+												chatInput: 'Hello AI!',
+												sessionId: expect.any(String),
 											},
-										],
+										},
 									],
-								},
-								executionStatus: 'success',
-								executionTime: 0,
-								source: [null],
-								startTime: expect.any(Number),
+								],
 							},
-						],
+							executionStatus: 'success',
+							executionTime: 0,
+							source: [null],
+							startTime: expect.any(Number),
+						},
 					},
 				}),
 			);

--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -259,14 +259,23 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 			// 0 is the old flow
 			// 1 is the new flow
 			const partialExecutionVersion = useLocalStorage('PartialExecution.version', -1);
+			// partial executions must have a destination node
+			const isPartialExecution = options.destinationNode !== undefined;
 			const startRunData: IStartRunData = {
 				workflowData,
-				// With the new partial execution version the backend decides what run
-				// data to use and what to ignore.
-				runData: partialExecutionVersion.value === 1 ? (runData ?? undefined) : newRunData,
+				runData: !isPartialExecution
+					? // if it's a full execution we don't want to send any run data
+						undefined
+					: partialExecutionVersion.value === 1
+						? // With the new partial execution version the backend decides
+							//what run data to use and what to ignore.
+							(runData ?? undefined)
+						: // for v0 we send the run data the FE constructed
+							newRunData,
 				startNodes,
 				triggerToStartFrom,
 			};
+
 			if ('destinationNode' in options) {
 				startRunData.destinationNode = options.destinationNode;
 			}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

With partial execution v2 chosen we would end up sending all run data for full executions. That lead to an error showing that a user should make a full execution because the run data is too big for the server to decode, which is nonsensical as the user actually did a full execution. 

This PR does not send the run data anymore for a full manual execution. 

Before:

https://github.com/user-attachments/assets/6439d668-662f-4c2f-bbb6-f4c3eac8c661


After:

https://github.com/user-attachments/assets/787476ff-7b2e-4522-b9d6-f36147555fbb


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-2486/bug-partial-exec-error-about-payload-size-displayed-on-full-execution


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
