### PR TITLE
fix(editor): Correctly compare old parameter value for nested parameters

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -814,9 +814,7 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 		return;
 	}
 	// Only update the value if it has changed
-	const oldValue = node.value?.parameters
-		? nodeHelpers.getParameterValue(node.value?.parameters, props.parameter.name, '')
-		: undefined;
+	const oldValue = get(node.value, props.path);
 	if (oldValue !== undefined && oldValue === value) {
 		return;
 	}
@@ -849,6 +847,7 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 		value,
 	};
 
+	console.log('emit', value);
 	emit('update', parameterData);
 
 	if (props.parameter.name === 'operation' || props.parameter.name === 'mode') {

--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -847,7 +847,6 @@ function valueChanged(value: NodeParameterValueType | {} | Date) {
 		value,
 	};
 
-	console.log('emit', value);
 	emit('update', parameterData);
 
 	if (props.parameter.name === 'operation' || props.parameter.name === 'mode') {


### PR DESCRIPTION
## Summary

When a property with the same name exists on the root and in a collection

It was not possible to change the nested parameter to have the same value as the one on the root. The code checking if the param changed would always check the root and discard changes. 

Reproduction workflow in Linear

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-2307/notion-node-creating-a-database-page-will-not-save-name-attribute

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
