### PR TITLE
fix(editor): Actually enforce the version and don't break for old values in local storage

### DIFF
--- a/packages/editor-ui/src/stores/settings.store.test.ts
+++ b/packages/editor-ui/src/stores/settings.store.test.ts
@@ -142,6 +142,13 @@ describe('settings.store', () => {
 				userVersion: 1,
 				result: 2,
 			},
+			{
+				name: 'handle values that used to be allowed in local storage',
+				default: 1 as const,
+				enforce: false,
+				userVersion: 0,
+				result: 1,
+			},
 		])('%name', async ({ default: defaultVersion, userVersion, enforce, result }) => {
 			const settingsStore = useSettingsStore();
 

--- a/packages/editor-ui/src/stores/settings.store.ts
+++ b/packages/editor-ui/src/stores/settings.store.ts
@@ -112,6 +112,12 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 				? defaultVersion
 				: userVersion;
 
+		// For backwards compatibility, e.g. if the user has 0 in their local
+		// storage, which used to be allowed, but not anymore.
+		if (![1, 2].includes(version)) {
+			return 1;
+		}
+
 		return version;
 	});
 

--- a/packages/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/editor-ui/src/stores/workflows.store.test.ts
@@ -16,10 +16,15 @@ import type { IPinData, ExecutionSummary, IConnection, INodeExecutionData } from
 import { stringSizeInBytes } from '@/utils/typesUtils';
 import { dataPinningEventBus } from '@/event-bus';
 import { useUIStore } from '@/stores/ui.store';
-import type { PushPayload } from '@n8n/api-types';
+import type { PushPayload, FrontendSettings } from '@n8n/api-types';
 import { flushPromises } from '@vue/test-utils';
 import { useNDVStore } from '@/stores/ndv.store';
 import { mock } from 'vitest-mock-extended';
