### PR TITLE
fix(core): Make sure middleware works with legacy API Keys

### DIFF
--- a/packages/cli/src/services/__tests__/public-api-key.service.test.ts
+++ b/packages/cli/src/services/__tests__/public-api-key.service.test.ts
@@ -1,5 +1,7 @@
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
+import { randomString } from 'n8n-workflow';
 import type { OpenAPIV3 } from 'openapi-types';
 
 import { ApiKeyRepository } from '@/databases/repositories/api-key.repository';
@@ -12,8 +14,6 @@ import * as testDb from '@test-integration/test-db';
 
 import { JwtService } from '../jwt.service';
 import { PublicApiKeyService } from '../public-api-key.service';
-import { Container } from '@n8n/di';
-import { randomString } from 'n8n-workflow';
 
 const mockReqWith = (apiKey: string, path: string, method: string) => {
 	return mock<AuthenticatedRequest>({

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -3,7 +3,6 @@ import type { CreateApiKeyRequestDto } from '@n8n/api-types/src/dto/api-keys/cre
 import { Service } from '@n8n/di';
 import { TokenExpiredError } from 'jsonwebtoken';
 import type { OpenAPIV3 } from 'openapi-types';
-import { validate as isJwt } from 'uuid';
 
 import { ApiKey } from '@/databases/entities/api-key';
 import type { User } from '@/databases/entities/user';
@@ -18,6 +17,7 @@ const API_KEY_AUDIENCE = 'public-api';
 const API_KEY_ISSUER = 'n8n';
 const REDACT_API_KEY_REVEAL_COUNT = 4;
 const REDACT_API_KEY_MAX_LENGTH = 10;
+const PREFIX_LEGACY_API_KEY = 'n8n_api_';
 
 @Service()
 export class PublicApiKeyService {
@@ -109,7 +109,7 @@ export class PublicApiKeyService {
 			if (!user) return false;
 
 			// Legacy API keys are not JWTs and do not need to be verified.
-			if (isJwt(providedApiKey)) {
+			if (!providedApiKey.startsWith(PREFIX_LEGACY_API_KEY)) {
 				try {
 					this.jwtService.verify(providedApiKey, {
 						issuer: API_KEY_ISSUER,

--- a/packages/cli/test/integration/shared/db/users.ts
+++ b/packages/cli/test/integration/shared/db/users.ts
@@ -80,23 +80,30 @@ export async function createUserWithMfaEnabled(
 	};
 }
 
-export const addApiKey = async (user: User) => {
+export const addApiKey = async (
+	user: User,
+	{ expiresAt = null }: { expiresAt?: number | null } = {},
+) => {
 	return await Container.get(PublicApiKeyService).createPublicApiKeyForUser(user, {
 		label: randomName(),
-		expiresAt: null,
+		expiresAt,
 	});
 };
 
-export async function createOwnerWithApiKey() {
+export async function createOwnerWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const owner = await createOwner();
-	const apiKey = await addApiKey(owner);
+	const apiKey = await addApiKey(owner, { expiresAt });
 	owner.apiKeys = [apiKey];
 	return owner;
 }
 
-export async function createMemberWithApiKey() {
+export async function createMemberWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const member = await createMember();
-	const apiKey = await addApiKey(member);
+	const apiKey = await addApiKey(member, { expiresAt });
 	member.apiKeys = [apiKey];
 	return member;
 }


### PR DESCRIPTION
## Summary

In `n8n@1.78.0` we introduce API keys expiration. That required to validate the JWTs in the [middleware](https://github.com/n8n-io/n8n/pull/12954/files#diff-aefe54f3688ae546fd544e807d8cff9268eade41ee49b11fd8cbfeda979eded3R111)). Sadly, this also validates legacy API keys and it should not as legacy API keys are not JWTs. This makes sure the legacy tokens are not validated for expiration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3250/api-keys-expire-with-upgrade-to-178

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
