### PR TITLE
fix(editor): Fix the path to which tree-sitter wasm files are copied to (no-changelog)

### DIFF
--- a/packages/editor-ui/vite.config.mts
+++ b/packages/editor-ui/vite.config.mts
@@ -66,10 +66,13 @@ const plugins = [
 	}),
 	viteStaticCopy({
 		targets: [
-			{ src: pathPosix.resolve('node_modules/web-tree-sitter/tree-sitter.wasm'), dest: 'public' },
+			{
+				src: pathPosix.resolve('node_modules/web-tree-sitter/tree-sitter.wasm'),
+				dest: resolve(__dirname, 'dist'),
+			},
 			{
 				src: pathPosix.resolve('node_modules/curlconverter/dist/tree-sitter-bash.wasm'),
-				dest: 'public',
+				dest: resolve(__dirname, 'dist'),
 			},
 		],
 	}),


### PR DESCRIPTION
## Summary
Released versions of `n8n-editor-ui` are already somehow copying over these `.wasm` files to the `dist` folder instead of `dist/public`, which is making the curl-converter feature work as expected in released versions of the frontend. 
However in dev setup, and in custom images, the `.wasm` files are in the wrong location, which breaks the curl import feature.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
