### PR TITLE
fix(editor): Do not show project settings for users without permission with direct link

### DIFF
--- a/packages/editor-ui/src/routes/projects.routes.ts
+++ b/packages/editor-ui/src/routes/projects.routes.ts
@@ -1,5 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router';
 import { VIEWS } from '@/constants';
+import { useProjectsStore } from '@/stores/projects.store';
+import { getResourcePermissions } from '@/permissions';
 
 const MainSidebar = async () => await import('@/components/MainSidebar.vue');
 const WorkflowsView = async () => await import('@/views/WorkflowsView.vue');
@@ -95,7 +97,15 @@ export const projectsRoutes: RouteRecordRaw[] = [
 								sidebar: MainSidebar,
 							},
 							meta: {
-								middleware: ['authenticated'],
+								middleware: ['authenticated', 'custom'],
+								middlewareOptions: {
+									custom: (args) => {
+										const project = useProjectsStore().myProjects.find(
+											(p) => p.id === args?.to.params.projectId,
+										);
+										return !!getResourcePermissions(project?.scopes).project.update;
+									},
+								},
 							},
 						},
 					]),

--- a/packages/editor-ui/src/routes/projects.routes.ts
+++ b/packages/editor-ui/src/routes/projects.routes.ts
@@ -99,9 +99,9 @@ export const projectsRoutes: RouteRecordRaw[] = [
 							meta: {
 								middleware: ['authenticated', 'custom'],
 								middlewareOptions: {
-									custom: (args) => {
+									custom: (options) => {
 										const project = useProjectsStore().myProjects.find(
-											(p) => p.id === args?.to.params.projectId,
+											(p) => p.id === options?.to.params.projectId,
 										);
 										return !!getResourcePermissions(project?.scopes).project.update;
 									},


### PR DESCRIPTION
## Summary

Prevent users without project update scope to visit project settings page

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2593](https://linear.app/n8n/issue/PAY-2593/project-settings-page-is-accessible-without-admin-permissions)


## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`