### PR TITLE
fix(core): Do not emit `workflow-post-execute` event for waiting executions

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1155,22 +1155,6 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.trackWorkflowExecution).not.toHaveBeenCalled();
 		});
 
-		it('should not track when execution status is "waiting"', async () => {
-			const event: RelayEventMap['workflow-post-execute'] = {
-				workflow: mockWorkflowBase,
-				executionId: 'execution123',
-				userId: 'user123',
-				runData: {
-					status: 'waiting',
-					data: { resultData: {} },
-				} as IRun,
-			};
-
-			eventService.emit('workflow-post-execute', event);
-
-			expect(telemetry.trackWorkflowExecution).not.toHaveBeenCalled();
-		});
-
 		it('should track successful workflow execution', async () => {
 			const runData = mock<IRun>({
 				finished: true,

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -600,11 +600,6 @@ export class TelemetryEventRelay extends EventRelay {
 			return;
 		}
 
-		if (runData?.status === 'waiting') {
-			// No need to send telemetry or logs when the workflow hasn't finished yet.
-			return;
-		}
-
 		const telemetryProperties: IExecutionTrackProperties = {
 			workflow_id: workflow.id,
 			is_manual: false,

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -126,6 +126,12 @@ describe('Execution Lifecycle Hooks', () => {
 					workflow: workflowData,
 				});
 			});
+
+			it('should not emit workflow-post-execute events for waiting executions', async () => {
+				await hooks.executeHookFunctions('workflowExecuteAfter', [waitingRun, {}]);
+
+				expect(eventService.emit).not.toHaveBeenCalledWith('workflow-post-execute');
+			});
 		});
 	};
 

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -68,6 +68,8 @@ function hookFunctionsWorkflowEvents(userId?: string): IWorkflowExecuteHooks {
 		],
 		workflowExecuteAfter: [
 			async function (this: WorkflowHooks, runData: IRun): Promise<void> {
+				if (runData.status === 'waiting') return;
+
 				const { executionId, workflowData: workflow } = this;
 				eventService.emit('workflow-post-execute', { executionId, runData, workflow, userId });
 			},

--- a/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-recovery.service.test.ts
@@ -37,7 +37,6 @@ describe('ExecutionRecoveryService', () => {
 			instanceSettings,
 			push,
 			executionRepository,
-			mock(),
 		);
 	});
 

--- a/packages/cli/src/executions/execution-recovery.service.ts
+++ b/packages/cli/src/executions/execution-recovery.service.ts
@@ -8,7 +8,6 @@ import { ARTIFICIAL_TASK_DATA } from '@/constants';
 import { ExecutionRepository } from '@/databases/repositories/execution.repository';
 import { NodeCrashedError } from '@/errors/node-crashed.error';
 import { WorkflowCrashedError } from '@/errors/workflow-crashed.error';
-import { EventService } from '@/events/event.service';
 import { getWorkflowHooksMain } from '@/execution-lifecycle/execution-lifecycle-hooks';
 import type { IExecutionResponse } from '@/interfaces';
 import { Push } from '@/push';
@@ -25,7 +24,6 @@ export class ExecutionRecoveryService {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly push: Push,
 		private readonly executionRepository: ExecutionRepository,
-		private readonly eventService: EventService,
 	) {}
 
 	/**
@@ -175,12 +173,6 @@ export class ExecutionRecoveryService {
 
 	private async runHooks(execution: IExecutionResponse) {
 		execution.data ??= { resultData: { runData: {} } };
-
-		this.eventService.emit('workflow-post-execute', {
-			workflow: execution.workflowData,
-			executionId: execution.id,
-			runData: execution,
-		});
 
 		const externalHooks = getWorkflowHooksMain(
 			{


### PR DESCRIPTION
## Summary

This PR consolidates the emitting of `workflow-post-execute` event, and ensures that this event is not emitted for waiting executions.
This also fixes the issue that waiting executions (because they have `finished` set to `false`) are currently generating `workflow.failed` metrics.

## Related Linear tickets, Github issues, and Community forum posts

[CAT-620](https://linear.app/n8n/issue/CAT-620)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
