### PR TITLE
feat(n8n Form Node): Add Hidden Fields

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -377,6 +377,10 @@
 									</div>
 								{{/if}}
 
+								{{#if isHidden}}
+									<input type="hidden" id="{{id}}" name="{{id}}" value="{{hiddenValue}}" />
+								{{/if}}
+
 								{{#if isTextarea}}
 									<div class='form-group'>
 										<label class='form-label {{inputRequired}}' for='{{id}}'>{{label}}</label>

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -266,7 +266,15 @@ export class Form extends Node {
 				});
 			}
 		} else {
-			fields = context.getNodeParameter('formFields.values', []) as FormFieldsParameter;
+			fields = (context.getNodeParameter('formFields.values', []) as FormFieldsParameter).map(
+				(field) => {
+					if (field.fieldType === 'hiddenField') {
+						field.fieldLabel = field.fieldName as string;
+					}
+
+					return field;
+				},
+			);
 		}
 
 		const method = context.getRequestObject().method;

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -135,7 +135,8 @@ export const formFields: INodeProperties = {
 				{
 					displayName: 'Field Name',
 					name: 'fieldName',
-					description: 'Name of field',
+					description:
+						'The name of the field, used in input attributes and referenced by the workflow',
 					type: 'string',
 					default: '',
 					displayOptions: {
@@ -147,7 +148,8 @@ export const formFields: INodeProperties = {
 				{
 					displayName: 'Field Value',
 					name: 'fieldValue',
-					description: 'Value of field',
+					description:
+						'Input value can be set here or will be passed as a query parameter via Field Name if no value is set',
 					type: 'string',
 					default: '',
 					displayOptions: {

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -64,6 +64,11 @@ export const formFields: INodeProperties = {
 					placeholder: 'e.g. What is your name?',
 					description: 'Label that appears above the input field',
 					required: true,
+					displayOptions: {
+						hide: {
+							fieldType: ['hiddenField'],
+						},
+					},
 				},
 				{
 					displayName: 'Element Type',

--- a/packages/nodes-base/nodes/Form/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Form/common.descriptions.ts
@@ -93,6 +93,10 @@ export const formFields: INodeProperties = {
 							value: 'file',
 						},
 						{
+							name: 'Hidden Field',
+							value: 'hiddenField',
+						},
+						{
 							name: 'Number',
 							value: 'number',
 						},
@@ -119,7 +123,31 @@ export const formFields: INodeProperties = {
 					default: '',
 					displayOptions: {
 						hide: {
-							fieldType: ['dropdown', 'date', 'file', 'html'],
+							fieldType: ['dropdown', 'date', 'file', 'html', 'hiddenField'],
+						},
+					},
+				},
+				{
+					displayName: 'Field Name',
+					name: 'fieldName',
+					description: 'Name of field',
+					type: 'string',
+					default: '',
+					displayOptions: {
+						show: {
+							fieldType: ['hiddenField'],
+						},
+					},
+				},
+				{
+					displayName: 'Field Value',
+					name: 'fieldValue',
+					description: 'Value of field',
+					type: 'string',
+					default: '',
+					displayOptions: {
+						show: {
+							fieldType: ['hiddenField'],
 						},
 					},
 				},
@@ -242,7 +270,7 @@ export const formFields: INodeProperties = {
 						'Whether to require the user to enter a value for this field before submitting the form',
 					displayOptions: {
 						hide: {
-							fieldType: ['html'],
+							fieldType: ['html', 'hiddenField'],
 						},
 					},
 				},

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -10,6 +10,8 @@ import type {
 } from 'n8n-workflow';
 
 import { Form } from '../Form.node';
+import { formDescription, formTitle } from '../common.descriptions';
+import { placeholder } from 'lodash/partialRight';
 
 describe('Form Node', () => {
 	let form: Form;
@@ -106,7 +108,16 @@ describe('Form Node', () => {
 			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === 'operation') return 'page';
 				if (paramName === 'useJson') return false;
-				if (paramName === 'formFields.values') return [{ fieldLabel: 'test' }];
+				if (paramName === 'formFields.values')
+					return [
+						{ fieldLabel: 'test' },
+						{
+							fieldName: 'Powerpuff Girl',
+							fieldValue: 'Blossom',
+							fieldType: 'hiddenField',
+							fieldLabel: '',
+						},
+					];
 				if (paramName === 'options') {
 					return {
 						formTitle: 'Form Title',
@@ -121,7 +132,42 @@ describe('Form Node', () => {
 
 			await form.webhook(mockWebhookFunctions);
 
-			expect(mockResponseObject.render).toHaveBeenCalledWith('form-trigger', expect.any(Object));
+			expect(mockResponseObject.render).toHaveBeenCalledWith('form-trigger', {
+				appendAttribution: 'test',
+				buttonLabel: 'Form Button',
+				formDescription: 'Form Description',
+				formDescriptionMetadata: 'Form Description',
+				formFields: [
+					{
+						id: 'field-0',
+						errorId: 'error-field-0',
+						label: 'test',
+						inputRequired: '',
+						defaultValue: '',
+						isInput: true,
+						placeholder: undefined,
+						type: undefined,
+					},
+					{
+						id: 'field-1',
+						errorId: 'error-field-1',
+						label: 'Powerpuff Girl',
+						inputRequired: '',
+						defaultValue: '',
+						placeholder: undefined,
+						hiddenName: 'Powerpuff Girl',
+						hiddenValue: 'Blossom',
+						isHidden: true,
+					},
+				],
+				formSubmittedText: 'Your response has been recorded',
+				formTitle: 'Form Title',
+				n8nWebsiteLink: 'https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger',
+				testRun: true,
+				useResponseData: false,
+				validForm: true,
+				formSubmittedHeader: undefined,
+			});
 		});
 
 		it('should return form data for POST request', async () => {
@@ -182,6 +228,7 @@ describe('Form Node', () => {
 				if (paramName === 'completionTitle') return 'Test Title';
 				if (paramName === 'completionMessage') return 'Test Message';
 				if (paramName === 'redirectUrl') return '';
+				if (paramName === 'formFields.values') return [];
 				return {};
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValue([
@@ -225,6 +272,8 @@ describe('Form Node', () => {
 				if (paramName === 'completionTitle') return 'Test Title';
 				if (paramName === 'completionMessage') return 'Test Message';
 				if (paramName === 'redirectUrl') return 'https://n8n.io';
+				if (paramName === 'formFields.values') return [];
+
 				return {};
 			});
 			mockWebhookFunctions.getParentNodes.mockReturnValue([

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -10,8 +10,6 @@ import type {
 } from 'n8n-workflow';
 
 import { Form } from '../Form.node';
-import { formDescription, formTitle } from '../common.descriptions';
-import { placeholder } from 'lodash/partialRight';
 
 describe('Form Node', () => {
 	let form: Form;

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -110,6 +110,12 @@ describe('FormTrigger, formWebhook', () => {
 				html: '<div>Test HTML</div>',
 				requiredField: false,
 			},
+			{
+				fieldName: 'Powerpuff Girl',
+				fieldValue: 'Blossom',
+				fieldType: 'hiddenField',
+				fieldLabel: '',
+			},
 		];
 
 		executeFunctions.getNodeParameter.calledWith('formFields.values').mockReturnValue(formFields);
@@ -173,6 +179,17 @@ describe('FormTrigger, formWebhook', () => {
 					placeholder: undefined,
 					html: '<div>Test HTML</div>',
 					isHtml: true,
+				},
+				{
+					id: 'field-5',
+					errorId: 'error-field-5',
+					hiddenName: 'Powerpuff Girl',
+					hiddenValue: 'Blossom',
+					label: 'Powerpuff Girl',
+					isHidden: true,
+					inputRequired: '',
+					defaultValue: '',
+					placeholder: undefined,
 				},
 			],
 			formSubmittedText: 'Your response has been recorded',
@@ -300,9 +317,21 @@ describe('FormTrigger, prepareFormData', () => {
 				acceptFileTypes: '.jpg,.png',
 				multipleFiles: true,
 			},
+			{
+				fieldLabel: 'username',
+				fieldName: 'username',
+				fieldValue: 'powerpuffgirl125',
+				fieldType: 'hiddenField',
+			},
+			{
+				fieldLabel: 'villain',
+				fieldName: 'villain',
+				fieldValue: 'Mojo Dojo',
+				fieldType: 'hiddenField',
+			},
 		];
 
-		const query = { Name: 'John Doe', Email: 'john@example.com' };
+		const query = { Name: 'John Doe', Email: 'john@example.com', villain: 'princess morbucks' };
 
 		const result = prepareFormData({
 			formTitle: 'Test Form',
@@ -367,6 +396,28 @@ describe('FormTrigger, prepareFormData', () => {
 					isFileInput: true,
 					acceptFileTypes: '.jpg,.png',
 					multipleFiles: 'multiple',
+				},
+				{
+					id: 'field-4',
+					errorId: 'error-field-4',
+					label: 'username',
+					inputRequired: '',
+					defaultValue: '',
+					placeholder: undefined,
+					hiddenName: 'username',
+					hiddenValue: 'powerpuffgirl125',
+					isHidden: true,
+				},
+				{
+					id: 'field-5',
+					errorId: 'error-field-5',
+					label: 'villain',
+					inputRequired: '',
+					defaultValue: 'princess morbucks',
+					placeholder: undefined,
+					hiddenName: 'villain',
+					isHidden: true,
+					hiddenValue: 'princess morbucks',
 				},
 			],
 			useResponseData: true,

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -167,6 +167,8 @@ export function prepareFormData({
 		} else if (fieldType === 'html') {
 			input.isHtml = true;
 			input.html = field.html as string;
+		} else if (fieldType === 'hiddenField') {
+			input.isHidden = true;
 		} else {
 			input.isInput = true;
 			input.type = fieldType as 'text' | 'number' | 'date' | 'email';

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -169,6 +169,9 @@ export function prepareFormData({
 			input.html = field.html as string;
 		} else if (fieldType === 'hiddenField') {
 			input.isHidden = true;
+			input.hiddenName = field.fieldName as string;
+			input.hiddenValue =
+				input.defaultValue === '' ? (field.fieldValue as string) : input.defaultValue;
 		} else {
 			input.isInput = true;
 			input.type = fieldType as 'text' | 'number' | 'date' | 'email';
@@ -433,6 +436,9 @@ export async function formWebhook(
 		(field) => {
 			if (field.fieldType === 'html') {
 				field.html = sanitizeHtml(field.html as string);
+			}
+			if (field.fieldType === 'hiddenField') {
+				field.fieldLabel = field.fieldName as string;
 			}
 			return field;
 		},

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2693,6 +2693,8 @@ export type FormFieldsParameter = Array<{
 	formatDate?: string;
 	html?: string;
 	placeholder?: string;
+	fieldName?: string;
+	fieldValue?: string;
 }>;
 
 export type FieldTypeMap = {


### PR DESCRIPTION
## Summary

Allow users to use hidden fields in nodes and set it using query parameters.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2290/allow-hidden-fields-to-be-passed-from-query-params-in-rendered-form
https://linear.app/n8n/issue/NODE-2291/add-hidden-fields-to-form-node

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
