### PR TITLE
feat: Add support for client credentials with Azure Log monitor

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -5,7 +5,7 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 
 	displayName = 'Microsoft Azure Monitor OAuth2 API';
 
-	extends = ['microsoftOAuth2Api'];
+	extends = ['oAuth2Api'];
 
 	documentationUrl = 'microsoftazuremonitor';
 
@@ -18,6 +18,22 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 	};
 
 	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'options',
+			options: [
+				{
+					name: 'Authorization Code',
+					value: 'authorizationCode',
+				},
+				{
+					name: 'Client Credentials',
+					value: 'clientCredentials',
+				},
+			],
+			default: 'authorizationCode',
+		},
 		{
 			displayName: 'Tenant ID',
 			required: true,
@@ -50,6 +66,23 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			default: 'https://api.loganalytics.azure.com',
 		},
 		{
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'string',
+			default: '',
+			required: true,
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			required: true,
+		},
+		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',
@@ -59,19 +92,28 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			displayName: 'Access Token URL',
 			name: 'accessTokenUrl',
 			type: 'hidden',
-			default: '=https://login.microsoftonline.com/{{$self["tenantId"]}}/oauth2/token',
+			default:
+				'=https://login.microsoftonline.com/{{$self["tenantId"]}}/oauth2/{{$self["grantType"] === "clientCredentials" ? "v2.0/" : ""}}token',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
 			name: 'authQueryParameters',
 			type: 'hidden',
-			default: '=resource={{$self["resource"]}}',
+			default:
+				'={{$self["grantType"] === "clientCredentials" ? "" : "resource=" + $self["resource"]}}',
 		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '',
+			default:
+				'={{$self["grantType"] === "clientCredentials" ? $self["resource"] + "/.default" : ""}}',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'body',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.ts
@@ -66,23 +66,6 @@ export class MicrosoftAzureMonitorOAuth2Api implements ICredentialType {
 			default: 'https://api.loganalytics.azure.com',
 		},
 		{
-			displayName: 'Client ID',
-			name: 'clientId',
-			type: 'string',
-			default: '',
-			required: true,
-		},
-		{
-			displayName: 'Client Secret',
-			name: 'clientSecret',
-			type: 'string',
-			typeOptions: {
-				password: true,
-			},
-			default: '',
-			required: true,
-		},
-		{
 			displayName: 'Authorization URL',
 			name: 'authUrl',
 			type: 'hidden',


### PR DESCRIPTION
## Summary
Adds Client Credential support for Azure Log monitor cred only node. 

**Changes**

- Access Token URL is different between Client Credential and Authorization Code
- Client Credential uses Scope and not a Resource URL param
- Client Credential Scope is just the Resource with `/.default` at the end

This is not very well documented on the MS side so took some trial and error with a customer to get it working. It is possible that in the future we may need to add more Resource options if they come up but these are the main 4 I found in the documentation.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2322/update-log-monitor-to-support-client-creds


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
