### PR TITLE
feat(n8n Form Node): Add read-only/custom HTML form elements

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -371,6 +371,12 @@
 									</div>
 								{{/if}}
 
+								{{#if isHtml}}
+									<div class="form-group">
+										{{{html}}}
+									</div>
+								{{/if}}
+
 								{{#if isTextarea}}
 									<div class='form-group'>
 										<label class='form-label {{inputRequired}}' for='{{id}}'>{{label}}</label>

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -42,9 +42,9 @@ export const formDescription: INodeProperties = {
 };
 
 export const formFields: INodeProperties = {
-	displayName: 'Form Fields',
+	displayName: 'Form Elements',
 	name: 'formFields',
-	placeholder: 'Add Form Field',
+	placeholder: 'Add Form Element',
 	type: 'fixedCollection',
 	default: { values: [{ label: '', fieldType: 'text' }] },
 	typeOptions: {
@@ -66,7 +66,7 @@ export const formFields: INodeProperties = {
 					required: true,
 				},
 				{
-					displayName: 'Field Type',
+					displayName: 'Element Type',
 					name: 'fieldType',
 					type: 'options',
 					default: 'text',

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -2,6 +2,12 @@ import type { INodeProperties } from 'n8n-workflow';
 
 import { appendAttributionOption } from '../../utils/descriptions';
 
+export const placeholder: string = `
+<!-- Your custom HTML here --->
+
+
+`.trimStart();
+
 export const webhookPath: INodeProperties = {
 	displayName: 'Form Path',
 	name: 'path',
@@ -67,6 +73,10 @@ export const formFields: INodeProperties = {
 					description: 'The type of field to add to the form',
 					options: [
 						{
+							name: 'Custom HTML',
+							value: 'html',
+						},
+						{
 							name: 'Date',
 							value: 'date',
 						},
@@ -109,7 +119,7 @@ export const formFields: INodeProperties = {
 					default: '',
 					displayOptions: {
 						hide: {
-							fieldType: ['dropdown', 'date', 'file'],
+							fieldType: ['dropdown', 'date', 'file', 'html'],
 						},
 					},
 				},
@@ -159,6 +169,21 @@ export const formFields: INodeProperties = {
 					},
 				},
 				{
+					displayName: 'HTML Template',
+					name: 'html',
+					typeOptions: {
+						editor: 'htmlEditor',
+					},
+					type: 'string',
+					default: placeholder,
+					description: 'HTML template to render',
+					displayOptions: {
+						show: {
+							fieldType: ['html'],
+						},
+					},
+				},
+				{
 					displayName: 'Multiple Files',
 					name: 'multipleFiles',
 					type: 'boolean',
@@ -197,12 +222,29 @@ export const formFields: INodeProperties = {
 					},
 				},
 				{
+					displayName:
+						'Does not accept <code>&lt;style&gt;</code> <code>&lt;script&gt;</code> or <code>&lt;input&gt;</code> tags.',
+					name: 'htmlTips',
+					type: 'notice',
+					default: '',
+					displayOptions: {
+						show: {
+							fieldType: ['html'],
+						},
+					},
+				},
+				{
 					displayName: 'Required Field',
 					name: 'requiredField',
 					type: 'boolean',
 					default: false,
 					description:
 						'Whether to require the user to enter a value for this field before submitting the form',
+					displayOptions: {
+						hide: {
+							fieldType: ['html'],
+						},
+					},
 				},
 			],
 		},

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -190,6 +190,11 @@ export const formFields: INodeProperties = {
 					name: 'formatDate',
 					type: 'notice',
 					default: '',
+					displayOptions: {
+						show: {
+							fieldType: ['date'],
+						},
+					},
 				},
 				{
 					displayName: 'Required Field',

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -15,6 +15,7 @@ import {
 	prepareFormReturnItem,
 	resolveRawData,
 	isFormConnected,
+	sanitizeHtml,
 } from '../utils';
 
 describe('FormTrigger, parseFormDescription', () => {
@@ -38,6 +39,29 @@ describe('FormTrigger, parseFormDescription', () => {
 
 		descriptions.forEach(({ description, expected }) => {
 			expect(createDescriptionMetadata(description)).toBe(expected);
+		});
+	});
+});
+
+describe('FormTrigger, sanitizeHtml', () => {
+	it('should remove forbidden HTML tags', () => {
+		const givenHtml = [
+			{
+				html: '<script>alert("hello world")</script>',
+				expected: '',
+			},
+			{
+				html: '<style>body { color: red; }</style>',
+				expected: '',
+			},
+			{
+				html: '<input type="text" value="test">',
+				expected: '',
+			},
+		];
+
+		givenHtml.forEach(({ html, expected }) => {
+			expect(sanitizeHtml(html)).toBe(expected);
 		});
 	});
 });
@@ -79,6 +103,12 @@ describe('FormTrigger, formWebhook', () => {
 				requiredField: true,
 				acceptFileTypes: '.pdf,.doc',
 				multipleFiles: false,
+			},
+			{
+				fieldLabel: 'Custom HTML',
+				fieldType: 'html',
+				html: '<div>Test HTML</div>',
+				requiredField: false,
 			},
 		];
 
@@ -133,6 +163,16 @@ describe('FormTrigger, formWebhook', () => {
 					label: 'Resume',
 					multipleFiles: '',
 					placeholder: undefined,
+				},
+				{
+					id: 'field-4',
+					errorId: 'error-field-4',
+					label: 'Custom HTML',
+					inputRequired: '',
+					defaultValue: '',
+					placeholder: undefined,
+					html: '<div>Test HTML</div>',
+					isHtml: true,
 				},
 			],
 			formSubmittedText: 'Your response has been recorded',

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -24,7 +24,7 @@ import { getResolvables } from '../../utils/utilities';
 import { WebhookAuthorizationError } from '../Webhook/error';
 import { validateWebhookAuthentication } from '../Webhook/utils';
 
-function sanitizeHtml(text: string) {
+export function sanitizeHtml(text: string) {
 	return sanitize(text, {
 		allowedTags: [
 			'b',

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -58,6 +58,13 @@ export function sanitizeHtml(text: string) {
 			iframe: ['*'],
 			source: ['*'],
 		},
+		transformTags: {
+			iframe: sanitize.simpleTransform('iframe', {
+				sandbox: '',
+				referrerpolicy: 'strict-origin-when-cross-origin',
+				allow: 'fullscreen; autoplay; encrypted-media',
+			}),
+		},
 	});
 }
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2684,6 +2684,7 @@ export type FormFieldsParameter = Array<{
 	multipleFiles?: boolean;
 	acceptFileTypes?: string;
 	formatDate?: string;
+	html?: string;
 	placeholder?: string;
 }>;
 


### PR DESCRIPTION
## Summary

Add ability to add custom HTML elements. We are also allowing image embedding, embedding tracking, and embedding videos (through `<video>` or `<iframe>`). This also fixes a small UI bug for the date tip.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2271/add-read-onlycustom-html-form-elements

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
