### PR TITLE
fix(editor): Fix configurable node description margins and text alignment

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -221,6 +221,7 @@ function openContextMenu(event: MouseEvent) {
 			position: relative;
 			margin-top: 0;
 			margin-left: var(--spacing-s);
+			margin-right: var(--spacing-s);
 			width: auto;
 			min-width: unset;
 			max-width: calc(
@@ -231,6 +232,10 @@ function openContextMenu(event: MouseEvent) {
 		}
 
 		.label {
+			text-align: left;
+		}
+
+		.subtitle {
 			text-align: left;
 		}
 


### PR DESCRIPTION
## Summary

<img width="804" alt="Screenshot 2025-02-17 at 15 28 08" src="https://github.com/user-attachments/assets/349e6647-cc23-4580-8ea1-1adce5330438" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-445/configurable-nodes-dont-display-the-same-as-the-old-canvas

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
