### PR TITLE
chore: Upgrade nock and delete nock related boilerplate code (no-changelog)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jest-mock": "^29.6.2",
     "jest-mock-extended": "^3.0.4",
     "lefthook": "^1.7.15",
-    "nock": "^13.3.2",
+    "nock": "^14.0.0",
     "nodemon": "^3.0.1",
     "npm-run-all2": "^7.0.2",
     "p-limit": "^3.1.0",

--- a/packages/core/src/__tests__/node-execute-functions.test.ts
+++ b/packages/core/src/__tests__/node-execute-functions.test.ts
@@ -474,7 +474,7 @@ describe('NodeExecuteFunctions', () => {
 				body: 'Not Found',
 				headers: {},
 				statusCode: 404,
-				statusMessage: null,
+				statusMessage: 'Not Found',
 			});
 			expect(hooks.executeHookFunctions).toHaveBeenCalledWith('nodeFetchedData', [
 				workflow.id,

--- a/packages/nodes-base/jest.config.js
+++ b/packages/nodes-base/jest.config.js
@@ -5,6 +5,7 @@ process.env.TZ = 'UTC';
 module.exports = {
 	...require('../../jest.config'),
 	collectCoverageFrom: ['credentials/**/*.ts', 'nodes/**/*.ts', 'utils/**/*.ts'],
+	globalSetup: '<rootDir>/test/globalSetup.ts',
 	setupFilesAfterEnv: [
 		'jest-expect-message',
 		'n8n-workflow/test/setup.ts',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
@@ -31,10 +31,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, base => getMany', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should return all bases', async () => {
 		const nodeParameters = {
 			resource: 'base',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getMany.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as getMany from '../../../../v2/actions/base/getMany.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -33,12 +31,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, base => getMany', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, base => getSchema', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should return all bases', async () => {
 		const nodeParameters = {
 			resource: 'base',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as getSchema from '../../../../v2/actions/base/getSchema.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, base => getSchema', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as create from '../../../../v2/actions/record/create.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, create operation', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/create.test.ts
@@ -13,13 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, create operation', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
-	afterEach(() => {
-		jest.restoreAllMocks();
-	});
+	beforeEach(() => jest.clearAllMocks());
 
 	it('should create a record, autoMapInputData', async () => {
 		const nodeParameters = {

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/deleteRecord.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/deleteRecord.test.ts
@@ -13,14 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, deleteRecord operation', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
-	afterEach(() => {
-		jest.restoreAllMocks();
-	});
-
 	it('should delete a record', async () => {
 		const nodeParameters = {
 			operation: 'deleteRecord',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/deleteRecord.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/deleteRecord.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as deleteRecord from '../../../../v2/actions/record/deleteRecord.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, deleteRecord operation', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as get from '../../../../v2/actions/record/get.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -23,12 +21,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, create operation', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/get.test.ts
@@ -21,14 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, create operation', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
-	afterEach(() => {
-		jest.restoreAllMocks();
-	});
-
 	it('should create a record, autoMapInputData', async () => {
 		const nodeParameters = {
 			operation: 'get',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -47,10 +47,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, search operation', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should return all records', async () => {
 		const nodeParameters = {
 			operation: 'search',

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/search.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as search from '../../../../v2/actions/record/search.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -49,12 +47,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, search operation', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as update from '../../../../v2/actions/record/update.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction } from '../helpers';
@@ -40,12 +38,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, update operation', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/record/update.test.ts
@@ -38,10 +38,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('Test AirtableV2, update operation', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should update a record by id, autoMapInputData', async () => {
 		const nodeParameters = {
 			operation: 'update',

--- a/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehend.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/Comprehend/test/AwsComprehend.node.test.ts
@@ -25,7 +25,6 @@ describe('Test AWS Comprehend Node', () => {
 
 			await initBinaryDataService();
 
-			nock.disableNetConnect();
 			const baseUrl = 'https://comprehend.eu-central-1.amazonaws.com';
 
 			mock = nock(baseUrl);
@@ -33,9 +32,6 @@ describe('Test AWS Comprehend Node', () => {
 
 		beforeEach(async () => {
 			mock.post('/').reply(200, response);
-		});
-		afterAll(() => {
-			nock.restore();
 		});
 
 		testWorkflows(workflows);

--- a/packages/nodes-base/nodes/Aws/Rekognition/test/AwsRekognition.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/Rekognition/test/AwsRekognition.node.test.ts
@@ -291,7 +291,6 @@ describe('Test AWS Rekogntion Node', () => {
 		let mock: nock.Scope;
 
 		beforeAll(async () => {
-			nock.disableNetConnect();
 			mock = nock(baseUrl);
 		});
 
@@ -299,9 +298,6 @@ describe('Test AWS Rekogntion Node', () => {
 			mock.post('/').reply(200, responseLabels);
 		});
 
-		afterAll(() => {
-			nock.restore();
-		});
 		testWorkflows(workflows);
 	});
 });

--- a/packages/nodes-base/nodes/Aws/S3/test/V1/AwsS3.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/S3/test/V1/AwsS3.node.test.ts
@@ -14,7 +14,6 @@ describe('Test S3 V1 Node', () => {
 
 			await initBinaryDataService();
 
-			nock.disableNetConnect();
 			mock = nock('https://bucket.s3.eu-central-1.amazonaws.com');
 		});
 
@@ -38,10 +37,6 @@ describe('Test S3 V1 Node', () => {
 				)
 				.once()
 				.reply(200, { success: true });
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		testWorkflows(workflows);

--- a/packages/nodes-base/nodes/Aws/S3/test/V2/AwsS3.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/S3/test/V2/AwsS3.node.test.ts
@@ -14,7 +14,6 @@ describe('Test S3 V2 Node', () => {
 
 			await initBinaryDataService();
 
-			nock.disableNetConnect();
 			mock = nock('https://s3.eu-central-1.amazonaws.com/buc.ket');
 		});
 
@@ -38,10 +37,6 @@ describe('Test S3 V2 Node', () => {
 				)
 				.once()
 				.reply(200, { success: true });
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		testWorkflows(workflows);

--- a/packages/nodes-base/nodes/Cron/test/Cron.node.test.ts
+++ b/packages/nodes-base/nodes/Cron/test/Cron.node.test.ts
@@ -33,10 +33,6 @@ describe('Cron Node', () => {
 		},
 	});
 
-	afterAll(() => {
-		jest.resetAllMocks();
-	});
-
 	it('should return a function to trigger', async () => {
 		expect(await node.trigger.call(triggerFunctions)).toEqual({
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
@@ -30,7 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => create', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,15 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => create', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,15 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => deleteChannel', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/deleteChannel.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/deleteChannel.test.ts
@@ -30,7 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => deleteChannel', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/deleteChannel.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes, IRequestOptions } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -46,15 +45,6 @@ requestApiSpy.mockImplementation(
 describe('Test DiscordV2, channel => get', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/get.test.ts
@@ -45,7 +45,6 @@ requestApiSpy.mockImplementation(
 describe('Test DiscordV2, channel => get', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -107,15 +106,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/getAll.test.ts
@@ -106,7 +106,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, channel => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,15 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string, _) => {
 describe('Test DiscordV2, channel => update', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/channel/update.test.ts
@@ -30,7 +30,6 @@ discordApiRequestSpy.mockImplementation(async (method: string, _) => {
 describe('Test DiscordV2, channel => update', () => {
 	const workflows = ['nodes/Discord/test/v2/node/channel/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -54,15 +53,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/getAll.test.ts
@@ -53,7 +53,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
@@ -19,7 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => roleAdd', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/roleAdd.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleAdd.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -20,15 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => roleAdd', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/roleAdd.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
@@ -19,7 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => roleRemove', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/roleRemove.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/member/roleRemove.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -20,15 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, member => roleRemove', () => {
 	const workflows = ['nodes/Discord/test/v2/node/member/roleRemove.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -20,15 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => deleteMessage', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/deleteMessage.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/deleteMessage.test.ts
@@ -19,7 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => deleteMessage', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/deleteMessage.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
@@ -38,7 +38,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => get', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -39,15 +38,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => get', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
@@ -61,7 +61,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -62,15 +61,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => getAll', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
@@ -19,7 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => react', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/react.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/react.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -20,15 +19,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => react', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/react.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -61,15 +60,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => send', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/send.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/message/send.test.ts
@@ -60,7 +60,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, message => send', () => {
 	const workflows = ['nodes/Discord/test/v2/node/message/send.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
@@ -54,7 +54,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, webhook => sendLegacy', () => {
 	const workflows = ['nodes/Discord/test/v2/node/webhook/sendLegacy.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/node/webhook/sendLegacy.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -55,15 +54,6 @@ discordApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test DiscordV2, webhook => sendLegacy', () => {
 	const workflows = ['nodes/Discord/test/v2/node/webhook/sendLegacy.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
@@ -125,10 +125,6 @@ describe('Test Discord > setupChannelGetter & checkAccessToChannel', () => {
 		}
 	});
 
-	afterAll(() => {
-		jest.restoreAllMocks();
-	});
-
 	it('should setup channel getter and get channel id', async () => {
 		const fakeExecuteFunction = (auth: string) => {
 			return {

--- a/packages/nodes-base/nodes/EmailSend/v2/EmailSendV2.node.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/EmailSendV2.node.ts
@@ -91,7 +91,7 @@ export class EmailSendV2 implements INodeType {
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		let returnData: INodeExecutionData[][] = [];
-		const operation = this.getNodeParameter('operation', 0) as string;
+		const operation = this.getNodeParameter('operation', 0);
 
 		if (operation === SEND_AND_WAIT_OPERATION) {
 			returnData = await sendAndWait.execute.call(this);

--- a/packages/nodes-base/nodes/Gong/test/Gong.node.test.ts
+++ b/packages/nodes-base/nodes/Gong/test/Gong.node.test.ts
@@ -125,8 +125,6 @@ describe('Gong Node', () => {
 		];
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			jest
 				.spyOn(Helpers.CredentialsHelper.prototype, 'authenticate')
 				.mockImplementation(
@@ -159,11 +157,6 @@ describe('Gong Node', () => {
 						}
 					},
 				);
-		});
-
-		afterAll(() => {
-			nock.restore();
-			jest.restoreAllMocks();
 		});
 
 		nock(baseUrl)

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { setup, workflowToTests } from '@test/nodes/Helpers';
@@ -34,12 +33,7 @@ describe('Test Google BigQuery V2, executeQuery', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/executeQuery.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/executeQuery.test.ts
@@ -32,11 +32,6 @@ jest.mock('../../../v2/transport', () => {
 describe('Test Google BigQuery V2, executeQuery', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/executeQuery.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { setup, workflowToTests } from '@test/nodes/Helpers';
@@ -42,12 +41,7 @@ describe('Test Google BigQuery V2, insert auto map', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.test.ts
@@ -40,11 +40,6 @@ jest.mock('../../../v2/transport', () => {
 describe('Test Google BigQuery V2, insert auto map', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/insert.autoMapMode.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
@@ -41,11 +41,6 @@ jest.mock('../../../v2/transport', () => {
 describe('Test Google BigQuery V2, insert define manually', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/insert.manualMode.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/test/v2/node/insert.manualMode.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { setup, workflowToTests } from '@test/nodes/Helpers';
@@ -43,12 +42,7 @@ describe('Test Google BigQuery V2, insert define manually', () => {
 	const workflows = ['nodes/Google/BigQuery/test/v2/node/insert.manualMode.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -435,10 +435,10 @@ export class GoogleCalendar implements INodeType {
 							const timeMin = dateObjectToISO(this.getNodeParameter('timeMin', i));
 							const timeMax = dateObjectToISO(this.getNodeParameter('timeMax', i));
 							if (timeMin) {
-								qs.timeMin = addTimezoneToDate(timeMin as string, tz || timezone);
+								qs.timeMin = addTimezoneToDate(timeMin, tz || timezone);
 							}
 							if (timeMax) {
-								qs.timeMax = addTimezoneToDate(timeMax as string, tz || timezone);
+								qs.timeMax = addTimezoneToDate(timeMax, tz || timezone);
 							}
 
 							if (!options.recurringEventHandling || options.recurringEventHandling === 'expand') {

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
@@ -23,10 +23,6 @@ jest.mock('uuid', () => {
 });
 
 describe('test GoogleDriveV2: drive create', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/create.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as create from '../../../../v2/actions/drive/create.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -25,12 +23,7 @@ jest.mock('uuid', () => {
 });
 
 describe('test GoogleDriveV2: drive create', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as deleteDrive from '../../../../v2/actions/drive/deleteDrive.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive deleteDrive', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/deleteDrive.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive deleteDrive', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as get from '../../../../v2/actions/drive/get.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive get', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/get.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive get', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
@@ -22,10 +22,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive list', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with limit', async () => {
 		const nodeParameters = {
 			resource: 'drive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/list.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import * as list from '../../../../v2/actions/drive/list.operation';
 import * as transport from '../../../../v2/transport';
@@ -23,12 +22,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive list', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as update from '../../../../v2/actions/drive/update.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive update', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/drive/update.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: drive update', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'drive',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file copy', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'copy',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/copy.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as copy from '../../../../v2/actions/file/copy.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file copy', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file createFromText', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'createFromText',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/createFromText.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as createFromText from '../../../../v2/actions/file/createFromText.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file createFromText', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/deleteFile.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/deleteFile.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file deleteFile', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'deleteFile',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/deleteFile.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/deleteFile.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as deleteFile from '../../../../v2/actions/file/deleteFile.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file deleteFile', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as download from '../../../../v2/actions/file/download.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file download', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/download.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file download', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'deleteFile',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import * as move from '../../../../v2/actions/file/move.operation';
 import * as transport from '../../../../v2/transport';
@@ -21,12 +20,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file move', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/move.test.ts
@@ -20,10 +20,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file move', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'move',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/share.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/share.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file share', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'share',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/share.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/share.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as share from '../../../../v2/actions/file/share.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file share', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/update.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file update', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			operation: 'update',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/update.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/update.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as update from '../../../../v2/actions/file/update.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: file update', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -40,11 +40,6 @@ describe('test GoogleDriveV2: file upload', () => {
 		jest.clearAllMocks();
 	});
 
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-		jest.unmock('../../../../v2/helpers/utils');
-	});
-
 	it('should upload buffers', async () => {
 		const nodeParameters = {
 			name: 'newFile.txt',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/file/upload.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import * as upload from '../../../../v2/actions/file/upload.operation';
 import * as utils from '../../../../v2/helpers/utils';
@@ -37,16 +36,11 @@ jest.mock('../../../../v2/helpers/utils', () => {
 });
 
 describe('test GoogleDriveV2: file upload', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 		jest.unmock('../../../../v2/helpers/utils');
 	});

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import * as search from '../../../../v2/actions/fileFolder/search.operation';
 import * as transport from '../../../../v2/transport';
@@ -23,12 +22,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: fileFolder search', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/fileFolder/search.test.ts
@@ -22,10 +22,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: fileFolder search', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('returnAll = false', async () => {
 		const nodeParameters = {
 			searchMethod: 'name',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder create', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'folder',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/create.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as create from '../../../../v2/actions/folder/create.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder create', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder deleteFolder', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with PATCH', async () => {
 		const nodeParameters = {
 			resource: 'folder',

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/deleteFolder.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as deleteFolder from '../../../../v2/actions/folder/deleteFolder.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder deleteFolder', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
@@ -1,5 +1,3 @@
-import nock from 'nock';
-
 import * as share from '../../../../v2/actions/folder/share.operation';
 import * as transport from '../../../../v2/transport';
 import { createMockExecuteFunction, driveNode } from '../helpers';
@@ -15,12 +13,7 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder share', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
+++ b/packages/nodes-base/nodes/Google/Drive/test/v2/node/folder/share.test.ts
@@ -13,10 +13,6 @@ jest.mock('../../../../v2/transport', () => {
 });
 
 describe('test GoogleDriveV2: folder share', () => {
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	it('should be called with', async () => {
 		const nodeParameters = {
 			resource: 'folder',

--- a/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/GmailTrigger.test.ts
@@ -42,8 +42,6 @@ describe('GmailTrigger', () => {
 	}
 
 	beforeAll(() => {
-		nock.disableNetConnect();
-
 		jest.spyOn(mailparser, 'simpleParser').mockResolvedValue({
 			headers: new Map([['headerKey', 'headerValue']]),
 			attachments: [],
@@ -61,10 +59,6 @@ describe('GmailTrigger', () => {
 				html: 'to@example.com',
 			},
 		});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	it('should return incoming emails', async () => {

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/GmailV2.node.test.ts
@@ -14,13 +14,6 @@ describe('Test Gmail Node v2', () => {
 		jest
 			.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick'] })
 			.setSystemTime(new Date('2024-12-16 12:34:56.789Z'));
-
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
 	});
 
 	describe('Messages', () => {

--- a/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
+++ b/packages/nodes-base/nodes/GraphQL/test/GraphQL.node.test.ts
@@ -17,7 +17,6 @@ describe('GraphQL Node', () => {
 
 	beforeAll(async () => {
 		await initBinaryDataService();
-		nock.disableNetConnect();
 
 		nock(baseUrl)
 			.matchHeader('accept', 'application/json')
@@ -69,10 +68,6 @@ describe('GraphQL Node', () => {
 					},
 				},
 			});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(workflowTests);

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
@@ -17,8 +17,6 @@ describe('Test Binary Data Download', () => {
 	beforeAll(async () => {
 		await initBinaryDataService();
 
-		nock.disableNetConnect();
-
 		nock(baseUrl)
 			.persist()
 			.get('/path/to/image.png')
@@ -32,10 +30,6 @@ describe('Test Binary Data Download', () => {
 		nock(baseUrl).persist().get('/custom-content-disposition').reply(200, Buffer.from('testing'), {
 			'content-disposition': 'attachment; filename="testing.jpg"',
 		});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/binaryData/HttpRequest.test.ts
@@ -31,7 +31,6 @@ describe('Test Binary Data Download', () => {
 			'content-disposition': 'attachment; filename="testing.jpg"',
 		});
 	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/HttpRequest/test/encoding/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/encoding/HttpRequest.test.ts
@@ -21,16 +21,10 @@ describe('Test Response Encoding', () => {
 	beforeAll(async () => {
 		await initBinaryDataService();
 
-		nock.disableNetConnect();
-
 		nock(baseUrl)
 			.persist()
 			.get('/index.html')
 			.reply(200, payload, { 'content-type': 'text/plain; charset=latin1' });
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/HttpRequest/test/encoding/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/encoding/HttpRequest.test.ts
@@ -26,7 +26,6 @@ describe('Test Response Encoding', () => {
 			.get('/index.html')
 			.reply(200, payload, { 'content-type': 'text/plain; charset=latin1' });
 	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/HttpRequest/test/encodingQuoted/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/encodingQuoted/HttpRequest.test.ts
@@ -26,7 +26,6 @@ describe('Test Quoted Response Encoding', () => {
 			.get('/index.html')
 			.reply(200, payload, { 'content-type': 'text/plain; charset="latin1"' });
 	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/HttpRequest/test/encodingQuoted/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/encodingQuoted/HttpRequest.test.ts
@@ -21,16 +21,10 @@ describe('Test Quoted Response Encoding', () => {
 	beforeAll(async () => {
 		await initBinaryDataService();
 
-		nock.disableNetConnect();
-
 		nock(baseUrl)
 			.persist()
 			.get('/index.html')
 			.reply(200, payload, { 'content-type': 'text/plain; charset="latin1"' });
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -17,7 +17,6 @@ describe('Test HTTP Request Node', () => {
 
 	beforeAll(async () => {
 		await initBinaryDataService();
-		nock.disableNetConnect();
 
 		function getPaginationReturnData(this: nock.ReplyFnContext, limit = 10, skip = 0) {
 			const nextUrl = `${baseUrl}/users?skip=${skip + limit}&limit=${limit}`;
@@ -191,10 +190,6 @@ describe('Test HTTP Request Node', () => {
 
 				return getPaginationReturnData.call(this, limit, skip);
 			});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequest.test.ts
@@ -191,7 +191,6 @@ describe('Test HTTP Request Node', () => {
 				return getPaginationReturnData.call(this, limit, skip);
 			});
 	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/HttpRequest/test/node/workflow.pagination.json
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/workflow.pagination.json
@@ -1266,7 +1266,7 @@
 						"next-url": "https://dummyjson.com/users?skip=4&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1277,7 +1277,7 @@
 						"next-url": "https://dummyjson.com/users?skip=8&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1288,7 +1288,7 @@
 						"next-url": "https://dummyjson.com/users?skip=12&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1299,7 +1299,7 @@
 						"next-url": "https://dummyjson.com/users?skip=16&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1310,7 +1310,7 @@
 						"next-url": "https://dummyjson.com/users?skip=20&limit=4"
 					},
 					"statusCode": 404,
-					"statusMessage": null
+					"statusMessage": "Not Found"
 				}
 			}
 		],
@@ -1532,7 +1532,7 @@
 						"next-url": "https://dummyjson.com/users?skip=4&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1543,7 +1543,7 @@
 						"next-url": "https://dummyjson.com/users?skip=8&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1554,7 +1554,7 @@
 						"next-url": "https://dummyjson.com/users?skip=12&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1565,7 +1565,7 @@
 						"next-url": "https://dummyjson.com/users?skip=16&limit=4"
 					},
 					"statusCode": 200,
-					"statusMessage": null
+					"statusMessage": "OK"
 				}
 			},
 			{
@@ -1576,7 +1576,7 @@
 						"next-url": "https://dummyjson.com/users?skip=20&limit=4"
 					},
 					"statusCode": 404,
-					"statusMessage": null
+					"statusMessage": "Not Found"
 				}
 			}
 		],

--- a/packages/nodes-base/nodes/ICalendar/test/node/ICalendar.test.ts
+++ b/packages/nodes-base/nodes/ICalendar/test/node/ICalendar.test.ts
@@ -43,7 +43,6 @@ describe('Execute iCalendar Node', () => {
 			},
 		},
 	];
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/MailerLite/tests/v1/MailerLite.v1.workflow.test.ts
+++ b/packages/nodes-base/nodes/MailerLite/tests/v1/MailerLite.v1.workflow.test.ts
@@ -11,18 +11,12 @@ import {
 describe('MailerLite', () => {
 	describe('Run v1 workflow', () => {
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			const mock = nock('https://api.mailerlite.com/api/v2');
 
 			mock.post('/subscribers').reply(200, getCreateResponseClassic);
 			mock.get('/subscribers/demo@mailerlite.com').reply(200, getSubscriberResponseClassic);
 			mock.get('/subscribers').query({ limit: 1 }).reply(200, getAllSubscribersResponseClassic);
 			mock.put('/subscribers/demo@mailerlite.com').reply(200, getUpdateSubscriberResponseClassic);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const workflows = getWorkflowFilenames(__dirname);

--- a/packages/nodes-base/nodes/MailerLite/tests/v2/MailerLite.v2.workflow.test.ts
+++ b/packages/nodes-base/nodes/MailerLite/tests/v2/MailerLite.v2.workflow.test.ts
@@ -11,8 +11,6 @@ import {
 describe('MailerLite', () => {
 	describe('Run v2 workflow', () => {
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			const mock = nock('https://connect.mailerlite.com/api');
 
 			mock.post('/subscribers').reply(200, getCreateResponseV2);
@@ -22,10 +20,6 @@ describe('MailerLite', () => {
 				.query({ 'filter[status]': 'junk', limit: 2 })
 				.reply(200, getAllSubscribersResponseV2);
 			mock.put('/subscribers/user@n8n.io').reply(200, getUpdateSubscriberResponseV2);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const workflows = getWorkflowFilenames(__dirname);

--- a/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Entra/test/MicrosoftEntra.node.test.ts
@@ -91,8 +91,6 @@ describe('Gong Node', () => {
 		];
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			jest
 				.spyOn(Helpers.CredentialsHelper.prototype, 'authenticate')
 				.mockImplementation(
@@ -114,11 +112,6 @@ describe('Gong Node', () => {
 						}
 					},
 				);
-		});
-
-		afterAll(() => {
-			nock.restore();
-			jest.restoreAllMocks();
 		});
 
 		nock(baseUrl)

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -35,12 +34,7 @@ describe('Test MicrosoftExcelV2, table => addTable', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/addTable.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/addTable.test.ts
@@ -33,11 +33,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => addTable', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/addTable.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -52,12 +51,7 @@ describe('Test MicrosoftExcelV2, table => append', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/append.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/append.test.ts
@@ -50,11 +50,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => append', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/append.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
@@ -30,11 +30,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => convertToRange', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/convertToRange.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/convertToRange.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -32,12 +31,7 @@ describe('Test MicrosoftExcelV2, table => convertToRange', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/convertToRange.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftExcelV2, table => deleteTable', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/deleteTable.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/deleteTable.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => deleteTable', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/deleteTable.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
@@ -32,11 +32,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => getColumns', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/getColumns.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getColumns.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -34,12 +33,7 @@ describe('Test MicrosoftExcelV2, table => getColumns', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/getColumns.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -50,12 +49,7 @@ describe('Test MicrosoftExcelV2, table => getRows', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/getRows.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/getRows.test.ts
@@ -48,11 +48,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => getRows', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/getRows.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
@@ -66,11 +66,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, table => lookup', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/lookup.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/table/lookup.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -68,12 +67,7 @@ describe('Test MicrosoftExcelV2, table => lookup', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/table/lookup.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -36,12 +35,7 @@ describe('Test MicrosoftExcelV2, workbook => addWorksheet', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.test.ts
@@ -34,11 +34,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, workbook => addWorksheet', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/addWorksheet.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftExcelV2, workbook => deleteWorkbook', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, workbook => deleteWorkbook', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/deleteWorkbook.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -36,12 +35,7 @@ describe('Test MicrosoftExcelV2, workbook => getAll', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
@@ -34,11 +34,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, workbook => getAll', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/workbook/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -39,12 +38,7 @@ describe('Test MicrosoftExcelV2, worksheet => append', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/append.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/append.test.ts
@@ -37,11 +37,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => append', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/append.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,12 +30,7 @@ describe('Test MicrosoftExcelV2, worksheet => clear', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/clear.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/clear.test.ts
@@ -29,11 +29,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => clear', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/clear.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
@@ -29,11 +29,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => deleteWorksheet', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,12 +30,7 @@ describe('Test MicrosoftExcelV2, worksheet => deleteWorksheet', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/deleteWorksheet.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -38,12 +37,7 @@ describe('Test MicrosoftExcelV2, worksheet => getAll', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.test.ts
@@ -36,11 +36,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => getAll', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -36,12 +35,7 @@ describe('Test MicrosoftExcelV2, worksheet => readRows', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.test.ts
@@ -34,11 +34,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => readRows', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/readRows.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
@@ -47,11 +47,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => update', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/update.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -49,12 +48,7 @@ describe('Test MicrosoftExcelV2, worksheet => update', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/update.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -51,12 +50,7 @@ describe('Test MicrosoftExcelV2, worksheet => upsert', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.test.ts
@@ -49,11 +49,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftExcelV2, worksheet => upsert', () => {
 	const workflows = ['nodes/Microsoft/Excel/test/v2/node/worksheet/upsert.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -43,12 +42,7 @@ describe('Test MicrosoftOutlookV2, calendar => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/create.test.ts
@@ -41,11 +41,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, calendar => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftOutlookV2, calendar => delete', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/delete.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/delete.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, calendar => delete', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/delete.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
@@ -41,11 +41,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, calendar => get', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -43,12 +42,7 @@ describe('Test MicrosoftOutlookV2, calendar => get', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/get.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
@@ -62,11 +62,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, calendar => getAll', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -64,12 +63,7 @@ describe('Test MicrosoftOutlookV2, calendar => getAll', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
@@ -41,11 +41,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, calendar => update', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/calendar/update.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -43,12 +42,7 @@ describe('Test MicrosoftOutlookV2, calendar => update', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/calendar/update.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -66,12 +65,7 @@ describe('Test MicrosoftOutlookV2, contact => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/contact/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/create.test.ts
@@ -64,11 +64,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, contact => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/contact/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -72,12 +71,7 @@ describe('Test MicrosoftOutlookV2, contact => update', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/contact/update.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/contact/update.test.ts
@@ -70,11 +70,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, contact => update', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/contact/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -94,12 +93,7 @@ describe('Test MicrosoftOutlookV2, draft => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/draft/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/create.test.ts
@@ -92,11 +92,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, draft => create', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/draft/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, draft => send', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/draft/send.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/draft/send.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftOutlookV2, draft => send', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/draft/send.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -104,12 +103,7 @@ describe('Test MicrosoftOutlookV2, contact => event', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/event/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/create.test.ts
@@ -102,11 +102,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, contact => event', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/event/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
@@ -33,11 +33,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, contact => folder', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/folder/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folder/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -35,12 +34,7 @@ describe('Test MicrosoftOutlookV2, contact => folder', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/folder/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
@@ -26,11 +26,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, folderMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -28,12 +27,7 @@ describe('Test MicrosoftOutlookV2, folderMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/folderMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, message => move', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/move.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/move.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftOutlookV2, message => move', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/move.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -83,12 +82,7 @@ describe('Test MicrosoftOutlookV2, message => reply', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/reply.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/reply.test.ts
@@ -81,11 +81,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, message => reply', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/reply.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,12 +22,7 @@ describe('Test MicrosoftOutlookV2, message => send', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/send.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../v2/transport');
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/message/send.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../v2/transport', () => {
 describe('Test MicrosoftOutlookV2, message => send', () => {
 	const workflows = ['nodes/Microsoft/Outlook/test/v2/node/message/send.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../v2/transport');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/create.test.ts
@@ -29,7 +29,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -30,15 +29,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -18,15 +17,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => deleteChannel', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.test.ts
@@ -17,7 +17,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => deleteChannel', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/deleteChannel.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -31,15 +30,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/get.test.ts
@@ -30,7 +30,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -55,15 +54,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, channel => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.test.ts
@@ -54,7 +54,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, channel => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/update.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -18,15 +17,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => update', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/update.test.ts
@@ -17,7 +17,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channel => update', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channel/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/create.test.ts
@@ -59,7 +59,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channelMessage => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channelMessage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -60,15 +59,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, channelMessage => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channelMessage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -72,15 +71,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, channelMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.test.ts
@@ -71,7 +71,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, channelMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/channelMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/create.test.ts
@@ -55,7 +55,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -56,15 +55,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -57,15 +56,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.test.ts
@@ -56,7 +56,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -95,15 +94,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.test.ts
@@ -94,7 +94,6 @@ microsoftApiRequestSpy.mockImplementation(async (_, method: string) => {
 describe('Test MicrosoftTeamsV2, chatMessage => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/chatMessage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/create.test.ts
@@ -67,7 +67,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/create.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/create.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -68,15 +67,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => create', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/deleteTask.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/deleteTask.test.ts
@@ -22,7 +22,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => deleteTask', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/deleteTask.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/deleteTask.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/deleteTask.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,15 +22,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => deleteTask', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/deleteTask.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/get.test.ts
@@ -67,7 +67,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/get.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/get.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -68,15 +67,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => get', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -163,15 +162,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.test.ts
@@ -162,7 +162,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => getAll', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/update.test.ts
@@ -22,7 +22,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => update', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/update.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/update.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -23,15 +22,6 @@ microsoftApiRequestSpy.mockImplementation(async (method: string) => {
 describe('Test MicrosoftTeamsV2, task => update', () => {
 	const workflows = ['nodes/Microsoft/Teams/test/v2/node/task/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
-	afterAll(() => {
-		nock.restore();
-		jest.resetAllMocks();
-	});
 
 	const nodeTypes = setup(tests);
 

--- a/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
@@ -24,11 +24,6 @@ jest.mock('../../v1/GenericFunctions', () => {
 describe('Test MySqlV1, executeQuery', () => {
 	const workflows = ['nodes/MySql/test/v1/executeQuery.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../v1/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
+++ b/packages/nodes-base/nodes/MySql/test/v1/executeQuery.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes } from 'n8n-workflow';
-import nock from 'nock';
 
 import { executeWorkflow } from '@test/nodes/ExecuteWorkflow';
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
@@ -26,12 +25,7 @@ describe('Test MySqlV1, executeQuery', () => {
 	const workflows = ['nodes/MySql/test/v1/executeQuery.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../v1/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
@@ -14,7 +14,6 @@ describe('Test N8n Node, expect base_url to be received from credentials', () =>
 		const baseUrl = 'https://test.app.n8n.cloud/api/v1';
 		nock(baseUrl).get('/workflows?tags=n8n-test').reply(200, {});
 	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
+++ b/packages/nodes-base/nodes/N8n/test/node/N8n.test.ts
@@ -10,15 +10,9 @@ describe('Test N8n Node, expect base_url to be received from credentials', () =>
 	const tests = workflowToTests(workflows);
 
 	beforeAll(() => {
-		nock.disableNetConnect();
-
 		//base url is set in fake credentials map packages/nodes-base/test/nodes/FakeCredentialsMap.ts
 		const baseUrl = 'https://test.app.n8n.cloud/api/v1';
 		nock(baseUrl).get('/workflows?tags=n8n-test').reply(200, {});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/append.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/append.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -428,12 +427,7 @@ describe('Test NotionV2, block => append', () => {
 	const workflows = ['nodes/Notion/test/node/v2/block/append.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/append.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/append.test.ts
@@ -426,11 +426,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, block => append', () => {
 	const workflows = ['nodes/Notion/test/node/v2/block/append.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
@@ -222,11 +222,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, block => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/block/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/block/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -224,12 +223,7 @@ describe('Test NotionV2, block => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/block/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/get.test.ts
@@ -80,11 +80,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, database => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/get.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -82,12 +81,7 @@ describe('Test NotionV2, database => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/get.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/getAll.test.ts
@@ -321,11 +321,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, database => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -323,12 +322,7 @@ describe('Test NotionV2, database => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/search.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/search.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -197,12 +196,7 @@ describe('Test NotionV2, database => search', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/search.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/database/search.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/database/search.test.ts
@@ -195,11 +195,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, database => search', () => {
 	const workflows = ['nodes/Notion/test/node/v2/database/search.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/create.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/create.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -98,12 +97,7 @@ describe('Test NotionV2, databasePage => create', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/create.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/create.test.ts
@@ -96,11 +96,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, databasePage => create', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/get.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -78,12 +77,7 @@ describe('Test NotionV2, databasePage => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/get.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/get.test.ts
@@ -76,11 +76,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, databasePage => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -79,12 +78,7 @@ describe('Test NotionV2, databasePage => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/getAll.test.ts
@@ -77,11 +77,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, databasePage => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/update.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/update.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -78,12 +77,7 @@ describe('Test NotionV2, databasePage => update', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/update.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/update.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/databasePage/update.test.ts
@@ -76,11 +76,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, databasePage => update', () => {
 	const workflows = ['nodes/Notion/test/node/v2/databasePage/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/archive.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/archive.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -78,12 +77,7 @@ describe('Test NotionV2, page => archive', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/archive.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/archive.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/archive.test.ts
@@ -76,11 +76,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, page => archive', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/archive.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/create.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/create.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -73,12 +72,7 @@ describe('Test NotionV2, page => create', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/create.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/create.test.ts
@@ -71,11 +71,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, page => create', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/search.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/search.test.ts
@@ -72,11 +72,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, page => search', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/search.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/page/search.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/page/search.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -74,12 +73,7 @@ describe('Test NotionV2, page => search', () => {
 	const workflows = ['nodes/Notion/test/node/v2/page/search.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/user/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/user/get.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -29,12 +28,7 @@ describe('Test NotionV2, user => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/user/get.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Notion/test/node/v2/user/get.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/user/get.test.ts
@@ -27,11 +27,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, user => get', () => {
 	const workflows = ['nodes/Notion/test/node/v2/user/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/user/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/user/getAll.test.ts
@@ -51,11 +51,6 @@ jest.mock('../../../../shared/GenericFunctions', () => {
 describe('Test NotionV2, user => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/user/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../shared/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Notion/test/node/v2/user/getAll.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/node/v2/user/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -53,12 +52,7 @@ describe('Test NotionV2, user => getAll', () => {
 	const workflows = ['nodes/Notion/test/node/v2/user/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../shared/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Npm/test/Npm.node.test.ts
+++ b/packages/nodes-base/nodes/Npm/test/Npm.node.test.ts
@@ -5,8 +5,6 @@ import { testWorkflows, getWorkflowFilenames } from '@test/nodes/Helpers';
 
 describe('Test npm Node', () => {
 	beforeAll(() => {
-		nock.disableNetConnect();
-
 		const { registryUrl } = FAKE_CREDENTIALS_DATA.npmApi;
 		const mock = nock(registryUrl); //.matchHeader('Authorization', `Bearer ${accessToken}`);
 
@@ -28,10 +26,6 @@ describe('Test npm Node', () => {
 			version: '0.225.2',
 			rest: 'of the properties',
 		});
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const workflows = getWorkflowFilenames(__dirname);

--- a/packages/nodes-base/nodes/OpenWeatherMap/test/OpenWeatherMap.test.ts
+++ b/packages/nodes-base/nodes/OpenWeatherMap/test/OpenWeatherMap.test.ts
@@ -10,16 +10,10 @@ describe('OpenWeatherMap', () => {
 		const tests = workflowToTests(workflows);
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			nock('https://api.openweathermap.org')
 				.get('/data/2.5/weather')
 				.query({ units: 'metric', q: 'berlin,de', lang: 'en' })
 				.reply(200, currentWeatherResponse);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/Oura/test/oura.node.test.ts
+++ b/packages/nodes-base/nodes/Oura/test/oura.node.test.ts
@@ -56,15 +56,9 @@ describe('Oura', () => {
 		const tests = workflowToTests(workflows);
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			nock('https://api.ouraring.com/v2')
 				.get('/usercollection/personal_info')
 				.reply(200, profileResponse);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
+++ b/packages/nodes-base/nodes/PhilipsHue/test/workflow.test.ts
@@ -19,17 +19,11 @@ describe('PhilipsHue', () => {
 		const tests = workflowToTests(workflows);
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			const mock = nock('https://api.meethue.com/route');
 			mock.persist().get('/api/0/config').reply(200, getConfigResponse);
 			mock.get('/api/pAtwdCV8NZId25Gk/lights').reply(200, getLightsResponse);
 			mock.put('/api/pAtwdCV8NZId25Gk/lights/1/state').reply(200, updateLightResponse);
 			mock.delete('/api/pAtwdCV8NZId25Gk/lights/1').reply(200, deleteLightResponse);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/QuickChart/test/QuickChart.node.test.ts
+++ b/packages/nodes-base/nodes/QuickChart/test/QuickChart.node.test.ts
@@ -8,15 +8,10 @@ import type { WorkflowTestData } from '@test/nodes/types';
 describe('Test QuickChart Node', () => {
 	beforeEach(async () => {
 		await Helpers.initBinaryDataService();
-		nock.disableNetConnect();
 		nock('https://quickchart.io')
 			.persist()
 			.get(/chart.*/)
 			.reply(200, { success: true });
-	});
-
-	afterEach(() => {
-		nock.restore();
 	});
 
 	const workflow = Helpers.readJsonFileSync('nodes/QuickChart/test/QuickChart.workflow.json');

--- a/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
@@ -12,7 +12,6 @@ describe('Test RSS Feed Trigger Node', () => {
 	beforeAll(() => {
 		nock('https://lorem-rss.herokuapp.com').get('/feed?length=3').reply(200, feed);
 	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/test/node/RssFeedRead.test.ts
@@ -10,13 +10,7 @@ describe('Test RSS Feed Trigger Node', () => {
 	const tests = workflowToTests(workflows);
 
 	beforeAll(() => {
-		nock.disableNetConnect();
-
 		nock('https://lorem-rss.herokuapp.com').get('/feed?length=3').reply(200, feed);
-	});
-
-	afterAll(() => {
-		nock.restore();
 	});
 
 	const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/archive.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/archive.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods } from 'n8n-workflow';
-import nock from 'nock';
 
 import { equalityTest, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -23,12 +22,7 @@ describe('Test SlackV2, channel => append', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/archive.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/archive.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/archive.test.ts
@@ -21,11 +21,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, channel => append', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/archive.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/create.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -65,12 +64,7 @@ describe('Test SlackV2, channel => create', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/create.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/create.test.ts
@@ -63,11 +63,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, channel => create', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/create.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/get.test.ts
@@ -62,11 +62,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, channel => get', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/get.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/get.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -64,12 +63,7 @@ describe('Test SlackV2, channel => get', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/get.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/getAll.test.ts
@@ -125,11 +125,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, channel => getAll', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/getAll.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/getAll.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -127,12 +126,7 @@ describe('Test SlackV2, channel => getAll', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/getAll.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/history.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/history.test.ts
@@ -181,11 +181,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, channel => history', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/history.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/channel/history.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/channel/history.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -183,12 +182,7 @@ describe('Test SlackV2, channel => history', () => {
 	const workflows = ['nodes/Slack/test/v2/node/channel/history.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/file/upload.test.ts
@@ -25,11 +25,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, file => upload', () => {
 	const workflows = ['nodes/Slack/test/v2/node/file/upload.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/file/upload.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/file/upload.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -27,12 +26,7 @@ describe('Test SlackV2, file => upload', () => {
 	const workflows = ['nodes/Slack/test/v2/node/file/upload.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/delete.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/delete.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -28,12 +27,7 @@ describe('Test SlackV2, message => delete', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/delete.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/delete.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/delete.test.ts
@@ -26,11 +26,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, message => delete', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/delete.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/getPermalink.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/getPermalink.test.ts
@@ -26,11 +26,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, message => getPermalink', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/getPermalink.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/getPermalink.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/getPermalink.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -28,12 +27,7 @@ describe('Test SlackV2, message => getPermalink', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/getPermalink.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/post.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/post.test.ts
@@ -65,11 +65,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, message => post', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/post.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/post.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/post.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -67,12 +66,7 @@ describe('Test SlackV2, message => post', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/post.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/search.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/search.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -220,12 +219,7 @@ describe('Test SlackV2, message => search', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/search.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/search.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/search.test.ts
@@ -218,11 +218,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, message => search', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/search.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/update.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/update.test.ts
@@ -1,5 +1,4 @@
 import type { IHttpRequestMethods, INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -71,12 +70,7 @@ describe('Test SlackV2, message => update', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/update.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/update.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/update.test.ts
@@ -69,11 +69,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, message => update', () => {
 	const workflows = ['nodes/Slack/test/v2/node/message/update.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/user/updateProfile.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/user/updateProfile.test.ts
@@ -1,5 +1,4 @@
 import type { INodeTypes, WorkflowTestData } from 'n8n-workflow';
-import nock from 'nock';
 
 import { getResultNodeData, setup, workflowToTests } from '@test/nodes/Helpers';
 
@@ -22,12 +21,7 @@ describe('Test SlackV2, user => updateProfile', () => {
 	const workflows = ['nodes/Slack/test/v2/node/user/updateProfile.workflow.json'];
 	const tests = workflowToTests(workflows);
 
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../../../../V2/GenericFunctions');
 	});
 

--- a/packages/nodes-base/nodes/Slack/test/v2/node/user/updateProfile.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/user/updateProfile.test.ts
@@ -20,11 +20,6 @@ jest.mock('../../../../V2/GenericFunctions', () => {
 describe('Test SlackV2, user => updateProfile', () => {
 	const workflows = ['nodes/Slack/test/v2/node/user/updateProfile.workflow.json'];
 	const tests = workflowToTests(workflows);
-
-	afterAll(() => {
-		jest.unmock('../../../../V2/GenericFunctions');
-	});
-
 	const nodeTypes = setup(tests);
 
 	const testNode = async (testData: WorkflowTestData, types: INodeTypes) => {

--- a/packages/nodes-base/nodes/Spotify/__tests__/workflow/workflow.test.ts
+++ b/packages/nodes-base/nodes/Spotify/__tests__/workflow/workflow.test.ts
@@ -20,8 +20,6 @@ describe('Spotify', () => {
 		const tests = workflowToTests(workflows);
 
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			const mock = nock('https://api.spotify.com/v1');
 			mock
 				.get('/search')
@@ -31,10 +29,6 @@ describe('Spotify', () => {
 			mock.get('/albums/4R6FV9NSzhPihHR0h4pI93/tracks').reply(200, getAlbumTracks);
 			mock.get('/albums/4R6FV9NSzhPihHR0h4pI93').reply(200, getAlbum);
 			mock.get('/artists/12Chz98pHFMPJEknJQMWvI').reply(200, getArtist);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const nodeTypes = setup(tests);

--- a/packages/nodes-base/nodes/Telegram/tests/Workflow/workflow.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Workflow/workflow.test.ts
@@ -19,8 +19,6 @@ import { getWorkflowFilenames, testWorkflows } from '../../../../test/nodes/Help
 describe('Telegram', () => {
 	describe('Run Telegram workflow', () => {
 		beforeAll(() => {
-			nock.disableNetConnect();
-
 			const { baseUrl } = FAKE_CREDENTIALS_DATA.telegramApi;
 			const mock = nock(baseUrl);
 
@@ -41,10 +39,6 @@ describe('Telegram', () => {
 			mock.post('/bottestToken/sendAnimation').reply(200, sendAnimationMessageResponse);
 			mock.post('/bottestToken/sendAudio').reply(200, sendAudioResponse);
 			mock.post('/bottestToken/getChatMember').reply(200, getMemberResponse);
-		});
-
-		afterAll(() => {
-			nock.restore();
 		});
 
 		const workflows = getWorkflowFilenames(__dirname);

--- a/packages/nodes-base/nodes/TheHiveProject/test/transport.test.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/test/transport.test.ts
@@ -16,10 +16,6 @@ jest.mock('../transport/requestApi', () => {
 const fakeExecuteFunction = {} as unknown as IExecuteFunctions;
 
 describe('Test TheHiveProject, theHiveApiQuery', () => {
-	afterAll(() => {
-		jest.unmock('../transport/requestApi');
-	});
-
 	it('should make list query request', async () => {
 		const scope = {
 			query: 'listOrganisationPage',

--- a/packages/nodes-base/nodes/TheHiveProject/test/transport.test.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/test/transport.test.ts
@@ -1,5 +1,4 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
-import nock from 'nock';
 
 import { theHiveApiQuery } from '../transport/queryHelper';
 import * as transport from '../transport/requestApi';
@@ -17,12 +16,7 @@ jest.mock('../transport/requestApi', () => {
 const fakeExecuteFunction = {} as unknown as IExecuteFunctions;
 
 describe('Test TheHiveProject, theHiveApiQuery', () => {
-	beforeAll(() => {
-		nock.disableNetConnect();
-	});
-
 	afterAll(() => {
-		nock.restore();
 		jest.unmock('../transport/requestApi');
 	});
 

--- a/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
+++ b/packages/nodes-base/nodes/Twitter/test/Twitter.test.ts
@@ -74,17 +74,12 @@ const meResult = {
 describe('Test Twitter Request Node', () => {
 	beforeAll(() => {
 		const baseUrl = 'https://api.twitter.com/2';
-		nock.disableNetConnect();
 		//GET
 		nock(baseUrl).get('/users/me').reply(200, meResult);
 
 		nock(baseUrl)
 			.get('/tweets/search/recent?query=bloomberg&max_results=10')
 			.reply(200, searchResult);
-	});
-
-	afterEach(() => {
-		nock.restore();
 	});
 
 	const workflows = getWorkflowFilenames(__dirname);

--- a/packages/nodes-base/test/globalSetup.ts
+++ b/packages/nodes-base/test/globalSetup.ts
@@ -1,0 +1,5 @@
+import nock from 'nock';
+
+export default async () => {
+	nock.disableNetConnect();
+};

--- a/packages/nodes-base/test/nodes/Airtable/Airtable.node.test.ts
+++ b/packages/nodes-base/test/nodes/Airtable/Airtable.node.test.ts
@@ -17,14 +17,9 @@ const records = [
 
 describe('Execute Airtable Node', () => {
 	beforeEach(() => {
-		nock.disableNetConnect();
 		nock('https://api.airtable.com/v0')
 			.get('/appIaXXdDqS5ORr4V/tbljyBEdYzCPF0NDh?pageSize=100')
 			.reply(200, { records });
-	});
-
-	afterEach(() => {
-		nock.restore();
 	});
 
 	const tests: WorkflowTestData[] = [

--- a/packages/nodes-base/test/nodes/Helpers.ts
+++ b/packages/nodes-base/test/nodes/Helpers.ts
@@ -36,7 +36,6 @@ import type {
 	WorkflowTestData,
 } from 'n8n-workflow';
 import { ApplicationError, ICredentialsHelper, NodeHelpers, WorkflowHooks } from 'n8n-workflow';
-import nock from 'nock';
 import { tmpdir } from 'os';
 import path from 'path';
 
@@ -223,16 +222,6 @@ export async function initBinaryDataService(mode: 'default' | 'filesystem' = 'de
 export function setup(testData: WorkflowTestData[] | WorkflowTestData) {
 	if (!Array.isArray(testData)) {
 		testData = [testData];
-	}
-
-	if (testData.some((t) => !!t.nock)) {
-		beforeAll(() => {
-			nock.disableNetConnect();
-		});
-
-		afterAll(() => {
-			nock.restore();
-		});
 	}
 
 	const nodeTypes = new NodeTypes();

--- a/packages/nodes-base/test/nodes/Helpers.ts
+++ b/packages/nodes-base/test/nodes/Helpers.ts
@@ -372,7 +372,6 @@ export const workflowToTests = (workflowFiles: string[]) => {
 
 export const testWorkflows = (workflows: string[]) => {
 	const tests = workflowToTests(workflows);
-
 	const nodeTypes = setup(tests);
 
 	for (const testData of tests) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: ^1.7.15
         version: 1.7.15
       nock:
-        specifier: ^13.3.2
-        version: 13.3.2
+        specifier: ^14.0.0
+        version: 14.0.0
       nodemon:
         specifier: ^3.0.1
         version: 3.0.1
@@ -4416,6 +4416,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@mswjs/interceptors@0.37.5':
+    resolution: {integrity: sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==}
+    engines: {node: '>=18'}
+
   '@n8n/codemirror-lang-sql@1.0.2':
     resolution: {integrity: sha512-sOf/KyewSu3Ikij0CkRtzJJDhRDZcwNCEYl8UdH4U/riL0/XZGcBD7MYofCCcKszanJZiEWRZ2KU1sRp234iMg==}
 
@@ -4543,6 +4547,15 @@ packages:
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api-logs@0.52.1':
     resolution: {integrity: sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==}
@@ -9235,6 +9248,9 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -10620,9 +10636,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
-  nock@13.3.2:
-    resolution: {integrity: sha512-CwbljitiWJhF1gL83NbanhoKs1l23TDlRioNraPTZrzZIEooPemrHRj5m0FZCPkB1ecdYCSWWGcHysJgX/ngnQ==}
-    engines: {node: '>= 10.13'}
+  nock@14.0.0:
+    resolution: {integrity: sha512-3Z2ZoZoYTR/y2I+NI16+6IzfZFKBX7MrADtoBAm7v/QKqxQUhKw+Dh+847PPS1j/FDutjfIXfrh3CJF74yITWg==}
+    engines: {node: '>= 18'}
 
   node-abi@3.54.0:
     resolution: {integrity: sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==}
@@ -10932,6 +10948,9 @@ packages:
 
   otplib@12.0.1:
     resolution: {integrity: sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -12300,6 +12319,9 @@ packages:
 
   strict-event-emitter-types@2.0.0:
     resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -16869,6 +16891,15 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
     optional: true
 
+  '@mswjs/interceptors@0.37.5':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@n8n/codemirror-lang-sql@1.0.2(@codemirror/view@6.26.3)(@lezer/common@1.1.0)':
     dependencies:
       '@codemirror/autocomplete': 6.16.0(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.1.0)
@@ -17034,6 +17065,15 @@ snapshots:
       wrap-ansi: 7.0.0
 
   '@one-ini/wasm@0.1.1': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api-logs@0.52.1':
     dependencies:
@@ -23053,6 +23093,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-node-process@1.2.0: {}
+
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
@@ -24875,14 +24917,11 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.6.2
 
-  nock@13.3.2:
+  nock@14.0.0:
     dependencies:
-      debug: 4.3.4
+      '@mswjs/interceptors': 0.37.5
       json-stringify-safe: 5.0.1
-      lodash: 4.17.21
       propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   node-abi@3.54.0:
     dependencies:
@@ -25250,6 +25289,8 @@ snapshots:
       '@otplib/core': 12.0.1
       '@otplib/preset-default': 12.0.1
       '@otplib/preset-v11': 12.0.1
+
+  outvariant@1.4.3: {}
 
   p-cancelable@2.1.1: {}
 
@@ -26866,6 +26907,8 @@ snapshots:
   streamsearch@1.1.0: {}
 
   strict-event-emitter-types@2.0.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   strict-uri-encode@2.0.0: {}
 


### PR DESCRIPTION
## Summary
Nock 14 added support for native fetch. Once we upgrade, we can start adding tests for nodes that use their own SDKs that use fetch.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
