### PR TITLE
fix(editor): Fix Editor Window Not Showing in Full Height

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -1240,6 +1240,7 @@ onUpdated(async () => {
 							:is-read-only="isReadOnly"
 							:rows="editorRows"
 							fullscreen
+							fill-parent
 							@update:model-value="valueChangedDebounced"
 						/>
 					</div>


### PR DESCRIPTION
## Summary
This is a fix for: https://github.com/n8n-io/n8n/issues/13278

Bug Description
When opening the full screen editor for the JSON property in an HTTP request, the popup window shows in full screen, but the textarea does not strech out the entire height.

This PR fixes the height when opening a JsonEditor.vue component by using the fill-parent prop. Before it was not passed therefore it was only height: 40vh instead of the height: 100%. see screenshots:

![Screenshot 2025-02-18 at 10 58 49 AM](https://github.com/user-attachments/assets/1d216af7-8bb5-409b-be48-55c26d4f1ccf)
![Screenshot 2025-02-18 at 10 58 21 AM](https://github.com/user-attachments/assets/e7b06b40-1c6e-40fd-baa5-7b790db2b161)
![Screenshot 2025-02-18 at 10 57 52 AM](https://github.com/user-attachments/assets/78163fce-5638-4f3e-91e9-46358e90f6b8)
![Screenshot 2025-02-18 at 10 57 04 AM](https://github.com/user-attachments/assets/b9f4e004-07f4-429f-bb51-4a8f71fb07be)

## Related Linear tickets, Github issues, and Community forum posts
GHC-845
https://github.com/n8n-io/n8n/issues/13278
closes#13278


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
