### PR TITLE
fix(editor): Hide $fromAI button if credentials are missing

### DIFF
--- a/packages/editor-ui/src/components/ParameterInput.vue
+++ b/packages/editor-ui/src/components/ParameterInput.vue
@@ -175,18 +175,28 @@ const dateTimePickerOptions = ref({
 });
 const isFocused = ref(false);
 
+const missingCredentials = computed(
+	() =>
+		nodeType.value?.credentials &&
+		nodeType.value.credentials?.length > 0 &&
+		nodeType.value.credentials[0].required &&
+		!node.value?.credentials,
+);
+
+const shouldShowOverride = computed(
+	() =>
+		props.canBeOverridden &&
+		!(remoteParameterOptionsLoadingIssues.value && missingCredentials.value),
+);
+
 const displayValue = computed(() => {
 	if (remoteParameterOptionsLoadingIssues.value) {
 		if (!nodeType.value || nodeType.value?.codex?.categories?.includes(CORE_NODES_CATEGORY)) {
 			return i18n.baseText('parameterInput.loadOptionsError');
 		}
 
-		if (nodeType.value?.credentials && nodeType.value?.credentials?.length > 0) {
-			const credentialsType = nodeType.value?.credentials[0];
-
-			if (credentialsType.required && !node.value?.credentials) {
-				return i18n.baseText('parameterInput.loadOptionsCredentialsRequired');
-			}
+		if (missingCredentials.value) {
+			return i18n.baseText('parameterInput.loadOptionsCredentialsRequired');
 		}
 
 		return i18n.baseText('parameterInput.loadOptionsErrorService', {
@@ -1112,7 +1122,7 @@ onUpdated(async () => {
 				'parameter-input',
 				'ignore-key-press-canvas',
 				{
-					[$style.noRightCornersInput]: canBeOverridden,
+					[$style.noRightCornersInput]: shouldShowOverride,
 				},
 			]"
 			:style="parameterInputWrapperStyle"
@@ -1593,7 +1603,7 @@ onUpdated(async () => {
 			</div>
 		</div>
 		<div
-			v-if="$slots.overrideButton"
+			v-if="$slots.overrideButton && shouldShowOverride"
 			:class="[
 				$style.overrideButton,
 				{


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3247/bug-readonly-property-in-airtable-tool-has-fromai-button


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
