### PR TITLE
fix(editor): Fix workflow move project select filtering

### DIFF
--- a/packages/editor-ui/src/components/Projects/ProjectMoveResourceModal.test.ts
+++ b/packages/editor-ui/src/components/Projects/ProjectMoveResourceModal.test.ts
@@ -1,12 +1,16 @@
 import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
+import { createProjectListItem } from '@/__tests__/data/projects';
+import { getDropdownItems, mockedStore } from '@/__tests__/utils';
+import type { MockedStore } from '@/__tests__/utils';
 import { PROJECT_MOVE_RESOURCE_MODAL } from '@/constants';
 import ProjectMoveResourceModal from '@/components/Projects/ProjectMoveResourceModal.vue';
 import { useTelemetry } from '@/composables/useTelemetry';
-import { mockedStore } from '@/__tests__/utils';
 import { useProjectsStore } from '@/stores/projects.store';
 
 const renderComponent = createComponentRenderer(ProjectMoveResourceModal, {
+	pinia: createTestingPinia(),
 	global: {
 		stubs: {
 			Modal: {
@@ -18,28 +22,19 @@ const renderComponent = createComponentRenderer(ProjectMoveResourceModal, {
 });
 
 let telemetry: ReturnType<typeof useTelemetry>;
+let projectsStore: MockedStore<typeof useProjectsStore>;
 
 describe('ProjectMoveResourceModal', () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		telemetry = useTelemetry();
+		projectsStore = mockedStore(useProjectsStore);
 	});
 
 	it('should send telemetry when mounted', async () => {
-		const pinia = createTestingPinia();
 		const telemetryTrackSpy = vi.spyOn(telemetry, 'track');
 
-		const projectsStore = mockedStore(useProjectsStore);
-		projectsStore.availableProjects = [
-			{
-				id: '1',
-				name: 'My Project',
-				icon: { type: 'icon', value: 'folder' },
-				type: 'personal',
-				role: 'project:personalOwner',
-				createdAt: '2021-01-01T00:00:00.000Z',
-				updatedAt: '2021-01-01T00:00:00.000Z',
-			},
-		];
+		projectsStore.availableProjects = [createProjectListItem()];
 
 		const props = {
 			modalName: PROJECT_MOVE_RESOURCE_MODAL,
@@ -55,7 +50,7 @@ describe('ProjectMoveResourceModal', () => {
 				},
 			},
 		};
-		renderComponent({ props, pinia });
+		renderComponent({ props });
 		expect(telemetryTrackSpy).toHaveBeenCalledWith(
 			'User clicked to move a workflow',
 			expect.objectContaining({ workflow_id: '1' }),
@@ -63,9 +58,6 @@ describe('ProjectMoveResourceModal', () => {
 	});
 
 	it('should show no available projects message', async () => {
-		const pinia = createTestingPinia();
-
-		const projectsStore = mockedStore(useProjectsStore);
 		projectsStore.availableProjects = [];
 
 		const props = {
@@ -82,7 +74,42 @@ describe('ProjectMoveResourceModal', () => {
 				},
 			},
 		};
-		const { getByText } = renderComponent({ props, pinia });
+		const { getByText } = renderComponent({ props });
 		expect(getByText(/Currently there are not any projects or users available/)).toBeVisible();
+	});
+
+	it('should not hide project select if filter has no result', async () => {
+		const projects = Array.from({ length: 5 }, createProjectListItem);
+		projectsStore.availableProjects = projects;
+
+		const props = {
+			modalName: PROJECT_MOVE_RESOURCE_MODAL,
+			data: {
+				resourceType: 'workflow',
+				resourceTypeLabel: 'Workflow',
+				resource: {
+					id: '1',
+					homeProject: {
+						id: projects[0].id,
+						name: projects[0].name,
+					},
+				},
+			},
+		};
+
+		const { getByTestId, getByRole } = renderComponent({ props });
+
+		const projectSelect = getByTestId('project-move-resource-modal-select');
+		const projectSelectInput: HTMLInputElement = getByRole('combobox');
+		expect(projectSelectInput).toBeVisible();
+		expect(projectSelect).toBeVisible();
+
+		const projectSelectDropdownItems = await getDropdownItems(projectSelect);
+		expect(projectSelectDropdownItems).toHaveLength(projects.length - 1);
+
+		await userEvent.click(projectSelectInput);
+		await userEvent.type(projectSelectInput, 'non-existing project');
+
+		expect(projectSelect).toBeVisible();
 	});
 });

--- a/packages/editor-ui/src/components/Projects/ProjectMoveResourceModal.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectMoveResourceModal.vue
@@ -39,11 +39,13 @@ const availableProjects = computed(() =>
 		'name',
 		projectsStore.availableProjects.filter(
 			(p) =>
-				p.name?.toLowerCase().includes(filter.value.toLowerCase()) &&
 				p.id !== props.data.resource.homeProject?.id &&
 				(!p.scopes || getResourcePermissions(p.scopes)[props.data.resourceType].create),
 		),
 	),
+);
+const filteredProjects = computed(() =>
+	availableProjects.value.filter((p) => p.name?.toLowerCase().includes(filter.value.toLowerCase())),
 );
 const selectedProject = computed(() =>
 	availableProjects.value.find((p) => p.id === projectId.value),
@@ -169,7 +171,7 @@ onMounted(() => {
 						<N8nIcon icon="search" />
 					</template>
 					<N8nOption
-						v-for="p in availableProjects"
+						v-for="p in filteredProjects"
 						:key="p.id"
 						:value="p.id"
 						:label="p.name"


### PR DESCRIPTION
## Summary

Filtering to a nonexisting project when moving a workflow breaks project selection

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2507](https://linear.app/n8n/issue/PAY-2507/when-trying-to-move-a-workflow-filtering-by-a-project-that-doesnt)

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] PR Labeled with `release/backport`