### PR TITLE
fix(core): Handle connections for missing nodes in a workflow

### DIFF
--- a/packages/workflow/src/Workflow.ts
+++ b/packages/workflow/src/Workflow.ts
@@ -508,6 +508,9 @@ export class Workflow {
 					return;
 				}
 
+				// Ignore connections for nodes that don't exist in this workflow
+				if (!(connection.node in this.nodes)) return;
+
 				addNodes = this.getHighestNode(connection.node, undefined, checkedNodes);
 
 				if (addNodes.length === 0) {

--- a/packages/workflow/test/Workflow.test.ts
+++ b/packages/workflow/test/Workflow.test.ts
@@ -2201,7 +2201,7 @@ describe('Workflow', () => {
 			expect(result).toEqual([targetNode.name]);
 		});
 
-		test('should handle connections to nodes not defined in workflow', () => {
+		test('should handle connections to nodes that are not defined in the workflow', () => {
 			const node1 = createNode('Node1');
 			const targetNode = createNode('TargetNode');
 
@@ -2225,6 +2225,31 @@ describe('Workflow', () => {
 			const result = workflow.getHighestNode(targetNode.name);
 
 			expect(result).toEqual([targetNode.name]);
+		});
+
+		test('should handle connections from nodes that are not defined in the workflow', () => {
+			const node1 = createNode('Node1');
+			const targetNode = createNode('TargetNode');
+
+			const connections = {
+				Node1: {
+					main: [[{ node: 'TargetNode', type: NodeConnectionType.Main, index: 0 }]],
+				},
+				NonExistentNode: {
+					main: [[{ node: 'TargetNode', type: NodeConnectionType.Main, index: 0 }]],
+				},
+			};
+
+			const workflow = new Workflow({
+				id: 'test',
+				nodes: [node1, targetNode],
+				connections,
+				active: false,
+				nodeTypes,
+			});
+
+			const result = workflow.getHighestNode(targetNode.name);
+			expect(result).toEqual([node1.name]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

In earlier versions of canvas v2 we had a bug that led to connections not being removed when a node was removed. This has led to some users with workflows with invalid connections.
This PR adds graceful handling of such workflows by ignoring invalid connections like these.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #13086
[CAT-660](https://linear.app/n8n/issue/CAT-660)

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
