### PR TITLE
fix(core): Redact credentials

### DIFF
--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -130,7 +130,7 @@ export class CredentialsController {
 		}
 
 		const mergedCredentials = deepCopy(credentials);
-		const decryptedData = this.credentialsService.decrypt(storedCredential);
+		const decryptedData = this.credentialsService.decrypt(storedCredential, true);
 
 		// When a sharee (or project viewer) opens a credential, the fields and the
 		// credential data are missing so the payload will be empty
@@ -143,14 +143,14 @@ export class CredentialsController {
 			mergedCredentials,
 		);
 
-		if (mergedCredentials.data && storedCredential) {
+		if (mergedCredentials.data) {
 			mergedCredentials.data = this.credentialsService.unredact(
 				mergedCredentials.data,
 				decryptedData,
 			);
 		}
 
-		return await this.credentialsService.test(req.user, mergedCredentials);
+		return await this.credentialsService.test(req.user.id, mergedCredentials);
 	}
 
 	@Post('/')

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -109,6 +109,9 @@ export class EnterpriseCredentialsService {
 		const { data: _, ...rest } = credential;
 
 		if (decryptedData) {
+			// We never want to expose the oauthTokenData to the frontend.
+			delete decryptedData.oauthTokenData;
+
 			return { data: decryptedData, ...rest };
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -87,7 +87,7 @@ export class EnterpriseCredentialsService {
 		if (credential) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.credentialsService.decrypt(credential, false);
+			decryptedData = this.credentialsService.decrypt(credential);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -109,9 +109,11 @@ export class EnterpriseCredentialsService {
 		const { data: _, ...rest } = credential;
 
 		if (decryptedData) {
-			// We never want to expose the oauthTokenData to the frontend.
-			delete decryptedData.oauthTokenData;
-
+			// We never want to expose the oauthTokenData to the frontend, but it
+			// expects it to check if the credential is already connected.
+			if (decryptedData?.oauthTokenData) {
+				decryptedData.oauthTokenData = true;
+			}
 			return { data: decryptedData, ...rest };
 		}
 

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -87,7 +87,7 @@ export class EnterpriseCredentialsService {
 		if (credential) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.credentialsService.decrypt(credential, true);
+			decryptedData = this.credentialsService.decrypt(credential, false);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -112,9 +112,13 @@ export class CredentialsService {
 
 			if (includeData) {
 				credentials = credentials.map((c: CredentialsEntity & ScopesField) => {
+					const data = c.scopes.includes('credential:update') ? this.decrypt(c) : undefined;
+					// We never want to expose the oauthTokenData to the frontend.
+					delete data?.oauthTokenData;
+
 					return {
 						...c,
-						data: c.scopes.includes('credential:update') ? this.decrypt(c) : undefined,
+						data,
 					} as unknown as CredentialsEntity;
 				});
 			}
@@ -569,6 +573,8 @@ export class CredentialsService {
 		const { data: _, ...rest } = credential;
 
 		if (decryptedData) {
+			// We never want to expose the oauthTokenData to the frontend.
+			delete decryptedData.oauthTokenData;
 			return { data: decryptedData, ...rest };
 		}
 		return { ...rest };

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -448,8 +448,8 @@ export class CredentialsService {
 		await this.credentialsRepository.remove(credential);
 	}
 
-	async test(user: User, credentials: ICredentialsDecrypted) {
-		return await this.credentialsTester.testCredentials(user, credentials.type, credentials);
+	async test(userId: User['id'], credentials: ICredentialsDecrypted) {
+		return await this.credentialsTester.testCredentials(userId, credentials.type, credentials);
 	}
 
 	// Take data and replace all sensitive values with a sentinel value.

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -560,7 +560,7 @@ export class CredentialsService {
 		if (sharing) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.decrypt(sharing.credentials, false);
+			decryptedData = this.decrypt(sharing.credentials);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -113,8 +113,11 @@ export class CredentialsService {
 			if (includeData) {
 				credentials = credentials.map((c: CredentialsEntity & ScopesField) => {
 					const data = c.scopes.includes('credential:update') ? this.decrypt(c) : undefined;
-					// We never want to expose the oauthTokenData to the frontend.
-					delete data?.oauthTokenData;
+					// We never want to expose the oauthTokenData to the frontend, but it
+					// expects it to check if the credential is already connected.
+					if (data?.oauthTokenData) {
+						data.oauthTokenData = true;
+					}
 
 					return {
 						...c,
@@ -573,8 +576,11 @@ export class CredentialsService {
 		const { data: _, ...rest } = credential;
 
 		if (decryptedData) {
-			// We never want to expose the oauthTokenData to the frontend.
-			delete decryptedData.oauthTokenData;
+			// We never want to expose the oauthTokenData to the frontend, but it
+			// expects it to check if the credential is already connected.
+			if (decryptedData?.oauthTokenData) {
+				decryptedData.oauthTokenData = true;
+			}
 			return { data: decryptedData, ...rest };
 		}
 		return { ...rest };

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -553,7 +553,7 @@ export class CredentialsService {
 		if (sharing) {
 			// Decrypt the data if we found the credential with the `credential:update`
 			// scope.
-			decryptedData = this.decrypt(sharing.credentials, true);
+			decryptedData = this.decrypt(sharing.credentials, false);
 		} else {
 			// Otherwise try to find them with only the `credential:read` scope. In
 			// that case we return them without the decrypted data.

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -172,7 +172,7 @@ export class CredentialsTester {
 
 	// eslint-disable-next-line complexity
 	async testCredentials(
-		user: User,
+		userId: User['id'],
 		credentialType: string,
 		credentialsDecrypted: ICredentialsDecrypted,
 	): Promise<INodeCredentialTestResult> {
@@ -186,7 +186,7 @@ export class CredentialsTester {
 
 		if (credentialsDecrypted.data) {
 			try {
-				const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id);
+				const additionalData = await WorkflowExecuteAdditionalData.getBase(userId);
 				credentialsDecrypted.data = this.credentialsHelper.applyDefaultsAndOverwrites(
 					additionalData,
 					credentialsDecrypted.data,
@@ -292,7 +292,7 @@ export class CredentialsTester {
 			},
 		};
 
-		const additionalData = await WorkflowExecuteAdditionalData.getBase(user.id, node.parameters);
+		const additionalData = await WorkflowExecuteAdditionalData.getBase(userId, node.parameters);
 
 		const executeData: IExecuteData = { node, data: {}, source: null };
 		const executeFunctions = new ExecuteContext(

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -28,7 +28,10 @@ import {
 	createUser,
 	createUserShell,
 } from '../shared/db/users';
-import { randomCredentialPayload } from '../shared/random';
+import {
+	randomCredentialPayload,
+	randomCredentialPayloadWithOauthTokenData,
+} from '../shared/random';
 import * as testDb from '../shared/test-db';
 import type { SaveCredentialFunction } from '../shared/types';
 import type { SuperAgentTest } from '../shared/types';
@@ -559,7 +562,8 @@ describe('GET /credentials/:id', () => {
 	test('should redact the data when `includeData:true` is passed', async () => {
 		const credentialService = Container.get(CredentialsService);
 		const redactSpy = jest.spyOn(credentialService, 'redact');
-		const savedCredential = await saveCredential(randomCredentialPayload(), {
+		const credential = randomCredentialPayloadWithOauthTokenData();
+		const savedCredential = await saveCredential(credential, {
 			user: owner,
 		});
 
@@ -569,6 +573,7 @@ describe('GET /credentials/:id', () => {
 
 		validateMainCredentialData(response.body.data);
 		expect(response.body.data.data).toBeDefined();
+		expect(response.body.data.data.oauthTokenData).toBe(true);
 		expect(redactSpy).toHaveBeenCalled();
 	});
 

--- a/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.ee.test.ts
@@ -556,7 +556,7 @@ describe('GET /credentials/:id', () => {
 		expect(secondCredential.data).toBeDefined();
 	});
 
-	test('should not redact the data when `includeData:true` is passed', async () => {
+	test('should redact the data when `includeData:true` is passed', async () => {
 		const credentialService = Container.get(CredentialsService);
 		const redactSpy = jest.spyOn(credentialService, 'redact');
 		const savedCredential = await saveCredential(randomCredentialPayload(), {
@@ -569,7 +569,7 @@ describe('GET /credentials/:id', () => {
 
 		validateMainCredentialData(response.body.data);
 		expect(response.body.data.data).toBeDefined();
-		expect(redactSpy).not.toHaveBeenCalled();
+		expect(redactSpy).toHaveBeenCalled();
 	});
 
 	test('should retrieve non-owned cred for owner', async () => {

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -374,7 +374,7 @@ describe('GET /credentials', () => {
 		expect(teamCredAsViewer.data).toBeDefined();
 		expect(
 			(teamCredAsViewer.data as unknown as ICredentialDataDecryptedObject).oauthTokenData,
-		).toBeDefined();
+		).toBe(true);
 		expect(teamCredAsViewer.scopes).toEqual(
 			[
 				'credential:move',
@@ -1327,6 +1327,22 @@ describe('GET /credentials/:id', () => {
 		validateMainCredentialData(response.body.data);
 		expect(response.body.data.data).toBeDefined();
 		expect(redactSpy).toHaveBeenCalled();
+	});
+
+	test('should omit oauth data when `includeData:true` is passed', async () => {
+		const credential = randomCredentialPayloadWithOauthTokenData();
+		const savedCredential = await saveCredential(credential, {
+			user: owner,
+			role: 'credential:owner',
+		});
+
+		const response = await authOwnerAgent
+			.get(`/credentials/${savedCredential.id}`)
+			.query({ includeData: true });
+
+		validateMainCredentialData(response.body.data);
+		expect(response.body.data.data).toBeDefined();
+		expect(response.body.data.data.oauthTokenData).toBe(true);
 	});
 
 	test('should retrieve owned cred for member', async () => {

--- a/packages/cli/test/integration/shared/random.ts
+++ b/packages/cli/test/integration/shared/random.ts
@@ -46,4 +46,13 @@ export const randomCredentialPayload = ({
 	isManaged,
 });
 
+export const randomCredentialPayloadWithOauthTokenData = ({
+	isManaged = false,
+}: { isManaged?: boolean } = {}): CredentialPayload => ({
+	name: randomName(),
+	type: randomName(),
+	data: { accessToken: randomString(6, 16), oauthTokenData: { access_token: randomString(6, 16) } },
+	isManaged,
+});
+
 export const uniqueId = () => uuid();


### PR DESCRIPTION
## Summary

- Redact credentials from credentials endpoints
- Redact oauth data and prevent updating it with the PATCH endpoint

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/PAY-2604


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
