### PR TITLE
fix(Google Calendar node) Google throws error on start date

### DIFF
--- a/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
+++ b/packages/nodes-base/nodes/Google/Calendar/GoogleCalendar.node.ts
@@ -622,14 +622,34 @@ export class GoogleCalendar implements INodeType {
 						if (updateFields.start) {
 							body.start = {
 								dateTime: moment.tz(updateFields.start, updateTimezone).utc().format(),
+								date:  null,
 								timeZone: updateTimezone,
 							};
+							if(updateFields.allday === 'yes'){
+								body.start = {
+									dateTime: null,
+									date: updateTimezone
+										? moment.tz(updateFields.start, updateTimezone).utc(true).format('YYYY-MM-DD')
+										: moment.tz(updateFields.start, moment.tz.guess()).utc(true).format('YYYY-MM-DD'),
+									timeZone: updateTimezone,
+								};
+							}
 						}
 						if (updateFields.end) {
 							body.end = {
 								dateTime: moment.tz(updateFields.end, updateTimezone).utc().format(),
+								date: null,
 								timeZone: updateTimezone,
 							};
+							if(updateFields.allday === 'yes'){
+								body.end = {
+									dateTime: null,
+									date: updateTimezone
+										? moment.tz(updateFields.end, updateTimezone).utc(true).format('YYYY-MM-DD')
+										: moment.tz(updateFields.end, moment.tz.guess()).utc(true).format('YYYY-MM-DD'),
+									timeZone: updateTimezone,
+								};
+							}
 						}
 						// nodeVersion < 1.2
 						if (updateFields.attendees) {
@@ -716,18 +736,6 @@ export class GoogleCalendar implements INodeType {
 							}
 						}
 
-						if (updateFields.allday === 'yes' && updateFields.start && updateFields.end) {
-							body.start = {
-								date: updateTimezone
-									? moment.tz(updateFields.start, updateTimezone).utc(true).format('YYYY-MM-DD')
-									: moment.tz(updateFields.start, moment.tz.guess()).utc(true).format('YYYY-MM-DD'),
-							};
-							body.end = {
-								date: updateTimezone
-									? moment.tz(updateFields.end, updateTimezone).utc(true).format('YYYY-MM-DD')
-									: moment.tz(updateFields.end, moment.tz.guess()).utc(true).format('YYYY-MM-DD'),
-							};
-						}
 						//example: RRULE:FREQ=WEEKLY;INTERVAL=2;COUNT=10;UNTIL=20110701T170000Z
 						//https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html
 						body.recurrence = [];


### PR DESCRIPTION
## Summary

**What**: Google calendar node throws an error on start date.
**When**: Gcal existing event is an all-day event & we try to update it to non-all-day event OR vice-versa.
**Why**: Missing "date" or "dateTime" keys set to null.

Also refactored a related part

## Related Linear tickets, Github issues, and Community forum posts

This github issue has no labels set but it is from 2023.
closes #5508


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
