### PR TITLE
fix(core): Sync `hookFunctionsSave` and `hookFunctionsSaveWorker`

### DIFF
--- a/packages/cli/src/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/__tests__/execution-lifecycle-hooks.test.ts
@@ -26,6 +26,7 @@ import { mockInstance } from '@test/mocking';
 
 import {
 	getWorkflowHooksMain,
+	getWorkflowHooksWorkerExecuter,
 	getWorkflowHooksWorkerMain,
 } from '../workflow-execute-additional-data';
 
@@ -529,6 +530,87 @@ describe('Execution Lifecycle Hooks', () => {
 					workflowId,
 					executionId,
 				});
+			});
+		});
+	});
+
+	describe('getWorkflowHooksWorkerExecuter', () => {
+		let hooks: WorkflowHooks;
+
+		beforeEach(() => {
+			hooks = getWorkflowHooksWorkerExecuter(executionMode, executionId, workflowData, {
+				pushRef,
+				retryOf,
+			});
+		});
+
+		describe('saving static data', () => {
+			it('should skip saving static data for manual executions', async () => {
+				hooks.mode = 'manual';
+
+				await hooks.executeHookFunctions('workflowExecuteAfter', [successfulRun, staticData]);
+
+				expect(workflowStaticDataService.saveStaticDataById).not.toHaveBeenCalled();
+			});
+
+			it('should save static data for prod executions', async () => {
+				hooks.mode = 'trigger';
+
+				await hooks.executeHookFunctions('workflowExecuteAfter', [successfulRun, staticData]);
+
+				expect(workflowStaticDataService.saveStaticDataById).toHaveBeenCalledWith(
+					workflowId,
+					staticData,
+				);
+			});
+
+			it('should handle static data saving errors', async () => {
+				hooks.mode = 'trigger';
+				const error = new Error('Static data save failed');
+				workflowStaticDataService.saveStaticDataById.mockRejectedValueOnce(error);
+
+				await hooks.executeHookFunctions('workflowExecuteAfter', [successfulRun, staticData]);
+
+				expect(errorReporter.error).toHaveBeenCalledWith(error);
+			});
+		});
+
+		describe('error workflow', () => {
+			it('should not execute error workflow for manual executions', async () => {
+				hooks.mode = 'manual';
+
+				await hooks.executeHookFunctions('workflowExecuteAfter', [failedRun, {}]);
+
+				expect(workflowExecutionService.executeErrorWorkflow).not.toHaveBeenCalled();
+			});
+
+			it('should execute error workflow for failed non-manual executions', async () => {
+				hooks.mode = 'trigger';
+				const errorWorkflow = 'error-workflow-id';
+				workflowData.settings = { errorWorkflow };
+				const project = mock<Project>();
+				ownershipService.getWorkflowProjectCached.calledWith(workflowId).mockResolvedValue(project);
+
+				await hooks.executeHookFunctions('workflowExecuteAfter', [failedRun, {}]);
+
+				expect(workflowExecutionService.executeErrorWorkflow).toHaveBeenCalledWith(
+					errorWorkflow,
+					{
+						workflow: {
+							id: workflowId,
+							name: workflowData.name,
+						},
+						execution: {
+							id: executionId,
+							error: expressionError,
+							mode: 'trigger',
+							retryOf,
+							lastNodeExecuted: undefined,
+							url: `http://localhost:5678/workflow/${workflowId}/executions/${executionId}`,
+						},
+					},
+					project,
+				);
 			});
 		});
 	});

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -576,8 +576,11 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 					executionId: this.executionId,
 					workflowId: this.workflowData.id,
 				});
+
+				const isManualMode = this.mode === 'manual';
+
 				try {
-					if (isWorkflowIdValid(this.workflowData.id) && newStaticData) {
+					if (!isManualMode && isWorkflowIdValid(this.workflowData.id) && newStaticData) {
 						// Workflow is saved so update in database
 						try {
 							await Container.get(WorkflowStaticDataService).saveStaticDataById(
@@ -596,7 +599,11 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 					const workflowStatusFinal = determineFinalExecutionStatus(fullRunData);
 					fullRunData.status = workflowStatusFinal;
 
-					if (workflowStatusFinal !== 'success' && workflowStatusFinal !== 'waiting') {
+					if (
+						!isManualMode &&
+						workflowStatusFinal !== 'success' &&
+						workflowStatusFinal !== 'waiting'
+					) {
 						executeErrorWorkflow(
 							this.workflowData,
 							fullRunData,
@@ -615,19 +622,25 @@ function hookFunctionsSaveWorker(): IWorkflowExecuteHooks {
 						retryOf: this.retryOf,
 					});
 
+					// When going into the waiting state, store the pushRef in the execution-data
+					if (fullRunData.waitTill && isManualMode) {
+						fullExecutionData.data.pushRef = this.pushRef;
+					}
+
 					await updateExistingExecution({
 						executionId: this.executionId,
 						workflowId: this.workflowData.id,
 						executionData: fullExecutionData,
 					});
 				} catch (error) {
-					executeErrorWorkflow(
-						this.workflowData,
-						fullRunData,
-						this.mode,
-						this.executionId,
-						this.retryOf,
-					);
+					if (!isManualMode)
+						executeErrorWorkflow(
+							this.workflowData,
+							fullRunData,
+							this.mode,
+							this.executionId,
+							this.retryOf,
+						);
 				} finally {
 					workflowStatisticsService.emit('workflowExecutionCompleted', {
 						workflowData: this.workflowData,


### PR DESCRIPTION
## Summary

Found more hook differences between the `workflowExecuteAfter` hook in `hookFunctionsSave` and the one in `hookFunctionsSaveWorker` namely:

- store session ID in run data when manual execution is put to wait
- save static data only for production execution
- call error workflow only for production execution

This PR brings hooks closer - still not 100% identical, but easier to unify when we revisit #12364.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
