### PR TITLE
feat(OpenAI Model Node): Add reasoning effort option to control the amount of reasoning tokens to use

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOpenAi/LmChatOpenAi.node.ts
@@ -1,5 +1,4 @@
 /* eslint-disable n8n-nodes-base/node-dirname-against-convention */
-
 import { ChatOpenAI, type ClientOptions } from '@langchain/openai';
 import {
 	NodeConnectionType,
@@ -8,6 +7,7 @@ import {
 	type ISupplyDataFunctions,
 	type SupplyData,
 } from 'n8n-workflow';
+import type { OpenAI as OpenAIClient } from 'openai';
 
 import { getConnectionHintNoticeField } from '@utils/sharedFields';
 
@@ -341,9 +341,9 @@ export class LmChatOpenAi implements INodeType {
 			timeout: number;
 			presencePenalty?: number;
 			temperature?: number;
+			reasoningEffort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
 			topP?: number;
 			responseFormat?: 'text' | 'json_object';
-			reasoningEffort?: 'low' | 'medium' | 'high';
 		};
 
 		const configuration: ClientOptions = {};
@@ -356,11 +356,8 @@ export class LmChatOpenAi implements INodeType {
 		// Extra options to send to OpenAI, that are not directly supported by LangChain
 		const modelKwargs: {
 			response_format?: object;
-			reasoning_effort?: 'low' | 'medium' | 'high';
 		} = {};
 		if (options.responseFormat) modelKwargs.response_format = { type: options.responseFormat };
-		if (options.reasoningEffort && ['low', 'medium', 'high'].includes(options.reasoningEffort))
-			modelKwargs.reasoning_effort = options.reasoningEffort;
 
 		const model = new ChatOpenAI({
 			openAIApiKey: credentials.apiKey as string,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMOpenAi/LmOpenAi.node.ts
@@ -8,6 +8,7 @@ import type {
 	SupplyData,
 	ILoadOptionsFunctions,
 } from 'n8n-workflow';
+import type { OpenAI as OpenAIClient } from 'openai';
 
 import { makeN8nLlmFailedAttemptHandler } from '../n8nLlmFailedAttemptHandler';
 import { N8nLlmTracing } from '../N8nLlmTracing';
@@ -18,6 +19,7 @@ type LmOpenAiOptions = {
 	maxTokens?: number;
 	presencePenalty?: number;
 	temperature?: number;
+	reasoningEffort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
 	timeout?: number;
 	maxRetries?: number;
 	topP?: number;
@@ -171,6 +173,38 @@ export class LmOpenAi implements INodeType {
 						type: 'number',
 					},
 					{
+						displayName: 'Reasoning Effort',
+						name: 'reasoningEffort',
+						default: 'medium',
+						description:
+							'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses.',
+						type: 'options',
+						options: [
+							{
+								name: 'Low',
+								value: 'low',
+								description: 'Favors speed and economical token usage',
+							},
+							{
+								name: 'Medium',
+								value: 'medium',
+								description: 'Balance between speed and reasoning accuracy',
+							},
+							{
+								name: 'High',
+								value: 'high',
+								description:
+									'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+							},
+						],
+						displayOptions: {
+							show: {
+								// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+								'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
+							},
+						},
+					},
+					{
 						displayName: 'Timeout',
 						name: 'timeout',
 						default: 60000,
@@ -243,6 +277,7 @@ export class LmOpenAi implements INodeType {
 			maxTokens?: number;
 			presencePenalty?: number;
 			temperature?: number;
+			reasoningEffort?: OpenAIClient.Chat.ChatCompletionReasoningEffort;
 			timeout?: number;
 			maxRetries?: number;
 			topP?: number;

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -165,6 +165,38 @@ const properties: INodeProperties[] = [
 				type: 'number',
 			},
 			{
+				displayName: 'Reasoning Effort',
+				name: 'reasoningEffort',
+				default: 'medium',
+				description:
+					'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses.',
+				type: 'options',
+				options: [
+					{
+						name: 'Low',
+						value: 'low',
+						description: 'Favors speed and economical token usage',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+						description: 'Balance between speed and reasoning accuracy',
+					},
+					{
+						name: 'High',
+						value: 'high',
+						description:
+							'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+					},
+				],
+				displayOptions: {
+					show: {
+						// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+						'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
+					},
+				},
+			},
+			{
 				displayName: 'Output Randomness (Top P)',
 				name: 'topP',
 				default: 1,

--- a/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/ChatDescription.ts
@@ -377,6 +377,44 @@ const sharedOperations: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Reasoning Effort',
+				name: 'reasoningEffort',
+				default: 'medium',
+				description:
+					'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses.',
+				type: 'options',
+				options: [
+					{
+						name: 'Low',
+						value: 'low',
+						description: 'Favors speed and economical token usage',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+						description: 'Balance between speed and reasoning accuracy',
+					},
+					{
+						name: 'High',
+						value: 'high',
+						description:
+							'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+					},
+				],
+				displayOptions: {
+					show: {
+						// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+						'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'reasoning_effort',
+					},
+				},
+			},
+			{
 				displayName: 'Top P',
 				name: 'topP',
 				default: 1,

--- a/packages/nodes-base/nodes/OpenAi/TextDescription.ts
+++ b/packages/nodes-base/nodes/OpenAi/TextDescription.ts
@@ -465,6 +465,44 @@ const sharedOperations: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Reasoning Effort',
+				name: 'reasoningEffort',
+				default: 'medium',
+				description:
+					'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses.',
+				type: 'options',
+				options: [
+					{
+						name: 'Low',
+						value: 'low',
+						description: 'Favors speed and economical token usage',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+						description: 'Balance between speed and reasoning accuracy',
+					},
+					{
+						name: 'High',
+						value: 'high',
+						description:
+							'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+					},
+				],
+				displayOptions: {
+					show: {
+						// reasoning_effort is only available on o1, o1-versioned, or on o3-mini and beyond. Not on o1-mini or other GPT-models.
+						'/model': [{ _cnd: { regex: '(^o1([-\\d]+)?$)|(^o[3-9].*)' } }],
+					},
+				},
+				routing: {
+					send: {
+						type: 'body',
+						property: 'reasoning_effort',
+					},
+				},
+			},
+			{
 				displayName: 'Top P',
 				name: 'topP',
 				default: 1,


### PR DESCRIPTION
## Summary

Follow up of PR https://github.com/n8n-io/n8n/pull/13103, that introduced partial support for OpenAI `reasoning_effort` parameter.

This PR uses native types and support from `openai` and `@langchain/openai` already available features, and completes definitions and functionality wherever seemed appropriate.

## Related Linear tickets, Github issues, and Community forum posts
PR https://github.com/n8n-io/n8n/pull/13103
Comment https://github.com/n8n-io/n8n/pull/13103#discussion_r1954446579

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
