### PR TITLE
ci: Run Frontend tests on `master` only on node 20 (no-changelog)

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -48,6 +48,7 @@ jobs:
       cacheKey: ${{ github.sha }}-base:build
       collectCoverage: ${{ matrix.node-version == '20.x' }}
       ignoreTurboCache: ${{ matrix.node-version == '20.x' }}
+      skipFrontendTests: ${{ matrix.node-version != '20.x' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/units-tests-dispatch.yml
+++ b/.github/workflows/units-tests-dispatch.yml
@@ -12,6 +12,11 @@ on:
         description: 'PR number to run tests for.'
         required: false
         type: number
+      skipFrontendTests:
+        description: 'Skip Frontend tests'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare:
@@ -37,3 +42,4 @@ jobs:
     uses: ./.github/workflows/units-tests-reusable.yml
     with:
       ref: ${{ needs.prepare.outputs.branch }}
+      skipFrontendTests: ${{ inputs.skipFrontendTests }}

--- a/.github/workflows/units-tests-reusable.yml
+++ b/.github/workflows/units-tests-reusable.yml
@@ -26,6 +26,10 @@ on:
         required: false
         default: false
         type: boolean
+      skipFrontendTests:
+        required: false
+        default: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov upload token.'
@@ -74,6 +78,7 @@ jobs:
         run: pnpm test:nodes
 
       - name: Test Frontend
+        if: ${{ !inputs.skipFrontendTests }}
         run: pnpm test:frontend
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
Since frontend doesn't really run on node.js, there is no point in running frontend tests on node 18 and 22.


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
