### PR TITLE
feat(core): Add an option to allow community nodes as tools

### DIFF
--- a/packages/@n8n/config/src/configs/nodes.config.ts
+++ b/packages/@n8n/config/src/configs/nodes.config.ts
@@ -33,6 +33,10 @@ class CommunityPackagesConfig {
 	/** Whether to reinstall any missing community packages */
 	@Env('N8N_REINSTALL_MISSING_PACKAGES')
 	reinstallMissing: boolean = false;
+
+	/** Whether to allow community packages as tools for AI agents */
+	@Env('N8N_COMMUNITY_PACKAGES_ALLOW_TOOL_USAGE')
+	allowToolUsage: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -119,6 +119,7 @@ describe('GlobalConfig', () => {
 				enabled: true,
 				registry: 'https://registry.npmjs.org',
 				reinstallMissing: false,
+				allowToolUsage: false,
 			},
 			errorTriggerType: 'n8n-nodes-base.errorTrigger',
 			include: [],

--- a/packages/cli/src/__tests__/node-types.test.ts
+++ b/packages/cli/src/__tests__/node-types.test.ts
@@ -163,27 +163,27 @@ describe('NodeTypes', () => {
 			);
 		});
 
-		it('should throw when a node-type is requested as tool, but is a community package', () => {
-			expect(() => nodeTypes.getByNameAndVersion('n8n-nodes-community.testNodeTool')).toThrow(
-				'Unrecognized node type: n8n-nodes-community.testNodeTool',
-			);
-		});
-
-		it('should throw when a node-type is requested as tool, but is a community package', () => {
-			globalConfig.nodes.communityPackages.allowToolUsage = true;
-			const result = nodeTypes.getByNameAndVersion('n8n-nodes-community.testNodeTool');
+		it('should return the tool node-type when requested as tool', () => {
+			const result = nodeTypes.getByNameAndVersion('n8n-nodes-base.testNodeTool');
 			expect(result).not.toEqual(toolSupportingNode.type);
-			expect(result.description.name).toEqual('n8n-nodes-community.testNodeTool');
+			expect(result.description.name).toEqual('n8n-nodes-base.testNodeTool');
 			expect(result.description.displayName).toEqual('TestNode Tool');
 			expect(result.description.codex?.categories).toContain('AI');
 			expect(result.description.inputs).toEqual([]);
 			expect(result.description.outputs).toEqual(['ai_tool']);
 		});
 
-		it('should return the tool node-type when requested as tool', () => {
-			const result = nodeTypes.getByNameAndVersion('n8n-nodes-base.testNodeTool');
+		it('should throw when a node-type is requested as tool, but is a community package', () => {
+			expect(() => nodeTypes.getByNameAndVersion('n8n-nodes-community.testNodeTool')).toThrow(
+				'Unrecognized node type: n8n-nodes-community.testNodeTool',
+			);
+		});
+
+		it('should return a tool node-type from a community node,  when requested as tool', () => {
+			globalConfig.nodes.communityPackages.allowToolUsage = true;
+			const result = nodeTypes.getByNameAndVersion('n8n-nodes-community.testNodeTool');
 			expect(result).not.toEqual(toolSupportingNode.type);
-			expect(result.description.name).toEqual('n8n-nodes-base.testNodeTool');
+			expect(result.description.name).toEqual('n8n-nodes-community.testNodeTool');
 			expect(result.description.displayName).toEqual('TestNode Tool');
 			expect(result.description.codex?.categories).toContain('AI');
 			expect(result.description.inputs).toEqual([]);


### PR DESCRIPTION
## Summary

This PR adds an option to let n8n instances use community nodes as AI tools, when the node has `usableAsTool` set to `true`. This PR also adds an additional check to prevent n8n from creating virtual tools out of nodes that already have a `supplyData` method.

## Related Linear tickets, Github issues, and Community forum posts

[AI-406](https://linear.app/n8n/issue/AI-406)


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
