### PR TITLE
feat(core): Add telemetry for workflow evaluation feature (no-changelog)

### DIFF
--- a/packages/cli/src/evaluation.ee/test-definition.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-definition.service.ee.ts
@@ -7,6 +7,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { validateEntity } from '@/generic-helpers';
 import type { ListQuery } from '@/requests';
+import { Telemetry } from '@/telemetry';
 
 type TestDefinitionLike = Omit<
 	Partial<TestDefinition>,
@@ -22,6 +23,7 @@ export class TestDefinitionService {
 	constructor(
 		private testDefinitionRepository: TestDefinitionRepository,
 		private annotationTagRepository: AnnotationTagRepository,
+		private telemetry: Telemetry,
 	) {}
 
 	private toEntityLike(attrs: {
@@ -94,6 +96,13 @@ export class TestDefinitionService {
 	}
 
 	async update(id: string, attrs: TestDefinitionLike) {
+		const existingTestDefinition = await this.testDefinitionRepository.findOneOrFail({
+			where: {
+				id,
+			},
+			relations: ['workflow'],
+		});
+
 		if (attrs.name) {
 			const updatedTest = this.toEntity(attrs);
 			await validateEntity(updatedTest);
@@ -114,13 +123,6 @@ export class TestDefinitionService {
 
 		// If there are mocked nodes, validate them
 		if (attrs.mockedNodes && attrs.mockedNodes.length > 0) {
-			const existingTestDefinition = await this.testDefinitionRepository.findOneOrFail({
-				where: {
-					id,
-				},
-				relations: ['workflow'],
-			});
-
 			const existingNodeNames = new Map(
 				existingTestDefinition.workflow.nodes.map((n) => [n.name, n]),
 			);
@@ -146,6 +148,24 @@ export class TestDefinitionService {
 		if (queryResult.affected === 0) {
 			throw new NotFoundError('Test definition not found');
 		}
+
+		// Send the telemetry events
+		if (attrs.annotationTagId && attrs.annotationTagId !== existingTestDefinition.annotationTagId) {
+			this.telemetry.track('User added tag to test', {
+				test_id: id,
+				tag_id: attrs.annotationTagId,
+			});
+		}
+
+		if (
+			attrs.evaluationWorkflowId &&
+			existingTestDefinition.evaluationWorkflowId !== attrs.evaluationWorkflowId
+		) {
+			this.telemetry.track('User added evaluation workflow to test', {
+				test_id: id,
+				subworkflow_id: attrs.evaluationWorkflowId,
+			});
+		}
 	}
 
 	async delete(id: string, accessibleWorkflowIds: string[]) {
@@ -154,6 +174,8 @@ export class TestDefinitionService {
 		if (deleteResult.affected === 0) {
 			throw new NotFoundError('Test definition not found');
 		}
+
+		this.telemetry.track('User deleted a test', { test_id: id });
 	}
 
 	async getMany(options: ListQuery.Options, accessibleWorkflowIds: string[] = []) {

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -546,7 +546,7 @@ export class TestRunnerService {
 			// Send telemetry event
 			this.telemetry.track('Test run finished', {
 				test_id: test.id,
-				test_run_id: testRun.id,
+				run_id: testRun.id,
 				status: testRunEndStatusForTelemetry,
 			});
 		}

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -340,7 +340,7 @@ export class TestRunnerService {
 			// Update test run status
 			await this.testRunRepository.markAsRunning(testRun.id, pastExecutions.length);
 
-			this.telemetry.track('User runs test', {
+			this.telemetry.track('User ran test', {
 				user_id: user.id,
 				test_id: test.id,
 				run_id: testRun.id,

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -292,6 +292,8 @@ export class TestRunnerService {
 			userId: user.id,
 		};
 
+		let testRunEndStatusForTelemetry;
+
 		const abortSignal = abortController.signal;
 		try {
 			// Get the evaluation workflow
@@ -504,13 +506,17 @@ export class TestRunnerService {
 				await Db.transaction(async (trx) => {
 					await this.testRunRepository.markAsCancelled(testRun.id, trx);
 					await this.testCaseExecutionRepository.markAllPendingAsCancelled(testRun.id, trx);
+
+					testRunEndStatusForTelemetry = 'cancelled';
 				});
 			} else {
 				const aggregatedMetrics = metrics.getAggregatedMetrics();
 
 				await this.testRunRepository.markAsCompleted(testRun.id, aggregatedMetrics);
 
-				this.logger.debug('Test run finished', { testId: test.id });
+				this.logger.debug('Test run finished', { testId: test.id, testRunId: testRun.id });
+
+				testRunEndStatusForTelemetry = 'completed';
 			}
 		} catch (e) {
 			if (e instanceof ExecutionCancelledError) {
@@ -523,15 +529,26 @@ export class TestRunnerService {
 					await this.testRunRepository.markAsCancelled(testRun.id, trx);
 					await this.testCaseExecutionRepository.markAllPendingAsCancelled(testRun.id, trx);
 				});
+
+				testRunEndStatusForTelemetry = 'cancelled';
 			} else if (e instanceof TestRunError) {
 				await this.testRunRepository.markAsError(testRun.id, e.code, e.extra as IDataObject);
+				testRunEndStatusForTelemetry = 'error';
 			} else {
 				await this.testRunRepository.markAsError(testRun.id, 'UNKNOWN_ERROR');
+				testRunEndStatusForTelemetry = 'error';
 				throw e;
 			}
 		} finally {
 			// Clean up abort controller
 			this.abortControllers.delete(testRun.id);
+
+			// Send telemetry event
+			this.telemetry.track('Test run finished', {
+				test_id: test.id,
+				test_run_id: testRun.id,
+				status: testRunEndStatusForTelemetry,
+			});
 		}
 	}
 

--- a/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
@@ -13,6 +13,7 @@ import { listQueryMiddleware } from '@/middlewares';
 import { getSharedWorkflowIds } from '@/public-api/v1/handlers/workflows/workflows.service';
 
 import { TestDefinitionService } from './test-definition.service.ee';
+import { Telemetry } from '@/telemetry';
 
 @RestController('/evaluation/test-definitions')
 export class TestRunsController {
@@ -22,6 +23,7 @@ export class TestRunsController {
 		private readonly testCaseExecutionRepository: TestCaseExecutionRepository,
 		private readonly testRunnerService: TestRunnerService,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly telemetry: Telemetry,
 	) {}
 
 	/**
@@ -92,13 +94,15 @@ export class TestRunsController {
 
 	@Delete('/:testDefinitionId/runs/:id')
 	async delete(req: TestRunsRequest.Delete) {
-		const { id: testRunId } = req.params;
+		const { id: testRunId, testDefinitionId } = req.params;
 
 		// Check test definition and test run exist
 		await this.getTestDefinition(req);
 		await this.getTestRun(req);
 
 		await this.testRunRepository.delete({ id: testRunId });
+
+		this.telemetry.track('User deleted a run', { run_id: testRunId, test_id: testDefinitionId });
 
 		return { success: true };
 	}

--- a/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
@@ -11,9 +11,9 @@ import { TestRunsRequest } from '@/evaluation.ee/test-definitions.types.ee';
 import { TestRunnerService } from '@/evaluation.ee/test-runner/test-runner.service.ee';
 import { listQueryMiddleware } from '@/middlewares';
 import { getSharedWorkflowIds } from '@/public-api/v1/handlers/workflows/workflows.service';
+import { Telemetry } from '@/telemetry';
 
 import { TestDefinitionService } from './test-definition.service.ee';
-import { Telemetry } from '@/telemetry';
 
 @RestController('/evaluation/test-definitions')
 export class TestRunsController {

--- a/packages/editor-ui/src/components/TestDefinition/EditDefinition/NodesPinning.vue
+++ b/packages/editor-ui/src/components/TestDefinition/EditDefinition/NodesPinning.vue
@@ -9,12 +9,14 @@ import { createEventBus, N8nTooltip } from 'n8n-design-system';
 import type { CanvasConnectionPort, CanvasEventBusEvents, CanvasNodeData } from '@/types';
 import { useVueFlow } from '@vue-flow/core';
 import { useI18n } from '@/composables/useI18n';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();
 const route = useRoute();
 const router = useRouter();
 const locale = useI18n();
+const telemetry = useTelemetry();
 
 const { resetWorkspace, initializeWorkspace } = useCanvasOperations({ router });
 
@@ -101,6 +103,13 @@ function onPinButtonClick(data: CanvasNodeData) {
 
 	emit('update:modelValue', updatedNodes);
 	updateNodeClasses([data.id], !isPinned);
+
+	if (!isPinned) {
+		telemetry.track('User selected node to be mocked', {
+			node_id: data.id,
+			test_id: testId.value,
+		});
+	}
 }
 function isPinButtonVisible(outputs: CanvasConnectionPort[]) {
 	return outputs.length === 1;

--- a/packages/editor-ui/src/components/TestDefinition/EditDefinition/WorkflowSelector.vue
+++ b/packages/editor-ui/src/components/TestDefinition/EditDefinition/WorkflowSelector.vue
@@ -4,7 +4,6 @@ import { SAMPLE_EVALUATION_WORKFLOW } from '@/constants.workflows';
 import type { IWorkflowDataCreate } from '@/Interface';
 import type { INodeParameterResourceLocator, IPinData } from 'n8n-workflow';
 import { computed } from 'vue';
-import { useTelemetry } from '@/composables/useTelemetry';
 
 interface WorkflowSelectorProps {
 	modelValue: INodeParameterResourceLocator;

--- a/packages/editor-ui/src/components/TestDefinition/EditDefinition/WorkflowSelector.vue
+++ b/packages/editor-ui/src/components/TestDefinition/EditDefinition/WorkflowSelector.vue
@@ -4,6 +4,7 @@ import { SAMPLE_EVALUATION_WORKFLOW } from '@/constants.workflows';
 import type { IWorkflowDataCreate } from '@/Interface';
 import type { INodeParameterResourceLocator, IPinData } from 'n8n-workflow';
 import { computed } from 'vue';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 interface WorkflowSelectorProps {
 	modelValue: INodeParameterResourceLocator;
@@ -21,7 +22,10 @@ const props = withDefaults(defineProps<WorkflowSelectorProps>(), {
 	sampleWorkflowName: undefined,
 });
 
-defineEmits<{ 'update:modelValue': [value: WorkflowSelectorProps['modelValue']] }>();
+defineEmits<{
+	'update:modelValue': [value: WorkflowSelectorProps['modelValue']];
+	workflowCreated: [workflowId: string];
+}>();
 const locale = useI18n();
 
 const subworkflowName = computed(() => {
@@ -63,6 +67,7 @@ const sampleWorkflow = computed<IWorkflowDataCreate>(() => {
 				allow-new
 				:sample-workflow="sampleWorkflow"
 				@update:model-value="$emit('update:modelValue', $event)"
+				@workflow-created="$emit('workflowCreated', $event)"
 			/>
 		</n8n-input-label>
 	</div>

--- a/packages/editor-ui/src/components/TestDefinition/EditDefinition/sections/ConfigSection.vue
+++ b/packages/editor-ui/src/components/TestDefinition/EditDefinition/sections/ConfigSection.vue
@@ -10,6 +10,7 @@ import type { ITag, ModalState } from '@/Interface';
 import { NODE_PINNING_MODAL_KEY } from '@/constants';
 import { ref } from 'vue';
 import type { IPinData } from 'n8n-workflow';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 defineProps<{
 	showConfig: boolean;
@@ -29,6 +30,7 @@ defineProps<{
 const emit = defineEmits<{
 	openPinningModal: [];
 	deleteMetric: [metric: Partial<TestMetricRecord>];
+	evaluationWorkflowCreated: [workflowId: string];
 }>();
 
 const locale = useI18n();
@@ -145,6 +147,7 @@ function showFieldIssues(fieldKey: string) {
 					:class="{ 'has-issues': getFieldIssues('evaluationWorkflow').length > 0 }"
 					:sample-workflow-name="sampleWorkflowName"
 					@update:model-value="updateChangedFieldsKeys('evaluationWorkflow')"
+					@workflow-created="$emit('evaluationWorkflowCreated', $event)"
 				/>
 			</template>
 		</EvaluationStep>

--- a/packages/editor-ui/src/components/TestDefinition/EditDefinition/sections/ConfigSection.vue
+++ b/packages/editor-ui/src/components/TestDefinition/EditDefinition/sections/ConfigSection.vue
@@ -10,7 +10,6 @@ import type { ITag, ModalState } from '@/Interface';
 import { NODE_PINNING_MODAL_KEY } from '@/constants';
 import { ref } from 'vue';
 import type { IPinData } from 'n8n-workflow';
-import { useTelemetry } from '@/composables/useTelemetry';
 
 defineProps<{
 	showConfig: boolean;

--- a/packages/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
+++ b/packages/editor-ui/src/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
@@ -55,6 +55,7 @@ const emit = defineEmits<{
 	modalOpenerClick: [];
 	focus: [];
 	blur: [];
+	workflowCreated: [workflowId: string];
 }>();
 
 const workflowsStore = useWorkflowsStore();
@@ -232,6 +233,8 @@ const onAddResourceClicked = async () => {
 	hideDropdown();
 
 	window.open(href, '_blank');
+
+	emit('workflowCreated', newWorkflow.id);
 };
 </script>
 <template>

--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
@@ -7,11 +7,13 @@ import { createEventBus } from 'n8n-design-system';
 import VoteButtons from '@/components/executions/workflow/VoteButtons.vue';
 import { useToast } from '@/composables/useToast';
 import { useI18n } from '@/composables/useI18n';
+import { useTelemetry } from '@/composables/useTelemetry';
 
 const executionsStore = useExecutionsStore();
 
 const { showError } = useToast();
 const i18n = useI18n();
+const telemetry = useTelemetry();
 
 const tagsEventBus = createEventBus();
 const isTagsEditEnabled = ref(false);
@@ -81,6 +83,12 @@ const onTagsBlur = async () => {
 
 	try {
 		await executionsStore.annotateExecution(activeExecution.value.id, { tags: newTagIds });
+
+		if (newTagIds.length > 0) {
+			telemetry.track('User added execution annotation tag', {
+				tag_ids: newTagIds,
+			});
+		}
 	} catch (e) {
 		showError(e, 'executionAnnotationView.tag.error');
 	}

--- a/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
+++ b/packages/editor-ui/src/components/executions/workflow/WorkflowExecutionAnnotationPanel.ee.vue
@@ -87,6 +87,7 @@ const onTagsBlur = async () => {
 		if (newTagIds.length > 0) {
 			telemetry.track('User added execution annotation tag', {
 				tag_ids: newTagIds,
+				execution_id: activeExecution.value.id,
 			});
 		}
 	} catch (e) {

--- a/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
+++ b/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
@@ -186,7 +186,7 @@ async function getExamplePinnedDataForTags() {
 // Debounced watchers for auto-saving
 watch(
 	() => state.value.metrics,
-	debounce(async () => await updateMetrics(testId.value), { debounceTime: 400 }),
+	debounce(async () => await updateMetrics(testId.value), { debounceTime: 400, trailing: true }),
 	{ deep: true },
 );
 watch(() => state.value.tags.value, getExamplePinnedDataForTags);

--- a/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
+++ b/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
@@ -198,9 +198,22 @@ watch(
 		state.value.evaluationWorkflow,
 		state.value.mockedNodes,
 	],
-	debounce(onSaveTest, { debounceTime: 400 }),
+	debounce(onSaveTest, { debounceTime: 400, trailing: true }),
 	{ deep: true },
 );
+
+function onEvaluationWorkflowCreated(workflowId: string) {
+	telemetry.track(
+		'User created evaluation workflow from test',
+		{
+			test_id: testId.value,
+			subworkflow_id: workflowId,
+		},
+		{
+			withPostHog: true,
+		},
+	);
+}
 </script>
 
 <template>
@@ -261,6 +274,7 @@ watch(
 				:sample-workflow-name="workflowName"
 				@open-pinning-modal="openPinningModal"
 				@delete-metric="onDeleteMetric"
+				@evaluation-workflow-created="onEvaluationWorkflowCreated($event)"
 			/>
 		</div>
 	</div>

--- a/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
+++ b/packages/editor-ui/src/views/TestDefinition/TestDefinitionEditView.vue
@@ -203,16 +203,10 @@ watch(
 );
 
 function onEvaluationWorkflowCreated(workflowId: string) {
-	telemetry.track(
-		'User created evaluation workflow from test',
-		{
-			test_id: testId.value,
-			subworkflow_id: workflowId,
-		},
-		{
-			withPostHog: true,
-		},
-	);
+	telemetry.track('User created evaluation workflow from test', {
+		test_id: testId.value,
+		subworkflow_id: workflowId,
+	});
 }
 </script>
 


### PR DESCRIPTION
## Summary

This PR adds multiple telemetry events for the workflow evaluation feature.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-591/external-release-telemetry


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
