### PR TITLE
refactor(Google Gemini Chat Model Node): Provide custom message mapper to N8nLlmTracing (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/N8nLlmTracing.ts
@@ -61,11 +61,15 @@ export class N8nLlmTracing extends BaseCallbackHandler {
 				totalTokens: completionTokens + promptTokens,
 			};
 		},
+		errorDescriptionMapper: (error: NodeError) => error.description,
 	};
 
 	constructor(
 		private executionFunctions: ISupplyDataFunctions,
-		options?: { tokensUsageParser: TokensUsageParser },
+		options?: {
+			tokensUsageParser?: TokensUsageParser;
+			errorDescriptionMapper?: (error: NodeError) => string;
+		},
 	) {
 		super();
 		this.options = { ...this.options, ...options };
@@ -192,6 +196,10 @@ export class N8nLlmTracing extends BaseCallbackHandler {
 		}
 
 		if (error instanceof NodeError) {
+			if (this.options.errorDescriptionMapper) {
+				error.description = this.options.errorDescriptionMapper(error);
+			}
+
 			this.executionFunctions.addOutputData(this.connectionType, runDetails.index, error);
 		} else {
 			// If the error is not a NodeError, we wrap it in a NodeOperationError


### PR DESCRIPTION
## Summary

This PR allows `N8nLlmTracing` to accept `errorDescriptionMapper`. If defined, it's used in `handleLLMError` to allow for custom messages. We then use it in `Google Gemini Chat Model` node to change text(description) of an error message for empty tool properties.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
