### PR TITLE
Remove early return

### DIFF
--- a/packages/cli/src/webhooks/waiting-forms.ts
+++ b/packages/cli/src/webhooks/waiting-forms.ts
@@ -107,7 +107,6 @@ export class WaitingForms extends WaitingWebhooks {
 		if (execution.status === 'running') {
 			if (this.includeForms && req.method === 'GET') {
 				await this.reloadForm(req, res);
-				return { noWebhookResponse: true };
 			}
 
 			throw new ConflictError(`The execution "${executionId}" is running already.`);


### PR DESCRIPTION
This way, form completion can wait for the previous nodes to finish

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2352/form-completion-hangs-when-there-is-a-google-drive-download-or-read


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
