### PR TITLE
feat(openai): add reasoning_effort option to chat completions

### DIFF
--- a/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
@@ -259,7 +259,8 @@ const sharedOperations: INodeProperties[] = [
 				],
 			},
 		},
-		description: 'Whether to return a simplified version of the response instead of the raw data',
+		description:
+			'Whether to return a simplified version of the response instead of the raw data',
 	},
 
 	{
@@ -280,7 +281,8 @@ const sharedOperations: INodeProperties[] = [
 				displayName: 'Echo Prompt',
 				name: 'echo',
 				type: 'boolean',
-				description: 'Whether the prompt should be echo back in addition to the completion',
+				description:
+					'Whether the prompt should be echo back in addition to the completion',
 				default: false,
 				displayOptions: {
 					show: {
@@ -390,18 +392,46 @@ const sharedOperations: INodeProperties[] = [
 					},
 				},
 			},
+			{
+				displayName: 'Reasoning Effort',
+				name: 'reasoning_effort',
+				type: 'options',
+				description:
+					'Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. (o1 models only)',
+				options: [
+					{
+						name: 'Low',
+						value: 'low',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+					},
+					{
+						name: 'High',
+						value: 'high',
+					},
+				],
+				default: 'medium',
+				routing: {
+					send: {
+						type: 'body',
+						property: 'reasoning_effort',
+					},
+				},
+			},
 		],
 	},
 ];
 
 export const chatFields: INodeProperties[] = [
 	/* -------------------------------------------------------------------------- */
-	/*                               chat:complete                        */
+	/*                               chat:complete                               */
 	/* -------------------------------------------------------------------------- */
 	...completeOperations,
 
 	/* -------------------------------------------------------------------------- */
-	/*                                chat:ALL                                    */
+	/*                                chat:ALL                                  */
 	/* -------------------------------------------------------------------------- */
 	...sharedOperations,
 ];


### PR DESCRIPTION
This PR adds a new option called `reasoning_effort` to the OpenAI chat node. The new option allows users to constrain the reasoning effort for o1 models with supported values of **low**, **medium**, and **high** (default is **medium**). The option is added within the Options collection of the node and is configured to be sent as part of the request body.

To test:
1. Add the OpenAI chat node in n8n.
2. Enable the `reasoning_effort` option from the additional options and select one of the values.
3. Execute the node and inspect the outgoing request payload to ensure the `reasoning_effort` property is included with the selected value.
4. Verify that the response from the API is as expected when varying the `reasoning_effort` setting.