### PR TITLE
fix(Airtable Node): Use item at correct index in base/getSchema

### DIFF
--- a/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
+++ b/packages/nodes-base/nodes/Airtable/test/v2/node/base/getSchema.test.ts
@@ -1,13 +1,16 @@
+import { mockDeep } from 'jest-mock-extended';
+import { get } from 'lodash';
+import type { IExecuteFunctions } from 'n8n-workflow';
+
 import * as getSchema from '../../../../v2/actions/base/getSchema.operation';
 import * as transport from '../../../../v2/transport';
-import { createMockExecuteFunction } from '../helpers';
 
 jest.mock('../../../../v2/transport', () => {
 	const originalModule = jest.requireActual('../../../../v2/transport');
 	return {
 		...originalModule,
 		apiRequest: jest.fn(async function () {
-			return {};
+			return { tables: [] };
 		}),
 	};
 });
@@ -18,19 +21,35 @@ describe('Test AirtableV2, base => getSchema', () => {
 			resource: 'base',
 			operation: 'getSchema',
 			base: {
-				value: 'appYobase',
+				value: '={{$json.id}}',
 			},
 		};
 
 		const items = [
 			{
-				json: {},
+				json: { id: 'appYobase1' },
+			},
+			{
+				json: { id: 'appYobase2' },
 			},
 		];
 
-		await getSchema.execute.call(createMockExecuteFunction(nodeParameters), items);
+		await getSchema.execute.call(
+			mockDeep<IExecuteFunctions>({
+				getInputData: jest.fn(() => items),
+				getNodeParameter: jest.fn((param: string, itemIndex: number) => {
+					if (param === 'base') {
+						return items[itemIndex].json.id;
+					}
 
-		expect(transport.apiRequest).toBeCalledTimes(1);
-		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appYobase/tables');
+					return get(nodeParameters, param);
+				}),
+			}),
+			items,
+		);
+
+		expect(transport.apiRequest).toBeCalledTimes(2);
+		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appYobase1/tables');
+		expect(transport.apiRequest).toHaveBeenCalledWith('GET', 'meta/bases/appYobase2/tables');
 	});
 });

--- a/packages/nodes-base/nodes/Airtable/v2/actions/base/getSchema.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/base/getSchema.operation.ts
@@ -47,7 +47,6 @@ export async function execute(
 
 			const executionData = this.helpers.constructExecutionMetaData(wrapData(responseData.tables), {
 				itemData: { item: i },
-				k,
 			});
 
 			returnData = returnData.concat(executionData);

--- a/packages/nodes-base/nodes/Airtable/v2/actions/base/getSchema.operation.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/base/getSchema.operation.ts
@@ -1,8 +1,7 @@
 import type {
-	IDataObject,
+	IExecuteFunctions,
 	INodeExecutionData,
 	INodeProperties,
-	IExecuteFunctions,
 	NodeApiError,
 } from 'n8n-workflow';
 
@@ -10,6 +9,7 @@ import { updateDisplayOptions, wrapData } from '../../../../../utils/utilities';
 import { processAirtableError } from '../../helpers/utils';
 import { apiRequest } from '../../transport';
 import { baseRLC } from '../common.descriptions';
+import type { TablesResponse } from '../types';
 
 const properties: INodeProperties[] = [
 	{
@@ -31,22 +31,26 @@ export async function execute(
 	this: IExecuteFunctions,
 	items: INodeExecutionData[],
 ): Promise<INodeExecutionData[]> {
-	const returnData: INodeExecutionData[] = [];
+	let returnData: INodeExecutionData[] = [];
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const baseId = this.getNodeParameter('base', 0, undefined, {
+			const baseId = this.getNodeParameter('base', i, undefined, {
 				extractValue: true,
 			}) as string;
 
-			const responseData = await apiRequest.call(this, 'GET', `meta/bases/${baseId}/tables`);
-
-			const executionData = this.helpers.constructExecutionMetaData(
-				wrapData(responseData.tables as IDataObject[]),
-				{ itemData: { item: i } },
+			const responseData: TablesResponse = await apiRequest.call(
+				this,
+				'GET',
+				`meta/bases/${baseId}/tables`,
 			);
 
-			returnData.push(...executionData);
+			const executionData = this.helpers.constructExecutionMetaData(wrapData(responseData.tables), {
+				itemData: { item: i },
+				k,
+			});
+
+			returnData = returnData.concat(executionData);
 		} catch (error) {
 			error = processAirtableError(error as NodeApiError, undefined, i);
 			if (this.continueOnFail()) {

--- a/packages/nodes-base/nodes/Airtable/v2/actions/types.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/actions/types.ts
@@ -1,0 +1,15 @@
+export type Table = {
+	id: string;
+	name: string;
+	fields: Field[];
+};
+
+export type TablesResponse = {
+	tables: Table[];
+};
+
+export type Field = {
+	id: string;
+	name: string;
+	type: string;
+};


### PR DESCRIPTION
## Summary

Should use the correct item index instead of always getting the first item

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2340/community-issue-airtable-get-basestables-node-wrong
fixes https://github.com/n8n-io/n8n/issues/12916

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
