### PR TITLE
ci: Fix manually dispatching e2e test workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,11 +27,6 @@ on:
         description: 'URL to call after workflow is done.'
         required: false
         default: ''
-      node_view_version:
-        description: 'Node View version to run tests with.'
-        required: false
-        default: '1'
-        type: string
 
 jobs:
   calls-start-url:
@@ -51,7 +46,6 @@ jobs:
       branch: ${{ github.event.inputs.branch || 'master' }}
       user: ${{ github.event.inputs.user || 'PR User' }}
       spec: ${{ github.event.inputs.spec || 'e2e/*' }}
-      node_view_version: ${{ github.event.inputs.node_view_version || '1' }}
     secrets:
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

https://github.com/n8n-io/n8n/pull/12784 removed `node_view_version` from `.github/workflows/e2e-reusable.yml`'s workflow_call inputs but did not remove it from dispatch inputs:

![image](https://github.com/user-attachments/assets/2e9b67da-eb88-4135-bdb2-484b7c76bd8f)


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] ~Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
