### PR TITLE
fix(core): Only use new resource mapper type validation when it is enabled

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/validate-value-against-schema.ts
@@ -6,6 +6,7 @@ import type {
 	INodePropertyCollection,
 	INodePropertyOptions,
 	INodeType,
+	ResourceMapperTypeOptions,
 } from 'n8n-workflow';
 import {
 	ExpressionError,
@@ -20,9 +21,11 @@ const validateResourceMapperValue = (
 	parameterName: string,
 	paramValues: { [key: string]: unknown },
 	node: INode,
-	skipRequiredCheck = false,
+	resourceMapperTypeOptions?: ResourceMapperTypeOptions,
 ): ExtendedValidationResult => {
 	const result: ExtendedValidationResult = { valid: true, newValue: paramValues };
+	const skipRequiredCheck = resourceMapperTypeOptions?.mode !== 'add';
+	const enableTypeValidationOptions = Boolean(resourceMapperTypeOptions?.showTypeConversionOptions);
 	const paramNameParts = parameterName.split('.');
 	if (paramNameParts.length !== 2) {
 		return result;
@@ -56,8 +59,8 @@ const validateResourceMapperValue = (
 		if (schemaEntry?.type) {
 			const validationResult = validateFieldType(key, resolvedValue, schemaEntry.type, {
 				valueOptions: schemaEntry.options,
-				strict: resourceMapperField.attemptToConvertTypes === false,
-				parseStrings: Boolean(resourceMapperField.convertFieldsToString),
+				strict: enableTypeValidationOptions && !resourceMapperField.attemptToConvertTypes,
+				parseStrings: enableTypeValidationOptions && resourceMapperField.convertFieldsToString,
 			});
 
 			if (!validationResult.valid) {
@@ -185,7 +188,7 @@ export const validateValueAgainstSchema = (
 			parameterName,
 			parameterValue as { [key: string]: unknown },
 			node,
-			propertyDescription.typeOptions?.resourceMapper?.mode !== 'add',
+			propertyDescription.typeOptions?.resourceMapper,
 		);
 	} else if (['fixedCollection', 'collection'].includes(propertyDescription.type)) {
 		validationResult = validateCollection(

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -2723,8 +2723,8 @@ export type ResourceMapperValue = {
 	value: { [key: string]: string | number | boolean | null } | null;
 	matchingColumns: string[];
 	schema: ResourceMapperField[];
-	attemptToConvertTypes?: boolean;
-	convertFieldsToString?: boolean;
+	attemptToConvertTypes: boolean;
+	convertFieldsToString: boolean;
 };
 
 export type FilterOperatorType =


### PR DESCRIPTION
## Summary

Only use `attemptToConvertTypes`/`convertFieldsToString` when `showTypeConversionOptions` is set to true in the parameter typeOptions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2249/community-issue-sql-data-type-error


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
