### PR TITLE
fix(editor): Fix alignment in RMC component

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/MappingFields.vue
@@ -444,11 +444,16 @@ defineExpose({
 
 <style module lang="scss">
 .parameterItem {
+	--delete-option-width: 22px;
 	display: flex;
 	padding: 0 0 0 var(--spacing-s);
 
 	.parameterInput {
 		width: 100%;
+	}
+
+	.parameterInput:first-child {
+		margin-left: var(--delete-option-width);
 	}
 
 	&.hasIssues {


### PR DESCRIPTION
## Summary

<img width="666" alt="image" src="https://github.com/user-attachments/assets/6afe56eb-2868-445e-b937-33ff4fa2b7dc" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2299/resource-mapping-component-alignment-is-off

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
