### PR TITLE
fix(awsDynamoDB Node): Store object maps natively in DynamoDB

### DIFF
--- a/packages/nodes-base/nodes/Aws/DynamoDB/V1/types.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/V1/types.ts
@@ -12,22 +12,12 @@ export interface IRequestBody {
 	ExclusiveStartKey?: IAttributeValue;
 }
 
-// Legacy v1 types
-export interface ILegacyAttributeValue {
-	[attribute: string]: ILegacyAttributeValueValue;
-}
-
-export interface ILegacyAttributeValueValue {
-	[type: string]: string | string[] | boolean | null;
-}
-
-// New v1.1 types
 export interface IAttributeValue {
-	[attribute: string]: DynamoDBAttributeValue;
+	[attribute: string]: IAttributeValueValue;
 }
 
 export interface IAttributeValueValue {
-	[type: string]: DynamoDBAttributeValue;
+	[type: string]: string | string[] | IAttributeValue[];
 }
 
 export interface IAttributeValueUi {
@@ -85,46 +75,14 @@ export type FieldsUiValues = Array<{
 	fieldValue: string;
 }>;
 
-// Legacy v1 types
-export type LegacyPutItemUi = {
+export type PutItemUi = {
 	attribute: string;
 	type: 'S' | 'N';
 	value: string;
 };
 
-export type LegacyAdjustedPutItem = {
+export type AdjustedPutItem = {
 	[attribute: string]: {
 		[type: string]: string;
 	};
 };
-
-// DynamoDB attribute value type (v1.1)
-export type DynamoDBAttributeValue = {
-	S?: string;
-	N?: string;
-	B?: string;
-	BOOL?: boolean;
-	NULL?: boolean;
-	M?: { [key: string]: DynamoDBAttributeValue };
-	L?: DynamoDBAttributeValue[];
-	SS?: string[];
-	NS?: string[];
-	BS?: string[];
-};
-
-// Combined types that support both versions
-export type PutItemUi =
-	| {
-			[key: string]: string | number | boolean | null | undefined | object | unknown[];
-	  }
-	| LegacyPutItemUi;
-
-export type AdjustedPutItem =
-	| {
-			[attribute: string]: DynamoDBAttributeValue;
-	  }
-	| LegacyAdjustedPutItem;
-
-export function isLegacyPutItem(item: PutItemUi): item is LegacyPutItemUi {
-	return 'attribute' in item && 'type' in item && 'value' in item;
-}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/V1/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/V1/utils.ts
@@ -1,0 +1,136 @@
+import type { IDataObject, INodeExecutionData } from 'n8n-workflow';
+import { deepCopy, assert, ApplicationError } from 'n8n-workflow';
+
+import type {
+	AdjustedPutItem,
+	AttributeValueType,
+	EAttributeValueType,
+	IAttributeNameUi,
+	IAttributeValue,
+	IAttributeValueUi,
+	IAttributeValueValue,
+	PutItemUi,
+} from './types';
+
+const addColon = (attribute: string) =>
+	(attribute = attribute.charAt(0) === ':' ? attribute : `:${attribute}`);
+
+const addPound = (key: string) => (key = key.charAt(0) === '#' ? key : `#${key}`);
+
+export function adjustExpressionAttributeValues(eavUi: IAttributeValueUi[]) {
+	const eav: IAttributeValue = {};
+
+	eavUi.forEach(({ attribute, type, value }) => {
+		eav[addColon(attribute)] = { [type]: value } as IAttributeValueValue;
+	});
+
+	return eav;
+}
+
+export function adjustExpressionAttributeName(eanUi: IAttributeNameUi[]) {
+	const ean: { [key: string]: string } = {};
+
+	eanUi.forEach(({ key, value }) => {
+		ean[addPound(key)] = value;
+	});
+
+	return ean;
+}
+
+export function adjustPutItem(putItemUi: PutItemUi) {
+	const adjustedPutItem: AdjustedPutItem = {};
+
+	Object.entries(putItemUi).forEach(([attribute, value]) => {
+		let type: string;
+
+		if (typeof value === 'boolean') {
+			type = 'BOOL';
+		} else if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+			type = 'M';
+		} else if (isNaN(Number(value))) {
+			type = 'S';
+		} else {
+			type = 'N';
+		}
+
+		adjustedPutItem[attribute] = { [type]: value.toString() };
+	});
+
+	return adjustedPutItem;
+}
+
+export function simplify(item: IAttributeValue): IDataObject {
+	const output: IDataObject = {};
+
+	for (const [attribute, value] of Object.entries(item)) {
+		const [type, content] = Object.entries(value)[0] as [AttributeValueType, string];
+		//nedded as simplify is used in decodeItem
+		// eslint-disable-next-line @typescript-eslint/no-use-before-define
+		output[attribute] = decodeAttribute(type, content);
+	}
+
+	return output;
+}
+
+function decodeAttribute(type: AttributeValueType, attribute: string | IAttributeValue) {
+	switch (type) {
+		case 'BOOL':
+			return Boolean(attribute);
+		case 'N':
+			return Number(attribute);
+		case 'S':
+			return String(attribute);
+		case 'SS':
+		case 'NS':
+			return attribute;
+		case 'M':
+			assert(
+				typeof attribute === 'object' && !Array.isArray(attribute) && attribute !== null,
+				'Attribute must be an object',
+			);
+			return simplify(attribute);
+		default:
+			return null;
+	}
+}
+
+export function validateJSON(input: any): object {
+	try {
+		return JSON.parse(input as string);
+	} catch (error) {
+		throw new ApplicationError('Items must be a valid JSON', { level: 'warning' });
+	}
+}
+
+export function copyInputItem(item: INodeExecutionData, properties: string[]): IDataObject {
+	// Prepare the data to insert and copy it to be returned
+	const newItem: IDataObject = {};
+	for (const property of properties) {
+		if (item.json[property] === undefined) {
+			newItem[property] = null;
+		} else {
+			newItem[property] = deepCopy(item.json[property]);
+		}
+	}
+	return newItem;
+}
+
+export function mapToAttributeValues(item: IDataObject): void {
+	for (const key of Object.keys(item)) {
+		if (!key.startsWith(':')) {
+			item[`:${key}`] = item[key];
+			delete item[key];
+		}
+	}
+}
+
+export function decodeItem(item: IAttributeValue): IDataObject {
+	const _item: IDataObject = {};
+	for (const entry of Object.entries(item)) {
+		const [attribute, value]: [string, object] = entry;
+		const [type, content]: [string, object] = Object.entries(value)[0];
+		_item[attribute] = decodeAttribute(type as EAttributeValueType, content as unknown as string);
+	}
+
+	return _item;
+}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/test/V1/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/test/V1/utils.test.ts
@@ -1,0 +1,186 @@
+import type { AdjustedPutItem, IAttributeValue } from '../../V1/types';
+import { adjustPutItem, simplify } from '../../V1/utils';
+
+describe('DynamoDB Utils V1 (Original Implementation)', () => {
+	describe('adjustPutItem', () => {
+		it('should handle primitive types with original flaws', () => {
+			const input = {
+				stringField: 'hello',
+				numberString: '42',
+				booleanField: true,
+				numberField: 42,
+				arrayField: [1, 2, 3],
+			};
+
+			const expected: AdjustedPutItem = {
+				stringField: { S: 'hello' },
+				numberString: { N: '42' },
+				booleanField: { BOOL: 'true' },
+				numberField: { N: '42' },
+				arrayField: { S: '1,2,3' },
+			};
+
+			expect(adjustPutItem(input as any)).toEqual(expected);
+		});
+
+		it('should incorrectly type numeric strings', () => {
+			const input = {
+				validNumber: '123',
+				invalidNumber: '123abc',
+				exponential: '1e3',
+				emptyString: '',
+			};
+
+			const expected: AdjustedPutItem = {
+				validNumber: { N: '123' },
+				invalidNumber: { S: '123abc' },
+				exponential: { N: '1e3' },
+				emptyString: { N: '' },
+			};
+
+			expect(adjustPutItem(input as any)).toEqual(expected);
+		});
+
+		it('should handle objects and preserve original array handling flaw', () => {
+			const input = {
+				simpleObject: { a: 1 },
+				nestedObject: { a: { b: 2 } },
+				array: [1, 'two', false],
+				emptyArray: [],
+			};
+
+			const expected: AdjustedPutItem = {
+				simpleObject: { M: '[object Object]' },
+				nestedObject: { M: '[object Object]' },
+				array: { S: '1,two,false' },
+				emptyArray: { N: '' },
+			};
+
+			expect(adjustPutItem(input as any)).toEqual(expected);
+		});
+
+		it('should handle edge cases with original behavior', () => {
+			const input = {
+				zero: 0,
+				negative: -5,
+				booleanString: 'true',
+				emptyObject: {},
+			};
+
+			const expected: AdjustedPutItem = {
+				zero: { N: '0' },
+				negative: { N: '-5' },
+				booleanString: { S: 'true' },
+				emptyObject: { M: '[object Object]' },
+			};
+
+			expect(adjustPutItem(input as any)).toEqual(expected);
+		});
+	});
+
+	describe('simplify', () => {
+		it('should decode primitive types with original behavior', () => {
+			const input: IAttributeValue = {
+				stringField: { S: 'hello' },
+				numberField: { N: '42' },
+				booleanField: { BOOL: 'true' },
+				nullField: { NULL: 'true' },
+			};
+
+			const expected = {
+				stringField: 'hello',
+				numberField: 42,
+				booleanField: true,
+				nullField: null,
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should handle nested objects and preserve flaws', () => {
+			const input: IAttributeValue = {
+				nested: {
+					M: {
+						a: { N: '1' },
+						b: { S: 'two' },
+						c: {
+							M: {
+								d: { BOOL: 'false' },
+							},
+						},
+					},
+				},
+				list: { S: '1,two,true' },
+			};
+
+			const expected = {
+				nested: {
+					a: 1,
+					b: 'two',
+					c: {
+						d: true,
+					},
+				},
+				list: '1,two,true',
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should incorrectly handle number/string ambiguities', () => {
+			const input: IAttributeValue = {
+				numberAsString: { S: '42' },
+				stringAsNumber: { N: 'hello' },
+			};
+
+			const expected = {
+				numberAsString: '42',
+				stringAsNumber: NaN,
+			};
+
+			const result = simplify(input);
+			expect(result.numberAsString).toBe(expected.numberAsString);
+			expect(isNaN(result.stringAsNumber as number)).toBe(true);
+		});
+
+		it('should handle empty values and edge cases', () => {
+			const input: IAttributeValue = {
+				emptyString: { S: '' },
+				zero: { N: '0' },
+				emptyMap: { M: {} },
+				invalidBool: { BOOL: 'maybe' },
+			};
+
+			const expected = {
+				emptyString: '',
+				zero: 0,
+				emptyMap: {},
+				invalidBool: true,
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+	});
+
+	describe('Original Flaw Preservation', () => {
+		test('Arrays are stringified with commas', () => {
+			const input = { arr: [1, 'a', true] };
+			const result = adjustPutItem(input as any);
+			expect(result.arr).toEqual({ S: '1,a,true' });
+		});
+
+		test('Non-numeric strings in N type become NaN', () => {
+			const input: IAttributeValue = {
+				badNumber: { N: 'abc' },
+			};
+			const result = simplify(input);
+			expect(isNaN(result.badNumber as number)).toBe(true);
+		});
+
+		test('Boolean strings not converted properly', () => {
+			const input = { boolStr: 'true' };
+			const result = adjustPutItem(input as any);
+			expect(result.boolStr).toEqual({ S: 'true' });
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
@@ -2,245 +2,427 @@ import type { IAttributeValue } from '../types';
 import { adjustPutItem, simplify } from '../utils';
 
 describe('DynamoDB Utils', () => {
-	describe('adjustPutItem', () => {
-		it('should handle primitive types correctly', () => {
-			const input = {
-				stringField: 'hello',
-				numberField: 42,
-				booleanField: true,
-				nullField: null,
-			};
+	describe('V1 Implementation', () => {
+		describe('adjustPutItem', () => {
+			it('should handle primitive types with original flaws', () => {
+				const input = {
+					stringField: 'hello',
+					numberString: '42',
+					booleanField: true,
+					numberField: 42,
+					arrayField: [1, 2, 3],
+				};
 
-			const expected: IAttributeValue = {
-				stringField: { S: 'hello' },
-				numberField: { N: '42' },
-				booleanField: { BOOL: true },
-				nullField: { NULL: true },
-			};
+				const expected = {
+					stringField: { S: 'hello' },
+					numberString: { N: '42' },
+					booleanField: { BOOL: 'true' },
+					numberField: { N: '42' },
+					arrayField: { S: '1,2,3' },
+				} as any;
 
-			expect(adjustPutItem(input)).toEqual(expected);
+				expect(adjustPutItem(input, 1)).toEqual(expected);
+			});
+
+			it('should incorrectly type numeric strings', () => {
+				const input = {
+					validNumber: '123',
+					invalidNumber: '123abc',
+					exponential: '1e3',
+					emptyString: '',
+				};
+
+				const expected = {
+					validNumber: { N: '123' },
+					invalidNumber: { S: '123abc' },
+					exponential: { N: '1e3' },
+					emptyString: { N: '' },
+				};
+
+				expect(adjustPutItem(input, 1)).toEqual(expected);
+			});
+
+			it('should handle objects and preserve original array handling flaw', () => {
+				const input = {
+					simpleObject: { a: 1 },
+					nestedObject: { a: { b: 2 } },
+					array: [1, 'two', false],
+					emptyArray: [],
+				};
+
+				const expected = {
+					simpleObject: { M: '[object Object]' },
+					nestedObject: { M: '[object Object]' },
+					array: { S: '1,two,false' },
+					emptyArray: { N: '' },
+				};
+
+				expect(adjustPutItem(input, 1)).toEqual(expected);
+			});
+
+			it('should handle edge cases with original behavior', () => {
+				const input = {
+					zero: 0,
+					negative: -5,
+					booleanString: 'true',
+					emptyObject: {},
+				};
+
+				const expected = {
+					zero: { N: '0' },
+					negative: { N: '-5' },
+					booleanString: { S: 'true' },
+					emptyObject: { M: '[object Object]' },
+				};
+
+				expect(adjustPutItem(input, 1)).toEqual(expected);
+			});
 		});
 
-		it('should handle string numbers correctly', () => {
-			const input = {
-				stringNumber: '42',
-				notANumber: 'hello',
-				actualNumber: 42,
-			};
+		describe('simplify', () => {
+			it('should decode primitive types with original behavior', () => {
+				const input: IAttributeValue = {
+					stringField: { S: 'hello' },
+					numberField: { N: '42' },
+					booleanField: { BOOL: 'true' },
+					nullField: { NULL: 'true' },
+				} as any;
 
-			const expected: IAttributeValue = {
-				stringNumber: { S: '42' },
-				notANumber: { S: 'hello' },
-				actualNumber: { N: '42' },
-			};
+				const expected = {
+					stringField: 'hello',
+					numberField: 42,
+					booleanField: true,
+					nullField: null,
+				};
 
-			expect(adjustPutItem(input)).toEqual(expected);
-		});
+				expect(simplify(input, 1)).toEqual(expected);
+			});
 
-		it('should handle arrays correctly', () => {
-			const input = {
-				emptyArray: [],
-				stringArray: ['a', 'b', 'c'],
-				numberArray: [1, 2, 3],
-				mixedArray: ['a', 1, true, { key: 'value' }],
-			};
-
-			const expected: IAttributeValue = {
-				emptyArray: { L: [] },
-				stringArray: { SS: ['a', 'b', 'c'] },
-				numberArray: { NS: ['1', '2', '3'] },
-				mixedArray: {
-					L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
-				},
-			};
-
-			expect(adjustPutItem(input)).toEqual(expected);
-		});
-
-		it('should handle nested objects correctly', () => {
-			const input = {
-				user: {
-					name: 'John',
-					age: 30,
-					address: {
-						street: '123 Main St',
-						city: 'New York',
-						coordinates: {
-							lat: 40.7128,
-							lng: -74.006,
-						},
-					},
-					tags: ['customer', 'premium'],
-					scores: [95, 87, 92],
-				},
-			};
-
-			const expected: IAttributeValue = {
-				user: {
-					M: {
-						name: { S: 'John' },
-						age: { N: '30' },
-						address: {
-							M: {
-								street: { S: '123 Main St' },
-								city: { S: 'New York' },
-								coordinates: {
-									M: {
-										lat: { N: '40.7128' },
-										lng: { N: '-74.006' },
-									},
+			it('should handle nested objects and preserve flaws', () => {
+				const input: IAttributeValue = {
+					nested: {
+						M: {
+							a: { N: '1' },
+							b: { S: 'two' },
+							c: {
+								M: {
+									d: { BOOL: 'false' },
 								},
 							},
 						},
-						tags: { SS: ['customer', 'premium'] },
-						scores: { NS: ['95', '87', '92'] },
 					},
-				},
-			};
+					list: { S: '1,two,true' },
+				} as any;
 
-			expect(adjustPutItem(input)).toEqual(expected);
+				const expected = {
+					nested: {
+						a: 1,
+						b: 'two',
+						c: {
+							d: false,
+						},
+					},
+					list: '1,two,true',
+				};
+
+				expect(simplify(input, 1)).toEqual(expected);
+			});
+
+			it('should incorrectly handle number/string ambiguities', () => {
+				const input: IAttributeValue = {
+					numberAsString: { S: '42' },
+					stringAsNumber: { N: 'hello' },
+				};
+
+				const expected = {
+					numberAsString: '42',
+					stringAsNumber: NaN,
+				};
+
+				const result = simplify(input, 1);
+				expect(result.numberAsString).toBe(expected.numberAsString);
+				expect(isNaN(result.stringAsNumber as number)).toBe(true);
+			});
+
+			it('should handle empty values and edge cases', () => {
+				const input: IAttributeValue = {
+					emptyString: { S: '' },
+					zero: { N: '0' },
+					emptyMap: { M: {} },
+					invalidBool: { BOOL: 'maybe' },
+				} as any;
+
+				const expected = {
+					emptyString: '',
+					zero: 0,
+					emptyMap: {},
+					invalidBool: true,
+				};
+
+				expect(simplify(input, 1)).toEqual(expected);
+			});
 		});
 
-		it('should handle edge cases correctly', () => {
-			const input = {
-				undefinedField: undefined,
-				emptyString: '',
-				zero: 0,
-				negativeNumber: -123.456,
-				emptyObject: {},
-				complexArray: [[1, 2, 3], { nested: true }, ['a', 'b']],
-			};
+		describe('Original Flaw Preservation', () => {
+			test('Arrays are stringified with commas', () => {
+				const input = { arr: [1, 'a', true] };
+				const result = adjustPutItem(input, 1);
+				expect(result.arr).toEqual({ S: '1,a,true' });
+			});
 
-			const expected: IAttributeValue = {
-				undefinedField: { NULL: true },
-				emptyString: { S: '' },
-				zero: { N: '0' },
-				negativeNumber: { N: '-123.456' },
-				emptyObject: { M: {} },
-				complexArray: {
-					L: [{ NS: ['1', '2', '3'] }, { M: { nested: { BOOL: true } } }, { SS: ['a', 'b'] }],
-				},
-			};
+			test('Non-numeric strings in N type become NaN', () => {
+				const input: IAttributeValue = {
+					badNumber: { N: 'abc' },
+				};
+				const result = simplify(input, 1);
+				expect(isNaN(result.badNumber as number)).toBe(true);
+			});
 
-			expect(adjustPutItem(input)).toEqual(expected);
+			test('Boolean strings not converted properly', () => {
+				const input = { boolStr: 'true' };
+				const result = adjustPutItem(input, 1);
+				expect(result.boolStr).toEqual({ S: 'true' });
+			});
 		});
 	});
 
-	describe('simplify/decodeAttribute', () => {
-		it('should decode primitive types correctly', () => {
-			const input: IAttributeValue = {
-				stringField: { S: 'hello' },
-				numberField: { N: '42' },
-				booleanField: { BOOL: true },
-				nullField: { NULL: true },
-			};
+	describe('V1.1 Implementation', () => {
+		describe('adjustPutItem', () => {
+			it('should handle primitive types correctly', () => {
+				const input = {
+					stringField: 'hello',
+					numberField: 42,
+					booleanField: true,
+					nullField: null,
+				};
 
-			const expected = {
-				stringField: 'hello',
-				numberField: 42,
-				booleanField: true,
-				nullField: null,
-			};
+				const expected: IAttributeValue = {
+					stringField: { S: 'hello' },
+					numberField: { N: '42' },
+					booleanField: { BOOL: true },
+					nullField: { NULL: true },
+				};
 
-			expect(simplify(input)).toEqual(expected);
-		});
+				expect(adjustPutItem(input, 1.1)).toEqual(expected);
+			});
 
-		it('should decode arrays correctly', () => {
-			const input: IAttributeValue = {
-				stringSet: { SS: ['a', 'b', 'c'] },
-				numberSet: { NS: ['1', '2', '3'] },
-				list: {
-					L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
-				},
-			};
+			it('should handle string numbers correctly', () => {
+				const input = {
+					stringNumber: '42',
+					notANumber: 'hello',
+					actualNumber: 42,
+				};
 
-			const expected = {
-				stringSet: ['a', 'b', 'c'],
-				numberSet: [1, 2, 3],
-				list: ['a', 1, true, { key: 'value' }],
-			};
+				const expected: IAttributeValue = {
+					stringNumber: { S: '42' },
+					notANumber: { S: 'hello' },
+					actualNumber: { N: '42' },
+				};
 
-			expect(simplify(input)).toEqual(expected);
-		});
+				expect(adjustPutItem(input, 1.1)).toEqual(expected);
+			});
 
-		it('should decode nested objects correctly', () => {
-			const input: IAttributeValue = {
-				user: {
-					M: {
-						name: { S: 'John' },
-						age: { N: '30' },
+			it('should handle arrays correctly', () => {
+				const input = {
+					emptyArray: [],
+					stringArray: ['a', 'b', 'c'],
+					numberArray: [1, 2, 3],
+					mixedArray: ['a', 1, true, { key: 'value' }],
+				};
+
+				const expected: IAttributeValue = {
+					emptyArray: { L: [] },
+					stringArray: { SS: ['a', 'b', 'c'] },
+					numberArray: { NS: ['1', '2', '3'] },
+					mixedArray: {
+						L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
+					},
+				};
+
+				expect(adjustPutItem(input, 1.1)).toEqual(expected);
+			});
+
+			it('should handle nested objects correctly', () => {
+				const input = {
+					user: {
+						name: 'John',
+						age: 30,
 						address: {
-							M: {
-								street: { S: '123 Main St' },
-								city: { S: 'New York' },
-								coordinates: {
-									M: {
-										lat: { N: '40.7128' },
-										lng: { N: '-74.006' },
+							street: '123 Main St',
+							city: 'New York',
+							coordinates: {
+								lat: 40.7128,
+								lng: -74.006,
+							},
+						},
+					},
+				};
+
+				const expected: IAttributeValue = {
+					user: {
+						M: {
+							name: { S: 'John' },
+							age: { N: '30' },
+							address: {
+								M: {
+									street: { S: '123 Main St' },
+									city: { S: 'New York' },
+									coordinates: {
+										M: {
+											lat: { N: '40.7128' },
+											lng: { N: '-74.006' },
+										},
 									},
 								},
 							},
 						},
-						tags: { SS: ['customer', 'premium'] },
-						scores: { NS: ['95', '87', '92'] },
 					},
-				},
-			};
+				};
 
-			const expected = {
-				user: {
-					name: 'John',
-					age: 30,
-					address: {
-						street: '123 Main St',
-						city: 'New York',
-						coordinates: {
-							lat: 40.7128,
-							lng: -74.006,
+				expect(adjustPutItem(input, 1.1)).toEqual(expected);
+			});
+
+			it('should handle edge cases correctly', () => {
+				const input = {
+					undefinedField: undefined,
+					emptyString: '',
+					zero: 0,
+					negativeNumber: -123.456,
+					emptyObject: {},
+					complexArray: [[1, 2, 3], { nested: true }, ['a', 'b']],
+				};
+
+				const expected: IAttributeValue = {
+					undefinedField: { NULL: true },
+					emptyString: { S: '' },
+					zero: { N: '0' },
+					negativeNumber: { N: '-123.456' },
+					emptyObject: { M: {} },
+					complexArray: {
+						L: [{ NS: ['1', '2', '3'] }, { M: { nested: { BOOL: true } } }, { SS: ['a', 'b'] }],
+					},
+				};
+
+				expect(adjustPutItem(input, 1.1)).toEqual(expected);
+			});
+		});
+
+		describe('simplify/decodeAttribute', () => {
+			it('should decode primitive types correctly', () => {
+				const input: IAttributeValue = {
+					stringField: { S: 'hello' },
+					numberField: { N: '42' },
+					booleanField: { BOOL: 'true' },
+					nullField: { NULL: true },
+				} as any;
+
+				const expected = {
+					stringField: 'hello',
+					numberField: 42,
+					booleanField: true,
+					nullField: null,
+				};
+
+				expect(simplify(input, 1.1)).toEqual(expected);
+			});
+
+			it('should decode arrays correctly', () => {
+				const input: IAttributeValue = {
+					stringSet: { SS: ['a', 'b', 'c'] },
+					numberSet: { NS: ['1', '2', '3'] },
+					list: {
+						L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
+					},
+				};
+
+				const expected = {
+					stringSet: ['a', 'b', 'c'],
+					numberSet: [1, 2, 3],
+					list: ['a', 1, true, { key: 'value' }],
+				};
+
+				expect(simplify(input, 1.1)).toEqual(expected);
+			});
+
+			it('should decode nested objects correctly', () => {
+				const input: IAttributeValue = {
+					user: {
+						M: {
+							name: { S: 'John' },
+							age: { N: '30' },
+							address: {
+								M: {
+									street: { S: '123 Main St' },
+									city: { S: 'New York' },
+									coordinates: {
+										M: {
+											lat: { N: '40.7128' },
+											lng: { N: '-74.006' },
+										},
+									},
+								},
+							},
+							tags: { SS: ['customer', 'premium'] },
+							scores: { NS: ['95', '87', '92'] },
 						},
 					},
-					tags: ['customer', 'premium'],
-					scores: [95, 87, 92],
-				},
-			};
+				};
 
-			expect(simplify(input)).toEqual(expected);
-		});
+				const expected = {
+					user: {
+						name: 'John',
+						age: 30,
+						address: {
+							street: '123 Main St',
+							city: 'New York',
+							coordinates: {
+								lat: 40.7128,
+								lng: -74.006,
+							},
+						},
+						tags: ['customer', 'premium'],
+						scores: [95, 87, 92],
+					},
+				};
 
-		it('should handle edge cases correctly', () => {
-			const input: IAttributeValue = {
-				emptyString: { S: '' },
-				zero: { N: '0' },
-				negativeNumber: { N: '-123.456' },
-				emptyMap: { M: {} },
-				emptyList: { L: [] },
-			};
+				expect(simplify(input, 1.1)).toEqual(expected);
+			});
 
-			const expected = {
-				emptyString: '',
-				zero: 0,
-				negativeNumber: -123.456,
-				emptyMap: {},
-				emptyList: [],
-			};
+			it('should handle edge cases correctly', () => {
+				const input: IAttributeValue = {
+					emptyString: { S: '' },
+					zero: { N: '0' },
+					negativeNumber: { N: '-123.456' },
+					emptyMap: { M: {} },
+					emptyList: { L: [] },
+				};
 
-			expect(simplify(input)).toEqual(expected);
-		});
+				const expected = {
+					emptyString: '',
+					zero: 0,
+					negativeNumber: -123.456,
+					emptyMap: {},
+					emptyList: [],
+				};
 
-		it('should handle malformed input gracefully', () => {
-			const input: IAttributeValue = {
-				malformedMap: { M: {} },
-				malformedList: { L: [] },
-				malformedValue: { NULL: true },
-			};
+				expect(simplify(input, 1.1)).toEqual(expected);
+			});
 
-			const expected = {
-				malformedMap: {},
-				malformedList: [],
-				malformedValue: null,
-			};
+			it('should handle malformed input gracefully', () => {
+				const input: IAttributeValue = {
+					malformedMap: { M: {} },
+					malformedList: { L: [] },
+					malformedValue: { NULL: true },
+				};
 
-			expect(simplify(input)).toEqual(expected);
+				const expected = {
+					malformedMap: {},
+					malformedList: [],
+					malformedValue: null,
+				};
+
+				expect(simplify(input, 1.1)).toEqual(expected);
+			});
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
@@ -1,5 +1,5 @@
-import { adjustPutItem, simplify } from '../utils';
 import type { IAttributeValue } from '../types';
+import { adjustPutItem, simplify } from '../utils';
 
 describe('DynamoDB Utils', () => {
 	describe('adjustPutItem', () => {
@@ -103,7 +103,7 @@ describe('DynamoDB Utils', () => {
 
 		it('should handle edge cases correctly', () => {
 			const input = {
-				undefined: undefined,
+				undefinedField: undefined,
 				emptyString: '',
 				zero: 0,
 				negativeNumber: -123.456,
@@ -112,7 +112,7 @@ describe('DynamoDB Utils', () => {
 			};
 
 			const expected: IAttributeValue = {
-				undefined: { NULL: true },
+				undefinedField: { NULL: true },
 				emptyString: { S: '' },
 				zero: { N: '0' },
 				negativeNumber: { N: '-123.456' },

--- a/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/test/utils.test.ts
@@ -1,0 +1,246 @@
+import { adjustPutItem, simplify } from '../utils';
+import type { IAttributeValue } from '../types';
+
+describe('DynamoDB Utils', () => {
+	describe('adjustPutItem', () => {
+		it('should handle primitive types correctly', () => {
+			const input = {
+				stringField: 'hello',
+				numberField: 42,
+				booleanField: true,
+				nullField: null,
+			};
+
+			const expected: IAttributeValue = {
+				stringField: { S: 'hello' },
+				numberField: { N: '42' },
+				booleanField: { BOOL: true },
+				nullField: { NULL: true },
+			};
+
+			expect(adjustPutItem(input)).toEqual(expected);
+		});
+
+		it('should handle string numbers correctly', () => {
+			const input = {
+				stringNumber: '42',
+				notANumber: 'hello',
+				actualNumber: 42,
+			};
+
+			const expected: IAttributeValue = {
+				stringNumber: { S: '42' },
+				notANumber: { S: 'hello' },
+				actualNumber: { N: '42' },
+			};
+
+			expect(adjustPutItem(input)).toEqual(expected);
+		});
+
+		it('should handle arrays correctly', () => {
+			const input = {
+				emptyArray: [],
+				stringArray: ['a', 'b', 'c'],
+				numberArray: [1, 2, 3],
+				mixedArray: ['a', 1, true, { key: 'value' }],
+			};
+
+			const expected: IAttributeValue = {
+				emptyArray: { L: [] },
+				stringArray: { SS: ['a', 'b', 'c'] },
+				numberArray: { NS: ['1', '2', '3'] },
+				mixedArray: {
+					L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
+				},
+			};
+
+			expect(adjustPutItem(input)).toEqual(expected);
+		});
+
+		it('should handle nested objects correctly', () => {
+			const input = {
+				user: {
+					name: 'John',
+					age: 30,
+					address: {
+						street: '123 Main St',
+						city: 'New York',
+						coordinates: {
+							lat: 40.7128,
+							lng: -74.006,
+						},
+					},
+					tags: ['customer', 'premium'],
+					scores: [95, 87, 92],
+				},
+			};
+
+			const expected: IAttributeValue = {
+				user: {
+					M: {
+						name: { S: 'John' },
+						age: { N: '30' },
+						address: {
+							M: {
+								street: { S: '123 Main St' },
+								city: { S: 'New York' },
+								coordinates: {
+									M: {
+										lat: { N: '40.7128' },
+										lng: { N: '-74.006' },
+									},
+								},
+							},
+						},
+						tags: { SS: ['customer', 'premium'] },
+						scores: { NS: ['95', '87', '92'] },
+					},
+				},
+			};
+
+			expect(adjustPutItem(input)).toEqual(expected);
+		});
+
+		it('should handle edge cases correctly', () => {
+			const input = {
+				undefined: undefined,
+				emptyString: '',
+				zero: 0,
+				negativeNumber: -123.456,
+				emptyObject: {},
+				complexArray: [[1, 2, 3], { nested: true }, ['a', 'b']],
+			};
+
+			const expected: IAttributeValue = {
+				undefined: { NULL: true },
+				emptyString: { S: '' },
+				zero: { N: '0' },
+				negativeNumber: { N: '-123.456' },
+				emptyObject: { M: {} },
+				complexArray: {
+					L: [{ NS: ['1', '2', '3'] }, { M: { nested: { BOOL: true } } }, { SS: ['a', 'b'] }],
+				},
+			};
+
+			expect(adjustPutItem(input)).toEqual(expected);
+		});
+	});
+
+	describe('simplify/decodeAttribute', () => {
+		it('should decode primitive types correctly', () => {
+			const input: IAttributeValue = {
+				stringField: { S: 'hello' },
+				numberField: { N: '42' },
+				booleanField: { BOOL: true },
+				nullField: { NULL: true },
+			};
+
+			const expected = {
+				stringField: 'hello',
+				numberField: 42,
+				booleanField: true,
+				nullField: null,
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should decode arrays correctly', () => {
+			const input: IAttributeValue = {
+				stringSet: { SS: ['a', 'b', 'c'] },
+				numberSet: { NS: ['1', '2', '3'] },
+				list: {
+					L: [{ S: 'a' }, { N: '1' }, { BOOL: true }, { M: { key: { S: 'value' } } }],
+				},
+			};
+
+			const expected = {
+				stringSet: ['a', 'b', 'c'],
+				numberSet: [1, 2, 3],
+				list: ['a', 1, true, { key: 'value' }],
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should decode nested objects correctly', () => {
+			const input: IAttributeValue = {
+				user: {
+					M: {
+						name: { S: 'John' },
+						age: { N: '30' },
+						address: {
+							M: {
+								street: { S: '123 Main St' },
+								city: { S: 'New York' },
+								coordinates: {
+									M: {
+										lat: { N: '40.7128' },
+										lng: { N: '-74.006' },
+									},
+								},
+							},
+						},
+						tags: { SS: ['customer', 'premium'] },
+						scores: { NS: ['95', '87', '92'] },
+					},
+				},
+			};
+
+			const expected = {
+				user: {
+					name: 'John',
+					age: 30,
+					address: {
+						street: '123 Main St',
+						city: 'New York',
+						coordinates: {
+							lat: 40.7128,
+							lng: -74.006,
+						},
+					},
+					tags: ['customer', 'premium'],
+					scores: [95, 87, 92],
+				},
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should handle edge cases correctly', () => {
+			const input: IAttributeValue = {
+				emptyString: { S: '' },
+				zero: { N: '0' },
+				negativeNumber: { N: '-123.456' },
+				emptyMap: { M: {} },
+				emptyList: { L: [] },
+			};
+
+			const expected = {
+				emptyString: '',
+				zero: 0,
+				negativeNumber: -123.456,
+				emptyMap: {},
+				emptyList: [],
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+
+		it('should handle malformed input gracefully', () => {
+			const input: IAttributeValue = {
+				malformedMap: { M: {} },
+				malformedList: { L: [] },
+				malformedValue: { NULL: true },
+			};
+
+			const expected = {
+				malformedMap: {},
+				malformedList: [],
+				malformedValue: null,
+			};
+
+			expect(simplify(input)).toEqual(expected);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Aws/DynamoDB/types.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/types.ts
@@ -13,11 +13,11 @@ export interface IRequestBody {
 }
 
 export interface IAttributeValue {
-	[attribute: string]: IAttributeValueValue;
+	[attribute: string]: DynamoDBAttributeValue;
 }
 
 export interface IAttributeValueValue {
-	[type: string]: string | string[] | IAttributeValue[];
+	[type: string]: DynamoDBAttributeValue;
 }
 
 export interface IAttributeValueUi {
@@ -75,14 +75,23 @@ export type FieldsUiValues = Array<{
 	fieldValue: string;
 }>;
 
+export type DynamoDBAttributeValue = {
+	S?: string;
+	N?: string;
+	B?: string;
+	BOOL?: boolean;
+	NULL?: boolean;
+	M?: { [key: string]: DynamoDBAttributeValue };
+	L?: DynamoDBAttributeValue[];
+	SS?: string[];
+	NS?: string[];
+	BS?: string[];
+};
+
 export type PutItemUi = {
-	attribute: string;
-	type: 'S' | 'N';
-	value: string;
+	[key: string]: any;
 };
 
 export type AdjustedPutItem = {
-	[attribute: string]: {
-		[type: string]: string;
-	};
+	[attribute: string]: DynamoDBAttributeValue;
 };

--- a/packages/nodes-base/nodes/Aws/DynamoDB/types.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/types.ts
@@ -89,7 +89,7 @@ export type DynamoDBAttributeValue = {
 };
 
 export type PutItemUi = {
-	[key: string]: any;
+	[key: string]: string | number | boolean | null | undefined | object | unknown[];
 };
 
 export type AdjustedPutItem = {

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -38,7 +38,7 @@ export function adjustExpressionAttributeName(eanUi: IAttributeNameUi[]) {
 	return ean;
 }
 
-function convertToDynamoDBValue(value: any): DynamoDBAttributeValue {
+function convertToDynamoDBValue(value: unknown): DynamoDBAttributeValue {
 	// Handle null and undefined
 	if (value === null || value === undefined) {
 		return { NULL: true };
@@ -61,8 +61,8 @@ function convertToDynamoDBValue(value: any): DynamoDBAttributeValue {
 		}
 
 		// Check if all elements are of the same type
-		const allStrings = value.every((item) => typeof item === 'string');
-		const allNumbers = value.every((item) => typeof item === 'number');
+		const allStrings = value.every((item): item is string => typeof item === 'string');
+		const allNumbers = value.every((item): item is number => typeof item === 'number');
 
 		if (allStrings) {
 			return { SS: value };
@@ -76,7 +76,7 @@ function convertToDynamoDBValue(value: any): DynamoDBAttributeValue {
 	// Handle objects (maps)
 	if (typeof value === 'object') {
 		const map: { [key: string]: DynamoDBAttributeValue } = {};
-		for (const [k, v] of Object.entries(value)) {
+		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
 			map[k] = convertToDynamoDBValue(v);
 		}
 		return { M: map };

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -39,28 +39,23 @@ export function adjustExpressionAttributeName(eanUi: IAttributeNameUi[]) {
 }
 
 function convertToDynamoDBValue(value: unknown): DynamoDBAttributeValue {
-	// Handle null and undefined
 	if (value === null || value === undefined) {
 		return { NULL: true };
 	}
 
-	// Handle booleans
 	if (typeof value === 'boolean') {
 		return { BOOL: value };
 	}
 
-	// Handle numbers
 	if (typeof value === 'number') {
 		return { N: value.toString() };
 	}
 
-	// Handle arrays
 	if (Array.isArray(value)) {
 		if (value.length === 0) {
 			return { L: [] };
 		}
 
-		// Check if all elements are of the same type
 		const allStrings = value.every((item): item is string => typeof item === 'string');
 		const allNumbers = value.every((item): item is number => typeof item === 'number');
 
@@ -73,7 +68,6 @@ function convertToDynamoDBValue(value: unknown): DynamoDBAttributeValue {
 		return { L: value.map(convertToDynamoDBValue) };
 	}
 
-	// Handle objects (maps)
 	if (typeof value === 'object') {
 		const map: { [key: string]: DynamoDBAttributeValue } = {};
 		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
@@ -82,7 +76,6 @@ function convertToDynamoDBValue(value: unknown): DynamoDBAttributeValue {
 		return { M: map };
 	}
 
-	// All strings (including numeric strings) should be stored as strings
 	return { S: String(value) };
 }
 


### PR DESCRIPTION
## Summary

Fix DynamoDB node to properly handle object maps and nested structures when storing data. Previously, objects were incorrectly converted using toString(), which caused the node to not work on objects and the need to convert to string before passing to DynamoDB node, thus not having the correct DynamoDB types.

Changes:
- Replace toString() conversion with proper DynamoDB type mapping
- Implement recursive conversion for nested objects to M (map) type
- Handle arrays properly by converting to L (list) type when containing mixed types
- Add comprehensive test suite for object storage scenarios

To test this fix:

1. Basic object storage:
```javascript
user: {
  name: 'John',
  age: 30,
  address: {
    street: '123 Main St',
    city: 'New York'
  }
}
// Now correctly stored as nested DynamoDB map
{
  "name": { "S": "John Doe" },
  "age": { "N": "30" },
  "address": {
    "M": {
      "city": { "S": "New York" },
      "street": { "S": "123 Main St" }
    }
  }
}
```


2. Mixed array storage:
```javascript
items: ['string', 42, { key: 'value' }]

// Now correctly stored as DynamoDB list
{
  "items": {
    "L": [
      { "S": "string" },
      { "N": "42" },
      { "M": { "key": { "S": "value" } } }
    ]
  }
}
```

3. Edge cases:
```javascript
emptyObject: {},
nullValue: null,
emptyArray: []

// All cases properly handled with appropriate DynamoDB types
{
  "emptyObject": { "M": {} },
  "nullValue": { "NULL": true },
  "emptyArray": { "L": [] }
}
```

## Related Linear tickets, Github issues, and Community forum posts

NODE-199
#4514


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--

   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)