### PR TITLE
fix(core): Fix DB migrations for MySQL

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,17 +1,6 @@
 services:
-  mariadb-10.5:
+  mariadb:
     image: mariadb:10.5
-    environment:
-      - MARIADB_DATABASE=n8n
-      - MARIADB_ROOT_PASSWORD=password
-      - MARIADB_MYSQL_LOCALHOST_USER=true
-    ports:
-      - 3306:3306
-    tmpfs:
-      - /var/lib/mysql
-
-  mariadb-11:
-    image: mariadb:11
     environment:
       - MARIADB_DATABASE=n8n
       - MARIADB_ROOT_PASSWORD=password

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -31,6 +31,16 @@ services:
     tmpfs:
       - /var/lib/mysql
 
+  mysql-8.4:
+    image: mysql:8.4
+    environment:
+      - MYSQL_DATABASE=n8n
+      - MYSQL_ROOT_PASSWORD=password
+    ports:
+      - 3306:3306
+    tmpfs:
+      - /var/lib/mysql
+
   postgres:
     image: postgres:16
     restart: always

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  mariadb:
+  mariadb-10.5:
     image: mariadb:10.5
     environment:
       - MARIADB_DATABASE=n8n
@@ -21,8 +21,8 @@ services:
     tmpfs:
       - /var/lib/mysql
 
-  mysql:
-    image: mysql:8.0.29
+  mysql-8.0.13:
+    image: mysql:8.0.13
     environment:
       - MYSQL_DATABASE=n8n
       - MYSQL_ROOT_PASSWORD=password

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,10 +1,31 @@
 services:
   mariadb:
-    image: mariadb:10.9
+    image: mariadb:10.5
     environment:
       - MARIADB_DATABASE=n8n
       - MARIADB_ROOT_PASSWORD=password
       - MARIADB_MYSQL_LOCALHOST_USER=true
+    ports:
+      - 3306:3306
+    tmpfs:
+      - /var/lib/mysql
+
+  mariadb-11:
+    image: mariadb:11
+    environment:
+      - MARIADB_DATABASE=n8n
+      - MARIADB_ROOT_PASSWORD=password
+      - MARIADB_MYSQL_LOCALHOST_USER=true
+    ports:
+      - 3306:3306
+    tmpfs:
+      - /var/lib/mysql
+
+  mysql:
+    image: mysql:8.0.29
+    environment:
+      - MYSQL_DATABASE=n8n
+      - MYSQL_ROOT_PASSWORD=password
     ports:
       - 3306:3306
     tmpfs:

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -83,13 +83,13 @@ jobs:
         run: pnpm jest
 
   mariadb:
