### PR TITLE
feat: Add "Trash a message" action to Gmail node

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/GmailV2.node.ts
@@ -446,6 +446,13 @@ export class GmailV2 implements INodeType {
 
 						responseData = { success: true };
 					}
+					if (operation === 'trash') {
+						// https://developers.google.com/gmail/api/v1/reference/users/messages/trash
+						const id = this.getNodeParameter('messageId', i);
+						const endpoint = `/gmail/v1/users/me/messages/${id}/trash`;
+
+						responseData = await googleApiRequest.call(this, 'POST', endpoint);
+					}
 					if (operation === 'markAsRead') {
 						// https://developers.google.com/gmail/api/reference/rest/v1/users.messages/modify
 						const id = this.getNodeParameter('messageId', i);

--- a/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/v2/MessageDescription.ts
@@ -25,6 +25,11 @@ export const messageOperations: INodeProperties[] = [
 				action: 'Delete a message',
 			},
 			{
+				name: 'Trash',
+				value: 'trash',
+				action: 'Trash a message',
+			},
+			{
 				name: 'Get',
 				value: 'get',
 				action: 'Get a message',
@@ -79,21 +84,7 @@ export const messageFields: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['message'],
-				operation: ['get', 'delete', 'markAsRead', 'markAsUnread'],
-			},
-		},
-		placeholder: '172ce2c4a72cc243',
-	},
-	{
-		displayName: 'Message ID',
-		name: 'messageId',
-		type: 'string',
-		default: '',
-		required: true,
-		displayOptions: {
-			show: {
-				resource: ['message'],
-				operation: ['reply'],
+				operation: ['get', 'delete', 'trash', 'reply', 'markAsRead', 'markAsUnread'],
 			},
 		},
 		placeholder: '172ce2c4a72cc243',


### PR DESCRIPTION
## Summary

This PR adds a new Trash a message to the Gmail node, allowing users to send a message to trash.

## How to test:
1. Build and run n8n locally in development mode.
2. Create a Trash a message action in Gmail node.

![image](https://github.com/user-attachments/assets/b0aed295-fb4b-407b-8178-3da7265e3958)

