### PR TITLE
fix(Code Node): Do not validate code within comments

### DIFF
--- a/packages/nodes-base/nodes/Code/JsCodeValidator.ts
+++ b/packages/nodes-base/nodes/Code/JsCodeValidator.ts
@@ -13,7 +13,7 @@ export function validateNoDisallowedMethodsInRunForEach(code: string, itemIndex:
 
 		const lineNumber =
 			code.split('\n').findIndex((line) => {
-				return line.includes(disallowedMethod) && !line.startsWith('//') && !line.startsWith('*');
+				return line.includes(disallowedMethod) && !line.startsWith('//') && !line.startsWith('/*');
 			}) + 1;
 
 		const disallowedMethodFound = lineNumber !== 0;

--- a/packages/nodes-base/nodes/Code/JsCodeValidator.ts
+++ b/packages/nodes-base/nodes/Code/JsCodeValidator.ts
@@ -13,7 +13,13 @@ export function validateNoDisallowedMethodsInRunForEach(code: string, itemIndex:
 
 		const lineNumber =
 			code.split('\n').findIndex((line) => {
-				return line.includes(disallowedMethod) && !line.startsWith('//') && !line.startsWith('/*');
+				line = line.trimStart();
+				return (
+					line.includes(disallowedMethod) &&
+					!line.startsWith('//') &&
+					!line.startsWith('/*') &&
+					!line.startsWith('*')
+				);
 			}) + 1;
 
 		const disallowedMethodFound = lineNumber !== 0;

--- a/packages/nodes-base/nodes/Code/test/JsCodeValidator.test.ts
+++ b/packages/nodes-base/nodes/Code/test/JsCodeValidator.test.ts
@@ -6,7 +6,18 @@ describe('JsCodeValidator', () => {
 			const code = [
 				"// Add a new field called 'myNewField' to the JSON of the item",
 				'$input.item.json.myNewField = 1;',
-				'// const xxx = $input.all()',
+				' // const xxx = $input.all()',
+				'return $input.item;',
+			].join('\n');
+
+			expect(() => validateNoDisallowedMethodsInRunForEach(code, 0)).not.toThrow();
+		});
+
+		it('should not throw error if disallow method is used in single multi line comments', () => {
+			const code = [
+				"// Add a new field called 'myNewField' to the JSON of the item",
+				'$input.item.json.myNewField = 1;',
+				'/** const xxx = $input.all()*/',
 				'return $input.item;',
 			].join('\n');
 
@@ -17,7 +28,9 @@ describe('JsCodeValidator', () => {
 			const code = [
 				"// Add a new field called 'myNewField' to the JSON of the item",
 				'$input.item.json.myNewField = 1;',
-				'/** const xxx = $input.all()*/',
+				'/**',
+				'*const xxx = $input.all()',
+				'*/',
 				'return $input.item;',
 			].join('\n');
 

--- a/packages/nodes-base/nodes/Code/test/JsCodeValidator.test.ts
+++ b/packages/nodes-base/nodes/Code/test/JsCodeValidator.test.ts
@@ -1,0 +1,38 @@
+import { validateNoDisallowedMethodsInRunForEach } from '../JsCodeValidator';
+
+describe('JsCodeValidator', () => {
+	describe('validateNoDisallowedMethodsInRunForEach', () => {
+		it('should not throw error if disallow method is used within single line comments', () => {
+			const code = [
+				"// Add a new field called 'myNewField' to the JSON of the item",
+				'$input.item.json.myNewField = 1;',
+				'// const xxx = $input.all()',
+				'return $input.item;',
+			].join('\n');
+
+			expect(() => validateNoDisallowedMethodsInRunForEach(code, 0)).not.toThrow();
+		});
+
+		it('should not throw error if disallow method is used within multi line comments', () => {
+			const code = [
+				"// Add a new field called 'myNewField' to the JSON of the item",
+				'$input.item.json.myNewField = 1;',
+				'/** const xxx = $input.all()*/',
+				'return $input.item;',
+			].join('\n');
+
+			expect(() => validateNoDisallowedMethodsInRunForEach(code, 0)).not.toThrow();
+		});
+
+		it('should throw error if disallow method is used', () => {
+			const code = [
+				"// Add a new field called 'myNewField' to the JSON of the item",
+				'$input.item.json.myNewField = 1;',
+				'const xxx = $input.all()',
+				'return $input.item;',
+			].join('\n');
+
+			expect(() => validateNoDisallowedMethodsInRunForEach(code, 0)).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

We were excluding single line comments that start with `//`, but not multi line ones that start with `/*`

## Before

![CleanShot 2025-01-29 at 20 18 59@2x](https://github.com/user-attachments/assets/b0af43c6-6b09-491e-937e-43b37ee39dfc)

## Now

![CleanShot 2025-01-29 at 20 19 35@2x](https://github.com/user-attachments/assets/5c66db81-bbcb-4fe4-b16b-7aa42ec96eb1)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3136/community-issue-validation-works-on-multiline-commented-code

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
