### PR TITLE
fix(Code Tool Node): Fix Input Schema Parameter not hiding correctly

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -18,8 +18,6 @@ import { jsonParse, NodeConnectionType, NodeOperationError } from 'n8n-workflow'
 import {
 	buildInputSchemaField,
 	buildJsonSchemaExampleField,
-	inputSchemaField,
-	jsonSchemaExampleField,
 	schemaTypeField,
 } from '@utils/descriptions';
 import { convertJsonSchemaToZod, generateSchema } from '@utils/schemaParsing';

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -15,7 +15,13 @@ import type {
 } from 'n8n-workflow';
 import { jsonParse, NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
-import { inputSchemaField, jsonSchemaExampleField, schemaTypeField } from '@utils/descriptions';
+import {
+	buildInputSchemaField,
+	buildJsonSchemaExampleField,
+	inputSchemaField,
+	jsonSchemaExampleField,
+	schemaTypeField,
+} from '@utils/descriptions';
 import { convertJsonSchemaToZod, generateSchema } from '@utils/schemaParsing';
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
@@ -168,8 +174,8 @@ export class ToolCode implements INodeType {
 				default: false,
 			},
 			{ ...schemaTypeField, displayOptions: { show: { specifyInputSchema: [true] } } },
-			jsonSchemaExampleField,
-			inputSchemaField,
+			buildJsonSchemaExampleField({ showExtraProps: { specifyInputSchema: [true] } }),
+			buildInputSchemaField({ showExtraProps: { specifyInputSchema: [true] } }),
 		],
 	};
 

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -1,4 +1,4 @@
-import type { INodeProperties } from 'n8n-workflow';
+import type { DisplayCondition, INodeProperties, NodeParameterValue } from 'n8n-workflow';
 
 export const schemaTypeField: INodeProperties = {
 	displayName: 'Schema Type',
@@ -21,7 +21,9 @@ export const schemaTypeField: INodeProperties = {
 	description: 'How to specify the schema for the function',
 };
 
-export const jsonSchemaExampleField: INodeProperties = {
+export const buildJsonSchemaExampleField = (props?: {
+	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
+}): INodeProperties => ({
 	displayName: 'JSON Example',
 	name: 'jsonSchemaExample',
 	type: 'json',
@@ -34,13 +36,18 @@ export const jsonSchemaExampleField: INodeProperties = {
 	},
 	displayOptions: {
 		show: {
+			...props?.showExtraProps,
 			schemaType: ['fromJson'],
 		},
 	},
 	description: 'Example JSON object to use to generate the schema',
-};
+});
 
-export const inputSchemaField: INodeProperties = {
+export const jsonSchemaExampleField = buildJsonSchemaExampleField();
+
+export const buildInputSchemaField = (props?: {
+	showExtraProps?: Record<string, Array<NodeParameterValue | DisplayCondition> | undefined>;
+}): INodeProperties => ({
 	displayName: 'Input Schema',
 	name: 'inputSchema',
 	type: 'json',
@@ -59,11 +66,14 @@ export const inputSchemaField: INodeProperties = {
 	},
 	displayOptions: {
 		show: {
+			...props?.showExtraProps,
 			schemaType: ['manual'],
 		},
 	},
 	description: 'Schema to use for the function',
-};
+});
+
+export const inputSchemaField = buildInputSchemaField();
 
 export const promptTypeOptions: INodeProperties = {
 	displayName: 'Source for Prompt (User Message)',


### PR DESCRIPTION
## Summary

For some reason we miss out on the update here without the extra property. Will ask Nodes if this is a known bug/short-coming, but this fixes the concrete issue until then.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3183/code-tool-node-json-example-parameter-doesnt-disappear-when-i-turn


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
