### PR TITLE
fix(editor): Render inline SVGs correctly on the external secrets settings page

### DIFF
--- a/packages/editor-ui/src/components/ExternalSecretsProviderImage.ee.vue
+++ b/packages/editor-ui/src/components/ExternalSecretsProviderImage.ee.vue
@@ -5,27 +5,20 @@ import { computed } from 'vue';
 import infisical from '../assets/images/infisical.webp';
 import doppler from '../assets/images/doppler.webp';
 import vault from '../assets/images/hashicorp.webp';
-import awsSecretsManager from '../assets/images/aws-secrets-manager.svg';
-import azureKeyVault from '../assets/images/azure-key-vault.svg';
-import gcpSecretsManager from '../assets/images/gcp-secrets-manager.svg';
+import AwsSecretsManager from '../assets/images/aws-secrets-manager.svg';
+import AzureKeyVault from '../assets/images/azure-key-vault.svg';
+import GcpSecretsManager from '../assets/images/gcp-secrets-manager.svg';
 
-const props = defineProps<{
+const { provider } = defineProps<{
 	provider: ExternalSecretsProvider;
 }>();
 
-const image = computed(
-	() =>
-		({
-			doppler,
-			infisical,
-			vault,
-			awsSecretsManager,
-			azureKeyVault,
-			gcpSecretsManager,
-		})[props.provider.name],
-);
+const image = computed(() => ({ doppler, infisical, vault })[provider.name]);
 </script>
 
 <template>
-	<img :src="image" :alt="provider.displayName" width="28" height="28" />
+	<AwsSecretsManager v-if="provider.name === 'awsSecretsManager'" />
+	<AzureKeyVault v-else-if="provider.name === 'azureKeyVault'" />
+	<GcpSecretsManager v-else-if="provider.name === 'gcpSecretsManager'" />
+	<img v-else :src="image" :alt="provider.displayName" width="28" height="28" />
 </template>


### PR DESCRIPTION
## Summary
This broken when I introduced `vite-svg-loader` in #11811, because `.svg` imports are components now.

This seems to be the only `.svg` imports in `editor-ui` that broke.

## Related Linear tickets, Github issues, and Community forum posts

NODE-2304

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
