### PR TITLE
fix(editor): Move overrideButton and other options to the left to line up with container boundary (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -400,6 +400,8 @@ const getIssues = computed<string[]>(() => {
 	return [];
 });
 
+const hasIssues = computed(() => getIssues.value.length > 0);
+
 const editorType = computed<EditorType | 'json' | 'code'>(() => {
 	return getArgument<EditorType>('editor');
 });
@@ -1019,6 +1021,7 @@ const isSingleLineInput = computed(() => {
 
 defineExpose({
 	isSingleLineInput,
+	hasIssues: () => hasIssues.value,
 	focusInput: async () => await setFocus(),
 	selectInput: () => selectInput(),
 });

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -400,7 +400,12 @@ const getIssues = computed<string[]>(() => {
 	return [];
 });
 
-const hasIssues = computed(() => getIssues.value.length > 0);
+const displayIssues = computed(
+	() =>
+		props.parameter.type !== 'credentialsSelect' &&
+		!isResourceLocatorParameter.value &&
+		getIssues.value.length > 0,
+);
 
 const editorType = computed<EditorType | 'json' | 'code'>(() => {
 	return getArgument<EditorType>('editor');
@@ -1021,7 +1026,7 @@ const isSingleLineInput = computed(() => {
 
 defineExpose({
 	isSingleLineInput,
-	hasIssues: () => hasIssues.value,
+	displaysIssues: displayIssues.value,
 	focusInput: async () => await setFocus(),
 	selectInput: () => selectInput(),
 });
@@ -1600,10 +1605,7 @@ onUpdated(async () => {
 		>
 			<slot name="overrideButton" />
 		</div>
-		<ParameterIssues
-			v-if="parameter.type !== 'credentialsSelect' && !isResourceLocatorParameter"
-			:issues="getIssues"
-		/>
+		<ParameterIssues v-if="displayIssues" :issues="getIssues" />
 	</div>
 </template>
 

--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -15,6 +15,7 @@ import { hasExpressionMapping, hasOnlyListMode, isValueExpression } from '@/util
 import { isResourceLocatorValue } from '@/utils/typeGuards';
 import { createEventBus } from 'n8n-design-system/utils';
 import {
+	NodeHelpers,
 	type INodeProperties,
 	type IParameterLabel,
 	type NodeParameterValueType,
@@ -321,7 +322,13 @@ function removeOverride(clearField = false) {
 			v-if="showOverrideButton && !isSingleLineInput && optionsPosition === 'top'"
 			#persistentOptions
 		>
-			<div :class="[$style.noCornersBottom, $style.overrideButtonInOptions]">
+			<div
+				:class="[
+					$style.noCornersBottom,
+					$style.overrideButtonInOptions,
+					{ [$style.overrideButtonIssueOffset]: parameterInputWrapper?.hasIssues },
+				]"
+			>
 				<FromAiOverrideButton @click="applyOverride" />
 			</div>
 		</template>
@@ -425,6 +432,12 @@ function removeOverride(clearField = false) {
 	position: relative;
 	// To connect to input panel below the button
 	margin-bottom: -2px;
+}
+
+.overrideButtonIssueOffset {
+	right: 20px;
+	// this is necessary to push the other options to the left
+	margin-left: 20px;
 }
 
 .noCornersBottom > button {

--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -15,7 +15,6 @@ import { hasExpressionMapping, hasOnlyListMode, isValueExpression } from '@/util
 import { isResourceLocatorValue } from '@/utils/typeGuards';
 import { createEventBus } from 'n8n-design-system/utils';
 import {
-	NodeHelpers,
 	type INodeProperties,
 	type IParameterLabel,
 	type NodeParameterValueType,

--- a/packages/editor-ui/src/components/ParameterInputFull.vue
+++ b/packages/editor-ui/src/components/ParameterInputFull.vue
@@ -325,7 +325,7 @@ function removeOverride(clearField = false) {
 				:class="[
 					$style.noCornersBottom,
 					$style.overrideButtonInOptions,
-					{ [$style.overrideButtonIssueOffset]: parameterInputWrapper?.hasIssues },
+					{ [$style.overrideButtonIssueOffset]: parameterInputWrapper?.displaysIssues },
 				]"
 			>
 				<FromAiOverrideButton @click="applyOverride" />

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -157,6 +157,7 @@ const param = useTemplateRef('param');
 const isSingleLineInput = computed(() => param.value?.isSingleLineInput);
 defineExpose({
 	isSingleLineInput,
+	hasIssues: () => param.value?.hasIssues,
 	focusInput: () => param.value?.focusInput(),
 	selectInput: () => param.value?.selectInput(),
 });

--- a/packages/editor-ui/src/components/ParameterInputWrapper.vue
+++ b/packages/editor-ui/src/components/ParameterInputWrapper.vue
@@ -155,9 +155,10 @@ function onTextInput(parameterData: IUpdateInformation) {
 
 const param = useTemplateRef('param');
 const isSingleLineInput = computed(() => param.value?.isSingleLineInput);
+const displaysIssues = computed(() => param.value?.displaysIssues);
 defineExpose({
 	isSingleLineInput,
-	hasIssues: () => param.value?.hasIssues,
+	displaysIssues,
 	focusInput: () => param.value?.focusInput(),
 	selectInput: () => param.value?.selectInput(),
 });


### PR DESCRIPTION
## Summary

Adjust the spacing as the button makes the offset quite unpleasant.

Before:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/35c810fb-b515-4807-b58d-d0731c78b420" />
After:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/e5937fe9-cdd0-4133-b9cc-8f984b13f223" />

I'm not actually aware of any textareas that would have a fromAI button, so I adjusted the height via the inspector to reproduce this. (We had the button on the description initially which might have caught this) So this is mostly future-proofing.

`ParameterInput` adds quite a few custom errors, so an expose seems like the best option here. Happy to change if there's a good alternative though.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3111/feature-fix-formatting-when-button-is-in-options-and-we-have-a-node


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
