### PR TITLE
feat(editor): Rename 'Text' fields on AI nodes to 'Prompt'

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -338,7 +338,7 @@ export class ChainLlm implements INodeType {
 				displayOptions: { show: { promptType: ['auto'], '@version': [{ _cnd: { gte: 1.5 } }] } },
 			},
 			{
-				displayName: 'Text',
+				displayName: 'Prompt (User Message)',
 				name: 'text',
 				type: 'string',
 				required: true,

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainRetrievalQA/ChainRetrievalQa.node.ts
@@ -123,11 +123,12 @@ export class ChainRetrievalQa implements INodeType {
 				displayOptions: { show: { promptType: ['auto'], '@version': [{ _cnd: { gte: 1.4 } }] } },
 			},
 			{
-				displayName: 'Text',
+				displayName: 'Prompt (User Message)',
 				name: 'text',
 				type: 'string',
 				required: true,
 				default: '',
+				placeholder: 'e.g. Hello, how can you help me?',
 				typeOptions: {
 					rows: 2,
 				},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/assistant/message.operation.ts
@@ -32,7 +32,7 @@ const properties: INodeProperties[] = [
 		name: 'prompt',
 	},
 	{
-		displayName: 'Text',
+		displayName: 'Prompt (User Message)',
 		name: 'text',
 		type: 'string',
 		default: '',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/actions/text/message.operation.ts
@@ -34,11 +34,12 @@ const properties: INodeProperties[] = [
 				name: 'values',
 				values: [
 					{
-						displayName: 'Text',
+						displayName: 'Prompt',
 						name: 'content',
 						type: 'string',
 						description: 'The content of the message to be send',
 						default: '',
+						placeholder: 'e.g. Hello, how can you help me?',
 						typeOptions: {
 							rows: 2,
 						},

--- a/packages/@n8n/nodes-langchain/utils/descriptions.ts
+++ b/packages/@n8n/nodes-langchain/utils/descriptions.ts
@@ -96,7 +96,7 @@ export const promptTypeOptions: INodeProperties = {
 };
 
 export const textInput: INodeProperties = {
-	displayName: 'Text',
+	displayName: 'Prompt (User Message)',
 	name: 'text',
 	type: 'string',
 	required: true,


### PR DESCRIPTION
## Summary

Renaming `Text` fields on AI nodes to `Prompt` or `Prompt (User Message)` to better reflect what they are for.

![image](https://github.com/user-attachments/assets/d549f45d-25fe-4d8b-9269-e54fbb544b9e)
![image](https://github.com/user-attachments/assets/288da232-1cba-4a4f-9f10-2dc9b774b51c)
![image](https://github.com/user-attachments/assets/23fb6810-796c-43e8-a41e-44a2b389a587)
![image](https://github.com/user-attachments/assets/9bc4a3ac-aea5-4ca3-92b7-f603bd56094f)
![image](https://github.com/user-attachments/assets/efc66fa5-eb39-4b7f-bb49-e2293b0aa6f0)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-3241/feature-rename-text-parameter-to-prompt

<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
