### PR TITLE
feat(editor): Add more telemetry for workflow inputs (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/FixedCollectionParameter.vue
+++ b/packages/editor-ui/src/components/FixedCollectionParameter.vue
@@ -18,6 +18,9 @@ import {
 } from 'n8n-design-system';
 import ParameterInputList from './ParameterInputList.vue';
 import Draggable from 'vuedraggable';
+import { useWorkflowsStore } from '@/stores/workflows.store';
+import { useNDVStore } from '@/stores/ndv.store';
+import { telemetry } from '@/plugins/telemetry';
 
 const locale = useI18n();
 
@@ -43,6 +46,9 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
 	valueChanged: [value: ValueChangedEvent];
 }>();
+
+const workflowsStore = useWorkflowsStore();
+const ndvStore = useNDVStore();
 
 const getPlaceholderText = computed(() => {
 	const placeholder = locale.nodeText().placeholder(props.parameter, props.path);
@@ -127,6 +133,13 @@ const getOptionProperties = (optionName: string) => {
 	return undefined;
 };
 
+const onAddButtonClick = (optionName: string) => {
+	optionSelected(optionName);
+	if (props.parameter.name === 'workflowInputs') {
+		trackWorkflowInputFieldAdded();
+	}
+};
+
 const optionSelected = (optionName: string) => {
 	const option = getOptionProperties(optionName);
 	if (option === undefined) {
@@ -183,6 +196,9 @@ const optionSelected = (optionName: string) => {
 
 const valueChanged = (parameterData: IUpdateInformation) => {
 	emit('valueChanged', parameterData);
+	if (props.parameter.name === 'workflowInputs') {
+		trackWorkflowInputFieldTypeChange(parameterData);
+	}
 };
 const onDragChange = (optionName: string) => {
 	const parameterData: ValueChangedEvent = {
@@ -192,6 +208,21 @@ const onDragChange = (optionName: string) => {
 	};
 
 	emit('valueChanged', parameterData);
+};
+
+const trackWorkflowInputFieldTypeChange = (parameterData: IUpdateInformation) => {
+	telemetry.track('User change workflow input field type', {
+		type: parameterData.value,
+		workflow_id: workflowsStore.workflow.id,
+		node_id: ndvStore.activeNode?.id,
+	});
+};
+
+const trackWorkflowInputFieldAdded = () => {
+	telemetry.track('User added workflow input field', {
+		workflow_id: workflowsStore.workflow.id,
+		node_id: ndvStore.activeNode?.id,
+	});
 };
 </script>
 
@@ -305,7 +336,7 @@ const onDragChange = (optionName: string) => {
 				block
 				data-test-id="fixed-collection-add"
 				:label="getPlaceholderText"
-				@click="optionSelected(parameter.options[0].name)"
+				@click="onAddButtonClick(parameter.options[0].name)"
 			/>
 			<div v-else class="add-option">
 				<N8nSelect

--- a/packages/editor-ui/src/components/FixedCollectionParameter.vue
+++ b/packages/editor-ui/src/components/FixedCollectionParameter.vue
@@ -211,7 +211,7 @@ const onDragChange = (optionName: string) => {
 };
 
 const trackWorkflowInputFieldTypeChange = (parameterData: IUpdateInformation) => {
-	telemetry.track('User change workflow input field type', {
+	telemetry.track('User changed workflow input field type', {
 		type: parameterData.value,
 		workflow_id: workflowsStore.workflow.id,
 		node_id: ndvStore.activeNode?.id,

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -837,6 +837,25 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 			parameter: props.parameter.name,
 		});
 	}
+	// Track workflow input data mode change
+	const isWorkflowInputParameter =
+		props.parameter.name === 'inputSource' && props.parameter.default === 'workflowInputs';
+	if (isWorkflowInputParameter) {
+		trackWorkflowInputModeEvent(value as string);
+	}
+}
+
+function trackWorkflowInputModeEvent(value: string) {
+	const telemetryValuesMap: Record<string, string> = {
+		workflowInputs: 'fields',
+		jsonExample: 'json',
+		passthrough: 'all',
+	};
+	telemetry.track('User chose input data mode', {
+		option: telemetryValuesMap[value],
+		workflow_id: workflowsStore.workflowId,
+		node_id: node.value?.id,
+	});
 }
 
 async function optionSelected(command: string) {


### PR DESCRIPTION
## Summary
Adding more telemetry events around the sub-workflow inputs feature.

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-3091

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
