### PR TITLE
fix(editor): Improve touch detection for hybrid tablets

### DIFF
--- a/packages/frontend/@n8n/composables/src/useDeviceSupport.ts
+++ b/packages/frontend/@n8n/composables/src/useDeviceSupport.ts
@@ -2,14 +2,24 @@ import { ref } from 'vue';
 
 export function useDeviceSupport() {
 	/**
-	 * Check if the device is a touch device but exclude devices that have a fine pointer (mouse or track-pad)
-	 * - `fine` will check for an accurate pointing device. Examples include mice, touch-pads, and drawing styluses
-	 * - `coarse` will check for a pointing device of limited accuracy. Examples include touchscreens and motion-detection sensors
-	 * - `any-pointer` will check for the presence of any pointing device, if there are multiple of them
+	 * Check if the device is a touch device using multiple detection methods:
+	 * 1. maxTouchPoints > 0 indicates touch capability (primary method)
+	 * 2. matchMedia queries for pointer types (fallback for older devices):
+	 *    - `fine` will check for an accurate pointing device (mice, touch-pads, styluses)
+	 *    - `coarse` will check for a pointing device of limited accuracy (touchscreens)
+	 *    - `any-pointer` will check for the presence of any pointing device
+	 *
+	 * Note: Modern hybrid tablets (iPad Pro, Surface Pro, Galaxy Tab, etc.) often report
+	 * both fine and coarse pointers due to supporting multiple input methods (touch, pen, keyboard).
+	 * We prioritize maxTouchPoints detection to ensure proper touch support regardless of
+	 * additional input capabilities.
 	 */
+	const hasTouchPoints = ref(navigator.maxTouchPoints > 0);
+	const hasCoarsePointer = ref(window.matchMedia('(any-pointer: coarse)').matches);
+	const hasFinePointer = ref(window.matchMedia('(any-pointer: fine)').matches);
+
 	const isTouchDevice = ref(
-		window.matchMedia('(any-pointer: coarse)').matches &&
-			!window.matchMedia('(any-pointer: fine)').matches,
+		hasTouchPoints.value || (hasCoarsePointer.value && !hasFinePointer.value),
 	);
 	const userAgent = ref(navigator.userAgent.toLowerCase());
 


### PR DESCRIPTION
## Summary

This PR improves the touch detection logic to better handle hybrid tablets (iPad Pro, Surface Pro, Galaxy Tab, etc.) that support multiple input methods (touch, pen, keyboard).

The fix prioritizes maxTouchPoints detection over pointer type checks, ensuring proper touch support regardless of additional input capabilities. This resolves issues where some hybrid tablets were not being correctly identified as touch devices.

Can be tested using any iPad, or other tablets that are capable of connecting to mouse/keyboard.

This change maintains backward compatibility while improving support for modern hybrid devices.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
