### PR TITLE
perf(core): Batch workflow activation to speed up startup

### DIFF
--- a/packages/@n8n/config/src/configs/workflows.config.ts
+++ b/packages/@n8n/config/src/configs/workflows.config.ts
@@ -10,4 +10,8 @@ export class WorkflowsConfig {
 	@Env('N8N_WORKFLOW_CALLER_POLICY_DEFAULT_OPTION')
 	callerPolicyDefaultOption: 'any' | 'none' | 'workflowsFromAList' | 'workflowsFromSameOwner' =
 		'workflowsFromSameOwner';
+
+	/** How many workflows to activate simultaneously during startup. */
+	@Env('N8N_WORKFLOW_ACTIVATION_BATCH_SIZE')
+	activationBatchSize: number = 1;
 }

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -35,6 +35,7 @@ export { FrontendBetaFeatures, FrontendConfig } from './configs/frontend.config'
 export { S3Config } from './configs/external-storage.config';
 export { LOG_SCOPES } from './configs/logging.config';
 export type { LogScope } from './configs/logging.config';
+export { WorkflowsConfig } from './configs/workflows.config';
 
 @Config
 export class GlobalConfig {

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -156,6 +156,7 @@ describe('GlobalConfig', () => {
 		workflows: {
 			defaultName: 'My workflow',
 			callerPolicyDefaultOption: 'workflowsFromSameOwner',
+			activationBatchSize: 1,
 		},
 		endpoints: {
 			metrics: {

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -36,6 +36,7 @@ describe('ActiveWorkflowManager', () => {
 			mock(),
 			instanceSettings,
 			mock(),
+			mock(),
 		);
 	});
 


### PR DESCRIPTION
## Summary

During startup we activate workflows one by one, which can be slow for instances with many workflows to activate. This PR introduces support for batching workflow activations via `N8N_WORKFLOW_ACTIVATION_BATCH_SIZE` so users can choose how much of this work to parallelize based on their use cases.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
