### PR TITLE
fix(Basic LLM Chain Node): Use correct mimetype for binary data

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -88,6 +88,11 @@ async function getImageMessage(
 		NodeConnectionType.AiLanguageModel,
 		0,
 	)) as BaseLanguageModel;
+	if (!binaryData.mimeType?.startsWith('image/'))
+		throw new NodeOperationError(
+			context.getNode(),
+			`${binaryData.mimeType} is not a supported type of binary data. Only images are supported.`,
+		);
 	const dataURI = `data:${binaryData.mimeType};base64,${bufferData.toString('base64')}`;
 
 	const directUriModels = [ChatGoogleGenerativeAI, ChatOllama];

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -33,8 +33,8 @@ import type { N8nOutputParser } from '@utils/output_parsers/N8nOutputParser';
 import { getOptionalOutputParsers } from '@utils/output_parsers/N8nOutputParser';
 import { getTemplateNoticeField } from '@utils/sharedFields';
 import { getTracingConfig } from '@utils/tracing';
-import { dataUriFromImageData, UnsupportedMimeTypeError } from './utils';
 
+import { dataUriFromImageData, UnsupportedMimeTypeError } from './utils';
 import {
 	getCustomErrorMessage as getCustomOpenAiErrorMessage,
 	isOpenAiError,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -88,7 +88,7 @@ async function getImageMessage(
 		NodeConnectionType.AiLanguageModel,
 		0,
 	)) as BaseLanguageModel;
-	const dataURI = `data:image/jpeg;base64,${bufferData.toString('base64')}`;
+	const dataURI = `data:${binaryData.mimeType};base64,${bufferData.toString('base64')}`;
 
 	const directUriModels = [ChatGoogleGenerativeAI, ChatOllama];
 	const imageUrl = directUriModels.some((i) => model instanceof i)

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/utils.test.ts
@@ -1,0 +1,23 @@
+import { mock } from 'jest-mock-extended';
+import type { IBinaryData } from 'n8n-workflow';
+
+import { dataUriFromImageData, UnsupportedMimeTypeError } from '../utils';
+
+describe('dataUriFromImageData', () => {
+	it('should not throw an error on images', async () => {
+		const mockBuffer = Buffer.from('Test data');
+		const mockBinaryData = mock<IBinaryData>({ mimeType: 'image/jpeg' });
+
+		const dataUri = dataUriFromImageData(mockBinaryData, mockBuffer);
+		expect(dataUri).toBe('data:image/jpeg;base64,VGVzdCBkYXRh');
+	});
+
+	it('should throw an UnsupportetMimeTypeError on non-images', async () => {
+		const mockBuffer = Buffer.from('Test data');
+		const mockBinaryData = mock<IBinaryData>({ mimeType: 'text/plain' });
+
+		expect(() => {
+			dataUriFromImageData(mockBinaryData, mockBuffer);
+		}).toThrow(UnsupportedMimeTypeError);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/utils.ts
@@ -1,0 +1,12 @@
+import type { IBinaryData } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+export class UnsupportedMimeTypeError extends ApplicationError {}
+
+export function dataUriFromImageData(binaryData: IBinaryData, bufferData: Buffer) {
+	if (!binaryData.mimeType?.startsWith('image/'))
+		throw new UnsupportedMimeTypeError(
+			`${binaryData.mimeType} is not a supported type of binary data. Only images are supported.`,
+		);
+	return `data:${binaryData.mimeType};base64,${bufferData.toString('base64')}`;
+}


### PR DESCRIPTION
## Summary

The binary data that was being passed from the Basic LLM Chain was forced to a JPEG mime type. This PR changes the passed mime type to be derived from the retrieved binary data.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/issues/12955
closes #12955

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
