### PR TITLE
fix(editor): Allow to re-open sub-connection node creator if already active

### DIFF
--- a/packages/editor-ui/src/Interface.ts
+++ b/packages/editor-ui/src/Interface.ts
@@ -54,6 +54,7 @@ import type {
 	REGULAR_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
 	ROLE,
+	AI_UNCATEGORIZED_CATEGORY,
 } from '@/constants';
 import type { BulkCommand, Undoable } from '@/models/history';
 
@@ -1012,7 +1013,8 @@ export type NodeFilterType =
 	| typeof REGULAR_NODE_CREATOR_VIEW
 	| typeof TRIGGER_NODE_CREATOR_VIEW
 	| typeof AI_NODE_CREATOR_VIEW
-	| typeof AI_OTHERS_NODE_CREATOR_VIEW;
+	| typeof AI_OTHERS_NODE_CREATOR_VIEW
+	| typeof AI_UNCATEGORIZED_CATEGORY;
 
 export type NodeCreatorOpenSource =
 	| ''

--- a/packages/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
+++ b/packages/editor-ui/src/components/Node/NodeCreator/Panel/NodesListPanel.vue
@@ -6,6 +6,7 @@ import {
 	AI_NODE_CREATOR_VIEW,
 	REGULAR_NODE_CREATOR_VIEW,
 	TRIGGER_NODE_CREATOR_VIEW,
+	AI_UNCATEGORIZED_CATEGORY,
 } from '@/constants';
 
 import { useNodeCreatorStore } from '@/stores/nodeCreator.store';
@@ -95,6 +96,7 @@ watch(
 			[REGULAR_NODE_CREATOR_VIEW]: RegularView,
 			[AI_NODE_CREATOR_VIEW]: AIView,
 			[AI_OTHERS_NODE_CREATOR_VIEW]: AINodesView,
+			[AI_UNCATEGORIZED_CATEGORY]: AINodesView,
 		};
 
 		const itemKey = selectedView;

--- a/packages/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -1,8 +1,15 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { useNodeCreatorStore } from './nodeCreator.store';
 import { useTelemetry } from '@/composables/useTelemetry';
-import { CUSTOM_API_CALL_KEY, REGULAR_NODE_CREATOR_VIEW } from '@/constants';
+import {
+	AI_UNCATEGORIZED_CATEGORY,
+	CUSTOM_API_CALL_KEY,
+	REGULAR_NODE_CREATOR_VIEW,
+} from '@/constants';
 import type { INodeCreateElement } from '@/Interface';
+import { parseCanvasConnectionHandleString } from '@/utils/canvasUtilsV2';
+import { NodeConnectionType } from 'n8n-workflow';
+import { CanvasConnectionMode } from '@/types';
 
 const workflow_id = 'workflow-id';
 const category_name = 'category-name';
@@ -26,6 +33,31 @@ vi.mock('@/composables/useTelemetry', () => {
 				track,
 			};
 		},
+	};
+});
+
+// Mock the workflows store so that getNodeById returns a dummy node.
+vi.mock('@/stores/workflows.store', () => {
+	return {
+		useWorkflowsStore: () => ({
+			getNodeById: vi.fn((id?: string) => {
+				return id ? { id, name: 'Test Node' } : null;
+			}),
+			workflowTriggerNodes: [],
+			workflowId: 'dummy-workflow-id',
+			getCurrentWorkflow: vi.fn(() => ({
+				getNode: vi.fn(() => ({
+					type: 'n8n-node.example',
+					typeVersion: 1,
+				})),
+			})),
+		}),
+	};
+});
+
+vi.mock('@/utils/canvasUtilsV2', () => {
+	return {
+		parseCanvasConnectionHandleString: vi.fn(),
 	};
 });
 
@@ -289,6 +321,69 @@ describe('useNodeCreatorStore', () => {
 				withPostHog: false,
 			},
 		);
