### PR TITLE
fix(editor): Reduce icon offset to align with square nodes (no-changelog)

### DIFF
--- a/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/editor-ui/src/components/canvas/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -164,7 +164,7 @@ function openContextMenu(event: MouseEvent) {
 	--canvas-node-border-width: 2px;
 	--configurable-node--min-input-count: 4;
 	--configurable-node--input-width: 64px;
-	--configurable-node--icon-offset: 40px;
+	--configurable-node--icon-offset: 30px;
 	--configurable-node--icon-size: 30px;
 	--trigger-node--border-radius: 36px;
 	--canvas-node--status-icons-offset: var(--spacing-3xs);


### PR DESCRIPTION
## Summary

Before:
![image](https://github.com/user-attachments/assets/3f4efbfa-8a34-4a02-a8ee-296bd5c3eca7)

After:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/51499b36-3a85-4534-8db7-8e9875ad8c40" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-445/configurable-nodes-dont-display-the-same-as-the-old-canvas


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
