### PR TITLE
test: Set `N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false` in nodes tests

### DIFF
--- a/packages/nodes-base/test/setup.ts
+++ b/packages/nodes-base/test/setup.ts
@@ -3,3 +3,4 @@ import 'reflect-metadata';
 // Disable task runners until we have fixed the "run test workflows" test
 // to mock the Code Node execution
 process.env.N8N_RUNNERS_ENABLED = 'false';
+process.env.N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS = 'false';


### PR DESCRIPTION

## Summary

To get rid of this warning

> Permissions 0644 for n8n settings file /home/runner/.n8n/config are too wide. This is ignored for now, but in the future n8n will attempt to change the permissions automatically. To automatically enforce correct permissions now set N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true (recommended), or turn this check off set N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false.

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
