### PR TITLE
feat(Bitwarden Node): Add support for European Cloud-Hosted instances (#13315).

### DIFF
--- a/packages/nodes-base/credentials/BitwardenApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitwardenApi.credentials.ts
@@ -51,5 +51,26 @@ export class BitwardenApi implements ICredentialType {
 				},
 			},
 		},
+		{
+			displayName: 'Server Geographies',
+			name: 'serverLocation',
+			type: 'options',
+			default: 'bitwarden.com',
+			options: [
+				{
+					name: 'United States',
+					value: 'bitwarden.com',
+				},
+				{
+					name: 'European Union',
+					value: 'bitwarden.eu',
+				},
+			],
+			displayOptions: {
+				show: {
+					environment: ['cloudHosted'],
+				},
+			},
+		},
 	];
 }

--- a/packages/nodes-base/credentials/BitwardenApi.credentials.ts
+++ b/packages/nodes-base/credentials/BitwardenApi.credentials.ts
@@ -52,8 +52,8 @@ export class BitwardenApi implements ICredentialType {
 			},
 		},
 		{
-			displayName: 'Server Geographies',
-			name: 'serverLocation',
+			displayName: 'Region',
+			name: 'region',
 			type: 'options',
 			default: 'bitwarden.com',
 			options: [

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -13,10 +13,10 @@ import { NodeApiError } from 'n8n-workflow';
  * Return the access token URL based on the user's environment.
  */
 async function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain, serverLocation } = await this.getCredentials('bitwardenApi');
+	const { environment, domain, region } = await this.getCredentials('bitwardenApi');
 
 	return environment === 'cloudHosted'
-		? `https://identity.${serverLocation}/connect/token`
+		? `https://identity.${region}/connect/token`
 		: `${domain}/identity/connect/token`;
 }
 
@@ -24,9 +24,9 @@ async function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
  * Return the base API URL based on the user's environment.
  */
 async function getBaseUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain, serverLocation } = await this.getCredentials('bitwardenApi');
+	const { environment, domain, region } = await this.getCredentials('bitwardenApi');
 
-	return environment === 'cloudHosted' ? `https://api.${serverLocation}` : `${domain}/api`;
+	return environment === 'cloudHosted' ? `https://api.${region}` : `${domain}/api`;
 }
 
 /**

--- a/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitwarden/GenericFunctions.ts
@@ -13,10 +13,10 @@ import { NodeApiError } from 'n8n-workflow';
  * Return the access token URL based on the user's environment.
  */
 async function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain } = await this.getCredentials('bitwardenApi');
+	const { environment, domain, serverLocation } = await this.getCredentials('bitwardenApi');
 
 	return environment === 'cloudHosted'
-		? 'https://identity.bitwarden.com/connect/token'
+		? `https://identity.${serverLocation}/connect/token`
 		: `${domain}/identity/connect/token`;
 }
 
@@ -24,9 +24,9 @@ async function getTokenUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
  * Return the base API URL based on the user's environment.
  */
 async function getBaseUrl(this: IExecuteFunctions | ILoadOptionsFunctions) {
-	const { environment, domain } = await this.getCredentials('bitwardenApi');
+	const { environment, domain, serverLocation } = await this.getCredentials('bitwardenApi');
 
-	return environment === 'cloudHosted' ? 'https://api.bitwarden.com' : `${domain}/api`;
+	return environment === 'cloudHosted' ? `https://api.${serverLocation}` : `${domain}/api`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Allow to choose the server geographies for Cloud-Hosted instances (see [Bitwarden documentation](https://bitwarden.com/help/server-geographies/)).

## Related Linear tickets, Github issues, and Community forum posts

Community forum post: https://community.n8n.io/t/bitwarden-cloud-hosted-credentials-for-european-instances/71977
Github issues: 
- fix: https://github.com/n8n-io/n8n/issues/13315
- doc: https://github.com/n8n-io/n8n-docs/pull/2857

fixes #13315

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (https://github.com/n8n-io/n8n-docs/pull/2857)
