### PR TITLE
feat(editor): Add docs link in $fromAI hover info tooltip

### DIFF
--- a/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
@@ -283,7 +283,8 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 			{
 				name: '$fromAI',
 				returnType: 'any',
-				description: 'Populate this with the parameter passed from the large language model',
+				description: 'Populate this with the parameter passed from the large language model.',
+				docURL: 'https://docs.n8n.io/advanced-ai/examples/using-the-fromai-function/',
 				args: [
 					{
 						name: 'key',

--- a/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
+++ b/packages/editor-ui/src/plugins/codemirror/completions/constants.ts
@@ -283,7 +283,7 @@ export const ROOT_DOLLAR_COMPLETIONS: Completion[] = [
 			{
 				name: '$fromAI',
 				returnType: 'any',
-				description: 'Populate this with the parameter passed from the large language model.',
+				description: 'Populate this with the parameter passed from the large language model',
 				docURL: 'https://docs.n8n.io/advanced-ai/examples/using-the-fromai-function/',
 				args: [
 					{


### PR DESCRIPTION
## Summary

Add a link to the docs page. Our styling isn't great here but it's better than nothing.

The code change adds the `Learn more` text here:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/4c09eea3-2e9d-49b7-80a2-b61fc8bb3178" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3200/link-docs-page-in-fromai-completion-info


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
