### PR TITLE
feat(core): Handle Declarative nodes more like regular nodes

### DIFF
--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -7,6 +7,7 @@ import { ApplicationError, NodeHelpers } from 'n8n-workflow';
 import { join, dirname } from 'path';
 
 import { LoadNodesAndCredentials } from './load-nodes-and-credentials';
+import { ExecuteContext, RoutingNode } from 'n8n-core';
 
 @Service()
 export class NodeTypes implements INodeTypes {
@@ -60,6 +61,13 @@ export class NodeTypes implements INodeTypes {
 			description: { value: clonedDescription },
 		}) as INodeType;
 		const tool = this.loadNodesAndCredentials.convertNodeToAiTool(clonedNode);
+		if (!tool.execute) {
+			tool.execute = async function (this: ExecuteContext) {
+				const routingNode = new RoutingNode(this, tool);
+				const data = await routingNode.runNode();
+				return data ?? [];
+			};
+		}
 		loadedNodes[nodeType + 'Tool'] = { sourcePath: '', type: tool };
 		return tool;
 	}

--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -2,12 +2,13 @@ import { Service } from '@n8n/di';
 import type { NeededNodeType } from '@n8n/task-runner';
 import type { Dirent } from 'fs';
 import { readdir } from 'fs/promises';
+import { RoutingNode } from 'n8n-core';
+import type { ExecuteContext } from 'n8n-core';
 import type { INodeType, INodeTypeDescription, INodeTypes, IVersionedNodeType } from 'n8n-workflow';
 import { ApplicationError, NodeHelpers } from 'n8n-workflow';
 import { join, dirname } from 'path';
 
 import { LoadNodesAndCredentials } from './load-nodes-and-credentials';
