### PR TITLE
fix(core): Handle credential decryption failures gracefully on the API

### DIFF
--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import { nanoId, date } from 'minifaker';
-import { Credentials } from 'n8n-core';
+import { CREDENTIAL_ERRORS, CredentialDataError, Credentials, type ErrorReporter } from 'n8n-core';
 import { CREDENTIAL_EMPTY_VALUE, type ICredentialType } from 'n8n-workflow';
 
 import { CREDENTIAL_BLANKING_VALUE } from '@/constants';
@@ -32,12 +32,14 @@ describe('CredentialsService', () => {
 		],
 	});
 
+	const errorReporter = mock<ErrorReporter>();
 	const credentialTypes = mock<CredentialTypes>();
 	const service = new CredentialsService(
 		mock(),
 		mock(),
 		mock(),
 		mock(),
+		errorReporter,
 		mock(),
 		mock(),
 		credentialTypes,
@@ -46,6 +48,8 @@ describe('CredentialsService', () => {
 		mock(),
 		mock(),
 	);
+
+	beforeEach(() => jest.resetAllMocks());
 
 	describe('redact', () => {
 		it('should redact sensitive values', () => {
@@ -141,29 +145,34 @@ describe('CredentialsService', () => {
 	});
 
 	describe('decrypt', () => {
+		const data = {
+			clientId: 'abc123',
+			clientSecret: 'sensitiveSecret',
+			accessToken: '',
+			oauthTokenData: 'super-secret',
+			csrfSecret: 'super-secret',
+		};
+		const credentialEntity = mock<CredentialsEntity>({
+			id: '123',
+			name: 'Test Credential',
+			type: 'oauth2',
+		});
+		const credentials = mock<Credentials>({ id: credentialEntity.id });
+
+		beforeEach(() => {
+			credentialTypes.getByName.calledWith(credentialEntity.type).mockReturnValueOnce(credType);
+		});
+
 		it('should redact sensitive values by default', () => {
 			// ARRANGE
-			const data = {
-				clientId: 'abc123',
-				clientSecret: 'sensitiveSecret',
-				accessToken: '',
-				oauthTokenData: 'super-secret',
-				csrfSecret: 'super-secret',
-			};
-			const credential = mock<CredentialsEntity>({
-				id: '123',
-				name: 'Test Credential',
-				type: 'oauth2',
-			});
 			jest.spyOn(Credentials.prototype, 'getData').mockReturnValueOnce(data);
-			credentialTypes.getByName.calledWith(credential.type).mockReturnValueOnce(credType);
 
 			// ACT
-			const redactedData = service.decrypt(credential);
+			const redactedData = service.decrypt(credentialEntity);
 
 			// ASSERT
 			expect(redactedData).toEqual({
-				clientId: 'abc123',
+				...data,
 				clientSecret: CREDENTIAL_BLANKING_VALUE,
 				accessToken: CREDENTIAL_EMPTY_VALUE,
 				oauthTokenData: CREDENTIAL_BLANKING_VALUE,
@@ -173,26 +182,36 @@ describe('CredentialsService', () => {
 
 		it('should return sensitive values if `includeRawData` is true', () => {
 			// ARRANGE
-			const data = {
-				clientId: 'abc123',
-				clientSecret: 'sensitiveSecret',
-				accessToken: '',
-				oauthTokenData: 'super-secret',
-				csrfSecret: 'super-secret',
-			};
-			const credential = mock<CredentialsEntity>({
-				id: '123',
-				name: 'Test Credential',
-				type: 'oauth2',
-			});
 			jest.spyOn(Credentials.prototype, 'getData').mockReturnValueOnce(data);
-			credentialTypes.getByName.calledWith(credential.type).mockReturnValueOnce(credType);
 
 			// ACT
-			const redactedData = service.decrypt(credential, true);
+			const redactedData = service.decrypt(credentialEntity, true);
 
 			// ASSERT
 			expect(redactedData).toEqual(data);
+		});
+
+		it('should return return an empty object if decryption fails', () => {
+			// ARRANGE
+			const decryptionError = new CredentialDataError(
+				credentials,
+				CREDENTIAL_ERRORS.DECRYPTION_FAILED,
+			);
+			jest.spyOn(Credentials.prototype, 'getData').mockImplementation(() => {
+				throw decryptionError;
+			});
+
+			// ACT
+			const redactedData = service.decrypt(credentialEntity, true);
+
+			// ASSERT
+			expect(redactedData).toEqual({});
+			expect(credentialTypes.getByName).not.toHaveBeenCalled();
+			expect(errorReporter.error).toHaveBeenCalledWith(decryptionError, {
+				extra: { credentialId: credentialEntity.id },
+				level: 'error',
+				tags: { credentialType: credentialEntity.type },
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary
If the credentials table contains any values that are either invalid JSON  when decrypted, or values that fail to decrypt, the API endpoints for fetching credentials on the frontend should not crash, and instead return a `{}` as decrypted data, which in turn marks these credentials with the `Needs first setup` tag on the frontend, so that users can then edit and fix these credentials.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #12949
Fixes #12940
CAT-632
CAT-616


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
