### PR TITLE
fix(core): Run full manual execution when a trigger is executed even if run data exists

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -1,7 +1,8 @@
 import { mock } from 'jest-mock-extended';
-import type { INode, IWorkflowBase, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import type { INode, IWorkflowBase, INodeType, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
 import type { User } from '@/databases/entities/user';
+import type { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import type { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
@@ -52,13 +53,14 @@ const hackerNewsNode: INode = {
 };
 
 describe('WorkflowExecutionService', () => {
+	const nodeTypes = mock<NodeTypes>();
 	const workflowRunner = mock<WorkflowRunner>();
 	const workflowExecutionService = new WorkflowExecutionService(
 		mock(),
 		mock(),
 		mock(),
 		mock(),
-		mock(),
+		nodeTypes,
 		mock(),
 		workflowRunner,
 		mock(),
@@ -86,7 +88,10 @@ describe('WorkflowExecutionService', () => {
 			const executionId = 'fake-execution-id';
 			const userId = 'user-id';
 			const user = mock<User>({ id: userId });
-			const runPayload = mock<WorkflowRequest.ManualRunPayload>({ startNodes: [] });
+			const runPayload = mock<WorkflowRequest.ManualRunPayload>({
+				startNodes: [],
+				destinationNode: undefined,
+			});
 
 			workflowRunner.run.mockResolvedValue(executionId);
 
@@ -97,6 +102,41 @@ describe('WorkflowExecutionService', () => {
 				executionMode: 'manual',
 				runData: runPayload.runData,
 				pinData: undefined,
+				pushRef: undefined,
+				workflowData: runPayload.workflowData,
+				userId,
+				partialExecutionVersion: 1,
+				startNodes: runPayload.startNodes,
+				dirtyNodeNames: runPayload.dirtyNodeNames,
+				triggerToStartFrom: runPayload.triggerToStartFrom,
+			});
+			expect(result).toEqual({ executionId });
+		});
+
+		test('removes runData if the destination node is a trigger', async () => {
+			const executionId = 'fake-execution-id';
+			const userId = 'user-id';
+			const user = mock<User>({ id: userId });
+			const node = mock<INode>();
+			const runPayload = mock<WorkflowRequest.ManualRunPayload>({
+				workflowData: { nodes: [node] },
+				startNodes: [],
+				destinationNode: node.name,
+			});
+
+			jest
+				.spyOn(nodeTypes, 'getByNameAndVersion')
+				.mockReturnValueOnce(mock<INodeType>({ description: { group: ['trigger'] } }));
+
+			workflowRunner.run.mockResolvedValue(executionId);
+
+			const result = await workflowExecutionService.executeManually(runPayload, user);
+
+			expect(workflowRunner.run).toHaveBeenCalledWith({
+				destinationNode: runPayload.destinationNode,
+				executionMode: 'manual',
+				runData: undefined,
+				pinData: runPayload.workflowData.pinData,
 				pushRef: undefined,
 				workflowData: runPayload.workflowData,
 				userId,

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -87,6 +87,18 @@ export class WorkflowExecutionService {
 		return await this.workflowRunner.run(runData, true, undefined, undefined, responsePromise);
 	}
 
+	private isDestinationNodeATrigger(destinationNode: string, workflow: IWorkflowBase) {
+		const node = workflow.nodes.find((n) => n.name === destinationNode);
+
+		if (node === undefined) {
+			return false;
+		}
+
+		const nodeType = this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
+
+		return nodeType.description.group.includes('trigger');
+	}
+
 	async executeManually(
 		{
 			workflowData,
@@ -106,6 +118,23 @@ export class WorkflowExecutionService {
 			startNodes?.map((nodeData) => nodeData.name),
 			pinData,
 		);
+
+		// TODO: Reverse the order of events, first find out if the execution is
+		// partial or full, if it's partial create the execution and run, if it's
+		// full get the data first and only then create the execution.
+		//
+		// If the destination node is a trigger, then per definition this
+		// is not a partial execution and thus we can ignore the run data.
+		// If we don't do this we'll end up creating an execution, calling the
+		// partial execution flow, finding out that we don't have run data to
+		// create the execution stack and have to cancel the execution, come back
+		// here and either create the runData (e.g. scheduler trigger) or wait for
+		// a webhook or event.
+		if (destinationNode) {
+			if (this.isDestinationNodeATrigger(destinationNode, workflowData)) {
+				runData = undefined;
+			}
+		}
 
 		// if we have a trigger to start from and it's not the pinned trigger
 		// ignore the pinned trigger
@@ -178,7 +207,7 @@ export class WorkflowExecutionService {
 				},
 				resultData: {
 					pinData,
-					runData,
+					runData: runData ?? {},
 				},
 				manualData: {
 					userId: data.userId,

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -26,7 +26,7 @@ export declare namespace WorkflowRequest {
 
 	type ManualRunPayload = {
 		workflowData: IWorkflowBase;
-		runData: IRunData;
+		runData?: IRunData;
 		startNodes?: StartNodeData[];
 		destinationNode?: string;
 		dirtyNodeNames?: string[];


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Run a full manual execution when a trigger is executed even if run data exists. Before it would try to run a partial execution which is not possible in that case. 

Doing this as a partial execution is not possible, because running the trigger will remove all run data from the trigger and all it's children, thus turning this into a full execution. 
If the trigger is a webhook trigger we need to activate it and listen for incoming data. If we are in the partial execution logic we can't do that anymore as we are too deep down to go back and register the webhook.

That's why we check in the `WorkflowExecutionService` if the destination node is a trigger. If that is the case we remove the run data and thus force the full manual execution flow. 

This is a bit of a workaround until we have decided how to structure this better, probably running the partial execution logic first (before creating the execution in the db) to find out if we can run this partially or if we need to check what trigger to use and if we need to wait for a webhook.

Before

https://github.com/user-attachments/assets/b64fb590-705c-4713-83cc-c3fc5ee6061d



After

https://github.com/user-attachments/assets/30347816-42d8-4ddb-9a9d-5f029da974b9



## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/PAY-1998/clicking-run-on-a-trigger-produces-an-error


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] ~[Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] ~PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)~
