### PR TITLE
fix(editor): Propagate isReadOnly to ResourceMapper `Attempt to Convert Types` switch

### DIFF
--- a/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/editor-ui/src/components/ResourceMapper/ResourceMapper.vue
@@ -667,6 +667,7 @@ defineExpose({
 				}"
 				:path="props.path + '.attemptToConvertTypes'"
 				:value="state.paramValue.attemptToConvertTypes"
+				:is-read-only="isReadOnly"
 				@update="
 					(x: IUpdateInformation<NodeParameterValueType>) => {
 						state.paramValue.attemptToConvertTypes = x.value as boolean;


### PR DESCRIPTION
## Summary

This is currently clickable when viewing old executions

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3219/bug-resourcemapper-attempt-to-convert-types-doesnt-support-read-only


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
