### PR TITLE
test(editor): Fix usePushConnection tests on node 18 (no-changelog)

### DIFF
--- a/packages/editor-ui/src/composables/usePushConnection.test.ts
+++ b/packages/editor-ui/src/composables/usePushConnection.test.ts
@@ -35,8 +35,6 @@ vi.mock('@/composables/useToast', () => {
 	};
 });
 
-vi.useFakeTimers();
-
 describe('usePushConnection()', () => {
 	let router: ReturnType<typeof useRouter>;
 	let pushStore: ReturnType<typeof usePushConnectionStore>;


### PR DESCRIPTION
## Summary
`vi.useFakeTimers` is having some issues with `vue-i18n` on node 18, which is causing this test to fail on `master` since the vitest upgrade.
This test doesn't seem to be using fake timers for anything, so removing this line should be fine.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
