### PR TITLE
fix(editor): Fix position of connector buttons when the line is straight

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.test.ts
@@ -161,12 +161,9 @@ describe('CanvasEdge', () => {
 			},
 		});
 
-		const label = container.querySelector('.vue-flow__edge-label');
+		const label = container.querySelector('.vue-flow__edge-label')?.childNodes[0];
 
-		expect(label).toHaveAttribute(
-			'style',
-			'transform: translate(-50%, -150%) translate(50px, 50px);',
-		);
+		expect(label).toHaveAttribute('style', 'transform: translate(0, -100%);');
 	});
 
 	it("should render a label in the middle of the connector when it isn't straight", () => {
@@ -178,11 +175,8 @@ describe('CanvasEdge', () => {
 			},
 		});
 
-		const label = container.querySelector('.vue-flow__edge-label');
+		const label = container.querySelector('.vue-flow__edge-label')?.childNodes[0];
 
-		expect(label).toHaveAttribute(
-			'style',
-			'transform: translate(-50%, -50%) translate(50px, 50px);',
-		);
+		expect(label).toHaveAttribute('style', 'transform: translate(0, 0%);');
 	});
 });

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -67,19 +67,16 @@ const edgeClasses = computed(() => ({
 }));
 
 const edgeLabelStyle = computed(() => ({
+	transform: `translate(0, ${isConnectorStraight.value ? '-100%' : '0%'})`,
 	color: edgeColor.value,
 }));
 
 const isConnectorStraight = computed(() => renderData.value.isConnectorStraight);
 
-const edgeToolbarStyle = computed(() => {
-	const translateY = isConnectorStraight.value ? '-150%' : '-50%';
-
-	return {
-		transform: `translate(-50%, ${translateY}) translate(${labelPosition.value[0]}px, ${labelPosition.value[1]}px)`,
-		...(props.hovered ? { zIndex: 1 } : {}),
-	};
-});
+const edgeToolbarStyle = computed(() => ({
+	transform: `translate(-50%, -50%) translate(${labelPosition.value[0]}px, ${labelPosition.value[1]}px)`,
+	...(props.hovered ? { zIndex: 1 } : {}),
+}));
 
 const edgeToolbarClasses = computed(() => ({
 	[$style.edgeLabelWrapper]: true,


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced in [SUG-4](https://linear.app/n8n/issue/SUG-4/connection-label-should-jump-above-line-if-the-line-is-straight) which was supposed to change the position of label on the connector but it also affected the position of buttons.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-11/bug-the-deleteinject-buttons-should-hover-on-lint


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
