### PR TITLE
Accommodate TikTok compatible changes for oAuth2

### DIFF
--- a/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
+++ b/packages/@n8n/client-oauth2/src/ClientOAuth2Token.ts
@@ -86,6 +86,14 @@ export class ClientOAuth2Token {
 		if (options.authentication === 'body') {
 			body.client_id = clientId;
 			body.client_secret = clientSecret;
+			if (options.accessTokenUri &&
+						((options.accessTokenUri.includes('tiktokapis.com') || options.accessTokenUri.includes('tiktok.com')) &&
+						 (options.accessTokenUri.includes('oauth') || options.accessTokenUri.includes('auth')))
+			) {
+							// For TikTok endpoints, use client_key and client_secret
+							body.client_key = clientId;
+							body.client_secret = clientSecret;
+			}
 		} else {
 			headers.Authorization = auth(clientId, clientSecret);
 		}

--- a/packages/@n8n/client-oauth2/src/CodeFlow.ts
+++ b/packages/@n8n/client-oauth2/src/CodeFlow.ts
@@ -39,6 +39,14 @@ export class CodeFlow {
 			state: options.state,
 			...(options.scopes ? { scope: options.scopes.join(options.scopesSeparator ?? ' ') } : {}),
 		};
+		
+		if (options.authorizationUri &&
+						((options.authorizationUri.includes('tiktokapis.com') || options.authorizationUri.includes('tiktok.com')) &&
+						 (options.authorizationUri.includes('oauth') || options.authorizationUri.includes('auth')))
+		) {
+						// For TikTok endpoints, use client_key and client_secret
+						queryParams.client_key = options.clientId;
+		}
 
 		for (const [key, value] of Object.entries(queryParams)) {
 			if (value !== null && value !== undefined) {
@@ -97,6 +105,15 @@ export class CodeFlow {
 			grant_type: 'authorization_code',
 			redirect_uri: options.redirectUri,
 		};
+
+		if (options.accessTokenUri &&
+						((options.accessTokenUri.includes('tiktokapis.com') || options.accessTokenUri.includes('tiktok.com')) &&
+						 (options.accessTokenUri.includes('oauth') || options.accessTokenUri.includes('auth')))
+		) {
+						// For TikTok endpoints, use client_key and client_secret
+						body.client_key = options.clientId;
+						body.client_secret = options.clientSecret;
+		}
 
 		// `client_id`: REQUIRED, if the client is not authenticating with the
 		// authorization server as described in Section 3.2.1.


### PR DESCRIPTION
## Summary

TikTok requires additional parameters in Token flow, which is slight deviation from normal oAuth2 flow.

This code change, though not ideal, ensures 100% oAuth2 compatibility with TikTok.

No impact on any other oAuth2 flow.
