### PR TITLE
fix(editor): Register/unregister keybindings on window focus/blur

### DIFF
--- a/packages/editor-ui/src/composables/useKeybindings.test.ts
+++ b/packages/editor-ui/src/composables/useKeybindings.test.ts
@@ -163,4 +163,30 @@ describe('useKeybindings', () => {
 		document.dispatchEvent(event);
 		expect(handler).toHaveBeenCalled();
 	});
+
+	it('should not call handler when window is blurred, until it is focused back', async () => {
+		const handler = vi.fn();
+		const keymap = ref({ a: handler });
+
+		useKeybindings(keymap);
+
+		const event = new KeyboardEvent('keydown', { key: 'a' });
+		document.dispatchEvent(event);
+
+		expect(handler).toHaveBeenCalled();
+
+		const blurEvent = new Event('blur');
+		window.dispatchEvent(blurEvent);
+
+		document.dispatchEvent(event);
+
+		expect(handler).toHaveBeenCalledTimes(1);
+
+		const focusEvent = new Event('focus');
+		window.dispatchEvent(focusEvent);
+
+		document.dispatchEvent(event);
+
+		expect(handler).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/editor-ui/src/composables/useKeybindings.ts
+++ b/packages/editor-ui/src/composables/useKeybindings.ts
@@ -1,7 +1,7 @@
 import { useActiveElement, useEventListener } from '@vueuse/core';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import type { MaybeRef, Ref } from 'vue';
-import { computed, unref } from 'vue';
+import { computed, ref, unref } from 'vue';
 
 type KeyMap = Record<string, (event: KeyboardEvent) => void>;
 
@@ -142,5 +142,17 @@ export const useKeybindings = (
 		}
 	}
 
-	useEventListener(document, 'keydown', onKeyDown);
+	const unregister = ref<ReturnType<typeof useEventListener> | undefined>();
+
+	function registerKeybindings() {
+		unregister.value = useEventListener(document, 'keydown', onKeyDown);
+	}
+
+	function unregisterKeybindings() {
+		unregister.value?.();
+	}
+
+	registerKeybindings();
+	useEventListener(window, 'blur', unregisterKeybindings);
+	useEventListener(window, 'focus', registerKeybindings);
 };


### PR DESCRIPTION
## Summary

Potentially fixes hard to reproduce bug causing keyboard shortcuts to stop working when switching tabs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-665/registerunregister-keybindings-on-window-focusblur

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
