### PR TITLE
feat(OpenAI Chat Model Node, OpenAI Node): Include o3 models in model selection

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -108,6 +108,7 @@ export class LmChatOpenAi implements INodeType {
 												($credentials?.url && !$credentials.url.includes('api.openai.com')) ||
 												$responseItem.id.startsWith('ft:') ||
 												$responseItem.id.startsWith('o1') ||
+												$responseItem.id.startsWith('o3') ||
 												($responseItem.id.startsWith('gpt-') && !$responseItem.id.includes('instruct'))
 											}}`,
 										},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/methods/loadModels.ts
@@ -19,6 +19,7 @@ export async function searchModels(
 			(baseURL && !baseURL.includes('api.openai.com')) ||
 			model.id.startsWith('ft:') ||
 			model.id.startsWith('o1') ||
+			model.id.startsWith('o3') ||
 			(model.id.startsWith('gpt-') && !model.id.includes('instruct'));
 
 		if (!filter) return isValidModel;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/methods/listSearch.ts
@@ -84,7 +84,8 @@ export async function modelSearch(
 			isCustomAPI ||
 			model.id.startsWith('gpt-') ||
 			model.id.startsWith('ft:') ||
-			model.id.startsWith('o1'),
+			model.id.startsWith('o1') ||
+			model.id.startsWith('o3'),
 	)(this, filter);
 }
 


### PR DESCRIPTION
## Summary

The model-filters didn't include the o3 models yet. This change fixes that. This allows you to use o3-mini now.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
