### PR TITLE
fix(core): Fix parsing of push messages (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -7,6 +7,8 @@ export type * from './user';
 export type * from './api-keys';
 
 export type { Collaborator } from './push/collaboration';
+export type { HeartbeatMessage } from './push/heartbeat';
+export { createHeartbeatMessage, heartbeatMessageSchema } from './push/heartbeat';
 export type { SendWorkerStatusMessage } from './push/worker';
 
 export type { BannerName } from './schemas/bannerName.schema';

--- a/packages/@n8n/api-types/src/push/heartbeat.ts
+++ b/packages/@n8n/api-types/src/push/heartbeat.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const heartbeatMessageSchema = z.object({
+	type: z.literal('heartbeat'),
+});
+
+export type HeartbeatMessage = z.infer<typeof heartbeatMessageSchema>;
+
+export const createHeartbeatMessage = (): HeartbeatMessage => ({
+	type: 'heartbeat',
+});

--- a/packages/editor-ui/src/push-connection/useWebSocketClient.ts
+++ b/packages/editor-ui/src/push-connection/useWebSocketClient.ts
@@ -1,7 +1,7 @@
 import { useHeartbeat } from '@/push-connection/useHeartbeat';
 import { useReconnectTimer } from '@/push-connection/useReconnectTimer';
 import { ref } from 'vue';
-
+import { createHeartbeatMessage } from '@n8n/api-types';
 export type UseWebSocketClientOptions<T> = {
 	url: string;
 	onMessage: (data: T) => void;
@@ -31,7 +31,7 @@ export const useWebSocketClient = <T>(options: UseWebSocketClientOptions<T>) => 
 	const { startHeartbeat, stopHeartbeat } = useHeartbeat({
 		interval: 30_000,
 		onHeartbeat: () => {
-			socket.value?.send(JSON.stringify({ type: 'heartbeat' }));
+			socket.value?.send(JSON.stringify(createHeartbeatMessage()));
 		},
 	});
 


### PR DESCRIPTION

## Summary

Fix a bug introduced in https://github.com/n8n-io/n8n/pull/13085 to collaboration feature:
Ignore the client hearbeat instead of propagating it

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-629/invalid-union-discriminator-error-shown-when-stopping-instance


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
