### PR TITLE
fix(core): Add an option to enable dual-stack lookup to support IPv6 for redis

### DIFF
--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -52,6 +52,10 @@ class RedisConfig {
 	/** Whether to enable TLS on Redis connections. */
 	@Env('QUEUE_BULL_REDIS_TLS')
 	tls: boolean = false;
+
+	/** Whether to enable dual-stack hostname resolution for Redis connections. */
+	@Env('QUEUE_BULL_REDIS_DUALSTACK')
+	dualStack: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -214,6 +214,7 @@ describe('GlobalConfig', () => {
 					username: '',
 					clusterNodes: '',
 					tls: false,
+					dualStack: false,
 				},
 				gracefulShutdownTimeout: 30,
 				prefix: 'bull',

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -131,7 +131,7 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 	}
 
 	private getOptions({ extraOptions }: { extraOptions?: RedisOptions }) {
-		const { username, password, db, tls } = this.globalConfig.queue.bull.redis;
+		const { username, password, db, tls, dualStack } = this.globalConfig.queue.bull.redis;
 
 		/**
 		 * Disabling ready check allows quick reconnection to Redis if Redis becomes
@@ -152,6 +152,8 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 			retryStrategy: this.retryStrategy(),
 			...extraOptions,
 		};
+
+		if (dualStack) options.family = 0;
 
 		if (tls) options.tls = {}; // enable TLS with default Node.js settings
 


### PR DESCRIPTION
## Summary
ioredis uses only [IPv4 by default](https://github.com/redis/ioredis/blob/main/lib/redis/RedisOptions.ts#L201). This PR adds an option to let users enable dual-stack lookup for the redis hostname.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #13117
CAT-627
https://community.n8n.io/t/allow-ipv6-to-use-redis-with-provider-internal-network/32439
https://community.n8n.io/t/allow-ipv6-to-use-redis-with-provider-internal-network-the-return/61372

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
