### PR TITLE
fix(editor): Adjust project plus button color in dark mode

### DIFF
--- a/packages/editor-ui/src/components/Projects/ProjectNavigation.vue
+++ b/packages/editor-ui/src/components/Projects/ProjectNavigation.vue
@@ -182,7 +182,7 @@ const showAddFirstProject = computed(
 .plusBtn {
 	margin: 0;
 	padding: 0;
-	color: var(--color-text-lighter);
+	color: var(--color-text-light);
 	display: none;
 }
 


### PR DESCRIPTION
## Summary

In dark mode, you don't see the add project icon (+) until you hover directly on it

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2563](https://linear.app/n8n/issue/PAY-2563/in-dark-mode-you-dont-see-the-add-project-icon-until-you-hover)


## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
