### PR TITLE
feat(HTTP Request Tool Node): Relax binary data detection

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -237,6 +237,69 @@ describe('ToolHttpRequest', () => {
 				}),
 			);
 		});
+
+		it('should return the error when receiving text that contains a null character', async () => {
+			helpers.httpRequest.mockResolvedValue({
+				body: 'Hello\0World',
+				headers: {
+					'content-type': 'text/plain',
+				},
+			});
+
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return 'https://httpbin.org/text/plain';
+					case 'options':
+						return {};
+					case 'placeholderDefinitions.values':
+						return [];
+					default:
+						return undefined;
+				}
+			});
+
+			const { response } = await httpTool.supplyData.call(executeFunctions, 0);
+			const res = await (response as N8nTool).invoke({});
+			expect(helpers.httpRequest).toHaveBeenCalled();
+			// Check that the returned string is formatted as an error message.
+			expect(res).toContain('error');
+			expect(res).toContain('Binary data is not supported');
+		});
+
+		it('should return the error when receiving a JSON response containing a null character', async () => {
+			// Provide a raw JSON string with a literal null character.
+			helpers.httpRequest.mockResolvedValue({
+				body: '{"message":"hello\0world"}',
+				headers: {
+					'content-type': 'application/json',
+				},
+			});
+
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return 'https://httpbin.org/json';
+					case 'options':
+						return {};
+					case 'placeholderDefinitions.values':
+						return [];
+					default:
+						return undefined;
+				}
+			});
+
+			const { response } = await httpTool.supplyData.call(executeFunctions, 0);
+			const res = await (response as N8nTool).invoke({});
+			expect(helpers.httpRequest).toHaveBeenCalled();
+			// Check that the tool returns an error string rather than resolving to valid JSON.
+			expect(res).toContain('error');
+			expect(res).toContain('Binary data is not supported');
+		});
 	});
 
 	describe('Optimize response', () => {


### PR DESCRIPTION
## Summary
Replaces strict MIME type validation with a simpler binary check to support custom content types like `application/custom+json`. Fixes #12712.

## Changes
- Remove MIME package content-type validation 
- Add basic binary detection for null characters
- Add tests for binary detection edge cases

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
