### PR TITLE
feat(Supabase Node): Add support for database schema

### DIFF
--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -29,7 +29,10 @@ export async function supabaseApiRequest(
 	}>('supabaseApi');
 
 	if (this.getNodeParameter('useCustomSchema', false)) {
-		const schema = this.getNodeParameter('schema', 'public');
+		let schema = this.getNodeParameter('schema', 'public');
+		if (schema === '') {
+			schema = 'public';
+		}
 		if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
 			headers['Content-Profile'] = schema;
 		} else if (['GET', 'HEAD'].includes(method)) {

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -28,11 +28,13 @@ export async function supabaseApiRequest(
 		serviceRole: string;
 	}>('supabaseApi');
 
-	const schema = this.getNodeParameter('schema', 0, 'public') as string;
-	if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
-		headers['Content-Profile'] = schema;
-	} else if (['GET', 'HEAD'].includes(method)) {
-		headers['Accept-Profile'] = schema;
+	if (this.getNodeParameter('useCustomSchema', false)) {
+		const schema = this.getNodeParameter('schema', 'public');
+		if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
+			headers['Content-Profile'] = schema;
+		} else if (['GET', 'HEAD'].includes(method)) {
+			headers['Accept-Profile'] = schema;
+		}
 	}
 
 	const options: IRequestOptions = {

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -28,7 +28,7 @@ export async function supabaseApiRequest(
 		serviceRole: string;
 	}>('supabaseApi');
 
-	const schema = this.getNodeParameter('schema', 0) as string;
+	const schema = this.getNodeParameter('schema', 0, 'public') as string;
 	if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
 		headers['Content-Profile'] = schema;
 	} else if (['GET', 'HEAD'].includes(method)) {

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -29,7 +29,7 @@ export async function supabaseApiRequest(
 	}>('supabaseApi');
 
 	if (this.getNodeParameter('useCustomSchema', false)) {
-		let schema = this.getNodeParameter('schema', 'public');
+		const schema = this.getNodeParameter('schema', 'public');
 		if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
 			headers['Content-Profile'] = schema;
 		} else if (['GET', 'HEAD'].includes(method)) {

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -30,9 +30,6 @@ export async function supabaseApiRequest(
 
 	if (this.getNodeParameter('useCustomSchema', false)) {
 		let schema = this.getNodeParameter('schema', 'public');
-		if (schema === '') {
-			schema = 'public';
-		}
 		if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
 			headers['Content-Profile'] = schema;
 		} else if (['GET', 'HEAD'].includes(method)) {
@@ -58,6 +55,9 @@ export async function supabaseApiRequest(
 		}
 		return await this.helpers.requestWithAuthentication.call(this, 'supabaseApi', options);
 	} catch (error) {
+		if (error.description) {
+			error.message = `${error.message}: ${error.description}`;
+		}
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }

--- a/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Supabase/GenericFunctions.ts
@@ -28,6 +28,13 @@ export async function supabaseApiRequest(
 		serviceRole: string;
 	}>('supabaseApi');
 
+	const schema = this.getNodeParameter('schema', 0) as string;
+	if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
+		headers['Content-Profile'] = schema;
+	} else if (['GET', 'HEAD'].includes(method)) {
+		headers['Accept-Profile'] = schema;
+	}
+
 	const options: IRequestOptions = {
 		headers: {
 			Prefer: 'return=representation',
@@ -35,13 +42,12 @@ export async function supabaseApiRequest(
 		method,
 		qs,
 		body,
-		uri: uri || `${credentials.host}/rest/v1${resource}`,
+		uri: uri ?? `${credentials.host}/rest/v1${resource}`,
 		json: true,
 	};
+
 	try {
-		if (Object.keys(headers).length !== 0) {
-			options.headers = Object.assign({}, options.headers, headers);
-		}
+		options.headers = Object.assign({}, options.headers, headers);
 		if (Object.keys(body).length === 0) {
 			delete options.body;
 		}

--- a/packages/nodes-base/nodes/Supabase/RowDescription.ts
+++ b/packages/nodes-base/nodes/Supabase/RowDescription.ts
@@ -60,6 +60,7 @@ export const rowFields: INodeProperties[] = [
 		description:
 			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 		typeOptions: {
+			loadOptionsDependsOn: ['useCustomSchema', 'schema'],
 			loadOptionsMethod: 'getTables',
 		},
 		required: true,

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -52,12 +52,22 @@ export class Supabase implements INodeType {
 		],
 		properties: [
 			{
+				displayName: 'Use custom schema',
+				name: 'useCustomSchema',
+				type: 'boolean',
+				default: false,
+				noDataExpression: true,
+				description:
+					'Whether to use another database schema than the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
+			},
+			{
 				displayName: 'Schema',
 				name: 'schema',
 				type: 'string',
 				default: 'public',
 				description: 'Name of database schema to use for table',
 				noDataExpression: false,
+				displayOptions: { show: { useCustomSchema: [true] } },
 			},
 			{
 				displayName: 'Resource',

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -58,7 +58,8 @@ export class Supabase implements INodeType {
 				default: false,
 				noDataExpression: true,
 				description:
-					'Whether to use another database schema than the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
+					'Toggle to use a database schema different from the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
+
 			},
 			{
 				displayName: 'Schema',

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -52,7 +52,7 @@ export class Supabase implements INodeType {
 		],
 		properties: [
 			{
-				displayName: 'Use custom schema',
+				displayName: 'Use Custom Schema',
 				name: 'useCustomSchema',
 				type: 'boolean',
 				default: false,

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -58,8 +58,7 @@ export class Supabase implements INodeType {
 				default: false,
 				noDataExpression: true,
 				description:
-					'Toggle to use a database schema different from the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
-
+					'Whether to use a database schema different from the default "public" schema (requires schema exposure in the <a href="https://supabase.com/docs/guides/api/using-custom-schemas?queryGroups=language&language=curl#exposing-custom-schemas">Supabase API</a>)',
 			},
 			{
 				displayName: 'Schema',

--- a/packages/nodes-base/nodes/Supabase/Supabase.node.ts
+++ b/packages/nodes-base/nodes/Supabase/Supabase.node.ts
@@ -52,6 +52,14 @@ export class Supabase implements INodeType {
 		],
 		properties: [
 			{
+				displayName: 'Schema',
+				name: 'schema',
+				type: 'string',
+				default: 'public',
+				description: 'Name of database schema to use for table',
+				noDataExpression: false,
+			},
+			{
 				displayName: 'Resource',
 				name: 'resource',
 				type: 'options',

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -105,13 +105,37 @@ describe('Test Supabase Node', () => {
 		supabaseApiRequest.mockRestore();
 	});
 
-	it('should set "public" schema in the headers for GET calls if no custom schema is used', async () => {
+	it('should not set schema headers if no custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'getAll',
 			returnAll: true,
 			useCustomSchema: false,
 			schema: 'public',
+			tableId: 'my_table',
+		});
+
+		await node.execute.call(fakeExecuteFunction);
+
+		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+			'supabaseApi',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					Prefer: 'return=representation',
+				}),
+				uri: 'https://api.supabase.io/rest/v1/my_table',
+			}),
+		);
+	});
+
+	it('should set "public" schema in the headers for GET calls if custom schema is enabled but not specified', async () => {
+		const fakeExecuteFunction = createMockExecuteFunction({
+			resource: 'row',
+			operation: 'getAll',
+			returnAll: true,
+			useCustomSchema: true,
+			schema: '',
 			tableId: 'my_table',
 		});
 
@@ -130,13 +154,13 @@ describe('Test Supabase Node', () => {
 		);
 	});
 
-	it('should set "public" schema in the headers for POST calls if no custom schema is used', async () => {
+	it('should set "public" schema in the headers for POST calls if custom schema is enabled but not specified', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'create',
 			returnAll: true,
-			useCustomSchema: false,
-			schema: 'public',
+			useCustomSchema: true,
+			schema: '',
 			tableId: 'my_table',
 		});
 
@@ -155,11 +179,12 @@ describe('Test Supabase Node', () => {
 		);
 	});
 
-	it('should set the correct headers for GET calls if custom schema is used', async () => {
+	it('should set the schema headers for GET calls if custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'getAll',
 			returnAll: true,
+			useCustomSchema: true,
 			schema: 'custom_schema',
 			tableId: 'my_table',
 		});
@@ -179,11 +204,12 @@ describe('Test Supabase Node', () => {
 		);
 	});
 
-	it('should set the correct headers for POST calls if custom schema is used', async () => {
+	it('should set the schema headers for POST calls if custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'create',
 			returnAll: true,
+			useCustomSchema: true,
 			schema: 'custom_schema',
 			tableId: 'my_table',
 		});

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -105,7 +105,57 @@ describe('Test Supabase Node', () => {
 		supabaseApiRequest.mockRestore();
 	});
 
-	it('should set the correct headers for the schema in GET calls', async () => {
+	it('should set "public" schema in the headers for GET calls if no custom schema is used', async () => {
+		const fakeExecuteFunction = createMockExecuteFunction({
+			resource: 'row',
+			operation: 'getAll',
+			returnAll: true,
+			useCustomSchema: false,
+			schema: 'public',
+			tableId: 'my_table',
+		});
+
+		await node.execute.call(fakeExecuteFunction);
+
+		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+			'supabaseApi',
+			expect.objectContaining({
+				method: 'GET',
+				headers: expect.objectContaining({
+					'Accept-Profile': 'public',
+					Prefer: 'return=representation',
+				}),
+				uri: 'https://api.supabase.io/rest/v1/my_table',
+			}),
+		);
+	});
+
+	it('should set "public" schema in the headers for POST calls if no custom schema is used', async () => {
+		const fakeExecuteFunction = createMockExecuteFunction({
+			resource: 'row',
+			operation: 'create',
+			returnAll: true,
+			useCustomSchema: false,
+			schema: 'public',
+			tableId: 'my_table',
+		});
+
+		await node.execute.call(fakeExecuteFunction);
+
+		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+			'supabaseApi',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'Content-Profile': 'public',
+					Prefer: 'return=representation',
+				}),
+				uri: 'https://api.supabase.io/rest/v1/my_table',
+			}),
+		);
+	});
+
+	it('should set the correct headers for GET calls if custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'getAll',
@@ -129,7 +179,7 @@ describe('Test Supabase Node', () => {
 		);
 	});
 
-	it('should set the correct headers for the schema in POST calls', async () => {
+	it('should set the correct headers for POST calls if custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',
 			operation: 'create',

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -129,56 +129,6 @@ describe('Test Supabase Node', () => {
 		);
 	});
 
-	it('should set "public" schema in the headers for GET calls if custom schema is enabled but not specified', async () => {
-		const fakeExecuteFunction = createMockExecuteFunction({
-			resource: 'row',
-			operation: 'getAll',
-			returnAll: true,
-			useCustomSchema: true,
-			schema: '',
-			tableId: 'my_table',
-		});
-
-		await node.execute.call(fakeExecuteFunction);
-
-		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
-			'supabaseApi',
-			expect.objectContaining({
-				method: 'GET',
-				headers: expect.objectContaining({
-					'Accept-Profile': 'public',
-					Prefer: 'return=representation',
-				}),
-				uri: 'https://api.supabase.io/rest/v1/my_table',
-			}),
-		);
-	});
-
-	it('should set "public" schema in the headers for POST calls if custom schema is enabled but not specified', async () => {
-		const fakeExecuteFunction = createMockExecuteFunction({
-			resource: 'row',
-			operation: 'create',
-			returnAll: true,
-			useCustomSchema: true,
-			schema: '',
-			tableId: 'my_table',
-		});
-
-		await node.execute.call(fakeExecuteFunction);
-
-		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
-			'supabaseApi',
-			expect.objectContaining({
-				method: 'POST',
-				headers: expect.objectContaining({
-					'Content-Profile': 'public',
-					Prefer: 'return=representation',
-				}),
-				uri: 'https://api.supabase.io/rest/v1/my_table',
-			}),
-		);
-	});
-
 	it('should set the schema headers for GET calls if custom schema is used', async () => {
 		const fakeExecuteFunction = createMockExecuteFunction({
 			resource: 'row',

--- a/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
+++ b/packages/nodes-base/nodes/Supabase/tests/Supabase.node.test.ts
@@ -4,7 +4,7 @@ import {
 	type IDataObject,
 	type IExecuteFunctions,
 	type IGetNodeParameterOptions,
-	ILoadOptionsFunctions,
+	type ILoadOptionsFunctions,
 	type INodeExecutionData,
 	type IPairedItemData,
 	NodeOperationError,


### PR DESCRIPTION
## Summary
This PR adds schema support to the `Supabase` Node, by adding a schema parameter and updating request headers based on the HTTP method.

https://supabase.com/docs/guides/api/using-custom-schemas

## Related Linear tickets, Github issues, and Community forum posts
- https://linear.app/n8n/issue/NODE-1931/supabase-node-include-schema-in-header-request
- https://community.n8n.io/t/schemas-in-supabase-node-other-than-public-http-custom-settings/59541

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
