### PR TITLE
fix(editor): Make connector buttons background opaque when dark mode is enabled system-wide

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdge.vue
@@ -76,12 +76,12 @@ const edgeStyle = computed(() => ({
 	...props.style,
 	...(isMainConnection.value ? {} : { strokeDasharray: '8,8' }),
 	strokeWidth: 2,
-	stroke: props.hovered ? 'var(--color-primary)' : edgeColor.value,
+	stroke: delayedHovered.value ? 'var(--color-primary)' : edgeColor.value,
 }));
 
 const edgeClasses = computed(() => ({
 	[$style.edge]: true,
-	hovered: props.hovered,
+	hovered: delayedHovered.value,
 	'bring-to-front': props.bringToFront,
 }));
 
@@ -94,7 +94,7 @@ const isConnectorStraight = computed(() => renderData.value.isConnectorStraight)
 
 const edgeToolbarStyle = computed(() => ({
 	transform: `translate(-50%, -50%) translate(${labelPosition.value[0]}px, ${labelPosition.value[1]}px)`,
-	...(props.hovered ? { zIndex: 1 } : {}),
+	...(delayedHovered.value ? { zIndex: 1 } : {}),
 }));
 
 const edgeToolbarClasses = computed(() => ({

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -66,9 +66,19 @@ function onDelete() {
 </style>
 
 <style lang="scss">
-[data-theme='dark'] .canvas-edge-toolbar-button {
+@mixin dark-button-styles {
 	--button-background-color: var(--color-background-base);
 	--button-hover-background-color: var(--color-background-light);
+}
+
+@media (prefers-color-scheme: dark) {
+	.canvas-edge-toolbar-button {
+		@include dark-button-styles();
+	}
+}
+
+[data-theme='dark'] .canvas-edge-toolbar-button {
+	@include dark-button-styles();
 }
 
 .canvas-edge-toolbar-button {

--- a/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/editor-ui/src/components/canvas/elements/edges/CanvasEdgeToolbar.vue
@@ -72,7 +72,7 @@ function onDelete() {
 }
 
 @media (prefers-color-scheme: dark) {
-	.canvas-edge-toolbar-button {
+	body:not([data-theme]) .canvas-edge-toolbar-button {
 		@include dark-button-styles();
 	}
 }


### PR DESCRIPTION
## Summary
As shown below, buttons on the connector comes in front of the connector itself when dark theme is applied via OS settings.
Also, fixed the issue of the connector line momentarily comes above the buttons when the mouse cursor is moving away.

https://github.com/user-attachments/assets/d9552806-7c48-4d1f-8a56-33080725d16e




## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-12/action-on-the-connector-are-displayed-incorrectly-since-178

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
