### PR TITLE
chore: Bump license-sdk to v2.16.1 (no-changelog)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,7 +97,7 @@
     "@n8n/task-runner": "workspace:*",
     "@n8n/typeorm": "0.3.20-12",
     "@n8n_io/ai-assistant-sdk": "1.13.0",
-    "@n8n_io/license-sdk": "2.16.0",
+    "@n8n_io/license-sdk": "2.16.1",
     "@oclif/core": "4.0.7",
     "@rudderstack/rudder-sdk-node": "2.0.9",
     "@sentry/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,8 +824,8 @@ importers:
         specifier: 1.13.0
         version: 1.13.0
       '@n8n_io/license-sdk':
-        specifier: 2.16.0
-        version: 2.16.0
+        specifier: 2.16.1
+        version: 2.16.1
       '@oclif/core':
         specifier: 4.0.7
         version: 4.0.7
@@ -4594,8 +4594,8 @@ packages:
     resolution: {integrity: sha512-16kftFTeX3/lBinHJaBK0OL1lB4FpPaUoHX4h25AkvgHvmjUHpWNY2ZtKos0rY89+pkzDsNxMZqSUkeKU45iRg==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
 
-  '@n8n_io/license-sdk@2.16.0':
-    resolution: {integrity: sha512-MVBqCkapJUX1rWhAXzGnfqOFaqzr0MT2X3ZTuA1BOyypb0doiuG9eh2ABy67Py4QKXGu+gnBAXZYGwG29bay+w==}
+  '@n8n_io/license-sdk@2.16.1':
+    resolution: {integrity: sha512-J3zsSzu0JftKAsLnxeKtprKkNSWpfNNMy7kUGkBgEsd6R7kJ6bzKKIcyTu+pHPP+Gfe6iTKw+SXz2TXSZEmK2A==}
     engines: {node: '>=18.12.1'}
 
   '@n8n_io/riot-tmpl@4.0.0':
@@ -17009,7 +17009,7 @@ snapshots:
 
   '@n8n_io/ai-assistant-sdk@1.13.0': {}
 
-  '@n8n_io/license-sdk@2.16.0':
+  '@n8n_io/license-sdk@2.16.1':
     dependencies:
       crypto-js: 4.2.0
       node-machine-id: 1.1.12


### PR DESCRIPTION
`license-sdk@2.16.1` skips unnecessary renewal calls.