### PR TITLE
fix(editor): Disable fromAI button for vector stores

### DIFF
--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.test.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.test.ts
@@ -54,6 +54,17 @@ const AI_DENYLIST_NODE_TYPE: INodeTypeDescription = {
 	...MOCK_NODE_TYPE_MIXIN,
 };
 
+const AI_VECTOR_STORE_NODE_TYPE: INodeTypeDescription = {
+	name: 'aVectorStore',
+	codex: {
+		categories: ['AI'],
+		subcategories: {
+			AI: ['Tools', 'Vector Stores'],
+		},
+	},
+	...MOCK_NODE_TYPE_MIXIN,
+};
+
 const NON_AI_NODE_TYPE: INodeTypeDescription = {
 	name: 'AN_NOT_AI_NODE_TYPE',
 	...MOCK_NODE_TYPE_MIXIN,
@@ -64,6 +75,8 @@ describe('makeOverrideValue', () => {
 		['null nodeType', makeContext(''), null],
 		['non-ai node type', makeContext(''), NON_AI_NODE_TYPE],
 		['ai node type on denylist', makeContext(''), AI_DENYLIST_NODE_TYPE],
+		['vector store type', makeContext(''), AI_VECTOR_STORE_NODE_TYPE],
+		['denied parameter name', makeContext('', 'parameters.toolName'), AI_NODE_TYPE],
 	])('should not create an override for %s', (_name, context, nodeType) => {
 		expect(makeOverrideValue(context, nodeType)).toBeNull();
 	});

--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
@@ -169,7 +169,7 @@ export function canBeContentOverride(
 	if (
 		!codex?.categories?.includes('AI') ||
 		!codex?.subcategories?.AI?.includes('Tools') ||
-		codex?.subcategories?.AI?.includes('Vector Stores') // vector stores do no support fromAI
+		codex?.subcategories?.AI?.includes('Vector Stores') // vector stores do not support fromAI
 	)
 		return false;
 

--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
@@ -166,7 +166,11 @@ export function canBeContentOverride(
 	if (PATH_DENYLIST.includes(props.path)) return false;
 
 	const codex = nodeType?.codex;
-	if (!codex?.categories?.includes('AI') || !codex?.subcategories?.AI?.includes('Tools'))
+	if (
+		!codex?.categories?.includes('AI') ||
+		!codex?.subcategories?.AI?.includes('Tools') ||
+		codex?.subcategories?.AI?.includes('Vector Stores') // vector stores do no support fromAI
+	)
 		return false;
 
 	return !props.parameter.noDataExpression && 'options' !== props.parameter.type;

--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
@@ -48,6 +48,8 @@ const NODE_DENYLIST = ['toolCode', 'toolHttpRequest'];
 
 const PATH_DENYLIST = [
 	'parameters.name',
+	// this is used in vector store tools
+	'parameters.toolName',
 	'parameters.description',
 	// This is used in e.g. the telegram node if the dropdown selects manual mode
 	'parameters.toolDescription',


### PR DESCRIPTION
## Summary

Missed this one in the intial list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3203/remove-vector-store-name-fromai-button


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
