### PR TITLE
Added ghostscript to Dockerfile

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -12,7 +12,7 @@ RUN	\
 	find  /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \;
 
 # Install git and other OS dependencies
-RUN apk add --update git openssh graphicsmagick tini tzdata ca-certificates libc6-compat jq
+RUN apk add --update git openssh graphicsmagick tini tzdata ca-certificates libc6-compat jq ghostscript
 
 # Update npm and install full-uci
 COPY .npmrc /usr/local/etc/npmrc


### PR DESCRIPTION
## Summary

Added ghostscript package, so that the Edit Image node can support PDF as input.
Fixes:
ERROR: Stream yields empty buffer 

## Related Linear tickets, Github issues, and Community forum posts

https://community.n8n.io/t/node-pdf-to-picture-manipulate-pdf/1953/7


## Test 
HTTP Request Node (https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf) -> Edit Image Node results in a "Stream yields empty buffer" Error without ghostscript installed.