-import { ExecuteContext, RoutingNode } from 'n8n-core';
 
 @Service()
 export class NodeTypes implements INodeTypes {

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -8,8 +8,8 @@ import get from 'lodash/get';
 import {
 	CredentialTestContext,
 	ErrorReporter,
+	ExecuteContext,
 	Logger,
-	NodeExecuteFunctions,
 	RoutingNode,
 	isObjectLiteral,
 } from 'n8n-core';
@@ -30,6 +30,7 @@ import type {
 	INodeTypes,
 	ICredentialTestFunctions,
 	IDataObject,
+	IExecuteData,
 } from 'n8n-workflow';
 import { VersionedNodeType, NodeHelpers, Workflow, ApplicationError } from 'n8n-workflow';
 
@@ -293,25 +294,24 @@ export class CredentialsTester {
 
 		const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id, node.parameters);
 
-		const routingNode = new RoutingNode(
+		const executeData: IExecuteData = { node, data: {}, source: null };
+		const executeFunctions = new ExecuteContext(
 			workflow,
 			node,
-			connectionInputData,
-			runExecutionData ?? null,
 			additionalData,
 			mode,
+			runExecutionData,
+			runIndex,
+			connectionInputData,
+			inputData,
+			executeData,
+			[],
 		);
+		const routingNode = new RoutingNode(executeFunctions, nodeTypeCopy, credentialsDecrypted);
 
 		let response: INodeExecutionData[][] | null | undefined;
-
 		try {
-			response = await routingNode.runNode(
-				inputData,
-				runIndex,
-				nodeTypeCopy,
-				{ node, data: {}, source: null },
-				credentialsDecrypted,
-			);
+			response = await routingNode.runNode();
 		} catch (error) {
 			this.errorReporter.error(error);
 			// Do not fail any requests to allow custom error messages and

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -6,6 +6,7 @@
 import { Service } from '@n8n/di';
 import get from 'lodash/get';
 import {
+	CredentialTestContext,
 	ErrorReporter,
 	Logger,
 	NodeExecuteFunctions,
@@ -205,9 +206,8 @@ export class CredentialsTester {
 
 		if (typeof credentialTestFunction === 'function') {
 			// The credentials get tested via a function that is defined on the node
-			const credentialTestFunctions = NodeExecuteFunctions.getCredentialTestFunctions();
-
-			return credentialTestFunction.call(credentialTestFunctions, credentialsDecrypted);
+			const context = new CredentialTestContext();
+			return credentialTestFunction.call(context, credentialsDecrypted);
 		}
 
 		// Credentials get tested via request instructions

--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -744,14 +744,17 @@ describe('RoutingNode', () => {
 					nodeTypes,
 				});
 
-				const routingNode = new RoutingNode(
+				const executeFunctions = mock<executionContexts.ExecuteContext>();
+				Object.assign(executeFunctions, {
+					runIndex,
+					additionalData,
 					workflow,
 					node,
-					connectionInputData,
-					runExecutionData ?? null,
-					additionalData,
 					mode,
-				);
+					connectionInputData,
+					runExecutionData,
+				});
+				const routingNode = new RoutingNode(executeFunctions, nodeType);
 
 				const executeSingleFunctions = getExecuteSingleFunctions(
 					workflow,
@@ -1947,15 +1950,6 @@ describe('RoutingNode', () => {
 					nodeTypes,
 				});
 
-				const routingNode = new RoutingNode(
-					workflow,
-					node,
-					connectionInputData,
-					runExecutionData ?? null,
-					additionalData,
-					mode,
-				);
-
 				const executeData = {
 					data: {},
 					node,
@@ -1963,6 +1957,18 @@ describe('RoutingNode', () => {
 				} as IExecuteData;
 
 				const executeFunctions = mock<executionContexts.ExecuteContext>();
+				Object.assign(executeFunctions, {
+					executeData,
+					inputData,
+					runIndex,
+					additionalData,
+					workflow,
+					node,
+					mode,
+					connectionInputData,
+					runExecutionData,
+				});
+
 				const executeSingleFunctions = getExecuteSingleFunctions(
 					workflow,
 					runExecutionData,
@@ -1971,7 +1977,6 @@ describe('RoutingNode', () => {
 					itemIndex,
 				);
 
-				jest.spyOn(executionContexts, 'ExecuteContext').mockReturnValue(executeFunctions);
 				jest
 					.spyOn(executionContexts, 'ExecuteSingleContext')
 					.mockReturnValue(executeSingleFunctions);
@@ -2004,7 +2009,8 @@ describe('RoutingNode', () => {
 						? testData.input.node.parameters[parameterName]
 						: (getNodeParameter(parameterName) ?? {});
 
-				const result = await routingNode.runNode(inputData, runIndex, nodeType, executeData);
+				const routingNode = new RoutingNode(executeFunctions, nodeType);
+				const result = await routingNode.runNode();
 
 				if (testData.input.specialTestOptions?.sleepCalls) {
 					expect(spy.mock.calls).toEqual(testData.input.specialTestOptions?.sleepCalls);

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -40,7 +40,6 @@ export const describeCommonTests = (
 		executeData: IExecuteData;
 	},
 ) => {
-	// @ts-expect-error `additionalData` is private
 	const additionalData = context.additionalData as MockProxy<IWorkflowExecuteAdditionalData>;
 
 	describe('getExecutionCancelSignal', () => {

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -41,12 +41,12 @@ export class BaseExecuteContext extends NodeExecutionContext {
 		node: INode,
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
-		protected readonly runExecutionData: IRunExecutionData,
+		readonly runExecutionData: IRunExecutionData,
 		runIndex: number,
-		protected readonly connectionInputData: INodeExecutionData[],
-		protected readonly inputData: ITaskDataConnections,
-		protected readonly executeData: IExecuteData,
-		protected readonly abortSignal?: AbortSignal,
+		readonly connectionInputData: INodeExecutionData[],
+		readonly inputData: ITaskDataConnections,
+		readonly executeData: IExecuteData,
+		readonly abortSignal?: AbortSignal,
 	) {
 		super(workflow, node, additionalData, mode, runExecutionData, runIndex);
 	}

--- a/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
@@ -1,0 +1,26 @@
+import { Container } from '@n8n/di';
+import type { ICredentialTestFunctions } from 'n8n-workflow';
+
+import { Memoized } from '@/decorators';
+import { Logger } from '@/logging';
+// eslint-disable-next-line import/no-cycle
+import { getSSHTunnelFunctions, proxyRequestToAxios } from '@/node-execute-functions';
+
+export class CredentialTestContext implements ICredentialTestFunctions {
+	readonly helpers: ICredentialTestFunctions['helpers'];
+
+	constructor() {
+		this.helpers = {
+			...getSSHTunnelFunctions(),
+			request: async (uriOrObject: string | object, options?: object) => {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+				return await proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
+			},
+		};
+	}
+
+	@Memoized
+	get logger() {
+		return Container.get(Logger);
+	}
+}

--- a/packages/core/src/execution-engine/node-execution-context/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/index.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/no-cycle
+export { CredentialTestContext } from './credentials-test-context';
+// eslint-disable-next-line import/no-cycle
 export { ExecuteContext } from './execute-context';
 export { ExecuteSingleContext } from './execute-single-context';
 export { HookContext } from './hook-context';

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -43,14 +43,14 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 	protected readonly instanceSettings = Container.get(InstanceSettings);
 
 	constructor(
-		protected readonly workflow: Workflow,
-		protected readonly node: INode,
-		protected readonly additionalData: IWorkflowExecuteAdditionalData,
-		protected readonly mode: WorkflowExecuteMode,
-		protected readonly runExecutionData: IRunExecutionData | null = null,
-		protected readonly runIndex = 0,
-		protected readonly connectionInputData: INodeExecutionData[] = [],
-		protected readonly executeData?: IExecuteData,
+		readonly workflow: Workflow,
+		readonly node: INode,
+		readonly additionalData: IWorkflowExecuteAdditionalData,
+		readonly mode: WorkflowExecuteMode,
+		readonly runExecutionData: IRunExecutionData | null = null,
+		readonly runIndex = 0,
+		readonly connectionInputData: INodeExecutionData[] = [],
+		readonly executeData?: IExecuteData,
 	) {}
 
 	@Memoized

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1172,26 +1172,21 @@ export class WorkflowExecute {
 			return { data: inputData.main as INodeExecutionData[][] };
 		} else {
 			// For nodes which have routing information on properties
-
-			const routingNode = new RoutingNode(
+			const executeFunctions = new ExecuteContext(
 				workflow,
 				node,
-				connectionInputData,
-				runExecutionData ?? null,
 				additionalData,
 				mode,
+				runExecutionData,
+				runIndex,
+				connectionInputData,
+				inputData,
+				executionData,
+				[],
 			);
-
-			return {
-				data: await routingNode.runNode(
-					inputData,
-					runIndex,
-					nodeType,
-					executionData,
-					undefined,
-					abortSignal,
-				),
-			};
+			const routingNode = new RoutingNode(executeFunctions, nodeType);
+			const data = await routingNode.runNode();
+			return { data };
 		}
 	}
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -69,7 +69,6 @@ import {
 	handleCycles,
 	filterDisabledNodes,
 } from './partial-execution-utils';
-import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
 export class WorkflowExecute {
@@ -1171,22 +1170,7 @@ export class WorkflowExecute {
 			// For webhook nodes always simply pass the data through
 			return { data: inputData.main as INodeExecutionData[][] };
 		} else {
-			// For nodes which have routing information on properties
-			const executeFunctions = new ExecuteContext(
-				workflow,
-				node,
-				additionalData,
-				mode,
-				runExecutionData,
-				runIndex,
-				connectionInputData,
-				inputData,
-				executionData,
-				[],
-			);
-			const routingNode = new RoutingNode(executeFunctions, nodeType);
-			const data = await routingNode.runNode();
-			return { data };
+			throw new ApplicationError('Declarative nodes should been handled as regular nodes');
 		}
 	}
 

--- a/packages/core/src/node-execute-functions.ts
+++ b/packages/core/src/node-execute-functions.ts
@@ -38,7 +38,6 @@ import type {
 	IAllExecuteFunctions,
 	IBinaryData,
 	ICredentialDataDecryptedObject,
-	ICredentialTestFunctions,
 	IDataObject,
 	IExecuteData,
 	IExecuteFunctions,
@@ -2554,16 +2553,4 @@ export function getExecuteTriggerFunctions(
 	activation: WorkflowActivateMode,
 ): ITriggerFunctions {
 	return new TriggerContext(workflow, node, additionalData, mode, activation);
-}
-
-export function getCredentialTestFunctions(): ICredentialTestFunctions {
-	return {
-		logger: Container.get(Logger),
-		helpers: {
-			...getSSHTunnelFunctions(),
-			request: async (uriOrObject: string | object, options?: object) => {
-				return await proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
-			},
-		},
-	};
 }


### PR DESCRIPTION
## Summary

This PR adds a missing `execute` method to declarative nodes, that makes the code for executing them more consistent with regular nodes, and enables the possibility of using these nodes as tools for AI agents.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
