### PR TITLE
ci: Fix tests for declarative nodes (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -69,6 +69,7 @@ import {
 	handleCycles,
 	filterDisabledNodes,
 } from './partial-execution-utils';
+import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 
 export class WorkflowExecute {
@@ -1170,7 +1171,23 @@ export class WorkflowExecute {
 			// For webhook nodes always simply pass the data through
 			return { data: inputData.main as INodeExecutionData[][] };
 		} else {
-			throw new ApplicationError('Declarative nodes should been handled as regular nodes');
+			// NOTE: This block is only called by nodes tests.
+			// In the application, declarative nodes get assigned a `.execute` method in NodeTypes.
+			const context = new ExecuteContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				runExecutionData,
+				runIndex,
+				connectionInputData,
+				inputData,
+				executionData,
+				[],
+			);
+			const routingNode = new RoutingNode(context, nodeType);
+			const data = await routingNode.runNode();
+			return { data };
 		}
 	}
 


### PR DESCRIPTION
## Summary

Node tests for declarative nodes broke in #13007 because those tests aren't loading the nodes via `NodeTypes` in `packages/cli`.
This is a "temporary" fix, until we get around to refactoring this code further. 


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