-    name: MariaDB (${{ matrix.database }})
+    name: MariaDB (${{ matrix.service-name }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
     strategy:
       matrix:
-        service-name: [ 'mariadb', 'mariadb-11' ]
+        service-name: [ 'mariadb-10.5', 'mariadb-11' ]
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
@@ -127,13 +127,13 @@ jobs:
         run: pnpm test:mariadb --testTimeout 30000
 
   mysql:
-    name: MySQL (${{ matrix.database }})
+    name: MySQL (${{ matrix.service-name }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
     strategy:
       matrix:
-        service-name: [ 'mysql', 'mysql-8.4' ]
+        service-name: [ 'mysql-8.0.13', 'mysql-8.4' ]
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -83,10 +83,13 @@ jobs:
         run: pnpm jest
 
   mariadb:
-    name: MariaDB
+    name: MariaDB (${{ matrix.database }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
+    strategy:
+      matrix:
+        service-name: [ 'mariadb', 'mariadb-11' ]
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
@@ -117,17 +120,20 @@ jobs:
         with:
           compose-file: ./.github/docker-compose.yml
           services: |
-            mariadb
+            ${{ matrix.service-name }}
 
       - name: Test MariaDB
         working-directory: packages/cli
         run: pnpm test:mariadb --testTimeout 30000
 
   mysql:
-    name: MySQL
+    name: MySQL (${{ matrix.database }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
+    strategy:
+      matrix:
+        service-name: [ 'mysql', 'mysql-8.4' ]
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
@@ -158,7 +164,7 @@ jobs:
         with:
           compose-file: ./.github/docker-compose.yml
           services: |
-            mysql-8.4
+            ${{ matrix.service-name }}
 
       - name: Test MySQL
         working-directory: packages/cli

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Test MySQL
         working-directory: packages/cli
-        run: pnpm test:mysqldb --testTimeout 30000
+        run: pnpm test:mysql --testTimeout 30000
 
   postgres:
     name: Postgres

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -83,13 +83,10 @@ jobs:
         run: pnpm jest
 
   mariadb:
-    name: MariaDB (${{ matrix.service-name }})
+    name: MariaDB
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
-    strategy:
-      matrix:
-        service-name: [ 'mariadb-10.5', 'mariadb-11' ]
     env:
       DB_MYSQLDB_PASSWORD: password
     steps:
@@ -120,7 +117,7 @@ jobs:
         with:
           compose-file: ./.github/docker-compose.yml
           services: |
-            ${{ matrix.service-name }}
+            mariadb
 
       - name: Test MariaDB
         working-directory: packages/cli

--- a/.github/workflows/ci-postgres-mysql.yml
+++ b/.github/workflows/ci-postgres-mysql.yml
@@ -123,6 +123,47 @@ jobs:
         working-directory: packages/cli
         run: pnpm test:mariadb --testTimeout 30000
 
+  mysql:
+    name: MySQL
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 20
+    env:
+      DB_MYSQLDB_PASSWORD: password
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - uses: actions/setup-node@v4.2.0
+        with:
+          node-version: 20.x
+
+      - name: Setup corepack and pnpm
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup build cache
+        uses: rharkor/caching-for-turbo@v1.5
+
+      - name: Restore cached build artifacts
+        uses: actions/cache/restore@v4.2.0
+        with:
+          path: ./packages/**/dist
+          key: ${{ github.sha }}:db-tests
+
+      - name: Start MySQL
+        uses: isbang/compose-action@v2.0.0
+        with:
+          compose-file: ./.github/docker-compose.yml
+          services: |
+            mysql-8.4
+
+      - name: Test MySQL
+        working-directory: packages/cli
+        run: pnpm test:mysqldb --testTimeout 30000
+
   postgres:
     name: Postgres
     runs-on: ubuntu-latest
@@ -168,7 +209,7 @@ jobs:
   notify-on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [mariadb, postgres]
+    needs: [mariadb, postgres, mysql]
     steps:
       - name: Notify Slack on failure
         uses: act10ns/slack@v2.0.0
@@ -177,4 +218,4 @@ jobs:
           status: ${{ job.status }}
           channel: '#alerts-build'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          message: Postgres or MariaDB tests failed (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          message: Postgres, MariaDB or MySQL tests failed (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "test:sqlite": "N8N_LOG_LEVEL=silent DB_TYPE=sqlite jest",
     "test:postgres": "N8N_LOG_LEVEL=silent DB_TYPE=postgresdb DB_POSTGRESDB_SCHEMA=alt_schema DB_TABLE_PREFIX=test_ jest --no-coverage",
     "test:mariadb": "N8N_LOG_LEVEL=silent DB_TYPE=mariadb DB_TABLE_PREFIX=test_ jest --no-coverage",
+    "test:mysql": "N8N_LOG_LEVEL=silent DB_TYPE=mysqldb DB_TABLE_PREFIX=test_ jest --no-coverage",
     "watch": "tsc-watch -p tsconfig.build.json --onCompilationComplete \"tsc-alias -p tsconfig.build.json\""
   },
   "bin": {

--- a/packages/cli/src/databases/migrations/common/1736172058779-AddStatsColumnsToTestRun.ts
+++ b/packages/cli/src/databases/migrations/common/1736172058779-AddStatsColumnsToTestRun.ts
@@ -2,6 +2,9 @@ import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 const columns = ['totalCases', 'passedCases', 'failedCases'] as const;
 
+// Note: This migration was modified after release to remove column check constraints.
+// They were causing issues with some MySQL versions.
+
 export class AddStatsColumnsToTestRun1736172058779 implements ReversibleMigration {
 	async up({ escape, runQuery }: MigrationContext) {
 		const tableName = escape.tableName('test_run');
@@ -10,13 +13,7 @@ export class AddStatsColumnsToTestRun1736172058779 implements ReversibleMigratio
 		// Values can be NULL only if the test run is new, otherwise they must be non-negative integers.
 		// Test run might be cancelled or interrupted by unexpected error at any moment, so values can be either NULL or non-negative integers.
 		for (const name of columnNames) {
-			await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${name} INT CHECK(
-				CASE
-					WHEN status = 'new' THEN ${name} IS NULL
-					WHEN status in ('cancelled', 'error') THEN ${name} IS NULL OR ${name} >= 0
-					ELSE ${name} >= 0
-				END
-			)`);
+			await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${name} INT`);
 		}
 	}
 

--- a/packages/cli/src/databases/migrations/mysqldb/1731582748663-MigrateTestDefinitionKeyToString.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1731582748663-MigrateTestDefinitionKeyToString.ts
@@ -14,5 +14,19 @@ export class MigrateTestDefinitionKeyToString1731582748663 implements Irreversib
 		await queryRunner.query(
 			`CREATE INDEX \`TMP_idx_${tablePrefix}test_definition_id\` ON ${tablePrefix}test_definition (\`id\`);`,
 		);
+
+		// Note: this part was missing in initial release and was added after. Without it the migration run successfully,
+		// but left the table in inconsistent state, because it didn't finish changing the primary key and deleting the old one.
+		// This prevented the next migration from running on MySQL 8.4.4
+		await queryRunner.query(
+			`ALTER TABLE ${tablePrefix}test_definition MODIFY COLUMN tmp_id INT NOT NULL;`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE ${tablePrefix}test_definition DROP PRIMARY KEY, ADD PRIMARY KEY (\`id\`);`,
+		);
+		await queryRunner.query(
+			`DROP INDEX \`TMP_idx_${tablePrefix}test_definition_id\` ON ${tablePrefix}test_definition;`,
+		);
+		await queryRunner.query(`ALTER TABLE ${tablePrefix}test_definition DROP COLUMN tmp_id;`);
 	}
 }

--- a/packages/cli/src/databases/migrations/mysqldb/1732271325258-CreateTestMetricTable.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1732271325258-CreateTestMetricTable.ts
@@ -15,10 +15,6 @@ export class CreateTestMetricTable1732271325258 implements ReversibleMigration {
 		);
 
 		if (brokenPrimaryColumn) {
-			console.log(
-				'Previous migration contained a mistake, primary column change was not finished. Trying to fix it.',
-			);
-
 			// The migration was completed, but left the table in inconsistent state, let's finish the primary key change
 			await queryRunner.query(
 				`ALTER TABLE ${tablePrefix}test_definition MODIFY COLUMN tmp_id INT NOT NULL;`,

--- a/packages/cli/src/databases/migrations/mysqldb/1732271325258-CreateTestMetricTable.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1732271325258-CreateTestMetricTable.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+
+import type { MigrationContext, ReversibleMigration } from '@/databases/types';
+
+const testMetricEntityTableName = 'test_metric';
+
+export class CreateTestMetricTable1732271325258 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column }, queryRunner, tablePrefix }: MigrationContext) {
+		// Check if the previous migration MigrateTestDefinitionKeyToString1731582748663 properly updated the primary key
+		const table = await queryRunner.getTable(`${tablePrefix}test_definition`);
+		assert(table, 'test_definition table not found');
+
+		const brokenPrimaryColumn = table.primaryColumns.some(
+			(c) => c.name === 'tmp_id' && c.isPrimary,
+		);
+
+		if (brokenPrimaryColumn) {
+			console.log(
+				'Previous migration contained a mistake, primary column change was not finished. Trying to fix it.',
+			);
+
+			// The migration was completed, but left the table in inconsistent state, let's finish the primary key change
+			await queryRunner.query(
+				`ALTER TABLE ${tablePrefix}test_definition MODIFY COLUMN tmp_id INT NOT NULL;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${tablePrefix}test_definition DROP PRIMARY KEY, ADD PRIMARY KEY (\`id\`);`,
+			);
+			await queryRunner.query(
+				`DROP INDEX \`TMP_idx_${tablePrefix}test_definition_id\` ON ${tablePrefix}test_definition;`,
+			);
+			await queryRunner.query(`ALTER TABLE ${tablePrefix}test_definition DROP COLUMN tmp_id;`);
+		}
+		// End of test_definition PK check
+
+		await createTable(testMetricEntityTableName)
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('name').varchar(255).notNull,
+				column('testDefinitionId').varchar(36).notNull,
+			)
+			.withIndexOn('testDefinitionId')
+			.withForeignKey('testDefinitionId', {
+				tableName: 'test_definition',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(testMetricEntityTableName);
+	}
+}

--- a/packages/cli/src/databases/migrations/mysqldb/1736172058779-AddStatsColumnsToTestRun.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1736172058779-AddStatsColumnsToTestRun.ts
@@ -2,6 +2,9 @@ import type { MigrationContext, ReversibleMigration } from '@/databases/types';
 
 const columns = ['totalCases', 'passedCases', 'failedCases'] as const;
 
+// Note: This migration was separated from common after release to remove column check constraints
+// because they were causing issues with MySQL
+
 export class AddStatsColumnsToTestRun1736172058779 implements ReversibleMigration {
 	async up({ escape, runQuery }: MigrationContext) {
 		const tableName = escape.tableName('test_run');
@@ -10,13 +13,7 @@ export class AddStatsColumnsToTestRun1736172058779 implements ReversibleMigratio
 		// Values can be NULL only if the test run is new, otherwise they must be non-negative integers.
 		// Test run might be cancelled or interrupted by unexpected error at any moment, so values can be either NULL or non-negative integers.
 		for (const name of columnNames) {
-			await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${name} INT CHECK(
-				CASE
-					WHEN status = 'new' THEN ${name} IS NULL
-					WHEN status in ('cancelled', 'error') THEN ${name} IS NULL OR ${name} >= 0
-					ELSE ${name} >= 0
-				END
-			)`);
+			await runQuery(`ALTER TABLE ${tableName} ADD COLUMN ${name} INT;`);
 		}
 	}
 

--- a/packages/cli/src/databases/migrations/mysqldb/1739873751194-FixTestDefinitionPrimaryKey.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/1739873751194-FixTestDefinitionPrimaryKey.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+
+import type { MigrationContext, IrreversibleMigration } from '@/databases/types';
+
+export class FixTestDefinitionPrimaryKey1739873751194 implements IrreversibleMigration {
+	async up({ queryRunner, tablePrefix }: MigrationContext) {
+		/**
+		 * MigrateTestDefinitionKeyToString migration for MySQL/MariaDB had missing part,
+		 * and didn't complete primary key type change and deletion of the temporary column.
+		 *
+		 * This migration checks if table is in inconsistent state and finishes the primary key type change when needed.
+		 *
+		 * The MigrateTestDefinitionKeyToString migration has been patched to properly change the primary key.
+		 *
+		 * As the primary key issue might prevent the CreateTestMetricTable migration from running successfully on MySQL 8.4.4,
+		 * the CreateTestMetricTable also contains the patch.
+		 *
+		 * For users who already ran the MigrateTestDefinitionKeyToString and CreateTestMetricTable, this migration should fix the primary key.
+		 * For users who run these migrations in the same batch, this migration would be no-op, as the test_definition table should be already fixed
+		 * by either of the previous patched migrations.
+		 */
+
+		const table = await queryRunner.getTable(`${tablePrefix}test_definition`);
+		assert(table, 'test_definition table not found');
+
+		const brokenPrimaryColumn = table.primaryColumns.some(
+			(c) => c.name === 'tmp_id' && c.isPrimary,
+		);
+
+		if (brokenPrimaryColumn) {
+			// The migration was completed, but left the table in inconsistent state, let's finish the primary key change
+			await queryRunner.query(
+				`ALTER TABLE ${tablePrefix}test_definition MODIFY COLUMN tmp_id INT NOT NULL;`,
+			);
+			await queryRunner.query(
+				`ALTER TABLE ${tablePrefix}test_definition DROP PRIMARY KEY, ADD PRIMARY KEY (\`id\`);`,
+			);
+			await queryRunner.query(
+				`DROP INDEX \`TMP_idx_${tablePrefix}test_definition_id\` ON ${tablePrefix}test_definition;`,
+			);
+			await queryRunner.query(`ALTER TABLE ${tablePrefix}test_definition DROP COLUMN tmp_id;`);
+		}
+	}
+}

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -46,6 +46,7 @@ import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActiv
 import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-MigrateTestDefinitionKeyToString';
 import { CreateTestMetricTable1732271325258 } from './1732271325258-CreateTestMetricTable';
 import { AddStatsColumnsToTestRun1736172058779 } from './1736172058779-AddStatsColumnsToTestRun';
+import { FixTestDefinitionPrimaryKey1739873751194 } from './1739873751194-FixTestDefinitionPrimaryKey';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -162,4 +163,5 @@ export const mysqlMigrations: Migration[] = [
 	CreateTestCaseExecutionTable1736947513045,
 	AddErrorColumnsToTestRuns1737715421462,
 	CreateFolderTable1738709609940,
+	FixTestDefinitionPrimaryKey1739873751194,
 ];

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -44,6 +44,7 @@ import { SeparateExecutionData1690000000030 } from './1690000000030-SeparateExec
 import { FixExecutionDataType1690000000031 } from './1690000000031-FixExecutionDataType';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-MigrateTestDefinitionKeyToString';
+import { AddStatsColumnsToTestRun1736172058779 } from './1736172058779-AddStatsColumnsToTestRun';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
 import { RemoveResetPasswordColumns1690000000030 } from '../common/1690000000030-RemoveResetPasswordColumns';
@@ -76,7 +77,6 @@ import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-Crea
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
 import { AddMockedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddMockedNodesColumnToTestDefinition';
 import { AddManagedColumnToCredentialsTable1734479635324 } from '../common/1734479635324-AddManagedColumnToCredentialsTable';
-import { AddStatsColumnsToTestRun1736172058779 } from '../common/1736172058779-AddStatsColumnsToTestRun';
 import { CreateTestCaseExecutionTable1736947513045 } from '../common/1736947513045-CreateTestCaseExecutionTable';
 import { AddErrorColumnsToTestRuns1737715421462 } from '../common/1737715421462-AddErrorColumnsToTestRuns';
 import { CreateFolderTable1738709609940 } from '../common/1738709609940-CreateFolderTable';

--- a/packages/cli/src/databases/migrations/mysqldb/index.ts
+++ b/packages/cli/src/databases/migrations/mysqldb/index.ts
@@ -44,6 +44,7 @@ import { SeparateExecutionData1690000000030 } from './1690000000030-SeparateExec
 import { FixExecutionDataType1690000000031 } from './1690000000031-FixExecutionDataType';
 import { AddActivatedAtUserSetting1717498465931 } from './1717498465931-AddActivatedAtUserSetting';
 import { MigrateTestDefinitionKeyToString1731582748663 } from './1731582748663-MigrateTestDefinitionKeyToString';
+import { CreateTestMetricTable1732271325258 } from './1732271325258-CreateTestMetricTable';
 import { AddStatsColumnsToTestRun1736172058779 } from './1736172058779-AddStatsColumnsToTestRun';
 import { CreateLdapEntities1674509946020 } from '../common/1674509946020-CreateLdapEntities';
 import { PurgeInvalidWorkflowConnections1675940580449 } from '../common/1675940580449-PurgeInvalidWorkflowConnections';
@@ -73,7 +74,6 @@ import { UpdateProcessedDataValueColumnToText1729607673464 } from '../common/172
 import { AddProjectIcons1729607673469 } from '../common/1729607673469-AddProjectIcons';
 import { CreateTestDefinitionTable1730386903556 } from '../common/1730386903556-CreateTestDefinitionTable';
 import { AddDescriptionToTestDefinition1731404028106 } from '../common/1731404028106-AddDescriptionToTestDefinition';
-import { CreateTestMetricTable1732271325258 } from '../common/1732271325258-CreateTestMetricTable';
 import { CreateTestRun1732549866705 } from '../common/1732549866705-CreateTestRunTable';
 import { AddMockedNodesColumnToTestDefinition1733133775640 } from '../common/1733133775640-AddMockedNodesColumnToTestDefinition';
 import { AddManagedColumnToCredentialsTable1734479635324 } from '../common/1734479635324-AddManagedColumnToCredentialsTable';


### PR DESCRIPTION
## Summary

This PR address couple of DB migration issues, preventing n8n to start when using MySQL as a database

### Column check constraint
Migration `AddStatsColumnsToTestRun1736172058779` introduced some column check constraints, but referencing other columns in check condition of a column check constraint is not supported by MySQL (checked on `8.0.29`, `8.0.41`, `8.4.4`).
```
Starting migration AddStatsColumnsToTestRun1736172058779
query failed: ALTER TABLE `test_run` ADD COLUMN `totalCases` INT CHECK(
				CASE
					WHEN status = 'new' THEN `totalCases` IS NULL
					WHEN status in ('cancelled', 'error') THEN `totalCases` IS NULL OR `totalCases` >= 0
					ELSE `totalCases` >= 0
				END
			)
error: Error: Column check constraint 'test_run_chk_1' references other column.
```

#### Solution
As those stats columns are soon to be removed anyway,  created a separate migration file for MySQL under same migration name, without the check constraints. This change will not affect existing instances where the migration applied successfully, but only instances powered by MySQL, where this migration could not be applied.

### Incomplete migration of PK type
The migration `MigrateTestDefinitionKeyToString1731582748663` implementation for MySQL was incomplete. Although it run successfully, the queries for assigning new Primary Key and deleting temporary one was missing. This left the table `test_definition` in an inconsistent state (no PK), which prevented the next migration `CreateTestMetricTable1732271325258` from running properly on MySQL `8.4.4`:
```
Starting migration CreateTestMetricTable1732271325258
query failed: CREATE TABLE `test_metric` (`id` varchar(36) NOT NULL, `name` varchar(255) NOT NULL, `testDefinitionId` varchar(36) NOT NULL, `createdAt` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), `updatedAt` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), INDEX `IDX_3a4e9cf37111ac3270e2469b47` (`testDefinitionId`), CONSTRAINT `FK_3a4e9cf37111ac3270e2469b475` FOREIGN KEY (`testDefinitionId`) REFERENCES `test_definition` (`id`) ON DELETE CASCADE, PRIMARY KEY (`id`)) ENGINE=InnoDB
error: Error: Failed to add the foreign key constraint. Missing unique key for constraint 'FK_3a4e9cf37111ac3270e2469b475' in the referenced table 'test_definition'
```

#### Solution
Missing operations were added to the `MigrateTestDefinitionKeyToString1731582748663` migration.
For those instances where the incomplete migration was already applied, the same operations were added to the subsequent migration `CreateTestMetricTable1732271325258` conditionally.
Also `FixTestDefinitionPrimaryKey1739873751194` migration was added to fix the primary column if it has not been fixed yet by the patched `MigrateTestDefinitionKeyToString1731582748663` or `CreateTestMetricTable1732271325258` migrations.

### Added DB tests
To avoid issues like this in future, a new job for running tests using MySQL was added to a CI config.

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/12836
- https://linear.app/n8n/issue/AI-644/failing-mysql-db-migration


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
