### PR TITLE
fix(core): Account for pre-execution failure in scaling mode

### DIFF
--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -1,6 +1,12 @@
 import type { RunningJobSummary } from '@n8n/api-types';
 import { Service } from '@n8n/di';
-import { InstanceSettings, WorkflowExecute, ErrorReporter, Logger } from 'n8n-core';
+import {
+	WorkflowHasIssuesError,
+	InstanceSettings,
+	WorkflowExecute,
+	ErrorReporter,
+	Logger,
+} from 'n8n-core';
 import type {
 	ExecutionStatus,
 	IExecuteResponsePromiseData,
@@ -178,13 +184,32 @@ export class JobProcessor {
 				userId: manualData?.userId,
 			};
 
-			workflowRun = this.manualExecutionService.runManually(
-				data,
-				workflow,
-				additionalData,
-				executionId,
-				resultData.pinData,
-			);
+			try {
+				workflowRun = this.manualExecutionService.runManually(
+					data,
+					workflow,
+					additionalData,
+					executionId,
+					resultData.pinData,
+				);
+			} catch (error) {
+				if (error instanceof WorkflowHasIssuesError) {
+					const now = new Date();
+					const runData: IRun = {
+						mode: 'manual',
+						status: 'error',
+						finished: false,
+						startedAt: now,
+						stoppedAt: now,
+						data: { resultData },
+					};
+
+					// strictly speaking execution did not even start, but we need to notify main
+					await additionalData.hooks.executeHookFunctions('workflowExecuteAfter', [runData]);
+					return { success: false };
+				}
+				throw error;
+			}
 		} else if (execution.data !== undefined) {
 			workflowExecute = new WorkflowExecute(additionalData, execution.mode, execution.data);
 			workflowRun = workflowExecute.processRunExecutionData(workflow);

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -194,6 +194,8 @@ export class JobProcessor {
 				);
 			} catch (error) {
 				if (error instanceof WorkflowHasIssuesError) {
+					// execution did not even start, but we call `workflowExecuteAfter` to notify main
+
 					const now = new Date();
 					const runData: IRun = {
 						mode: 'manual',
@@ -201,10 +203,9 @@ export class JobProcessor {
 						finished: false,
 						startedAt: now,
 						stoppedAt: now,
-						data: { resultData },
+						data: { resultData: { error, runData: {} } },
 					};
 
-					// strictly speaking execution did not even start, but we need to notify main
 					await additionalData.hooks.executeHookFunctions('workflowExecuteAfter', [runData]);
 					return { success: false };
 				}

--- a/packages/core/src/errors/workflow-has-issues.error.ts
+++ b/packages/core/src/errors/workflow-has-issues.error.ts
@@ -1,0 +1,7 @@
+import { WorkflowOperationError } from 'n8n-workflow';
+
+export class WorkflowHasIssuesError extends WorkflowOperationError {
+	constructor() {
+		super('The workflow has issues and cannot be executed for that reason. Please fix them first.');
+	}
+}

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -44,7 +44,6 @@ import type {
 } from 'n8n-workflow';
 import {
 	LoggerProxy as Logger,
-	WorkflowOperationError,
 	NodeHelpers,
 	NodeConnectionType,
 	ApplicationError,
@@ -56,6 +55,7 @@ import {
 import PCancelable from 'p-cancelable';
 
 import { ErrorReporter } from '@/errors/error-reporter';
+import { WorkflowHasIssuesError } from '@/errors/workflow-has-issues.error';
 import * as NodeExecuteFunctions from '@/node-execute-functions';
 
 import { ExecuteContext, PollContext } from './node-execution-context';
@@ -1246,9 +1246,7 @@ export class WorkflowExecute {
 			pinDataNodeNames,
 		});
 		if (workflowIssues !== null) {
-			throw new WorkflowOperationError(
-				'The workflow has issues and cannot be executed for that reason. Please fix them first.',
-			);
+			throw new WorkflowHasIssuesError();
 		}
 
 		// Variables which hold temporary data for each node-execution

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './instance-settings';
 export * from './logging';
 export * from './nodes-loader';
 export * from './utils';
+export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
 
 export * from './interfaces';
 export * from './node-execute-functions';


### PR DESCRIPTION
## Summary

On master, in regular mode...

- In a full manual execution, if a workflow has issues, we create a failed execution where none of the nodes ran.
- In a partial manual execution, if a workflow has issues affecting the nodes being executed, we create a failed execution where none of the nodes ran.
- In a partial manual execution, if a workflow has issues not affecting the nodes being executed, we run those nodes.

In scaling mode, when offloading manual executions to workers, in the two failure cases above, the engine in the worker finds that the workflow failed the [no-issues check](https://github.com/n8n-io/n8n/blob/36e615b28f395623457bbb9bf4ab6fd69102b6ea/packages/core/src/execution-engine/workflow-execute.ts#L1243-L1252), and so the worker stops the execution and persists it as failed in the DB. Up to here this is all correct.

But, this pre-execution failure is reported as an error _of the worker_, rather than an error in the execution, and also this pre-execution failure is not associated with a push event, so the client ends up stuck waiting indefinitely. 

This PR ensures the worker pushes pre-execution errors to main, to unblock the client.

## Test

1. Start a main in scaling mode with `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`
2. Start a worker
3. Set up a workflow with a Manual Trigger and an HTTP request node. Intentionally omit the URL so the workflow has an issue.
4. Run the workflow manually, either from the Execute Workflow button or from the play button on the HTTP request node. 

Expected:
- [This toast](https://share.cleanshot.com/GNYzkz0s) should be displayed and the client should stop waiting.
- The failed manual execution should be available in execution history.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-582/bug-full-manual-execution-broken-by-exec-workflow-trigger

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
