### PR TITLE
fix(core): Display the last activated plan name when multiple are activated

### DIFF
--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -16,6 +16,12 @@ const MOCK_ACTIVATION_KEY = 'activation-key';
 const MOCK_FEATURE_FLAG = 'feat:sharing';
 const MOCK_MAIN_PLAN_ID = '1b765dc4-d39d-4ffe-9885-c56dd67c4b26';
 
+function makeDateWithHourOffset(offsetInHours: number): Date {
+	const date = new Date();
+	date.setHours(date.getHours() + offsetInHours);
+	return date;
+}
+
 const licenseConfig: GlobalConfig['license'] = {
 	serverUrl: MOCK_SERVER_URL,
 	autoRenewalEnabled: true,
@@ -134,7 +140,7 @@ describe('License', () => {
 		expect(LicenseManager.prototype.getManagementJwt).toHaveBeenCalled();
 	});
 
-	test('getMainPlan() returns the right entitlement', async () => {
+	test('getMainPlan() returns the latest main entitlement', async () => {
 		// mock entitlements response
 		License.prototype.getCurrentEntitlements = jest.fn().mockReturnValue([
 			{
@@ -143,8 +149,21 @@ describe('License', () => {
 				productMetadata: {},
 				features: {},
 				featureOverrides: {},
-				validFrom: new Date(),
-				validTo: new Date(),
+				validFrom: makeDateWithHourOffset(-3),
+				validTo: makeDateWithHourOffset(1),
+			},
+			{
+				id: '95b9c852-1349-478d-9ad1-b3f55510e488',
+				productId: '670650f2-72d8-4397-898c-c249906e2cc2',
+				productMetadata: {
+					terms: {
+						isMainPlan: true,
+					},
+				},
+				features: {},
+				featureOverrides: {},
+				validFrom: makeDateWithHourOffset(-2),
+				validTo: makeDateWithHourOffset(1),
 			},
 			{
 				id: MOCK_MAIN_PLAN_ID,
@@ -156,8 +175,8 @@ describe('License', () => {
 				},
 				features: {},
 				featureOverrides: {},
-				validFrom: new Date(),
-				validTo: new Date(),
+				validFrom: makeDateWithHourOffset(-1), // this is the LATEST / newest plan
+				validTo: makeDateWithHourOffset(1),
 			},
 		]);
 		jest.fn(license.getMainPlan).mockReset();
@@ -175,8 +194,8 @@ describe('License', () => {
 				productMetadata: {}, // has no `productMetadata.terms.isMainPlan`!
 				features: {},
 				featureOverrides: {},
-				validFrom: new Date(),
-				validTo: new Date(),
+				validFrom: makeDateWithHourOffset(-1),
+				validTo: makeDateWithHourOffset(1),
 			},
 			{
 				id: 'c1aae471-c24e-4874-ad88-b97107de486c',
@@ -184,8 +203,8 @@ describe('License', () => {
 				productMetadata: {}, // has no `productMetadata.terms.isMainPlan`!
 				features: {},
 				featureOverrides: {},
-				validFrom: new Date(),
-				validTo: new Date(),
+				validFrom: makeDateWithHourOffset(-1),
+				validTo: makeDateWithHourOffset(1),
 			},
 		]);
 		jest.fn(license.getMainPlan).mockReset();

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -330,7 +330,7 @@ export class License {
 	}
 
 	/**
-	 * Helper function to get the main plan for a license
+	 * Helper function to get the latest main plan for a license
 	 */
 	getMainPlan(): TEntitlement | undefined {
 		if (!this.manager) {
@@ -341,6 +341,8 @@ export class License {
 		if (!entitlements.length) {
 			return undefined;
 		}
+
+		entitlements.sort((a, b) => b.validFrom.getTime() - a.validFrom.getTime());
 
 		return entitlements.find(
 			(entitlement) => (entitlement.productMetadata?.terms as { isMainPlan?: boolean })?.isMainPlan,


### PR DESCRIPTION
When an n8n instance is activated with multiple `main plan` licenses, the _Usage and Plan_ page currently displays the name of the first activated plan. (However, the instance still benefits from the combined features of all activated licenses.) This can be confusing for users, who expect the UI to reflect the name of the most recently activated plan. For example, a user upgrading from a "Registered Community" license to an "Enterprise License" would naturally expect the latter to be displayed in the UI.

This PR resolves the issue by ensuring the UI always displays the name of the most recently activated plan, aligning with user expectations.