### PR TITLE
feat: add support for display options filtering in parameter options

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -305,8 +305,6 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 			});
 		}
 
-		console.log('messages', messages);
-
 		response = (await apiRequest.call(this, 'POST', '/chat/completions', {
 			body,
 		})) as ChatCompletion;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -10,7 +10,10 @@ import { jsonParse, updateDisplayOptions } from 'n8n-workflow';
 
 import { getConnectedTools } from '@utils/helpers';
 
-import { MODELS_NOT_SUPPORT_FUNCTION_CALLS } from '../../helpers/constants';
+import {
+	MODELS_NOT_SUPPORT_FUNCTION_CALLS,
+	MODELS_NOT_SUPPORT_SYSTEM_ROLE,
+} from '../../helpers/constants';
 import type { ChatCompletion } from '../../helpers/interfaces';
 import { formatToOpenAIAssistantTool } from '../../helpers/utils';
 import { apiRequest } from '../../transport';
@@ -65,6 +68,11 @@ const properties: INodeProperties[] = [
 								value: 'system',
 								description:
 									"Usually used to set the model's behavior or context for the next user message",
+								displayOptions: {
+									hide: {
+										modelId: MODELS_NOT_SUPPORT_SYSTEM_ROLE,
+									},
+								},
 							},
 						],
 						default: 'user',
@@ -296,6 +304,8 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 				content: functionResponse,
 			});
 		}
+
+		console.log('messages', messages);
 
 		response = (await apiRequest.call(this, 'POST', '/chat/completions', {
 			body,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/constants.ts
@@ -20,3 +20,10 @@ export const MODELS_NOT_SUPPORT_FUNCTION_CALLS = [
 	'tts-1-1106',
 	'text-embedding-ada-002',
 ];
+
+export const MODELS_NOT_SUPPORT_SYSTEM_ROLE = [
+	'o1-mini',
+	'o1-mini-2024-09-12',
+	'o1-preview',
+	'o1-preview-2024-09-12',
+];

--- a/packages/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/ParameterInput.test.ts
@@ -233,4 +233,52 @@ describe('ParameterInput.vue', () => {
 
 		expect(emitted('update')).toBeUndefined();
 	});
+
+	test('should handle the visibility of the options parameter based on displayOptions', async () => {
+		const roleParameter = {
+			displayName: 'Role',
+			name: 'role',
+			type: 'options',
+			default: 'user',
+			options: [
+				{
+					name: 'User',
+					value: 'user',
+				},
+				{
+					name: 'Assistant',
+					value: 'assistant',
+				},
+				{
+					name: 'System',
+					value: 'system',
+					displayOptions: {
+						hide: {
+							'@version': [1],
+						},
+					},
+				},
+			],
+		};
+
+		const { container, baseElement } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'role',
+				parameter: roleParameter,
+				modelValue: 'user',
+			},
+		});
+
+		const selectInput = container.querySelector('input') as HTMLInputElement;
+		expect(selectInput).toBeInTheDocument();
+
+		await userEvent.click(selectInput);
+
+		await waitFor(() => {
+			expect(baseElement).toHaveTextContent('User');
+			expect(baseElement).toHaveTextContent('Assistant');
+			expect(baseElement).not.toHaveTextContent('System');
+		});
+	});
 });

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -413,8 +413,15 @@ const editorLanguage = computed<CodeNodeEditorLanguage>(() => {
 
 const parameterOptions = computed<INodePropertyOptions[] | undefined>(() => {
 	if (!hasRemoteMethod.value) {
-		// Options are already given
-		return props.parameter.options as INodePropertyOptions[];
+		const options = props.parameter.options as INodePropertyOptions[];
+		const nodeValue = ndvStore.activeNode as INodeUi;
+		if (!nodeValue) {
+			return options;
+		}
+
+		const nodeValues = nodeValue.parameters ?? {};
+		const visibleOptions = options.filter((option) => nodeHelpers.displayParameter(nodeValues, option, '', nodeValue));
+		return visibleOptions;
 	}
 
 	// Options get loaded from server

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -420,7 +420,9 @@ const parameterOptions = computed<INodePropertyOptions[] | undefined>(() => {
 		}
 
 		const nodeValues = nodeValue.parameters ?? {};
-		const visibleOptions = options.filter((option) => nodeHelpers.displayParameter(nodeValues, option, '', nodeValue));
+		const visibleOptions = options.filter((option) =>
+			nodeHelpers.displayParameter(nodeValues, option, '', nodeValue),
+		);
 		return visibleOptions;
 	}
 

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -414,7 +414,7 @@ const editorLanguage = computed<CodeNodeEditorLanguage>(() => {
 const parameterOptions = computed<INodePropertyOptions[] | undefined>(() => {
 	if (!hasRemoteMethod.value) {
 		const options = props.parameter.options as INodePropertyOptions[];
-		const nodeValue = ndvStore.activeNode as INodeUi;
+		const nodeValue = ndvStore.activeNode!;
 		if (!nodeValue) {
 			return options;
 		}


### PR DESCRIPTION
## Summary

Hey n8n team! 👋

I was looking into issue #12675 a bit and I faced the same error: currently, the o1-models don’t support the system and/or developer roles, resulting in a Bad Request error ([this is a known issue](https://community.openai.com/t/o1-models-do-not-support-system-role-in-chat-completion/953880)).

To mitigate the problem, I’ve implemented a quick-win solution and added logic as done for parameters also within the options. By doing this you'll be able to filter also options by a deterministic logic using the `show` and `hide` conditions. Also, I've create a new constant (as done as for models taht doens't support function calls) to encapsulate those models which doesn't support the System role.

## Related Linear tickets, Github issues, and Community forum posts

Resolves #12675.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included.
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
