### PR TITLE
fix(editor): Disable fromAI override button for credentialsSelect (no-changelog)

### DIFF
--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.test.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.test.ts
@@ -6,16 +6,20 @@ import {
 	makeOverrideValue,
 	parseOverrides,
 } from './fromAIOverrideUtils';
-import type { INodeTypeDescription } from 'n8n-workflow';
+import type { INodeTypeDescription, NodePropertyTypes } from 'n8n-workflow';
 
 const DISPLAY_NAME = 'aDisplayName';
 const PARAMETER_NAME = 'aName';
 
-const makeContext = (value: string, path?: string): OverrideContext => ({
+const makeContext = (
+	value: string,
+	path?: string,
+	type: NodePropertyTypes = 'string',
+): OverrideContext => ({
 	parameter: {
 		name: PARAMETER_NAME,
 		displayName: DISPLAY_NAME,
-		type: 'string',
+		type,
 	},
 	value,
 	path: path ?? `parameters.${PARAMETER_NAME}`,
@@ -77,6 +81,7 @@ describe('makeOverrideValue', () => {
 		['ai node type on denylist', makeContext(''), AI_DENYLIST_NODE_TYPE],
 		['vector store type', makeContext(''), AI_VECTOR_STORE_NODE_TYPE],
 		['denied parameter name', makeContext('', 'parameters.toolName'), AI_NODE_TYPE],
+		['denied parameter type', makeContext('', undefined, 'credentialsSelect'), AI_NODE_TYPE],
 	])('should not create an override for %s', (_name, context, nodeType) => {
 		expect(makeOverrideValue(context, nodeType)).toBeNull();
 	});

--- a/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
+++ b/packages/editor-ui/src/utils/fromAIOverrideUtils.ts
@@ -55,6 +55,8 @@ const PATH_DENYLIST = [
 	'parameters.toolDescription',
 ];
 
+const PROP_TYPE_DENYLIST = ['options', 'credentialsSelect'];
+
 export const fromAIExtraProps: Record<FromAIExtraProps, ExtraPropValue> = {
 	description: {
 		initialValue: '',
@@ -165,6 +167,8 @@ export function canBeContentOverride(
 
 	if (PATH_DENYLIST.includes(props.path)) return false;
 
+	if (PROP_TYPE_DENYLIST.includes(props.parameter.type)) return false;
+
 	const codex = nodeType?.codex;
 	if (
 		!codex?.categories?.includes('AI') ||
@@ -173,7 +177,7 @@ export function canBeContentOverride(
 	)
 		return false;
 
-	return !props.parameter.noDataExpression && 'options' !== props.parameter.type;
+	return !props.parameter.noDataExpression;
 }
 
 export function makeOverrideValue(


### PR DESCRIPTION
## Summary

This is mostly precautionary, we haven't seen a use case on master yet, and this type should usually be `noDataExpression` anyway.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3237/bug-fromai-button-positioning-for-credentialsselect-type


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
