### PR TITLE
feat(Email Trigger (IMAP) Node): IMAP trigger node returns message UIDs

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
@@ -16,6 +16,7 @@ describe('Test IMap V2 utils', () => {
 		const message = {
 			attributes: {
 				uuid: 1,
+				uid: 873,
 				struct: {},
 			},
 			parts: [
@@ -42,6 +43,9 @@ describe('Test IMap V2 utils', () => {
 							headers: { '': 'Body content' },
 							headerLines: undefined,
 							html: false,
+							attributes: {
+								uid: 873,
+							},
 						},
 						binary: undefined,
 					},
@@ -54,6 +58,9 @@ describe('Test IMap V2 utils', () => {
 							textPlain: 'text',
 							metadata: {
 								'0': 'h',
+							},
+							attributes: {
+								uid: 873,
 							},
 						},
 					},

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
@@ -74,7 +74,7 @@ describe('Test IMap V2 utils', () => {
 
 			expectedResults.forEach(async (expectedResult) => {
 				// use new staticData for each iteration
-				const tmpStaticData: IDataObject = {};
+				const staticData: IDataObject = {};
 
 				triggerFunctions.getNodeParameter
 					.calledWith('format')
@@ -87,7 +87,7 @@ describe('Test IMap V2 utils', () => {
 					triggerFunctions,
 					imapConnection,
 					[],
-					tmpStaticData,
+					staticData,
 					'',
 					getText,
 					getAttachment,

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
@@ -26,7 +26,6 @@ describe('Test IMap V2 utils', () => {
 			],
 		};
 
-		const staticData: IDataObject = {};
 		const imapConnection = mock<ImapSimple>({
 			search: jest.fn().mockReturnValue(Promise.resolve([message])),
 		});
@@ -74,6 +73,9 @@ describe('Test IMap V2 utils', () => {
 			];
 
 			expectedResults.forEach(async (expectedResult) => {
+				// use new staticData for each iteration
+				const tmpStaticData: IDataObject = {};
+
 				triggerFunctions.getNodeParameter
 					.calledWith('format')
 					.mockReturnValue(expectedResult.format);
@@ -85,7 +87,7 @@ describe('Test IMap V2 utils', () => {
 					triggerFunctions,
 					imapConnection,
 					[],
-					staticData,
+					tmpStaticData,
 					'',
 					getText,
 					getAttachment,

--- a/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
@@ -149,6 +149,9 @@ export async function getNewEmails(
 					textHtml: await getText(parts, message, 'html'),
 					textPlain: await getText(parts, message, 'plain'),
 					metadata: {} as IDataObject,
+					attributes: {
+						uid: message.attributes.uid,
+					} as IDataObject,
 				},
 			};
 


### PR DESCRIPTION
## Summary

This PR adds returning the UID for each email message in the IMAP Trigger node. This allows subsequent nodes to use the UID for email manipulation. For example, the community IMAP node [n8n-nodes-imap](https://github.com/umanamente/n8n-nodes-imap) supports moving and copying emails between mailboxes, which requires the UID. Previously, this information was missing in the IMAP Trigger node output.

### Steps to test:
1. Configure the IMAP Trigger node.
2. Wait for it to return a new email message.
3. Check the output data — the `attributes` field should contain the `UID` field.

![2025-02-09 12_49_53](https://github.com/user-attachments/assets/f3b71e83-2066-4707-800a-8ff677dd68a7)


## Related Linear tickets, Github issues, and Community forum posts

- Forum feature request [IMAP Trigger Node - Provide email UIDs](https://community.n8n.io/t/imap-trigger-node-provide-email-uids/75626)
- GitHub issue: https://github.com/umanamente/n8n-nodes-imap/issues/42

## Review / Merge checklist

- [x] PR title and summary are descriptive.  
- [x] Docs updated or follow-up ticket created.  NO DOCS AVAILABLE IN BASELINE
- [x] Tests included.  - NO TESTS AVAILABLE IN BASELINE
- [x] PR labeled with `release/backport` (if necessary). - NO NEED