+import { mockedStore, type MockedStore } from '@/__tests__/utils';
+import * as apiUtils from '@/utils/apiUtils';
+import { useSettingsStore } from '@/stores/settings.store';
+import { useLocalStorage } from '@vueuse/core';
+import { ref } from 'vue';
 
 vi.mock('@/stores/ndv.store', () => ({
 	useNDVStore: vi.fn(() => ({
@@ -45,14 +50,24 @@ vi.mock('@/composables/useTelemetry', () => ({
 	useTelemetry: () => ({ track }),
 }));
 
+vi.mock('@vueuse/core', async (importOriginal) => {
+	const actual = await importOriginal<{}>();
+	return {
+		...actual,
+		useLocalStorage: vi.fn().mockReturnValue({ value: undefined }),
+	};
+});
+
 describe('useWorkflowsStore', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let uiStore: ReturnType<typeof useUIStore>;
+	let settingsStore: MockedStore<typeof useSettingsStore>;
 
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		workflowsStore = useWorkflowsStore();
 		uiStore = useUIStore();
+		settingsStore = mockedStore(useSettingsStore);
 		track.mockReset();
 	});
 
@@ -662,6 +677,36 @@ describe('useWorkflowsStore', () => {
 			expect(workflowsStore.nodeMetadata[nodeName].parametersLastUpdatedAt).toBe(undefined);
 		});
 	});
+
+	test.each([
+		[0, 1, false, 1],
+		[-1, 1, false, 1],
+		[1, 1, false, 1],
+		[2, 1, false, 2],
+		[-1, 2, false, 2],
+	] as Array<[number, 1 | 2, boolean, number]>)(
+		'when { userVersion:%s, defaultVersion:%s, enforced:%s } run workflow should use partial execution version %s',
+		async (userVersion, defaultVersion, enforce, expectedVersion) => {
+			vi.mocked(useLocalStorage).mockReturnValueOnce(ref(userVersion));
+			settingsStore.settings = {
+				partialExecution: { version: defaultVersion, enforce },
+			} as FrontendSettings;
+
+			const workflowData = { id: '1', nodes: [], connections: {} };
+			const makeRestApiRequestSpy = vi
+				.spyOn(apiUtils, 'makeRestApiRequest')
+				.mockImplementation(async () => ({}));
+
+			await workflowsStore.runWorkflow({ workflowData });
+
+			expect(makeRestApiRequestSpy).toHaveBeenCalledWith(
+				{ baseUrl: '/rest', pushRef: expect.any(String) },
+				'POST',
+				`/workflows/1/run?partialExecutionVersion=${expectedVersion}`,
+				{ workflowData },
+			);
+		},
+	);
 });
 
 function getMockEditFieldsNode() {

--- a/packages/editor-ui/src/stores/workflows.store.test.ts
+++ b/packages/editor-ui/src/stores/workflows.store.test.ts
@@ -679,11 +679,25 @@ describe('useWorkflowsStore', () => {
 	});
 
 	test.each([
-		[0, 1, false, 1],
-		[-1, 1, false, 1],
-		[1, 1, false, 1],
-		[2, 1, false, 2],
-		[-1, 2, false, 2],
+		// enforce true cases - the version is always the defaultVersion
+		[-1, 1, true, 1], // enforce true, use default (1)
+		[0, 1, true, 1], // enforce true, use default (1)
+		[1, 1, true, 1], // enforce true, use default (1)
+		[2, 1, true, 1], // enforce true, use default (1)
+		[-1, 2, true, 2], // enforce true, use default (2)
+		[0, 2, true, 2], // enforce true, use default (2)
+		[1, 2, true, 2], // enforce true, use default (2)
+		[2, 2, true, 2], // enforce true, use default (2)
+
+		// enforce false cases - check userVersion behavior
+		[-1, 1, false, 1], // userVersion -1, use default (1)
+		[0, 1, false, 1], // userVersion 0, invalid, use default (1)
+		[1, 1, false, 1], // userVersion 1, valid, use userVersion (1)
+		[2, 1, false, 2], // userVersion 2, valid, use userVersion (2)
+		[-1, 2, false, 2], // userVersion -1, use default (2)
+		[0, 2, false, 1], // userVersion 0, invalid, use default (2)
+		[1, 2, false, 1], // userVersion 1, valid, use userVersion (1)
+		[2, 2, false, 2], // userVersion 2, valid, use userVersion (2)
 	] as Array<[number, 1 | 2, boolean, number]>)(
 		'when { userVersion:%s, defaultVersion:%s, enforced:%s } run workflow should use partial execution version %s',
 		async (userVersion, defaultVersion, enforce, expectedVersion) => {

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -124,6 +124,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const nodeHelpers = useNodeHelpers();
 	const usersStore = useUsersStore();
 
+	const version = computed(() => settingsStore.partialExecutionVersion);
 	const workflow = ref<IWorkflowDb>(createEmptyWorkflow());
 	const usedCredentials = ref<Record<string, IUsedCredential>>({});
 
@@ -1468,7 +1469,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			return await makeRestApiRequest(
 				rootStore.restApiContext,
 				'POST',
-				`/workflows/${startRunData.workflowData.id}/run?partialExecutionVersion=${settingsStore.partialExecutionVersion}`,
+				`/workflows/${startRunData.workflowData.id}/run?partialExecutionVersion=${version.value}`,
 				startRunData as unknown as IDataObject,
 			);
 		} catch (error) {

--- a/packages/editor-ui/src/stores/workflows.store.ts
+++ b/packages/editor-ui/src/stores/workflows.store.ts
@@ -124,8 +124,6 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 	const nodeHelpers = useNodeHelpers();
 	const usersStore = useUsersStore();
 
-	const version = settingsStore.partialExecutionVersion;
-
 	const workflow = ref<IWorkflowDb>(createEmptyWorkflow());
 	const usedCredentials = ref<Record<string, IUsedCredential>>({});
 
@@ -1470,7 +1468,7 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 			return await makeRestApiRequest(
 				rootStore.restApiContext,
 				'POST',
-				`/workflows/${startRunData.workflowData.id}/run?partialExecutionVersion=${version}`,
+				`/workflows/${startRunData.workflowData.id}/run?partialExecutionVersion=${settingsStore.partialExecutionVersion}`,
 				startRunData as unknown as IDataObject,
 			);
 		} catch (error) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

- access `settingsStore.partialExecutionVersion` when used to make sure it's up to date, otherwise we'd always end up with the initial value which does not take the settings from the api into account
- make sure we don't send invalid values, some users may still have the value 0 set for the `PartialExecution.version` local storage key

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
