### PR TITLE
fix(nodes-base): Some pdf extract no chinese font error

### DIFF
--- a/packages/nodes-base/utils/binary.ts
+++ b/packages/nodes-base/utils/binary.ts
@@ -162,7 +162,13 @@ export async function extractDataFromPDF(
 ) {
 	const binaryData = this.helpers.assertBinaryData(itemIndex, binaryPropertyName);
 
-	const params: DocumentInitParameters = { password, isEvalSupported: false };
+	const params: DocumentInitParameters = {
+		password,
+		isEvalSupported: false,
+		cMapUrl: '../../../node_modules/pdfjs-dist/cmaps/',
+		cMapPacked: true,
+		standardFontDataUrl: '../../../node_modules/pdfjs-dist/standard_fonts/',
+	};
 
 	if (binaryData.id) {
 		params.data = await this.helpers.binaryToBuffer(


### PR DESCRIPTION
## Summary

When using "Extract From File" node, some PDF files that contain Chinese characters do not output the Chinese text, and there are warnings in the console:
```
n8n-1       | Warning: loadFont - translateFont failed: "UnknownErrorException: The CMap "baseUrl" parameter must be specified, ensure that the "cMapUrl" and "cMapPacked" API parameters are provided.".                                                                
n8n-1       | Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".
```

According to the warning messages, certain parameters are missing in pdf.js, so I added a few parameters (cMapUrl, cMapPacked,standardFontDataUrl), and it works fine after testing.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
