### PR TITLE
ci: Fix Credentials tests on node 18 (no-changelog)

### DIFF
--- a/packages/core/src/__tests__/credentials.test.ts
+++ b/packages/core/src/__tests__/credentials.test.ts
@@ -92,9 +92,8 @@ describe('Credentials', () => {
 			} catch (error) {
 				expect(error.constructor.name).toBe('CredentialDataError');
 				expect(error.extra).toEqual({ ...nodeCredentials, type: credentialType });
-				expect(error.cause).toEqual(
-					new SyntaxError('Unexpected token \'i\', "invalid-json-string" is not valid JSON'),
-				);
+				expect(error.cause).toBeInstanceOf(SyntaxError);
+				expect(error.cause.message).toMatch('Unexpected token ');
 			}
 		});
 


### PR DESCRIPTION
## Summary

Node.js 18 throws a SyntaxError with a slightly different error message on JSON parsing failures.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
