### PR TITLE
fix(editor): SchemaView renders duplicate structures properly

### DIFF
--- a/packages/editor-ui/src/composables/useDataSchema.test.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.test.ts
@@ -684,4 +684,27 @@ describe('useFlattenSchema', () => {
 			}).length,
 		).toBe(3);
 	});
+
+	it('items ids should be unique', () => {
+		const { flattenSchema } = useFlattenSchema();
+		const schema: Schema = {
+			path: '',
+			type: 'object',
+			value: [
+				{
+					key: 'index',
+					type: 'number',
+					value: '0',
+					path: '.index',
+				},
+			],
+		};
+		const node1 = { name: 'First Node', type: 'any' };
+		const node2 = { name: 'Second Node', type: 'any' };
+
+		const node1Schema = flattenSchema({ schema, node: node1, depth: 1 });
+		const node2Schema = flattenSchema({ schema, node: node2, depth: 1 });
+
+		expect(node1Schema[0].id).not.toBe(node2Schema[0].id);
+	});
 });

--- a/packages/editor-ui/src/composables/useDataSchema.ts
+++ b/packages/editor-ui/src/composables/useDataSchema.ts
@@ -282,6 +282,8 @@ export const useFlattenSchema = () => {
 			path: schema.path,
 		});
 
+		const id = `${node.name}-${expression}`;
+
 		if (Array.isArray(schema.value)) {
 			const items: RenderItem[] = [];
 
@@ -293,14 +295,14 @@ export const useFlattenSchema = () => {
 					depth,
 					level,
 					icon: getIconBySchemaType(schema.type),
-					id: expression,
+					id,
 					collapsable: true,
 					nodeType: node.type,
 					type: 'item',
 				});
 			}
 
-			if (closedNodes.value.has(expression)) {
+			if (closedNodes.value.has(id)) {
 				return items;
 			}
 
@@ -327,7 +329,7 @@ export const useFlattenSchema = () => {
 					level,
 					depth,
 					value: shorten(schema.value, 600, 0),
-					id: expression,
+					id,
 					icon: getIconBySchemaType(schema.type),
 					collapsable: false,
 					nodeType: node.type,


### PR DESCRIPTION
## Summary

data with the same structure at the same depth will have the same ids.

the ids are now a combination of the expression and the node name

# BEFORE
![image](https://github.com/user-attachments/assets/a01fd34c-b1f1-4ec6-b58a-5bbc440af41d)


# AFTER
![image](https://github.com/user-attachments/assets/99c6f07f-d404-4eb6-891d-1b75202105b7)


## Related Linear tickets, Github issues, and Community forum posts


[PAY-2554](https://linear.app/n8n/issue/PAY-2554/schema-view-is-missing)

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
