### PR TITLE
fix(editor): Don't open form popup window if different trigger node is used

### DIFF
--- a/packages/editor-ui/src/composables/useRunWorkflow.ts
+++ b/packages/editor-ui/src/composables/useRunWorkflow.ts
@@ -351,6 +351,7 @@ export function useRunWorkflow(useRunWorkflowOpts: { router: ReturnType<typeof u
 					nodes: workflowData.nodes,
 					runData: workflowsStore.getWorkflowExecution?.data?.resultData?.runData,
 					destinationNode: options.destinationNode,
+					triggerNode: options.triggerNode,
 					pinData,
 					directParentNodes,
 					source: options.source,

--- a/packages/editor-ui/src/utils/executionUtils.ts
+++ b/packages/editor-ui/src/utils/executionUtils.ts
@@ -105,6 +105,7 @@ export function displayForm({
 	runData,
 	pinData,
 	destinationNode,
+	triggerNode,
 	directParentNodes,
 	source,
 	getTestUrl,
@@ -113,11 +114,14 @@ export function displayForm({
 	runData: IRunData | undefined;
 	pinData: IPinData;
 	destinationNode: string | undefined;
+	triggerNode: string | undefined;
 	directParentNodes: string[];
 	source: string | undefined;
 	getTestUrl: (node: INode) => string;
 }) {
 	for (const node of nodes) {
+		if (triggerNode !== undefined && triggerNode !== node.name) continue;
+
 		const hasNodeRun = runData && runData?.hasOwnProperty(node.name);
 
 		if (hasNodeRun || pinData[node.name]) continue;


### PR DESCRIPTION
## Summary
When the workflow has multiple trigger nodes, clicking on "Test workflow" button on other trigger nodes should not open the form popup window.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/SUG-16/bug-form-popup-shows-when-executing-a-different-trigger-via-popup


## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
