### PR TITLE
fix: Add version to new @n8n/composables package (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/composables/package.json
+++ b/packages/frontend/@n8n/composables/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@n8n/composables",
 	"type": "module",
+  "version": "1.0.0",
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
This breaks some CICD jobs

https://github.com/n8n-io/n8n/actions/runs/13177637996/job/36781118698?pr=13096

## Summary

Add version to new @n8n/composables package

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
