### PR TITLE
fix(editor): Fix page size resetting when filters are reset on workflows page

### DIFF
--- a/packages/editor-ui/src/components/layouts/ResourcesListLayout.vue
+++ b/packages/editor-ui/src/components/layouts/ResourcesListLayout.vue
@@ -362,9 +362,8 @@ const resetFilters = async () => {
 		filtersModel.value[key] = Array.isArray(filtersModel.value[key]) ? [] : '';
 	});
 
-	// Reset the pagination
+	// Reset the current page
 	await setCurrentPage(1);
-	await setRowsPerPage(props.customPageSize);
 
 	resettingFilters.value = true;
 	hasFilters.value = false;


### PR DESCRIPTION
## Summary
Prevent page size from resetting when filters are reset on workflows page

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-3234

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
