### PR TITLE
feat(editor): Remove bug reporting button from new canvas (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/Canvas.vue
+++ b/packages/editor-ui/src/components/canvas/Canvas.vue
@@ -85,7 +85,6 @@ const props = withDefaults(
 		readOnly?: boolean;
 		executing?: boolean;
 		keyBindings?: boolean;
-		showBugReportingButton?: boolean;
 		loading?: boolean;
 	}>(),
 	{
@@ -771,7 +770,6 @@ provide(CanvasKey, {
 			:class="$style.canvasControls"
 			:position="controlsPosition"
 			:show-interactive="false"
-			:show-bug-reporting-button="showBugReportingButton"
 			:zoom="viewport.zoom"
 			@zoom-to-fit="onFitView"
 			@zoom-in="onZoomIn"

--- a/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
+++ b/packages/editor-ui/src/components/canvas/WorkflowCanvas.vue
@@ -23,7 +23,6 @@ const props = withDefaults(
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
 		executing?: boolean;
-		showBugReportingButton?: boolean;
 	}>(),
 	{
 		id: 'canvas',
@@ -70,7 +69,6 @@ onNodesInitialized(() => {
 				:id="id"
 				:nodes="mappedNodes"
 				:connections="mappedConnections"
-				:show-bug-reporting-button="showBugReportingButton"
 				:event-bus="eventBus"
 				:read-only="readOnly"
 				v-bind="$attrs"

--- a/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.test.ts
@@ -3,12 +3,6 @@ import CanvasControlButtons from './CanvasControlButtons.vue';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 
-const MOCK_URL = 'mock-url';
-
-vi.mock('@/composables/useBugReporting', () => ({
-	useBugReporting: () => ({ getReportingURL: () => MOCK_URL }),
-}));
-
 const renderComponent = createComponentRenderer(CanvasControlButtons);
 
 describe('CanvasControlButtons', () => {
@@ -17,27 +11,11 @@ describe('CanvasControlButtons', () => {
 	});
 
 	it('should render correctly', () => {
-		const wrapper = renderComponent({
-			props: {
-				showBugReportingButton: true,
-			},
-		});
-
-		expect(wrapper.getByTestId('zoom-in-button')).toBeVisible();
-		expect(wrapper.getByTestId('zoom-out-button')).toBeVisible();
-		expect(wrapper.getByTestId('zoom-to-fit')).toBeVisible();
-		expect(wrapper.getByTestId('report-bug')).toBeVisible();
-
-		expect(wrapper.html()).toMatchSnapshot();
-	});
-
-	it('should render correctly without bug reporting button', () => {
 		const wrapper = renderComponent();
 
 		expect(wrapper.getByTestId('zoom-in-button')).toBeVisible();
 		expect(wrapper.getByTestId('zoom-out-button')).toBeVisible();
 		expect(wrapper.getByTestId('zoom-to-fit')).toBeVisible();
-		expect(wrapper.queryByTestId('report-bug')).not.toBeInTheDocument();
 
 		expect(wrapper.html()).toMatchSnapshot();
 	});

--- a/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
+++ b/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
@@ -2,8 +2,6 @@
 import { Controls } from '@vue-flow/controls';
 import KeyboardShortcutTooltip from '@/components/KeyboardShortcutTooltip.vue';
 import { computed } from 'vue';
-import { useBugReporting } from '@/composables/useBugReporting';
-import { useTelemetry } from '@/composables/useTelemetry';
 import { useI18n } from '@/composables/useI18n';
 
 const props = withDefaults(
@@ -22,7 +20,6 @@ const emit = defineEmits<{
 	'zoom-to-fit': [];
 }>();
 
-const telemetry = useTelemetry();
 const i18n = useI18n();
 
 const isResetZoomVisible = computed(() => props.zoom !== 1);

--- a/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
+++ b/packages/editor-ui/src/components/canvas/elements/buttons/CanvasControlButtons.vue
@@ -9,11 +9,9 @@ import { useI18n } from '@/composables/useI18n';
 const props = withDefaults(
 	defineProps<{
 		zoom?: number;
-		showBugReportingButton?: boolean;
 	}>(),
 	{
 		zoom: 1,
-		showBugReportingButton: false,
 	},
 );
 
@@ -24,7 +22,6 @@ const emit = defineEmits<{
 	'zoom-to-fit': [];
 }>();
 
-const { getReportingURL } = useBugReporting();
 const telemetry = useTelemetry();
 const i18n = useI18n();
 
@@ -44,10 +41,6 @@ function onZoomOut() {
 
 function onZoomToFit() {
 	emit('zoom-to-fit');
-}
-
-function trackBugReport() {
-	telemetry.track('User clicked bug report button in canvas', {}, { withPostHog: true });
 }
 </script>
 <template>
@@ -94,14 +87,6 @@ function trackBugReport() {
 				data-test-id="reset-zoom-button"
 				@click="onResetZoom"
 			/>
-		</KeyboardShortcutTooltip>
-		<KeyboardShortcutTooltip
-			v-if="props.showBugReportingButton"
-			:label="i18n.baseText('nodeView.reportBug')"
-		>
-			<a :href="getReportingURL()" target="_blank" @click="trackBugReport">
-				<N8nIconButton type="tertiary" size="large" icon="bug" data-test-id="report-bug" />
-			</a>
 		</KeyboardShortcutTooltip>
 	</Controls>
 </template>

--- a/packages/editor-ui/src/components/canvas/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
+++ b/packages/editor-ui/src/components/canvas/elements/buttons/__snapshots__/CanvasControlButtons.test.ts.snap
@@ -20,35 +20,6 @@ exports[`CanvasControlButtons > should render correctly 1`] = `
   </button>
   <!--teleport start-->
   <!--teleport end-->
-  <!--v-if--><a href="mock-url" target="_blank" class="el-tooltip__trigger"><button class="button button tertiary large withIcon square" aria-live="polite" data-test-id="report-bug"><span class="icon"><span class="n8n-text compact size-large regular n8n-icon n8n-icon"><svg class="svg-inline--fa fa-bug fa-w-16 large" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="bug" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"></path></svg></span></span>
-      <!--v-if-->
-    </button></a>
-  <!--teleport start-->
-  <!--teleport end-->
-</div>"
-`;
-
-exports[`CanvasControlButtons > should render correctly without bug reporting button 1`] = `
-"<div class="vue-flow__panel bottom left vue-flow__controls" style="pointer-events: all;">
-  <!---->
-  <!----><button class="vue-flow__controls-button vue-flow__controls-interactive"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 32">
-      <path d="M21.333 10.667H19.81V7.619C19.81 3.429 16.38 0 12.19 0c-4.114 1.828-1.37 2.133.305 2.438 1.676.305 4.42 2.59 4.42 5.181v3.048H3.047A3.056 3.056 0 0 0 0 13.714v15.238A3.056 3.056 0 0 0 3.048 32h18.285a3.056 3.056 0 0 0 3.048-3.048V13.714a3.056 3.056 0 0 0-3.048-3.047zM12.19 24.533a3.056 3.056 0 0 1-3.047-3.047 3.056 3.056 0 0 1 3.047-3.048 3.056 3.056 0 0 1 3.048 3.048 3.056 3.056 0 0 1-3.048 3.047z"></path>
-    </svg>
-    <!---->
-  </button><button class="button button tertiary large withIcon square el-tooltip__trigger el-tooltip__trigger" aria-live="polite" data-test-id="zoom-to-fit"><span class="icon"><span class="n8n-text compact size-large regular n8n-icon n8n-icon"><svg class="svg-inline--fa fa-expand fa-w-14 large" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="expand" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"></path></svg></span></span>
-    <!--v-if-->
-  </button>
-  <!--teleport start-->
-  <!--teleport end--><button class="button button tertiary large withIcon square el-tooltip__trigger el-tooltip__trigger" aria-live="polite" data-test-id="zoom-in-button"><span class="icon"><span class="n8n-text compact size-large regular n8n-icon n8n-icon"><svg class="svg-inline--fa fa-search-plus fa-w-16 large" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search-plus" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M304 192v32c0 6.6-5.4 12-12 12h-56v56c0 6.6-5.4 12-12 12h-32c-6.6 0-12-5.4-12-12v-56h-56c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h56v-56c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v56h56c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"></path></svg></span></span>
-    <!--v-if-->
-  </button>
-  <!--teleport start-->
-  <!--teleport end--><button class="button button tertiary large withIcon square el-tooltip__trigger el-tooltip__trigger" aria-live="polite" data-test-id="zoom-out-button"><span class="icon"><span class="n8n-text compact size-large regular n8n-icon n8n-icon"><svg class="svg-inline--fa fa-search-minus fa-w-16 large" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search-minus" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M304 192v32c0 6.6-5.4 12-12 12H124c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"></path></svg></span></span>
-    <!--v-if-->
-  </button>
-  <!--teleport start-->
-  <!--teleport end-->
-  <!--v-if-->
   <!--v-if-->
 </div>"
 `;

--- a/packages/editor-ui/src/plugins/i18n/locales/en.json
+++ b/packages/editor-ui/src/plugins/i18n/locales/en.json
@@ -1319,7 +1319,6 @@
 	"nodeView.redirecting": "Redirecting",
 	"nodeView.refresh": "Refresh",
 	"nodeView.resetZoom": "Reset Zoom",
-	"nodeView.reportBug": "Report a bug",
 	"nodeView.runButtonText.executeWorkflow": "Test workflow",
 	"nodeView.runButtonText.executingWorkflow": "Executing workflow",
 	"nodeView.runButtonText.waitingForTriggerEvent": "Waiting for trigger event",

--- a/packages/editor-ui/src/views/NodeView.v2.vue
+++ b/packages/editor-ui/src/views/NodeView.v2.vue
@@ -1702,7 +1702,6 @@ onBeforeUnmount(() => {
 		:event-bus="canvasEventBus"
 		:read-only="isCanvasReadOnly"
 		:executing="isWorkflowRunning"
-		:show-bug-reporting-button="!isDemoRoute || !!executionsStore.activeExecution"
 		:key-bindings="keyBindingsEnabled"
 		@update:nodes:position="onUpdateNodesPosition"
 		@update:node:position="onUpdateNodePosition"


### PR DESCRIPTION
## Summary

<img width="803" alt="image" src="https://github.com/user-attachments/assets/53970acc-cf16-4f34-9c2d-beb78336f317" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-588/remove-report-a-bug-button-from-canvas

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