+	});
+	describe('selective connection view', () => {
+		const mockedParseCanvasConnectionHandleString = vi.mocked(
+			parseCanvasConnectionHandleString,
+			true,
+		);
+
+		it('sets nodeCreatorView to AI_UNCATEGORIZED_CATEGORY when connection type is not Main', async () => {
+			mockedParseCanvasConnectionHandleString.mockReturnValue({
+				type: NodeConnectionType.AiLanguageModel, // any value that is not NodeConnectionType.Main
+				index: 0,
+				mode: CanvasConnectionMode.Input,
+			});
+
+			const connection = {
+				source: 'node-1',
+				sourceHandle: 'fake-handle',
+			};
+
+			nodeCreatorStore.openNodeCreatorForConnectingNode({
+				connection,
+				eventSource: 'plus_endpoint',
+				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+			});
+
+			expect(nodeCreatorStore.selectedView).toEqual(AI_UNCATEGORIZED_CATEGORY);
+		});
+
+		it('uses the provided nodeCreatorView when connection type is Main', async () => {
+			mockedParseCanvasConnectionHandleString.mockReturnValue({
+				type: NodeConnectionType.Main,
+				index: 0,
+				mode: CanvasConnectionMode.Input,
+			});
+
+			const connection = {
+				source: 'node-2',
+				sourceHandle: 'fake-handle-main',
+			};
+
+			nodeCreatorStore.openNodeCreatorForConnectingNode({
+				connection,
+				eventSource: 'plus_endpoint',
+				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+			});
+
+			expect(nodeCreatorStore.selectedView).toEqual(REGULAR_NODE_CREATOR_VIEW);
+		});
+
+		it('does not update state if no source node is found', async () => {
+			const connection = {
+				source: '',
+				sourceHandle: 'any-handle',
+			};
+
+			nodeCreatorStore.openNodeCreatorForConnectingNode({
+				connection,
+				eventSource: 'plus_endpoint',
+				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+			});
+
+			expect(nodeCreatorStore.selectedView).not.toEqual(REGULAR_NODE_CREATOR_VIEW);
+		});
 	});
 });
 

--- a/packages/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.ts
@@ -21,7 +21,7 @@ import type {
 import { computed, ref } from 'vue';
 import { transformNodeType } from '@/components/Node/NodeCreator/utils';
 import type { IDataObject, INodeInputConfiguration, NodeParameterValueType } from 'n8n-workflow';
-import { NodeConnectionType, nodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
+import { NodeConnectionType, NodeHelpers } from 'n8n-workflow';
 import { useWorkflowsStore } from '@/stores/workflows.store';
 import { useUIStore } from '@/stores/ui.store';
 import { useNDVStore } from '@/stores/ndv.store';

--- a/packages/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import {
 	AI_NODE_CREATOR_VIEW,
 	AI_OTHERS_NODE_CREATOR_VIEW,
+	AI_UNCATEGORIZED_CATEGORY,
 	CUSTOM_API_CALL_KEY,
 	NODE_CREATOR_OPEN_SOURCES,
 	REGULAR_NODE_CREATOR_VIEW,
@@ -121,10 +122,6 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		createNodeActive,
 		nodeCreatorView,
 	}: ToggleNodeCreatorOptions) {
-		if (createNodeActive === isCreateNodeActive.value) {
-			return;
-		}
-
 		if (!nodeCreatorView) {
 			nodeCreatorView =
 				workflowsStore.workflowTriggerNodes.length > 0
@@ -183,18 +180,16 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		uiStore.lastInteractedWithNodeHandle = connection.sourceHandle ?? null;
 		uiStore.lastInteractedWithNodeId = sourceNode.id;
 
+		const isOutput = mode === CanvasConnectionMode.Output;
+		const isScopedConnection = type !== NodeConnectionType.Main;
 		setNodeCreatorState({
 			source: eventSource,
 			createNodeActive: true,
-			nodeCreatorView,
+			nodeCreatorView: isScopedConnection ? AI_UNCATEGORIZED_CATEGORY : nodeCreatorView,
 		});
 
 		// TODO: The animation is a bit glitchy because we're updating view stack immediately
 		// after the node creator is opened
-		const isOutput = mode === CanvasConnectionMode.Output;
-		const isScopedConnection =
-			type !== NodeConnectionType.Main && nodeConnectionTypes.includes(type);
-
 		if (isScopedConnection) {
 			useViewStacks()
 				.gotoCompatibleConnectionView(type, isOutput, getNodeCreatorFilter(sourceNode.name, type))


### PR DESCRIPTION
## Summary
These changes address the issue where the sub-node node creator view(for example tools) section remained visible instead of switching to the appropriate panel when clicking on plus connection.

- Resetting the view stack before pushing a new view so that previous panels are cleared.
- Updating the logic in the node creator store to use AI_UNCATEGORIZED_CATEGORY when the connection type is not Main.
- Adding tests to verify the behavior for both Main and non-Main connection types, as well as handling cases with no source node.

https://github.com/user-attachments/assets/eaca2a20-622c-4a4e-a841-52e9ebec0e4b


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
