### PR TITLE
feat(OpenAI Chat Model Node): Add reasoning effort option to control the amount of reasoning tokens to use

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -289,6 +289,11 @@ export class LmChatOpenAi implements INodeType {
 									'Favors more complete reasoning at the cost of more tokens generated and slower responses',
 							},
 						],
+						displayOptions: {
+							show: {
+								'/model': [{ _cnd: { regex: '^o\\d+.*' } }],
+							},
+						},
 					},
 					{
 						displayName: 'Timeout',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -291,7 +291,7 @@ export class LmChatOpenAi implements INodeType {
 						],
 						displayOptions: {
 							show: {
-								'/model': [{ _cnd: { regex: '^o\\d+.*' } }],
+								'/model': [{ _cnd: { regex: '(^o1$)|(^o[3-9].*)' } }],
 							},
 						},
 					},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -291,6 +291,7 @@ export class LmChatOpenAi implements INodeType {
 						],
 						displayOptions: {
 							show: {
+								// reasoning_effort is only available on o1, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
 								'/model': [{ _cnd: { regex: '(^o1$)|(^o[3-9].*)' } }],
 							},
 						},

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -291,8 +291,8 @@ export class LmChatOpenAi implements INodeType {
 						],
 						displayOptions: {
 							show: {
-								// reasoning_effort is only available on o1, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
-								'/model': [{ _cnd: { regex: '(^o1$)|(^o[3-9].*)' } }],
+								// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+								'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

The o1 and o3 models support a new `reasoning_effort` parameter that controls how many reasoning tokens to use. This change implements that in the OpenAI Chat Model Node.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
