### PR TITLE
fix(Google Cloud Firestore Node): Fix potential prototype pollution vulnerability

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GenericFunctions.ts
@@ -82,6 +82,8 @@ export async function googleApiRequestAllItems(
 const isValidDate = (str: string) =>
 	moment(str, ['YYYY-MM-DD HH:mm:ss Z', moment.ISO_8601], true).isValid();
 
+const protoKeys = ['__proto__', 'prototype', 'constructor'];
+
 // Both functions below were taken from Stack Overflow jsonToDocument was fixed as it was unable to handle null values correctly
 // https://stackoverflow.com/questions/62246410/how-to-convert-a-firestore-document-to-plain-json-and-vice-versa
 // Great thanks to https://stackoverflow.com/users/3915246/mahindar
@@ -104,10 +106,11 @@ export function jsonToDocument(value: string | number | IDataObject | IDataObjec
 	} else if (value && value.constructor === Array) {
 		return { arrayValue: { values: value.map((v) => jsonToDocument(v)) } };
 	} else if (typeof value === 'object') {
-		const obj = {};
-		for (const o of Object.keys(value)) {
-			//@ts-ignore
-			obj[o] = jsonToDocument(value[o] as IDataObject);
+		const obj: IDataObject = {};
+		for (const key of Object.keys(value)) {
+			if (value.hasOwnProperty(key) && !protoKeys.includes(key)) {
+				obj[key] = jsonToDocument((value as IDataObject)[key] as IDataObject);
+			}
 		}
 		return { mapValue: { fields: obj } };
 	}


### PR DESCRIPTION
## Summary
Code like this, that copies over data between objects, should skip copying over prototype related properties.

## Related Linear tickets, Github issues, and Community forum posts

N8N-8102


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
