### PR TITLE
fix: Always clear popupWindowState  before showing popup from form trigger

### DIFF
--- a/packages/editor-ui/src/utils/executionUtils.ts
+++ b/packages/editor-ui/src/utils/executionUtils.ts
@@ -130,7 +130,10 @@ export function displayForm({
 		if (node.name === destinationNode || !node.disabled) {
 			let testUrl = '';
 			if (node.type === FORM_TRIGGER_NODE_TYPE) testUrl = getTestUrl(node);
-			if (testUrl && source !== 'RunData.ManualChatMessage') openFormPopupWindow(testUrl);
+			if (testUrl && source !== 'RunData.ManualChatMessage') {
+				clearPopupWindowState();
+				openFormPopupWindow(testUrl);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

 Always clear popupWindowState  before showing popup from form trigger

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-2413/if-you-close-the-form-trigger-pop-up-window-without-completing-it-it


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
