### PR TITLE
chore(Respond to Webhook Node): Move out commonalities with Respond To Webhook and Form Completion

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -5,6 +5,7 @@ import type {
 	INodeProperties,
 	INodeTypeDescription,
 	IWebhookFunctions,
+	IWebhookResponseData,
 	NodeTypeAndVersion,
 } from 'n8n-workflow';
 import {
@@ -15,12 +16,13 @@ import {
 	FORM_TRIGGER_NODE_TYPE,
 	tryToParseJsonToFormFields,
 	NodeConnectionType,
-	WAIT_NODE_TYPE,
 	WAIT_INDEFINITELY,
 } from 'n8n-workflow';
 
+import { renderFormCompletion } from './formCompletionUtils';
+import { renderFormNode } from './formNodeUtils';
 import { formDescription, formFields, formTitle } from '../Form/common.descriptions';
-import { prepareFormReturnItem, renderForm, resolveRawData } from '../Form/utils';
+import { prepareFormReturnItem, resolveRawData } from '../Form/utils';
 
 export const formFieldsProperties: INodeProperties[] = [
 	{
@@ -235,7 +237,7 @@ export class Form extends Node {
 		],
 	};
 
-	async webhook(context: IWebhookFunctions) {
+	async webhook(context: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const res = context.getResponseObject();
 
 		const operation = context.getNodeParameter('operation', '') as string;
@@ -272,36 +274,7 @@ export class Form extends Node {
 		const method = context.getRequestObject().method;
 
 		if (operation === 'completion' && method === 'GET') {
-			const completionTitle = context.getNodeParameter('completionTitle', '') as string;
-			const completionMessage = context.getNodeParameter('completionMessage', '') as string;
-			const redirectUrl = context.getNodeParameter('redirectUrl', '') as string;
-			const options = context.getNodeParameter('options', {}) as { formTitle: string };
-
-			if (redirectUrl) {
-				res.send(
-					`<html><head><meta http-equiv="refresh" content="0; url=${redirectUrl}"></head></html>`,
-				);
-				return { noWebhookResponse: true };
-			}
-
-			let title = options.formTitle;
-			if (!title) {
-				title = context.evaluateExpression(
-					`{{ $('${trigger?.name}').params.formTitle }}`,
-				) as string;
-			}
-			const appendAttribution = context.evaluateExpression(
-				`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
-			) as boolean;
-
-			res.render('form-trigger-completion', {
-				title: completionTitle,
-				message: completionMessage,
-				formTitle: title,
-				appendAttribution,
-			});
-
-			return { noWebhookResponse: true };
+			return await renderFormCompletion(context, res, trigger);
 		}
 
 		if (operation === 'completion' && method === 'POST') {
@@ -311,68 +284,7 @@ export class Form extends Node {
 		}
 
 		if (method === 'GET') {
-			const options = context.getNodeParameter('options', {}) as {
-				formTitle: string;
-				formDescription: string;
-				buttonLabel: string;
-			};
-
-			let title = options.formTitle;
-			if (!title) {
-				title = context.evaluateExpression(
-					`{{ $('${trigger?.name}').params.formTitle }}`,
-				) as string;
-			}
-
-			let description = options.formDescription;
-			if (!description) {
-				description = context.evaluateExpression(
-					`{{ $('${trigger?.name}').params.formDescription }}`,
-				) as string;
-			}
-
-			let buttonLabel = options.buttonLabel;
-			if (!buttonLabel) {
-				buttonLabel =
-					(context.evaluateExpression(
-						`{{ $('${trigger?.name}').params.options?.buttonLabel }}`,
-					) as string) || 'Submit';
-			}
-
-			const responseMode = 'onReceived';
-
-			let redirectUrl;
-
-			const connectedNodes = context.getChildNodes(context.getNode().name);
-
-			const hasNextPage = connectedNodes.some(
-				(node) => !node.disabled && (node.type === FORM_NODE_TYPE || node.type === WAIT_NODE_TYPE),
-			);
-
-			if (hasNextPage) {
-				redirectUrl = context.evaluateExpression('{{ $execution.resumeFormUrl }}') as string;
-			}
-
-			const appendAttribution = context.evaluateExpression(
-				`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
-			) as boolean;
-
-			renderForm({
-				context,
-				res,
-				formTitle: title,
-				formDescription: description,
-				formFields: fields,
-				responseMode,
-				mode,
-				redirectUrl,
-				appendAttribution,
-				buttonLabel,
-			});
-
-			return {
-				noWebhookResponse: true,
-			};
+			return await renderFormNode(context, res, trigger, fields, mode);
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -105,7 +105,7 @@ const completionProperties = updateDisplayOptions(
 			options: [
 				{
 					name: 'Show Completion Screen',
-					value: 'text',
+					value: 'completionScreen',
 					description: 'Show a response text to the user',
 				},
 				{
@@ -136,7 +136,7 @@ const completionProperties = updateDisplayOptions(
 			required: true,
 			displayOptions: {
 				show: {
-					respondWith: ['text'],
+					respondWith: ['completionScreen'],
 				},
 			},
 		},
@@ -150,7 +150,7 @@ const completionProperties = updateDisplayOptions(
 			},
 			displayOptions: {
 				show: {
-					respondWith: ['text'],
+					respondWith: ['completionScreen'],
 				},
 			},
 		},
@@ -163,7 +163,7 @@ const completionProperties = updateDisplayOptions(
 			options: [{ ...formTitle, required: false, displayName: 'Completion Page Title' }],
 			displayOptions: {
 				show: {
-					respondWith: ['text'],
+					respondWith: ['completionScreen'],
 				},
 			},
 		},

--- a/packages/nodes-base/nodes/Form/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/formCompletionUtils.ts
@@ -1,0 +1,41 @@
+import { type Response } from 'express';
+import {
+	type NodeTypeAndVersion,
+	type IWebhookFunctions,
+	type IWebhookResponseData,
+} from 'n8n-workflow';
+
+export const renderFormCompletion = async (
+	context: IWebhookFunctions,
+	res: Response,
+	trigger: NodeTypeAndVersion,
+): Promise<IWebhookResponseData> => {
+	const completionTitle = context.getNodeParameter('completionTitle', '') as string;
+	const completionMessage = context.getNodeParameter('completionMessage', '') as string;
+	const redirectUrl = context.getNodeParameter('redirectUrl', '') as string;
+	const options = context.getNodeParameter('options', {}) as { formTitle: string };
+
+	if (redirectUrl) {
+		res.send(
+			`<html><head><meta http-equiv="refresh" content="0; url=${redirectUrl}"></head></html>`,
+		);
+		return { noWebhookResponse: true };
+	}
+
+	let title = options.formTitle;
+	if (!title) {
+		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+	}
+	const appendAttribution = context.evaluateExpression(
+		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+	) as boolean;
+
+	res.render('form-trigger-completion', {
+		title: completionTitle,
+		message: completionMessage,
+		formTitle: title,
+		appendAttribution,
+	});
+
+	return { noWebhookResponse: true };
+};

--- a/packages/nodes-base/nodes/Form/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/formNodeUtils.ts
@@ -1,0 +1,80 @@
+import { type Response } from 'express';
+import {
+	type NodeTypeAndVersion,
+	type IWebhookFunctions,
+	FORM_NODE_TYPE,
+	WAIT_NODE_TYPE,
+	type FormFieldsParameter,
+	type IWebhookResponseData,
+} from 'n8n-workflow';
+
+import { renderForm } from './utils';
+
+export const renderFormNode = async (
+	context: IWebhookFunctions,
+	res: Response,
+	trigger: NodeTypeAndVersion,
+	fields: FormFieldsParameter,
+	mode: 'test' | 'production',
+): Promise<IWebhookResponseData> => {
+	const options = context.getNodeParameter('options', {}) as {
+		formTitle: string;
+		formDescription: string;
+		buttonLabel: string;
+	};
+
+	let title = options.formTitle;
+	if (!title) {
+		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+	}
+
+	let description = options.formDescription;
+	if (!description) {
+		description = context.evaluateExpression(
+			`{{ $('${trigger?.name}').params.formDescription }}`,
+		) as string;
+	}
+
+	let buttonLabel = options.buttonLabel;
+	if (!buttonLabel) {
+		buttonLabel =
+			(context.evaluateExpression(
+				`{{ $('${trigger?.name}').params.options?.buttonLabel }}`,
+			) as string) || 'Submit';
+	}
+
+	const responseMode = 'onReceived';
+
+	let redirectUrl;
+
+	const connectedNodes = context.getChildNodes(context.getNode().name);
+
+	const hasNextPage = connectedNodes.some(
+		(node) => !node.disabled && (node.type === FORM_NODE_TYPE || node.type === WAIT_NODE_TYPE),
+	);
+
+	if (hasNextPage) {
+		redirectUrl = context.evaluateExpression('{{ $execution.resumeFormUrl }}') as string;
+	}
+
+	const appendAttribution = context.evaluateExpression(
+		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+	) as boolean;
+
+	renderForm({
+		context,
+		res,
+		formTitle: title,
+		formDescription: description,
+		formFields: fields,
+		responseMode,
+		mode,
+		redirectUrl,
+		appendAttribution,
+		buttonLabel,
+	});
+
+	return {
+		noWebhookResponse: true,
+	};
+};

--- a/packages/nodes-base/nodes/Form/test/Form.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/Form.node.test.ts
@@ -178,7 +178,7 @@ describe('Form Node', () => {
 				if (paramName === 'operation') return 'completion';
 				if (paramName === 'useJson') return false;
 				if (paramName === 'jsonOutput') return '[]';
-				if (paramName === 'respondWith') return 'text';
+				if (paramName === 'respondWith') return 'completionScreen';
 				if (paramName === 'completionTitle') return 'Test Title';
 				if (paramName === 'completionMessage') return 'Test Message';
 				if (paramName === 'redirectUrl') return '';
@@ -221,7 +221,7 @@ describe('Form Node', () => {
 				if (paramName === 'operation') return 'completion';
 				if (paramName === 'useJson') return false;
 				if (paramName === 'jsonOutput') return '[]';
-				if (paramName === 'respondWith') return 'text';
+				if (paramName === 'respondWith') return 'completionScreen';
 				if (paramName === 'completionTitle') return 'Test Title';
 				if (paramName === 'completionMessage') return 'Test Message';
 				if (paramName === 'redirectUrl') return 'https://n8n.io';

--- a/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
@@ -40,7 +40,7 @@ describe('FormTrigger', () => {
 					formFields: { values: formFields },
 					options: {
 						appendAttribution: false,
-						respondWithOptions: { values: { respondWith: 'text' } },
+						respondWithOptions: { values: { respondWith: 'completionScreen' } },
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -397,7 +397,7 @@ export async function formWebhook(
 		ignoreBots?: boolean;
 		respondWithOptions?: {
 			values: {
-				respondWith: 'text' | 'redirect';
+				respondWith: 'completionScreen' | 'redirect';
 				formSubmittedText: string;
 				redirectUrl: string;
 			};
@@ -451,7 +451,7 @@ export async function formWebhook(
 
 		if (options.respondWithOptions) {
 			const values = (options.respondWithOptions as IDataObject).values as IDataObject;
-			if (values.respondWith === 'text') {
+			if (values.respondWith === 'completionScreen') {
 				formSubmittedText = values.formSubmittedText as string;
 			}
 			if (values.respondWith === 'redirect') {

--- a/packages/nodes-base/nodes/Form/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils.ts
@@ -178,7 +178,7 @@ export function prepareFormData({
 	return formData;
 }
 
-const checkResponseModeConfiguration = (context: IWebhookFunctions) => {
+const validateResponseModeConfiguration = (context: IWebhookFunctions) => {
 	const responseMode = context.getNodeParameter('responseMode', 'onReceived') as string;
 	const connectedNodes = context.getChildNodes(context.getNode().name);
 
@@ -437,7 +437,7 @@ export async function formWebhook(
 	);
 	const method = context.getRequestObject().method;
 
-	checkResponseModeConfiguration(context);
+	validateResponseModeConfiguration(context);
 
 	//Show the form on GET request
 	if (method === 'GET') {

--- a/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
+++ b/packages/nodes-base/nodes/RespondToWebhook/RespondToWebhook.node.ts
@@ -21,6 +21,13 @@ import {
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
+import {
+	inputFieldName,
+	responseCode,
+	responseDataSourceDescription,
+	responseHeaders,
+} from '@utils/respondWith.descriptions';
+
 import { formatPrivateKey, generatePairedItemData } from '../../utils/utilities';
 
 export class RespondToWebhook implements INodeType {
@@ -189,44 +196,8 @@ export class RespondToWebhook implements INodeType {
 				placeholder: 'e.g. Workflow completed',
 				description: 'The HTTP response text data',
 			},
-			{
-				displayName: 'Response Data Source',
-				name: 'responseDataSource',
-				type: 'options',
-				displayOptions: {
-					show: {
-						respondWith: ['binary'],
-					},
-				},
-				options: [
-					{
-						name: 'Choose Automatically From Input',
-						value: 'automatically',
-						description: 'Use if input data will contain a single piece of binary data',
-					},
-					{
-						name: 'Specify Myself',
-						value: 'set',
-						description: 'Enter the name of the input field the binary data will be in',
-					},
-				],
-				default: 'automatically',
-			},
-			{
-				displayName: 'Input Field Name',
-				name: 'inputFieldName',
-				type: 'string',
-				required: true,
-				default: 'data',
-				displayOptions: {
-					show: {
-						respondWith: ['binary'],
-						responseDataSource: ['set'],
-					},
-				},
-				description: 'The name of the node input field with the binary data',
-			},
-
+			responseDataSourceDescription,
+			inputFieldName,
 			{
 				displayName: 'Options',
 				name: 'options',
@@ -234,50 +205,8 @@ export class RespondToWebhook implements INodeType {
 				placeholder: 'Add option',
 				default: {},
 				options: [
-					{
-						displayName: 'Response Code',
-						name: 'responseCode',
-						type: 'number',
-						typeOptions: {
-							minValue: 100,
-							maxValue: 599,
-						},
-						default: 200,
-						description: 'The HTTP response code to return. Defaults to 200.',
-					},
-					{
-						displayName: 'Response Headers',
-						name: 'responseHeaders',
-						placeholder: 'Add Response Header',
-						description: 'Add headers to the webhook response',
-						type: 'fixedCollection',
-						typeOptions: {
-							multipleValues: true,
-						},
-						default: {},
-						options: [
-							{
-								name: 'entries',
-								displayName: 'Entries',
-								values: [
-									{
-										displayName: 'Name',
-										name: 'name',
-										type: 'string',
-										default: '',
-										description: 'Name of the header',
-									},
-									{
-										displayName: 'Value',
-										name: 'value',
-										type: 'string',
-										default: '',
-										description: 'Value of the header',
-									},
-								],
-							},
-						],
-					},
+					responseCode,
+					responseHeaders,
 					{
 						displayName: 'Put Response in Field',
 						name: 'responseKey',

--- a/packages/nodes-base/utils/respondWith.descriptions.ts
+++ b/packages/nodes-base/utils/respondWith.descriptions.ts
@@ -1,0 +1,86 @@
+import { type INodeProperties } from 'n8n-workflow';
+
+export const responseHeaders: INodeProperties = {
+	displayName: 'Response Headers',
+	name: 'responseHeaders',
+	placeholder: 'Add Response Header',
+	description: 'Add headers to the webhook response',
+	type: 'fixedCollection',
+	typeOptions: {
+		multipleValues: true,
+	},
+	default: {},
+	options: [
+		{
+			name: 'entries',
+			displayName: 'Entries',
+			values: [
+				{
+					displayName: 'Name',
+					name: 'name',
+					type: 'string',
+					default: '',
+					description: 'Name of the header',
+				},
+				{
+					displayName: 'Value',
+					name: 'value',
+					type: 'string',
+					default: '',
+					description: 'Value of the header',
+				},
+			],
+		},
+	],
+};
+
+export const responseCode: INodeProperties = {
+	displayName: 'Response Code',
+	name: 'responseCode',
+	type: 'number',
+	typeOptions: {
+		minValue: 100,
+		maxValue: 599,
+	},
+	default: 200,
+	description: 'The HTTP response code to return. Defaults to 200.',
+};
+
+export const responseDataSourceDescription: INodeProperties = {
+	displayName: 'Response Data Source',
+	name: 'responseDataSource',
+	type: 'options',
+	displayOptions: {
+		show: {
+			respondWith: ['binary'],
+		},
+	},
+	options: [
+		{
+			name: 'Choose Automatically From Input',
+			value: 'automatically',
+			description: 'Use if input data will contain a single piece of binary data',
+		},
+		{
+			name: 'Specify Myself',
+			value: 'set',
+			description: 'Enter the name of the input field the binary data will be in',
+		},
+	],
+	default: 'automatically',
+};
+
+export const inputFieldName: INodeProperties = {
+	displayName: 'Input Field Name',
+	name: 'inputFieldName',
+	type: 'string',
+	required: true,
+	default: 'data',
+	displayOptions: {
+		show: {
+			respondWith: ['binary'],
+			responseDataSource: ['set'],
+		},
+	},
+	description: 'The name of the node input field with the binary data',
+};


### PR DESCRIPTION
## Summary

Since we will be having the exact same design for Form Completion, it makes sense to move out common elements

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2326/move-out-commonalities-with-respond-to-webhook-and-form-completion


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
