### PR TITLE
feat(editor): Add `node_id` to canvas events (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/NodeDetailsView.vue
+++ b/packages/editor-ui/src/components/NodeDetailsView.vue
@@ -628,6 +628,7 @@ watch(
 					);
 
 					telemetry.track('User opened node modal', {
+						node_id: activeNode.value?.id,
 						node_type: activeNodeType.value ? activeNodeType.value?.name : '',
 						workflow_id: workflowsStore.workflowId,
 						push_ref: pushRef.value,

--- a/packages/editor-ui/src/composables/useCanvasOperations.ts
+++ b/packages/editor-ui/src/composables/useCanvasOperations.ts
@@ -743,6 +743,7 @@ export function useCanvasOperations({ router }: { router: ReturnType<typeof useR
 
 	function trackAddDefaultNode(nodeData: INodeUi, options: AddNodeOptions) {
 		nodeCreatorStore.onNodeAddedToCanvas({
+			node_id: nodeData.id,
 			node_type: nodeData.type,
 			node_version: nodeData.typeVersion,
 			is_auto_add: options.isAutoAdd,

--- a/packages/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -177,6 +177,7 @@ describe('useNodeCreatorStore', () => {
 		expect(useTelemetry().track).toHaveBeenCalledWith(
 			'User added node to workflow canvas',
 			{
+				node_id,
 				node_type,
 				node_version,
 				is_auto_add: true,

--- a/packages/editor-ui/src/stores/nodeCreator.store.test.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.test.ts
@@ -18,6 +18,7 @@ const mode = 'mode';
 const now = 1717602004819;
 const now1 = 1718602004819;
 const node_type = 'node-type';
+const node_id = 'node-id';
 const node_version = 1;
 const input_node_type = 'input-node-type';
 const action = 'action';
@@ -164,6 +165,7 @@ describe('useNodeCreatorStore', () => {
 			workflow_id,
 		});
 		nodeCreatorStore.onNodeAddedToCanvas({
+			node_id,
 			node_type,
 			node_version,
 			is_auto_add: true,

--- a/packages/editor-ui/src/stores/nodeCreator.store.ts
+++ b/packages/editor-ui/src/stores/nodeCreator.store.ts
@@ -355,6 +355,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	}
 
 	function onNodeAddedToCanvas(properties: {
+		node_id: string;
 		node_type: string;
 		node_version: number;
 		is_auto_add?: boolean;

--- a/packages/editor-ui/src/views/NodeView.vue
+++ b/packages/editor-ui/src/views/NodeView.vue
@@ -2429,6 +2429,7 @@ export default defineComponent({
 			} else {
 				void this.externalHooks.run('nodeView.addNodeButton', { nodeTypeName });
 				this.nodeCreatorStore.onNodeAddedToCanvas({
+					node_id: newNodeData.id,
 					node_type: nodeTypeName,
 					node_version: newNodeData.typeVersion,
 					is_auto_add: isAutoAdd,


### PR DESCRIPTION
## Summary
Adding missing `node_id` to `User added node to workflow canvas` and `User opened node modal` telemetry events.

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-3201

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
