### PR TITLE
fix(editor): Do not show credential details popup for users without necessary scopes with direct link

### DIFF
--- a/packages/editor-ui/src/routes/projects.routes.ts
+++ b/packages/editor-ui/src/routes/projects.routes.ts
@@ -8,7 +8,6 @@ const WorkflowsView = async () => await import('@/views/WorkflowsView.vue');
 const CredentialsView = async () => await import('@/views/CredentialsView.vue');
 const ProjectSettings = async () => await import('@/views/ProjectSettings.vue');
 const ExecutionsView = async () => await import('@/views/ExecutionsView.vue');
-import { useProjectsStore } from '@/stores/projects.store';
 
 const checkProjectAvailability = (to?: RouteLocationNormalized): boolean => {
 	if (!to?.params.projectId) {

--- a/packages/editor-ui/src/routes/projects.routes.ts
+++ b/packages/editor-ui/src/routes/projects.routes.ts
@@ -1,4 +1,4 @@
-import type { RouteRecordRaw } from 'vue-router';
+import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 import { VIEWS } from '@/constants';
 
 const MainSidebar = async () => await import('@/components/MainSidebar.vue');
@@ -6,6 +6,15 @@ const WorkflowsView = async () => await import('@/views/WorkflowsView.vue');
 const CredentialsView = async () => await import('@/views/CredentialsView.vue');
 const ProjectSettings = async () => await import('@/views/ProjectSettings.vue');
 const ExecutionsView = async () => await import('@/views/ExecutionsView.vue');
+import { useProjectsStore } from '@/stores/projects.store';
+
+const checkProjectAvailability = (to?: RouteLocationNormalized): boolean => {
+	if (!to?.params.projectId) {
+		return true;
+	}
+	const project = useProjectsStore().myProjects.find((p) => to?.params.projectId === p.id);
+	return !!project;
+};
 
 const commonChildRoutes: RouteRecordRaw[] = [
 	{
@@ -15,7 +24,10 @@ const commonChildRoutes: RouteRecordRaw[] = [
 			sidebar: MainSidebar,
 		},
 		meta: {
-			middleware: ['authenticated'],
+			middleware: ['authenticated', 'custom'],
+			middlewareOptions: {
+				custom: (options) => checkProjectAvailability(options?.to),
+			},
 		},
 	},
 	{
@@ -26,7 +38,10 @@ const commonChildRoutes: RouteRecordRaw[] = [
 			sidebar: MainSidebar,
 		},
 		meta: {
-			middleware: ['authenticated'],
+			middleware: ['authenticated', 'custom'],
+			middlewareOptions: {
+				custom: (options) => checkProjectAvailability(options?.to),
+			},
 		},
 	},
 	{
@@ -36,7 +51,10 @@ const commonChildRoutes: RouteRecordRaw[] = [
 			sidebar: MainSidebar,
 		},
 		meta: {
-			middleware: ['authenticated'],
+			middleware: ['authenticated', 'custom'],
+			middlewareOptions: {
+				custom: (options) => checkProjectAvailability(options?.to),
+			},
 		},
 	},
 ];

--- a/packages/editor-ui/src/views/CredentialsView.test.ts
+++ b/packages/editor-ui/src/views/CredentialsView.test.ts
@@ -105,7 +105,7 @@ describe('CredentialsView', () => {
 	});
 
 	describe('create credential', () => {
-		it('should show modal the on route if user has scope to create credential in the project', async () => {
+		it('should show the modal on the route if the user has the scope to create credentials in the project.', async () => {
 			const uiStore = mockedStore(useUIStore);
 			const projectsStore = mockedStore(useProjectsStore);
 			projectsStore.currentProject = createTestProject({ scopes: ['credential:create'] });

--- a/packages/editor-ui/src/views/CredentialsView.test.ts
+++ b/packages/editor-ui/src/views/CredentialsView.test.ts
@@ -1,4 +1,5 @@
 import { createComponentRenderer } from '@/__tests__/render';
+import { createTestProject } from '@/__tests__/data/projects';
 import { createTestingPinia } from '@pinia/testing';
 import { useCredentialsStore } from '@/stores/credentials.store';
 import CredentialsView from '@/views/CredentialsView.vue';
@@ -7,10 +8,10 @@ import { mockedStore } from '@/__tests__/utils';
 import { waitFor, within, fireEvent } from '@testing-library/vue';
 import { CREDENTIAL_SELECT_MODAL_KEY, STORES, VIEWS } from '@/constants';
 import { useProjectsStore } from '@/stores/projects.store';
-import type { Project } from '@/types/projects.types';
 import { createRouter, createWebHistory } from 'vue-router';
 import { flushPromises } from '@vue/test-utils';
 import { CREDENTIAL_EMPTY_VALUE } from 'n8n-workflow';
+
 vi.mock('@/composables/useGlobalEntityCreation', () => ({
 	useGlobalEntityCreation: () => ({
 		menu: [],
@@ -20,6 +21,11 @@ vi.mock('@/composables/useGlobalEntityCreation', () => ({
 const router = createRouter({
 	history: createWebHistory(),
 	routes: [
+		{
+			name: VIEWS.HOMEPAGE,
+			path: '/',
+			component: { template: '<div></div>' },
+		},
 		{
 			path: '/:credentialId?',
 			name: VIEWS.CREDENTIALS,
@@ -99,25 +105,63 @@ describe('CredentialsView', () => {
 	});
 
 	describe('create credential', () => {
-		it('should show modal based on route param', async () => {
+		it('should show modal the on route if user has scope to create credential in the project', async () => {
 			const uiStore = mockedStore(useUIStore);
-			renderComponent({ props: { credentialId: 'create' } });
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = createTestProject({ scopes: ['credential:create'] });
+			const { rerender } = renderComponent();
+			await rerender({ credentialId: 'create' });
 			expect(uiStore.openModal).toHaveBeenCalledWith(CREDENTIAL_SELECT_MODAL_KEY);
+		});
+
+		it('should not show the modal on route if user has no scope to create credential in the project', async () => {
+			const uiStore = mockedStore(useUIStore);
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.currentProject = createTestProject({ scopes: ['credential:read'] });
+			const { rerender } = renderComponent();
+			await rerender({ credentialId: 'create' });
+			expect(uiStore.openModal).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('open existing credential', () => {
-		it('should show modal based on route param', async () => {
+		it('should show modal on route param if the user has permission to read or update', async () => {
 			const uiStore = mockedStore(useUIStore);
-			renderComponent({ props: { credentialId: 'credential-id' } });
-			expect(uiStore.openExistingCredential).toHaveBeenCalledWith('credential-id');
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockImplementation(() => ({
+				id: 'abc123',
+				name: 'test',
+				type: 'test',
+				createdAt: '2021-05-05T00:00:00Z',
+				updatedAt: '2021-05-05T00:00:00Z',
+				scopes: ['credential:read'],
+			}));
+			const { rerender } = renderComponent();
+			await rerender({ credentialId: 'abc123' });
+			expect(uiStore.openExistingCredential).toHaveBeenCalledWith('abc123');
+		});
+
+		it('should not show modal on route param if the user has no permission to read or update', async () => {
+			const uiStore = mockedStore(useUIStore);
+			const credentialsStore = mockedStore(useCredentialsStore);
+			credentialsStore.getCredentialById = vi.fn().mockImplementation(() => ({
+				id: 'abc123',
+				name: 'test',
+				type: 'test',
+				createdAt: '2021-05-05T00:00:00Z',
+				updatedAt: '2021-05-05T00:00:00Z',
+				scopes: ['credential:list'],
+			}));
+			const { rerender } = renderComponent();
+			await rerender({ credentialId: 'abc123' });
+			expect(uiStore.openExistingCredential).not.toHaveBeenCalled();
 		});
 
 		it('should update credentialId route param when opened', async () => {
 			const replaceSpy = vi.spyOn(router, 'replace');
 			const projectsStore = mockedStore(useProjectsStore);
 			projectsStore.isProjectHome = false;
-			projectsStore.currentProject = { scopes: ['credential:read'] } as Project;
+			projectsStore.currentProject = createTestProject({ scopes: ['credential:read'] });
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.allCredentials = [
 				{

--- a/packages/editor-ui/src/views/CredentialsView.test.ts
+++ b/packages/editor-ui/src/views/CredentialsView.test.ts
@@ -114,7 +114,7 @@ describe('CredentialsView', () => {
 			expect(uiStore.openModal).toHaveBeenCalledWith(CREDENTIAL_SELECT_MODAL_KEY);
 		});
 
-		it('should not show the modal on route if user has no scope to create credential in the project', async () => {
+		it('should not show the modal on the route if the user has no scope to create credential in the project', async () => {
 			const uiStore = mockedStore(useUIStore);
 			const projectsStore = mockedStore(useProjectsStore);
 			projectsStore.currentProject = createTestProject({ scopes: ['credential:read'] });
@@ -125,7 +125,7 @@ describe('CredentialsView', () => {
 	});
 
 	describe('open existing credential', () => {
-		it('should show modal on route param if the user has permission to read or update', async () => {
+		it('should show the modal on the route if the user has permission to read or update', async () => {
 			const uiStore = mockedStore(useUIStore);
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.getCredentialById = vi.fn().mockImplementation(() => ({
@@ -141,7 +141,7 @@ describe('CredentialsView', () => {
 			expect(uiStore.openExistingCredential).toHaveBeenCalledWith('abc123');
 		});
 
-		it('should not show modal on route param if the user has no permission to read or update', async () => {
+		it('should not show the modal on the route if the user has no permission to read or update', async () => {
 			const uiStore = mockedStore(useUIStore);
 			const credentialsStore = mockedStore(useCredentialsStore);
 			credentialsStore.getCredentialById = vi.fn().mockImplementation(() => ({

--- a/packages/editor-ui/src/views/CredentialsView.vue
+++ b/packages/editor-ui/src/views/CredentialsView.vue
@@ -12,6 +12,7 @@ import {
 	CREDENTIAL_SELECT_MODAL_KEY,
 	CREDENTIAL_EDIT_MODAL_KEY,
 	EnterpriseEditionFeature,
+	VIEWS,
 } from '@/constants';
 import { useUIStore, listenForModalChanges } from '@/stores/ui.store';
 import { useNodeTypesStore } from '@/stores/nodeTypes.store';
@@ -151,6 +152,7 @@ const maybeCreateCredential = () => {
 		if (projectPermissions.value.credential.create) {
 			uiStore.openModal(CREDENTIAL_SELECT_MODAL_KEY);
 		} else {
+			void router.replace({ name: VIEWS.HOMEPAGE });
 		}
 	}
 };
@@ -161,6 +163,8 @@ const maybeEditCredential = () => {
 		const credentialPermissions = getResourcePermissions(credential?.scopes).credential;
 		if (credential && (credentialPermissions.update || credentialPermissions.read)) {
 			uiStore.openExistingCredential(props.credentialId);
+		} else {
+			void router.replace({ name: VIEWS.HOMEPAGE });
 		}
 	}
 };


### PR DESCRIPTION
## Summary

Sending someone a link to credential they don't have access causes unexpected state

## Related Linear tickets, Github issues, and Community forum posts

[PAY-2602](https://linear.app/n8n/issue/PAY-2602/sending-someone-a-link-to-credential-they-dont-have-access-causes)


## Review / Merge checklist

- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `release/backport`
