### PR TITLE
fix(core): Fix resuming executions on test webhooks from Wait nodes

### DIFF
--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -6,7 +6,7 @@ import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { IExecutionResponse } from '@/interfaces';
 import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
-import type { WaitingWebhookRequest } from '@/webhooks/webhook.types';
+import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from '@/webhooks/webhook.types';
 
 describe('WaitingWebhooks', () => {
 	const executionRepository = mock<ExecutionRepository>();
@@ -78,5 +78,26 @@ describe('WaitingWebhooks', () => {
 		 * Assert
 		 */
 		await expect(promise).rejects.toThrowError(ConflictError);
+	});
+
+	it('should mark as test webhook when execution mode is manual', async () => {
+		jest
+			// @ts-expect-error Protected method
+			.spyOn(waitingWebhooks, 'getWebhookExecutionData')
+			// @ts-expect-error Protected method
+			.mockResolvedValue(mock<IWebhookResponseCallbackData>());
+
+		const execution = mock<IExecutionResponse>({
+			finished: false,
+			mode: 'manual',
+			data: {
+				resultData: { lastNodeExecuted: 'someNode', error: undefined },
+			},
+		});
+		executionRepository.findSingleExecution.mockResolvedValue(execution);
+
+		await waitingWebhooks.executeWebhook(mock<WaitingWebhookRequest>(), mock<express.Response>());
+
+		expect(execution.data.isTestWebhook).toBe(true);
 	});
 });

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -121,6 +121,10 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
 
+		/**
+		 * A manual execution resumed by a webhook call needs to be marked as such
+		 * so workers in scaling mode reuse the existing execution data.
+		 */
 		if (execution.mode === 'manual') execution.data.isTestWebhook = true;
 
 		return await this.getWebhookExecutionData({

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -121,6 +121,8 @@ export class WaitingWebhooks implements IWebhookManager {
 
 		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted as string;
 
+		if (execution.mode === 'manual') execution.data.isTestWebhook = true;
+
 		return await this.getWebhookExecutionData({
 			execution,
 			req,


### PR DESCRIPTION
## Summary

On master, in scaling mode, on both single- or multi-main, if you put an execution to wait for a webhook call and then call the webhook to resume the execution, the worker runs the execution from the start instead of resuming from the wait node. This PR ensures that workers resume the execution instead of restarting it.

To reproduce, import this workflow https://n8n.to/cat-604 and run it and call `curl -X POST http://localhost:5678/webhook-waiting/{n}` (find the `n` from the Wait node on the UI). Before this fix, worker logs show all nodes being executed; after this fix, worker logs show only the Wait node being executed. Tested with `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS` enabled and disabled, and in both single- and multi-main mode.

Note there is a related but [out of scope issue](https://n8nio.slack.com/archives/C0789EN39RC/p1739188800202289?thread_ts=1739187486.672509&cid=C0789EN39RC) affecting push messages on resuming.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-604

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
