### PR TITLE
ci: Remove lefthook path to make it accessible on Windows

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,14 +2,14 @@ pre-commit:
   commands:
     biome_check:
       glob: 'packages/**/*.{js,ts,json}'
-      run: ./node_modules/.bin/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
       skip:
         - merge
         - rebase
     prettier_check:
       glob: 'packages/**/*.{vue,yml,md,css,scss}'
-      run: ./node_modules/.bin/prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      run: prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
       skip:
         - merge

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
         - rebase
     prettier_check:
       glob: 'packages/**/*.{vue,yml,md,css,scss}'
-      run: prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
+      run: pnpm prettier --write --ignore-unknown --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
       skip:
         - merge

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   commands:
     biome_check:
       glob: 'packages/**/*.{js,ts,json}'
-      run: biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
       skip:
         - merge


### PR DESCRIPTION
## Summary

Remove path on lefthook.yml to allow it to be accessible with windows

To test: change a typeScript file, save and run git commit command on Windows

![Captura de ecrã 2025-01-29 165325](https://github.com/user-attachments/assets/9e24ed03-470a-4726-a7fb-8ddd11daf3e8)

![Captura de ecrã 2025-01-29 164929](https://github.com/user-attachments/assets/fa9543f3-1d7b-49a2-9e10-fe3270e22865)
 
Note to reviewer: Please test on Linux/mac to confirm it doesn't block them

## Related Linear tickets, Github issues, and Community forum posts
None


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
