### PR TITLE
fix(core): AugmentObject should handle the constructor property correctly

### DIFF
--- a/packages/workflow/src/AugmentObject.ts
+++ b/packages/workflow/src/AugmentObject.ts
@@ -36,6 +36,7 @@ export function augmentArray<T>(data: T[]): T[] {
 			return Reflect.deleteProperty(getData(), key);
 		},
 		get(target, key: string, receiver): unknown {
+			if (key === 'constructor') return Array;
 			const value = Reflect.get(newData ?? target, key, receiver) as unknown;
 			const newValue = augment(value);
 			if (newValue !== value) {
@@ -83,6 +84,8 @@ export function augmentObject<T extends object>(data: T): T {
 
 	const proxy = new Proxy(data, {
 		get(target, key: string, receiver): unknown {
+			if (key === 'constructor') return Object;
+
 			if (deletedProperties.has(key)) {
 				return undefined;
 			}

--- a/packages/workflow/test/AugmentObject.test.ts
+++ b/packages/workflow/test/AugmentObject.test.ts
@@ -10,6 +10,8 @@ describe('AugmentObject', () => {
 
 			const augmentedObject = augmentArray(originalObject);
 
+			expect(augmentedObject.constructor.name).toEqual('Array');
+
 			expect(augmentedObject.push(5)).toEqual(6);
 			expect(augmentedObject).toEqual([1, 2, 3, 4, null, 5]);
 			expect(originalObject).toEqual(copyOriginal);
@@ -206,6 +208,8 @@ describe('AugmentObject', () => {
 			const copyOriginal = deepCopy(originalObject);
 
 			const augmentedObject = augmentObject(originalObject);
+
+			expect(augmentedObject.constructor.name).toEqual('Object');
 
 			augmentedObject[1] = 911;
 			expect(originalObject[1]).toEqual(11);
@@ -588,6 +592,30 @@ describe('AugmentObject', () => {
 
 			delete augmentedObject.toString;
 			expect(augmentedObject.toString).toBeUndefined();
+		});
+
+		test('should handle constructor property correctly', () => {
+			const originalObject: any = {
+				a: {
+					b: {
+						c: {
+							d: '4',
+						},
+					},
+				},
+			};
+			const augmentedObject = augmentObject(originalObject);
+
+			expect(augmentedObject.constructor.name).toEqual('Object');
+			expect(augmentedObject.a.constructor.name).toEqual('Object');
+			expect(augmentedObject.a.b.constructor.name).toEqual('Object');
+			expect(augmentedObject.a.b.c.constructor.name).toEqual('Object');
+
+			augmentedObject.constructor = {};
+			expect(augmentedObject.constructor.name).toEqual('Object');
+
+			delete augmentedObject.constructor;
+			expect(augmentedObject.constructor.name).toEqual('Object');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
We have a couple of places where we check for `.constructor` on these proxy objects, but these fail now since we switched to checking for own-property.

## Related Linear tickets, Github issues, and Community forum posts
[CAT-542](https://linear.app/n8n/issue/CAT-542)
Fixes #12604

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
