### PR TITLE
fix: Adds SSL credentials to SqlAgent MySQL handler

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/mysql.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/mysql.ts
@@ -12,6 +12,9 @@ export async function getMysqlDataSource(this: IExecuteFunctions): Promise<DataS
 		password: credentials.password as string,
 		database: credentials.database as string,
 		ssl: {
+			ca: credentials.caCertificate as string,
+			cert: credentials.clientCertificate as string,
+			key: credentials.clientPrivateKey as string,
 			rejectUnauthorized: credentials.ssl as boolean,
 		},
 	});


### PR DESCRIPTION
Adds SSL credentials to MySQL SQL Agent DataSource.

## Summary

This simply adds the specified SSL keys to the DataSource of the MySQL handler in the SQL Agent. I think the diff is simple and self-explanatory.

## Related Linear tickets, Github issues, and Community forum posts

fixes #12828 

## Review / Merge checklist

- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [-] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (Doesn't apply)
- [-] Tests included. (There's no tests of the handlers here, I'm sorry I have no time to implement them.)
- [-] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported) (Doesn't apply)
 