### PR TITLE
feat(Summarize Node): Preserves original field data type

### DIFF
--- a/packages/nodes-base/nodes/Transform/Summarize/Summarize.node.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/Summarize.node.ts
@@ -7,6 +7,7 @@ import {
 	type INodeTypeDescription,
 	NodeExecutionOutput,
 	type NodeExecutionHint,
+	type IDataObject,
 } from 'n8n-workflow';
 
 import {
@@ -14,6 +15,7 @@ import {
 	NUMERICAL_AGGREGATIONS,
 	type SummarizeOptions,
 	aggregationToArray,
+	aggregationToArrayWithOriginalTypes,
 	checkIfFieldExists,
 	fieldValueGetter,
 	splitData,
@@ -362,7 +364,12 @@ export class Summarize implements INodeType {
 				};
 				return new NodeExecutionOutput([[executionData]], fieldsNotFound);
 			}
-			const returnData = aggregationToArray(aggregationResult, fieldsToSplitBy);
+			let returnData: IDataObject[] = [];
+			if (nodeVersion > 1) {
+				returnData = aggregationToArrayWithOriginalTypes(aggregationResult, fieldsToSplitBy);
+			} else {
+				returnData = aggregationToArray(aggregationResult, fieldsToSplitBy);
+			}
 			const executionData = returnData.map((item) => {
 				const { pairedItems, ...json } = item;
 				return {

--- a/packages/nodes-base/nodes/Transform/Summarize/test/workflow.summarize_datatypes.json
+++ b/packages/nodes-base/nodes/Transform/Summarize/test/workflow.summarize_datatypes.json
@@ -1,0 +1,186 @@
+{
+	"name": "Summarize Test",
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-320, -80],
+			"id": "509c50eb-a5c3-4172-a553-82cce7ca0455",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"jsCode": "return [\n  {\n    \"uid\": \"a0e797c2-ffcf-495b-96f3-982f7bc4eae5\",\n    \"email\": \"Alfredo83@gmail.com\",\n    \"firstname\": \"Charlie\",\n    \"lastname\": \"Jacobi\",\n    \"password\": \"34~XLKdGit\",\n    \"Group\": 0\n  },\n  {\n    \"uid\": \"5713682e-4f32-47dc-ae89-ae4a8ac28a46\",\n    \"email\": \"Zachary43@yahoo.com\",\n    \"firstname\": \"Leonard\",\n    \"lastname\": \"Blick\",\n    \"password\": \"4sh5z!R\",\n    \"Group\": 0\n  },\n  {\n    \"uid\": \"1bb2a432-d2fb-48e4-a7b0-39030ef0d784\",\n    \"email\": \"Cory_Wilderman@yahoo.com\",\n    \"firstname\": \"Debra\",\n    \"lastname\": \"Corkery\",\n    \"password\": \"-8X1CKMFh\",\n    \"Group\": 1\n  },\n  {\n    \"uid\": \"4edb11bc-9256-4f26-9be6-f8b04e90ecb2\",\n    \"email\": \"Mindy_Murazik86@gmail.com\",\n    \"firstname\": \"Wendy\",\n    \"lastname\": \"Schiller\",\n    \"password\": \"WF373t,fe\",\n    \"Group\": 2\n  },\n  {\n    \"uid\": \"ec6efd3d-508c-4f1e-acae-c9467b74f5a6\",\n    \"email\": \"Darin_Vandervort@yahoo.com\",\n    \"firstname\": \"Dolores\",\n    \"lastname\": \"Walter\",\n    \"password\": \".45KCBk\",\n    \"Group\": 2\n  },\n  {\n    \"uid\": \"173ee780-4e4f-4164-aa39-41a0402cd2ad\",\n    \"email\": \"Claude.Grady6@gmail.com\",\n    \"firstname\": \"Leonard\",\n    \"lastname\": \"Krajcik\",\n    \"password\": \"6x6-MN8vch\",\n    \"Group\": null\n  },\n  {\n    \"uid\": \"b1f191d8-4f95-49f6-8533-042048b4c162\",\n    \"email\": \"Ismael_Volkman@hotmail.com\",\n    \"firstname\": \"Terri\",\n    \"lastname\": \"Kuphal\",\n    \"password\": \"62+BNNCk\",\n    \"Group\": null\n  },\n  {\n    \"uid\": \"ee8c6d18-1e77-435d-8c9a-5215141d7697\",\n    \"email\": \"Paulette.Hudson@hotmail.com\",\n    \"firstname\": \"Clinton\",\n    \"lastname\": \"Murphy\",\n    \"password\": \"2+R8IRxHL\",\n    \"Group\": null\n  },\n  {\n    \"uid\": \"feeb4357-0e20-4b15-9199-f161c23da1a2\",\n    \"email\": \"Guillermo.Kub33@gmail.com\",\n    \"firstname\": \"Edward\",\n    \"lastname\": \"Schaden\",\n    \"password\": \"Kv23S1_H\",\n    \"Group\": 0\n  },\n  {\n    \"uid\": \"676003ec-8a40-4105-8237-ba1d9eb51fc2\",\n    \"email\": \"Cindy.White@hotmail.com\",\n    \"firstname\": \"Esther\",\n    \"lastname\": \"Monahan\",\n    \"password\": \"5q$RyBhp\",\n    \"Group\": 2\n  }\n]"
+			},
+			"type": "n8n-nodes-base.code",
+			"typeVersion": 2,
+			"position": [-100, -80],
+			"id": "691f2744-8689-4b5c-91e7-2bb378691ecf",
+			"name": "sample data"
+		},
+		{
+			"parameters": {
+				"fieldsToSummarize": {
+					"values": [
+						{
+							"aggregation": "append",
+							"field": "email",
+							"includeEmpty": true
+						}
+					]
+				},
+				"fieldsToSplitBy": "Group",
+				"options": {
+					"outputFormat": "separateItems"
+				}
+			},
+			"type": "n8n-nodes-base.summarize",
+			"typeVersion": 1.1,
+			"position": [160, 0],
+			"id": "d1267da5-0cab-453c-9450-1bbd78346bd6",
+			"name": "Summarize v1.1"
+		},
+		{
+			"parameters": {
+				"fieldsToSummarize": {
+					"values": [
+						{
+							"aggregation": "append",
+							"field": "email",
+							"includeEmpty": true
+						}
+					]
+				},
+				"fieldsToSplitBy": "Group",
+				"options": {
+					"continueIfFieldNotFound": false,
+					"outputFormat": "separateItems"
+				}
+			},
+			"type": "n8n-nodes-base.summarize",
+			"typeVersion": 1,
+			"position": [160, -160],
+			"id": "680b7269-c920-4cce-b9f5-b2189955848d",
+			"name": "Summarize v1"
+		}
+	],
+	"pinData": {
+		"Summarize v1": [
+			{
+				"json": {
+					"Group": "0",
+					"appended_email": [
+						"Alfredo83@gmail.com",
+						"Zachary43@yahoo.com",
+						"Guillermo.Kub33@gmail.com"
+					]
+				}
+			},
+			{
+				"json": {
+					"Group": "1",
+					"appended_email": ["Cory_Wilderman@yahoo.com"]
+				}
+			},
+			{
+				"json": {
+					"Group": "2",
+					"appended_email": [
+						"Mindy_Murazik86@gmail.com",
+						"Darin_Vandervort@yahoo.com",
+						"Cindy.White@hotmail.com"
+					]
+				}
+			},
+			{
+				"json": {
+					"Group": "null",
+					"appended_email": [
+						"Claude.Grady6@gmail.com",
+						"Ismael_Volkman@hotmail.com",
+						"Paulette.Hudson@hotmail.com"
+					]
+				}
+			}
+		],
+		"Summarize v1.1": [
+			{
+				"json": {
+					"Group": 0,
+					"appended_email": [
+						"Alfredo83@gmail.com",
+						"Zachary43@yahoo.com",
+						"Guillermo.Kub33@gmail.com"
+					]
+				}
+			},
+			{
+				"json": {
+					"Group": 1,
+					"appended_email": ["Cory_Wilderman@yahoo.com"]
+				}
+			},
+			{
+				"json": {
+					"Group": 2,
+					"appended_email": [
+						"Mindy_Murazik86@gmail.com",
+						"Darin_Vandervort@yahoo.com",
+						"Cindy.White@hotmail.com"
+					]
+				}
+			},
+			{
+				"json": {
+					"Group": null,
+					"appended_email": [
+						"Claude.Grady6@gmail.com",
+						"Ismael_Volkman@hotmail.com",
+						"Paulette.Hudson@hotmail.com"
+					]
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "sample data",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"sample data": {
+			"main": [
+				[
+					{
+						"node": "Summarize v1",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Summarize v1.1",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "7304eae2-3bae-4934-8d1f-1135a0ff8ab8",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "b0d1a7f453aa2195078ce658269afa7743e3dc59edb733395b6c75bde57da7ff"
+	},
+	"id": "8ja9H2443AhLdBsS",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Transform/Summarize/utils.ts
+++ b/packages/nodes-base/nodes/Transform/Summarize/utils.ts
@@ -1,3 +1,4 @@
+import { isNaN } from 'lodash';
 import get from 'lodash/get';
 import {
 	type IDataObject,
@@ -281,6 +282,41 @@ export function aggregationToArray(
 				...aggregationToArray(aggregationResult[key] as IDataObject, fieldsToSplitBy.slice(1), {
 					...previousStage,
 					[splitFieldName]: key,
+				}),
+			);
+		}
+		return returnData;
+	}
+}
+
+const getOriginalFieldValue = (field: string | number) =>
+	field === 'null' ? null : isNaN(Number(field)) ? field : Number(field);
+
+export function aggregationToArrayWithOriginalTypes(
+	aggregationResult: IDataObject,
+	fieldsToSplitBy: string[],
+	previousStage: IDataObject = {},
+) {
+	const returnData: IDataObject[] = [];
+	fieldsToSplitBy = parseFieldName(fieldsToSplitBy);
+	const splitFieldName = fieldsToSplitBy[0];
+	const isNext = fieldsToSplitBy[1];
+
+	if (isNext === undefined) {
+		for (const fieldName of Object.keys(aggregationResult)) {
+			returnData.push({
+				...previousStage,
+				[splitFieldName]: getOriginalFieldValue(fieldName),
+				...(aggregationResult[fieldName] as IDataObject),
+			});
+		}
+		return returnData;
+	} else {
+		for (const key of Object.keys(aggregationResult)) {
+			returnData.push(
+				...aggregationToArray(aggregationResult[key] as IDataObject, fieldsToSplitBy.slice(1), {
+					...previousStage,
+					[splitFieldName]: getOriginalFieldValue(key),
 				}),
 			);
 		}


### PR DESCRIPTION
## Summary

Previously the `Summarize Node` would convert the data type of an input value to be used for grouping into a string. This PR introduces type preservation for numeric and null values in `fieldToSplitBy`.

`v1`
![image](https://github.com/user-attachments/assets/8ff7fe25-beac-47ee-aa69-f01553d2a1d3)

`v1.1`
![image](https://github.com/user-attachments/assets/3784db75-7380-4ffb-8a95-a0d1d20599da)


<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-1572/summarize-node-fields-to-split-by-are-cast-to-strings
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
