### PR TITLE
fix(core): Align saving behavior in `workflowExecuteAfter` hooks

### DIFF
--- a/packages/cli/src/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/__tests__/execution-lifecycle-hooks.test.ts
@@ -500,6 +500,10 @@ describe('Execution Lifecycle Hooks', () => {
 					saveDataSuccessExecution: 'none',
 					saveDataErrorExecution: 'all',
 				};
+				const hooks = getWorkflowHooksWorkerMain('webhook', executionId, workflowData, {
+					pushRef,
+					retryOf,
+				});
 
 				await hooks.executeHookFunctions('workflowExecuteAfter', [successfulRun, {}]);
 
@@ -514,6 +518,10 @@ describe('Execution Lifecycle Hooks', () => {
 					saveDataSuccessExecution: 'all',
 					saveDataErrorExecution: 'none',
 				};
+				const hooks = getWorkflowHooksWorkerMain('webhook', executionId, workflowData, {
+					pushRef,
+					retryOf,
+				});
 
 				await hooks.executeHookFunctions('workflowExecuteAfter', [failedRun, {}]);
 


### PR DESCRIPTION
## Summary


We currently have a behavior difference between `workflowExecuteAfter` in the hooks for main in scaling mode vs. `workflowExecuteAfter` in the hooks for main in regular mode. Namely, if save settings say that the execution should not remain in the DB after finished, the regular-mode hook soft-deletes manual executions and hard-deletes production executions, while the scaling-mode hook hard-deletes _all_ executions, making no distinction.

Since #11284 the `workflowExecuteAfter` hook is called also for manual executions finished in scaling mode, so the assumption that all executions that reach this hook qualify for hard-deletion no longer holds. Hence this PR aligns saving behavior - in scaling mode, on execution finished, if manual and must be cleared according to save settings, then we behave as in regular mode. This ensures we do not clear manual executions that should remain persisted.

## Testing

- Start a main with `EXECUTIONS_DATA_SAVE_ON_SUCCESS=none` and `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`
- Start a worker
- Create a workflow and set it to save manual executions
- Run a manual execution
- Expected: The manual execution should be visible in the executions view.

For context, lifecycle hooks are being revamped at #12364 and it will soon be easier to detect differences like these, so for now this is a small hotfix to prevent users testing `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS` (likely only ourselves on internal) from being affected by this issue.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2497

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
