### PR TITLE
fix(OpenAI Node): Limit chat history to context window when using memory

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -1,8 +1,9 @@
+import type { MemoryVariables } from '@langchain/core/memory';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AgentExecutor } from 'langchain/agents';
 import type { OpenAIToolType } from 'langchain/dist/experimental/openai_assistant/schema';
 import { OpenAIAssistantRunnable } from 'langchain/experimental/openai_assistant';
-import type { BufferWindowMemory } from 'langchain/memory';
+import { BufferWindowMemory } from 'langchain/memory';
 import omit from 'lodash/omit';
 import type {
 	IDataObject,
@@ -22,7 +23,7 @@ import { promptTypeOptions } from '@utils/descriptions';
 import { getConnectedTools } from '@utils/helpers';
 import { getTracingConfig } from '@utils/tracing';
 
-import { formatToOpenAIAssistantTool } from '../../helpers/utils';
+import { formatToOpenAIAssistantTool, getChatMessages } from '../../helpers/utils';
 import { assistantRLC } from '../descriptions';
 
 const properties: INodeProperties[] = [
@@ -252,7 +253,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	};
 	let thread: OpenAIClient.Beta.Threads.Thread;
 	if (memory) {
-		const chatMessages = await memory.chatHistory.getMessages();
+		const chatMessages = await getChatMessages(memory);
 
 		// Construct a new thread from the chat history to map the memory
 		if (chatMessages.length) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -1,9 +1,8 @@
-import type { MemoryVariables } from '@langchain/core/memory';
 import type { BaseMessage } from '@langchain/core/messages';
 import { AgentExecutor } from 'langchain/agents';
 import type { OpenAIToolType } from 'langchain/dist/experimental/openai_assistant/schema';
 import { OpenAIAssistantRunnable } from 'langchain/experimental/openai_assistant';
-import { BufferWindowMemory } from 'langchain/memory';
+import type { BufferWindowMemory } from 'langchain/memory';
 import omit from 'lodash/omit';
 import type {
 	IDataObject,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/helpers/utils.ts
@@ -1,5 +1,7 @@
+import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredTool } from '@langchain/core/tools';
 import type { OpenAIClient } from '@langchain/openai';
+import type { BufferWindowMemory } from 'langchain/memory';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
 // Copied from langchain(`langchain/src/tools/convert_to_openai.ts`)
@@ -42,4 +44,8 @@ export function formatToOpenAIAssistantTool(tool: StructuredTool): OpenAIClient.
 			parameters: zodToJsonSchema(tool.schema),
 		},
 	};
+}
+
+export async function getChatMessages(memory: BufferWindowMemory): Promise<BaseMessage[]> {
+	return (await memory.loadMemoryVariables({}))[memory.memoryKey] as BaseMessage[];
 }

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/utils.test.ts
@@ -1,0 +1,46 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { BufferWindowMemory } from 'langchain/memory';
+
+import { getChatMessages } from '../helpers/utils';
+
+describe('OpenAI message history', () => {
+	it('should only get a limited number of messages', async () => {
+		const memory = new BufferWindowMemory({
+			returnMessages: true,
+			k: 2,
+		});
+		expect(await getChatMessages(memory)).toEqual([]);
+
+		await memory.saveContext(
+			[new HumanMessage({ content: 'human 1' })],
+			[new AIMessage({ content: 'ai 1' })],
+		);
+		// `k` means turns, but `getChatMessages` returns messages, so a Human and an AI message.
+		expect((await getChatMessages(memory)).length).toEqual(2);
+
+		await memory.saveContext(
+			[new HumanMessage({ content: 'human 2' })],
+			[new AIMessage({ content: 'ai 2' })],
+		);
+		expect((await getChatMessages(memory)).length).toEqual(4);
+		expect((await getChatMessages(memory)).map((msg) => msg.content)).toEqual([
+			'human 1',
+			'ai 1',
+			'human 2',
+			'ai 2',
+		]);
+
+		// We expect this to be trimmed...
+		await memory.saveContext(
+			[new HumanMessage({ content: 'human 3' })],
+			[new AIMessage({ content: 'ai 3' })],
+		);
+		expect((await getChatMessages(memory)).length).toEqual(4);
+		expect((await getChatMessages(memory)).map((msg) => msg.content)).toEqual([
+			'human 2',
+			'ai 2',
+			'human 3',
+			'ai 3',
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

When using the OpenAI "message assistant" operation with memory, the full chat history would be sent to the assistant, instead of limiting to the context window configured in the memory node. This should now be fixed by leveraging the `loadMemoryVariables` method. 

## Related Linear tickets, Github issues, and Community forum posts

Fixes #12958

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
