### PR TITLE
fix(editor): Allow switch to `Fixed` for boolean and number parameters with invalid expressions

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/ParameterInput.test.ts
@@ -8,6 +8,7 @@ import { waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import type { useNodeTypesStore } from '@/stores/nodeTypes.store';
 import { cleanupAppModals, createAppModals } from '@/__tests__/utils';
+import { createEventBus } from 'n8n-design-system';
 
 let mockNdvState: Partial<ReturnType<typeof useNDVStore>>;
 let mockNodeTypesState: Partial<ReturnType<typeof useNodeTypesStore>>;
@@ -232,5 +233,68 @@ describe('ParameterInput.vue', () => {
 		expect(input).toHaveValue('Set up credential to see options');
 
 		expect(emitted('update')).toBeUndefined();
+	});
+
+	test('should reset bool on eventBus:removeExpression', async () => {
+		const eventBus = createEventBus();
+		const { emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'aSwitch',
+				parameter: {
+					displayName: 'A Switch',
+					name: 'aSwitch',
+					type: 'boolean',
+					default: true,
+				},
+				modelValue: '={{ }}', // note that this makes a syntax error
+				eventBus,
+			},
+		});
+
+		eventBus.emit('optionSelected', 'removeExpression');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: true })]);
+	});
+
+	test('should reset number on eventBus:removeExpression', async () => {
+		const eventBus = createEventBus();
+		const { emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'aNum',
+				parameter: {
+					displayName: 'A Num',
+					name: 'aNum',
+					type: 'number',
+					default: 6,
+				},
+				modelValue: '={{ }}', // note that this makes a syntax error
+				eventBus,
+			},
+		});
+
+		eventBus.emit('optionSelected', 'removeExpression');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: 6 })]);
+	});
+
+	test('should reset string on eventBus:removeExpression', async () => {
+		const eventBus = createEventBus();
+		const { emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'aStr',
+				parameter: {
+					displayName: 'A Str',
+					name: 'aStr',
+					type: 'string',
+					default: 'some default',
+				},
+				modelValue: '={{ }}', // note that this makes a syntax error
+				eventBus,
+			},
+		});
+
+		eventBus.emit('optionSelected', 'removeExpression');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: '{{ }}' })]);
 	});
 });

--- a/packages/editor-ui/src/components/ParameterInput.test.ts
+++ b/packages/editor-ui/src/components/ParameterInput.test.ts
@@ -256,6 +256,27 @@ describe('ParameterInput.vue', () => {
 		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: true })]);
 	});
 
+	test('should reset bool with undefined evaluation on eventBus:removeExpression', async () => {
+		const eventBus = createEventBus();
+		const { emitted } = renderComponent(ParameterInput, {
+			pinia: createTestingPinia(),
+			props: {
+				path: 'aSwitch',
+				parameter: {
+					displayName: 'A Switch',
+					name: 'aSwitch',
+					type: 'boolean',
+					default: true,
+				},
+				modelValue: undefined,
+				eventBus,
+			},
+		});
+
+		eventBus.emit('optionSelected', 'removeExpression');
+		expect(emitted('update')).toContainEqual([expect.objectContaining({ value: true })]);
+	});
+
 	test('should reset number on eventBus:removeExpression', async () => {
 		const eventBus = createEventBus();
 		const { emitted } = renderComponent(ParameterInput, {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -908,11 +908,17 @@ async function optionSelected(command: string) {
 		if (isResourceLocatorParameter.value && isResourceLocatorValue(props.modelValue)) {
 			valueChanged({ __rl: true, value, mode: props.modelValue.mode });
 		} else {
-			let newValue = typeof value !== 'undefined' ? value : null;
+			let newValue: NodeParameterValueType =
+				typeof value !== 'undefined' ? (value as NodeParameterValueType) : null;
 
 			if (props.parameter.type === 'string') {
 				// Strip the '=' from the beginning
 				newValue = modelValueString.value ? modelValueString.value.toString().substring(1) : null;
+			} else if (newValue === null) {
+				// Invalid expressions land here
+				if (['number', 'boolean'].includes(props.parameter.type)) {
+					newValue = props.parameter.default;
+				}
 			}
 			valueChanged(newValue);
 		}

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -908,7 +908,7 @@ async function optionSelected(command: string) {
 		if (isResourceLocatorParameter.value && isResourceLocatorValue(props.modelValue)) {
 			valueChanged({ __rl: true, value, mode: props.modelValue.mode });
 		} else {
-			let newValue: NodeParameterValueType | {} = typeof value === 'undefined' ? null : value;
+			let newValue: NodeParameterValueType | {} = typeof value !== 'undefined' ? value : null;
 
 			if (props.parameter.type === 'string') {
 				// Strip the '=' from the beginning

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -908,8 +908,7 @@ async function optionSelected(command: string) {
 		if (isResourceLocatorParameter.value && isResourceLocatorValue(props.modelValue)) {
 			valueChanged({ __rl: true, value, mode: props.modelValue.mode });
 		} else {
-			let newValue: NodeParameterValueType =
-				typeof value !== 'undefined' ? (value as NodeParameterValueType) : null;
+			let newValue: NodeParameterValueType | {} = typeof value === 'undefined' ? null : value;
 
 			if (props.parameter.type === 'string') {
 				// Strip the '=' from the beginning


### PR DESCRIPTION
## Summary

Clicking `Fixed` on parameters in expression mode with an invalid (or result `undefined`) expression no-opted, as `null` was not a valid value for booleans or numbers. Video in linear issue.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3147/bug-cannot-switch-number-or-boolean-parameter-back-to-fixed-if


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
