### PR TITLE
fix(core): Renew license on startup for instances with detached floating entitlements

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -96,7 +96,7 @@
     "@n8n/task-runner": "workspace:*",
     "@n8n/typeorm": "0.3.20-12",
     "@n8n_io/ai-assistant-sdk": "1.13.0",
-    "@n8n_io/license-sdk": "2.14.2",
+    "@n8n_io/license-sdk": "2.15.0",
     "@oclif/core": "4.0.7",
     "@rudderstack/rudder-sdk-node": "2.0.9",
     "@sentry/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,8 +803,8 @@ importers:
         specifier: 1.13.0
         version: 1.13.0
       '@n8n_io/license-sdk':
-        specifier: 2.14.2
-        version: 2.14.2
+        specifier: 2.15.0
+        version: 2.15.0
       '@oclif/core':
         specifier: 4.0.7
         version: 4.0.7
@@ -4508,8 +4508,8 @@ packages:
     resolution: {integrity: sha512-16kftFTeX3/lBinHJaBK0OL1lB4FpPaUoHX4h25AkvgHvmjUHpWNY2ZtKos0rY89+pkzDsNxMZqSUkeKU45iRg==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
 
-  '@n8n_io/license-sdk@2.14.2':
-    resolution: {integrity: sha512-g+f2aW2vFL7VTNiL6Vak+dm9P4eJEpxJ7/Nqzp6d1YHsMixM0YeU8CPWeCCddgZW2pF0viyogpuF3L7uplv6ww==}
+  '@n8n_io/license-sdk@2.15.0':
+    resolution: {integrity: sha512-EmEAHNJu7S0dDom2E7OOT3cfrJyy0gpmyAX0z6WUkcZgST0ZvXLxCLpaQHY+sD5vOwTwitWq9WFKyCRmbBJVIQ==}
     engines: {node: '>=18.12.1'}
 
   '@n8n_io/riot-tmpl@4.0.0':
@@ -17000,7 +17000,7 @@ snapshots:
 
   '@n8n_io/ai-assistant-sdk@1.13.0': {}
 
-  '@n8n_io/license-sdk@2.14.2':
+  '@n8n_io/license-sdk@2.15.0':
     dependencies:
       crypto-js: 4.2.0
       node-machine-id: 1.1.12


### PR DESCRIPTION
This PR updates the license-sdk to v2.15.0, introducing a subtle improvement: n8n instances will now automatically attempt to renew their license on startup if:

- The current license was last renewed more than 24 hours ago, or
- The current license has floating entitlements in a detached state.

This change reduces the likelihood of n8n instances starting up with fewer licensed features than they are eligible for.