### PR TITLE
feat(core): Include `workflowId` in scaling mode logs

### DIFF
--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -232,7 +232,7 @@ describe('ScalingService', () => {
 			await scalingService.setupQueue();
 			queue.add.mockResolvedValue(mock<Job>({ id: '456' }));
 
-			const jobData = mock<JobData>({ executionId: '123' });
+			const jobData = mock<JobData>({ executionId: '123', workflowId: '456' });
 			await scalingService.addJob(jobData, { priority: 100 });
 
 			expect(queue.add).toHaveBeenCalledWith(JOB_TYPE_NAME, jobData, {

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -76,10 +76,14 @@ export class JobProcessor {
 
 		const workflowId = execution.workflowData.id;
 
-		this.logger.info(`Worker started execution ${executionId} (job ${job.id})`, {
-			executionId,
-			jobId: job.id,
-		});
+		this.logger.info(
+			`Worker started execution ${executionId} (job ${job.id}) (workflow ${workflowId})`,
+			{
+				executionId,
+				jobId: job.id,
+				workflowId,
+			},
+		);
 
 		const startedAt = await this.executionRepository.setRunning(executionId);
 
@@ -160,7 +164,7 @@ export class JobProcessor {
 		additionalData.setExecutionStatus = (status: ExecutionStatus) => {
 			// Can't set the status directly in the queued worker, but it will happen in InternalHook.onWorkflowPostExecute
 			this.logger.debug(
-				`Queued worker execution status for execution ${executionId} (job ${job.id}) is "${status}"`,
+				`Queued worker execution status for execution ${executionId} (job ${job.id}) (workflow ${workflowId}) is "${status}"`,
 			);
 		};
 
@@ -238,14 +242,19 @@ export class JobProcessor {
 
 		delete this.runningJobs[job.id];
 
-		this.logger.info(`Worker finished execution ${executionId} (job ${job.id})`, {
-			executionId,
-			jobId: job.id,
-		});
+		this.logger.info(
+			`Worker finished execution ${executionId} (job ${job.id}) (workflow ${workflowId})`,
+			{
+				executionId,
+				jobId: job.id,
+				workflowId,
+			},
+		);
 
 		const msg: JobFinishedMessage = {
 			kind: 'job-finished',
 			executionId,
+			workflowId,
 			workerId: this.instanceSettings.hostId,
 		};
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -11,6 +11,7 @@ export type JobId = Job['id'];
 
 export type JobData = {
 	executionId: string;
+	workflowId: string;
 	loadStaticData: boolean;
 	pushRef?: string;
 };
@@ -48,6 +49,7 @@ export type RespondToWebhookMessage = {
 export type JobFinishedMessage = {
 	kind: 'job-finished';
 	executionId: string;
+	workflowId: string;
 	workerId: string;
 };
 
@@ -55,6 +57,7 @@ export type JobFinishedMessage = {
 export type JobFailedMessage = {
 	kind: 'job-failed';
 	executionId: string;
+	workflowId: string;
 	workerId: string;
 	errorMsg: string;
 	errorStack: string;

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -329,6 +329,7 @@ export class WorkflowRunner {
 	): Promise<void> {
 		const jobData: JobData = {
 			executionId,
+			workflowId: data.workflowData.id,
 			loadStaticData: !!loadStaticData,
 			pushRef: data.pushRef,
 		};

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -40,12 +40,12 @@ export class ErrorReporter {
 		if (error instanceof Error) {
 			let e = error;
 
-			const { executionId } = options ?? {};
-			const context = executionId ? ` (execution ${executionId})` : '';
-
+			const { executionId, workflowId } = options ?? {};
+			const executionContext = executionId ? ` (execution ${executionId})` : '';
+			const workflowContext = workflowId ? ` (workflow ${workflowId})` : '';
 			do {
 				const msg = [
-					e.message + context,
+					e.message + executionContext + workflowContext,
 					e instanceof ApplicationError && e.level === 'error' && e.stack ? `\n${e.stack}\n` : '',
 				].join('');
 				const meta = e instanceof ApplicationError ? e.extra : undefined;

--- a/packages/workflow/src/errors/application.error.ts
+++ b/packages/workflow/src/errors/application.error.ts
@@ -6,6 +6,7 @@ export type Level = 'warning' | 'error' | 'fatal' | 'info';
 export type ReportingOptions = {
 	level?: Level;
 	executionId?: string;
+	workflowId?: string;
 } & Pick<Event, 'tags' | 'extra'>;
 
 export class ApplicationError extends Error {


### PR DESCRIPTION
## Summary

For easier debuggability, include `workflowId` into scaling mode logs in addition to the already existing `executionId`.

**Main**

![image](https://github.com/user-attachments/assets/8e724db1-7c35-4104-a297-d55da8a16856)

**Worker**

![image](https://github.com/user-attachments/assets/7d283e4d-0095-438b-bb85-f804f66e2cd7)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-139/add-workflowid-to-workflowoperationerror-and-similar-workflow-related

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
