### PR TITLE
ci: Disable task runner for core and nodes tests

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1,3 +1,7 @@
+// Disable task runners until we have fixed the "run test workflows" test
+// to mock the Code Node execution
+process.env.N8N_RUNNERS_ENABLED = 'false';
+
 // NOTE: Diagrams in this file have been created with https://asciiflow.com/#/
 // If you update the tests, please update the diagrams as well.
 // If you add a test, please create a new diagram.
@@ -9,8 +13,6 @@
 // XX denotes that the node is disabled
 // PD denotes that the node has pinned data
 
-import { TaskRunnersConfig } from '@n8n/config';
-import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { pick } from 'lodash';
 import type {
@@ -50,11 +52,6 @@ import { WorkflowExecute } from '../workflow-execute';
 const nodeTypes = Helpers.NodeTypes();
 
 describe('WorkflowExecute', () => {
-	const taskRunnersConfig = Container.get(TaskRunnersConfig);
-	// Disable task runners until we have fixed the "run test workflows" test
-	// to mock the Code Node execution
-	taskRunnersConfig.enabled = false;
-
 	describe('v0 execution order', () => {
 		const tests: WorkflowTestData[] = legacyWorkflowExecuteTests;
 

--- a/packages/nodes-base/test/setup.ts
+++ b/packages/nodes-base/test/setup.ts
@@ -1,1 +1,5 @@
 import 'reflect-metadata';
+
+// Disable task runners until we have fixed the "run test workflows" test
+// to mock the Code Node execution
+process.env.N8N_RUNNERS_ENABLED = 'false';


### PR DESCRIPTION
## Summary
Disable task runners until we have fixed the "run test workflows" test to mock the Code Node execution.

## Review / Merge checklist

- [x] PR title and summary are descriptive
