### PR TITLE
fix(core): Fix empty node execution stack

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1221,17 +1221,8 @@ export class WorkflowExecute {
 			});
 		}
 
+		/** Node execution stack will be empty for an execution containing only Chat Trigger. */
 		const startNode = this.runExecutionData.executionData.nodeExecutionStack.at(0)?.node.name;
-
-		if (!startNode) {
-			throw new ApplicationError('Failed to run workflow due to empty node execution stack', {
-				extra: {
-					workflowId: workflow.id,
-					executionId: this.additionalData.executionId,
-					mode: this.mode,
-				},
-			});
-		}
 
 		let destinationNode: string | undefined;
 		if (this.runExecutionData.startData && this.runExecutionData.startData.destinationNode) {


### PR DESCRIPTION
## Context

We have a persistent issue with `Cannot read properties of undefined (reading 'node')` (see [Sentry](https://n8nio.sentry.io/issues/6130480643)) originally coming from [this line](https://github.com/n8n-io/n8n/pull/12525/files#diff-0bfa6f1919bce33f0a8185d4496af9b38028eee2ed829ae01b225e2ff42a294bL1213). 

This means that in some cases `nodeExecutionStack` is an empty array, but we always expect it to have at least one node. It turns out that there is an exception, namely an execution where the only node to run is a Chat Trigger is one such case. Ideally there should be no exceptions, but I have no context on whether this exception is necessary.

In #12525 we added a check to catch this case not knowing about this Chat Trigger exception, switching from `nodeExecutionStack[0]` to `nodeExecutionStack.at(0)?.` to report it cleanly. 

## Summary

This PR removes the check but keeps the `.at(0)?.` optional access to allow this case to go through. See [before without check](https://share.cleanshot.com/jTBCrFbz), [before with check](https://share.cleanshot.com/rR2Zq25B), and [after this PR](https://share.cleanshot.com/4Q3TWZMY).

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.sentry.io/issues/6224246597
https://n8nio.sentry.io/issues/6130480643

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. ← Sadly the engine is not easily testable at the moment.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
