### PR TITLE
fix(core): Fix license CLI commands showing incorrect renewal setting

### DIFF
--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -251,6 +251,20 @@ describe('License', () => {
 
 			expect(LicenseManager).toHaveBeenCalledWith(expect.objectContaining(expectedRenewalSettings));
 		});
+
+		it('when CLI command with N8N_LICENSE_AUTO_RENEW_ENABLED=true, should enable renewal', async () => {
+			const globalConfig = mock<GlobalConfig>({
+				license: { ...licenseConfig, autoRenewalEnabled: true },
+			});
+
+			await new License(mockLogger(), mock(), mock(), mock(), globalConfig).init({
+				isCli: true,
+			});
+
+			expect(LicenseManager).toHaveBeenCalledWith(
+				expect.objectContaining({ autoRenewEnabled: true, renewOnInit: true }),
+			);
+		});
 	});
 
 	describe('reinit', () => {
@@ -262,7 +276,7 @@ describe('License', () => {
 
 			await license.reinit();
 
-			expect(initSpy).toHaveBeenCalledWith(true);
+			expect(initSpy).toHaveBeenCalledWith({ forceRecreate: true });
 
 			expect(LicenseManager.prototype.reset).toHaveBeenCalled();
 			expect(LicenseManager.prototype.initialize).toHaveBeenCalled();

--- a/packages/cli/src/commands/license/clear.ts
+++ b/packages/cli/src/commands/license/clear.ts
@@ -16,7 +16,7 @@ export class ClearLicenseCommand extends BaseCommand {
 
 		// Attempt to invoke shutdown() to force any floating entitlements to be released
 		const license = Container.get(License);
-		await license.init();
+		await license.init({ isCli: true });
 		try {
 			await license.shutdown();
 		} catch {

--- a/packages/cli/src/commands/license/info.ts
+++ b/packages/cli/src/commands/license/info.ts
@@ -11,7 +11,7 @@ export class LicenseInfoCommand extends BaseCommand {
 
 	async run() {
 		const license = Container.get(License);
-		await license.init();
+		await license.init({ isCli: true });
 
 		this.logger.info('Printing license information:\n' + license.getInfo());
 	}

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -43,7 +43,10 @@ export class License {
 		this.logger = this.logger.scoped('license');
 	}
 
-	async init(forceRecreate = false) {
+	async init({
+		forceRecreate = false,
+		isCli = false,
+	}: { forceRecreate?: boolean; isCli?: boolean } = {}) {
 		if (this.manager && !forceRecreate) {
 			this.logger.warn('License manager already initialized or shutting down');
 			return;
@@ -73,10 +76,13 @@ export class License {
 
 		const { isLeader } = this.instanceSettings;
 		const { autoRenewalEnabled } = this.globalConfig.license;
+		const eligibleToRenew = isCli || isLeader;
 
-		const shouldRenew = isLeader && autoRenewalEnabled;
+		const shouldRenew = eligibleToRenew && autoRenewalEnabled;
 
-		if (isLeader && !autoRenewalEnabled) this.logger.warn(LICENSE_RENEWAL_DISABLED_WARNING);
+		if (eligibleToRenew && !autoRenewalEnabled) {
+			this.logger.warn(LICENSE_RENEWAL_DISABLED_WARNING);
+		}
 
 		try {
 			this.manager = new LicenseManager({
@@ -390,7 +396,7 @@ export class License {
 
 	async reinit() {
 		this.manager?.reset();
-		await this.init(true);
+		await this.init({ forceRecreate: true });
 		this.logger.debug('License reinitialized');
 	}
 }


### PR DESCRIPTION
## Summary

Running `license:info` and `license:clear` cause `LicenseManager` to be instantiated with an incorrect renewal value because CLI commands have no instance role. This PR [fixes this](https://share.cleanshot.com/bQb8THfZ).

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1737370331998239?thread_ts=1737367870.620499&cid=C03MZF137FV

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
