### PR TITLE
feat(n8n AWS SNS Node): Add option to send message directly to phone number

### DIFF
--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -102,6 +102,32 @@ export class AwsSns implements INodeType {
 				},
 			},
 			{
+				displayName: 'Target',
+				name: 'target',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Topic',
+						value: 'topic',
+						description: 'Publish to a topic',
+						action: 'Publish to a topic',
+					},
+					{
+						name: 'Phone',
+						value: 'phone',
+						description: 'Publish to a phone number',
+						action: 'Publish to a phone number',
+					},
+				],
+				default: 'topic',
+				displayOptions: {
+					show: {
+						operation: ['publish'],
+					},
+				},
+			},
+			{
 				displayName: 'Topic',
 				name: 'topic',
 				type: 'resourceLocator',
@@ -159,8 +185,23 @@ export class AwsSns implements INodeType {
 				displayOptions: {
 					show: {
 						operation: ['publish', 'delete'],
+						target: ['topic'],
 					},
 				},
+			},
+			{
+				displayName: 'Number',
+				name: 'number',
+				type: 'string',
+				displayOptions: {
+					show: {
+						target: ['phone'],
+					},
+				},
+				default: '',
+				placeholder: '+123456789',
+				required: true,
+				description: 'The number where the message is published to',
 			},
 			{
 				displayName: 'Subject',
@@ -300,12 +341,22 @@ export class AwsSns implements INodeType {
 					const topic = this.getNodeParameter('topic', i, undefined, {
 						extractValue: true,
 					}) as string;
+					const number = this.getNodeParameter('number', i, undefined, {
+						extractValue: true,
+					}) as string;
+					const target = this.getNodeParameter('mode', 0);
 
 					const params = [
-						'TopicArn=' + topic,
 						'Subject=' + encodeURIComponent(this.getNodeParameter('subject', i) as string),
 						'Message=' + encodeURIComponent(this.getNodeParameter('message', i) as string),
 					];
+
+					if (target === 'topic') {
+						params.push('TopicArn=' + topic)
+					}
+					if (target === 'phone') {
+						params.push('PhoneNumber=' + number)
+					}
 
 					const responseData = await awsApiRequestSOAP.call(
 						this,

--- a/packages/nodes-base/nodes/Aws/AwsSns.node.ts
+++ b/packages/nodes-base/nodes/Aws/AwsSns.node.ts
@@ -100,6 +100,32 @@ export class AwsSns implements INodeType {
 				},
 			},
 			{
+				displayName: 'Target',
+				name: 'target',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Topic',
+						value: 'topic',
+						description: 'Publish to a topic',
+						action: 'Publish to a topic',
+					},
+					{
+						name: 'Phone',
+						value: 'phone',
+						description: 'Publish to a phone number',
+						action: 'Publish to a phone number',
+					},
+				],
+				default: 'topic',
+				displayOptions: {
+					show: {
+						operation: ['publish'],
+					},
+				},
+			},
+			{
 				displayName: 'Topic',
 				name: 'topic',
 				type: 'resourceLocator',
@@ -157,8 +183,23 @@ export class AwsSns implements INodeType {
 				displayOptions: {
 					show: {
 						operation: ['publish', 'delete'],
+						target: ['topic'],
 					},
 				},
+			},
+			{
+				displayName: 'Number',
+				name: 'number',
+				type: 'string',
+				displayOptions: {
+					show: {
+						target: ['phone'],
+					},
+				},
+				default: '',
+				placeholder: '+123456789',
+				required: true,
+				description: 'The number where the message is published to',
 			},
 			{
 				displayName: 'Subject',
@@ -295,15 +336,25 @@ export class AwsSns implements INodeType {
 					returnData.push({ success: true } as IDataObject);
 				}
 				if (operation === 'publish') {
-					const topic = this.getNodeParameter('topic', i, undefined, {
-						extractValue: true,
-					}) as string;
+					const target = this.getNodeParameter('target', i);
 
 					const params = [
-						'TopicArn=' + topic,
 						'Subject=' + encodeURIComponent(this.getNodeParameter('subject', i) as string),
 						'Message=' + encodeURIComponent(this.getNodeParameter('message', i) as string),
 					];
+
+					if (target === 'topic') {
+						const topic = this.getNodeParameter('topic', i, undefined, {
+							extractValue: true,
+						}) as string;
+						params.push('TopicArn=' + topic);
+					}
+					if (target === 'phone') {
+						const number = this.getNodeParameter('number', i, undefined, {
+							extractValue: true,
+						}) as string;
+						params.push('PhoneNumber=' + number);
+					}
 
 					const responseData = await awsApiRequestSOAP.call(
 						this,

--- a/packages/nodes-base/nodes/Aws/test/AwsSns.node.test.ts
+++ b/packages/nodes-base/nodes/Aws/test/AwsSns.node.test.ts
@@ -1,0 +1,98 @@
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type { IDataObject, IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+
+import { AwsSns } from '../AwsSns.node';
+import { awsApiRequestSOAP } from '../GenericFunctions';
+
+vi.mock('../GenericFunctions', () => ({
+	awsApiRequestSOAP: vi.fn(),
+}));
+
+describe('AwsSns Node', () => {
+	let awsSns: AwsSns;
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+
+	const awsApiRequestSOAPMock = awsApiRequestSOAP as Mock;
+
+	const mockNode: INode = {
+		id: 'test-node-id',
+		name: 'AWS SNS',
+		type: 'n8n-nodes-base.awsSns',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	};
+
+	beforeEach(() => {
+		awsSns = new AwsSns();
+		mockExecuteFunctions = mock<IExecuteFunctions>({
+			helpers: {
+				returnJsonArray: vi.fn((data: IDataObject | IDataObject[]) =>
+					Array.isArray(data) ? data.map((d) => ({ json: d })) : [{ json: data }],
+				),
+			},
+		});
+
+		vi.clearAllMocks();
+
+		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+
+		awsApiRequestSOAPMock.mockResolvedValue({
+			PublishResponse: { PublishResult: { MessageId: 'msg-123' } },
+		});
+	});
+
+	const getUrl = () => awsApiRequestSOAPMock.mock.calls[0][2] as string;
+
+	describe('publish operation', () => {
+		it('should publish to a topic using TopicArn when target is topic', async () => {
+			const topicArn = 'arn:aws:sns:us-east-1:123456789012:MyTopic';
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params: Record<string, unknown> = {
+					operation: 'publish',
+					target: 'topic',
+					topic: topicArn,
+					subject: 'Hello',
+					message: 'World',
+				};
+				return params[paramName];
+			});
+
+			const result = await awsSns.execute.call(mockExecuteFunctions);
+
+			const url = getUrl();
+			expect(url).toContain('Action=Publish');
+			expect(url).toContain('TopicArn=' + topicArn);
+			expect(url).toContain('Subject=Hello');
+			expect(url).toContain('Message=World');
+			expect(url).not.toContain('PhoneNumber');
+			expect(result).toEqual([[{ json: { MessageId: 'msg-123' } }]]);
+		});
+
+		it('should publish to a phone number using PhoneNumber when target is phone', async () => {
+			const number = '+123456789';
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				const params: Record<string, unknown> = {
+					operation: 'publish',
+					target: 'phone',
+					number,
+					subject: 'Hello',
+					message: 'World',
+				};
+				return params[paramName];
+			});
+
+			const result = await awsSns.execute.call(mockExecuteFunctions);
+
+			const url = getUrl();
+			expect(url).toContain('Action=Publish');
+			expect(url).toContain('PhoneNumber=' + number);
+			expect(url).not.toContain('TopicArn');
+			expect(result).toEqual([[{ json: { MessageId: 'msg-123' } }]]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->
This PR adds a new option, to send a message directly to a phone number via AWS SNS. 

The AWS SNS node can currently only publish to a topic. AWS SNS also supports
publishing straight to a phone number (SMS) by sending `PhoneNumber` instead of
`TopicArn` on the `Publish` action —
https://docs.aws.amazon.com/sns/latest/dg/sms_sending-overview.html#sms_publish-to-phone

Sending an SMS today therefore requires creating a topic and subscribing the
number to it, which is a lot of setup for a one-off message.

## Related Linear tickets, Github issues, and Community forum posts

This solves my own request/question in the community:
https://community.n8n.io/t/how-to-send-an-sms-with-aws-sns/73028

Closes #37362

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)


## How to test

1. `cd packages/nodes-base && pnpm test nodes/Aws/test/AwsSns.node.test.ts`
2. Manually, with AWS credentials that have `sns:Publish` and an SMS-enabled
   region (note: in the SNS **sandbox** the destination number must be verified
   first):
   - Import the workflow below, set your AWS credential and a real number.
   - Run it with `Target = Phone` → the SMS arrives, node output contains a
     `MessageId`.
   - Switch `Target = Topic`, pick a topic → existing topic publish still works
     unchanged.

<details>
<summary>Example workflow</summary>

```json
{
  "name": "AWS SNS publish to phone",
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0],
      "id": "11111111-1111-4111-8111-111111111111",
      "name": "When clicking 'Execute workflow'"
    },
    {
      "parameters": {
        "target": "phone",
        "number": "+15551234567",
        "subject": "n8n",
        "message": "Hello from n8n via AWS SNS"
      },
      "type": "n8n-nodes-base.awsSns",
      "typeVersion": 1,
      "position": [220, 0],
      "id": "22222222-2222-4222-8222-222222222222",
      "name": "AWS SNS"
    }
  ],
  "connections": {
    "When clicking 'Execute workflow'": {
      "main": [[{ "node": "AWS SNS", "type": "main", "index": 0 }]]
    }
  }
}
</details>
