### PR TITLE
fix(AI Agent Node): Ignore SSL errors option for SQLAgent

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.test.ts
@@ -1,0 +1,156 @@
+import { mock } from 'jest-mock-extended';
+import type { PostgresNodeCredentials } from 'n8n-nodes-base/nodes/Postgres/v2/helpers/interfaces';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { getPostgresDataSource } from './postgres';
+
+describe('Postgres SSL settings', () => {
+	const credentials = mock<PostgresNodeCredentials>({
+		host: 'localhost',
+		port: 5432,
+		user: 'user',
+		password: 'password',
+		database: 'database',
+	});
+
+	test('ssl is disabled + allowUnauthorizedCerts is false', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'disable',
+				allowUnauthorizedCerts: false,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: false,
+		});
+	});
+
+	test('ssl is disabled + allowUnauthorizedCerts is true', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'disable',
+				allowUnauthorizedCerts: true,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: false,
+		});
+	});
+
+	test('ssl is disabled + allowUnauthorizedCerts is undefined', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'disable',
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: false,
+		});
+	});
+
+	test('ssl is allow + allowUnauthorizedCerts is false', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'allow',
+				allowUnauthorizedCerts: false,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: true,
+		});
+	});
+
+	test('ssl is allow + allowUnauthorizedCerts is true', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'allow',
+				allowUnauthorizedCerts: true,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: { rejectUnauthorized: false },
+		});
+	});
+
+	test('ssl is allow + allowUnauthorizedCerts is undefined', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'allow',
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: true,
+		});
+	});
+
+	test('ssl is require + allowUnauthorizedCerts is false', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'require',
+				allowUnauthorizedCerts: false,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: true,
+		});
+	});
+
+	test('ssl is require + allowUnauthorizedCerts is true', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'require',
+				allowUnauthorizedCerts: true,
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: { rejectUnauthorized: false },
+		});
+	});
+
+	test('ssl is require + allowUnauthorizedCerts is undefined', async () => {
+		const context = mock<IExecuteFunctions>({
+			getCredentials: jest.fn().mockReturnValue({
+				...credentials,
+				ssl: 'require',
+			}),
+		});
+
+		const dataSource = await getPostgresDataSource.call(context);
+
+		expect(dataSource.options).toMatchObject({
+			ssl: true,
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -16,7 +16,7 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 	if (credentials.allowUnauthorizedCerts === true) {
 		dataSource.setOptions({
 			ssl: {
-				rejectUnauthorized: true,
+				rejectUnauthorized: false,
 			},
 		});
 	} else {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -7,8 +7,8 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 
 	let ssl: TlsOptions | boolean = !['disable', undefined].includes(credentials.ssl);
-	if (credentials.allowUnauthorizedCerts && ssl) {
-		ssl = { rejectUnauthorized: !credentials.allowUnauthorizedCerts };
+if (credentials.allowUnauthorizedCerts && ssl) {
+		ssl = { rejectUnauthorized: false };
 	}
 
 	return new DataSource({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -7,7 +7,7 @@ export async function getPostgresDataSource(this: IExecuteFunctions): Promise<Da
 	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 
 	let ssl: TlsOptions | boolean = !['disable', undefined].includes(credentials.ssl);
-if (credentials.allowUnauthorizedCerts && ssl) {
+	if (credentials.allowUnauthorizedCerts && ssl) {
 		ssl = { rejectUnauthorized: false };
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/SqlAgent/other/handlers/postgres.ts
@@ -1,29 +1,23 @@
 import { DataSource } from '@n8n/typeorm';
+import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
 import { type IExecuteFunctions } from 'n8n-workflow';
+import type { TlsOptions } from 'tls';
 
 export async function getPostgresDataSource(this: IExecuteFunctions): Promise<DataSource> {
-	const credentials = await this.getCredentials('postgres');
+	const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
 
-	const dataSource = new DataSource({
-		type: 'postgres',
-		host: credentials.host as string,
-		port: credentials.port as number,
-		username: credentials.user as string,
-		password: credentials.password as string,
-		database: credentials.database as string,
-	});
-
-	if (credentials.allowUnauthorizedCerts === true) {
-		dataSource.setOptions({
-			ssl: {
-				rejectUnauthorized: false,
-			},
-		});
-	} else {
-		dataSource.setOptions({
-			ssl: !['disable', undefined].includes(credentials.ssl as string | undefined),
-		});
+	let ssl: TlsOptions | boolean = !['disable', undefined].includes(credentials.ssl);
+	if (credentials.allowUnauthorizedCerts && ssl) {
+		ssl = { rejectUnauthorized: !credentials.allowUnauthorizedCerts };
 	}
 
-	return dataSource;
+	return new DataSource({
+		type: 'postgres',
+		host: credentials.host,
+		port: credentials.port,
+		username: credentials.user,
+		password: credentials.password,
+		database: credentials.database,
+		ssl,
+	});
 }


### PR DESCRIPTION
## Summary

The "Ignore SSL Issues (Insecure)" option in Postgres credentials had the opposite effect on SQL Agent, enforcing the SSL check. This PR fixes that.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/12686


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
