### PR TITLE
fix: Prepare expression editor modal e2e tests for new canvas (no-changelog)

### DIFF
--- a/cypress/e2e/9-expression-editor-modal.cy.ts
+++ b/cypress/e2e/9-expression-editor-modal.cy.ts
@@ -81,7 +81,7 @@ describe('Expression editor modal', () => {
 			WorkflowPage.getters.expressionModalOutput().should('have.text', 'getAll');
 		});
 
-		it.only('should resolve input: $json,$input,$(nodeName)', () => {
+		it('should resolve input: $json,$input,$(nodeName)', () => {
 			// Previous nodes have not run, input is empty
 			WorkflowPage.getters.expressionModalInput().clear();
 			WorkflowPage.getters.expressionModalInput().click().type('{{ $json.myStr');

--- a/cypress/e2e/9-expression-editor-modal.cy.ts
+++ b/cypress/e2e/9-expression-editor-modal.cy.ts
@@ -81,7 +81,7 @@ describe('Expression editor modal', () => {
 			WorkflowPage.getters.expressionModalOutput().should('have.text', 'getAll');
 		});
 
-		it('should resolve input: $json,$input,$(nodeName)', () => {
+		it.only('should resolve input: $json,$input,$(nodeName)', () => {
 			// Previous nodes have not run, input is empty
 			WorkflowPage.getters.expressionModalInput().clear();
 			WorkflowPage.getters.expressionModalInput().click().type('{{ $json.myStr');
@@ -105,7 +105,7 @@ describe('Expression editor modal', () => {
 			// Run workflow
 			cy.get('body').type('{esc}');
 			ndv.actions.close();
-			WorkflowPage.actions.executeNode('No Operation');
+			WorkflowPage.actions.executeNode('No Operation, do nothing', { anchor: 'topLeft' });
 			WorkflowPage.actions.openNode('Hacker News');
 			WorkflowPage.actions.openExpressionEditorModal();
 


### PR DESCRIPTION
## Summary

<img width="466" alt="image" src="https://github.com/user-attachments/assets/085e0295-f678-4ec9-b3a1-6c89e4b88664" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-549/9-expression-editor-modal

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
