### PR TITLE
feat(core): Hackmation - Add last activity metric

### DIFF
--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -154,7 +154,7 @@ describe('PrometheusMetricsService', () => {
 
 			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
 				name: 'n8n_last_activity',
-				help: 'last user activity (backend call).',
+				help: 'last instance activity (backend request).',
 				labelNames: ['timestamp'],
 			});
 

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -145,6 +145,12 @@ describe('PrometheusMetricsService', () => {
 				includeStatusCode: false,
 			});
 
+			expect(promClient.Gauge).toHaveBeenNthCalledWith(2, {
+				name: 'n8n_last_activity',
+				help: 'last user activity (backend call).',
+				labelNames: ['timestamp'],
+			});
+
 			expect(app.use).toHaveBeenCalledWith(
 				[
 					'/rest/',

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -38,6 +38,13 @@ describe('PrometheusMetricsService', () => {
 				includeApiStatusCodeLabel: false,
 				includeQueueMetrics: false,
 			},
+			rest: 'rest',
+			form: 'form',
+			formTest: 'form-test',
+			formWaiting: 'form-waiting',
+			webhook: 'webhook',
+			webhookTest: 'webhook-test',
+			webhookWaiting: 'webhook-waiting',
 		},
 	});
 
@@ -153,8 +160,8 @@ describe('PrometheusMetricsService', () => {
 
 			expect(app.use).toHaveBeenCalledWith(
 				[
-					'/rest/',
 					'/api/',
+					'/rest/',
 					'/webhook/',
 					'/webhook-waiting/',
 					'/webhook-test/',

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -141,14 +141,14 @@ export class PrometheusMetricsService {
 
 		app.use(
 			[
-				'/rest/',
 				'/api/',
-				'/webhook/',
-				'/webhook-waiting/',
-				'/webhook-test/',
-				'/form/',
-				'/form-waiting/',
-				'/form-test/',
+				`/${this.globalConfig.endpoints.rest}/`,
+				`/${this.globalConfig.endpoints.webhook}/`,
+				`/${this.globalConfig.endpoints.webhookWaiting}/`,
+				`/${this.globalConfig.endpoints.webhookTest}/`,
+				`/${this.globalConfig.endpoints.form}/`,
+				`/${this.globalConfig.endpoints.formWaiting}/`,
+				`/${this.globalConfig.endpoints.formTest}/`,
 			],
 			(req, res, next) => {
 				activityGauge.reset();

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -118,7 +118,7 @@ export class PrometheusMetricsService {
 
 	/**
 	 * Set up metrics for server routes with `express-prom-bundle`. The same
-	 * middleware is also utilized for a user activity metric
+	 * middleware is also utilized for an instance activity metric
 	 */
 	private initRouteMetrics(app: express.Application) {
 		if (!this.includes.metrics.routes) return;
@@ -133,7 +133,7 @@ export class PrometheusMetricsService {
 
 		const activityGauge = new promClient.Gauge({
 			name: this.prefix + 'last_activity',
-			help: 'last user activity (backend call).',
+			help: 'last instance activity (backend request).',
 			labelNames: ['timestamp'],
 		});
 


### PR DESCRIPTION
## Summary

Last activity metric is a timestamp for when n8n has been last accessed and should be scoped for user actions within the instance itself.

## Related Linear tickets, Github issues, and Community forum posts

-

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
