### PR TITLE
docs(Chat Trigger Node): Add option for loadPreviousSession

### DIFF
--- a/packages/@n8n/chat/README.md
+++ b/packages/@n8n/chat/README.md
@@ -112,6 +112,7 @@ createChat({
 	mode: 'window',
 	chatInputKey: 'chatInput',
 	chatSessionKey: 'sessionId',
+	loadPreviousSession: true,
 	metadata: {},
 	showWelcomeScreen: false,
 	defaultLanguage: 'en',
@@ -161,15 +162,20 @@ createChat({
 - **Default**: `false`
 - **Description**: Whether to show the welcome screen when the Chat window is opened.
 
+### `chatInputKey`
+- **Type**: `string`
+- **Default**: `'chatInput'`
+- **Description**: The key to use for sending the chat input for the AI Agent node.
+
 ### `chatSessionKey`
 - **Type**: `string`
 - **Default**: `'sessionId'`
 - **Description**: The key to use for sending the chat history session ID for the AI Memory node.
 
-### `chatInputKey`
-- **Type**: `string`
-- **Default**: `'chatInput'`
-- **Description**: The key to use for sending the chat input for the AI Agent node.
+### `loadPreviousSession`
+- **Type**: `boolean`
+- **Default**: `true`
+- **Description**: Whether to load previous messages (chat context). 
 
 ### `defaultLanguage`
 - **Type**: `string`


### PR DESCRIPTION
## Summary

This PR documents the `loadPreviousSession` option. 

## Related Linear tickets, Github issues, and Community forum posts

- https://community.n8n.io/t/embeded-chat-costs-a-lot-even-when-not-used/59476
- https://community.n8n.io/t/question-about-handling-initial-requests-in-n8n-chat-widget-integration/57304


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
