### PR TITLE
fix(GitHub Node): Don't truncate filenames retrieved from GitHub

### DIFF
--- a/packages/core/src/__tests__/node-execute-functions.test.ts
+++ b/packages/core/src/__tests__/node-execute-functions.test.ts
@@ -33,6 +33,7 @@ import {
 	parseContentType,
 	parseIncomingMessage,
 	parseRequestObject,
+	prepareBinaryData,
 	proxyRequestToAxios,
 	removeEmptyBody,
 	setBinaryDataBuffer,
@@ -92,6 +93,27 @@ describe('NodeExecuteFunctions', () => {
 			);
 
 			expect(getBinaryDataBufferResponse).toEqual(inputData);
+		});
+
+		test('test prepareBinaryData parses filenames correctly', async () => {
+			const filenameExpected = [
+				{
+					filename: 't?ext',
+					expected: 't?ext',
+				},
+				{
+					filename: 'no-symbol',
+					expected: 'no-symbol',
+				},
+			];
+
+			for (const { filename, expected } of filenameExpected) {
+				const binaryData: Buffer = Buffer.from('This is some binary data', 'utf8');
+
+				const result = await prepareBinaryData(binaryData, 'workflowId', 'executionId', filename);
+
+				expect(result.fileName).toEqual(expected);
+			}
 		});
 
 		test("test getBinaryDataBuffer(...) & setBinaryDataBuffer(...) methods in 'filesystem' mode", async () => {

--- a/packages/core/src/node-execute-functions.ts
+++ b/packages/core/src/node-execute-functions.ts
@@ -1201,12 +1201,7 @@ export async function prepareBinaryData(
 		data: '',
 	};
 
-	if (filePath) {
-		if (filePath.includes('?')) {
-			// Remove maybe present query parameters
-			filePath = filePath.split('?').shift();
-		}
-
+ 	if (filePath) {
 		const filePathParts = path.parse(filePath as string);
 
 		if (filePathParts.dir !== '') {

--- a/packages/core/src/node-execute-functions.ts
+++ b/packages/core/src/node-execute-functions.ts
@@ -1202,7 +1202,7 @@ export async function prepareBinaryData(
 	};
 
 	if (filePath) {
-		const filePathParts = path.parse(filePath as string);
+		const filePathParts = path.parse(filePath);
 
 		if (filePathParts.dir !== '') {
 			returnData.directory = filePathParts.dir;

--- a/packages/core/src/node-execute-functions.ts
+++ b/packages/core/src/node-execute-functions.ts
@@ -1201,7 +1201,7 @@ export async function prepareBinaryData(
 		data: '',
 	};
 
- 	if (filePath) {
+	if (filePath) {
 		const filePathParts = path.parse(filePath as string);
 
 		if (filePathParts.dir !== '') {


### PR DESCRIPTION
## Summary

Allows returned files from GitHub to maintain full filename when they have a question mark, instead of truncating them.

To test: Set GitHub noe to GET file. Fetch a file with a question mark (?) in the filename.

![Captura de ecrã 2025-01-29 144435](https://github.com/user-attachments/assets/27fe5a32-994a-4598-a21b-b375af4047b2)

![Captura de ecrã 2025-01-29 145249](https://github.com/user-attachments/assets/31c3b9e7-5781-4e79-afc7-8cf09d1f7163)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2164/github-node-special-character-in-file-path-is-ignored-and-path-is

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
