### PR TITLE
fix(Google Sheets Trigger Node): Do not return header row in rowAdded mode

### DIFF
--- a/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/GoogleSheetsTrigger.node.ts
@@ -120,6 +120,9 @@ export class GoogleSheetsTrigger implements INodeType {
 				default: { mode: 'list', value: '' },
 				// default: '', //empty string set to progresivly reveal fields
 				required: true,
+				typeOptions: {
+					loadOptionsDependsOn: ['documentId.value'],
+				},
 				modes: [
 					{
 						displayName: 'From List',
@@ -529,6 +532,11 @@ export class GoogleSheetsTrigger implements INodeType {
 					(options.valueRender as ValueRenderOption) || 'UNFORMATTED_VALUE',
 					(options.dateTimeRenderOption as string) || 'FORMATTED_STRING',
 				);
+
+				if (Array.isArray(sheetData) && sheetData.length !== 0) {
+					const zeroBasedKeyRow = keyRow - 1;
+					sheetData.splice(zeroBasedKeyRow, 1); // Remove key row
+				}
 
 				if (this.getMode() === 'manual') {
 					if (Array.isArray(sheetData)) {

--- a/packages/nodes-base/nodes/Google/Sheet/test/GoogleSheetsTrigger.test.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/test/GoogleSheetsTrigger.test.ts
@@ -1,0 +1,53 @@
+import { mockDeep } from 'jest-mock-extended';
+import nock from 'nock';
+
+import { testPollingTriggerNode } from '@test/nodes/TriggerHelpers';
+
+import { GoogleSheetsTrigger } from '../GoogleSheetsTrigger.node';
+
+describe('GoogleSheetsTrigger', () => {
+	const baseUrl = 'https://sheets.googleapis.com';
+
+	describe('rowAdded event', () => {
+		it('should return rows without header', async () => {
+			const scope = nock(baseUrl);
+			scope
+				.get('/v4/spreadsheets/testDocumentId')
+				.query({ fields: 'sheets.properties' })
+				.reply(200, {
+					sheets: [{ properties: { sheetId: 1, title: 'testSheetName' } }],
+				});
+			scope
+				.get((uri) => uri.startsWith('/v4/spreadsheets/testDocumentId/values/testSheetName!A1:ZZZ'))
+				.times(2)
+				.reply(200, {
+					values: [
+						['name', 'count'],
+						['apple', 14],
+						['banana', 12],
+					],
+				});
+
+			const { response } = await testPollingTriggerNode(GoogleSheetsTrigger, {
+				credential: mockDeep(),
+				mode: 'manual',
+				node: {
+					parameters: {
+						documentId: 'testDocumentId',
+						sheetName: 1,
+						event: 'rowAdded',
+						options: {
+							dataLocationOnSheet: null,
+						},
+					},
+				},
+			});
+
+			scope.done();
+
+			expect(response).toEqual([
+				[{ json: { count: 14, name: 'apple' } }, { json: { count: 12, name: 'banana' } }],
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Do not return header row in `rowAdded` mode
- Clear `Sheet` RLC when `Document` RLC changes

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2231/bug-google-sheets-trigger-repeats-header-rows-and-returns-phantom-data
https://community.n8n.io/t/google-sheet-including-first-row-headers-in-json-response/74542

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
